### PR TITLE
refactor(writer): Rename VeloxWriter to Writer (#18431)

### DIFF
--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
@@ -58,7 +58,7 @@ class WriterOptionsAdapter {
 /// `icebergFieldIds` carries the per-input-column Iceberg field-id tree.
 /// Honored only by the NIMBLE adapter, which uses it to stamp
 /// `iceberg.id` (and other Iceberg V3 keys) onto each NIMBLE schema node
-/// via `VeloxWriterOptions::schemaAttributes`. Pass an empty
+/// via `WriterOptions::schemaAttributes`. Pass an empty
 /// `IcebergFieldId{}` for formats / call sites that have no field-id tree
 /// available (the NIMBLE adapter then produces files without
 /// `iceberg.id` attributes, the same wire shape as a pre-attributes

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -35,14 +35,8 @@ add_executable(velox_functions_prestosql_benchmarks_array_contains ArrayContains
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_contains ArrayPositionBasic.h)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_contains ${BENCHMARK_DEPENDENCIES})
 
-add_executable(
-  velox_functions_prestosql_benchmarks_array_join
-  ArrayJoinBenchmark.cpp
-)
-target_link_libraries(
-  velox_functions_prestosql_benchmarks_array_join
-  ${BENCHMARK_DEPENDENCIES}
-)
+add_executable(velox_functions_prestosql_benchmarks_array_join ArrayJoinBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_array_join ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.cpp)
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.h)


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/1082

Nimble's writer class has been named `VeloxWriter` since it was introduced, but the `Velox` prefix no longer carries information: everything in `dwio/nimble/writer/` is Velox-facing, so the prefix distinguishes it from nothing. It also reads oddly next to the surrounding `WriterFactory`, `WriterOptions` builder, and `FlushPolicy` types, which never took the prefix. This drops it.

Renames, all tracked as Sapling renames so history follows:

- `writer/VeloxWriter.{h,cpp}` -> `writer/Writer.{h,cpp}`
- `writer/VeloxWriterOptions.h` -> `writer/WriterOptions.h`
- `writer/VeloxWriter{DefaultMetadata,MemoryReclaimer}OSS.cpp` -> `writer/Writer{...}OSS.cpp`
- `writer/fb/VeloxWriter{DefaultMetadata,MemoryReclaimer}.cpp` -> `writer/fb/Writer{...}.cpp`
- `velox/tests/VeloxWriter{Test,FuzzTest,TestUtils}` -> `velox/tests/Writer{...}`

The Buck target `//dwio/nimble/writer:velox_writer` becomes `//dwio/nimble/writer:writer`. 263 files change in total; every edit outside `dwio/nimble/` is a mechanical call-site, include-path, or dep update.

`nimble::Writer` now derives from `velox::dwio::common::Writer`. The names collide only when unqualified, and the base is spelled out in full at the one place it appears, so this is a non-issue in practice.

Deliberately left alone: `trabant`'s own `VeloxWriterIf` and `VeloxWriterImpl`, Spark's `commitTaskBucketedVeloxWriter` and `commitTaskNonBucketedVeloxWriter`, and adsatlas' `SaberVeloxWriter` string literal. These are unrelated types that merely share the substring.

Known pre-existing breakage, not introduced here: `scripts/yusuo/koski/cpp:direct_dwio_reader_benchmark` and `scripts/yusuo/koski/cpp/tests:direct_dwio_reader_test` fail to compile because they call `writerOpts.flatMapColumns.insert("some_string")`, but `flatMapColumns` is a `folly::F14FastMap<std::string, std::set<std::string>>`. `sl cat -r .` confirms both the map type and those `insert` calls already exist at the parent commit, so these two targets are equally broken at trunk. This diff only renames the type they name; the failing lines are untouched.

Stacked on D114716883 ("[nimble] refactor(writer): Replace Stats with keyed runtime stats").

Reviewed By: xiaoxmeng

Differential Revision: D114998981
