### PR TITLE
fix(io_uring): Handle ENOMEM from the availability probe

### DIFF
--- a/velox/common/file/IoUringReader.cpp
+++ b/velox/common/file/IoUringReader.cpp
@@ -275,7 +275,17 @@ IoUringReader::Stats getIoUringReaderStats(uint64_t& numReaders) {
 #if FOLLY_HAS_LIBURING
 
 bool IoUringReader::available() {
-  return folly::IoUringBackend::isAvailable();
+  // folly::IoUringBackend::isAvailable() reports unavailability by returning
+  // false, except when ring setup fails with ENOMEM: that path throws
+  // std::runtime_error instead. ENOMEM here usually means the host ran out of
+  // RLIMIT_MEMLOCK rather than out of memory, which is a transient, host-wide
+  // condition. Report it as unavailable so callers can fall back.
+  try {
+    return folly::IoUringBackend::isAvailable();
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "io_uring availability probe failed: " << e.what();
+    return false;
+  }
 }
 
 #else

--- a/velox/common/file/tests/LocalFileTest.cpp
+++ b/velox/common/file/tests/LocalFileTest.cpp
@@ -576,6 +576,10 @@ class LocalFileIoUringTest : public ::testing::Test {
   }
 
   void SetUp() override {
+    if (!IoUringReader::available()) {
+      GTEST_SKIP() << "io_uring is unavailable";
+    }
+
     ThreadLocalIoUringReader::testingClear();
 
     IoUringReader::Options options;


### PR DESCRIPTION
Summary:
Opening a local file with `useIoUring` aborted the process on hosts that are out of io_uring resources. The `LocalReadFile` constructor terminated with:

    terminate called after throwing an instance of 'std::runtime_error'
      what():  io_uring_queue_init error out of memory

This turns up on busy machines, where the underlying failure is `RLIMIT_MEMLOCK` exhaustion rather than actual memory pressure.

`IoUringReader::available()` forwarded straight to `folly::IoUringBackend::isAvailable()`. That function reports unavailability by returning false in every case except ENOMEM, which instead throws `std::runtime_error` — not something callers expect from a `bool` predicate. The probe now catches the exception and reports unavailable, so callers fall back or fail with a regular Velox error instead of terminating.

`LocalFileIoUringTest` also gains the availability guard `IoUringReaderTest` already had, so its cases skip rather than fail on a host without usable io_uring.

Differential Revision: D115091581


