### PR TITLE
refactor(hive): Share partition value conversion (#18419)

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -47,6 +47,7 @@ velox_add_library(
   HivePartitionName.cpp
   HiveSplitReader.cpp
   PartitionIdGenerator.cpp
+  PartitionValue.cpp
   TableHandle.cpp
   HEADERS
   BufferedInputBuilder.h
@@ -77,6 +78,7 @@ velox_add_library(
   HiveSplitReader.h
   IndexReader.h
   PartitionIdGenerator.h
+  PartitionValue.h
   TableHandle.h
 )
 

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -24,6 +24,7 @@
 #include "velox/connectors/hive/FileConfig.h"
 #include "velox/connectors/hive/FileConnectorSplit.h"
 #include "velox/connectors/hive/FileTableHandle.h"
+#include "velox/connectors/hive/PartitionValue.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/dwio/dwrf/common/Config.h"
@@ -213,50 +214,14 @@ bool applyPartitionFilter(
     bool isPartitionDateDaysSinceEpoch,
     const common::Filter* filter,
     bool asLocalTime) {
-  if (type->isDate()) {
-    int32_t result = 0;
-    // days_since_epoch partition values are integers in string format. Eg.
-    // Iceberg partition values.
-    if (isPartitionDateDaysSinceEpoch) {
-      result = folly::to<int32_t>(partitionValue);
-    } else {
-      result = DATE()->toDays(partitionValue);
-    }
-    return applyFilter(*filter, result);
-  }
-
-  switch (type->kind()) {
-    case TypeKind::BIGINT:
-    case TypeKind::INTEGER:
-    case TypeKind::SMALLINT:
-    case TypeKind::TINYINT: {
-      return applyFilter(*filter, folly::to<int64_t>(partitionValue));
-    }
-    case TypeKind::REAL:
-    case TypeKind::DOUBLE: {
-      return applyFilter(*filter, folly::to<double>(partitionValue));
-    }
-    case TypeKind::BOOLEAN: {
-      return applyFilter(*filter, folly::to<bool>(partitionValue));
-    }
-    case TypeKind::TIMESTAMP: {
-      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
-      auto result = util::fromTimestampString(
-          StringView(partitionValue), util::TimestampParseMode::kPrestoCast);
-      VELOX_CHECK(!result.hasError());
-      if (asLocalTime) {
-        result.value().toGMT(Timestamp::defaultTimezone());
-      }
-      return applyFilter(*filter, result.value());
-    }
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY: {
-      return applyFilter(*filter, partitionValue);
-    }
-    default:
-      VELOX_FAIL(
-          "Bad type {} for partition value: {}", type->kind(), partitionValue);
-  }
+  const auto value = PartitionValue::fromString(
+      partitionValue,
+      *type,
+      asLocalTime ? PartitionValue::TimestampMode::kLocalTime
+                  : PartitionValue::TimestampMode::kUtc,
+      isPartitionDateDaysSinceEpoch ? PartitionValue::DateMode::kDaysSinceEpoch
+                                    : PartitionValue::DateMode::kIsoString);
+  return applyFilter(*filter, value);
 }
 
 template <TypeKind kind>

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -21,71 +21,10 @@
 #include "velox/connectors/hive/FileConfig.h"
 #include "velox/connectors/hive/FileConnectorSplit.h"
 #include "velox/connectors/hive/FileConnectorUtil.h"
+#include "velox/connectors/hive/PartitionValue.h"
 #include "velox/dwio/common/ReaderFactory.h"
-#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::connector::hive {
-namespace {
-
-template <TypeKind kind>
-VectorPtr newConstantFromStringImpl(
-    const TypePtr& type,
-    const std::optional<std::string>& value,
-    velox::memory::MemoryPool* pool,
-    bool isLocalTimestamp,
-    bool isDaysSinceEpoch) {
-  using T = typename TypeTraits<kind>::NativeType;
-  if (!value.has_value()) {
-    return std::make_shared<ConstantVector<T>>(pool, 1, true, type, T());
-  }
-
-  if (type->isDate()) {
-    int32_t days = 0;
-    // For Iceberg, the date partition values are already in daysSinceEpoch
-    // form.
-    if (isDaysSinceEpoch) {
-      days = folly::to<int32_t>(value.value());
-    } else {
-      days = DATE()->toDays(value.value());
-    }
-    return std::make_shared<ConstantVector<int32_t>>(
-        pool, 1, false, type, std::move(days));
-  }
-
-  if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int128_t>) {
-    if (type->isDecimal()) {
-      T decimalValue = 0;
-      auto [precision, scale] = getDecimalPrecisionScale(*type);
-      auto status = DecimalUtil::castFromString(
-          StringView(value.value()), precision, scale, decimalValue);
-      if (!status.ok()) {
-        VELOX_USER_FAIL(status.message());
-      }
-      return std::make_shared<ConstantVector<T>>(
-          pool, 1, false, type, std::move(decimalValue));
-    }
-  }
-  if constexpr (std::is_same_v<T, StringView>) {
-    return std::make_shared<ConstantVector<StringView>>(
-        pool, 1, false, type, StringView(value.value()));
-  } else {
-    auto copy = velox::util::Converter<kind>::tryCast(value.value())
-                    .thenOrThrow(folly::identity, [&](const Status& status) {
-                      VELOX_USER_FAIL("{}", status.message());
-                    });
-    if constexpr (kind == TypeKind::TIMESTAMP) {
-      // TIMESTAMP partition value is read as local time subject to the
-      // 'readTimestampPartitionValueAsLocalTime' setting. TIMESTAMP_UTC
-      // partition value is always read as UTC.
-      if (type->equivalent(*TIMESTAMP()) && isLocalTimestamp) {
-        copy.toGMT(Timestamp::defaultTimezone());
-      }
-    }
-    return std::make_shared<ConstantVector<T>>(
-        pool, 1, false, type, std::move(copy));
-  }
-}
-} // namespace
 
 VectorPtr newConstantFromString(
     const TypePtr& type,
@@ -93,14 +32,20 @@ VectorPtr newConstantFromString(
     velox::memory::MemoryPool* pool,
     bool isLocalTimestamp,
     bool isDaysSinceEpoch) {
-  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
-      newConstantFromStringImpl,
-      type->kind(),
+  if (!value.has_value()) {
+    return BaseVector::createNullConstant(type, 1, pool);
+  }
+  return BaseVector::createConstant(
       type,
-      value,
-      pool,
-      isLocalTimestamp,
-      isDaysSinceEpoch);
+      PartitionValue::fromString(
+          value.value(),
+          *type,
+          isLocalTimestamp ? PartitionValue::TimestampMode::kLocalTime
+                           : PartitionValue::TimestampMode::kUtc,
+          isDaysSinceEpoch ? PartitionValue::DateMode::kDaysSinceEpoch
+                           : PartitionValue::DateMode::kIsoString),
+      1,
+      pool);
 }
 
 std::unique_ptr<FileSplitReader> FileSplitReader::create(

--- a/velox/connectors/hive/PartitionValue.cpp
+++ b/velox/connectors/hive/PartitionValue.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/PartitionValue.h"
+
+#include <string>
+#include <type_traits>
+
+#include <folly/Conv.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/type/Conversions.h"
+#include "velox/type/DecimalUtil.h"
+
+namespace facebook::velox::connector::hive {
+namespace {
+
+template <TypeKind kind>
+Variant fromStringImpl(
+    std::string_view value,
+    const Type& type,
+    PartitionValue::TimestampMode timestampMode,
+    PartitionValue::DateMode dateMode) {
+  using NativeType = typename TypeTraits<kind>::NativeType;
+
+  if (type.isDate()) {
+    const auto days = dateMode == PartitionValue::DateMode::kDaysSinceEpoch
+        ? folly::to<int32_t>(value)
+        : DATE()->toDays(value);
+    return Variant(days);
+  }
+
+  if constexpr (
+      std::is_same_v<NativeType, int64_t> ||
+      std::is_same_v<NativeType, int128_t>) {
+    if (type.isDecimal()) {
+      NativeType decimalValue{0};
+      const auto [precision, scale] = getDecimalPrecisionScale(type);
+      const auto status = DecimalUtil::castFromString(
+          StringView(value), precision, scale, decimalValue);
+      VELOX_USER_CHECK(status.ok(), "{}", status.message());
+      return Variant::create<kind>(decimalValue);
+    }
+  }
+
+  if constexpr (std::is_same_v<NativeType, StringView>) {
+    return Variant::create<kind>(std::string(value));
+  } else {
+    auto converted = util::Converter<kind>::tryCast(value).thenOrThrow(
+        folly::identity,
+        [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
+    if constexpr (kind == TypeKind::TIMESTAMP) {
+      if (type.equivalent(*TIMESTAMP()) &&
+          timestampMode == PartitionValue::TimestampMode::kLocalTime) {
+        converted.toGMT(Timestamp::defaultTimezone());
+      }
+    }
+    return Variant::create<kind>(converted);
+  }
+}
+
+} // namespace
+
+// static
+Variant PartitionValue::fromString(
+    std::string_view value,
+    const Type& type,
+    TimestampMode timestampMode,
+    DateMode dateMode) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      fromStringImpl, type.kind(), value, type, timestampMode, dateMode);
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/PartitionValue.h
+++ b/velox/connectors/hive/PartitionValue.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include "velox/type/Type.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Converts partition key strings to typed values. TIMESTAMP and DATE have
+/// more than one encoding, so the caller states which one applies.
+///
+///   auto value = PartitionValue::fromString(
+///       "2020-01-01 12:34:56",
+///       *TIMESTAMP(),
+///       PartitionValue::TimestampMode::kLocalTime,
+///       PartitionValue::DateMode::kIsoString);
+class PartitionValue {
+ public:
+  enum class TimestampMode {
+    /// Interprets the value as local time and shifts it to UTC. A
+    /// TIMESTAMP_UTC value is not shifted.
+    kLocalTime,
+
+    /// Interprets the value as UTC. No shift.
+    kUtc,
+  };
+
+  enum class DateMode {
+    /// Parses an ISO date, for example "2020-01-02".
+    kIsoString,
+
+    /// Parses an integer count of days since the epoch, for example "18263".
+    kDaysSinceEpoch,
+  };
+
+  /// 'value' must be non-null. Accepted input per type:
+  /// - BOOLEAN: t, f, 1, 0, true or false, case-insensitively.
+  /// - TINYINT, SMALLINT, INTEGER, BIGINT: an integer, range-checked against
+  ///   the native type rather than widened.
+  /// - REAL, DOUBLE: a floating point literal.
+  /// - DECIMAL: a decimal literal, scaled by the type's scale.
+  /// - VARCHAR, VARBINARY: taken verbatim.
+  /// - TIMESTAMP: parsed as TimestampParseMode::kPrestoCast, then shifted per
+  ///   'timestampMode'.
+  /// - DATE: parsed per 'dateMode'.
+  ///
+  /// Fails for a non-scalar type, and for a value that does not parse as
+  /// 'type'.
+  static Variant fromString(
+      std::string_view value,
+      const Type& type,
+      TimestampMode timestampMode,
+      DateMode dateMode);
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   HivePartitionNameTest.cpp
   HiveSplitTest.cpp
   PartitionIdGeneratorTest.cpp
+  PartitionValueTest.cpp
   TableHandleTest.cpp
 )
 add_test(velox_hive_connector_test velox_hive_connector_test)

--- a/velox/connectors/hive/tests/PartitionValueTest.cpp
+++ b/velox/connectors/hive/tests/PartitionValueTest.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/PartitionValue.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/Filter.h"
+#include "velox/type/TimestampConversion.h"
+
+namespace facebook::velox::connector::hive {
+namespace {
+
+using TimestampMode = PartitionValue::TimestampMode;
+using DateMode = PartitionValue::DateMode;
+
+Variant toVariant(
+    std::string_view value,
+    const TypePtr& type,
+    TimestampMode timestampMode = TimestampMode::kUtc,
+    DateMode dateMode = DateMode::kIsoString) {
+  return PartitionValue::fromString(value, *type, timestampMode, dateMode);
+}
+
+Timestamp parseTimestamp(std::string_view value) {
+  return util::fromTimestampString(
+             value.data(), value.size(), util::TimestampParseMode::kPrestoCast)
+      .value();
+}
+
+TEST(PartitionValueTest, scalarTypes) {
+  EXPECT_EQ(toVariant("true", BOOLEAN()), Variant(true));
+  EXPECT_EQ(toVariant("-1", TINYINT()), Variant(int8_t{-1}));
+  EXPECT_EQ(toVariant("-2", SMALLINT()), Variant(int16_t{-2}));
+  EXPECT_EQ(toVariant("-3", INTEGER()), Variant(int32_t{-3}));
+  EXPECT_EQ(toVariant("-4", BIGINT()), Variant(int64_t{-4}));
+  EXPECT_EQ(toVariant("1.25", REAL()), Variant(1.25f));
+  EXPECT_EQ(toVariant("2.5", DOUBLE()), Variant(2.5));
+  EXPECT_EQ(toVariant("hello", VARCHAR()), Variant(std::string("hello")));
+  EXPECT_EQ(toVariant("binary", VARBINARY()), Variant::binary("binary"));
+}
+
+TEST(PartitionValueTest, booleanAcceptedStrings) {
+  EXPECT_EQ(toVariant("t", BOOLEAN()), Variant(true));
+  EXPECT_EQ(toVariant("0", BOOLEAN()), Variant(false));
+  EXPECT_EQ(toVariant("FALSE", BOOLEAN()), Variant(false));
+
+  VELOX_ASSERT_USER_THROW(
+      toVariant("yes", BOOLEAN()), "Cannot cast yes to BOOLEAN");
+  VELOX_ASSERT_USER_THROW(
+      toVariant("off", BOOLEAN()), "Cannot cast off to BOOLEAN");
+}
+
+// Each integer type is range-checked against its own native type.
+TEST(PartitionValueTest, outOfRangeNarrowInteger) {
+  VELOX_ASSERT_USER_THROW(
+      toVariant("99999999999", INTEGER()), "Overflow during conversion");
+  VELOX_ASSERT_USER_THROW(
+      toVariant("40000", SMALLINT()), "Overflow during conversion");
+  VELOX_ASSERT_USER_THROW(
+      toVariant("300", TINYINT()), "Overflow during conversion");
+}
+
+TEST(PartitionValueTest, decimalTypes) {
+  EXPECT_EQ(
+      toVariant("12.34", DECIMAL(10, 2)).value<TypeKind::BIGINT>(), 1'234);
+  EXPECT_EQ(
+      toVariant("12345678901234567890.12", DECIMAL(25, 2))
+          .value<TypeKind::HUGEINT>(),
+      HugeInt::parse("1234567890123456789012"));
+}
+
+TEST(PartitionValueTest, dateEncodings) {
+  EXPECT_EQ(toVariant("2020-01-02", DATE()).value<TypeKind::INTEGER>(), 18'263);
+  EXPECT_EQ(
+      toVariant("18263", DATE(), TimestampMode::kUtc, DateMode::kDaysSinceEpoch)
+          .value<TypeKind::INTEGER>(),
+      18'263);
+}
+
+TEST(PartitionValueTest, timestampModes) {
+  const auto unshifted = parseTimestamp("2020-01-01 12:34:56");
+  auto shifted = unshifted;
+  shifted.toGMT(Timestamp::defaultTimezone());
+
+  EXPECT_EQ(
+      toVariant("2020-01-01 12:34:56", TIMESTAMP(), TimestampMode::kLocalTime)
+          .value<TypeKind::TIMESTAMP>(),
+      shifted);
+  EXPECT_EQ(
+      toVariant("2020-01-01 12:34:56", TIMESTAMP(), TimestampMode::kUtc)
+          .value<TypeKind::TIMESTAMP>(),
+      unshifted);
+  EXPECT_EQ(
+      toVariant(
+          "2020-01-01 12:34:56", TIMESTAMP_UTC(), TimestampMode::kLocalTime)
+          .value<TypeKind::TIMESTAMP>(),
+      unshifted);
+}
+
+TEST(PartitionValueTest, filterOnConvertedValue) {
+  const common::BigintRange bigintRange(10, 20, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(bigintRange, toVariant("15", BIGINT())));
+  EXPECT_FALSE(applyFilter(bigintRange, toVariant("25", BIGINT())));
+
+  // A REAL value is tested as a float, not as a double.
+  const common::FloatRange floatRange(
+      1.0f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      2.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(floatRange, toVariant("1.25", REAL())));
+  EXPECT_FALSE(applyFilter(floatRange, toVariant("2.5", REAL())));
+
+  const common::BigintRange dateRange(18'263, 18'263, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(dateRange, toVariant("2020-01-02", DATE())));
+
+  const common::BoolValue boolFilter(true, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(boolFilter, toVariant("true", BOOLEAN())));
+  EXPECT_FALSE(applyFilter(boolFilter, toVariant("false", BOOLEAN())));
+}
+
+TEST(PartitionValueTest, filterOnDecimal) {
+  const common::BigintRange shortRange(1'234, 1'234, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(shortRange, toVariant("12.34", DECIMAL(10, 2))));
+  EXPECT_FALSE(applyFilter(shortRange, toVariant("12.35", DECIMAL(10, 2))));
+
+  const auto longValue = HugeInt::parse("1234567890123456789012");
+  const common::HugeintRange longRange(
+      longValue, longValue, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(
+      longRange, toVariant("12345678901234567890.12", DECIMAL(25, 2))));
+}
+
+TEST(PartitionValueTest, filterUsesTimestampMode) {
+  const auto unshifted = parseTimestamp("2020-01-01 12:34:56");
+  auto shifted = unshifted;
+  shifted.toGMT(Timestamp::defaultTimezone());
+
+  const common::TimestampRange shiftedFilter(
+      shifted, shifted, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(
+      shiftedFilter,
+      toVariant(
+          "2020-01-01 12:34:56", TIMESTAMP(), TimestampMode::kLocalTime)));
+
+  const common::TimestampRange unshiftedFilter(
+      unshifted, unshifted, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(
+      unshiftedFilter,
+      toVariant("2020-01-01 12:34:56", TIMESTAMP(), TimestampMode::kUtc)));
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -26,6 +26,7 @@
 #include "velox/type/StringView.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
+#include "velox/type/Variant.h"
 
 namespace facebook::velox::common {
 
@@ -2505,6 +2506,21 @@ static inline bool applyFilter(TFilter& filter, std::string_view value) {
 template <typename TFilter>
 static inline bool applyFilter(TFilter& filter, StringView value) {
   return filter.testStringView(value);
+}
+
+namespace detail {
+template <TypeKind kind, typename TFilter>
+bool applyFilterToVariant(TFilter& filter, const Variant& value) {
+  return applyFilter(filter, value.value<kind>());
+}
+} // namespace detail
+
+/// 'value' must not be null.
+template <typename TFilter>
+static inline bool applyFilter(TFilter& filter, const Variant& value) {
+  VELOX_USER_CHECK(!value.isNull(), "Filter cannot be applied to a null value");
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      detail::applyFilterToVariant, value.kind(), filter, value);
 }
 
 /// Create a hash or bitmap based IN filter depending on value distribution.

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -21,6 +21,7 @@
 #include <optional>
 
 #include <velox/type/DecimalUtil.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/type/Filter.h"
 
@@ -2230,6 +2231,47 @@ TEST(FilterTest, dateRange) {
       between(DATE()->toDays("1970-01-01"), DATE()->toDays("1980-01-01"));
   EXPECT_TRUE(applyFilter(*filter, DATE()->toDays("1970-06-01")));
   EXPECT_FALSE(applyFilter(*filter, DATE()->toDays("1980-06-01")));
+}
+
+TEST(FilterTest, applyFilterToVariant) {
+  const BigintRange bigintFilter(10, 20, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(bigintFilter, Variant(int64_t{15})));
+  EXPECT_FALSE(applyFilter(bigintFilter, Variant(int64_t{25})));
+
+  // Every integer width reaches testInt64.
+  EXPECT_TRUE(applyFilter(bigintFilter, Variant(int32_t{15})));
+  EXPECT_TRUE(applyFilter(bigintFilter, Variant(int16_t{15})));
+
+  const auto huge = HugeInt::parse("1234567890123456789012");
+  const HugeintRange hugeintFilter(huge, huge, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(hugeintFilter, Variant(huge)));
+
+  const BoolValue boolFilter(true, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(boolFilter, Variant(true)));
+  EXPECT_FALSE(applyFilter(boolFilter, Variant(false)));
+
+  const FloatRange floatFilter(
+      1.0f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      2.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(floatFilter, Variant(1.25f)));
+  EXPECT_FALSE(applyFilter(floatFilter, Variant(2.5f)));
+
+  const Timestamp ts(10, 123000000);
+  const TimestampRange timestampFilter(ts, ts, /*nullAllowed=*/false);
+  EXPECT_TRUE(applyFilter(timestampFilter, Variant(ts)));
+
+  const auto bytesFilter = equal("abc");
+  EXPECT_TRUE(applyFilter(*bytesFilter, Variant(std::string("abc"))));
+  EXPECT_FALSE(applyFilter(*bytesFilter, Variant(std::string("abd"))));
+
+  VELOX_ASSERT_USER_THROW(
+      applyFilter(bigintFilter, Variant::null(TypeKind::BIGINT)),
+      "Filter cannot be applied to a null value");
 }
 
 TEST(FilterTest, timestampRange) {


### PR DESCRIPTION
Summary:

Partition values were parsed separately when readers materialized constants and when partition filters evaluated values. The two had diverged in which types they supported and which strings they accepted.

`PartitionValue::fromString` converts a non-null partition string to a `Variant`, and both paths now call it. Applying a filter to a `Variant` is a new `applyFilter` overload in `velox/type/Filter.h`.

Partition pruning carried its own string conversions and now shares the reader's, so the two agree where they previously did not.

This fixes DECIMAL: a short decimal threw from `folly::to<int64_t>("12.34")` and a long decimal hit `VELOX_FAIL("Bad type ...")` because HUGEINT was absent from the switch. Both now convert and filter.

It also makes pruning stricter for two types. In both cases the reader already rejected the value, so pruning was the more permissive of the two, and a corrupt partition value that pruning previously accepted and filtered out now fails the query instead:
- TINYINT, SMALLINT, INTEGER: values widened to `int64_t`. `Converter<kind>` range-checks against the native type.
- BOOLEAN: `folly::to<bool>` accepted `0 1 y yes n no t true f false on off`. `Converter<BOOLEAN>` accepts only `t f 1 0 true false` and their upper-case forms.

A partition value that fails to parse now raises a Velox user error rather than a `folly::ConversionError` or a runtime check failure. REAL parses as `float` rather than as a `double` narrowed to `float`, with no difference observed. VARCHAR, VARBINARY and DATE are unchanged. The reader path no longer dispatches `UNKNOWN` and `OPAQUE`, both of which already failed there.

Reviewed By: mbasmanova

Differential Revision: D113979882


