### PR TITLE
perf: Batch length writes and pre-reserve arena space in Presto serializer string path

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -438,6 +438,24 @@ class ByteOutputStream {
     append(folly::Range(&value, 1));
   }
 
+  /// Pre-allocates contiguous space for at least 'bytes' additional bytes so a
+  /// following run of small appends need not extend the stream one range at a
+  /// time. Does not change the append position.
+  void reserve(int64_t bytes) {
+    if (bytes <= 0 || current_ == nullptr) {
+      return;
+    }
+    const int64_t available = current_->size - current_->position;
+    if (available >= bytes) {
+      return;
+    }
+    // ensureSpace() takes an int32_t; cap the request and let the normal
+    // append path grow the stream for any remainder.
+    constexpr int64_t kMaxReserve = (int64_t{1} << 31) - 1;
+    ensureSpace(
+        static_cast<int32_t>(bytes < kMaxReserve ? bytes : kMaxReserve));
+  }
+
   void flush(OutputStream* stream);
 
   /// Returns the next byte that would be written to by a write. This

--- a/velox/serializers/PrestoSerializerSerializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerSerializationUtils.cpp
@@ -495,9 +495,13 @@ void appendStrings(
     VectorStream* stream,
     Scratch& scratch) {
   if (nulls == nullptr) {
+    int64_t totalBytes = 0;
     stream->appendLengths(nullptr, rows, rows.size(), [&](auto row) {
-      return views[row].size();
+      const auto size = views[row].size();
+      totalBytes += size;
+      return size;
     });
+    stream->values().reserve(totalBytes);
     for (auto i = 0; i < rows.size(); ++i) {
       const auto& view = views[rows[i]];
       stream->values().appendStringView(
@@ -510,8 +514,13 @@ void appendStrings(
   auto* nonNull = nonNullHolder.get(rows.size());
   const auto numNonNull =
       simd::indicesOfSetBits(nulls, 0, rows.size(), nonNull);
-  stream->appendLengths(
-      nulls, rows, numNonNull, [&](auto row) { return views[row].size(); });
+  int64_t totalBytes = 0;
+  stream->appendLengths(nulls, rows, numNonNull, [&](auto row) {
+    const auto size = views[row].size();
+    totalBytes += size;
+    return size;
+  });
+  stream->values().reserve(totalBytes);
   for (auto i = 0; i < numNonNull; ++i) {
     auto& view = views[rows[nonNull[i]]];
     stream->values().appendStringView(

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -122,20 +122,30 @@ class VectorStream {
       folly::Range<const vector_size_t*> rows,
       int32_t numNonNull,
       LengthFunc lengthFunc) {
-    const auto numRows = rows.size();
+    const auto numRows = static_cast<int32_t>(rows.size());
     if (nulls == nullptr) {
       appendNonNull(numRows);
-      for (auto i = 0; i < numRows; ++i) {
-        appendLength(lengthFunc(rows[i]));
-      }
     } else {
       appendNulls(nulls, 0, numRows, numNonNull);
+    }
+    if (numRows == 0) {
+      return;
+    }
+
+    Scratch scratch;
+    AppendWindow<int32_t> window(lengths_, scratch);
+    auto* output = reinterpret_cast<int32_t*>(window.get(numRows));
+    if (nulls == nullptr) {
+      for (auto i = 0; i < numRows; ++i) {
+        totalLength_ += static_cast<int32_t>(lengthFunc(rows[i]));
+        folly::storeUnaligned<int32_t>(output + i, totalLength_);
+      }
+    } else {
       for (auto i = 0; i < numRows; ++i) {
         if (bits::isBitSet(nulls, i)) {
-          appendLength(lengthFunc(rows[i]));
-        } else {
-          appendLength(0);
+          totalLength_ += static_cast<int32_t>(lengthFunc(rows[i]));
         }
+        folly::storeUnaligned<int32_t>(output + i, totalLength_);
       }
     }
   }


### PR DESCRIPTION
Summary:
We noticed `facebook::velox::serializer::presto::detail::serializeColumn::$_0::operator()` showing up meaningfully in performance profiles. This is an AI generate and human reviewed performance improvement change:

Two behavior-preserving optimizations reduce the inclusive CPU cost of serialization for the target lambda:
1. `VectorStream::appendLengths` now bulk-writes the int32 cumulative prefix-sum length array through a single `AppendWindow<int32_t>` reservation and a tight `folly::storeUnaligned` loop, instead of one `appendLength`/`appendOne<int32_t>` call per row. This eliminates per-element buffer bounds-checks and straddle fallbacks. Null rows leave the running length unchanged (matching the old `appendLength(0)`), so the emitted byte stream is identical.
2. A new `ByteOutputStream::reserve(int64_t)` pre-allocates contiguous space via the existing `ensureSpace` path without moving the append position. In `appendStrings`, the total string byte count is accumulated in the existing length callback (no extra pass) and `values().reserve(totalBytes)` is called before the per-string `appendStringView` loop in both the null and non-null branches. This collapses many small per-string arena `newRange`/`allocateNonContiguous` allocations into a single allocation, eliminating repeated `extend` overhead. Total bytes allocated and serialized output are unchanged.

Differential Revision: D112971926


