### PR TITLE
perf(vector): Return OPAQUE values by const ref from DecodedVector::valueAt

### DIFF
--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -175,9 +175,15 @@ class DecodedVector {
     return indices_[idx];
   }
 
-  /// Returns a scalar value for the top-level row 'idx'.
+  /// Type of value returned depends on T. std::shared_ptr, the physical
+  /// representation of OPAQUE, is returned by const reference to avoid an
+  /// atomic refcount bump; every other type is returned by value.
   template <typename T>
-  T valueAt(vector_size_t idx) const {
+  using TValueAt = std::conditional_t<is_shared_ptr<T>::value, const T&, T>;
+
+  /// Returns the value for the top-level row 'idx'.
+  template <typename T>
+  TValueAt<T> valueAt(vector_size_t idx) const {
     return reinterpret_cast<const T*>(data_)[index(idx)];
   }
 
@@ -560,12 +566,12 @@ class DecodedVector {
 };
 
 template <>
-inline bool DecodedVector::valueAt(vector_size_t idx) const {
+inline bool DecodedVector::valueAt<bool>(vector_size_t idx) const {
   return bits::isBitSet(reinterpret_cast<const uint64_t*>(data_), index(idx));
 }
 
 template <>
-inline int128_t DecodedVector::valueAt(vector_size_t idx) const {
+inline int128_t DecodedVector::valueAt<int128_t>(vector_size_t idx) const {
   auto valuePosition =
       reinterpret_cast<const char*>(data_) + sizeof(int128_t) * index(idx);
   return HugeInt::deserialize(valuePosition);

--- a/velox/vector/EncodedVectorCopy.cpp
+++ b/velox/vector/EncodedVectorCopy.cpp
@@ -371,7 +371,7 @@ VectorPtr newConstantImpl(
   }
   if constexpr (!std::is_same_v<T, ComplexType>) {
     return std::make_shared<ConstantVector<T>>(
-        options.pool, size, false, sourceBase->type(), source.valueAt<T>(0));
+        options.pool, size, false, sourceBase->type(), T(source.valueAt<T>(0)));
   } else {
     VectorPtr targetBase;
     BaseVector::CopyRange range = {source.index(0), 0, 1};

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -651,6 +651,60 @@ TEST_F(DecodedVectorTest, dictionary) {
       1000, [](vector_size_t i) { return std::make_shared<int>(i % 5); });
 }
 
+TEST_F(DecodedVectorTest, valueAtOpaqueDoesNotCopy) {
+  using TOpaque = std::shared_ptr<void>;
+  constexpr vector_size_t size = 100;
+
+  static_assert(
+      std::is_same_v<
+          decltype(std::declval<const DecodedVector&>().valueAt<TOpaque>(0)),
+          const TOpaque&>,
+      "Opaque values must be returned by const reference.");
+  static_assert(
+      std::is_same_v<
+          decltype(std::declval<const DecodedVector&>().valueAt<int64_t>(0)),
+          int64_t>,
+      "Non-opaque values must be returned by value.");
+
+  std::vector<TOpaque> values(size);
+  for (auto i = 0; i < size; ++i) {
+    values[i] = std::make_shared<int>(i);
+  }
+  auto flatVector =
+      makeFlatVector<TOpaque>(size, [&](vector_size_t i) { return values[i]; });
+
+  // 'row' of the decoded vector is expected to hold values[valueIndex].
+  auto check = [&](const DecodedVector& decoded,
+                   vector_size_t row,
+                   vector_size_t valueIndex) {
+    const auto useCount = values[valueIndex].use_count();
+    const auto& value = decoded.valueAt<TOpaque>(row);
+    // Returning by value would bind 'value' to a temporary copy, adding a use
+    // for as long as it stays in scope.
+    EXPECT_EQ(values[valueIndex].use_count(), useCount) << "at " << row;
+    // The reference points into the decoded data rather than at a copy.
+    EXPECT_EQ(&value, decoded.data<TOpaque>() + decoded.index(row));
+    EXPECT_EQ(value, values[valueIndex]);
+  };
+
+  {
+    DecodedVector decoded(*flatVector);
+    for (auto i = 0; i < size; ++i) {
+      check(decoded, i, i);
+    }
+  }
+
+  {
+    auto dictionarySize = size / 2;
+    auto dictionaryVector = BaseVector::wrapInDictionary(
+        BufferPtr(nullptr), makeEvenIndices(size), dictionarySize, flatVector);
+    DecodedVector decoded(*dictionaryVector);
+    for (auto i = 0; i < dictionarySize; ++i) {
+      check(decoded, i, 2 * i);
+    }
+  }
+}
+
 TEST_F(DecodedVectorTest, dictionaryOverLazy) {
   constexpr vector_size_t size = 1000;
   auto lazyVector = vectorMaker_.lazyFlatVector<int32_t>(


### PR DESCRIPTION
Summary:
`DecodedVector::valueAt<T>` returned every value by value, copying the
underlying element on each read. For OPAQUE columns the element is a
`std::shared_ptr`, so every read incurred an atomic refcount bump (and its
matching decrement on destruction of the temporary).

This changes `valueAt` to return `std::shared_ptr` values (the physical
representation of OPAQUE) by const reference into the decoded data, avoiding the
refcount traffic; all other types are still returned by value. The detection
reuses `velox::is_shared_ptr`, added to `Type.h` in the parent diff.

`EncodedVectorCopy` constructs a `ConstantVector` from `valueAt`; since the
shared_ptr result is now a const reference rather than a value, it takes an
explicit copy there.

Differential Revision: D114484180


