### PR TITLE
fix(dwrf): Apply key filters to preserved flat maps

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -383,6 +383,45 @@ void SelectiveStructColumnReaderBase::next(
   }
 }
 
+void SelectiveStructColumnReaderBase::readFlatMapChildren(
+    int64_t offset,
+    const RowSet& rows,
+    const uint64_t* incomingNulls) {
+  numReads_ = scanSpec_->newRead();
+  prepareRead<char>(offset, rows, incomingNulls);
+  VELOX_DCHECK(!hasDeletion());
+  auto activeRows = rows;
+  const auto* mapNulls =
+      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  if (scanSpec_->filter()) {
+    const auto kind = scanSpec_->filter()->kind();
+    VELOX_CHECK(
+        kind == velox::common::FilterKind::kIsNull ||
+        kind == velox::common::FilterKind::kIsNotNull);
+    filterNulls<int32_t>(
+        rows, kind == velox::common::FilterKind::kIsNull, false);
+    if (outputRows_.empty()) {
+      for (auto* child : children_) {
+        child->addParentNulls(offset, mapNulls, rows);
+      }
+      lazyVectorReadOffset_ = offset;
+      readOffset_ = offset + rows.back() + 1;
+      return;
+    }
+    activeRows = outputRows_;
+  }
+  // Separate the loop to be cache friendly.
+  for (auto* child : children_) {
+    advanceFieldReader(child, offset);
+  }
+  for (auto* child : children_) {
+    child->readWithTiming(offset, activeRows, mapNulls);
+    child->addParentNulls(offset, mapNulls, rows);
+  }
+  lazyVectorReadOffset_ = offset;
+  readOffset_ = offset + rows.back() + 1;
+}
+
 void SelectiveStructColumnReaderBase::read(
     int64_t offset,
     const RowSet& rows,

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -133,6 +133,13 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
     return hasDeletion_;
   }
 
+  // Reads physical flat-map value streams directly without interpreting the
+  // logical children in the scan spec.
+  void readFlatMapChildren(
+      int64_t offset,
+      const RowSet& rows,
+      const uint64_t* incomingNulls);
+
   // Returns true if the file doesn't have this child (in which case it will be
   // treated as null).
   bool isChildMissing(const velox::common::ScanSpec& childSpec) const;
@@ -314,40 +321,7 @@ void SelectiveFlatMapColumnReaderHelper<T, KeyNode, FormatData>::read(
     int64_t offset,
     RowSet rows,
     const uint64_t* incomingNulls) {
-  reader_.numReads_ = reader_.scanSpec_->newRead();
-  reader_.prepareRead<char>(offset, rows, incomingNulls);
-  VELOX_DCHECK(!reader_.hasDeletion());
-  auto activeRows = rows;
-  auto* mapNulls = reader_.nullsInReadRange_
-      ? reader_.nullsInReadRange_->as<uint64_t>()
-      : nullptr;
-  if (reader_.scanSpec_->filter()) {
-    auto kind = reader_.scanSpec_->filter()->kind();
-    VELOX_CHECK(
-        kind == velox::common::FilterKind::kIsNull ||
-        kind == velox::common::FilterKind::kIsNotNull);
-    reader_.filterNulls<int32_t>(
-        rows, kind == velox::common::FilterKind::kIsNull, false);
-    if (reader_.outputRows_.empty()) {
-      for (auto* child : reader_.children_) {
-        child->addParentNulls(offset, mapNulls, rows);
-      }
-      reader_.lazyVectorReadOffset_ = offset;
-      reader_.readOffset_ = offset + rows.back() + 1;
-      return;
-    }
-    activeRows = reader_.outputRows_;
-  }
-  // Separate the loop to be cache friendly.
-  for (auto* child : reader_.children_) {
-    reader_.advanceFieldReader(child, offset);
-  }
-  for (auto* child : reader_.children_) {
-    child->readWithTiming(offset, activeRows, mapNulls);
-    child->addParentNulls(offset, mapNulls, rows);
-  }
-  reader_.lazyVectorReadOffset_ = offset;
-  reader_.readOffset_ = offset + rows.back() + 1;
+  reader_.readFlatMapChildren(offset, rows, incomingNulls);
 }
 
 namespace detail {

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -116,12 +116,14 @@ std::vector<KeyNode<T>> getKeyNodes(
       break;
     }
     case FlatMapOutput::kFlatMap:
-      // Remove on filters on keys stream since it doesn't exist (it's common to
-      // filter out nulls).
+      // The keys filter is retained (not cleared) so requested keys prune which
+      // streams are read below. A null-only filter (commonly present on the
+      // keys stream) passes every key and therefore prunes nothing. The keys
+      // stream itself is never read; read() ignores this filter to avoid
+      // mistaking it for a struct-child filter.
       keysSpec = scanSpec.getOrCreateChild(common::ScanSpec::kMapKeysFieldName);
       valuesSpec =
           scanSpec.getOrCreateChild(common::ScanSpec::kMapValuesFieldName);
-      keysSpec->setFilter(nullptr);
       VELOX_CHECK(!valuesSpec->hasFilter());
       break;
   }
@@ -141,6 +143,10 @@ std::vector<KeyNode<T>> getKeyNodes(
         auto key = extractKey<T>(keyInfo);
         common::ScanSpec* childSpec;
         if (outputType == FlatMapOutput::kFlatMap) {
+          if (keysSpec->filter() &&
+              !common::applyFilter(*keysSpec->filter(), key.get())) {
+            return; // Subfield pruning.
+          }
           childSpec = scanSpec.getOrCreateChild(toString(key.get()));
           childSpec->setProjectOut(true);
           childSpec->setChannel(sequence - 1);
@@ -323,6 +329,11 @@ class SelectiveFlatMapReader
 
       rawKeys[i] = keyNodes_[i].key.get();
     }
+  }
+
+  void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
+      override {
+    readFlatMapChildren(offset, rows, incomingNulls);
   }
 
   const BufferPtr& inMapBuffer(column_index_t childIndex) const override {

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -2453,6 +2453,46 @@ createWriterReader(
   return std::make_pair(std::move(writer), std::move(reader));
 }
 
+struct FlatMapReaderWithKeyFilter {
+  std::unique_ptr<dwrf::Writer> writer;
+  std::unique_ptr<DwrfReader> reader;
+  std::unique_ptr<dwio::common::RowReader> rowReader;
+  RowTypePtr schema;
+  VectorPtr batch;
+};
+
+FlatMapReaderWithKeyFilter createFlatMapReaderWithKeyFilter(
+    const std::vector<VectorPtr>& inputs,
+    std::shared_ptr<common::Filter> keyFilter,
+    memory::MemoryPool* pool,
+    const std::shared_ptr<io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<io::IoStatistics>& metadataIoStats) {
+  auto config = std::make_shared<dwrf::Config>();
+  config->set(dwrf::Config::FLATTEN_MAP, true);
+  config->set(dwrf::Config::MAP_FLAT_COLS, {0});
+
+  auto [writer, reader] =
+      createWriterReader(inputs, pool, dataIoStats, metadataIoStats, config);
+  auto schema = asRowType(inputs.front()->type());
+  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
+  scanSpec->addAllChildFields(*schema);
+  scanSpec->childByName("c0")
+      ->childByName(common::ScanSpec::kMapKeysFieldName)
+      ->setFilter(std::move(keyFilter));
+
+  RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setPreserveFlatMapsInMemory(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+  auto batch = BaseVector::create(schema, 0, pool);
+  return {
+      std::move(writer),
+      std::move(reader),
+      std::move(rowReader),
+      std::move(schema),
+      std::move(batch)};
+}
+
 } // namespace
 
 TEST_F(TestReader, setRowNumberColumnInfo) {
@@ -2828,6 +2868,189 @@ TEST_F(TestReader, readFlatMapsAsFlatMaps) {
            {{0, 4}, {1, 5}, {2, 6}, {3, 7}},
            {{0, 8}, {1, 9}, {2, 10}, {3, 11}},
            {{0, 12}, {1, 13}, {2, 14}, {3, 15}}}));
+}
+
+TEST_F(TestReader, readFlatMapsAsFlatMapsWithKeyFilter) {
+  // Reading a flat map with preserveFlatMapsInMemory=true must honor a
+  // requested-key filter and project only the selected keys into the output
+  // FlatMapVector.
+  auto flatMap = makeFlatMapVector<int64_t, int64_t>({
+      {{0, 0}, {1, 1}, {2, 2}, {3, 3}},
+      {{0, 4}, {1, 5}, {2, 6}, {3, 7}},
+      {{0, 8}, {1, 9}, {2, 10}, {3, 11}},
+  });
+  auto input = makeRowVector({flatMap->toMapVector()});
+  auto result = createFlatMapReaderWithKeyFilter(
+      {input},
+      common::createBigintValues({1, 2}, false),
+      pool(),
+      dataIoStats_,
+      metadataIoStats_);
+
+  ASSERT_EQ(
+      result.rowReader->next(flatMap->size(), result.batch), flatMap->size());
+  auto rowVector = result.batch->as<RowVector>();
+  auto resultFlatMap =
+      rowVector->childAt(0)->loadedVector()->as<FlatMapVector>();
+  ASSERT_TRUE(resultFlatMap);
+
+  // Only the selected keys are projected out.
+  auto distinctKeys =
+      resultFlatMap->distinctKeys()->as<SimpleVector<int64_t>>();
+  std::unordered_set<int64_t> keySet;
+  for (auto i = 0; i < distinctKeys->size(); ++i) {
+    keySet.insert(distinctKeys->valueAt(i));
+  }
+  EXPECT_EQ(keySet, (std::unordered_set<int64_t>{1, 2}));
+
+  auto expected = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 1}, {2, 2}},
+      {{1, 5}, {2, 6}},
+      {{1, 9}, {2, 10}},
+  });
+  assertEqualVectors(expected->toMapVector(), resultFlatMap->toMapVector());
+}
+
+TEST_F(TestReader, readFlatMapsAsFlatMapsWithStringKeyFilter) {
+  // Key pruning in the preserving path must also work for string keys.
+  auto flatMap = makeFlatMapVector<StringView, int64_t>({
+      {{"a", 1}, {"b", 2}, {"c", 3}},
+      {{"a", 4}, {"b", 5}, {"c", 6}},
+  });
+  auto input = makeRowVector({flatMap->toMapVector()});
+  auto result = createFlatMapReaderWithKeyFilter(
+      {input},
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"a", "c"}, false),
+      pool(),
+      dataIoStats_,
+      metadataIoStats_);
+
+  ASSERT_EQ(
+      result.rowReader->next(flatMap->size(), result.batch), flatMap->size());
+  auto resultFlatMap = result.batch->as<RowVector>()
+                           ->childAt(0)
+                           ->loadedVector()
+                           ->as<FlatMapVector>();
+  ASSERT_TRUE(resultFlatMap);
+
+  auto expected = makeFlatMapVector<StringView, int64_t>({
+      {{"a", 1}, {"c", 3}},
+      {{"a", 4}, {"c", 6}},
+  });
+  assertEqualVectors(expected->toMapVector(), resultFlatMap->toMapVector());
+}
+
+TEST_F(TestReader, readFlatMapsAsFlatMapsKeyFilterExcludesAllKeys) {
+  // A key filter that matches no key in the stripe yields N empty maps, not
+  // zero rows.
+  auto flatMap = makeFlatMapVector<int64_t, int64_t>({
+      {{0, 0}, {1, 1}},
+      {{0, 2}, {1, 3}},
+  });
+  auto input = makeRowVector({flatMap->toMapVector()});
+  auto result = createFlatMapReaderWithKeyFilter(
+      {input},
+      common::createBigintValues({99}, false),
+      pool(),
+      dataIoStats_,
+      metadataIoStats_);
+
+  ASSERT_EQ(
+      result.rowReader->next(flatMap->size(), result.batch), flatMap->size());
+  auto resultFlatMap = result.batch->as<RowVector>()
+                           ->childAt(0)
+                           ->loadedVector()
+                           ->as<FlatMapVector>();
+  ASSERT_TRUE(resultFlatMap);
+  EXPECT_EQ(resultFlatMap->distinctKeys()->size(), 0);
+
+  auto resultMaps = resultFlatMap->toMapVector();
+  ASSERT_EQ(resultMaps->size(), 2);
+  for (vector_size_t row = 0; row < resultMaps->size(); ++row) {
+    EXPECT_FALSE(resultMaps->isNullAt(row));
+    EXPECT_EQ(resultMaps->sizeAt(row), 0);
+  }
+}
+
+TEST_F(TestReader, readFlatMapsAsFlatMapsWithKeyFilterAndNullMaps) {
+  // Key pruning must compose with null maps: null rows stay null and non-null
+  // rows are pruned to the requested keys.
+  auto flatMap = makeNullableFlatMapVector<int64_t, int64_t>({
+      {{{0, 0}, {1, 1}, {2, 2}, {3, 3}}},
+      {std::nullopt},
+      {{{0, 4}, {1, 5}, {2, 6}, {3, 7}}},
+      {std::nullopt},
+  });
+  auto input = makeRowVector({flatMap->toMapVector()});
+  auto result = createFlatMapReaderWithKeyFilter(
+      {input},
+      common::createBigintValues({1, 2, 3}, false),
+      pool(),
+      dataIoStats_,
+      metadataIoStats_);
+
+  ASSERT_EQ(
+      result.rowReader->next(flatMap->size(), result.batch), flatMap->size());
+  auto resultFlatMap = result.batch->as<RowVector>()
+                           ->childAt(0)
+                           ->loadedVector()
+                           ->as<FlatMapVector>();
+  ASSERT_TRUE(resultFlatMap);
+
+  auto expected = makeNullableFlatMapVector<int64_t, int64_t>({
+      {{{1, 1}, {2, 2}, {3, 3}}},
+      {std::nullopt},
+      {{{1, 5}, {2, 6}, {3, 7}}},
+      {std::nullopt},
+  });
+  assertEqualVectors(expected->toMapVector(), resultFlatMap->toMapVector());
+}
+
+TEST_F(TestReader, readFlatMapsAsFlatMapsMultiStripeWithKeyFilter) {
+  // The key filter must prune every stripe, not just the first. The ScanSpec
+  // is shared across stripes, so a fix that consumes/clears the filter would
+  // silently stop pruning after stripe 1.
+  auto stripe1 = makeRowVector({makeMapVector<int64_t, int64_t>({
+      {{0, 10}, {1, 11}, {2, 12}, {3, 13}, {4, 14}},
+      {{0, 20}, {1, 21}, {2, 22}, {3, 23}, {4, 24}},
+  })});
+  auto stripe2 = makeRowVector({makeMapVector<int64_t, int64_t>({
+      {{0, 30}, {1, 31}, {2, 32}},
+      {{0, 40}, {1, 41}, {2, 42}},
+      {{0, 50}, {1, 51}, {2, 52}},
+  })});
+
+  // simpleFlushPolicyFactory(true) produces one stripe per batch.
+  auto result = createFlatMapReaderWithKeyFilter(
+      {stripe1, stripe2},
+      common::createBigintValues({1, 2}, false),
+      pool(),
+      dataIoStats_,
+      metadataIoStats_);
+  ASSERT_EQ(result.reader->getNumberOfStripes(), 2);
+
+  uint64_t totalRows = 0;
+  // Read one row at a time to exercise repeated lazy materialization at
+  // non-zero reader offsets as well as the stripe transition.
+  while (result.rowReader->next(1, result.batch) > 0) {
+    auto resultMaps = result.batch->as<RowVector>()
+                          ->childAt(0)
+                          ->loadedVector()
+                          ->as<FlatMapVector>()
+                          ->toMapVector();
+    auto* resultKeys = resultMaps->mapKeys()->as<SimpleVector<int64_t>>();
+    for (vector_size_t row = 0; row < resultMaps->size(); ++row) {
+      std::unordered_set<int64_t> keySet;
+      const auto offset = resultMaps->offsetAt(row);
+      for (vector_size_t i = 0; i < resultMaps->sizeAt(row); ++i) {
+        keySet.insert(resultKeys->valueAt(offset + i));
+      }
+      EXPECT_EQ(keySet, (std::unordered_set<int64_t>{1, 2}));
+    }
+    totalRows += result.batch->size();
+  }
+  EXPECT_EQ(totalRows, 5); // 2 rows from stripe 1 + 3 rows from stripe 2.
 }
 
 // Regression test: reading a multi-stripe flatmap file with


### PR DESCRIPTION
Summary:
Reading a DWRF flat map into FlatMapVector type ignored filters on map keys as the reader would clear them.
This change retains the filters and uses them to select which key streams are read.

Differential Revision: D113141175


