### PR TITLE
perf(HashTable): K-way chain walk with per-slot buffered flush

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -2166,36 +2166,20 @@ int32_t HashTable<ignoreNullKeys>::listJoinResultsSingleHit(
         return projectedRowSize(iter, hit);
       });
 
+  // Dispatch guarantees at most one hit per probe row: either
+  // nextOffset_ == 0 (no chain pointer) or !hasDuplicates_.
   while (iter.lastRowIndex < iter.rows->size()) {
-    if (!iter.nextHit) {
-      const auto row = (*iter.rows)[iter.lastRowIndex];
-      iter.nextHit = (*iter.hits)[row]; // NOLINT
-      if (!iter.nextHit) {
-        ++iter.lastRowIndex;
-        if (includeMisses && !emit(row, nullptr)) {
-          return numOut;
-        }
-        continue;
-      }
-    }
-
-    while (iter.nextHit) {
-      char* next = nullptr;
-      if (nextOffset_) {
-        next = nextRow(iter.nextHit);
-        if (next) {
-          __builtin_prefetch(reinterpret_cast<char*>(next) + nextOffset_);
-        }
-      }
-      const auto row = (*iter.rows)[iter.lastRowIndex]; // NOLINT
-      char* hit = iter.nextHit;
-      iter.nextHit = next;
-      if (!iter.nextHit) {
-        ++iter.lastRowIndex;
-      }
-      if (!emit(row, hit)) {
+    const auto row = (*iter.rows)[iter.lastRowIndex]; // NOLINT
+    char* hit = (*iter.hits)[row];
+    ++iter.lastRowIndex;
+    if (hit == nullptr) {
+      if (includeMisses && !emit(row, nullptr)) {
         return numOut;
       }
+      continue;
+    }
+    if (!emit(row, hit)) {
+      return numOut;
     }
   }
   return numOut;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -2096,7 +2096,21 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
     return listJoinResultsFastPath(
         iter, includeMisses, inputRows, hits, maxBytes);
   }
+  if (nextOffset_ == 0 || !hasDuplicates_) {
+    return listJoinResultsSingleHit(
+        iter, includeMisses, inputRows, hits, maxBytes);
+  }
+  return listJoinResultsInterleaved(
+      iter, includeMisses, inputRows, hits, maxBytes);
+}
 
+template <bool ignoreNullKeys>
+int32_t HashTable<ignoreNullKeys>::listJoinResultsSingleHit(
+    JoinResultIterator& iter,
+    bool includeMisses,
+    folly::Range<vector_size_t*> inputRows,
+    folly::Range<char**> hits,
+    uint64_t maxBytes) {
   size_t numOut = 0;
   auto maxOut = inputRows.size();
   uint64_t totalBytes{0};
@@ -2144,6 +2158,126 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
     }
   }
   return numOut;
+}
+
+template <bool ignoreNullKeys>
+int32_t HashTable<ignoreNullKeys>::listJoinResultsInterleaved(
+    JoinResultIterator& iter,
+    bool includeMisses,
+    folly::Range<vector_size_t*> inputRows,
+    folly::Range<char**> hits,
+    uint64_t maxBytes) {
+  if (iter.rows == nullptr || iter.rows->empty()) {
+    return 0;
+  }
+
+  size_t numOut = 0;
+  const auto maxOut = inputRows.size();
+  uint64_t totalBytes{0};
+
+  constexpr int32_t kNumParallelChains =
+      JoinResultIterator::kNumParallelChains;
+  constexpr int32_t kAheadWindow = JoinResultIterator::kAheadWindow;
+  const auto numProbeRows = iter.rows->size();
+  const bool hasEstimatedSize = iter.estimatedRowSize.has_value();
+  const uint64_t estimatedSize =
+      hasEstimatedSize ? iter.estimatedRowSize.value() : 0;
+  const auto& varSizeListColumns = iter.varSizeListColumns;
+  const uint64_t fixedSizeListColumnsSizeSum =
+      iter.fixedSizeListColumnsSizeSum;
+
+  auto emit = [&](vector_size_t probeRow, char* hit) -> bool {
+    inputRows[numOut] = probeRow; // NOLINT
+    hits[numOut] = hit;
+    if (hit != nullptr) {
+      totalBytes += hasEstimatedSize
+          ? estimatedSize
+          : (joinProjectedVarColumnsSize(varSizeListColumns, hit) +
+             fixedSizeListColumnsSizeSum);
+    }
+    ++numOut;
+    return numOut < maxOut && totalBytes < maxBytes;
+  };
+
+  while (true) {
+    if (iter.slotHead >= iter.numActive) {
+      iter.slotHead = 0;
+      iter.numActive = 0;
+      while (iter.numActive < kNumParallelChains &&
+             iter.lastRowIndex < numProbeRows) {
+        const auto row = (*iter.rows)[iter.lastRowIndex]; // NOLINT
+        auto* hit = (*iter.hits)[row]; // NOLINT
+        ++iter.lastRowIndex;
+        if (hit == nullptr && !includeMisses) {
+          continue;
+        }
+        iter.slotProbeRows[iter.numActive] = row;
+        iter.slotCursors[iter.numActive] = hit;
+        if (hit == nullptr) {
+          iter.bufferData[iter.numActive][0] = nullptr;
+          iter.bufferLength[iter.numActive] = 1;
+        } else {
+          iter.bufferLength[iter.numActive] = 0;
+          __builtin_prefetch(hit);
+        }
+        ++iter.numActive;
+      }
+      if (iter.numActive == 0) {
+        return numOut;
+      }
+    }
+
+    const int32_t bufferLength = iter.bufferLength[iter.slotHead];
+    if (bufferLength > 0) {
+      const auto probeRow = iter.slotProbeRows[iter.slotHead];
+      while (iter.drainPosition < bufferLength) {
+        auto* bufferedHit =
+            iter.bufferData[iter.slotHead][iter.drainPosition++];
+        if (!emit(probeRow, bufferedHit)) {
+          if (iter.drainPosition == bufferLength) {
+            // Fully drained; reset so the next call skips this slot's
+            // flush and advances slotHead.
+            iter.bufferLength[iter.slotHead] = 0;
+            iter.drainPosition = 0;
+          }
+          return numOut;
+        }
+      }
+      iter.bufferLength[iter.slotHead] = 0;
+      iter.drainPosition = 0;
+    }
+
+    char* headCursor = iter.slotCursors[iter.slotHead];
+    if (headCursor == nullptr) {
+      ++iter.slotHead;
+      continue;
+    }
+
+    const int32_t numActive = iter.numActive;
+    const int32_t slotHead = iter.slotHead;
+    for (int32_t i = slotHead; i < numActive; ++i) {
+      char* cursor = iter.slotCursors[i];
+      if (cursor != nullptr &&
+          (i == slotHead || iter.bufferLength[i] < kAheadWindow)) {
+        __builtin_prefetch(cursor + nextOffset_);
+      }
+    }
+
+    for (int32_t i = slotHead + 1; i < numActive; ++i) {
+      char* cursor = iter.slotCursors[i];
+      if (cursor == nullptr || iter.bufferLength[i] >= kAheadWindow) {
+        continue;
+      }
+      iter.bufferData[i][iter.bufferLength[i]++] = cursor;
+      iter.slotCursors[i] = nextRow(cursor);
+    }
+
+    const auto headRow = iter.slotProbeRows[slotHead];
+    iter.slotCursors[slotHead] = nextRow(headCursor);
+    if (!emit(headRow, headCursor)) {
+      return numOut;
+    }
+  }
 }
 
 template <bool ignoreNullKeys>

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -2081,6 +2081,54 @@ inline uint64_t HashTable<ignoreNullKeys>::joinProjectedVarColumnsSize(
   return totalBytes;
 }
 
+namespace {
+
+// Appends one (probeRow, hit) result to inputRows/hits, updates the byte
+// accounting, and returns true when more results can still fit. The size
+// of one hit is looked up via `sizeFunction` so this stays independent of the
+// HashTable template.
+template <typename SizeFunction>
+struct JoinResultEmitter {
+  folly::Range<vector_size_t*> inputRows;
+  folly::Range<char**> hits;
+  size_t& numOut;
+  uint64_t& totalBytes;
+  const size_t maxOut;
+  const uint64_t maxBytes;
+  const SizeFunction sizeFunction;
+
+  bool operator()(vector_size_t probeRow, char* hit) {
+    inputRows[numOut] = probeRow; // NOLINT
+    hits[numOut] = hit;
+    if (hit != nullptr) {
+      totalBytes += sizeFunction(hit);
+    }
+    ++numOut;
+    return numOut < maxOut && totalBytes < maxBytes;
+  }
+};
+
+template <typename SizeFunction>
+JoinResultEmitter<SizeFunction> makeJoinResultEmitter(
+    folly::Range<vector_size_t*> inputRows,
+    folly::Range<char**> hits,
+    size_t& numOut,
+    uint64_t& totalBytes,
+    uint64_t maxBytes,
+    SizeFunction sizeFunction) {
+  return {
+      inputRows,
+      hits,
+      numOut,
+      totalBytes,
+      inputRows.size(),
+      maxBytes,
+      std::move(sizeFunction),
+  };
+}
+
+} // namespace
+
 template <bool ignoreNullKeys>
 int32_t HashTable<ignoreNullKeys>::listJoinResults(
     JoinResultIterator& iter,
@@ -2112,21 +2160,20 @@ int32_t HashTable<ignoreNullKeys>::listJoinResultsSingleHit(
     folly::Range<char**> hits,
     uint64_t maxBytes) {
   size_t numOut = 0;
-  auto maxOut = inputRows.size();
   uint64_t totalBytes{0};
+  auto emit = makeJoinResultEmitter(
+      inputRows, hits, numOut, totalBytes, maxBytes, [&](char* hit) {
+        return projectedRowSize(iter, hit);
+      });
+
   while (iter.lastRowIndex < iter.rows->size()) {
     if (!iter.nextHit) {
       const auto row = (*iter.rows)[iter.lastRowIndex];
       iter.nextHit = (*iter.hits)[row]; // NOLINT
       if (!iter.nextHit) {
         ++iter.lastRowIndex;
-        if (includeMisses) {
-          inputRows[numOut] = row; // NOLINT
-          hits[numOut] = nullptr;
-          ++numOut;
-          if (numOut >= maxOut) {
-            return numOut;
-          }
+        if (includeMisses && !emit(row, nullptr)) {
+          return numOut;
         }
         continue;
       }
@@ -2140,19 +2187,13 @@ int32_t HashTable<ignoreNullKeys>::listJoinResultsSingleHit(
           __builtin_prefetch(reinterpret_cast<char*>(next) + nextOffset_);
         }
       }
-      inputRows[numOut] = (*iter.rows)[iter.lastRowIndex]; // NOLINT
-      hits[numOut] = iter.nextHit;
-      totalBytes += iter.estimatedRowSize.has_value()
-          ? iter.estimatedRowSize.value()
-          : (joinProjectedVarColumnsSize(
-                 iter.varSizeListColumns, iter.nextHit) +
-             iter.fixedSizeListColumnsSizeSum);
-      ++numOut;
+      const auto row = (*iter.rows)[iter.lastRowIndex]; // NOLINT
+      char* hit = iter.nextHit;
       iter.nextHit = next;
       if (!iter.nextHit) {
         ++iter.lastRowIndex;
       }
-      if (numOut >= maxOut || totalBytes >= maxBytes) {
+      if (!emit(row, hit)) {
         return numOut;
       }
     }
@@ -2172,36 +2213,22 @@ int32_t HashTable<ignoreNullKeys>::listJoinResultsInterleaved(
   }
 
   size_t numOut = 0;
-  const auto maxOut = inputRows.size();
   uint64_t totalBytes{0};
-
   constexpr int32_t kNumParallelChains = JoinResultIterator::kNumParallelChains;
   constexpr int32_t kAheadWindow = JoinResultIterator::kAheadWindow;
   const auto numProbeRows = iter.rows->size();
-  const bool hasEstimatedSize = iter.estimatedRowSize.has_value();
-  const uint64_t estimatedSize =
-      hasEstimatedSize ? iter.estimatedRowSize.value() : 0;
-  const auto& varSizeListColumns = iter.varSizeListColumns;
-  const uint64_t fixedSizeListColumnsSizeSum = iter.fixedSizeListColumnsSizeSum;
+  auto& walker = iter.walker;
 
-  auto emit = [&](vector_size_t probeRow, char* hit) -> bool {
-    inputRows[numOut] = probeRow; // NOLINT
-    hits[numOut] = hit;
-    if (hit != nullptr) {
-      totalBytes += hasEstimatedSize
-          ? estimatedSize
-          : (joinProjectedVarColumnsSize(varSizeListColumns, hit) +
-             fixedSizeListColumnsSizeSum);
-    }
-    ++numOut;
-    return numOut < maxOut && totalBytes < maxBytes;
-  };
+  auto emit = makeJoinResultEmitter(
+      inputRows, hits, numOut, totalBytes, maxBytes, [&](char* hit) {
+        return projectedRowSize(iter, hit);
+      });
 
   while (true) {
-    if (iter.slotHead >= iter.numActive) {
-      iter.slotHead = 0;
-      iter.numActive = 0;
-      while (iter.numActive < kNumParallelChains &&
+    if (walker.slotHead >= walker.numActive) {
+      walker.slotHead = 0;
+      walker.numActive = 0;
+      while (walker.numActive < kNumParallelChains &&
              iter.lastRowIndex < numProbeRows) {
         const auto row = (*iter.rows)[iter.lastRowIndex]; // NOLINT
         auto* hit = (*iter.hits)[row]; // NOLINT
@@ -2209,69 +2236,69 @@ int32_t HashTable<ignoreNullKeys>::listJoinResultsInterleaved(
         if (hit == nullptr && !includeMisses) {
           continue;
         }
-        iter.slotProbeRows[iter.numActive] = row;
-        iter.slotCursors[iter.numActive] = hit;
+        walker.slotProbeRows[walker.numActive] = row;
+        walker.slotCursors[walker.numActive] = hit;
         if (hit == nullptr) {
-          iter.bufferData[iter.numActive][0] = nullptr;
-          iter.bufferLength[iter.numActive] = 1;
+          walker.bufferData[walker.numActive][0] = nullptr;
+          walker.bufferLength[walker.numActive] = 1;
         } else {
-          iter.bufferLength[iter.numActive] = 0;
+          walker.bufferLength[walker.numActive] = 0;
           __builtin_prefetch(hit);
         }
-        ++iter.numActive;
+        ++walker.numActive;
       }
-      if (iter.numActive == 0) {
+      if (walker.numActive == 0) {
         return numOut;
       }
     }
 
-    const int32_t bufferLength = iter.bufferLength[iter.slotHead];
+    const int32_t bufferLength = walker.bufferLength[walker.slotHead];
     if (bufferLength > 0) {
-      const auto probeRow = iter.slotProbeRows[iter.slotHead];
-      while (iter.drainPosition < bufferLength) {
+      const auto probeRow = walker.slotProbeRows[walker.slotHead];
+      while (walker.drainPosition < bufferLength) {
         auto* bufferedHit =
-            iter.bufferData[iter.slotHead][iter.drainPosition++];
+            walker.bufferData[walker.slotHead][walker.drainPosition++];
         if (!emit(probeRow, bufferedHit)) {
-          if (iter.drainPosition == bufferLength) {
+          if (walker.drainPosition == bufferLength) {
             // Fully drained; reset so the next call skips this slot's
             // flush and advances slotHead.
-            iter.bufferLength[iter.slotHead] = 0;
-            iter.drainPosition = 0;
+            walker.bufferLength[walker.slotHead] = 0;
+            walker.drainPosition = 0;
           }
           return numOut;
         }
       }
-      iter.bufferLength[iter.slotHead] = 0;
-      iter.drainPosition = 0;
+      walker.bufferLength[walker.slotHead] = 0;
+      walker.drainPosition = 0;
     }
 
-    char* headCursor = iter.slotCursors[iter.slotHead];
+    char* headCursor = walker.slotCursors[walker.slotHead];
     if (headCursor == nullptr) {
-      ++iter.slotHead;
+      ++walker.slotHead;
       continue;
     }
 
-    const int32_t numActive = iter.numActive;
-    const int32_t slotHead = iter.slotHead;
+    const int32_t numActive = walker.numActive;
+    const int32_t slotHead = walker.slotHead;
     for (int32_t i = slotHead; i < numActive; ++i) {
-      char* cursor = iter.slotCursors[i];
+      char* cursor = walker.slotCursors[i];
       if (cursor != nullptr &&
-          (i == slotHead || iter.bufferLength[i] < kAheadWindow)) {
+          (i == slotHead || walker.bufferLength[i] < kAheadWindow)) {
         __builtin_prefetch(cursor + nextOffset_);
       }
     }
 
     for (int32_t i = slotHead + 1; i < numActive; ++i) {
-      char* cursor = iter.slotCursors[i];
-      if (cursor == nullptr || iter.bufferLength[i] >= kAheadWindow) {
+      char* cursor = walker.slotCursors[i];
+      if (cursor == nullptr || walker.bufferLength[i] >= kAheadWindow) {
         continue;
       }
-      iter.bufferData[i][iter.bufferLength[i]++] = cursor;
-      iter.slotCursors[i] = nextRow(cursor);
+      walker.bufferData[i][walker.bufferLength[i]++] = cursor;
+      walker.slotCursors[i] = nextRow(cursor);
     }
 
-    const auto headRow = iter.slotProbeRows[slotHead];
-    iter.slotCursors[slotHead] = nextRow(headCursor);
+    const auto headRow = walker.slotProbeRows[slotHead];
+    walker.slotCursors[slotHead] = nextRow(headCursor);
     if (!emit(headRow, headCursor)) {
       return numOut;
     }

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -2175,16 +2175,14 @@ int32_t HashTable<ignoreNullKeys>::listJoinResultsInterleaved(
   const auto maxOut = inputRows.size();
   uint64_t totalBytes{0};
 
-  constexpr int32_t kNumParallelChains =
-      JoinResultIterator::kNumParallelChains;
+  constexpr int32_t kNumParallelChains = JoinResultIterator::kNumParallelChains;
   constexpr int32_t kAheadWindow = JoinResultIterator::kAheadWindow;
   const auto numProbeRows = iter.rows->size();
   const bool hasEstimatedSize = iter.estimatedRowSize.has_value();
   const uint64_t estimatedSize =
       hasEstimatedSize ? iter.estimatedRowSize.value() : 0;
   const auto& varSizeListColumns = iter.varSizeListColumns;
-  const uint64_t fixedSizeListColumnsSizeSum =
-      iter.fixedSizeListColumnsSizeSum;
+  const uint64_t fixedSizeListColumnsSizeSum = iter.fixedSizeListColumnsSizeSum;
 
   auto emit = [&](vector_size_t probeRow, char* hit) -> bool {
     inputRows[numOut] = probeRow; // NOLINT

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <array>
+#include <vector>
+
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/exec/OneWayStatusFlag.h"
@@ -189,6 +192,12 @@ class BaseHashTable {
   /// produce multiple batches of results. This is initialized from HashLookup,
   /// which is expected to stay constant while 'this' is being used.
   struct JoinResultIterator {
+    /// Number of probe rows whose chains are walked in an interleaved
+    /// fashion to overlap K next-pointer loads.
+    static constexpr int32_t kNumParallelChains = 8;
+    /// Maximum number of hits a non-head slot can buffer before pausing.
+    static constexpr int32_t kAheadWindow = 8;
+
     JoinResultIterator(
         std::vector<vector_size_t>&& _varSizeListColumns,
         uint64_t _fixedSizeListColumnsSizeSum,
@@ -202,10 +211,27 @@ class BaseHashTable {
       hits = &lookup.hits;
       lastRowIndex = 0;
       nextHit = nullptr;
+      slotHead = 0;
+      numActive = 0;
+      drainPosition = 0;
+      for (auto& length : bufferLength) {
+        length = 0;
+      }
     }
 
     bool atEnd() const {
-      return !rows || lastRowIndex == rows->size();
+      if (!rows) {
+        return true;
+      }
+      if (lastRowIndex < rows->size()) {
+        return false;
+      }
+      for (int32_t i = slotHead; i < numActive; ++i) {
+        if (slotCursors[i] != nullptr || bufferLength[i] > 0) {
+          return false;
+        }
+      }
+      return true;
     }
 
     /// The row size estimation of the projected output columns, if applicable.
@@ -221,6 +247,25 @@ class BaseHashTable {
 
     vector_size_t lastRowIndex{0};
     char* nextHit{nullptr};
+
+    /// Current chain node for each in-flight probe row. Only the head
+    /// slot emits inline; the others buffer hits to preserve probe order.
+    std::array<char*, kNumParallelChains> slotCursors{};
+    /// Probe row index paired with each slot cursor.
+    std::array<vector_size_t, kNumParallelChains> slotProbeRows{};
+    /// Buffered hits for each non-head slot, drained when it becomes head.
+    std::array<std::array<char*, kAheadWindow>, kNumParallelChains>
+        bufferData{};
+    /// Number of buffered entries per slot, in [0, kAheadWindow].
+    std::array<int32_t, kNumParallelChains> bufferLength{};
+
+    /// Index of the current head slot; advances 0..numActive per batch.
+    int32_t slotHead{0};
+    /// Number of slots holding a live probe row in the current batch,
+    /// in [0, kNumParallelChains].
+    int32_t numActive{0};
+    /// Resume position within the head slot's buffer across calls.
+    int32_t drainPosition{0};
   };
 
   struct RowsIterator {
@@ -913,6 +958,23 @@ class HashTable : public BaseHashTable {
   // Fast path for join results when there are no duplicates in the table and
   // only fixed size rows are to be extract.
   int32_t listJoinResultsFastPath(
+      JoinResultIterator& iter,
+      bool includeMisses,
+      folly::Range<vector_size_t*> inputRows,
+      folly::Range<char**> hits,
+      uint64_t maxBytes);
+
+  // Lists results when each probe row has at most one matching build row.
+  int32_t listJoinResultsSingleHit(
+      JoinResultIterator& iter,
+      bool includeMisses,
+      folly::Range<vector_size_t*> inputRows,
+      folly::Range<char**> hits,
+      uint64_t maxBytes);
+
+  // Interleaves K chain walks to overlap next-pointer loads while preserving
+  // probe-row output order via per-slot buffering.
+  int32_t listJoinResultsInterleaved(
       JoinResultIterator& iter,
       bool includeMisses,
       folly::Range<vector_size_t*> inputRows,

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -256,7 +256,6 @@ class BaseHashTable {
       rows = &lookup.rows;
       hits = &lookup.hits;
       lastRowIndex = 0;
-      nextHit = nullptr;
       walker.reset();
     }
 
@@ -287,7 +286,6 @@ class BaseHashTable {
     const raw_vector<char*>* hits{nullptr};
 
     vector_size_t lastRowIndex{0};
-    char* nextHit{nullptr};
 
     /// Cross-call state for the interleaved walker.
     InterleavedWalkerState walker;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -198,6 +198,52 @@ class BaseHashTable {
     /// Maximum number of hits a non-head slot can buffer before pausing.
     static constexpr int32_t kAheadWindow = 8;
 
+    /// Internal state for the interleaved chain walker. Not read outside
+    /// of HashTable.cpp; grouped here to keep the outer iterator focused
+    /// on its public state.
+    struct InterleavedWalkerState {
+      /// Current chain node for each in-flight probe row. Only the head
+      /// slot emits inline; the others buffer hits into `bufferData` to
+      /// preserve probe-row order.
+      std::array<char*, kNumParallelChains> slotCursors{};
+
+      /// Probe row index paired with each slot cursor.
+      std::array<vector_size_t, kNumParallelChains> slotProbeRows{};
+
+      /// Hits buffered for each non-head slot, drained when the slot
+      /// becomes head.
+      std::array<std::array<char*, kAheadWindow>, kNumParallelChains>
+          bufferData{};
+
+      /// Number of buffered entries per slot, in [0, kAheadWindow]. A
+      /// non-head slot pauses its walk once this reaches kAheadWindow.
+      std::array<int32_t, kNumParallelChains> bufferLength{};
+
+      /// Index of the current head slot; advances 0..numActive per batch.
+      int32_t slotHead{0};
+
+      /// Number of slots holding a live probe row in the current batch,
+      /// in [0, kNumParallelChains].
+      int32_t numActive{0};
+
+      /// Resume position within the head slot's buffer across calls.
+      int32_t drainPosition{0};
+
+      /// Marks the walker as holding no active slots so a fresh probe
+      /// batch starts empty. Stale `slotCursors` / `slotProbeRows` /
+      /// `bufferData` entries from a previous batch are left in place;
+      /// they are ignored until `numActive` grows past their index and
+      /// the walker overwrites them when refilling.
+      void reset() {
+        slotHead = 0;
+        numActive = 0;
+        drainPosition = 0;
+        for (auto& length : bufferLength) {
+          length = 0;
+        }
+      }
+    };
+
     JoinResultIterator(
         std::vector<vector_size_t>&& _varSizeListColumns,
         uint64_t _fixedSizeListColumnsSizeSum,
@@ -211,12 +257,7 @@ class BaseHashTable {
       hits = &lookup.hits;
       lastRowIndex = 0;
       nextHit = nullptr;
-      slotHead = 0;
-      numActive = 0;
-      drainPosition = 0;
-      for (auto& length : bufferLength) {
-        length = 0;
-      }
+      walker.reset();
     }
 
     bool atEnd() const {
@@ -226,8 +267,8 @@ class BaseHashTable {
       if (lastRowIndex < rows->size()) {
         return false;
       }
-      for (int32_t i = slotHead; i < numActive; ++i) {
-        if (slotCursors[i] != nullptr || bufferLength[i] > 0) {
+      for (int32_t i = walker.slotHead; i < walker.numActive; ++i) {
+        if (walker.slotCursors[i] != nullptr || walker.bufferLength[i] > 0) {
           return false;
         }
       }
@@ -248,24 +289,8 @@ class BaseHashTable {
     vector_size_t lastRowIndex{0};
     char* nextHit{nullptr};
 
-    /// Current chain node for each in-flight probe row. Only the head
-    /// slot emits inline; the others buffer hits to preserve probe order.
-    std::array<char*, kNumParallelChains> slotCursors{};
-    /// Probe row index paired with each slot cursor.
-    std::array<vector_size_t, kNumParallelChains> slotProbeRows{};
-    /// Buffered hits for each non-head slot, drained when it becomes head.
-    std::array<std::array<char*, kAheadWindow>, kNumParallelChains>
-        bufferData{};
-    /// Number of buffered entries per slot, in [0, kAheadWindow].
-    std::array<int32_t, kNumParallelChains> bufferLength{};
-
-    /// Index of the current head slot; advances 0..numActive per batch.
-    int32_t slotHead{0};
-    /// Number of slots holding a live probe row in the current batch,
-    /// in [0, kNumParallelChains].
-    int32_t numActive{0};
-    /// Resume position within the head slot's buffer across calls.
-    int32_t drainPosition{0};
+    /// Cross-call state for the interleaved walker.
+    InterleavedWalkerState walker;
   };
 
   struct RowsIterator {
@@ -963,6 +988,15 @@ class HashTable : public BaseHashTable {
       folly::Range<vector_size_t*> inputRows,
       folly::Range<char**> hits,
       uint64_t maxBytes);
+
+  // Returns the projected size in bytes of one build-side row, used for the
+  // byte-budget accounting in listJoinResults*.
+  uint64_t projectedRowSize(const JoinResultIterator& iter, char* hit) const {
+    return iter.estimatedRowSize.has_value()
+        ? iter.estimatedRowSize.value()
+        : joinProjectedVarColumnsSize(iter.varSizeListColumns, hit) +
+            iter.fixedSizeListColumnsSizeSum;
+  }
 
   // Lists results when each probe row has at most one matching build row.
   int32_t listJoinResultsSingleHit(

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -71,6 +71,10 @@ class HashTableTestHelper {
         mode, numNew, BaseHashTable::kNoSpillInputStartPartitionBit);
   }
 
+  void markHasDuplicates() {
+    table_->hasDuplicates_.set();
+  }
+
  private:
   explicit HashTableTestHelper(HashTable<ignoreNullKeys>* table)
       : table_(table) {
@@ -976,6 +980,100 @@ TEST_P(HashTableTest, listJoinResultsSize) {
         iter, true, inputRows, outputRows, testParam.maxBytes);
     ASSERT_EQ(numRows, testParam.expectedRows);
   }
+}
+
+TEST_P(HashTableTest, listJoinResultsInterleaved) {
+  std::vector<std::unique_ptr<VectorHasher>> keyHashers;
+  keyHashers.emplace_back(std::make_unique<VectorHasher>(BIGINT(), 0));
+  auto table = HashTable<true>::createForJoin(
+      std::move(keyHashers),
+      {BIGINT()},
+      /*allowDuplicates=*/true,
+      /*hasProbedFlag=*/false,
+      /*hasCountFlag=*/false,
+      1'000,
+      pool());
+
+  auto* rowContainer = table->rows();
+  const auto nextOffset = rowContainer->nextOffset();
+  ASSERT_GT(nextOffset, 0);
+
+  // The first chain advances long enough for the second chain to fill its
+  // ahead window and pause before it becomes head.
+  const std::vector<int32_t> chainLengths{10, 11, 3};
+  std::vector<std::vector<char*>> chains;
+  for (const auto chainLength : chainLengths) {
+    std::vector<char*> chain;
+    for (int32_t i = 0; i < chainLength; ++i) {
+      auto* row = rowContainer->newRow();
+      *reinterpret_cast<char**>(row + nextOffset) = nullptr;
+      chain.push_back(row);
+    }
+    for (int32_t i = 1; i < chainLength; ++i) {
+      *reinterpret_cast<char**>(chain[i - 1] + nextOffset) = chain[i];
+    }
+    chains.push_back(std::move(chain));
+  }
+
+  HashTableTestHelper<true>::create(table.get()).markHasDuplicates();
+  HashLookup lookup(table->hashers(), pool());
+  lookup.reset(4);
+  std::iota(lookup.rows.begin(), lookup.rows.end(), 0);
+  lookup.hits[0] = chains[0].front();
+  lookup.hits[1] = nullptr;
+  lookup.hits[2] = chains[1].front();
+  lookup.hits[3] = chains[2].front();
+
+  auto expected = [&](bool includeMisses) {
+    std::vector<vector_size_t> probeRows;
+    std::vector<char*> hits;
+    auto appendChain = [&](vector_size_t probeRow, const auto& chain) {
+      probeRows.insert(probeRows.end(), chain.size(), probeRow);
+      hits.insert(hits.end(), chain.begin(), chain.end());
+    };
+    appendChain(0, chains[0]);
+    if (includeMisses) {
+      probeRows.push_back(1);
+      hits.push_back(nullptr);
+    }
+    appendChain(2, chains[1]);
+    appendChain(3, chains[2]);
+    return std::make_pair(std::move(probeRows), std::move(hits));
+  };
+
+  auto run = [&](int32_t outputCapacity,
+                 bool includeMisses,
+                 uint64_t maxBytes) {
+    BaseHashTable::JoinResultIterator iter(
+        {}, /*fixedSizeListColumnsSizeSum=*/8, std::nullopt);
+    iter.reset(lookup);
+    std::vector<vector_size_t> probeRows;
+    std::vector<char*> hits;
+    std::vector<vector_size_t> outputProbeRows(outputCapacity);
+    std::vector<char*> outputHits(outputCapacity);
+    while (!iter.atEnd()) {
+      const auto numOutput = table->listJoinResults(
+          iter,
+          includeMisses,
+          folly::Range(outputProbeRows.data(), outputCapacity),
+          folly::Range(outputHits.data(), outputCapacity),
+          maxBytes);
+      ASSERT_GT(numOutput, 0);
+      probeRows.insert(
+          probeRows.end(),
+          outputProbeRows.begin(),
+          outputProbeRows.begin() + numOutput);
+      hits.insert(hits.end(), outputHits.begin(), outputHits.begin() + numOutput);
+    }
+    const auto [expectedProbeRows, expectedHits] = expected(includeMisses);
+    EXPECT_EQ(probeRows, expectedProbeRows);
+    EXPECT_EQ(hits, expectedHits);
+  };
+
+  run(64, false, std::numeric_limits<uint64_t>::max());
+  run(64, true, std::numeric_limits<uint64_t>::max());
+  run(1, true, std::numeric_limits<uint64_t>::max());
+  run(64, true, 16);
 }
 
 TEST_P(HashTableTest, groupBySpill) {

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -1041,34 +1041,34 @@ TEST_P(HashTableTest, listJoinResultsInterleaved) {
     return std::make_pair(std::move(probeRows), std::move(hits));
   };
 
-  auto run = [&](int32_t outputCapacity,
-                 bool includeMisses,
-                 uint64_t maxBytes) {
-    BaseHashTable::JoinResultIterator iter(
-        {}, /*fixedSizeListColumnsSizeSum=*/8, std::nullopt);
-    iter.reset(lookup);
-    std::vector<vector_size_t> probeRows;
-    std::vector<char*> hits;
-    std::vector<vector_size_t> outputProbeRows(outputCapacity);
-    std::vector<char*> outputHits(outputCapacity);
-    while (!iter.atEnd()) {
-      const auto numOutput = table->listJoinResults(
-          iter,
-          includeMisses,
-          folly::Range(outputProbeRows.data(), outputCapacity),
-          folly::Range(outputHits.data(), outputCapacity),
-          maxBytes);
-      ASSERT_GT(numOutput, 0);
-      probeRows.insert(
-          probeRows.end(),
-          outputProbeRows.begin(),
-          outputProbeRows.begin() + numOutput);
-      hits.insert(hits.end(), outputHits.begin(), outputHits.begin() + numOutput);
-    }
-    const auto [expectedProbeRows, expectedHits] = expected(includeMisses);
-    EXPECT_EQ(probeRows, expectedProbeRows);
-    EXPECT_EQ(hits, expectedHits);
-  };
+  auto run =
+      [&](int32_t outputCapacity, bool includeMisses, uint64_t maxBytes) {
+        BaseHashTable::JoinResultIterator iter(
+            {}, /*fixedSizeListColumnsSizeSum=*/8, std::nullopt);
+        iter.reset(lookup);
+        std::vector<vector_size_t> probeRows;
+        std::vector<char*> hits;
+        std::vector<vector_size_t> outputProbeRows(outputCapacity);
+        std::vector<char*> outputHits(outputCapacity);
+        while (!iter.atEnd()) {
+          const auto numOutput = table->listJoinResults(
+              iter,
+              includeMisses,
+              folly::Range(outputProbeRows.data(), outputCapacity),
+              folly::Range(outputHits.data(), outputCapacity),
+              maxBytes);
+          ASSERT_GT(numOutput, 0);
+          probeRows.insert(
+              probeRows.end(),
+              outputProbeRows.begin(),
+              outputProbeRows.begin() + numOutput);
+          hits.insert(
+              hits.end(), outputHits.begin(), outputHits.begin() + numOutput);
+        }
+        const auto [expectedProbeRows, expectedHits] = expected(includeMisses);
+        EXPECT_EQ(probeRows, expectedProbeRows);
+        EXPECT_EQ(hits, expectedHits);
+      };
 
   run(64, false, std::numeric_limits<uint64_t>::max());
   run(64, true, std::numeric_limits<uint64_t>::max());

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -71,8 +71,26 @@ class HashTableTestHelper {
         mode, numNew, BaseHashTable::kNoSpillInputStartPartitionBit);
   }
 
-  void markHasDuplicates() {
-    table_->hasDuplicates_.set();
+  // Bypasses dispatch so tests can compare the two walker paths directly.
+  int32_t testingListJoinResultsSingleHit(
+      BaseHashTable::JoinResultIterator& iter,
+      bool includeMisses,
+      folly::Range<vector_size_t*> inputRows,
+      folly::Range<char**> hits,
+      uint64_t maxBytes) {
+    return table_->listJoinResultsSingleHit(
+        iter, includeMisses, inputRows, hits, maxBytes);
+  }
+
+  // Bypasses dispatch so tests can invoke the interleaved walker directly.
+  int32_t testingListJoinResultsInterleaved(
+      BaseHashTable::JoinResultIterator& iter,
+      bool includeMisses,
+      folly::Range<vector_size_t*> inputRows,
+      folly::Range<char**> hits,
+      uint64_t maxBytes) {
+    return table_->listJoinResultsInterleaved(
+        iter, includeMisses, inputRows, hits, maxBytes);
   }
 
  private:
@@ -983,6 +1001,18 @@ TEST_P(HashTableTest, listJoinResultsSize) {
 }
 
 TEST_P(HashTableTest, listJoinResultsInterleaved) {
+  // Build a join table with duplicate keys via the normal insert path so
+  // the walker exercises the same chain structure as production. Probing
+  // yields lookup.hits pointing at the chain heads.
+  // Chains longer than `kAheadWindow` force a non-head slot's buffer to
+  // fill, pause, and resume once its slot becomes head — that boundary is
+  // what the interleaved walker rests on.
+  constexpr int32_t kNumKeys = 20;
+  constexpr int32_t kRowsPerKey =
+      BaseHashTable::JoinResultIterator::kAheadWindow + 4;
+  constexpr int32_t kNumRows = kNumKeys * kRowsPerKey;
+  auto buildType = ROW({"k", "v"}, {BIGINT(), BIGINT()});
+
   std::vector<std::unique_ptr<VectorHasher>> keyHashers;
   keyHashers.emplace_back(std::make_unique<VectorHasher>(BIGINT(), 0));
   auto table = HashTable<true>::createForJoin(
@@ -994,86 +1024,126 @@ TEST_P(HashTableTest, listJoinResultsInterleaved) {
       1'000,
       pool());
 
-  auto* rowContainer = table->rows();
-  const auto nextOffset = rowContainer->nextOffset();
-  ASSERT_GT(nextOffset, 0);
+  auto buildKeys = makeFlatVector<int64_t>(
+      kNumRows, [&](vector_size_t row) { return row % kNumKeys; });
+  auto buildValues =
+      makeFlatVector<int64_t>(kNumRows, [&](vector_size_t row) { return row; });
+  std::vector<RowVectorPtr> batches{makeRowVector({buildKeys, buildValues})};
+  copyVectorsToTable(batches, 0, table.get());
+  auto helper = HashTableTestHelper<true>::create(table.get());
+  table->prepareJoinTable(
+      {},
+      BaseHashTable::kNoSpillInputStartPartitionBit,
+      1'000'000,
+      false,
+      executor_.get());
+  ASSERT_GT(table->rows()->nextOffset(), 0);
+  // `hasDuplicates_` must be set by the insert path; combined with a
+  // non-zero `nextOffset_` this is what forces `listJoinResults` to
+  // dispatch to `listJoinResultsInterleaved` below.
+  ASSERT_TRUE(table->hasDuplicateKeys());
 
-  // The first chain advances long enough for the second chain to fill its
-  // ahead window and pause before it becomes head.
-  const std::vector<int32_t> chainLengths{10, 11, 3};
-  std::vector<std::vector<char*>> chains;
-  for (const auto chainLength : chainLengths) {
-    std::vector<char*> chain;
-    for (int32_t i = 0; i < chainLength; ++i) {
-      auto* row = rowContainer->newRow();
-      *reinterpret_cast<char**>(row + nextOffset) = nullptr;
-      chain.push_back(row);
-    }
-    for (int32_t i = 1; i < chainLength; ++i) {
-      *reinterpret_cast<char**>(chain[i - 1] + nextOffset) = chain[i];
-    }
-    chains.push_back(std::move(chain));
+  // Probe with more than kNumParallelChains keys so the walker refills a
+  // second slot batch mid-run. Some keys are deliberately absent from the
+  // build side to exercise the miss path. The `GetParam()` bool changes
+  // miss placement relative to the slot refill.
+  constexpr int32_t kNumProbe = 24;
+  const bool missesFirst = GetParam();
+  std::vector<int64_t> probeKeys(kNumProbe);
+  for (int32_t i = 0; i < kNumProbe; ++i) {
+    const bool miss = missesFirst ? (i < kNumProbe / 3) : (i % 3 == 0);
+    probeKeys[i] = miss ? (kNumKeys + i) : (i % kNumKeys);
   }
-
-  HashTableTestHelper<true>::create(table.get()).markHasDuplicates();
+  auto probeVector = makeRowVector({makeFlatVector<int64_t>(probeKeys)});
+  SelectivityVector selectivity(kNumProbe);
   HashLookup lookup(table->hashers(), pool());
-  lookup.reset(4);
+  table->prepareForJoinProbe(lookup, probeVector, selectivity, false);
+  lookup.hits.resize(kNumProbe);
+  std::fill(lookup.hits.begin(), lookup.hits.end(), nullptr);
+  table->joinProbe(lookup);
+  lookup.rows.resize(kNumProbe);
   std::iota(lookup.rows.begin(), lookup.rows.end(), 0);
-  lookup.hits[0] = chains[0].front();
-  lookup.hits[1] = nullptr;
-  lookup.hits[2] = chains[1].front();
-  lookup.hits[3] = chains[2].front();
 
-  auto expected = [&](bool includeMisses) {
+  // Collect the reference expansion via the (already tested) single-hit
+  // path; the interleaved walker must produce the same (row, hit) sequence.
+  auto collect = [&](auto&& runWalker,
+                     int32_t outputCapacity,
+                     bool includeMisses,
+                     uint64_t maxBytes) {
+    BaseHashTable::JoinResultIterator iter(
+        {}, /*fixedSizeListColumnsSizeSum=*/8, std::nullopt);
+    iter.reset(lookup);
     std::vector<vector_size_t> probeRows;
     std::vector<char*> hits;
-    auto appendChain = [&](vector_size_t probeRow, const auto& chain) {
-      probeRows.insert(probeRows.end(), chain.size(), probeRow);
-      hits.insert(hits.end(), chain.begin(), chain.end());
-    };
-    appendChain(0, chains[0]);
-    if (includeMisses) {
-      probeRows.push_back(1);
-      hits.push_back(nullptr);
+    std::vector<vector_size_t> outputProbeRows(outputCapacity);
+    std::vector<char*> outputHits(outputCapacity);
+    while (!iter.atEnd()) {
+      const auto numOutput = runWalker(
+          iter,
+          includeMisses,
+          folly::Range(outputProbeRows.data(), outputCapacity),
+          folly::Range(outputHits.data(), outputCapacity),
+          maxBytes);
+      if (numOutput == 0) {
+        // A call is allowed to return 0 only when it has just consumed
+        // the tail (e.g. trailing misses with includeMisses=false) —
+        // otherwise the loop would spin without making progress.
+        EXPECT_TRUE(iter.atEnd());
+        break;
+      }
+      probeRows.insert(
+          probeRows.end(),
+          outputProbeRows.begin(),
+          outputProbeRows.begin() + numOutput);
+      hits.insert(
+          hits.end(), outputHits.begin(), outputHits.begin() + numOutput);
     }
-    appendChain(2, chains[1]);
-    appendChain(3, chains[2]);
     return std::make_pair(std::move(probeRows), std::move(hits));
   };
 
-  auto run =
-      [&](int32_t outputCapacity, bool includeMisses, uint64_t maxBytes) {
-        BaseHashTable::JoinResultIterator iter(
-            {}, /*fixedSizeListColumnsSizeSum=*/8, std::nullopt);
-        iter.reset(lookup);
-        std::vector<vector_size_t> probeRows;
-        std::vector<char*> hits;
-        std::vector<vector_size_t> outputProbeRows(outputCapacity);
-        std::vector<char*> outputHits(outputCapacity);
-        while (!iter.atEnd()) {
-          const auto numOutput = table->listJoinResults(
-              iter,
-              includeMisses,
-              folly::Range(outputProbeRows.data(), outputCapacity),
-              folly::Range(outputHits.data(), outputCapacity),
-              maxBytes);
-          ASSERT_GT(numOutput, 0);
-          probeRows.insert(
-              probeRows.end(),
-              outputProbeRows.begin(),
-              outputProbeRows.begin() + numOutput);
-          hits.insert(
-              hits.end(), outputHits.begin(), outputHits.begin() + numOutput);
-        }
-        const auto [expectedProbeRows, expectedHits] = expected(includeMisses);
-        EXPECT_EQ(probeRows, expectedProbeRows);
-        EXPECT_EQ(hits, expectedHits);
-      };
+  // Three paths under test: the single-hit walker (used as the reference
+  // expansion), the interleaved walker invoked directly, and the public
+  // entry point which must dispatch to the interleaved walker under
+  // `hasDuplicates_ = true` + non-zero `nextOffset_`. Comparing all three
+  // catches both walker-level divergence and a dispatch regression that
+  // silently picks the wrong path.
+  auto singleHit = [&](auto&&... args) {
+    return helper.testingListJoinResultsSingleHit(
+        std::forward<decltype(args)>(args)...);
+  };
+  auto interleavedDirect = [&](auto&&... args) {
+    return helper.testingListJoinResultsInterleaved(
+        std::forward<decltype(args)>(args)...);
+  };
+  auto publicDispatch = [&](auto&&... args) {
+    return table->listJoinResults(std::forward<decltype(args)>(args)...);
+  };
 
-  run(64, false, std::numeric_limits<uint64_t>::max());
-  run(64, true, std::numeric_limits<uint64_t>::max());
-  run(1, true, std::numeric_limits<uint64_t>::max());
-  run(64, true, 16);
+  const std::vector<std::tuple<int32_t, bool, uint64_t>> cases{
+      {64, false, std::numeric_limits<uint64_t>::max()},
+      {64, true, std::numeric_limits<uint64_t>::max()},
+      {1, true, std::numeric_limits<uint64_t>::max()},
+      {kNumProbe / 2, true, std::numeric_limits<uint64_t>::max()},
+      {64, true, 16},
+  };
+  for (const auto& [outputCapacity, includeMisses, maxBytes] : cases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "outputCapacity={} includeMisses={} maxBytes={}",
+            outputCapacity,
+            includeMisses,
+            maxBytes));
+    const auto [refRows, refHits] =
+        collect(singleHit, outputCapacity, includeMisses, maxBytes);
+    const auto [directRows, directHits] =
+        collect(interleavedDirect, outputCapacity, includeMisses, maxBytes);
+    const auto [publicRows, publicHits] =
+        collect(publicDispatch, outputCapacity, includeMisses, maxBytes);
+    EXPECT_EQ(directRows, refRows);
+    EXPECT_EQ(directHits, refHits);
+    EXPECT_EQ(publicRows, refRows);
+    EXPECT_EQ(publicHits, refHits);
+  }
 }
 
 TEST_P(HashTableTest, groupBySpill) {

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -71,28 +71,6 @@ class HashTableTestHelper {
         mode, numNew, BaseHashTable::kNoSpillInputStartPartitionBit);
   }
 
-  // Bypasses dispatch so tests can compare the two walker paths directly.
-  int32_t testingListJoinResultsSingleHit(
-      BaseHashTable::JoinResultIterator& iter,
-      bool includeMisses,
-      folly::Range<vector_size_t*> inputRows,
-      folly::Range<char**> hits,
-      uint64_t maxBytes) {
-    return table_->listJoinResultsSingleHit(
-        iter, includeMisses, inputRows, hits, maxBytes);
-  }
-
-  // Bypasses dispatch so tests can invoke the interleaved walker directly.
-  int32_t testingListJoinResultsInterleaved(
-      BaseHashTable::JoinResultIterator& iter,
-      bool includeMisses,
-      folly::Range<vector_size_t*> inputRows,
-      folly::Range<char**> hits,
-      uint64_t maxBytes) {
-    return table_->listJoinResultsInterleaved(
-        iter, includeMisses, inputRows, hits, maxBytes);
-  }
-
  private:
   explicit HashTableTestHelper(HashTable<ignoreNullKeys>* table)
       : table_(table) {
@@ -1001,9 +979,14 @@ TEST_P(HashTableTest, listJoinResultsSize) {
 }
 
 TEST_P(HashTableTest, listJoinResultsInterleaved) {
-  // Build a join table with duplicate keys via the normal insert path so
-  // the walker exercises the same chain structure as production. Probing
-  // yields lookup.hits pointing at the chain heads.
+  if (GetParam()) {
+    // The fixture's `GetParam()==true` variant creates a threading executor,
+    // but this test's build passes `{}` for `otherTables`, so
+    // canApplyParallelJoinBuild() returns false and both variants take the
+    // same serial build path. Skip the redundant run.
+    GTEST_SKIP() << "No need to run this in multi-threaded mode";
+  }
+
   // Chains longer than `kAheadWindow` force a non-head slot's buffer to
   // fill, pause, and resume once its slot becomes head — that boundary is
   // what the interleaved walker rests on.
@@ -1011,7 +994,6 @@ TEST_P(HashTableTest, listJoinResultsInterleaved) {
   constexpr int32_t kRowsPerKey =
       BaseHashTable::JoinResultIterator::kAheadWindow + 4;
   constexpr int32_t kNumRows = kNumKeys * kRowsPerKey;
-  auto buildType = ROW({"k", "v"}, {BIGINT(), BIGINT()});
 
   std::vector<std::unique_ptr<VectorHasher>> keyHashers;
   keyHashers.emplace_back(std::make_unique<VectorHasher>(BIGINT(), 0));
@@ -1024,13 +1006,14 @@ TEST_P(HashTableTest, listJoinResultsInterleaved) {
       1'000,
       pool());
 
+  // Build side has `kRowsPerKey` rows per key; the value column carries a
+  // globally unique per-row id used to verify each chain expands fully.
   auto buildKeys = makeFlatVector<int64_t>(
       kNumRows, [&](vector_size_t row) { return row % kNumKeys; });
   auto buildValues =
       makeFlatVector<int64_t>(kNumRows, [&](vector_size_t row) { return row; });
   std::vector<RowVectorPtr> batches{makeRowVector({buildKeys, buildValues})};
   copyVectorsToTable(batches, 0, table.get());
-  auto helper = HashTableTestHelper<true>::create(table.get());
   table->prepareJoinTable(
       {},
       BaseHashTable::kNoSpillInputStartPartitionBit,
@@ -1038,111 +1021,134 @@ TEST_P(HashTableTest, listJoinResultsInterleaved) {
       false,
       executor_.get());
   ASSERT_GT(table->rows()->nextOffset(), 0);
-  // `hasDuplicates_` must be set by the insert path; combined with a
-  // non-zero `nextOffset_` this is what forces `listJoinResults` to
-  // dispatch to `listJoinResultsInterleaved` below.
   ASSERT_TRUE(table->hasDuplicateKeys());
 
-  // Probe with more than kNumParallelChains keys so the walker refills a
-  // second slot batch mid-run. Some keys are deliberately absent from the
-  // build side to exercise the miss path. The `GetParam()` bool changes
-  // miss placement relative to the slot refill.
-  constexpr int32_t kNumProbe = 24;
-  const bool missesFirst = GetParam();
-  std::vector<int64_t> probeKeys(kNumProbe);
-  for (int32_t i = 0; i < kNumProbe; ++i) {
-    const bool miss = missesFirst ? (i < kNumProbe / 3) : (i % 3 == 0);
-    probeKeys[i] = miss ? (kNumKeys + i) : (i % kNumKeys);
+  // Expected multiset of value-column ids for each key.
+  std::vector<std::multiset<int64_t>> expectedValuesByKey(kNumKeys);
+  for (int32_t row = 0; row < kNumRows; ++row) {
+    expectedValuesByKey[row % kNumKeys].insert(row);
   }
-  auto probeVector = makeRowVector({makeFlatVector<int64_t>(probeKeys)});
-  SelectivityVector selectivity(kNumProbe);
-  HashLookup lookup(table->hashers(), pool());
-  table->prepareForJoinProbe(lookup, probeVector, selectivity, false);
-  lookup.hits.resize(kNumProbe);
-  std::fill(lookup.hits.begin(), lookup.hits.end(), nullptr);
-  table->joinProbe(lookup);
-  lookup.rows.resize(kNumProbe);
-  std::iota(lookup.rows.begin(), lookup.rows.end(), 0);
 
-  // Collect the reference expansion via the (already tested) single-hit
-  // path; the interleaved walker must produce the same (row, hit) sequence.
-  auto collect = [&](auto&& runWalker,
-                     int32_t outputCapacity,
-                     bool includeMisses,
-                     uint64_t maxBytes) {
-    BaseHashTable::JoinResultIterator iter(
-        {}, /*fixedSizeListColumnsSizeSum=*/8, std::nullopt);
-    iter.reset(lookup);
-    std::vector<vector_size_t> probeRows;
-    std::vector<char*> hits;
-    std::vector<vector_size_t> outputProbeRows(outputCapacity);
-    std::vector<char*> outputHits(outputCapacity);
-    while (!iter.atEnd()) {
-      const auto numOutput = runWalker(
-          iter,
-          includeMisses,
-          folly::Range(outputProbeRows.data(), outputCapacity),
-          folly::Range(outputHits.data(), outputCapacity),
-          maxBytes);
-      if (numOutput == 0) {
-        // A call is allowed to return 0 only when it has just consumed
-        // the tail (e.g. trailing misses with includeMisses=false) —
-        // otherwise the loop would spin without making progress.
-        EXPECT_TRUE(iter.atEnd());
-        break;
-      }
-      probeRows.insert(
-          probeRows.end(),
-          outputProbeRows.begin(),
-          outputProbeRows.begin() + numOutput);
-      hits.insert(
-          hits.end(), outputHits.begin(), outputHits.begin() + numOutput);
-    }
-    return std::make_pair(std::move(probeRows), std::move(hits));
-  };
-
-  // Three paths under test: the single-hit walker (used as the reference
-  // expansion), the interleaved walker invoked directly, and the public
-  // entry point which must dispatch to the interleaved walker under
-  // `hasDuplicates_ = true` + non-zero `nextOffset_`. Comparing all three
-  // catches both walker-level divergence and a dispatch regression that
-  // silently picks the wrong path.
-  auto singleHit = [&](auto&&... args) {
-    return helper.testingListJoinResultsSingleHit(
-        std::forward<decltype(args)>(args)...);
-  };
-  auto interleavedDirect = [&](auto&&... args) {
-    return helper.testingListJoinResultsInterleaved(
-        std::forward<decltype(args)>(args)...);
-  };
-  auto publicDispatch = [&](auto&&... args) {
-    return table->listJoinResults(std::forward<decltype(args)>(args)...);
-  };
+  // Probe with more than kNumParallelChains keys so the walker refills the
+  // slot batch more than once mid-run.
+  constexpr int32_t kNumParallelChains =
+      BaseHashTable::JoinResultIterator::kNumParallelChains;
+  constexpr int32_t kNumProbe = kNumParallelChains * 3;
 
   const std::vector<std::tuple<int32_t, bool, uint64_t>> cases{
       {64, false, std::numeric_limits<uint64_t>::max()},
+      {1, false, std::numeric_limits<uint64_t>::max()},
       {64, true, std::numeric_limits<uint64_t>::max()},
       {1, true, std::numeric_limits<uint64_t>::max()},
       {kNumProbe / 2, true, std::numeric_limits<uint64_t>::max()},
       {64, true, 16},
   };
-  for (const auto& [outputCapacity, includeMisses, maxBytes] : cases) {
-    SCOPED_TRACE(
-        fmt::format(
-            "outputCapacity={} includeMisses={} maxBytes={}",
-            outputCapacity,
+
+  // `missesFirst=true` fills exactly the first slot batch with misses;
+  // `false` scatters misses across all batches. Both cover the miss-vs-
+  // refill boundary from different angles.
+  for (const bool missesFirst : {false, true}) {
+    SCOPED_TRACE(fmt::format("missesFirst={}", missesFirst));
+    std::vector<int64_t> probeKeys(kNumProbe);
+    for (int32_t i = 0; i < kNumProbe; ++i) {
+      const bool miss = missesFirst ? (i < kNumParallelChains) : (i % 3 == 0);
+      probeKeys[i] = miss ? (kNumKeys + i) : (i % kNumKeys);
+    }
+    auto probeVector = makeRowVector({makeFlatVector<int64_t>(probeKeys)});
+    SelectivityVector selectivity(kNumProbe);
+    HashLookup lookup(table->hashers(), pool());
+    table->prepareForJoinProbe(lookup, probeVector, selectivity, false);
+    lookup.hits.resize(kNumProbe);
+    std::fill(lookup.hits.begin(), lookup.hits.end(), nullptr);
+    table->joinProbe(lookup);
+    lookup.rows.resize(kNumProbe);
+    std::iota(lookup.rows.begin(), lookup.rows.end(), 0);
+
+    for (const auto& [outputCapacity, includeMisses, maxBytes] : cases) {
+      SCOPED_TRACE(
+          fmt::format(
+              "outputCapacity={} includeMisses={} maxBytes={}",
+              outputCapacity,
+              includeMisses,
+              maxBytes));
+
+      BaseHashTable::JoinResultIterator iter(
+          {}, /*fixedSizeListColumnsSizeSum=*/8, std::nullopt);
+      iter.reset(lookup);
+      std::vector<vector_size_t> probeRows;
+      std::vector<char*> hits;
+      std::vector<vector_size_t> outputProbeRows(outputCapacity);
+      std::vector<char*> outputHits(outputCapacity);
+      while (!iter.atEnd()) {
+        const auto numOutput = table->listJoinResults(
+            iter,
             includeMisses,
-            maxBytes));
-    const auto [refRows, refHits] =
-        collect(singleHit, outputCapacity, includeMisses, maxBytes);
-    const auto [directRows, directHits] =
-        collect(interleavedDirect, outputCapacity, includeMisses, maxBytes);
-    const auto [publicRows, publicHits] =
-        collect(publicDispatch, outputCapacity, includeMisses, maxBytes);
-    EXPECT_EQ(directRows, refRows);
-    EXPECT_EQ(directHits, refHits);
-    EXPECT_EQ(publicRows, refRows);
-    EXPECT_EQ(publicHits, refHits);
+            folly::Range(outputProbeRows.data(), outputCapacity),
+            folly::Range(outputHits.data(), outputCapacity),
+            maxBytes);
+        if (numOutput == 0) {
+          // A call may only return 0 after consuming everything reachable;
+          // otherwise the loop would spin without making progress.
+          EXPECT_TRUE(iter.atEnd());
+          break;
+        }
+        probeRows.insert(
+            probeRows.end(),
+            outputProbeRows.begin(),
+            outputProbeRows.begin() + numOutput);
+        hits.insert(
+            hits.end(), outputHits.begin(), outputHits.begin() + numOutput);
+      }
+
+      // Probe-row indices must be non-decreasing — this is the probe-order
+      // invariant the interleaved walker rests on.
+      for (size_t i = 1; i < probeRows.size(); ++i) {
+        EXPECT_LE(probeRows[i - 1], probeRows[i]);
+      }
+
+      // Partition emits into (probe row, hit) buckets in one pass: non-
+      // miss hits feed the per-probe-row multiset check below; misses go
+      // into a set so we can assert each miss row was emitted exactly once
+      // when `includeMisses` is true, and never when false.
+      std::vector<char*> nonNullHits;
+      std::vector<vector_size_t> nonNullProbeRows;
+      std::set<vector_size_t> observedMisses;
+      for (size_t i = 0; i < hits.size(); ++i) {
+        if (hits[i] == nullptr) {
+          observedMisses.insert(probeRows[i]);
+        } else {
+          nonNullHits.push_back(hits[i]);
+          nonNullProbeRows.push_back(probeRows[i]);
+        }
+      }
+      auto valuesColumn = BaseVector::create<FlatVector<int64_t>>(
+          BIGINT(), nonNullHits.size(), pool());
+      table->rows()->extractColumn(
+          nonNullHits.data(), nonNullHits.size(), 1, valuesColumn);
+
+      std::map<vector_size_t, std::multiset<int64_t>> observedByProbeRow;
+      for (size_t i = 0; i < nonNullHits.size(); ++i) {
+        observedByProbeRow[nonNullProbeRows[i]].insert(
+            valuesColumn->valueAt(i));
+      }
+
+      for (int32_t probeRow = 0; probeRow < kNumProbe; ++probeRow) {
+        const int64_t key = probeKeys[probeRow];
+        if (key >= kNumKeys) {
+          // Miss.
+          if (includeMisses) {
+            EXPECT_EQ(observedMisses.count(probeRow), 1u);
+          } else {
+            EXPECT_EQ(observedMisses.count(probeRow), 0u);
+          }
+          EXPECT_EQ(observedByProbeRow.count(probeRow), 0u);
+        } else {
+          auto it = observedByProbeRow.find(probeRow);
+          ASSERT_NE(it, observedByProbeRow.end());
+          EXPECT_EQ(it->second, expectedValuesByKey[key]);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Interleave `K=8` probe rows' chain walks in `HashTable::listJoinResults`
to overlap dependent next-pointer loads. The head slot emits inline;
the other `K-1` slots buffer hits and flush when they become head, so
probe-row order is preserved and every join type served by the slow
path benefits without gating.

Each slot's buffer is a fixed `kAheadWindow=8` stack array; a non-head
slot pauses once its buffer fills and resumes after becoming head, so
iterator state stays `O(K * kAheadWindow)` with no heap allocation.

Dispatch falls back to the single-hit path when `nextOffset_ == 0` or
`!hasDuplicates_` (every probe row has at most one hit, so the K-way
overhead would regress).

## Test environment

- Intel(R) Xeon(R) 6975P (GNR)
- Ubuntu 26.04 LTS
- Velox built `-O3` (`make release`)
- Gluten TPC-H SF300
- 3 executors × 4 cores; per executor: heap 4 GiB, off-heap (Velox native) 9 GiB, overhead 3 GiB

## Microbenchmark

`velox_hash_join_list_result_benchmark`, hash mode, 20M probe rows. Averages over 3 runs:

| Chain | Latency reduction |
  |:-----:|:-----------------:|
  | 1     | -11.9%   （regression）  |
  | 2     |  +0.3%            |
  | 6     | +27.2%            |
  | 11    | +34.6%            |
  | 26    | +20.7%            |
  | 50    | +10.1%            |

Chains up to `kAheadWindow` see the full MLP benefit; longer chains
trade some MLP for bounded iterator state — once every non-head slot
pauses, only the head slot advances.

## End-to-end

TPC-H SF300 via Gluten, 3 runs averaged. Total wall-clock latency:

| Query |  Latency Reduction       |
| ----- | ------- |
| q8 |  -11.61%  |
| q9 | -3.27% |  
|q21 |  -9.06% | 
| total |-3.29% |

No meaningful regressions on the remaining queries — the biggest wins concentrate on the join-heavy ones (q8, q9, q21), and the aggregate speedup carries through to the workload total.


Q21 metrics (matching CPU savings):

| Metric                          | ref            | opt            | Δ         |
  |---------------------------------|---------------:|---------------:|----------:|
  | Total cycles                    | 7 T        | 6.2 T        | −11.4%   |
  | listJoinResults share           | 29.98%         | 21.13%         | −8.85pt  |
  | listJoinResults cycles          | 2.1 T        | 1.3 T        | −38%    |

## Test plan

- [x] `HashTableTest.listJoinResultsInterleaved` (new)
- [x] Existing anti / left-semi / `leftJoinPreserveProbeOrder` tests
- [x] `velox_hash_join_list_result_benchmark` for chain 1..50
- [x] TPC-H SF300 end-to-end