### PR TITLE
refactor(memory): Remove dangling comment in SharedArbitrator.h

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -387,19 +387,6 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   // capacity limit by reclaiming used memory from the participant itself.
   bool ensureCapacity(ArbitrationOperation& op);
 
-  // Invoked to run local arbitration on the request memory pool. It first
-  // ensures the memory growth is within both memory pool and arbitrator
-  // capacity limits. This step might reclaim the used memory from the request
-  // memory pool itself. Then it tries to obtain free capacity from the
-  // arbitrator. At last, it tries to reclaim free memory from itself before it
-  // falls back to the global arbitration. The local arbitration run is
-  // protected by shared lock of 'arbitrationLock_' which can run in parallel
-  // for different query pools. The free memory reclamation is protected by
-  // arbitrator 'mutex_' which is an in-memory fast operation. The function
-  // returns false on failure. Otherwise, it needs to further check if
-  // 'needGlobalArbitration' is true or not. If true, needs to proceed with the
-  // global arbitration run.
-
   // Invoked to initialize the global arbitration on arbitrator start-up. It
   // starts the background threads to used memory from running queries
   // on-demand.


### PR DESCRIPTION
Delete the 12-line doc comment above ensureCapacity() that described the
now-removed `runLocalArbitration()` function.

The comment was added in #9649 ("Parallelize local memory arbitration")
for the `runLocalArbitration()` declaration. #11262 ("Global memory
arbitration optimization") removed that function but left its comment
behind, so it is now dead.