### PR TITLE
fix(ci): Move stalled ubuntu-latest jobs to 4-core-ubuntu (#18392)

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -46,7 +46,7 @@ jobs:
   get-changes:
     # Always runs — clang-tidy in the adapters job needs the changed-files
     # list and diff range in both selective and full modes.
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     outputs:
       run-clang-tidy: ${{ steps.changes.outputs.run_clang_tidy }}
       changed-files: ${{ steps.changes.outputs.files}}
@@ -387,7 +387,7 @@ jobs:
   adapters-build-status:
     if: always()
     needs: adapters
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     name: "BUILD: Linux release with adapters"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -413,7 +413,7 @@ jobs:
   adapters-test-status:
     if: always()
     needs: adapters
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     name: "TEST: Linux release with adapters"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -714,7 +714,7 @@ jobs:
     # didn't run.
     if: ${{ inputs.is-full-mode && always() }}
     needs: ubuntu-debug
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     name: "BUILD: Ubuntu debug with system dependencies"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -740,7 +740,7 @@ jobs:
   ubuntu-debug-test-status:
     if: ${{ inputs.is-full-mode && always() }}
     needs: ubuntu-debug
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     name: "TEST: Ubuntu debug with system dependencies"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -863,7 +863,7 @@ jobs:
   fedora-debug-build-status:
     if: ${{ inputs.is-full-mode && always() }}
     needs: fedora-debug
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     name: "BUILD: Fedora debug"
     steps:
       - run: |
@@ -1038,7 +1038,7 @@ jobs:
   asan-ubsan-build-status:
     if: ${{ inputs.is-full-mode && always() }}
     needs: asan-ubsan-adapters
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     name: "BUILD: Linux sanitizers with system dependencies"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1064,7 +1064,7 @@ jobs:
   asan-ubsan-test-status:
     if: ${{ inputs.is-full-mode && always() }}
     needs: asan-ubsan-adapters
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     name: "TEST: Linux sanitizers with system dependencies"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -40,7 +40,7 @@ jobs:
 
   title-check:
     name: PR Title Format
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     steps:
       - shell: python
         env:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -615,7 +615,7 @@ jobs:
 
   presto-bias-fuzzer:
     name: Presto Bias Fuzzer
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:centos9
     needs: compile
     if: ${{ needs.compile.outputs.presto_bias  == 'true' }}
@@ -732,7 +732,7 @@ jobs:
 
   spark-bias-aggregate-fuzzer-run:
     name: Spark Bias Aggregate Fuzzer
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:spark-server
     needs: compile
     if: ${{ needs.compile.outputs.spark_aggregate_bias  == 'true' }}
@@ -794,7 +794,7 @@ jobs:
 
   spark-bias-fuzzer:
     name: Spark Bias Fuzzer
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:centos9
     needs: compile
     if: ${{ needs.compile.outputs.spark_bias  == 'true' }}
@@ -1358,7 +1358,7 @@ jobs:
   presto-java-only-bias-function-expression-fuzzer-run:
     name: Biased Expression Fuzzer with Only Added/Updated Functions and Presto as source of truth
     needs: compile
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     if: ${{ needs.compile.outputs.presto_bias  == 'true' }}
@@ -1457,7 +1457,7 @@ jobs:
   presto-bias-java-aggregation-fuzzer-run:
     name: Biased Aggregation Fuzzer with Presto as source of truth
     needs: compile
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     if: ${{ needs.compile.outputs.presto_aggregate_bias  == 'true' }}

--- a/.github/workflows/selective-build-plan.yml
+++ b/.github/workflows/selective-build-plan.yml
@@ -61,7 +61,7 @@ jobs:
   # Lightweight decision job. Runs the fast-detect path inline.
   # ============================================================
   decide-mode:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     outputs:
       mode: ${{ steps.final.outputs.mode }}
       needs_slow_prepare: ${{ steps.final.outputs.needs_slow_prepare }}


### PR DESCRIPTION
Summary:

CI jobs that ran on `ubuntu-latest`, the default GitHub-hosted runner pool, stalled for hours when that pool hit its concurrency limit, blocking PRs from qualifying even though the heavy builds on `32-core-ubuntu` were unaffected.

Move the affected jobs to `4-core-ubuntu`, a separate larger-runner queue not subject to the default-pool limit: the required PR check and gate jobs (pre-commit, PR title check, the selective-build planner, the Linux build entry job, and the BUILD/TEST status checks) and the bias fuzzers, whose non-bias siblings already run on `4-core-ubuntu`.

macOS jobs stay on the GitHub-hosted macOS pool, which has no larger-runner equivalent.

Reviewed By: bikramSingh91

Differential Revision: D114755096


