### PR TITLE
test(fuzzer): Fuzz qdigest scalars over full value range (#18412)

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -583,9 +583,9 @@ class QDigestInputGenerator : public AbstractInputGenerator {
 
     auto makeDist = []() {
       if constexpr (std::is_integral_v<T>) {
-        return std::uniform_int_distribution<T>(0, 10000);
+        return std::uniform_int_distribution<T>(-10'000, 10'000);
       } else {
-        return std::uniform_real_distribution<T>(0.0, 10000.0);
+        return std::uniform_real_distribution<T>(-10'000.0, 10'000.0);
       }
     };
 

--- a/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
+++ b/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
@@ -34,8 +34,6 @@ const std::unordered_set<std::string>& prestoSkippedFunctions() {
       // (since TDigest is a user defined type), and tries to pass a
       // VARBINARY (since TDigest's implementation uses an
       // alias to VARBINARY).
-      "value_at_quantile",
-      "values_at_quantiles",
       "merge_tdigest",
       "scale_tdigest",
       "quantiles_at_values",


### PR DESCRIPTION
Summary:

The expression fuzzer skipped `value_at_quantile` and `values_at_quantiles`, and its qdigest input generator drew only non-negative values, so it never built a full-range REAL digest node. That is the shape that triggered undefined behavior in the `qdigest(real)` level decode. Un-skip both functions and widen the qdigest generator to signed values so the fuzzer builds full-range digests.

Reviewed By: kgpai

Differential Revision: D114831929


