### PR TITLE
fix(fuzzer): Cap KHyperLogLog generated sketch size

### DIFF
--- a/velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.cpp
@@ -22,6 +22,14 @@
 #include "velox/type/Variant.h"
 
 namespace facebook::velox::fuzzer {
+namespace {
+// Upper bound on the number of (join key, uii) pairs inserted into a single
+// generated sketch. Each insert adds an entry to the minhash map, which holds a
+// nested HyperLogLog per distinct join key, so generation cost grows quickly
+// with this bound. Inserts beyond 'maxSize_' are largely discarded by the
+// minhash, so a larger bound buys little additional coverage.
+constexpr int32_t kMaxNumPairs = 1000;
+} // namespace
 
 KHyperLogLogInputGenerator::KHyperLogLogInputGenerator(
     const size_t seed,
@@ -47,7 +55,7 @@ variant KHyperLogLogInputGenerator::generateTyped() {
   common::hll::KHyperLogLog<int64_t, HashStringAllocator> khll{
       maxSize_, hllBuckets_, &allocator};
 
-  auto numPairs = rand<int32_t>(rng_, minNumValues_, 10000);
+  auto numPairs = rand<int32_t>(rng_, minNumValues_, kMaxNumPairs);
   for (auto i = 0; i < numPairs; ++i) {
     auto value = rand<T>(rng_);
     int64_t joinKey = std::hash<T>{}(value);
@@ -68,7 +76,7 @@ variant KHyperLogLogInputGenerator::generateTyped<int64_t>() {
   common::hll::KHyperLogLog<int64_t, HashStringAllocator> khll{
       maxSize_, hllBuckets_, &allocator};
 
-  auto numPairs = rand<int32_t>(rng_, minNumValues_, 10000);
+  auto numPairs = rand<int32_t>(rng_, minNumValues_, kMaxNumPairs);
   for (auto i = 0; i < numPairs; ++i) {
     int64_t joinKey = rand<int64_t>(rng_);
     int64_t uii = rand<int64_t>(rng_);
@@ -97,7 +105,7 @@ variant KHyperLogLogInputGenerator::generateTyped<std::string>() {
       UTF8CharList::MATHEMATICAL_SYMBOLS};
   std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
 
-  auto numPairs = rand<int32_t>(rng_, minNumValues_, 10000);
+  auto numPairs = rand<int32_t>(rng_, minNumValues_, kMaxNumPairs);
   for (auto i = 0; i < numPairs; ++i) {
     auto size = rand<int32_t>(rng_, 0, 100);
     std::string result;


### PR DESCRIPTION
Summary:
`PrestoQueryRunnerKHyperLogLogTransformTest.transformMap` times out in CI. Almost all of the runtime goes into building fuzzer input rather than exercising the transform under test: an ASAN build takes 936 seconds against a 600 second limit.

`KHyperLogLogInputGenerator` inserted up to 10000 (join key, uii) pairs into every generated sketch, and each insert adds an entry to a minhash map that holds a nested HyperLogLog per distinct join key. The bound is now 1000, matching `HyperLogLogInputGenerator`. Generated sketches stay representative because `maxSize_` is drawn from [100, 5000], so the minhash already discarded most inserts beyond that point.

Differential Revision: D115067348


