### PR TITLE
perf: Hoist per-row null branches out of DecodedVector decode hot loops (#18403)

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -269,23 +269,32 @@ void DecodedVector::applyDictionaryWrapper(
       copyNulls(end(rows));
     }
   }
-  auto copiedNulls = copiedNulls_.data();
   auto currentIndices = indices_;
   if (indicesNotCopied()) {
     copiedIndices_.resize(size_);
     indices_ = copiedIndices_.data();
   }
+  auto copiedIndices = copiedIndices_.data();
 
-  applyToRows(rows, [&](vector_size_t row) {
-    if (!nulls_ || !bits::isBitNull(nulls_, row)) {
-      auto wrappedIndex = currentIndices[row];
-      if (newNulls && bits::isBitNull(newNulls, wrappedIndex)) {
-        bits::setNull(copiedNulls, row);
-      } else {
-        copiedIndices_[row] = newIndices[wrappedIndex];
+  if (!nulls_ && !newNulls) {
+    // Fast path: no parent nulls and no new wrapper nulls, so every row is
+    // a plain index remap with no null checks.
+    applyToRows(rows, [&](vector_size_t row) {
+      copiedIndices[row] = newIndices[currentIndices[row]];
+    });
+  } else {
+    auto copiedNulls = copiedNulls_.data();
+    applyToRows(rows, [&](vector_size_t row) {
+      if (!nulls_ || !bits::isBitNull(nulls_, row)) {
+        auto wrappedIndex = currentIndices[row];
+        if (newNulls && bits::isBitNull(newNulls, wrappedIndex)) {
+          bits::setNull(copiedNulls, row);
+        } else {
+          copiedIndices[row] = newIndices[wrappedIndex];
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 void DecodedVector::fillInIndices() const {
@@ -332,14 +341,18 @@ void DecodedVector::setFlatNulls(
       copyNulls(end(rows));
     }
     auto leafNulls = vector.rawNulls();
-    auto copiedNulls = &copiedNulls_[0];
-    applyToRows(rows, [&](vector_size_t row) {
-      if (!bits::isBitNull(nulls_, row) &&
-          (leafNulls && bits::isBitNull(leafNulls, indices_[row]))) {
-        bits::setNull(copiedNulls, row);
-      }
-    });
-    nulls_ = &copiedNulls_[0];
+    // When the leaf vector has no nulls, the loop below can never set a
+    // null, so the entire per-row pass is skipped.
+    if (leafNulls) {
+      auto copiedNulls = copiedNulls_.data();
+      applyToRows(rows, [&](vector_size_t row) {
+        if (!bits::isBitNull(nulls_, row) &&
+            bits::isBitNull(leafNulls, indices_[row])) {
+          bits::setNull(copiedNulls, row);
+        }
+      });
+    }
+    nulls_ = copiedNulls_.data();
   } else {
     nulls_ = vector.rawNulls();
     mayHaveNulls_ = nulls_ != nullptr;

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -276,16 +276,24 @@ void DecodedVector::applyDictionaryWrapper(
     indices_ = copiedIndices_.data();
   }
 
-  applyToRows(rows, [&](vector_size_t row) {
-    if (!nulls_ || !bits::isBitNull(nulls_, row)) {
-      auto wrappedIndex = currentIndices[row];
-      if (newNulls && bits::isBitNull(newNulls, wrappedIndex)) {
-        bits::setNull(copiedNulls, row);
-      } else {
-        copiedIndices_[row] = newIndices[wrappedIndex];
+  if (!nulls_ && !newNulls) {
+    // Fast path: no parent nulls and no new wrapper nulls, so every row is
+    // a plain index remap with no null checks.
+    applyToRows(rows, [&](vector_size_t row) {
+      copiedIndices_[row] = newIndices[currentIndices[row]];
+    });
+  } else {
+    applyToRows(rows, [&](vector_size_t row) {
+      if (!nulls_ || !bits::isBitNull(nulls_, row)) {
+        auto wrappedIndex = currentIndices[row];
+        if (newNulls && bits::isBitNull(newNulls, wrappedIndex)) {
+          bits::setNull(copiedNulls, row);
+        } else {
+          copiedIndices_[row] = newIndices[wrappedIndex];
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 void DecodedVector::fillInIndices() const {
@@ -332,13 +340,17 @@ void DecodedVector::setFlatNulls(
       copyNulls(end(rows));
     }
     auto leafNulls = vector.rawNulls();
-    auto copiedNulls = &copiedNulls_[0];
-    applyToRows(rows, [&](vector_size_t row) {
-      if (!bits::isBitNull(nulls_, row) &&
-          (leafNulls && bits::isBitNull(leafNulls, indices_[row]))) {
-        bits::setNull(copiedNulls, row);
-      }
-    });
+    // When the leaf vector has no nulls, the loop below can never set a
+    // null, so the entire per-row pass is skipped.
+    if (leafNulls) {
+      auto copiedNulls = copiedNulls_.data();
+      applyToRows(rows, [&](vector_size_t row) {
+        if (!bits::isBitNull(nulls_, row) &&
+            bits::isBitNull(leafNulls, indices_[row])) {
+          bits::setNull(copiedNulls, row);
+        }
+      });
+    }
     nulls_ = &copiedNulls_[0];
   } else {
     nulls_ = vector.rawNulls();


### PR DESCRIPTION
Summary:

We noticed `facebook::velox::DecodedVector::decode` showing up in profiles. This is an AI generated and human reviewed performance improvement:

Optimized the inclusive CPU cost of `facebook::velox::DecodedVector::decode` in `fbcode/velox/vector/DecodedVector.cpp` by hoisting branches out of two hot per-row loops that are callees of `decode` (via `decodeImpl` → `combineWrappers`/`setBaseData`):

1. **`applyDictionaryWrapper`**: Added a fast path for the common dictionary-without-nulls case (`!nulls_ && !newNulls`). Under exactly these conditions the original per-row null guards are provably no-ops, so the body reduces to a vectorizable gather `copiedIndices_[row] = newIndices[currentIndices[row]]`, eliminating two per-row branches. The `else` branch retains the original code byte-for-byte.

2. **`setFlatNulls`**: Added a fast path that skips the entire per-row null-checking loop when `leafNulls == nullptr`. In that case the original loop's `setNull` condition short-circuits to always-false, so the loop is pure wasted iteration. The non-null case keeps the identical loop with only the now-redundant `leafNulls &&` guard removed.

Both changes are provably functionality-preserving (dead-branch elimination / loop-invariant hoisting) and lint passes clean.

Differential Revision: D109655492
