### PR TITLE
feat(exchange): Add TransportKind::kMaterialized and TransportOptions to PartitionedOutput (#18425)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3440,6 +3440,7 @@ PartitionedOutputNode::PartitionedOutputNode(
     RowTypePtr outputType,
     std::string serdeKind,
     std::string transportKind,
+    std::string transportOptions,
     PlanNodePtr source)
     : PlanNode(id),
       kind_(kind),
@@ -3450,6 +3451,7 @@ PartitionedOutputNode::PartitionedOutputNode(
       partitionFunctionSpec_(std::move(partitionFunctionSpec)),
       serdeKind_(std::move(serdeKind)),
       transportKind_(std::move(transportKind)),
+      transportOptions_(std::move(transportOptions)),
       outputType_(std::move(outputType)) {
   VELOX_USER_CHECK_GT(numPartitions_, 0);
   if (numPartitions_ == 1) {
@@ -3603,6 +3605,7 @@ folly::dynamic PartitionedOutputNode::serialize() const {
   obj["partitionFunctionSpec"] = partitionFunctionSpec_->serialize();
   obj["serdeKind"] = serdeKind_;
   obj["transportKind"] = transportKind_;
+  obj["transportOptions"] = transportOptions_;
   obj["outputType"] = outputType_->serialize();
   return obj;
 }
@@ -3629,6 +3632,7 @@ PlanNodePtr PartitionedOutputNode::create(
       obj["serdeKind"].asString(),
       obj.getDefault("transportKind", std::string{TransportKind::kInMemory})
           .asString(),
+      obj.getDefault("transportOptions", "").asString(),
       deserializeSingleSource(obj, context));
 }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -45,6 +45,9 @@ struct TransportKind {
   /// delivered is decided by the layer above -- read locally, fetched over
   /// HTTP, or written to a shuffle service.
   static constexpr std::string_view kInMemory{"in-memory"};
+  /// Materialized output buffering backed by an application-provided durable
+  /// exchange implementation.
+  static constexpr std::string_view kMaterialized{"materialized"};
   /// UCX-based RDMA exchange for high-bandwidth GPU transfers between workers.
   static constexpr std::string_view kUcx{"UCX"};
   /// Deprecated source-compat alias for kInMemory; prefer kInMemory.
@@ -2726,7 +2729,32 @@ class PartitionedOutputNode : public PlanNode {
       RowTypePtr outputType,
       std::string serdeKind,
       std::string transportKind,
+      std::string transportOptions,
       PlanNodePtr source);
+
+  PartitionedOutputNode(
+      const PlanNodeId& id,
+      Kind kind,
+      const std::vector<TypedExprPtr>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      PartitionFunctionSpecPtr partitionFunctionSpec,
+      RowTypePtr outputType,
+      std::string serdeKind,
+      std::string transportKind,
+      PlanNodePtr source)
+      : PartitionedOutputNode(
+            id,
+            kind,
+            keys,
+            numPartitions,
+            replicateNullsAndAny,
+            std::move(partitionFunctionSpec),
+            std::move(outputType),
+            std::move(serdeKind),
+            std::move(transportKind),
+            {},
+            std::move(source)) {}
 
   // Backward-compatible ctor without an explicit transport; defaults to the
   // in-memory transport. Prefer the ctor above.
@@ -2831,6 +2859,7 @@ class PartitionedOutputNode : public PlanNode {
       outputType_ = other.outputType();
       serdeKind_ = other.serdeKind();
       transportKind_ = other.transportKind();
+      transportOptions_ = other.transportOptions();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
     }
@@ -2880,6 +2909,11 @@ class PartitionedOutputNode : public PlanNode {
       return *this;
     }
 
+    Builder& transportOptions(std::string transportOptions) {
+      transportOptions_ = std::move(transportOptions);
+      return *this;
+    }
+
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);
       return *this;
@@ -2921,6 +2955,7 @@ class PartitionedOutputNode : public PlanNode {
           outputType_.value(),
           serdeKind_.value(),
           transportKind_.value(),
+          transportOptions_.value_or(std::string{}),
           source_.value());
     }
 
@@ -2934,6 +2969,7 @@ class PartitionedOutputNode : public PlanNode {
     std::optional<RowTypePtr> outputType_;
     std::optional<std::string> serdeKind_;
     std::optional<std::string> transportKind_;
+    std::optional<std::string> transportOptions_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -2985,6 +3021,11 @@ class PartitionedOutputNode : public PlanNode {
     return transportKind_;
   }
 
+  /// Opaque configuration interpreted by the selected output transport.
+  const std::string& transportOptions() const {
+    return transportOptions_;
+  }
+
   /// Returns true if an arbitrary row and all rows with null keys must be
   /// replicated to all destinations. This is used to ensure correct results
   /// for anti-join which requires all nodes to know whether combined build
@@ -3021,6 +3062,7 @@ class PartitionedOutputNode : public PlanNode {
   const PartitionFunctionSpecPtr partitionFunctionSpec_;
   const std::string serdeKind_;
   const std::string transportKind_;
+  const std::string transportOptions_;
   const RowTypePtr outputType_;
 };
 

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -614,6 +614,7 @@ TEST_F(PlanNodeBuilderTest, partitionedOutputNode) {
       std::make_shared<GatherPartitionFunctionSpec>();
   const RowTypePtr outputType = ROW({"c0"}, {BIGINT()});
   const auto serdeKind = "Presto";
+  const std::string transportOptions = R"({"exchangeId":"test"})";
 
   const auto verify =
       [&](const std::shared_ptr<const PartitionedOutputNode>& node) {
@@ -624,6 +625,7 @@ TEST_F(PlanNodeBuilderTest, partitionedOutputNode) {
         EXPECT_EQ(node->isReplicateNullsAndAny(), replicateNullsAndAny);
         EXPECT_EQ(node->outputType(), outputType);
         EXPECT_EQ(node->serdeKind(), serdeKind);
+        EXPECT_EQ(node->transportOptions(), transportOptions);
         EXPECT_EQ(node->partitionFunctionSpecPtr(), partitionFunctionSpec);
         EXPECT_EQ(node->sources(), std::vector<PlanNodePtr>{source_});
       };
@@ -638,12 +640,15 @@ TEST_F(PlanNodeBuilderTest, partitionedOutputNode) {
                         .outputType(outputType)
                         .serdeKind(serdeKind)
                         .transportKind(std::string{TransportKind::kInMemory})
+                        .transportOptions(transportOptions)
                         .source(source_)
                         .build();
   verify(node);
 
   const auto node2 = PartitionedOutputNode::Builder(*node).build();
   verify(node2);
+
+  EXPECT_EQ(node->serialize()["transportOptions"], transportOptions);
 }
 
 TEST_F(PlanNodeBuilderTest, hashJoinNode) {

--- a/velox/exec/DefaultOutputBufferManager.cpp
+++ b/velox/exec/DefaultOutputBufferManager.cpp
@@ -134,7 +134,8 @@ void DefaultOutputBufferManager::initializeTask(
     std::shared_ptr<Task> task,
     core::PartitionedOutputNode::Kind kind,
     int numDestinations,
-    int numDrivers) {
+    int numDrivers,
+    const std::string& /*transportOptions*/) {
   const auto& taskId = task->taskId();
 
   buffers_.withLock([&](auto& buffers) {

--- a/velox/exec/DefaultOutputBufferManager.h
+++ b/velox/exec/DefaultOutputBufferManager.h
@@ -48,7 +48,8 @@ class DefaultOutputBufferManager : public OutputBufferManager {
       std::shared_ptr<Task> task,
       core::PartitionedOutputNode::Kind kind,
       int numDestinations,
-      int numDrivers) override;
+      int numDrivers,
+      const std::string& transportOptions = {}) override;
 
   /// Updates the number of destination buffers. Returns true if the buffer
   /// exists for a given taskId, else returns false.

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -74,12 +74,14 @@ class OutputBufferManager {
   /// initial destination-buffer count (fixed for kPartitioned, a starting point
   /// updateOutputBuffers() grows for broadcast / arbitrary); 'numDrivers' is
   /// the producing-driver count whose completion marks the output done (see
-  /// updateNumDrivers()).
+  /// updateNumDrivers()). 'transportOptions' is opaque configuration from the
+  /// PartitionedOutputNode and is interpreted only by the selected transport.
   virtual void initializeTask(
       std::shared_ptr<Task> task,
       core::PartitionedOutputNode::Kind kind,
       int numDestinations,
-      int numDrivers) = 0;
+      int numDrivers,
+      const std::string& transportOptions = {}) = 0;
 
   /// Publishes the destination-buffer count as consumers register, finalizing
   /// it when 'noMoreBuffers' is true. Returns false if the task has no output

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1337,7 +1337,8 @@ void Task::initializePartitionOutput() {
         shared_from_this(),
         partitionedOutputNode->kind(),
         partitionedOutputNode->numPartitions(),
-        numOutputDrivers);
+        numOutputDrivers,
+        partitionedOutputNode->transportOptions());
   }
 }
 

--- a/velox/exec/tests/OutputTransportRegistryTest.cpp
+++ b/velox/exec/tests/OutputTransportRegistryTest.cpp
@@ -47,7 +47,8 @@ class MockOutputBufferManager : public OutputBufferManager {
       std::shared_ptr<Task> /*task*/,
       core::PartitionedOutputNode::Kind /*kind*/,
       int /*numDestinations*/,
-      int /*numDrivers*/) override {
+      int /*numDrivers*/,
+      const std::string& /*transportOptions*/) override {
     ++initCount;
   }
 


### PR DESCRIPTION
Summary:

## Summary
2 Changes (building blocks) to support materialized exchange semantics

[1]  `TransportKind::kMaterialized`

This new kind represents materialized exchange and lets velox users specify Transport factory to supply materialized exchange operators and output buffers

[2] `TransportOptions` 

Flexible per-transport configuration field on `PartitionedOutputNode`.
Carries immutable configuration owned by that transport. 
Both fields are serialized with the plan and sent to each worker.


### Interactions & Usage

During task initialization, Velox resolves `transportKind` through `OutputTransportRegistry` and forwards `transportOptions` unchanged to `OutputBufferManager::initializeTask`. 
The selected manager interprets the options and creates its per-task buffer and transport state. The default in-memory manager ignores empty options.


```
// Startup registration
auto manager = std::make_shared<MaterializedOutputBufferManager>()

OutputTransportRegistry::global().insert(
  std::string{TransportKind::kMaterialized},
  manager->transportEntry(),
  /*overwrite=*/false);
```

```
// Coordinator scheduling time - exchange creation
// Annotate PartitionedOutputNode
node.transportKind = "materialized";
node.transportOptions = {rootDir, exchangeId};
```
```
// Worker - Task creation initializes output buffer / manager and
// passes down transportOptions to configure the
// materialized exchange writer/sink 
manager.initializeTask(..., node.transportOptions);
```

Differential Revision: D115094736


