### PR TITLE
feat: Add shared dictionary builder and encoding (#18418)

### DIFF
--- a/velox/common/Casts.h
+++ b/velox/common/Casts.h
@@ -76,6 +76,14 @@ To* checkedPointerCast(From* input) {
   return casted;
 }
 
+/// Checks that pointer is not null and returns it for expression contexts such
+/// as constructor initializer lists.
+template <typename T>
+T* checkedNotNull(T* pointer) {
+  VELOX_CHECK_NOT_NULL(pointer);
+  return pointer;
+}
+
 template <typename To, typename From>
 std::unique_ptr<To> staticUniquePointerCast(std::unique_ptr<From> input) {
   VELOX_CHECK_NOT_NULL(input.get());

--- a/velox/common/testutil/tests/CastsTest.cpp
+++ b/velox/common/testutil/tests/CastsTest.cpp
@@ -93,6 +93,16 @@ class CastsTest : public ::testing::Test {
   DerivedClass* derivedRawPtr_;
 };
 
+TEST_F(CastsTest, checkedNotNull) {
+  int value = 1;
+  EXPECT_EQ(&value, checkedNotNull(&value));
+
+  const int constValue = 2;
+  EXPECT_EQ(&constValue, checkedNotNull(&constValue));
+
+  VELOX_ASSERT_THROW(checkedNotNull(static_cast<int*>(nullptr)), "");
+}
+
 // Tests for checkedPointerCast with shared_ptr
 TEST_F(CastsTest, checkedPointerCastSharedPtrSuccess) {
   // Cast derived to base (should always work)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/1076


Add shared dictionary scope/type support, test alphabet APIs, builder-owned dictionary mapping state, and SharedDictionary encoding layout support.

SharedDictionary slicing now materializes only the referenced unique shared dictionary values into a local dictionary, remaps sliced rows through sorted local indices, preserves hinted alphabet/index encoding types when available, and falls back to normal encoding selection otherwise. Single-value slices are converted to top-level Constant encodings.

This also adds direct tests for the shared dictionary wire helpers, alphabet public API, SharedDictionaryEncoding materialize/skip/readWithVisitor behavior, and slice conversion cases with and without alphabet encoding hints.

Reviewed By: tanjialiang

Differential Revision: D114459328
