### PR TITLE
feat(torchwave): Multikernel parity with cg (#18390)

### DIFF
--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -441,8 +441,37 @@ nativert::Node* copyVariantNode(
           // Variant function created nodes directly in the variant graph.
           // Map all variant chain nodes to the original.
           mapVariantChain(variantRoot, node, valueMap, nodeMap);
+          // An original output can be produced by any node of the variant
+          // chain, not just variantRoot: a multi-stage expansion (e.g.
+          // masked_select_jagged -> head/scatter/lengths) yields the values
+          // list from the scatter stage and new_sizes from the lengths stage.
+          // Collect every chain-produced output (walking from variantRoot via
+          // producers, stopping at already-mapped external inputs, as
+          // mapVariantChain does) and match original outputs by id against all
+          // of them.
+          std::vector<nativert::Value*> chainOutputs;
+          {
+            std::unordered_set<NodeCP> seen;
+            std::function<void(NodeCP)> collect = [&](NodeCP chainNode) {
+              if (!seen.insert(chainNode).second) {
+                return;
+              }
+              for (const auto* out : chainNode->outputs()) {
+                chainOutputs.push_back(const_cast<nativert::Value*>(out));
+              }
+              for (const auto& input : chainNode->inputs()) {
+                if (valueMap.count(input.value)) {
+                  continue;
+                }
+                if (auto* producer = input.value->producer()) {
+                  collect(producer);
+                }
+              }
+            };
+            collect(variantRoot);
+          }
           for (auto* origOut : node->outputs()) {
-            for (auto* vrOut : variantRoot->outputs()) {
+            for (auto* vrOut : chainOutputs) {
               if (vrOut->id() == origOut->id()) {
                 valueMap[origOut] = vrOut;
                 if (origOut->type().kind() ==
@@ -860,6 +889,54 @@ static bool setsSizeOnDevice(NodeCP producer) {
   return false;
 }
 
+// True when the consumer described by 'consumerMeta' reads its input
+// 'inputIdx' from the memory output of an elementwise 'producer' that would
+// fuse into the consumer's kernel. Codegen orders
+// such an edge with an intra-kernel opBarrier (see callNeedsBarrier), which in
+// multi-kernel mode forces a cooperative, whole-grid-resident launch; ending
+// the producer's kernel avoids it. The read goes through memory when the input
+// is a whole tensor (argumentMeta wholeTensor) or the producer returns a
+// non-register (materialized) result. Only elementwise producers qualify:
+// non-elementwise ops already run standalone, and producers carrying
+// multiBlockReturnBarrier already end their own kernel via isKernelBreak.
+static bool readsFusedElementwiseProducerFromMemory(
+    int32_t inputIdx,
+    const Metadata* consumerMeta,
+    ValueCP inputValue,
+    NodeCP producer,
+    const ValueTypes& types,
+    bool allStandalone) {
+  if (!producer) {
+    return false;
+  }
+  const auto* producerMeta = nodeMeta(producer);
+  if (!producerMeta || !producerMeta->elementwise ||
+      producerMeta->isStandalone(producer, types) || allStandalone) {
+    return false;
+  }
+  const bool wholeTensorArg = consumerMeta &&
+      static_cast<size_t>(inputIdx) < consumerMeta->argumentMeta.size() &&
+      consumerMeta->argumentMeta[inputIdx].wholeTensor;
+  // Ask about the output the consumer actually reads, not the producer's
+  // first one. A producer with several outputs can pass some in registers and
+  // materialize others, so keying on returnMeta[0] would break the producer's
+  // kernel for a register-passed input (or fuse through a materialized one).
+  // Elementwise ops are usually single-output, in which case this resolves to
+  // index 0 anyway.
+  size_t outputIdx = 0;
+  const auto& producerOutputs = producer->outputs();
+  for (size_t i = 0; i < producerOutputs.size(); ++i) {
+    if (producerOutputs[i] == inputValue) {
+      outputIdx = i;
+      break;
+    }
+  }
+  const bool nonRegisterProducer =
+      outputIdx < producerMeta->returnMeta.size() &&
+      !producerMeta->returnMeta[outputIdx].isRegister;
+  return wholeTensorArg || nonRegisterProducer;
+}
+
 Context CompileCtx::placeKernels(NodeCP node, Context /*context*/) {
   if (node->target() == "prim.ListUnpack" && !node->inputs().empty()) {
     auto* inputValue = node->inputs()[0].value;
@@ -920,15 +997,9 @@ Context CompileCtx::placeKernels(NodeCP node, Context /*context*/) {
   // discards -- so push it directly instead, otherwise this op reads a buffer
   // its producer never wrote (an orphaned scan stage).
   if (meta && meta->inputFromPreviousKernel.has_value()) {
-    auto* prevProducer =
-        node->inputs()[meta->inputFromPreviousKernel.value()].value->producer();
-    if (prevProducer && !placed_.count(prevProducer) &&
-        !(inputs_ && inputs_->count(prevProducer))) {
-      placeKernels(prevProducer, Context::kFused);
-      if (!placed_.count(prevProducer)) {
-        pushdownFused(prevProducer);
-      }
-    }
+    breakProducerIntoOwnKernel(
+        node->inputs()[meta->inputFromPreviousKernel.value()]
+            .value->producer());
   }
 
   for (auto i = 0; i < node->inputs().size(); ++i) {
@@ -945,6 +1016,18 @@ Context CompileCtx::placeKernels(NodeCP node, Context /*context*/) {
     }
     auto* inputValue = node->inputs()[i].value;
     auto* producer = inputValue->producer();
+    // In multi-kernel mode, a fused elementwise producer whose output this op
+    // reads from memory would be ordered by an intra-kernel opBarrier, which
+    // forces a cooperative (whole-grid-resident) launch. End the producer's
+    // kernel instead so its output is materialized by a prior stream-ordered
+    // launch; the launch boundary is the barrier. cg and single-block keep the
+    // in-kernel barrier on purpose.
+    if (thisContext == Context::kFused && !isCgGrid_ && !isSingleBlock_ &&
+        readsFusedElementwiseProducerFromMemory(
+            i, meta, inputValue, producer, types_, allStandalone_)) {
+      breakProducerIntoOwnKernel(producer);
+      continue;
+    }
     auto inputKind = inputValue->type().kind();
     bool isScalarSize = isSizeArg(node->inputs()[i].name, meta) &&
         inputKind != nativert::Type::Kind::Tensor &&
@@ -1063,6 +1146,17 @@ void CompileCtx::pushdownFused(NodeCP node) {
   fillConstantIndices(sg, launch);
   placeKernelLaunch(std::move(launch));
   placed_.insert(node);
+}
+
+void CompileCtx::breakProducerIntoOwnKernel(NodeCP producer) {
+  if (!producer || placed_.count(producer) ||
+      (inputs_ && inputs_->count(producer))) {
+    return;
+  }
+  placeKernels(producer, Context::kFused);
+  if (!placed_.count(producer)) {
+    pushdownFused(producer);
+  }
 }
 
 std::unique_ptr<KernelOperation> CompileCtx::generateFused(const Subgraph& sg) {

--- a/velox/experimental/torchwave/Compile.h
+++ b/velox/experimental/torchwave/Compile.h
@@ -282,6 +282,13 @@ class CompileCtx {
 
   void pushdownFused(NodeCP node);
 
+  /// Places 'producer' and its own inputs, then emits 'producer' as its own
+  /// kernel launch so a consumer reads its output as a materialized border
+  /// across a kernel boundary. Used where the whole of 'producer's output must
+  /// be visible before the consumer runs, but an in-kernel barrier (which
+  /// forces a cooperative, whole-grid-resident launch) is undesirable.
+  void breakProducerIntoOwnKernel(NodeCP producer);
+
   std::unique_ptr<KernelOperation> generateFused(const Subgraph& sg);
 
   void generateFusedInner(const Subgraph& sg);

--- a/velox/experimental/torchwave/tests/CompileTest.cpp
+++ b/velox/experimental/torchwave/tests/CompileTest.cpp
@@ -364,6 +364,17 @@ TEST_F(CompileTest, planMatchers) {
   EXPECT_TRUE(multi.inLaterStep("tw.add_sizes", "tw.masked_select_head"));
   EXPECT_TRUE(multi.inLaterStep("tw.masked_select_final", "tw.add_sizes"));
 
+  // The cg plan for the SAME graph comes out different from the multi-kernel
+  // plan: cg fuses every stage into one cooperative kernel ordered by an
+  // intra-kernel barrier, whereas multi splits the stages across kernel
+  // boundaries with no barrier. Asserting both guards against the mode
+  // parameter silently ceasing to change the plan.
+  EXPECT_TRUE(multi.kernelBoundaryBetween(
+      "tw.masked_select_head", "tw.masked_select_final"));
+  auto cg = CompiledPlan::from(*graph, CompiledPlan::Mode::kCG);
+  EXPECT_TRUE(cg.fuses({"tw.masked_select_cg", "aten.add.Tensor"}));
+  EXPECT_TRUE(cg.barrierBetween("tw.masked_select_cg", "aten.add.Tensor"));
+
   // Single-block: the whole masked_select fuses into one kernel.
   auto single = CompiledPlan::from(*graph, CompiledPlan::Mode::kSingleBlock);
   EXPECT_TRUE(single.fuses(
@@ -389,18 +400,28 @@ TEST_F(CompileTest, planMatchers) {
       {"tw.masked_select_head", "aten.add.Tensor", "aten.lt.Scalar"}));
 }
 
-// tw.index_select is an all-elementwise op; an elementwise producer of its
-// source/index fuses INTO its kernel and is ordered by an intra-kernel barrier
-// (a barrier within one kernel, not a kernel boundary between two).
-TEST_F(CompileTest, planBarrier) {
+// tw.index_select reads its source and index as whole tensors (argumentMeta
+// wholeTensor). In multi-kernel mode an elementwise producer of a whole-tensor
+// input runs in its own earlier kernel: fusing it in would force an
+// intra-kernel opBarrier, which promotes the launch to cooperative (whole grid
+// resident). So the multi-kernel plan carries no barriers. (A downstream add
+// that merely consumes index_select's register output still fuses with it,
+// harmlessly and without a barrier -- which is why a name-based boundary
+// matcher cannot be used here.)
+TEST_F(CompileTest, planWholeTensorBoundary) {
   auto graph = loadAndCompile("data/index_select_test.pt2");
   ASSERT_NE(graph, nullptr);
 
   auto multi = CompiledPlan::from(*graph, CompiledPlan::Mode::kMultiKernel);
-  LOG(INFO) << multi.describe();
-
-  EXPECT_TRUE(multi.fuses({"tw.index_select", "aten.add.Tensor"}));
-  EXPECT_TRUE(multi.barrierBetween("tw.index_select", "aten.add.Tensor"));
+  int32_t numBarriers = 0;
+  for (const auto& node : multi.nodes()) {
+    for (const auto& step : node.steps) {
+      for (const auto& kernel : step.kernels) {
+        numBarriers += kernel.numBarriers;
+      }
+    }
+  }
+  EXPECT_EQ(numBarriers, 0) << multi.describe();
 }
 
 // A standalone op inside a cat that is the tensor repeated by


### PR DESCRIPTION
Summary:

Multi-kernel (non-cg) execution could lose block parallelism in two ways. An op with only a cooperative-grid variant fell back to a single-block kernel. A fused whole-tensor read emitted an intra-kernel barrier, which promotes the launch to cooperative -- all blocks must be resident at once. Both paths now stay block-parallel, matching the `--cg 1` kernel.

Add a multi-kernel variant of `tw.masked_select_jagged` that splits the four cooperative-grid stages (head, add_sizes, final_scatter, final_lengths) into separate wide kernels at the op-barrier boundaries. Unlike the cg and single-block forms it reserves the output list to the exact selected count, computed on the host after add_sizes, rather than over-allocating to the mask length.

In multi-kernel mode `placeKernels` now ends the kernel of a fused elementwise producer whose output the consumer reads from memory: a whole-tensor argument or a non-register result. The launch boundary then orders the two, so no intra-kernel `opBarrier` is emitted and the grid stays block-parallel.

Deferred: deviceFunc producers (`clone`, `cat`) and ops whose barriers are internal to one stage (`isin`, `repeat_interleave`) still force a cooperative launch in multi-kernel mode; each needs its own multi-kernel variant.
An empty batch -- a zero-length mask with the segments still present -- crashed every variant with an illegal memory access. It now returns what eager returns: empty output lists and a zero length for every segment.

Three things went wrong on that input. `bits` is reserved with one flag per mask element, so an empty mask leaves no room for the segment-start flags the code clears and writes; a start index also already equalled the mask length whenever the trailing segments were empty. `flag_counts` holds one entry per block of the mask, so `final_lengths` read its last entry from before the buffer. And each variant's finalization sits inside a loop bounded by the mask length, which runs zero iterations, so the output list and `new_sizes` kept the extents they were reserved with. The bit writes are now bounded by the buffer, the last-entry read is guarded, and each variant writes the empty result up front and returns.

Reviewed By: Yuhta

Differential Revision: D113871050


