### PR TITLE
build: Add build flag for LocalRunnerService (#18413)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -258,6 +258,7 @@ jobs:
             -DVELOX_BUILD_SHARED=ON
             -DVELOX_BUILD_PYTHON_PACKAGE=ON
             -DVELOX_PYTHON_LEGACY_ONLY=ON
+            -DVELOX_ENABLE_LOCAL_RUNNER_SERVICE=ON
             ${{ inputs.extraCMakeFlags }}
         run: |
           make python-venv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,11 @@ option(VELOX_ENABLE_NIMBLE "Enable Nimble support" OFF)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_GEO "Enable Geospatial support" ON)
 option(VELOX_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
+option(
+  VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  "Enable LocalRunnerService and VeloxQueryRunner for expression fuzzer regression testing"
+  OFF
+)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 option(VELOX_ENABLE_COMPRESSION_LZ4 "Enable Lz4 compression support." OFF)
 
@@ -711,9 +716,14 @@ if(${VELOX_BUILD_TESTING})
   velox_resolve_dependency(gRPC)
 endif()
 
-if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET)
-  # TODO: Move this to use resolve_dependency(). For some reason, FBThrift
-  # requires clients to explicitly install fizz and wangle.
+# FBThrift is required by remote functions and LocalRunnerService.
+if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET OR VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+  set(VELOX_NEEDS_FBTHRIFT ON)
+endif()
+
+# TODO: Move this to use resolve_dependency(). For some reason, FBThrift
+# requires clients to explicitly install fizz and wangle.
+if(VELOX_NEEDS_FBTHRIFT)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Generate Thrift library for LocalRunnerService early since velox_fuzzer_util
-# depends on it when VELOX_ENABLE_REMOTE_FUNCTIONS is enabled.
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# depends on it when VELOX_ENABLE_LOCAL_RUNNER_SERVICE is enabled.
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   include(FBThriftCppLibrary)
   add_fbthrift_cpp_library(
     local_runner_service_thrift
@@ -55,13 +55,12 @@ velox_add_test_headers(
   VeloxQueryRunner.h
 )
 
-# TODO Add VeloxQueryRunner to velox_fuzzer_util to support in
-# ExpressionFuzzerTest. More information can be found here:
-# https://github.com/facebookincubator/velox/issues/15414
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# VeloxQueryRunner requires LocalRunnerService thrift library
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   target_sources(velox_fuzzer_util PRIVATE VeloxQueryRunner.cpp)
   target_link_libraries(velox_fuzzer_util local_runner_service_thrift)
   target_include_directories(velox_fuzzer_util PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  target_compile_definitions(velox_fuzzer_util PUBLIC VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
 endif()
 
 target_link_libraries(
@@ -285,7 +284,7 @@ target_link_libraries(
 )
 
 # LocalRunnerService Library
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_library(velox_local_runner_service_lib LocalRunnerService.cpp)
   velox_add_test_headers(velox_local_runner_service_lib LocalRunnerService.h)
 

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(presto_sql_test presto_sql_test)
 target_link_libraries(presto_sql_test velox_fuzzer_util velox_presto_types)
 
 # LocalRunnerService Test (requires FBThrift support)
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_executable(local_runner_service_test LocalRunnerServiceTest.cpp)
   add_test(local_runner_service_test local_runner_service_test)
 


### PR DESCRIPTION
Summary:

Gate LocalRunnerService and VeloxQueryRunner behind a dedicated VELOX_ENABLE_LOCAL_RUNNER_SERVICE option rather than VELOX_ENABLE_REMOTE_FUNCTIONS. Building the expression fuzzer's reference service previously required turning on remote function support, which pulls in machinery the fuzzer never uses. The new option also defines a preprocessor macro of the same name so C++ callers can compile the VeloxQueryRunner path conditionally.

Reviewed By: kgpai

Differential Revision: D90206765


