### PR TITLE
fix: Always initialize shell for uv tool

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -437,17 +437,15 @@ function install_hdfs_deps {
 }
 
 function install_uv {
+  export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
+  export UV_INSTALL_DIR=${UV_INSTALL_DIR:-"$UV_TOOL_BIN_DIR"}
   if command -v uv >/dev/null 2>&1; then
     echo "uv is already installed."
   else
     echo "Installing uv..."
-
-    export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
-    export UV_INSTALL_DIR=${UV_INSTALL_DIR:-"$UV_TOOL_BIN_DIR"}
-
     curl -LsSf https://astral.sh/uv/install.sh | sh
-    uv tool update-shell
   fi
+  uv tool update-shell
 }
 
 function uv_install {


### PR DESCRIPTION
Summary:

Not only when it is installed

Test Plan:

Run

./scripts/setup-ubuntu.sh twice in a row in a container where cmake is not available

Reviewers: adutta

Subscribers:

Tasks:

Tags: