### PR TITLE
feat(base): Add ConcurrentRuntimeStatWriter (#18416)

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -32,6 +32,7 @@ velox_add_library(
   AdmissionController.cpp
   BitUtil.cpp
   BloomFilter.cpp
+  ConcurrentRuntimeStatWriter.cpp
   Counters.cpp
   Fs.cpp
   PeriodicStatsReporter.cpp
@@ -53,6 +54,7 @@ velox_add_library(
   ClassName.h
   CoalesceIo.h
   ConcurrentCounter.h
+  ConcurrentRuntimeStatWriter.h
   CountBits.h
   Counters.h
   Crc.h

--- a/velox/common/base/ConcurrentRuntimeStatWriter.cpp
+++ b/velox/common/base/ConcurrentRuntimeStatWriter.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox {
+
+void ConcurrentRuntimeStatWriter::addRuntimeStat(
+    std::string_view name,
+    const RuntimeCounter& value) {
+  auto lockedStats = runtimeStats_.wlock();
+  auto [it, unused] = lockedStats->try_emplace(std::string(name), value.unit);
+  it->second.merge(value);
+}
+
+void ConcurrentRuntimeStatWriter::setRuntimeStat(
+    std::string_view name,
+    const RuntimeMetric& metric) {
+  runtimeStats_.wlock()->insert_or_assign(std::string(name), metric);
+}
+
+std::unordered_map<std::string, RuntimeMetric>
+ConcurrentRuntimeStatWriter::runtimeStats() const {
+  return *runtimeStats_.rlock();
+}
+
+void ConcurrentRuntimeStatWriter::clear() {
+  runtimeStats_.wlock()->clear();
+}
+
+} // namespace facebook::velox

--- a/velox/common/base/ConcurrentRuntimeStatWriter.h
+++ b/velox/common/base/ConcurrentRuntimeStatWriter.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Synchronized.h>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "velox/common/base/RuntimeMetrics.h"
+
+namespace facebook::velox {
+
+/// Accumulates runtime metrics by name behind a lock, and exposes a snapshot.
+/// Unlike writers that forward each sample to an owning operator, this one owns
+/// the values, so any number of threads may record into it concurrently.
+class ConcurrentRuntimeStatWriter final : public BaseRuntimeStatWriter {
+ public:
+  /// Merges 'value' under 'name'. All samples under a name must share the same
+  /// unit; a mismatched unit throws.
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
+      override;
+
+  /// Replaces any existing metric under 'name'.
+  void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
+      override;
+
+  /// Returns a snapshot of the accumulated metrics.
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats() const;
+
+  /// Drops all accumulated metrics.
+  void clear();
+
+ private:
+  // All samples under a name share one unit; addRuntimeStat enforces it.
+  folly::Synchronized<std::unordered_map<std::string, RuntimeMetric>>
+      runtimeStats_;
+};
+
+} // namespace facebook::velox

--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -34,6 +34,11 @@ void RuntimeMetric::aggregate() {
   min = max = sum;
 }
 
+void RuntimeMetric::merge(const RuntimeCounter& value) {
+  VELOX_CHECK_EQ(unit, value.unit, "Unit mismatch for runtime stat");
+  addValue(value.value);
+}
+
 void RuntimeMetric::merge(const RuntimeMetric& other)
 #if defined(__has_feature)
 #if __has_feature(__address_sanitizer__)

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -18,7 +18,9 @@
 
 #include <fmt/format.h>
 #include <folly/CppAttributes.h>
+#include <chrono>
 #include <limits>
+#include <string>
 #include <string_view>
 
 namespace facebook::velox {
@@ -72,6 +74,9 @@ struct RuntimeMetric {
 
   void printMetric(std::ostream& stream) const;
 
+  /// Merges 'value' into this metric. Both must have the same unit.
+  void merge(const RuntimeCounter& value);
+
   void merge(const RuntimeMetric& other);
 
   std::string toString() const;
@@ -92,6 +97,22 @@ class BaseRuntimeStatWriter {
   virtual void setRuntimeStat(
       std::string_view /* name */,
       const RuntimeMetric& /* metric */) {}
+
+  /// Adds a wall or cpu duration sample under 'name', tagged as nanoseconds.
+  void addTiming(std::string_view name, std::chrono::nanoseconds duration) {
+    addRuntimeStat(
+        name, RuntimeCounter(duration.count(), RuntimeCounter::Unit::kNanos));
+  }
+
+  /// Adds a unitless count sample under 'name'.
+  void addCount(std::string_view name, int64_t value) {
+    addRuntimeStat(name, RuntimeCounter(value));
+  }
+
+  /// Adds a size sample under 'name', tagged as bytes.
+  void addBytes(std::string_view name, int64_t bytes) {
+    addRuntimeStat(name, RuntimeCounter(bytes, RuntimeCounter::Unit::kBytes));
+  }
 };
 
 /// Setting a concrete runtime stats writer on the thread will ensure that any

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   BloomFilterTest.cpp
   CoalesceIoTest.cpp
   ConcurrentCounterTest.cpp
+  ConcurrentRuntimeStatWriterTest.cpp
   ExceptionTest.cpp
   FsTest.cpp
   IndexedPriorityQueueTest.cpp

--- a/velox/common/base/tests/ConcurrentRuntimeStatWriterTest.cpp
+++ b/velox/common/base/tests/ConcurrentRuntimeStatWriterTest.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox {
+
+class ConcurrentRuntimeStatWriterTest : public testing::Test {
+ protected:
+  ConcurrentRuntimeStatWriter writer_;
+};
+
+TEST_F(ConcurrentRuntimeStatWriterTest, addAccumulates) {
+  writer_.addRuntimeStat(
+      "wall", RuntimeCounter(10, RuntimeCounter::Unit::kNanos));
+  writer_.addRuntimeStat(
+      "wall", RuntimeCounter(30, RuntimeCounter::Unit::kNanos));
+
+  const auto stats = writer_.runtimeStats();
+  const auto& wall = stats.at("wall");
+  EXPECT_EQ(wall.count, 2);
+  EXPECT_EQ(wall.sum, 40);
+  EXPECT_EQ(wall.min, 10);
+  EXPECT_EQ(wall.max, 30);
+  EXPECT_EQ(wall.unit, RuntimeCounter::Unit::kNanos);
+}
+
+TEST_F(ConcurrentRuntimeStatWriterTest, setReplaces) {
+  RuntimeMetric preset(RuntimeCounter::Unit::kBytes);
+  preset.addValue(5);
+  preset.addValue(15);
+  writer_.setRuntimeStat("bytes", preset);
+
+  RuntimeMetric replacement(RuntimeCounter::Unit::kBytes);
+  replacement.addValue(100);
+  writer_.setRuntimeStat("bytes", replacement);
+
+  // The second metric replaces the first rather than merging into it.
+  const auto stats = writer_.runtimeStats();
+  const auto& bytes = stats.at("bytes");
+  EXPECT_EQ(bytes.count, 1);
+  EXPECT_EQ(bytes.sum, 100);
+}
+
+TEST_F(ConcurrentRuntimeStatWriterTest, unitMismatchThrows) {
+  writer_.addRuntimeStat("m", RuntimeCounter(10, RuntimeCounter::Unit::kNanos));
+  VELOX_ASSERT_THROW(
+      writer_.addRuntimeStat(
+          "m", RuntimeCounter(20, RuntimeCounter::Unit::kBytes)),
+      "Unit mismatch for runtime stat");
+
+  // The rejected sample leaves the metric untouched.
+  const auto stats = writer_.runtimeStats();
+  const auto& metric = stats.at("m");
+  EXPECT_EQ(metric.count, 1);
+  EXPECT_EQ(metric.sum, 10);
+  EXPECT_EQ(metric.unit, RuntimeCounter::Unit::kNanos);
+}
+
+TEST_F(ConcurrentRuntimeStatWriterTest, unitMismatchThrowsAfterSet) {
+  // setRuntimeStat replaces without checking the unit, so the add path is what
+  // catches a mismatch on a name seeded by a set.
+  RuntimeMetric seeded(RuntimeCounter::Unit::kBytes);
+  seeded.addValue(10);
+  writer_.setRuntimeStat("m", seeded);
+
+  VELOX_ASSERT_THROW(
+      writer_.addRuntimeStat(
+          "m", RuntimeCounter(20, RuntimeCounter::Unit::kNanos)),
+      "Unit mismatch for runtime stat");
+}
+
+TEST_F(ConcurrentRuntimeStatWriterTest, unitHelpersApplyTheirUnit) {
+  writer_.addCount("splits", 3);
+  writer_.addBytes("read", 128);
+
+  const auto stats = writer_.runtimeStats();
+  EXPECT_EQ(stats.at("splits").sum, 3);
+  EXPECT_EQ(stats.at("splits").unit, RuntimeCounter::Unit::kNone);
+  EXPECT_EQ(stats.at("read").sum, 128);
+  EXPECT_EQ(stats.at("read").unit, RuntimeCounter::Unit::kBytes);
+}
+
+TEST_F(ConcurrentRuntimeStatWriterTest, clearDropsEverything) {
+  writer_.addRuntimeStat("a", RuntimeCounter(1));
+  writer_.addRuntimeStat("b", RuntimeCounter(2));
+  writer_.clear();
+  EXPECT_THAT(writer_.runtimeStats(), testing::IsEmpty());
+
+  // A cleared name may take a new unit, since nothing survives the clear.
+  writer_.addRuntimeStat("a", RuntimeCounter(5, RuntimeCounter::Unit::kBytes));
+  const auto stats = writer_.runtimeStats();
+  EXPECT_EQ(stats.at("a").sum, 5);
+  EXPECT_EQ(stats.at("a").unit, RuntimeCounter::Unit::kBytes);
+}
+
+TEST_F(ConcurrentRuntimeStatWriterTest, concurrentAddIsLossless) {
+  constexpr int32_t kNumThreads{8};
+  constexpr int32_t kSamplesPerThread{2'000};
+
+  // Every thread adds to one shared name and to a name only it uses, so the
+  // test covers both contended and uncontended keys.
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int32_t thread = 0; thread < kNumThreads; ++thread) {
+    threads.emplace_back([&, thread] {
+      const auto ownName = fmt::format("perThread{}", thread);
+      for (int32_t sample = 0; sample < kSamplesPerThread; ++sample) {
+        writer_.addCount("shared", 1);
+        writer_.addCount(ownName, 1);
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  const auto stats = writer_.runtimeStats();
+  const auto& shared = stats.at("shared");
+  EXPECT_EQ(shared.count, kNumThreads * kSamplesPerThread);
+  EXPECT_EQ(shared.sum, kNumThreads * kSamplesPerThread);
+
+  for (int32_t thread = 0; thread < kNumThreads; ++thread) {
+    const auto& perThread = stats.at(fmt::format("perThread{}", thread));
+    EXPECT_EQ(perThread.count, kSamplesPerThread);
+    EXPECT_EQ(perThread.sum, kSamplesPerThread);
+  }
+}
+
+} // namespace facebook::velox

--- a/velox/common/base/tests/RuntimeMetricsTest.cpp
+++ b/velox/common/base/tests/RuntimeMetricsTest.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/common/base/RuntimeMetrics.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
+#include "velox/common/base/VeloxException.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::velox {
 
@@ -99,27 +102,24 @@ TEST_F(RuntimeMetricsTest, saturateCast) {
   EXPECT_EQ(rm.max, maxInt64);
 }
 
-class SetThreadLocalRuntimeStatTest : public testing::Test {
- protected:
-  class RuntimeStatCollector : public BaseRuntimeStatWriter {
-   public:
-    void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
-        override {
-      stats_.insert_or_assign(std::string(name), metric);
-    }
+TEST_F(RuntimeMetricsTest, mergeCounter) {
+  RuntimeMetric rm(RuntimeCounter::Unit::kBytes);
 
-    const RuntimeMetric* getMetric(const std::string& name) const {
-      auto it = stats_.find(name);
-      return it != stats_.end() ? &it->second : nullptr;
-    }
+  rm.merge(RuntimeCounter(10, RuntimeCounter::Unit::kBytes));
+  testMetric(rm, 10, 1, 10, 10);
 
-   private:
-    std::unordered_map<std::string, RuntimeMetric> stats_;
-  };
-};
+  rm.merge(RuntimeCounter(30, RuntimeCounter::Unit::kBytes));
+  testMetric(rm, 40, 2, 10, 30);
+
+  VELOX_ASSERT_THROW(
+      rm.merge(RuntimeCounter(1, RuntimeCounter::Unit::kNanos)),
+      "Unit mismatch for runtime stat");
+}
+
+class SetThreadLocalRuntimeStatTest : public testing::Test {};
 
 TEST_F(SetThreadLocalRuntimeStatTest, singleMetric) {
-  RuntimeStatCollector collector;
+  ConcurrentRuntimeStatWriter collector;
   RuntimeStatWriterScopeGuard guard(&collector);
 
   RuntimeMetric metric(RuntimeCounter::Unit::kNone);
@@ -129,16 +129,17 @@ TEST_F(SetThreadLocalRuntimeStatTest, singleMetric) {
 
   setThreadLocalRuntimeStat("test.metric", metric);
 
-  const auto* result = collector.getMetric("test.metric");
-  ASSERT_NE(result, nullptr);
-  EXPECT_EQ(result->count, 3);
-  EXPECT_EQ(result->sum, 60);
-  EXPECT_EQ(result->min, 10);
-  EXPECT_EQ(result->max, 30);
+  const auto stats = collector.runtimeStats();
+  ASSERT_EQ(stats.count("test.metric"), 1);
+  const auto& result = stats.at("test.metric");
+  EXPECT_EQ(result.count, 3);
+  EXPECT_EQ(result.sum, 60);
+  EXPECT_EQ(result.min, 10);
+  EXPECT_EQ(result.max, 30);
 }
 
 TEST_F(SetThreadLocalRuntimeStatTest, existingMetric) {
-  RuntimeStatCollector collector;
+  ConcurrentRuntimeStatWriter collector;
   RuntimeStatWriterScopeGuard guard(&collector);
 
   RuntimeMetric first(RuntimeCounter::Unit::kNone);
@@ -150,24 +151,25 @@ TEST_F(SetThreadLocalRuntimeStatTest, existingMetric) {
   second.addValue(15);
   setThreadLocalRuntimeStat("test.metric", second);
 
-  const auto* result = collector.getMetric("test.metric");
-  ASSERT_NE(result, nullptr);
-  EXPECT_EQ(result->count, 2);
-  EXPECT_EQ(result->sum, 20);
-  EXPECT_EQ(result->min, 5);
-  EXPECT_EQ(result->max, 15);
+  const auto stats = collector.runtimeStats();
+  ASSERT_EQ(stats.count("test.metric"), 1);
+  const auto& result = stats.at("test.metric");
+  EXPECT_EQ(result.count, 2);
+  EXPECT_EQ(result.sum, 20);
+  EXPECT_EQ(result.min, 5);
+  EXPECT_EQ(result.max, 15);
 }
 
 TEST_F(SetThreadLocalRuntimeStatTest, emptyMetric) {
-  RuntimeStatCollector collector;
+  ConcurrentRuntimeStatWriter collector;
   RuntimeStatWriterScopeGuard guard(&collector);
 
   RuntimeMetric empty(RuntimeCounter::Unit::kNone);
   setThreadLocalRuntimeStat("test.empty", empty);
 
-  const auto* result = collector.getMetric("test.empty");
-  ASSERT_NE(result, nullptr);
-  EXPECT_EQ(result->count, 0);
+  const auto stats = collector.runtimeStats();
+  ASSERT_EQ(stats.count("test.empty"), 1);
+  EXPECT_EQ(stats.at("test.empty").count, 0);
 }
 
 TEST_F(SetThreadLocalRuntimeStatTest, noWriter) {

--- a/velox/common/base/tests/TrackedExecutorTest.cpp
+++ b/velox/common/base/tests/TrackedExecutorTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/TrackedExecutor.h"
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 
 #include <folly/BenchmarkUtil.h>
 #include <folly/executors/InlineExecutor.h>
@@ -22,7 +23,6 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
-#include <map>
 #include <stdexcept>
 #include <string>
 
@@ -30,30 +30,6 @@
 
 namespace facebook::velox {
 namespace {
-
-// Captures the metrics that TrackedExecutor::reportTo writes so the test can
-// inspect them by name.
-class MapStatWriter : public BaseRuntimeStatWriter {
- public:
-  void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
-      override {
-    metrics_.insert_or_assign(std::string{name}, metric);
-  }
-
-  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
-      override {
-    auto [it, inserted] =
-        metrics_.try_emplace(std::string{name}, RuntimeMetric(value.unit));
-    it->second.addValue(value.value);
-  }
-
-  const std::map<std::string, RuntimeMetric>& metrics() const {
-    return metrics_;
-  }
-
- private:
-  std::map<std::string, RuntimeMetric> metrics_;
-};
 
 class TrackedExecutorTest : public testing::Test {};
 
@@ -74,9 +50,9 @@ TEST_F(TrackedExecutorTest, reportsPerCallbackMetricsUnderPrefix) {
     });
   }
 
-  MapStatWriter writer;
+  ConcurrentRuntimeStatWriter writer;
   tracked.reportTo(writer, "myOp");
-  const auto& metrics = writer.metrics();
+  const auto metrics = writer.runtimeStats();
 
   ASSERT_THAT(
       metrics,
@@ -117,9 +93,9 @@ TEST_F(TrackedExecutorTest, keepsMetricCountsAlignedWhenCallbackThrows) {
       }),
       std::runtime_error);
 
-  MapStatWriter writer;
+  ConcurrentRuntimeStatWriter writer;
   tracked.reportTo(writer, "op");
-  const auto& metrics = writer.metrics();
+  const auto metrics = writer.runtimeStats();
 
   EXPECT_EQ(metrics.at("op-executorWaitNanos").count, 1);
   EXPECT_EQ(metrics.at("op-executorExecutionWallNanos").count, 1);

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -22,6 +22,7 @@
 #include <deque>
 #include <vector>
 #include "folly/synchronization/EventCount.h"
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
@@ -42,22 +43,6 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::memory {
-// Class to write runtime stats in the tests to the stats container.
-class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
- public:
-  explicit TestRuntimeStatWriter(
-      std::unordered_map<std::string, RuntimeMetric>& stats)
-      : stats_{stats} {}
-
-  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
-      override {
-    addOperatorRuntimeStats(name, value, stats_);
-  }
-
- private:
-  std::unordered_map<std::string, RuntimeMetric>& stats_;
-};
-
 constexpr int64_t KB = 1024L;
 constexpr int64_t MB = 1024L * KB;
 
@@ -1446,10 +1431,10 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, localArbitrationsFromSameQuery) {
 
   std::atomic_int allocationCount{0};
   auto runThread = std::thread([&]() {
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
     runPool->allocate(memoryCapacity / 2);
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_EQ(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -1471,10 +1456,10 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, localArbitrationsFromSameQuery) {
 
   auto waitThread = std::thread([&]() {
     allocationWait.await([&]() { return !allocationWaitFlag.load(); });
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
     waitPool->allocate(memoryCapacity / 2 + MB);
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_EQ(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -1548,11 +1533,11 @@ DEBUG_ONLY_TEST_F(
 
   std::atomic_int allocationCount{0};
   auto taskThread1 = std::thread([&]() {
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
     op1->allocate(MB);
     ASSERT_EQ(task1->capacity(), 8 * MB);
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_EQ(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -1573,11 +1558,11 @@ DEBUG_ONLY_TEST_F(
   });
 
   auto taskThread2 = std::thread([&]() {
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
     op2->allocate(MB);
     ASSERT_EQ(task2->capacity(), 8 * MB);
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_EQ(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -1801,9 +1786,8 @@ DEBUG_ONLY_TEST_F(
        .memoryPoolReserveCapacity = memoryPoolReservedCapacity});
 
   auto globalArbitrationTriggerThread = std::thread([&]() {
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
 
     std::vector<std::shared_ptr<MockTask>> tasks;
     std::vector<MockMemoryOperator*> ops;
@@ -1817,6 +1801,7 @@ DEBUG_ONLY_TEST_F(
       ops[i]->allocate(memoryPoolCapacity);
     }
     // We expect global arbitration has been triggered.
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_GE(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -1921,9 +1906,8 @@ DEBUG_ONLY_TEST_F(
           })));
 
   auto globalArbitrationTriggerThread = std::thread([&]() {
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
 
     std::vector<std::shared_ptr<MockTask>> tasks;
     std::vector<MockMemoryOperator*> ops;
@@ -1937,6 +1921,7 @@ DEBUG_ONLY_TEST_F(
       ops[i]->allocate(memoryPoolCapacity);
     }
     // We expect global arbitration has been triggered.
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_GE(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -1975,9 +1960,8 @@ DEBUG_ONLY_TEST_F(
   globalArbitrationStartWait.await(
       [&]() { return globalArbitrationStarted.load(); });
 
-  std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-  auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  ConcurrentRuntimeStatWriter statsWriter;
+  setThreadLocalRunTimeStatWriter(&statsWriter);
 
   localArbitrationOp->allocate(memoryPoolReservedCapacity);
   // Inject some delay for global arbitration.
@@ -1987,6 +1971,7 @@ DEBUG_ONLY_TEST_F(
 
   globalArbitrationTriggerThread.join();
   ASSERT_EQ(localArbitrationOp->capacity(), memoryPoolReservedCapacity);
+  auto runtimeStats = statsWriter.runtimeStats();
   ASSERT_EQ(
       runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
           .count,
@@ -2043,13 +2028,13 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, globalArbitrationAbortTimeRatio) {
                   std::chrono::nanoseconds(pauseTimeNs));
             })));
 
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
     const auto prevGlobalArbitrationRuns =
         arbitratorHelper.globalArbitrationRuns();
     op1->allocate(memoryCapacity / 2);
 
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_EQ(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -2109,11 +2094,11 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationWithoutSpill) {
   abortOp->allocate(memoryCapacity / 2);
   ASSERT_EQ(triggerTask->capacity(), memoryCapacity / 2);
 
-  std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-  auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  ConcurrentRuntimeStatWriter statsWriter;
+  setThreadLocalRunTimeStatWriter(&statsWriter);
   triggerOp->allocate(memoryCapacity / 2);
 
+  auto runtimeStats = statsWriter.runtimeStats();
   ASSERT_EQ(
       runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
           .count,
@@ -2164,15 +2149,15 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationSmallParticipantLargeGrow) {
   op1->allocate(kMemoryCapacity / 2);
   ASSERT_EQ(task0->capacity(), kMemoryCapacity / 2);
 
-  std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-  auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  ConcurrentRuntimeStatWriter statsWriter;
+  setThreadLocalRunTimeStatWriter(&statsWriter);
 
   // task0 has 256MB + 256MB (attempt) = 512MB in top abort capacity limit
   // bucket, which shall be evaluated first, and hence killed by global
   // arbitration.
   VELOX_ASSERT_THROW(op0->allocate(kMemoryCapacity / 2), "aborted");
 
+  auto runtimeStats = statsWriter.runtimeStats();
   ASSERT_EQ(
       runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
           .count,
@@ -2392,10 +2377,10 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, multipleGlobalRuns) {
   std::atomic_int allocations{0};
   auto waitThread = std::thread([&]() {
     allocationWait.await([&]() { return !allocationWaitFlag.load(); });
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
     waitPool->allocate(memoryCapacity / 2);
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_EQ(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,
@@ -2420,10 +2405,10 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, multipleGlobalRuns) {
   });
 
   auto runThread = std::thread([&]() {
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-    auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-    setThreadLocalRunTimeStatWriter(statsWriter.get());
+    ConcurrentRuntimeStatWriter statsWriter;
+    setThreadLocalRunTimeStatWriter(&statsWriter);
     runPool->allocate(memoryCapacity / 2);
+    auto runtimeStats = statsWriter.runtimeStats();
     ASSERT_EQ(
         runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
             .count,

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -35,31 +35,6 @@ using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::exec {
 using IndexSource = connector::IndexSource;
 
-void IndexLookupJoin::IndexStatWriter::addRuntimeStat(
-    std::string_view name,
-    const RuntimeCounter& value) {
-  auto lockedStats = runtimeStats_.wlock();
-  auto it = lockedStats->find(std::string(name));
-  if (it != lockedStats->end()) {
-    it->second.addValue(value.value);
-  } else {
-    RuntimeMetric metric(value.unit);
-    metric.addValue(value.value);
-    lockedStats->emplace(std::string(name), std::move(metric));
-  }
-}
-
-void IndexLookupJoin::IndexStatWriter::setRuntimeStat(
-    std::string_view name,
-    const RuntimeMetric& metric) {
-  runtimeStats_.wlock()->insert_or_assign(std::string(name), metric);
-}
-
-std::unordered_map<std::string, RuntimeMetric>
-IndexLookupJoin::IndexStatWriter::runtimeStats() const {
-  return *runtimeStats_.rlock();
-}
-
 namespace {
 
 void duplicateJoinKeyCheck(
@@ -229,7 +204,7 @@ int64_t extractStatSum(
 std::vector<OperatorStats> IndexLookupJoin::splitStats(
     const OperatorStats& combinedStats,
     const core::PlanNodeId& indexSourceNodeId,
-    const IndexStatWriter& indexSourceStatWriter) {
+    const ConcurrentRuntimeStatWriter& indexSourceStatWriter) {
   // Create stats for the IndexSource node from the accumulated index source
   // runtime stats.
   OperatorStats indexSourceStats;
@@ -342,7 +317,7 @@ IndexLookupJoin::IndexLookupJoin(
           1 + driverCtx->queryConfig().indexLookupJoinMaxPrefetchBatches()),
       isIndexSplitCollector_{driverCtx->partitionId == 0},
       joinNode_{joinNode},
-      indexStatWriter_(std::make_shared<IndexStatWriter>()) {
+      indexStatWriter_(std::make_shared<ConcurrentRuntimeStatWriter>()) {
   duplicateJoinKeyCheck(joinNode_->leftKeys());
   duplicateJoinKeyCheck(joinNode_->rightKeys());
 
@@ -1126,32 +1101,21 @@ void IndexLookupJoin::recordIndexSourceInputStats(
   if (batch.lookupInput == nullptr || batch.lookupInput->size() == 0) {
     return;
   }
-  indexStatWriter_->addRuntimeStat(
-      "inputPositions",
-      RuntimeCounter(
-          static_cast<int64_t>(batch.lookupInput->size()),
-          RuntimeCounter::Unit::kNone));
-  indexStatWriter_->addRuntimeStat(
+  indexStatWriter_->addCount(
+      "inputPositions", static_cast<int64_t>(batch.lookupInput->size()));
+  indexStatWriter_->addBytes(
       "inputBytes",
-      RuntimeCounter(
-          static_cast<int64_t>(batch.lookupInput->estimateFlatSize()),
-          RuntimeCounter::Unit::kBytes));
+      static_cast<int64_t>(batch.lookupInput->estimateFlatSize()));
 }
 
 void IndexLookupJoin::recordIndexSourceOutputStats(
     const InputBatchState& batch) {
-  indexStatWriter_->addRuntimeStat(
-      "outputPositions",
-      RuntimeCounter(
-          static_cast<int64_t>(batch.lookupResult->size()),
-          RuntimeCounter::Unit::kNone));
-  indexStatWriter_->addRuntimeStat(
+  indexStatWriter_->addCount(
+      "outputPositions", static_cast<int64_t>(batch.lookupResult->size()));
+  indexStatWriter_->addBytes(
       "outputBytes",
-      RuntimeCounter(
-          static_cast<int64_t>(batch.lookupResult->output->estimateFlatSize()),
-          RuntimeCounter::Unit::kBytes));
-  indexStatWriter_->addRuntimeStat(
-      "outputVectors", RuntimeCounter(1, RuntimeCounter::Unit::kNone));
+      static_cast<int64_t>(batch.lookupResult->output->estimateFlatSize()));
+  indexStatWriter_->addCount("outputVectors", 1);
 }
 
 void IndexLookupJoin::prepareLookupResult(InputBatchState& batch) {
@@ -1697,27 +1661,21 @@ void IndexLookupJoin::recordConnectorStats() {
   if (connectorStats.count(std::string(kConnectorLookupWallTime)) != 0) {
     const auto& lookupWallTime =
         connectorStats[std::string(kConnectorLookupWallTime)];
-    indexStatWriter_->addRuntimeStat(
-        "lookupCount",
-        RuntimeCounter(
-            static_cast<int64_t>(lookupWallTime.count),
-            RuntimeCounter::Unit::kNone));
-    indexStatWriter_->addRuntimeStat(
+    indexStatWriter_->addCount(
+        "lookupCount", static_cast<int64_t>(lookupWallTime.count));
+    indexStatWriter_->addTiming(
         "lookupWallNanos",
-        RuntimeCounter(
-            static_cast<int64_t>(lookupWallTime.sum),
-            RuntimeCounter::Unit::kNanos));
+        std::chrono::nanoseconds(static_cast<int64_t>(lookupWallTime.sum)));
     // NOTE: lookupCpuNanos may undercount CPU consumed on prefetch worker
     // threads or async I/O completion handlers, since CpuWallTimer measures
     // CPU on the calling thread only.
-    indexStatWriter_->addRuntimeStat(
+    indexStatWriter_->addTiming(
         "lookupCpuNanos",
-        RuntimeCounter(
+        std::chrono::nanoseconds(
             static_cast<int64_t>(
                 connectorStats[std::string(kConnectorResultPrepareTime)].sum +
                 connectorStats[std::string(kClientRequestProcessTime)].sum +
-                connectorStats[std::string(kClientResultProcessTime)].sum),
-            RuntimeCounter::Unit::kNanos));
+                connectorStats[std::string(kClientResultProcessTime)].sum)));
   }
   // Copy index source stats into the operator's own runtimeStats so they are
   // visible through the task-level runtime stats path.

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/exec/IndexLookupJoinBridge.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/VectorHasher.h"
@@ -87,33 +88,11 @@ class IndexLookupJoin : public Operator {
   static constexpr std::string_view kNumIndexSplits{"numIndexSplits"};
 
  private:
-  // Intercepts runtime stats emitted during index-side operations (getOutput /
-  // startLookup) and accumulates them into a local map, separating them from
-  // probe-side stats so Driver::processLazyIoStats() correctly attributes
-  // only probe-side stats to the scan operator. Held via shared_ptr so the
-  // stat splitter lambda can outlive the operator and read the final stats.
-  class IndexStatWriter : public BaseRuntimeStatWriter {
-   public:
-    void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
-        override;
-
-    // Sets a runtime metric in the index source stats map. Thread-safe.
-    void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
-        override;
-
-    // Returns a snapshot of the accumulated index source runtime stats.
-    std::unordered_map<std::string, RuntimeMetric> runtimeStats() const;
-
-   private:
-    folly::Synchronized<std::unordered_map<std::string, RuntimeMetric>>
-        runtimeStats_;
-  };
-
   // Produces separate OperatorStats for IndexLookupJoin and IndexSource nodes.
   static std::vector<OperatorStats> splitStats(
       const OperatorStats& combinedStats,
       const core::PlanNodeId& indexSourceNodeId,
-      const IndexStatWriter& indexSourceStatWriter);
+      const ConcurrentRuntimeStatWriter& indexSourceStatWriter);
 
   using ResultIterator = connector::IndexSource::ResultIterator;
   using Result = connector::IndexSource::Result;
@@ -479,6 +458,6 @@ class IndexLookupJoin : public Operator {
   // Intercepts and accumulates index source runtime stats. Held via
   // shared_ptr so the stat splitter lambda can read the final stats after the
   // operator is destroyed.
-  std::shared_ptr<IndexStatWriter> indexStatWriter_;
+  std::shared_ptr<ConcurrentRuntimeStatWriter> indexStatWriter_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -500,12 +500,8 @@ void addOperatorRuntimeStats(
     std::string_view name,
     const RuntimeCounter& value,
     std::unordered_map<std::string, RuntimeMetric>& stats) {
-  auto [statIt, inserted] =
-      stats.emplace(std::string(name), RuntimeMetric(value.unit));
-  if (!inserted) {
-    VELOX_CHECK_EQ(statIt->second.unit, value.unit);
-  }
-  statIt->second.addValue(value.value);
+  auto [statIt, unused] = stats.try_emplace(std::string(name), value.unit);
+  statIt->second.merge(value);
 }
 
 void setOperatorRuntimeStats(

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/SortBuffer.h"
 #include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
@@ -33,23 +34,6 @@ using namespace facebook::velox::memory;
 
 namespace facebook::velox::functions::test {
 using namespace facebook::velox::common::testutil;
-namespace {
-// Class to write runtime stats in the tests to the stats container.
-class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
- public:
-  explicit TestRuntimeStatWriter(
-      std::unordered_map<std::string, RuntimeMetric>& stats)
-      : stats_{stats} {}
-
-  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
-      override {
-    addOperatorRuntimeStats(name, value, stats_);
-  }
-
- private:
-  std::unordered_map<std::string, RuntimeMetric>& stats_;
-};
-} // namespace
 
 class SortBufferTest : public OperatorTestBase,
                        public testing::WithParamInterface<bool> {
@@ -58,8 +42,7 @@ class SortBufferTest : public OperatorTestBase,
     OperatorTestBase::SetUp();
     filesystems::registerLocalFileSystem();
     rng_.seed(123);
-    statWriter_ = std::make_unique<TestRuntimeStatWriter>(stats_);
-    setThreadLocalRunTimeStatWriter(statWriter_.get());
+    setThreadLocalRunTimeStatWriter(&statWriter_);
   }
 
   void TearDown() override {
@@ -128,8 +111,7 @@ class SortBufferTest : public OperatorTestBase,
 
   tsan_atomic<bool> nonReclaimableSection_{false};
   folly::Random::DefaultGenerator rng_;
-  std::unordered_map<std::string, RuntimeMetric> stats_;
-  std::unique_ptr<TestRuntimeStatWriter> statWriter_;
+  ConcurrentRuntimeStatWriter statWriter_;
 };
 
 TEST_P(SortBufferTest, singleKey) {
@@ -203,20 +185,21 @@ TEST_P(SortBufferTest, singleKey) {
           output->childAt(1)->asFlatVector<int32_t>()->valueAt(resultIndex++),
           expectedValue);
     }
+    const auto stats = statWriter_.runtimeStats();
     if (GetParam()) {
       ASSERT_EQ(
-          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
+          stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
+          stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
+          stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
           sortColumnIndices_.size());
     } else {
-      ASSERT_EQ(stats_.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
+      ASSERT_EQ(stats.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
     }
-    stats_.clear();
+    statWriter_.clear();
   }
 }
 
@@ -265,18 +248,19 @@ TEST_P(SortBufferTest, multipleKeys) {
   ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(7), 1);
   ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(8), 3);
   ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(9), 5);
+  const auto stats = statWriter_.runtimeStats();
   if (GetParam()) {
     ASSERT_EQ(
-        stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
+        stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
         sortColumnIndices_.size());
     ASSERT_EQ(
-        stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
+        stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
         sortColumnIndices_.size());
     ASSERT_EQ(
-        stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
+        stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
         sortColumnIndices_.size());
   } else {
-    ASSERT_EQ(stats_.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
+    ASSERT_EQ(stats.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
   }
 }
 
@@ -350,7 +334,7 @@ TEST_P(SortBufferTest, DISABLED_randomData) {
       inputVectors.push_back(input);
     }
     sortBuffer->noMoreInput();
-    stats_.clear();
+    statWriter_.clear();
     // todo: have a utility function buildExpectedSortResult and verify the
     // sorting result for random data.
   }
@@ -639,20 +623,21 @@ TEST_P(SortBufferTest, spill) {
             memory::spillMemoryPool()->stats().peakBytes, peakSpillMemoryUsage);
       }
     }
+    const auto stats = statWriter_.runtimeStats();
     if (GetParam()) {
       ASSERT_GE(
-          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
+          stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
+          stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
+          stats.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
           sortColumnIndices_.size());
     } else {
-      ASSERT_EQ(stats_.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
+      ASSERT_EQ(stats.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
     }
-    stats_.clear();
+    statWriter_.clear();
   }
 }
 

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -18,11 +18,11 @@
 #include <algorithm>
 #include <memory>
 
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
-#include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Spill.h"
 #include "velox/exec/tests/utils/MergeTestBase.h"
 #include "velox/serializers/PrestoSerializer.h"
@@ -38,21 +38,6 @@ using namespace facebook::velox::common::testutil;
 namespace {
 static const int64_t kGB = 1'000'000'000;
 
-// Class to write runtime stats in the tests to the stats container.
-class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
- public:
-  explicit TestRuntimeStatWriter(
-      std::unordered_map<std::string, RuntimeMetric>& stats)
-      : stats_{stats} {}
-
-  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
-      override {
-    addOperatorRuntimeStats(name, value, stats_);
-  }
-
- private:
-  std::unordered_map<std::string, RuntimeMetric>& stats_;
-};
 } // namespace
 
 struct TestParam {
@@ -86,9 +71,8 @@ inline void PrintTo(const TestParam& param, std::ostream* os) {
 class SpillTest : public ::testing::TestWithParam<uint32_t>,
                   public facebook::velox::test::VectorTestBase {
  public:
-  explicit SpillTest()
-      : statWriter_(std::make_unique<TestRuntimeStatWriter>(runtimeStats_)) {
-    setThreadLocalRunTimeStatWriter(statWriter_.get());
+  explicit SpillTest() {
+    setThreadLocalRunTimeStatWriter(&statWriter_);
     updateSpilledBytesCb_ = [&](uint64_t) {};
   }
 
@@ -240,7 +224,7 @@ class SpillTest : public ::testing::TestWithParam<uint32_t>,
     state_.reset();
     batchesByPartition_.clear();
     values_.clear();
-    runtimeStats_.clear();
+    statWriter_.clear();
     spillStats_.reset();
 
     fileNamePrefix_ = "test";
@@ -607,10 +591,12 @@ class SpillTest : public ::testing::TestWithParam<uint32_t>,
       ASSERT_TRUE(fs->exists(spilledFile));
     }
     // Verify stats.
+    const auto spillFileSizeCount =
+        statWriter_.runtimeStats().at("spillFileSize").count;
     if (!usePreMerge) {
-      ASSERT_EQ(runtimeStats_["spillFileSize"].count, spilledFiles.size());
+      ASSERT_EQ(spillFileSizeCount, spilledFiles.size());
     } else {
-      ASSERT_GE(runtimeStats_["spillFileSize"].count, spilledFiles.size());
+      ASSERT_GE(spillFileSizeCount, spilledFiles.size());
     }
   }
 
@@ -681,8 +667,7 @@ class SpillTest : public ::testing::TestWithParam<uint32_t>,
   std::string fileNamePrefix_;
   exec::SpillStats spillStats_;
   std::unique_ptr<SpillState> state_;
-  std::unordered_map<std::string, RuntimeMetric> runtimeStats_;
-  std::unique_ptr<TestRuntimeStatWriter> statWriter_;
+  ConcurrentRuntimeStatWriter statWriter_;
   common::UpdateAndCheckSpillLimitCB updateSpilledBytesCb_;
 };
 

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/Spiller.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <unordered_set>
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
@@ -48,22 +49,6 @@ enum class SpillerType {
   AGGREGATION_OUTPUT = 5,
   ROW_NUMBER_HASH_TABLE = 6,
   NUM_TYPES = 7,
-};
-
-// Class to write runtime stats in the tests to the stats container.
-class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
- public:
-  explicit TestRuntimeStatWriter(
-      std::unordered_map<std::string, RuntimeMetric>& stats)
-      : stats_{stats} {}
-
-  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
-      override {
-    addOperatorRuntimeStats(name, value, stats_);
-  }
-
- private:
-  std::unordered_map<std::string, RuntimeMetric>& stats_;
 };
 
 std::string typeName(SpillerType type) {
@@ -259,9 +244,8 @@ class SpillerTest : public exec::test::RowContainerTestBase {
              type_ == SpillerType::AGGREGATION_OUTPUT)
                 ? 0
                 : 2),
-        numPartitions_(hashBits_.numPartitions()),
-        statWriter_(std::make_unique<TestRuntimeStatWriter>(stats_)) {
-    setThreadLocalRunTimeStatWriter(statWriter_.get());
+        numPartitions_(hashBits_.numPartitions()) {
+    setThreadLocalRunTimeStatWriter(&statWriter_);
   }
 
   ~SpillerTest() {
@@ -623,7 +607,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     common::GetSpillDirectoryPathCB tempSpillDirCb = [&]() -> std::string_view {
       return tempDirPath_->getPath();
     };
-    stats_.clear();
+    statWriter_.clear();
     spillStats_ = folly::Synchronized<exec::SpillStats>();
     spillIoStats_ = IoStats();
 
@@ -1236,8 +1220,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
   const bool spillProbedFlag_;
   const HashBitRange hashBits_;
   const int32_t numPartitions_;
-  std::unordered_map<std::string, RuntimeMetric> stats_;
-  std::unique_ptr<TestRuntimeStatWriter> statWriter_;
+  ConcurrentRuntimeStatWriter statWriter_;
   folly::Random::DefaultGenerator rng_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
   std::shared_ptr<TempDirectoryPath> tempDirPath_;

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
@@ -26,19 +27,21 @@ class ReduceTest : public functions::test::FunctionBaseTest {
   void testReduceRewrite(
       const RowVectorPtr& input,
       const std::string& lambdaBody) {
-    TestRuntimeStatWriter writer;
+    ConcurrentRuntimeStatWriter writer;
     RuntimeStatWriterScopeGuard guard(&writer);
     auto actual = evaluate(
         fmt::format("reduce(c0, 10, (s, x) -> {}, s -> s)", lambdaBody), input);
-    ASSERT_EQ(writer.stats().size(), 1);
-    ASSERT_EQ(writer.stats()[0].first, "numReduceRewrite");
-    ASSERT_EQ(writer.stats()[0].second.value, 1);
+    const auto afterRewrite = writer.runtimeStats();
+    ASSERT_EQ(afterRewrite.size(), 1);
+    EXPECT_EQ(afterRewrite.at("numReduceRewrite").count, 1);
+    EXPECT_EQ(afterRewrite.at("numReduceRewrite").sum, 1);
     auto expected = evaluate(
         fmt::format("reduce(c0, 10, (s, x) -> {}, s -> 1 * s)", lambdaBody),
         input);
-    ASSERT_EQ(writer.stats().size(), 1);
-    ASSERT_EQ(writer.stats()[0].first, "numReduceRewrite");
-    ASSERT_EQ(writer.stats()[0].second.value, 1);
+    const auto afterNonRewrite = writer.runtimeStats();
+    ASSERT_EQ(afterNonRewrite.size(), 1);
+    EXPECT_EQ(afterNonRewrite.at("numReduceRewrite").count, 1);
+    EXPECT_EQ(afterNonRewrite.at("numReduceRewrite").sum, 1);
     assertEqualVectors(expected, actual);
   }
 };

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/common/memory/RawVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -676,7 +677,7 @@ TEST_F(LazyVectorTest, reset) {
 }
 
 TEST_F(LazyVectorTest, runtimeStats) {
-  TestRuntimeStatWriter writer;
+  ConcurrentRuntimeStatWriter writer;
   RuntimeStatWriterScopeGuard guard(&writer);
   auto lazy = std::make_shared<LazyVector>(
       pool_.get(),
@@ -686,17 +687,17 @@ TEST_F(LazyVectorTest, runtimeStats) {
         return makeFlatVector<int32_t>(rows.back() + 1, folly::identity);
       }));
   ASSERT_EQ(lazy->loadedVector()->size(), 10);
-  auto stats = writer.stats();
-  std::sort(stats.begin(), stats.end(), [](auto& x, auto& y) {
-    return x.first < y.first;
-  });
+  const auto stats = writer.runtimeStats();
   ASSERT_EQ(stats.size(), 3);
-  ASSERT_EQ(stats[0].first, LazyVector::kCpuNanos);
-  ASSERT_GE(stats[0].second.value, 0);
-  ASSERT_EQ(stats[1].first, LazyVector::kInputBytes);
-  ASSERT_GE(stats[1].second.value, 0);
-  ASSERT_EQ(stats[2].first, LazyVector::kWallNanos);
-  ASSERT_GE(stats[2].second.value, 0);
+  for (const auto& name :
+       {LazyVector::kCpuNanos,
+        LazyVector::kInputBytes,
+        LazyVector::kWallNanos}) {
+    SCOPED_TRACE(name);
+    const auto& metric = stats.at(std::string(name));
+    EXPECT_EQ(metric.count, 1);
+    EXPECT_GE(metric.sum, 0);
+  }
 }
 
 TEST_F(LazyVectorTest, chain) {

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -19,7 +19,6 @@
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/system/HardwareConcurrency.h>
 
-#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
@@ -888,21 +887,6 @@ class VectorTestBase {
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           folly::available_concurrency())};
-};
-
-class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
- public:
-  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
-      override {
-    stats_.emplace_back(std::string(name), value);
-  }
-
-  const std::vector<std::pair<std::string, RuntimeCounter>>& stats() const {
-    return stats_;
-  }
-
- private:
-  std::vector<std::pair<std::string, RuntimeCounter>> stats_;
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:

Adds `ConcurrentRuntimeStatWriter`, a `BaseRuntimeStatWriter` implementation that:

- Owns named metrics and accumulates them behind a lock  
- Allows concurrent sample recording from any number of threads  
- Exposes a snapshot of the accumulated values  

Unlike writers that forward each sample to an owning operator, this writer owns the values itself, enabling true concurrent recording.

Also adds unit-specific helpers - `addTiming`, `addCount`, and `addBytes` to `BaseRuntimeStatWriter` (one per `RuntimeCounter::Unit`) so callers don’t need to specify the unit at every call site. The unit becomes a property of the metric. `ConcurrentRuntimeStatWriter::addRuntimeStat` rejects unit mismatches.

## Deleted copies
| Copy | Location |
| --- | --- |
| `IndexLookupJoin::IndexStatWriter` | production |
| `MapStatWriter` | `TrackedExecutorTest` |
| `TestRuntimeStatWriter` | `SpillerTest`, `SpillTest`, `SortBufferTest` |
| `TestRuntimeStatWriter` | `VectorTestBase.h`, with `LazyVectorTest` and `ReduceTest` |
| `TestRuntimeStatWriter` | `MockSharedArbitratorTest` |
| `TestRuntimeStatWriter` | `E2EIndexTest` |
| `RuntimeStatCollector` | `RuntimeMetricsTest` |

Reviewed By: mbasmanova

Differential Revision: D114913439


