### PR TITLE
refactor(function): Make eq and neq header-inlinable like their siblings

### DIFF
--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <folly/CPortability.h>
+
 #include "velox/common/base/CompareFlags.h"
 #include "velox/functions/Macros.h"
 #include "velox/type/FloatingPointUtil.h"
@@ -85,7 +87,8 @@ struct EqFunction {
 
   // Used for primitive inputs.
   template <typename TInput>
-  void call(bool& out, const TInput& lhs, const TInput& rhs) {
+  FOLLY_ALWAYS_INLINE void
+  call(bool& out, const TInput& lhs, const TInput& rhs) {
     if constexpr (std::is_floating_point_v<TInput>) {
       out = util::floating_point::NaNAwareEquals<TInput>{}(lhs, rhs);
       return;
@@ -116,7 +119,8 @@ struct NeqFunction {
 
   // Used for primitive inputs.
   template <typename TInput>
-  void call(bool& out, const TInput& lhs, const TInput& rhs) {
+  FOLLY_ALWAYS_INLINE void
+  call(bool& out, const TInput& lhs, const TInput& rhs) {
     if constexpr (std::is_floating_point_v<TInput>) {
       out = !util::floating_point::NaNAwareEquals<TInput>{}(lhs, rhs);
       return;


### PR DESCRIPTION
## Summary

`lt`, `lte`, `gt`, and `gte` are generated by `VELOX_GEN_BINARY_EXPR`, which annotates their primitive `call()` overload `FOLLY_ALWAYS_INLINE`. `EqFunction` and `NeqFunction` are hand-written rather than macro-generated and never got the same annotation, leaving them the only members of the comparison family whose primitive overload is not inlinable.

This is the third in a small series making Velox's simple-function headers usable from `velox/experimental/cudf`, which compiles `call()` bodies with nvcc (see #18366). That backend redefines `FOLLY_ALWAYS_INLINE` to carry `__host__ __device__`, so the annotation is what allows a Velox function body to execute inside a CUDA kernel. Without it, `eq` and `neq` are the two gaps in an otherwise complete comparison set.

Verified directly rather than assumed — instantiating both from a `__device__` context today fails:

```
error: calling a __host__ function("EqFunction<GpuExec>::call<double>") from a
__device__ function is not allowed
```

while `lt`/`lte`/`gt`/`gte` compile.

The complex-type overloads taking `Generic<T1>` are deliberately untouched: they call `compare()` on view types and are not device-code candidates.

Also adds the missing `<folly/CPortability.h>`. The header has used `FOLLY_ALWAYS_INLINE` since the macro was introduced but only ever received it transitively via `Macros.h` → `SimpleFunctionApi.h` → `CppToType.h` → `Type.h`.

No behavior change.

## Test plan

- [x] `velox_functions_test` — 1926 passing
- [x] `velox_expression_test` — 1636 passing
- [x] 146 comparison-specific cases among them
- [x] Confirmed both functions become device-callable with the annotation