### PR TITLE
feat(fuzzer): Add regression fuzzer using LocalRunnerService

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -258,6 +258,7 @@ jobs:
             -DVELOX_BUILD_SHARED=ON
             -DVELOX_BUILD_PYTHON_PACKAGE=ON
             -DVELOX_PYTHON_LEGACY_ONLY=ON
+            -DVELOX_ENABLE_LOCAL_RUNNER_SERVICE=ON
             ${{ inputs.extraCMakeFlags }}
         run: |
           make python-venv
@@ -452,6 +453,108 @@ jobs:
           path: velox/_build/debug/lib/libvelox.so
           retention-days: ${{ env.RETENTION }}
 
+  compile-baseline-local-runner:
+    name: Build Baseline LocalRunnerService
+    if: ${{ github.repository == 'facebookincubator/velox' }}
+    runs-on: 32-core-ubuntu
+    container: ghcr.io/facebookincubator/velox-dev:centos9
+    timeout-minutes: 120
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      NUM_THREADS: ${{ inputs.numThreads || 32 }}
+      MAX_HIGH_MEM_JOBS: ${{ inputs.maxHighMemJobs || 8 }}
+      MAX_LINK_JOBS: ${{ inputs.maxLinkJobs || 6 }}
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: velox_main
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Get merge base with main
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_REF: ${{ inputs.ref || 'main' }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+        id: get-merge-base
+        run: |
+          source .github/scripts/gh-api-retry.sh
+          if [ '${{ github.event_name == 'push' }}' == "true" ]; then
+            head_main=$(gh_api -q '.parents.[0].sha' '/repos/facebookincubator/velox/commits/${{ github.sha }}')
+          elif [ '${{ github.event_name == 'pull_request' }}' == "true" ]; then
+            head_main=$(gh_api -q '.merge_base_commit.sha' \
+              /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
+            )
+          else
+            head_main=$INPUT_REF
+          fi
+          echo "Determined SHA: $head_main"
+          echo "head_main=$head_main" >> $GITHUB_OUTPUT
+
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-baseline-local-runner-centos
+
+      - name: Fix git permissions
+        working-directory: ${{ github.workspace }}
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox_main
+
+      - name: Ensure Stash Dirs Exists
+        working-directory: ${{ github.workspace }}
+        run: mkdir -p '$CCACHE_DIR'
+
+      - name: Checkout Main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.get-merge-base.outputs.head_main || 'main' }}
+          path: velox_main
+          persist-credentials: false
+
+      - name: Zero Ccache Statistics
+        run: ccache -sz
+
+      - name: Build Baseline LocalRunnerService
+        env:
+          EXTRA_CMAKE_FLAGS: >
+            -DVELOX_ENABLE_ARROW=ON
+            -DVELOX_ENABLE_GEO=ON
+            -DVELOX_ENABLE_REMOTE_FUNCTIONS=ON
+            -DVELOX_ENABLE_LOCAL_RUNNER_SERVICE=ON
+            ${{ inputs.extraCMakeFlags }}
+        run: |
+          make cmake BUILD_DIR=debug BUILD_TYPE=Debug
+          cmake --build _build/debug -j ${NUM_THREADS} --target \
+            velox_local_runner_service_runner
+
+      - name: Ccache after
+        run: ccache -s
+
+      - name: Save ccache
+        continue-on-error: true
+        if: ${{ github.event_name != 'schedule' }}
+        uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-baseline-local-runner-centos
+
+      - name: Upload baseline local runner service
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: baseline_local_runner_service_runner
+          path: velox_main/_build/debug/velox/exec/fuzzer/velox_local_runner_service_runner
+          retention-days: ${{ env.RETENTION }}
+
   presto-fuzzer-run:
     name: Presto Fuzzer
     if: ${{ needs.compile.outputs.presto_bias  != 'true' }}
@@ -532,6 +635,86 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: presto-fuzzer-failure-artifacts
+          path: |
+            /tmp/fuzzer_repro
+
+  presto-fuzzer-with-local-runner-run:
+    name: Presto Fuzzer with Local Runner
+    runs-on: ubuntu-latest
+    container: ghcr.io/facebookincubator/velox-dev:centos9
+    needs: [compile, compile-baseline-local-runner]
+    timeout-minutes: 120
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        if: github.event_name == 'pull_request'
+        id: changes
+        with:
+          filters: |
+            presto:
+              - 'velox/expression/!(test)**'
+              - 'velox/exec/!(test)**'
+              - 'velox/common/!(test)**'
+              - 'velox/core/!(test)**'
+              - 'velox/vector/!(test)**'
+
+      - name: Download presto fuzzer
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: presto
+
+      - name: Download baseline local runner service
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: baseline_local_runner_service_runner
+
+      - name: Download libvelox
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: libvelox
+
+      - name: Run Presto Fuzzer with Local Runner
+        run: |
+          export LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH
+          mkdir -p /tmp/fuzzer_repro/logs/
+          chmod -R 777 /tmp/fuzzer_repro
+          chmod +x velox_expression_fuzzer_test
+          chmod +x velox_local_runner_service_runner
+          # Start LocalRunnerService in the background
+          ./velox_local_runner_service_runner > /tmp/fuzzer_repro/logs/local_runner_service.log 2>&1 &
+          LOCAL_RUNNER_PID=$!
+          echo "Started LocalRunnerService with PID: ${LOCAL_RUNNER_PID}"
+          # Sleep for 10 seconds to allow service to start
+          sleep 10
+          random_seed=${RANDOM}
+          echo "Duration: $DURATION"
+          echo "Random seed: ${random_seed}"
+          ./velox_expression_fuzzer_test \
+                --seed ${random_seed} \
+                --enable_variadic_signatures \
+                --velox_fuzzer_enable_complex_types \
+                --velox_fuzzer_enable_decimal_type \
+                --lazy_vector_generation_ratio 0.2 \
+                --common_dictionary_wraps_generation_ratio=0.3 \
+                --velox_fuzzer_enable_column_reuse \
+                --velox_fuzzer_enable_expression_reuse \
+                --max_expression_trees_per_step 2 \
+                --retry_with_try \
+                --enable_dereference \
+                --duration_sec $DURATION \
+                --minloglevel=0 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/fuzzer_repro/logs \
+                --repro_persist_path=/tmp/fuzzer_repro \
+                --velox_runner_url=http://127.0.0.1:9091 \
+          && echo -e "\n\nFuzzer run finished successfully."
+          # Stop the LocalRunnerService
+          kill $LOCAL_RUNNER_PID || true
+
+      - name: Archive production artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: presto-fuzzer-with-local-runner-failure-artifacts
           path: |
             /tmp/fuzzer_repro
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,11 @@ option(VELOX_ENABLE_PARQUET "Enable Parquet support" ON)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_GEO "Enable Geospatial support" ON)
 option(VELOX_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
+option(
+  VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  "Enable LocalRunnerService and VeloxQueryRunner for expression fuzzer regression testing"
+  OFF
+)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 option(VELOX_ENABLE_COMPRESSION_LZ4 "Enable Lz4 compression support." OFF)
 
@@ -691,9 +696,14 @@ if(${VELOX_BUILD_TESTING})
   velox_resolve_dependency(gRPC)
 endif()
 
-if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET)
-  # TODO: Move this to use resolve_dependency(). For some reason, FBThrift
-  # requires clients to explicitly install fizz and wangle.
+# FBThrift is required by remote functions and LocalRunnerService.
+if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET OR VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+  set(VELOX_NEEDS_FBTHRIFT ON)
+endif()
+
+# TODO: Move this to use resolve_dependency(). For some reason, FBThrift
+# requires clients to explicitly install fizz and wangle.
+if(VELOX_NEEDS_FBTHRIFT)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Generate Thrift library for LocalRunnerService early since velox_fuzzer_util
-# depends on it when VELOX_ENABLE_REMOTE_FUNCTIONS is enabled.
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# depends on it when VELOX_ENABLE_LOCAL_RUNNER_SERVICE is enabled.
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   include(FBThriftCppLibrary)
   add_fbthrift_cpp_library(
     local_runner_service_thrift
@@ -55,13 +55,12 @@ velox_add_test_headers(
   VeloxQueryRunner.h
 )
 
-# TODO Add VeloxQueryRunner to velox_fuzzer_util to support in
-# ExpressionFuzzerTest. More information can be found here:
-# https://github.com/facebookincubator/velox/issues/15414
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# VeloxQueryRunner requires LocalRunnerService thrift library
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   target_sources(velox_fuzzer_util PRIVATE VeloxQueryRunner.cpp)
   target_link_libraries(velox_fuzzer_util local_runner_service_thrift)
   target_include_directories(velox_fuzzer_util PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  target_compile_definitions(velox_fuzzer_util PUBLIC VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
 endif()
 
 target_link_libraries(
@@ -285,7 +284,7 @@ target_link_libraries(
 )
 
 # LocalRunnerService Library
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_library(velox_local_runner_service_lib LocalRunnerService.cpp)
   velox_add_test_headers(velox_local_runner_service_lib LocalRunnerService.h)
 

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(presto_sql_test presto_sql_test)
 target_link_libraries(presto_sql_test velox_fuzzer_util velox_presto_types)
 
 # LocalRunnerService Test (requires FBThrift support)
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_executable(local_runner_service_test LocalRunnerServiceTest.cpp)
   add_test(local_runner_service_test local_runner_service_test)
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -19,6 +19,9 @@
 
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+#include "velox/exec/fuzzer/VeloxQueryRunner.h"
+#endif
 #include "velox/expression/fuzzer/ArgTypesGenerator.h"
 #include "velox/expression/fuzzer/ArgValuesGenerators.h"
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
@@ -48,6 +51,14 @@ DEFINE_string(
     "Presto coordinator URI along with port. If set, we use Presto as the "
     "source of truth. Otherwise, use the Velox simplified expression evaluation. Example: "
     "--presto_url=http://127.0.0.1:8080");
+
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+DEFINE_string(
+    velox_runner_url,
+    "",
+    "URI for thrift requests to LocalRunnerService. Defaults to localhost on port 9091. "
+    "Example: --velox_runner_url=http://127.0.0.1:9091");
+#endif
 
 DEFINE_uint32(
     req_timeout_ms,
@@ -153,6 +164,8 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
         {"s2_cell_from_token",
          std::make_shared<S2CellTokenArgValuesGenerator>()}};
 
+const std::unordered_set<std::string> skipFunctionsLocalRunner{};
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
@@ -174,6 +187,7 @@ int main(int argc, char** argv) {
   std::shared_ptr<facebook::velox::memory::MemoryPool> rootPool{
       facebook::velox::memory::memoryManager()->addRootPool()};
   std::shared_ptr<ReferenceQueryRunner> referenceQueryRunner{nullptr};
+  auto shouldAdjustTimestampToSessionTimezone = "true";
 
   if (!FLAGS_presto_url.empty()) {
     // Add additional functions to skip since we are now querying Presto
@@ -187,6 +201,17 @@ int main(int argc, char** argv) {
         "expression_fuzzer",
         static_cast<std::chrono::milliseconds>(FLAGS_req_timeout_ms));
     LOG(INFO) << "Using Presto as the reference DB.";
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  } else if (!FLAGS_velox_runner_url.empty()) {
+    shouldAdjustTimestampToSessionTimezone = "false";
+    skipFunctions.insert(
+        skipFunctionsLocalRunner.begin(), skipFunctionsLocalRunner.end());
+    referenceQueryRunner = std::make_shared<VeloxQueryRunner>(
+        rootPool.get(),
+        FLAGS_velox_runner_url,
+        std::chrono::milliseconds(FLAGS_req_timeout_ms));
+    LOG(INFO) << "Using LocalQueryRunner as the reference engine.";
+#endif
   }
   FuzzerRunner::runFromGtest(
       initialSeed,
@@ -194,7 +219,8 @@ int main(int argc, char** argv) {
       exprTransformers,
       {{facebook::velox::core::QueryConfig::kSessionTimezone,
         "America/Los_Angeles"},
-       {facebook::velox::core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+       {facebook::velox::core::QueryConfig::kAdjustTimestampToTimezone,
+        shouldAdjustTimestampToSessionTimezone},
        {facebook::velox::core::QueryConfig::kMinRowsForPeeling, "50"}},
       argTypesGenerators,
       argValuesGenerators,


### PR DESCRIPTION
Summary:
Add a regression fuzzer to the Fuzzer Jobs suite. The job runs the expression fuzzer with LocalRunnerService as the source of truth, sending serialized plans to it over thrift. Because the reference is Velox itself rather than an external engine, a result mismatch points directly at the change under test.

The reference has to come from mainline for that to hold. A new Build Baseline LocalRunnerService job resolves the merge base the same way the existing compile job does, checks it out, and builds velox_local_runner_service_runner there. The existing compile job builds the fuzzer from the contender commit. The fuzzer then reaches the baseline service at --velox_runner_url.

LocalRunnerService and VeloxQueryRunner are gated behind a dedicated VELOX_ENABLE_LOCAL_RUNNER_SERVICE option rather than VELOX_ENABLE_REMOTE_FUNCTIONS. Building the reference service previously required turning on remote function support, which pulls in machinery the fuzzer never uses. The option puts a matching preprocessor macro on velox_fuzzer_util, so the VeloxQueryRunner path compiles only where the library is actually built.

The baseline build passes both VELOX_ENABLE_REMOTE_FUNCTIONS and VELOX_ENABLE_LOCAL_RUNNER_SERVICE, since mainline gates LocalRunnerService on the former until this lands and on the latter afterwards. It is a static build so the baseline service does not pick up the contender libvelox.so that the fuzzer needs on LD_LIBRARY_PATH.

Differential Revision: D115106337


