### PR TITLE
feat(hive): Add read bytes and format to scan batch event (#18407)

### DIFF
--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -629,18 +629,28 @@ void FileDataSource::addDynamicFilter(
 }
 
 void FileDataSource::fireScanBatchCallback(core::ScanBatchEvent event) {
+  // Bytes are read when the reader loads a stripe, which for small files is
+  // entirely inside addSplit() and for large ones is spread across next()
+  // calls. Reporting the delta since the previous event captures them either
+  // way; a window around a single next() would not.
+  const uint64_t totalStorageReadBytes = dataIoStats_->read().sum();
+  const uint64_t storageReadBytesDelta =
+      totalStorageReadBytes - lastEventStorageReadBytes_;
+  lastEventStorageReadBytes_ = totalStorageReadBytes;
   if (!scanBatchCallback_) {
     return;
   }
   FileScanBatchEvent fileEvent;
   fileEvent.numRows = event.numRows;
   fileEvent.wallTimeMicros = event.wallTimeMicros;
+  fileEvent.storageReadBytes = storageReadBytesDelta;
   if (tableHandle_) {
     fileEvent.tableName = tableHandle_->name();
     fileEvent.dbName = tableHandle_->dbName();
   }
   if (split_) {
     fileEvent.filePath = split_->filePath;
+    fileEvent.fileFormat = split_->fileFormat;
     if (!split_->partitionKeys.empty()) {
       fileEvent.partitionKeys = &split_->partitionKeys;
     }

--- a/velox/connectors/hive/FileDataSource.h
+++ b/velox/connectors/hive/FileDataSource.h
@@ -46,6 +46,11 @@ struct FileScanBatchEvent : public core::ScanBatchEvent {
   /// Null when partition keys are not available.
   const std::unordered_map<std::string, std::optional<std::string>>*
       partitionKeys{nullptr};
+  /// File format of the current split.
+  dwio::common::FileFormat fileFormat{dwio::common::FileFormat::UNKNOWN};
+  /// Bytes fetched from storage producing this batch, including any read
+  /// amplification from coalescing adjacent regions.
+  uint64_t storageReadBytes{0};
 };
 
 class FileConfig;
@@ -148,6 +153,10 @@ class FileDataSource : public DataSource {
   std::shared_ptr<io::IoStatistics> dataIoStats_;
   std::shared_ptr<io::IoStatistics> metadataIoStats_;
   std::shared_ptr<IoStats> ioStats_;
+
+  // Cumulative dataIoStats_->read().sum() as of the last scan batch event, so
+  // each event reports only the bytes read since the previous one.
+  uint64_t lastEventStorageReadBytes_{0};
 
   /// Column handles for the split info columns keyed on their column names.
   std::unordered_map<std::string, FileColumnHandlePtr> infoColumns_;

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -7140,6 +7140,118 @@ TEST_F(TableScanTest, scanBatchCallbackNotSetIsNoOp) {
   EXPECT_GT(result->size(), 0);
 }
 
+TEST_F(TableScanTest, scanBatchCallbackStorageReadBytes) {
+  auto vectors = makeVectors(3, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+
+  uint64_t summedEventBytes{0};
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->setScanBatchCallback([&](const core::ScanBatchEvent& event) {
+    const auto* fileEvent =
+        dynamic_cast<const connector::hive::FileScanBatchEvent*>(&event);
+    ASSERT_TRUE(fileEvent != nullptr);
+    summedEventBytes += fileEvent->storageReadBytes;
+  });
+
+  std::shared_ptr<Task> task;
+  auto result = AssertQueryBuilder(tableScanNode())
+                    .splits(makeHiveConnectorSplits({filePath}))
+                    .queryCtx(queryCtx)
+                    .copyResults(pool_.get(), task);
+  EXPECT_GT(result->size(), 0);
+
+  // Events report deltas of the same counter the operator publishes as
+  // storageReadBytes, so together they must account for all of it. Bytes are
+  // read when a stripe loads, which happens inside addSplit() for a file this
+  // small -- a delta measured only around next() would report zero here.
+  const auto operatorBytes =
+      getTableScanRuntimeStats(task).at("storageReadBytes").sum;
+  EXPECT_GT(operatorBytes, 0);
+  EXPECT_EQ(summedEventBytes, operatorBytes);
+}
+
+TEST_F(TableScanTest, scanBatchCallbackStorageReadBytesMultiStripe) {
+  // A stripe size well below the data size forces many stripes. Note this
+  // does not by itself spread reads across next() calls: at this scale the
+  // reader still loads every stripe during addSplit(), so the bytes arrive in
+  // a single event. Accumulation across next() calls remains uncovered.
+  auto vectors = makeVectors(20, 1'000);
+  auto writeConfig = std::make_shared<dwrf::Config>();
+  writeConfig->set<uint64_t>(dwrf::Config::STRIPE_SIZE, 1'024);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors, writeConfig);
+
+  uint64_t summedEventBytes{0};
+  int32_t eventsCarryingBytes{0};
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->setScanBatchCallback([&](const core::ScanBatchEvent& event) {
+    const auto* fileEvent =
+        dynamic_cast<const connector::hive::FileScanBatchEvent*>(&event);
+    ASSERT_TRUE(fileEvent != nullptr);
+    summedEventBytes += fileEvent->storageReadBytes;
+    if (fileEvent->storageReadBytes > 0) {
+      ++eventsCarryingBytes;
+    }
+  });
+
+  std::shared_ptr<Task> task;
+  auto result = AssertQueryBuilder(tableScanNode())
+                    .splits(makeHiveConnectorSplits({filePath}))
+                    .queryCtx(queryCtx)
+                    .copyResults(pool_.get(), task);
+  EXPECT_GT(result->size(), 0);
+
+  const auto stats = getTableScanRuntimeStats(task);
+  // Guards against the file collapsing to a single stripe, which would make
+  // this a duplicate of the test above.
+  ASSERT_GT(stats.at("numStripes").sum, 1);
+  const auto operatorBytes = stats.at("storageReadBytes").sum;
+  EXPECT_GT(operatorBytes, 0);
+  EXPECT_EQ(summedEventBytes, operatorBytes);
+  EXPECT_GT(eventsCarryingBytes, 0);
+  LOG(INFO) << "multiStripe: numStripes=" << stats.at("numStripes").sum
+            << " eventsCarryingBytes=" << eventsCarryingBytes
+            << " bytes=" << operatorBytes;
+}
+
+TEST_F(TableScanTest, scanBatchCallbackStorageReadBytesPreload) {
+  // Preloading prepares the next split on a separate data source, then hands
+  // it over via setFromDataSource(), which merges and swaps the io stats. The
+  // preloading source reads its split's bytes but never fires an event, so the
+  // adopting source must still report them.
+  auto filePaths = makeFilePaths(8);
+  auto vectors = makeVectors(8, 1'000);
+  for (int32_t i = 0; i < vectors.size(); ++i) {
+    writeToFile(filePaths[i]->getPath(), vectors[i]);
+  }
+
+  uint64_t summedEventBytes{0};
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->setScanBatchCallback([&](const core::ScanBatchEvent& event) {
+    const auto* fileEvent =
+        dynamic_cast<const connector::hive::FileScanBatchEvent*>(&event);
+    ASSERT_TRUE(fileEvent != nullptr);
+    summedEventBytes += fileEvent->storageReadBytes;
+  });
+
+  std::shared_ptr<Task> task;
+  auto result = AssertQueryBuilder(tableScanNode())
+                    .splits(makeHiveConnectorSplits(filePaths))
+                    .queryCtx(queryCtx)
+                    .config(core::QueryConfig::kMaxSplitPreloadPerDriver, "4")
+                    .maxDrivers(1)
+                    .copyResults(pool_.get(), task);
+  EXPECT_GT(result->size(), 0);
+
+  const auto stats = getTableScanRuntimeStats(task);
+  // Without this the test would silently stop covering the handover path.
+  ASSERT_GT(stats.at("preloadedSplits").sum, 0);
+  const auto operatorBytes = stats.at("storageReadBytes").sum;
+  EXPECT_GT(operatorBytes, 0);
+  EXPECT_EQ(summedEventBytes, operatorBytes);
+}
+
 // --- Column extraction pushdown table scan tests ---
 
 TEST_F(TableScanTest, extractionMapKeys) {


### PR DESCRIPTION
Summary:

A consumer of the scan batch callback can see how many rows a batch produced but nothing about
what it cost to read them. `FileScanBatchEvent` now carries `storageReadBytes`, the bytes fetched
from storage for that batch including read amplification from coalescing, and `fileFormat` for the
split the batch came from, so a consumer can attribute read volume per format.

`FileDataSource` keeps a watermark of `dataIoStats_->read().sum()` as of the previous event and
reports the difference. Measuring across a single `next()` call instead would report zero for most
scans: a small file is read in full during `addSplit()`, before any batch is produced. Both
`CachedBufferedInput` and `DirectBufferedInput` have a whole-file preload path, and
`CachedBufferedInput::shouldPreload()` fires whenever the file's pages fit free cache capacity.

Preloaded splits are handled by leaving the watermark alone in `setFromDataSource()`. The
preloading data source reads its split's bytes but never fires an event, so re-arming the
watermark against the merged total would drop them. The merge is additive
(`source->dataIoStats_->merge(*dataIoStats_)` before the swap) and `IoCounter` only ever
accumulates, so the watermark difference cannot underflow.

Both new fields are on `FileScanBatchEvent` rather than the base `core::ScanBatchEvent`: the base
carries what `TableScan` fills in, the derived struct carries what the DataSource fills in.

Differential Revision: D114830812


