### PR TITLE
docs: Update README with most recent blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ of available functions [can be found here.](https://facebookincubator.github.io/
 
 Recent blog posts ([all posts](https://velox-lib.io/blog)):
 
+- [Build Once, Probe Many: Hash Table Caching in Velox](https://velox-lib.io/blog/hash-table-caching) (2026-08-03)
 - [War of the Allocators](https://velox-lib.io/blog/war-of-the-allocators) (2026-07-27)
 - [Making OpenZL Available in Nimble OSS](https://velox-lib.io/blog/openzl-in-nimble-oss) (2026-07-05)
-- [Why RIGHT SEMI JOIN Can Be Slower Than LEFT SEMI JOIN in Velox](https://velox-lib.io/blog/right-semi-join-performance) (2026-06-26)
 
 ## Community
 


### PR DESCRIPTION
## Summary

The `check-readme-blogs` pre-commit hook (see `.pre-commit-config.yaml`) enforces that `README.md` lists the three most recent blog posts. A recently added post — **"Build Once, Probe Many: Hash Table Caching in Velox"** (`website/blog/2026-08-03-hash-table-caching.mdx`, 2026-08-03) — was not reflected in `README.md`, so the hook rewrites the file and the **pre-commit** CI check (`Run Checks` workflow) fails on any PR that merges the latest `main`.

This regenerates the list via `scripts/checks/check-readme-blogs.sh`, adding the new post and dropping the oldest one.

## Changes
- `README.md`: refresh the "Recent blog posts" section to the three most recent posts.

## Testing
- `./scripts/checks/check-readme-blogs.sh` is now a no-op (idempotent) on the resulting tree, so the pre-commit check passes.
