### PR TITLE
test(iceberg): Guard IcebergNimbleInsertTest behind VELOX_ENABLE_NIMBLE

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+// This end-to-end test exercises the batch NimbleReader/NimbleWriter factories,
+// which live under dwio/nimble/.../fb/ and are internal-only (not shipped to
+// OSS). Guard the whole test so the OSS build (VELOX_ENABLE_NIMBLE off) does
+// not try to include the fb/ headers. Mirrors WriterOptionsAdapterTest.cpp.
+#ifdef VELOX_ENABLE_NIMBLE
+
 #include "dwio/nimble/velox/reader/fb/NimbleReader.h"
 #include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
 #include "velox/connectors/hive/HiveConfig.h"
@@ -312,3 +318,5 @@ TEST_F(IcebergNimbleInsertTest, fieldIdRenameInsideArrayStruct) {
 
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg
+
+#endif // VELOX_ENABLE_NIMBLE


### PR DESCRIPTION
Summary:
`velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp` unconditionally
includes `dwio/nimble/velox/reader/fb/NimbleReader.h` and
`dwio/nimble/velox/writer/fb/NimbleWriter.h`. Those `fb/` headers are
internal-only and are not shipped to OSS, and the test itself is a Buck-only
target (not in the OSS CMakeLists). When a diff modifies this file it is exported
to the OSS Velox PR, where clang-tidy compiles the changed file and fails with
`'dwio/nimble/velox/reader/fb/NimbleReader.h' file not found`.

Guard the whole test behind `#ifdef VELOX_ENABLE_NIMBLE`, mirroring the sibling
`WriterOptionsAdapterTest.cpp` (which already guards its Nimble include and every
Nimble test). With Nimble off (the OSS build) the file compiles to an empty
translation unit; internally (VELOX_ENABLE_NIMBLE on via the iceberg connector's
propagated `-DVELOX_ENABLE_NIMBLE`) it is unchanged and all tests still run.

This is a pre-existing OSS-export gap, split out of the writer-relocation stack
(D114316950) so it can be reviewed and verified on its own; that stack will
rebase on top of it.

Differential Revision: D114681826


