### PR TITLE
feat: TIMESTAMP WITH TIME ZONE session-zone rendering (#18422)

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -35,6 +35,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kSessionTimezone);
     VELOX_REGISTER_QUERY_CONFIG(kSessionStartTime);
     VELOX_REGISTER_QUERY_CONFIG(kAdjustTimestampToTimezone);
+    VELOX_REGISTER_QUERY_CONFIG(kLegacyTimestampWithTimezone);
 
     // Expression evaluation.
     VELOX_REGISTER_QUERY_CONFIG(kExprEvalSimplified);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -127,6 +127,19 @@ class QueryConfig {
       false,
       "Adjust timezone-less timestamp conversions to session timezone.")
 
+  /// If true (default), functions that read a TIMESTAMP WITH TIME ZONE (field
+  /// extraction, formatting, and date arithmetic, including the interval +/-
+  /// operators) render each value in its own embedded zone (legacy behavior).
+  /// If false, they render the UTC instant in the session timezone, so equal
+  /// values produce equal results. Does not cover CAST yet.
+  VELOX_QUERY_CONFIG(
+      kLegacyTimestampWithTimezone,
+      legacyTimestampWithTimezone,
+      "legacy_timestamp_with_timezone",
+      bool,
+      true,
+      "Render TIMESTAMP WITH TIME ZONE values in each value's embedded zone (true) or the session timezone (false).")
+
   /// Whether to use the simplified expression evaluation path. False by
   /// default.
   VELOX_QUERY_CONFIG(

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -72,6 +72,14 @@ Generic Configuration
        supplied "America/Los_Angeles", then "1970-01-01" will be converted to -28800 instead of 0. Similarly, timestamp
        to date conversions will adhere to user 'session_timezone', e.g: Timestamp(0) to Date will be -1 (number of days
        since epoch) for "America/Los_Angeles".
+   * - legacy_timestamp_with_timezone
+     - bool
+     - true
+     - If true, functions that read a TIMESTAMP WITH TIME ZONE render each value in its own embedded timezone. If false,
+       they render it in the session timezone, so values that compare equal produce equal results. Covers field
+       extraction, formatting, and date arithmetic, including the interval ``+`` and ``-`` operators. Of the interval
+       operators only ``INTERVAL YEAR TO MONTH`` is affected; ``INTERVAL DAY TO SECOND`` operates on milliseconds and
+       never consults a timezone.
    * - track_operator_cpu_usage
      - bool
      - true

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -105,6 +105,7 @@ std::unordered_map<std::string, std::shared_ptr<ExprTransformer>>
 std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
     argValuesGenerators = {
         {"at_timezone", std::make_shared<AtTimezoneArgValuesGenerator>()},
+        {"at_timezone_v2", std::make_shared<AtTimezoneArgValuesGenerator>()},
         {"cast", std::make_shared<CastVarcharAndJsonArgValuesGenerator>()},
         {"json_parse", std::make_shared<JsonParseArgValuesGenerator>()},
         {"json_extract", std::make_shared<JsonExtractArgValuesGenerator>()},

--- a/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
+++ b/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
@@ -200,6 +200,7 @@ const std::unordered_set<std::string>& prestoSkippedFunctionsSOT() {
       "map_update", // Velox-only function, not available in Presto
       "map_trim_values", // Velox-only function, not available in Presto
       "map_subset_key_in_range", // Velox-only function, not available in Presto
+      "at_timezone_v2", // Velox-only function, not available in Presto
       "noisy_empty_approx_set_sfm", // non-deterministic because of privacy.
       // https://github.com/facebookincubator/velox/issues/11034
       "cast(real) -> varchar",

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -114,21 +114,36 @@ struct FromUnixtimeFunction {
 
 namespace {
 
+// Returns the session render zone for non-legacy TIMESTAMP WITH TIME ZONE
+// rendering, or UTC when the session timezone is unset. Ignores
+// adjustTimestampToTimezone, which governs timezone-less TIMESTAMP only.
+FOLLY_ALWAYS_INLINE const tz::TimeZone* sessionRenderZone(
+    const core::QueryConfig& config) {
+  static const tz::TimeZone* kUtc = tz::locateZone("UTC");
+  const auto name = config.sessionTimezone();
+  return name.empty() ? kUtc : tz::locateZone(name);
+}
+
 template <typename T>
 struct TimestampWithTimezoneSupport {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  // Convert timestampWithTimezone to a timestamp representing the moment at the
-  // zone in timestampWithTimezone. If `asGMT` is set to true, return the GMT
-  // time at the same moment.
+  // Capture the render zone: embedded (legacy) or session.
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone*/) {
+    initializeTimeZoneSupport(config);
+  }
+
+  // Break the instant down at the render zone. If `asGMT`, keep it in GMT.
   FOLLY_ALWAYS_INLINE
   Timestamp toTimestamp(
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       bool asGMT = false) {
     auto timestamp = unpackTimestampUtc(*timestampWithTimezone);
     if (!asGMT) {
-      timestamp.toTimezone(
-          *tz::locateZone(unpackZoneKeyId(*timestampWithTimezone)));
+      timestamp.toTimezone(*renderZone(timestampWithTimezone));
     }
 
     return timestamp;
@@ -141,12 +156,42 @@ struct TimestampWithTimezoneSupport {
     Timestamp inputTimeStamp = this->toTimestamp(timestampWithTimezone);
     // Create a copy of inputTimeStamp and convert it to GMT
     auto gmtTimeStamp = inputTimeStamp;
-    gmtTimeStamp.toGMT(
-        *tz::locateZone(unpackZoneKeyId(*timestampWithTimezone)));
+    gmtTimeStamp.toGMT(*renderZone(timestampWithTimezone));
 
     // Get offset in seconds with GMT and convert to hour
     return (inputTimeStamp.getSeconds() - gmtTimeStamp.getSeconds());
   }
+
+ protected:
+  // Resolves the render zone from config. Call from every TIMESTAMP WITH TIME
+  // ZONE function that reads renderZone.
+  FOLLY_ALWAYS_INLINE void initializeTimeZoneSupport(
+      const core::QueryConfig& config) {
+    legacyTimestampWithTimezone_ = config.legacyTimestampWithTimezone();
+    // Under legacy behavior the session zone is never read, and locating it can
+    // throw on an invalid session timezone, so only resolve it when needed.
+    if (!legacyTimestampWithTimezone_) {
+      renderSessionZone_ = sessionRenderZone(config);
+    }
+  }
+
+  // Returns the embedded zone under legacy behavior, the session zone
+  // otherwise.
+  FOLLY_ALWAYS_INLINE const tz::TimeZone* renderZone(
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone) const {
+    const auto* zone = legacyTimestampWithTimezone_
+        ? tz::locateZone(unpackZoneKeyId(*timestampWithTimezone))
+        : renderSessionZone_;
+    VELOX_DCHECK_NOT_NULL(zone);
+    return zone;
+  }
+
+ private:
+  // Renders in each value's embedded zone when true, in the session zone when
+  // false.
+  bool legacyTimestampWithTimezone_{true};
+  // Session zone used for non-legacy rendering; unset under legacy behavior.
+  const tz::TimeZone* renderSessionZone_{nullptr};
 };
 
 } // namespace
@@ -172,8 +217,8 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<TimestampWithTimezone>* timestampWithTimezone) {
-    // Do nothing. Session timezone doesn't affect the result.
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone*/) {
+    this->initializeTimeZoneSupport(config);
   }
 
   FOLLY_ALWAYS_INLINE Status
@@ -207,6 +252,8 @@ template <typename T>
 struct WeekFunction : public InitSessionTimezone<T>,
                       public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
@@ -230,6 +277,8 @@ template <typename T>
 struct YearFunction : public InitSessionTimezone<T>,
                       public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE int64_t getYear(const std::tm& time) {
     return 1900 + time.tm_year;
@@ -268,6 +317,8 @@ template <typename T>
 struct QuarterFunction : public InitSessionTimezone<T>,
                          public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE int64_t getQuarter(const std::tm& time) {
     return time.tm_mon / 3 + 1;
@@ -295,6 +346,8 @@ template <typename T>
 struct MonthFunction : public InitSessionTimezone<T>,
                        public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE int64_t getMonth(const std::tm& time) {
     return 1 + time.tm_mon;
@@ -333,6 +386,8 @@ template <typename T>
 struct DayFunction : public InitSessionTimezone<T>,
                      public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
@@ -367,6 +422,8 @@ template <typename T>
 struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
                                 public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
@@ -485,7 +542,7 @@ struct TimestampMinusFunction {
 };
 
 template <typename T>
-struct TimestampPlusInterval {
+struct TimestampPlusInterval : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(
@@ -519,12 +576,31 @@ struct TimestampPlusInterval {
         timestamp, DateTimeUnit::kMonth, interval, sessionTimeZone_);
   }
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<TimestampWithTimezone>*,
+      const arg_type<IntervalDayTime>*) {
+    this->initializeTimeZoneSupport(config);
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalDayTime>& interval) {
     result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+        *timestampWithTimezone,
+        DateTimeUnit::kMillisecond,
+        interval,
+        *this->renderZone(timestampWithTimezone));
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<TimestampWithTimezone>*,
+      const arg_type<IntervalYearMonth>*) {
+    this->initializeTimeZoneSupport(config);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -532,7 +608,10 @@ struct TimestampPlusInterval {
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalYearMonth>& interval) {
     result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMonth, interval);
+        *timestampWithTimezone,
+        DateTimeUnit::kMonth,
+        interval,
+        *this->renderZone(timestampWithTimezone));
   }
 
  private:
@@ -672,7 +751,7 @@ struct IntervalPlusTime {
 };
 
 template <typename T>
-struct IntervalPlusTimestamp {
+struct IntervalPlusTimestamp : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(
@@ -706,12 +785,31 @@ struct IntervalPlusTimestamp {
         timestamp, DateTimeUnit::kMonth, interval, sessionTimeZone_);
   }
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<IntervalDayTime>*,
+      const arg_type<TimestampWithTimezone>*) {
+    this->initializeTimeZoneSupport(config);
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       out_type<TimestampWithTimezone>& result,
       const arg_type<IntervalDayTime>& interval,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+        *timestampWithTimezone,
+        DateTimeUnit::kMillisecond,
+        interval,
+        *this->renderZone(timestampWithTimezone));
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<IntervalYearMonth>*,
+      const arg_type<TimestampWithTimezone>*) {
+    this->initializeTimeZoneSupport(config);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -719,7 +817,10 @@ struct IntervalPlusTimestamp {
       const arg_type<IntervalYearMonth>& interval,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMonth, interval);
+        *timestampWithTimezone,
+        DateTimeUnit::kMonth,
+        interval,
+        *this->renderZone(timestampWithTimezone));
   }
 
  private:
@@ -728,7 +829,7 @@ struct IntervalPlusTimestamp {
 };
 
 template <typename T>
-struct TimestampMinusInterval {
+struct TimestampMinusInterval : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(
@@ -762,12 +863,31 @@ struct TimestampMinusInterval {
         timestamp, DateTimeUnit::kMonth, -interval, sessionTimeZone_);
   }
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<TimestampWithTimezone>*,
+      const arg_type<IntervalDayTime>*) {
+    this->initializeTimeZoneSupport(config);
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalDayTime>& interval) {
     result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMillisecond, -interval);
+        *timestampWithTimezone,
+        DateTimeUnit::kMillisecond,
+        -interval,
+        *this->renderZone(timestampWithTimezone));
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<TimestampWithTimezone>*,
+      const arg_type<IntervalYearMonth>*) {
+    this->initializeTimeZoneSupport(config);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -775,7 +895,10 @@ struct TimestampMinusInterval {
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalYearMonth>& interval) {
     result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMonth, -interval);
+        *timestampWithTimezone,
+        DateTimeUnit::kMonth,
+        -interval,
+        *this->renderZone(timestampWithTimezone));
   }
 
  private:
@@ -787,6 +910,8 @@ template <typename T>
 struct DayOfWeekFunction : public InitSessionTimezone<T>,
                            public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE int64_t getDayOfWeek(const std::tm& time) {
     return time.tm_wday == 0 ? 7 : time.tm_wday;
@@ -814,6 +939,8 @@ template <typename T>
 struct DayOfYearFunction : public InitSessionTimezone<T>,
                            public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE int64_t getDayOfYear(const std::tm& time) {
     return time.tm_yday + 1;
@@ -841,6 +968,8 @@ template <typename T>
 struct YearOfWeekFunction : public InitSessionTimezone<T>,
                             public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE int64_t computeYearOfWeek(const std::tm& dateTime) {
     int isoWeekDay = dateTime.tm_wday == 0 ? 7 : dateTime.tm_wday;
@@ -885,6 +1014,8 @@ template <typename T>
 struct HourFunction : public InitSessionTimezone<T>,
                       public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
@@ -929,6 +1060,8 @@ template <typename T>
 struct MinuteFunction : public InitSessionTimezone<T>,
                         public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using InitSessionTimezone<T>::initialize;
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
@@ -1152,9 +1285,10 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
-      const core::QueryConfig& /*config*/,
+      const core::QueryConfig& config,
       const arg_type<Varchar>* unitString,
       const arg_type<TimestampWithTimezone>* /*timestamp*/) {
+    this->initializeTimeZoneSupport(config);
     if (unitString != nullptr) {
       unit_ = getTimestampUnit(*unitString);
     }
@@ -1243,8 +1377,7 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
       // 25 or 23 hours at the transition points.
       auto updatedTimestamp =
           Timestamp::fromMillis(Timestamp::calendarUtcToEpoch(dateTime) * 1000);
-      updatedTimestamp.toGMT(
-          *tz::locateZone(unpackZoneKeyId(*timestampWithTimezone)));
+      updatedTimestamp.toGMT(*this->renderZone(timestampWithTimezone));
 
       resultMillis = updatedTimestamp.toMillis();
     }
@@ -1321,6 +1454,18 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
         unit, static_cast<int32_t>(value), timestamp, sessionTimeZone_);
   }
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* unitString,
+      const int64_t* /*value*/,
+      const arg_type<TimestampWithTimezone>* /*timestamp*/) {
+    this->initializeTimeZoneSupport(config);
+    if (unitString != nullptr) {
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/true);
+    }
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       out_type<TimestampWithTimezone>& result,
       const arg_type<Varchar>& unitString,
@@ -1332,7 +1477,10 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
     checkValueInInt32Range(value);
 
     result = addToTimestampWithTimezone(
-        *timestampWithTimezone, unit, static_cast<int32_t>(value));
+        *timestampWithTimezone,
+        unit,
+        static_cast<int32_t>(value),
+        *this->renderZone(timestampWithTimezone));
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -1404,6 +1552,7 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Varchar>* unitString,
       const arg_type<TimestampWithTimezone>* /*timestampWithTimezone1*/,
       const arg_type<TimestampWithTimezone>* /*timestampWithTimezone2*/) {
+    this->initializeTimeZoneSupport(config);
     if (unitString != nullptr) {
       unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/true);
     }
@@ -1450,15 +1599,12 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
     const auto unit = unit_.value_or(
         fromDateTimeUnitString(unitString, /*throwIfInvalid=*/true).value());
 
-    // Presto's behavior is to use the time zone of the first parameter to
-    // perform the calculation. Note that always normalizing to UTC is not
-    // correct as calculations may cross daylight savings boundaries.
-    auto timeZoneId = unpackZoneKeyId(*timestampWithTz1);
-
+    // Legacy uses the first argument's zone; the session zone otherwise.
     result = diffTimestampWithTimeZone(
         unit,
         *timestampWithTz1,
-        pack(unpackMillisUtc(*timestampWithTz2), timeZoneId));
+        *timestampWithTz2,
+        *this->renderZone(timestampWithTz1));
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -1495,9 +1641,10 @@ struct DateFormatFunction : public TimestampWithTimezoneSupport<T> {
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
-      const core::QueryConfig& /*config*/,
+      const core::QueryConfig& config,
       const arg_type<TimestampWithTimezone>* /*timestamp*/,
       const arg_type<Varchar>* formatString) {
+    this->initializeTimeZoneSupport(config);
     if (formatString != nullptr) {
       setFormatter(*formatString);
       isConstFormat_ = true;
@@ -1654,7 +1801,7 @@ struct DateParseFunction {
 };
 
 template <typename T>
-struct FormatDateTimeFunction {
+struct FormatDateTimeFunction : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void initialize(
@@ -1678,6 +1825,18 @@ struct FormatDateTimeFunction {
     format(timestamp, sessionTimeZone_, maxResultSize_, result);
   }
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<TimestampWithTimezone>* /*timestamp*/,
+      const arg_type<Varchar>* formatString) {
+    this->initializeTimeZoneSupport(config);
+    if (formatString != nullptr) {
+      setFormatter(*formatString);
+      isConstFormat_ = true;
+    }
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
@@ -1685,8 +1844,7 @@ struct FormatDateTimeFunction {
     ensureFormatter(formatString);
 
     const auto timestamp = unpackTimestampUtc(*timestampWithTimezone);
-    const auto timeZoneId = unpackZoneKeyId(*timestampWithTimezone);
-    auto* timezonePtr = tz::locateZone(tz::getTimeZoneName(timeZoneId));
+    const auto* timezonePtr = this->renderZone(timestampWithTimezone);
 
     const auto maxResultSize = jodaDateTime_->maxResultSize(timezonePtr);
     format(timestamp, timezonePtr, maxResultSize, result);
@@ -1871,8 +2029,9 @@ struct TimeZoneMinuteFunction : public TimestampWithTimezoneSupport<T> {
 };
 
 template <typename T>
-struct ToISO8601Function {
+struct ToISO8601Function : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  using TimestampWithTimezoneSupport<T>::initialize;
 
   ToISO8601Function() {
     auto formatter =
@@ -1910,8 +2069,7 @@ struct ToISO8601Function {
       out_type<Varchar>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     const auto timestamp = unpackTimestampUtc(*timestampWithTimezone);
-    const auto timeZoneId = unpackZoneKeyId(*timestampWithTimezone);
-    const auto* timeZone = tz::locateZone(tz::getTimeZoneName(timeZoneId));
+    const auto* timeZone = this->renderZone(timestampWithTimezone);
 
     toIso8601(timestamp, timeZone, result);
   }
@@ -1932,6 +2090,8 @@ struct ToISO8601Function {
   std::shared_ptr<DateTimeFormatter> formatter_;
 };
 
+// Inherits the base for signature consistency but uses no render helper:
+// at_timezone tags output with its explicit zone argument, ignoring the flag.
 template <typename T>
 struct AtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1966,6 +1966,78 @@ struct AtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
   }
 };
 
+/// at_timezone_v2(TIMESTAMP WITH TIME ZONE, varchar) -> TIMESTAMP
+/// Converts the UTC instant to the wall clock in the target zone and drops the
+/// zone, producing a naive timestamp.
+template <typename T>
+struct AtTimezoneV2ToTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Target zone when the timezone argument is constant; null otherwise.
+  const tz::TimeZone* targetTimeZone_{nullptr};
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone*/,
+      const arg_type<Varchar>* timezone) {
+    if (timezone) {
+      targetTimeZone_ =
+          tz::locateZone(std::string_view(timezone->data(), timezone->size()));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Timestamp>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<Varchar>& timezone) {
+    const auto* targetTimeZone = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(timezone.data(), timezone.size()));
+
+    Timestamp timestamp = unpackTimestampUtc(*timestampWithTimezone);
+    timestamp.toTimezone(*targetTimeZone);
+    result = timestamp;
+  }
+};
+
+/// at_timezone_v2(TIMESTAMP, varchar) -> TIMESTAMP WITH TIME ZONE
+/// Interprets the naive wall clock as being in the target zone and returns the
+/// UTC instant tagged with that zone.
+/// A DST spring-forward gap fails; a fall-back overlap resolves to the earliest
+/// instant.
+template <typename T>
+struct AtTimezoneV2ToTimestampWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Target zone when the timezone argument is constant; null otherwise.
+  const tz::TimeZone* targetTimeZone_{nullptr};
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Timestamp>* /*timestamp*/,
+      const arg_type<Varchar>* timezone) {
+    if (timezone) {
+      targetTimeZone_ =
+          tz::locateZone(std::string_view(timezone->data(), timezone->size()));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<Timestamp>& timestamp,
+      const arg_type<Varchar>& timezone) {
+    const auto* targetTimeZone = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(timezone.data(), timezone.size()));
+
+    Timestamp utcTime = timestamp;
+    utcTime.toGMT(*targetTimeZone);
+    result = pack(utcTime.toMillis(), targetTimeZone->id());
+  }
+};
+
 template <typename T>
 struct AtTimezoneTimeWithTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -104,10 +104,13 @@ FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
   }
 }
 
+// Adds 'value' units to 'timestampWithTimezone'. Day and larger units are
+// computed in 'renderZone'. The result keeps the value's embedded zone id.
 FOLLY_ALWAYS_INLINE int64_t addToTimestampWithTimezone(
     int64_t timestampWithTimezone,
     const DateTimeUnit unit,
-    const int32_t value) {
+    const int32_t value,
+    const tz::TimeZone& renderZone) {
   {
     int64_t finalSysMs;
     if (unit < DateTimeUnit::kDay) {
@@ -120,25 +123,23 @@ FOLLY_ALWAYS_INLINE int64_t addToTimestampWithTimezone(
       // the day it moves forward is 23 hours long. Daylight savings time
       // doesn't affect time units less than a day, and will produce incorrect
       // results if we use local time.
-      const tz::TimeZone* timeZone =
-          tz::locateZone(unpackZoneKeyId(timestampWithTimezone));
       auto originalTimestamp = Timestamp::fromMillis(
-          timeZone
-              ->to_local(
+          renderZone
+              .to_local(
                   std::chrono::milliseconds(
                       unpackMillisUtc(timestampWithTimezone)))
               .count());
       auto updatedTimeStamp =
           addToTimestamp(originalTimestamp, unit, (int32_t)value);
       updatedTimeStamp = Timestamp(
-          timeZone
-              ->correct_nonexistent_time(
+          renderZone
+              .correct_nonexistent_time(
                   std::chrono::seconds(updatedTimeStamp.getSeconds()))
               .count(),
           updatedTimeStamp.getNanos());
       finalSysMs =
-          timeZone
-              ->to_sys(
+          renderZone
+              .to_sys(
                   std::chrono::milliseconds(updatedTimeStamp.toMillis()),
                   tz::TimeZone::TChoose::kEarliest)
               .count();
@@ -148,17 +149,13 @@ FOLLY_ALWAYS_INLINE int64_t addToTimestampWithTimezone(
   }
 }
 
+// Returns the difference in 'unit's between the two values. Day and larger
+// units are computed in 'renderZone'.
 FOLLY_ALWAYS_INLINE int64_t diffTimestampWithTimeZone(
     const DateTimeUnit unit,
     const int64_t fromTimestampWithTimeZone,
-    const int64_t toTimestampWithTimeZone) {
-  auto fromTimeZoneId = unpackZoneKeyId(fromTimestampWithTimeZone);
-  auto toTimeZoneId = unpackZoneKeyId(toTimestampWithTimeZone);
-  VELOX_CHECK_EQ(
-      fromTimeZoneId,
-      toTimeZoneId,
-      "diffTimestampWithTimeZone must receive timestamps in the same time zone.");
-
+    const int64_t toTimestampWithTimeZone,
+    const tz::TimeZone& renderZone) {
   Timestamp fromTimestamp;
   Timestamp toTimestamp;
 
@@ -171,16 +168,15 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestampWithTimeZone(
     // the day it moves forward is 23 hours long. Daylight savings time
     // doesn't affect time units less than a day, and will produce incorrect
     // results if we use local time.
-    const tz::TimeZone* timeZone = tz::locateZone(fromTimeZoneId);
     fromTimestamp =
-        Timestamp::fromMillis(timeZone
-                                  ->to_local(
+        Timestamp::fromMillis(renderZone
+                                  .to_local(
                                       std::chrono::milliseconds(unpackMillisUtc(
                                           fromTimestampWithTimeZone)))
                                   .count());
     toTimestamp =
-        Timestamp::fromMillis(timeZone
-                                  ->to_local(
+        Timestamp::fromMillis(renderZone
+                                  .to_local(
                                       std::chrono::milliseconds(unpackMillisUtc(
                                           toTimestampWithTimeZone)))
                                   .count());

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -334,6 +334,26 @@ void registerSimpleFunctions(const std::string& prefix) {
       TimeWithTimezone,
       Varchar>({prefix + "at_timezone"});
 
+  registerFunction<
+      AtTimezoneV2ToTimestampFunction,
+      Timestamp,
+      TimestampWithTimezone,
+      Varchar>({prefix + "at_timezone_v2"});
+
+  registerFunction<
+      AtTimezoneV2ToTimestampWithTimezoneFunction,
+      TimestampWithTimezone,
+      Timestamp,
+      Varchar>({prefix + "at_timezone_v2"});
+
+  // TIME WITH TIME ZONE has no naive/zoned distinction, so at_timezone_v2
+  // deliberately reuses at_timezone's implementation.
+  registerFunction<
+      AtTimezoneTimeWithTimezoneFunction,
+      TimeWithTimezone,
+      TimeWithTimezone,
+      Varchar>({prefix + "at_timezone_v2"});
+
   registerFunction<ToMillisecondFunction, int64_t, IntervalDayTime>(
       {prefix + "to_milliseconds"});
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -84,6 +84,14 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     });
   }
 
+  // Session zone set, legacy_timestamp_with_timezone off (adjust left unset).
+  void setSessionZoneNonLegacy(const std::string& timeZone) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kLegacyTimestampWithTimezone, "false"},
+    });
+  }
+
   void setQuerySessionStartTime(int64_t sessionStartTime) {
     queryCtx_->testingOverrideConfigUnsafe({
         {core::QueryConfig::kSessionStartTime,
@@ -740,6 +748,35 @@ TEST_F(DateTimeFunctionsTest, hourTimestampWithTimezone) {
   EXPECT_EQ(
       2, hourTimestampWithTimezone(TimestampWithTimezone(-41028000, "+14:00")));
   EXPECT_EQ(std::nullopt, hourTimestampWithTimezone(std::nullopt));
+}
+
+TEST_F(DateTimeFunctionsTest, hourTimestampWithTimezoneSessionZone) {
+  // Under the flag, field functions use the session zone, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto hourTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<int64_t>(
+            "hour(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 08:00 UTC rendered in New York (EST, -05:00) is hour 3 for both.
+  EXPECT_EQ(3, hourTsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(3, hourTsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, hourTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) keeps legacy embedded-zone rendering.
+  setQueryTimeZone("America/New_York");
+  const auto hourTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<int64_t>(
+            "hour(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  EXPECT_EQ(4, hourTsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(1, hourTsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, hourDate) {
@@ -2712,6 +2749,42 @@ TEST_F(DateTimeFunctionsTest, dateTruncTimestampWithTimezone) {
       "year", "1968-05-20+23:01:02+05:30", "1968-01-01+00:00:00+05:30");
 }
 
+TEST_F(DateTimeFunctionsTest, dateTruncTimestampWithTimezoneSessionZone) {
+  // Under the flag, date_trunc truncates in the session zone, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto truncDayEpoch =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<double>(
+            "to_unixtime(date_trunc('day', c0))",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // Truncates to 1970-01-01 EST midnight for both = 05:00 UTC (18000s).
+  EXPECT_EQ(
+      18000.0, truncDayEpoch(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      18000.0, truncDayEpoch(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateTruncTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) truncates in each value's embedded
+  // zone.
+  setQueryTimeZone("America/New_York");
+  const auto truncDayEpoch =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<double>(
+            "to_unixtime(date_trunc('day', c0))",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // Midnight at -04:00 is 04:00 UTC (14400s); at -07:00 it is 07:00 UTC
+  // (25200s).
+  EXPECT_EQ(
+      14400.0, truncDayEpoch(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      25200.0, truncDayEpoch(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
 TEST_F(DateTimeFunctionsTest, dateAddDate) {
   const auto dateAdd = [&](const std::string& unit,
                            std::optional<int32_t> value,
@@ -3255,6 +3328,102 @@ TEST_F(DateTimeFunctionsTest, dateAddTimestampWithTimeZone) {
       "2023-03-12 03:30:00.000 America/Los_Angeles",
       dateAddAndCast(
           "day", -45, "2023-04-26 02:30:00.000 America/Los_Angeles"));
+}
+
+TEST_F(DateTimeFunctionsTest, dateAddTimestampWithTimezoneSessionZone) {
+  // Under the flag, date_add computes in the session zone, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto addMonthEpoch =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<double>(
+            "to_unixtime(date_add('month', 1, c0))",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 1970-02-28 23:30 UTC is Feb 28 18:30 in New York for both, so +1 month is
+  // Mar 28 18:30 EST = 1970-03-28 23:30 UTC.
+  EXPECT_EQ(
+      7'515'000.0,
+      addMonthEpoch(TimestampWithTimezone(5'095'800'000, "-04:00")));
+  EXPECT_EQ(
+      7'515'000.0,
+      addMonthEpoch(TimestampWithTimezone(5'095'800'000, "+09:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateAddTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) computes in each value's embedded
+  // zone, so the same instant lands on different months.
+  setQueryTimeZone("America/New_York");
+  const auto addMonthEpoch =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<double>(
+            "to_unixtime(date_add('month', 1, c0))",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // Feb 28 19:30 at -04:00 → Mar 28 19:30 = 1970-03-28 23:30 UTC; Mar 1 08:30
+  // at +09:00 → Apr 1 08:30 = 1970-03-31 23:30 UTC.
+  EXPECT_EQ(
+      7'515'000.0,
+      addMonthEpoch(TimestampWithTimezone(5'095'800'000, "-04:00")));
+  EXPECT_EQ(
+      7'774'200.0,
+      addMonthEpoch(TimestampWithTimezone(5'095'800'000, "+09:00")));
+}
+
+TEST_F(
+    DateTimeFunctionsTest,
+    plusMinusIntervalYearMonthTimestampWithTimezoneSessionZone) {
+  // The +/- interval operators must agree with date_add on the render zone.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto epochOf = [&](const std::string& expression) {
+    return evaluateOnce<double>(
+        fmt::format("to_unixtime({})", expression),
+        makeRowVector({
+            makeTimestampWithTimeZoneVector(5'095'800'000, "+09:00"),
+            makeNullableFlatVector<int32_t>({1}, INTERVAL_YEAR_MONTH()),
+        }));
+  };
+  // Feb 28 18:30 in New York, so +1 month is Mar 28 18:30 EST and -1 month is
+  // Jan 28 18:30 EST.
+  EXPECT_EQ(7'515'000.0, epochOf("c0 + c1"));
+  EXPECT_EQ(7'515'000.0, epochOf("c1 + c0"));
+  EXPECT_EQ(2'417'400.0, epochOf("c0 - c1"));
+}
+
+TEST_F(
+    DateTimeFunctionsTest,
+    plusMinusIntervalYearMonthTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) computes in the value's embedded
+  // zone.
+  setQueryTimeZone("America/New_York");
+  const auto epochOf = [&](const std::string& expression) {
+    return evaluateOnce<double>(
+        fmt::format("to_unixtime({})", expression),
+        makeRowVector({
+            makeTimestampWithTimeZoneVector(5'095'800'000, "+09:00"),
+            makeNullableFlatVector<int32_t>({1}, INTERVAL_YEAR_MONTH()),
+        }));
+  };
+  // Mar 1 08:30 at +09:00, so +1 month is Apr 1 08:30 and -1 month is Feb 1
+  // 08:30.
+  EXPECT_EQ(7'774'200.0, epochOf("c0 + c1"));
+  EXPECT_EQ(7'774'200.0, epochOf("c1 + c0"));
+  EXPECT_EQ(2'676'600.0, epochOf("c0 - c1"));
+}
+
+TEST_F(DateTimeFunctionsTest, dateAddHourTimestampWithTimezoneSpringForward) {
+  // Sub-day units add to the instant (the unit < kDay branch), so crossing a
+  // spring-forward transition skips the missing wall-clock hour.
+  setSessionZoneNonLegacy("America/Los_Angeles");
+  // 2024-03-10 09:30 UTC is 01:30 PST. +1 hour = 10:30 UTC, past the 02:00→
+  // 03:00 spring-forward, so it renders as 03:30 PDT (not 02:30).
+  const auto result = evaluateOnce<std::string>(
+      "date_format(date_add('hour', 1, c0), '%Y-%m-%d %H:%i')",
+      TIMESTAMP_WITH_TIME_ZONE(),
+      TimestampWithTimezone::pack(
+          TimestampWithTimezone(1'710'063'000'000, "UTC")));
+  EXPECT_EQ("2024-03-10 03:30", result);
 }
 
 TEST_F(DateTimeFunctionsTest, dateAddTime) {
@@ -3996,6 +4165,51 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezone) {
           "2023-03-11 00:00:00 America/Los_Angeles"));
 }
 
+TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezoneSessionZone) {
+  // Under the flag, date_diff computes "from" in the session zone, not the
+  // value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto diffMonth = [&](std::optional<TimestampWithTimezone> from) {
+    return evaluateOnce<int64_t>(
+        "date_diff('month', c0, from_iso8601_timestamp('1970-05-30T12:00:00Z'))",
+        TIMESTAMP_WITH_TIME_ZONE(),
+        TimestampWithTimezone::pack(from));
+  };
+  // Both "from" values are Feb 28 in New York, so both are 3 months from
+  // May 30.
+  EXPECT_EQ(3, diffMonth(TimestampWithTimezone(5'095'800'000, "-04:00")));
+  EXPECT_EQ(3, diffMonth(TimestampWithTimezone(5'095'800'000, "+09:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateDiffTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) computes "from" in each value's
+  // embedded zone, so the same instant sits in different months.
+  setQueryTimeZone("America/New_York");
+  const auto diffMonth = [&](std::optional<TimestampWithTimezone> from) {
+    return evaluateOnce<int64_t>(
+        "date_diff('month', c0, from_iso8601_timestamp('1970-05-30T12:00:00Z'))",
+        TIMESTAMP_WITH_TIME_ZONE(),
+        TimestampWithTimezone::pack(from));
+  };
+  // "from" is Feb 28 at -04:00 but Mar 1 at +09:00, so the month diff differs.
+  EXPECT_EQ(3, diffMonth(TimestampWithTimezone(5'095'800'000, "-04:00")));
+  EXPECT_EQ(2, diffMonth(TimestampWithTimezone(5'095'800'000, "+09:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateDiffDayTimestampWithTimezoneSpringForward) {
+  // Day-and-above units diff on local wall time in the session zone, so the
+  // 23-hour spring-forward day still counts as one calendar day.
+  setSessionZoneNonLegacy("America/Los_Angeles");
+  // 2024-03-10 00:00 PST (08:00 UTC) to 2024-03-11 00:00 PDT (07:00 UTC) spans
+  // 23 hours but one calendar day in Los Angeles.
+  const auto result = evaluateOnce<int64_t>(
+      "date_diff('day', c0, from_iso8601_timestamp('2024-03-11T07:00:00Z'))",
+      TIMESTAMP_WITH_TIME_ZONE(),
+      TimestampWithTimezone::pack(
+          TimestampWithTimezone(1'710'057'600'000, "UTC")));
+  EXPECT_EQ(1, result);
+}
+
 TEST_F(DateTimeFunctionsTest, parseDatetimeRoundtrip) {
   const auto parseDatetimeRoundTrip =
       [&](const std::optional<std::string>& input,
@@ -4691,6 +4905,47 @@ TEST_F(DateTimeFunctionsTest, formatDateTimeTimezone) {
           TimestampWithTimezone(0, "+00:07"), "YYYY-MM-dd HH:mm:ss"));
 }
 
+TEST_F(DateTimeFunctionsTest, formatDatetimeTimestampWithTimezoneSessionZone) {
+  // Under the flag, format_datetime uses the session zone, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto formatDatetimeTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<std::string>(
+            "format_datetime(c0, 'HH:mm')",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 08:00 UTC in New York (EST, -05:00) is 03:00 for both.
+  EXPECT_EQ(
+      "03:00",
+      formatDatetimeTsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      "03:00",
+      formatDatetimeTsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
+TEST_F(
+    DateTimeFunctionsTest,
+    formatDatetimeTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) renders in each value's embedded
+  // zone.
+  setQueryTimeZone("America/New_York");
+  const auto formatDatetimeTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<std::string>(
+            "format_datetime(c0, 'HH:mm')",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 08:00 UTC is 04:00 at -04:00 but 01:00 at -07:00.
+  EXPECT_EQ(
+      "04:00",
+      formatDatetimeTsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      "01:00",
+      formatDatetimeTsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
 TEST_F(DateTimeFunctionsTest, dateFormat) {
   const auto dateFormat = [&](std::optional<Timestamp> timestamp,
                               std::optional<std::string> format) {
@@ -4991,6 +5246,41 @@ TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
       "69-May-11 20:04:45 PM",
       dateFormatTimestampWithTimezone(
           "%y-%M-%e %T %p", TimestampWithTimezone(-20220915000, "-03:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezoneSessionZone) {
+  // Under the flag, date_format renders in the session zone, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto dateFormatTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<std::string>(
+            "date_format(c0, '%H:%i')",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 08:00 UTC rendered in New York (EST, -05:00) is 03:00 for both.
+  EXPECT_EQ(
+      "03:00", dateFormatTsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      "03:00", dateFormatTsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) renders in each value's embedded
+  // zone.
+  setQueryTimeZone("America/New_York");
+  const auto dateFormatTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<std::string>(
+            "date_format(c0, '%H:%i')",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 08:00 UTC is 04:00 at -04:00 but 01:00 at -07:00.
+  EXPECT_EQ(
+      "04:00", dateFormatTsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      "01:00", dateFormatTsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, test_week_year) {
@@ -5558,6 +5848,38 @@ TEST_F(DateTimeFunctionsTest, dateFunctionTimestampWithTimezone) {
           (-18297 * kSecondsInDay + 6 * 3'600) * 1'000, "America/Los_Angeles"));
 }
 
+TEST_F(DateTimeFunctionsTest, dateTimestampWithTimezoneSessionZone) {
+  // Under the flag, date() uses the session zone, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto dateTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<int32_t>(
+            "date(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 1970-01-02 02:00 UTC is still 1970-01-01 in New York (EST) → day 0 for
+  // both.
+  EXPECT_EQ(0, dateTsWithTz(TimestampWithTimezone(93'600'000, "-04:00")));
+  EXPECT_EQ(0, dateTsWithTz(TimestampWithTimezone(93'600'000, "+05:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) uses each value's embedded zone.
+  setQueryTimeZone("America/New_York");
+  const auto dateTsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<int32_t>(
+            "date(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 1970-01-02 02:00 UTC is still 1970-01-01 at -04:00 (day 0) but 1970-01-02
+  // at +05:00 (day 1).
+  EXPECT_EQ(0, dateTsWithTz(TimestampWithTimezone(93'600'000, "-04:00")));
+  EXPECT_EQ(1, dateTsWithTz(TimestampWithTimezone(93'600'000, "+05:00")));
+}
+
 TEST_F(DateTimeFunctionsTest, castDateForDateFunction) {
   setQueryTimeZone("America/Los_Angeles");
 
@@ -5692,6 +6014,35 @@ TEST_F(DateTimeFunctionsTest, timeZoneHour) {
   VELOX_ASSERT_THROW(
       timezone_hour("123456", "Canada/Atlantic"),
       "Unable to parse timestamp value: \"123456\", expected format is (YYYY-MM-DD HH:MM:SS[.MS])");
+}
+
+TEST_F(DateTimeFunctionsTest, timezoneHourTimestampWithTimezoneSessionZone) {
+  // Under the flag, timezone_hour reports the session offset, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto tzHour =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<int64_t>(
+            "timezone_hour(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // New York is -05:00 (EST) at this instant, so both report -5.
+  EXPECT_EQ(-5, tzHour(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(-5, tzHour(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, timezoneHourTimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) reports each value's embedded offset.
+  setQueryTimeZone("America/New_York");
+  const auto tzHour =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<int64_t>(
+            "timezone_hour(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  EXPECT_EQ(-4, tzHour(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(-7, tzHour(TimestampWithTimezone(28'800'000, "-07:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, timeZoneMinute) {
@@ -6252,6 +6603,45 @@ TEST_F(DateTimeFunctionsTest, toISO8601TimestampWithTimezone) {
   EXPECT_EQ("2024-11-01T10:00:00.000Z", toIso("2024-11-01 10:00", "UTC"));
   EXPECT_EQ("2024-11-04T10:00:45.120Z", toIso("2024-11-04 10:00:45.12", "UTC"));
   EXPECT_EQ("0022-11-01T10:00:00.000Z", toIso("22-11-01 10:00", "UTC"));
+}
+
+TEST_F(DateTimeFunctionsTest, toIso8601TimestampWithTimezoneSessionZone) {
+  // Under the flag, to_iso8601 uses the session zone, not the value's.
+  setSessionZoneNonLegacy("America/New_York");
+  const auto toIso8601TsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<std::string>(
+            "to_iso8601(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 08:00 UTC in New York (EST, -05:00) is 03:00 -05:00 for both.
+  EXPECT_EQ(
+      "1970-01-01T03:00:00.000-05:00",
+      toIso8601TsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      "1970-01-01T03:00:00.000-05:00",
+      toIso8601TsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
+}
+
+TEST_F(DateTimeFunctionsTest, toIso8601TimestampWithTimezoneLegacyDefault) {
+  // Regression guard: default (flag=true) renders in each value's embedded
+  // zone.
+  setQueryTimeZone("America/New_York");
+  const auto toIso8601TsWithTz =
+      [&](std::optional<TimestampWithTimezone> timestampWithTimezone) {
+        return evaluateOnce<std::string>(
+            "to_iso8601(c0)",
+            TIMESTAMP_WITH_TIME_ZONE(),
+            TimestampWithTimezone::pack(timestampWithTimezone));
+      };
+  // 08:00 UTC is 04:00-04:00 for one value and 01:00-07:00 for the other.
+  EXPECT_EQ(
+      "1970-01-01T04:00:00.000-04:00",
+      toIso8601TsWithTz(TimestampWithTimezone(28'800'000, "-04:00")));
+  EXPECT_EQ(
+      "1970-01-01T01:00:00.000-07:00",
+      toIso8601TsWithTz(TimestampWithTimezone(28'800'000, "-07:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, atTimezoneTest) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -6330,6 +6330,147 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
   EXPECT_EQ(at_timezone(std::nullopt, "Pacific/Fiji"), std::nullopt);
 }
 
+TEST_F(DateTimeFunctionsTest, atTimezoneV2Test) {
+  const auto toTimestamp = [&](std::optional<int64_t> timestampWithTimezone,
+                               std::optional<std::string> targetTimezone) {
+    return evaluateOnce<Timestamp>(
+        "at_timezone_v2(c0, c1)",
+        {TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()},
+        timestampWithTimezone,
+        std::move(targetTimezone));
+  };
+
+  const auto toTimestampWithTimezone =
+      [&](std::optional<Timestamp> timestamp,
+          std::optional<std::string> targetTimezone) {
+        return evaluateOnce<int64_t>(
+            "at_timezone_v2(c0, c1)",
+            {TIMESTAMP(), VARCHAR()},
+            timestamp,
+            std::move(targetTimezone));
+      };
+
+  // 2024-01-01 08:00 UTC is 2024-01-01 00:00 in Los Angeles (PST, -08:00).
+  const auto winterInstant = parseTimestamp("2024-01-01 08:00:00").toMillis();
+  EXPECT_EQ(
+      toTimestamp(
+          pack(winterInstant, tz::getTimeZoneID("UTC")), "America/Los_Angeles"),
+      parseTimestamp("2024-01-01 00:00:00"));
+  // The source zone tagged on the input is ignored; only the UTC instant
+  // matters.
+  EXPECT_EQ(
+      toTimestamp(
+          pack(winterInstant, tz::getTimeZoneID("America/New_York")),
+          "America/Los_Angeles"),
+      parseTimestamp("2024-01-01 00:00:00"));
+
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-01-01 00:00:00"), "America/Los_Angeles"),
+      pack(winterInstant, tz::getTimeZoneID("America/Los_Angeles")));
+
+  const auto original = parseTimestamp("2024-06-15 12:34:56");
+  EXPECT_EQ(
+      toTimestamp(
+          toTimestampWithTimezone(original, "America/Los_Angeles").value(),
+          "America/Los_Angeles"),
+      original);
+
+  // Daylight saving shifts the Los Angeles offset to -07:00 in summer, so
+  // 2024-07-01 08:00 UTC is 2024-07-01 01:00 local.
+  EXPECT_EQ(
+      toTimestamp(
+          pack(
+              parseTimestamp("2024-07-01 08:00:00").toMillis(),
+              tz::getTimeZoneID("UTC")),
+          "America/Los_Angeles"),
+      parseTimestamp("2024-07-01 01:00:00"));
+
+  // The reverse overload also honors summer DST: 2024-07-01 01:00 local in Los
+  // Angeles (PDT, -07:00) is 2024-07-01 08:00 UTC.
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-07-01 01:00:00"), "America/Los_Angeles"),
+      pack(
+          parseTimestamp("2024-07-01 08:00:00").toMillis(),
+          tz::getTimeZoneID("America/Los_Angeles")));
+
+  // A null timestamp or null zone propagates as null in both overloads.
+  EXPECT_EQ(toTimestamp(std::nullopt, "America/Los_Angeles"), std::nullopt);
+  EXPECT_EQ(
+      toTimestamp(pack(winterInstant, tz::getTimeZoneID("UTC")), std::nullopt),
+      std::nullopt);
+  EXPECT_EQ(
+      toTimestampWithTimezone(std::nullopt, "America/Los_Angeles"),
+      std::nullopt);
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-01-01 00:00:00"), std::nullopt),
+      std::nullopt);
+
+  // A non-constant zone column exercises the per-row zone lookup: the same UTC
+  // instant maps to 00:00 in Los Angeles (PST, -08:00) and 03:00 in New York
+  // (EST, -05:00).
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(
+          {pack(winterInstant, tz::getTimeZoneID("UTC")),
+           pack(winterInstant, tz::getTimeZoneID("UTC"))},
+          TIMESTAMP_WITH_TIME_ZONE()),
+      makeFlatVector<std::string>({"America/Los_Angeles", "America/New_York"}),
+  });
+  auto result = evaluate("at_timezone_v2(c0, c1)", data);
+  auto expected = makeFlatVector<Timestamp>({
+      parseTimestamp("2024-01-01 00:00:00"),
+      parseTimestamp("2024-01-01 03:00:00"),
+  });
+  assertEqualVectors(expected, result);
+
+  // A wall clock that falls in the spring-forward gap does not exist in the
+  // zone, so the conversion fails. 2024-03-10 02:30 is skipped in Los Angeles.
+  VELOX_ASSERT_THROW(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-03-10 02:30:00"), "America/Los_Angeles"),
+      "is in a gap between");
+
+  // A wall clock in the fall-back overlap is ambiguous; Velox resolves it to
+  // the earliest instant (PDT, -07:00), so 2024-11-03 01:30 local is
+  // 2024-11-03 08:30 UTC.
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-11-03 01:30:00"), "America/Los_Angeles"),
+      pack(
+          parseTimestamp("2024-11-03 08:30:00").toMillis(),
+          tz::getTimeZoneID("America/Los_Angeles")));
+
+  // An unrecognized target zone throws on both the constant and per-row paths.
+  VELOX_ASSERT_THROW(
+      toTimestamp(pack(winterInstant, tz::getTimeZoneID("UTC")), "Not/AZone"),
+      "Unknown time zone");
+  auto invalidZoneData = makeRowVector({
+      makeFlatVector<int64_t>(
+          {pack(winterInstant, tz::getTimeZoneID("UTC"))},
+          TIMESTAMP_WITH_TIME_ZONE()),
+      makeFlatVector<std::string>({"Not/AZone"}),
+  });
+  VELOX_ASSERT_THROW(
+      evaluate("at_timezone_v2(c0, c1)", invalidZoneData), "Unknown time zone");
+}
+
+TEST_F(DateTimeFunctionsTest, atTimezoneV2TimeWithTimezoneTest) {
+  // TIME WITH TIME ZONE shares at_timezone's implementation, so this guards the
+  // registration under the v2 name rather than the conversion itself.
+  const auto makeTimeWithTz = [](const std::string& time) -> int64_t {
+    return util::fromTimeWithTimezoneString(time.data(), time.size()).value();
+  };
+  EXPECT_EQ(
+      evaluateOnce<int64_t>(
+          "at_timezone_v2(c0, c1)",
+          {TIME_WITH_TIME_ZONE(), VARCHAR()},
+          std::optional<int64_t>(makeTimeWithTz("10:30:00+05:30")),
+          std::optional<std::string>("+08:00")),
+      makeTimeWithTz("13:00:00+08:00"));
+}
+
 TEST_F(DateTimeFunctionsTest, atTimezoneTimeWithTimezoneTest) {
   using namespace facebook::velox::util;
 


### PR DESCRIPTION
Summary:

Two `TIMESTAMP WITH TIME ZONE` values that are the same instant with different stored zones compare equal, but the functions that read them use each value's stored zone, so they return different results for equal inputs. That breaks the assumption that equal values are interchangeable and lets the optimizer produce wrong results.

The `legacy_timestamp_with_timezone` config, declared by the preceding commit, gates the change: when false, these functions render the UTC instant in the session zone, so equal values render equally. With the session zone in New York:

    hour(a), hour(b)   -- a, b same instant, stored zones -04:00 and -07:00

returns 3, 3 under the flag instead of 4, 1. The default is true, so this commit changes nothing on its own.

Every TIMESTAMP WITH TIME ZONE function resolves its rendering zone through one helper, `renderZone`; the flag switches what that helper returns. The session zone is read from `session_timezone` (UTC when unset), independent of `adjust_timestamp_to_session_timezone`.

Differential Revision: D112635465


