### PR TITLE
refactor(vector): Forbid unloaded lazy ARRAY/MAP children (#18429)

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -477,14 +477,14 @@ BaseVector* RowVector::loadedVector() {
       hasLazy = true;
     }
   }
-  containsLazyNotLoaded_.store(hasLazy ? 1 : 0, std::memory_order_relaxed);
+  containsLazyNotLoaded_ = hasLazy ? 1 : 0;
   childrenLoaded_ = true;
   return this;
 }
 
 void RowVector::invalidateContainsLazyNotLoaded() const {
   childrenLoaded_ = false;
-  containsLazyNotLoaded_.store(-1, std::memory_order_relaxed);
+  containsLazyNotLoaded_ = -1;
 }
 
 void RowVector::computeContainsLazyNotLoaded() const {
@@ -495,14 +495,14 @@ void RowVector::computeContainsLazyNotLoaded() const {
       break;
     }
   }
-  containsLazyNotLoaded_.store(result, std::memory_order_relaxed);
+  containsLazyNotLoaded_ = result;
 }
 
 bool RowVector::containsLazyNotLoaded() const {
-  if (containsLazyNotLoaded_.load(std::memory_order_relaxed) < 0) {
+  if (containsLazyNotLoaded_ < 0) {
     computeContainsLazyNotLoaded();
   }
-  return containsLazyNotLoaded_.load(std::memory_order_relaxed) == 1;
+  return containsLazyNotLoaded_ == 1;
 }
 
 void ArrayVectorBase::copyRangesImpl(

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <atomic>
-
 #include <folly/container/F14Map.h>
 #include <folly/hash/Hash.h>
 #include <glog/logging.h>
@@ -225,8 +223,6 @@ class RowVector : public BaseVector {
   /// Whether any child is a lazy vector that has not been loaded yet. The
   /// result is cached and computed lazily on first access to avoid scanning
   /// children when the flag is never read (common for intermediate RowVectors).
-  /// Safe to call concurrently even when the cached flag is dirty; see
-  /// containsLazyNotLoaded_ for why it is atomic.
   bool containsLazyNotLoaded() const;
 
   /// Invalidates the cached containsLazyNotLoaded flag, causing it to be
@@ -311,23 +307,11 @@ class RowVector : public BaseVector {
   // recomputation on next access), 0 means false, 1 means true. Computed lazily
   // on first read by computeContainsLazyNotLoaded().
   //
-  // Atomic because that first-read recomputation can run concurrently on the
-  // same vector. isLazyNotLoaded() does not recurse into ARRAY/MAP children, so
-  // a RowVector nested inside an ARRAY/MAP keeps a dirty flag that is never
-  // evaluated at the ARRAY/MAP layer; a later code path can then read it from
-  // several driver threads at once when the same base vector is shared (e.g.
-  // MinMaxByNTest.groupByRow with ARRAY<ROW<..>> partitioned via
-  // LocalPartition). The race is benign -- there are no real lazy children so
-  // it always resolves to 0 -- but TSAN flags the unsynchronized read+write, so
-  // we load/store with memory_order_relaxed, which is free on x86.
-  //
-  // The cleaner fix is to forbid unloaded lazy ARRAY/MAP children at
-  // construction (a VELOX_CHECK in the ArrayVector/MapVector constructors).
-  // That barrier runs on the single constructing thread and would populate the
-  // nested Row's flag eagerly, removing the need for this to be atomic. We
-  // cannot add it yet: some internal code points still build ARRAY/MAP over
-  // lazy children. Until those callers are fixed the flag stays atomic.
-  mutable std::atomic<int8_t> containsLazyNotLoaded_{-1};
+  // Not atomic: the ArrayVector and MapVector constructors reject unloaded lazy
+  // children, so a RowVector nested inside an ARRAY/MAP has its flag resolved
+  // on the single constructing thread before the ARRAY/MAP can be shared across
+  // driver threads.
+  mutable int8_t containsLazyNotLoaded_{-1};
 
   // Flag to indicate all children has been loaded (non-recursively).  Used to
   // optimize loadedVector calls.  If this is true, we don't recurse into
@@ -503,6 +487,9 @@ class ArrayVector : public ArrayVectorBase {
         "Unexpected element type: {}. Expected: {}",
         elements_->type()->toString(),
         type->childAt(0)->toString());
+    VELOX_CHECK(
+        !isLazyNotLoaded(*elements_),
+        "Cannot construct ArrayVector with an unloaded lazy vector as elements.");
   }
 
   bool containsNullAt(vector_size_t idx) const override;
@@ -634,6 +621,12 @@ class MapVector : public ArrayVectorBase {
         "Unexpected value type: {}. Expected: {}",
         values_->type()->toString(),
         type->childAt(1)->toString());
+    VELOX_CHECK(
+        !isLazyNotLoaded(*keys_),
+        "Cannot construct MapVector with an unloaded lazy vector as keys.");
+    VELOX_CHECK(
+        !isLazyNotLoaded(*values_),
+        "Cannot construct MapVector with an unloaded lazy vector as values.");
   }
 
   ~MapVector() override = default;

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/ConcurrentRuntimeStatWriter.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/RawVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -747,6 +748,153 @@ TEST_F(LazyVectorTest, containsLazyNotLoadedLazyEvaluation) {
   rowWithLazy->childAt(1) = lazy2;
   rowWithLazy->invalidateContainsLazyNotLoaded();
   EXPECT_TRUE(rowWithLazy->containsLazyNotLoaded());
+}
+
+TEST_F(LazyVectorTest, arrayRejectsLazyElements) {
+  constexpr vector_size_t size = 10;
+
+  auto offsets = allocateOffsets(1, pool_.get());
+  auto sizes = allocateSizes(1, pool_.get());
+  sizes->asMutable<vector_size_t>()[0] = size;
+
+  // Lazy flat vector as elements.
+  auto lazyFlat = std::make_shared<LazyVector>(
+      pool_.get(),
+      INTEGER(),
+      size,
+      std::make_unique<SimpleVectorLoader>([&](RowSet) {
+        return makeFlatVector<int32_t>(size, folly::identity);
+      }));
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(), ARRAY(INTEGER()), nullptr, 1, offsets, sizes, lazyFlat),
+      "Cannot construct ArrayVector with an unloaded lazy vector as elements.");
+
+  // A RowVector with a lazy child is also rejected, since isLazyNotLoaded()
+  // recurses into ROW.
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  auto rowWithLazyChild = makeRowVector(
+      {makeFlatVector<int32_t>(size, folly::identity),
+       vectorMaker_.lazyFlatVector<int32_t>(
+           size, [](vector_size_t row) { return row; })});
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(),
+          ARRAY(rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          rowWithLazyChild),
+      "Cannot construct ArrayVector with an unloaded lazy vector as elements.");
+
+  // After loading, construction succeeds.
+  lazyFlat->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(), ARRAY(INTEGER()), nullptr, 1, offsets, sizes, lazyFlat));
+
+  rowWithLazyChild->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(),
+          ARRAY(rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          rowWithLazyChild));
+}
+
+TEST_F(LazyVectorTest, mapRejectsLazyKeysOrValues) {
+  constexpr vector_size_t size = 10;
+
+  auto offsets = allocateOffsets(1, pool_.get());
+  auto sizes = allocateSizes(1, pool_.get());
+  sizes->asMutable<vector_size_t>()[0] = size;
+  auto flatIntegers = makeFlatVector<int32_t>(size, folly::identity);
+
+  auto makeLazyFlat = [&]() {
+    return std::make_shared<LazyVector>(
+        pool_.get(),
+        INTEGER(),
+        size,
+        std::make_unique<SimpleVectorLoader>([&](RowSet) {
+          return makeFlatVector<int32_t>(size, folly::identity);
+        }));
+  };
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), INTEGER()),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          makeLazyFlat(),
+          flatIntegers),
+      "Cannot construct MapVector with an unloaded lazy vector as keys.");
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), INTEGER()),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          makeLazyFlat()),
+      "Cannot construct MapVector with an unloaded lazy vector as values.");
+
+  // A RowVector with a lazy child is also rejected, since isLazyNotLoaded()
+  // recurses into ROW.
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  auto rowWithLazyChild = makeRowVector(
+      {makeFlatVector<int32_t>(size, folly::identity),
+       vectorMaker_.lazyFlatVector<int32_t>(
+           size, [](vector_size_t row) { return row; })});
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          rowWithLazyChild),
+      "Cannot construct MapVector with an unloaded lazy vector as values.");
+
+  // After loading, construction succeeds.
+  auto lazyFlat = makeLazyFlat();
+  lazyFlat->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), INTEGER()),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          lazyFlat));
+
+  rowWithLazyChild->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          rowWithLazyChild));
 }
 
 } // namespace

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/RawVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -746,6 +747,153 @@ TEST_F(LazyVectorTest, containsLazyNotLoadedLazyEvaluation) {
   rowWithLazy->childAt(1) = lazy2;
   rowWithLazy->invalidateContainsLazyNotLoaded();
   EXPECT_TRUE(rowWithLazy->containsLazyNotLoaded());
+}
+
+TEST_F(LazyVectorTest, arrayRejectsLazyElements) {
+  constexpr vector_size_t size = 10;
+
+  auto offsets = allocateOffsets(1, pool_.get());
+  auto sizes = allocateSizes(1, pool_.get());
+  sizes->asMutable<vector_size_t>()[0] = size;
+
+  // Lazy flat vector as elements.
+  auto lazyFlat = std::make_shared<LazyVector>(
+      pool_.get(),
+      INTEGER(),
+      size,
+      std::make_unique<SimpleVectorLoader>([&](RowSet) {
+        return makeFlatVector<int32_t>(size, folly::identity);
+      }));
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(), ARRAY(INTEGER()), nullptr, 1, offsets, sizes, lazyFlat),
+      "Cannot construct ArrayVector with an unloaded lazy vector as elements.");
+
+  // A RowVector with a lazy child is also rejected, since isLazyNotLoaded()
+  // recurses into ROW.
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  auto rowWithLazyChild = makeRowVector(
+      {makeFlatVector<int32_t>(size, folly::identity),
+       vectorMaker_.lazyFlatVector<int32_t>(
+           size, [](vector_size_t row) { return row; })});
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(),
+          ARRAY(rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          rowWithLazyChild),
+      "Cannot construct ArrayVector with an unloaded lazy vector as elements.");
+
+  // After loading, construction succeeds.
+  lazyFlat->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(), ARRAY(INTEGER()), nullptr, 1, offsets, sizes, lazyFlat));
+
+  rowWithLazyChild->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<ArrayVector>(
+          pool_.get(),
+          ARRAY(rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          rowWithLazyChild));
+}
+
+TEST_F(LazyVectorTest, mapRejectsLazyKeysOrValues) {
+  constexpr vector_size_t size = 10;
+
+  auto offsets = allocateOffsets(1, pool_.get());
+  auto sizes = allocateSizes(1, pool_.get());
+  sizes->asMutable<vector_size_t>()[0] = size;
+  auto flatIntegers = makeFlatVector<int32_t>(size, folly::identity);
+
+  auto makeLazyFlat = [&]() {
+    return std::make_shared<LazyVector>(
+        pool_.get(),
+        INTEGER(),
+        size,
+        std::make_unique<SimpleVectorLoader>([&](RowSet) {
+          return makeFlatVector<int32_t>(size, folly::identity);
+        }));
+  };
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), INTEGER()),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          makeLazyFlat(),
+          flatIntegers),
+      "Cannot construct MapVector with an unloaded lazy vector as keys.");
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), INTEGER()),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          makeLazyFlat()),
+      "Cannot construct MapVector with an unloaded lazy vector as values.");
+
+  // A RowVector with a lazy child is also rejected, since isLazyNotLoaded()
+  // recurses into ROW.
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  auto rowWithLazyChild = makeRowVector(
+      {makeFlatVector<int32_t>(size, folly::identity),
+       vectorMaker_.lazyFlatVector<int32_t>(
+           size, [](vector_size_t row) { return row; })});
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          rowWithLazyChild),
+      "Cannot construct MapVector with an unloaded lazy vector as values.");
+
+  // After loading, construction succeeds.
+  auto lazyFlat = makeLazyFlat();
+  lazyFlat->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), INTEGER()),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          lazyFlat));
+
+  rowWithLazyChild->loadedVector();
+  EXPECT_NO_THROW(
+      std::make_shared<MapVector>(
+          pool_.get(),
+          MAP(INTEGER(), rowType),
+          nullptr,
+          1,
+          offsets,
+          sizes,
+          flatIntegers,
+          rowWithLazyChild));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Constructing an `ArrayVector` or `MapVector` over an unloaded lazy vector now throws:

    Cannot construct ArrayVector with an unloaded lazy vector as elements.

This shape was never supported. `isLazyNotLoaded()` does not recurse into ARRAY or MAP, so a lazy vector nested under one is invisible to every laziness check in the engine and consumers read it as if it were loaded. The check also rejects an `ARRAY<ROW<...>>` whose row has a lazy child, because `isLazyNotLoaded()` does recurse into ROW.

The check runs on the single thread that constructs the vector, and it resolves the nested `RowVector`'s `containsLazyNotLoaded` flag there. That flag can therefore go back to a plain `int8_t`. It was `std::atomic<int8_t>` only because a dirty flag under an ARRAY/MAP could be computed by several driver threads at once.

Reviewed By: Yuhta

Differential Revision: D114919966


