### PR TITLE
feat: Add xxhash128 Presto scalar function (#18436)

### DIFF
--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -176,3 +176,13 @@ Binary Functions
    :noindex:
 
     Computes the xxhash64 hash of ``binary`` with ``bigint`` seed.
+
+.. function:: xxhash128(binary) -> varbinary
+
+    Computes the XXH3 128-bit hash of ``binary``, returned as the 16-byte
+    big-endian canonical representation.
+
+.. function:: xxhash128(binary, bigint) -> varbinary
+   :noindex:
+
+    Computes the XXH3 128-bit hash of ``binary`` with ``bigint`` seed.

--- a/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
+++ b/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
@@ -345,6 +345,9 @@ const std::unordered_set<std::string>& prestoSkippedFunctionsSOT() {
       // Skipping until the new signature is merged and released in Presto:
       // https://github.com/prestodb/presto/pull/25521
       "xxhash64(varbinary,bigint) -> varbinary",
+      // Skipping until xxhash128 is merged and released in Presto.
+      "xxhash128(varbinary) -> varbinary",
+      "xxhash128(varbinary,bigint) -> varbinary",
       "map_keys_by_top_n_values", // https://github.com/facebookincubator/velox/issues/14374
       "$internal$split_to_map",
       "$internal$canonicalize",

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -65,6 +65,29 @@ struct XxHash64Function {
   }
 };
 
+/// xxhash128(varbinary) → varbinary
+/// Return a 16-byte binary of the XXH3 128-bit hash of input (varbinary such as
+/// string) with optional seed. The result is the big-endian canonical
+/// representation produced by XXH128_canonicalFromHash.
+template <typename T>
+struct XxHash128Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(
+      out_type<Varbinary>& result,
+      const arg_type<Varbinary>& input,
+      const arg_type<int64_t>& seed = 0) {
+    const XXH128_hash_t hash =
+        XXH3_128bits_withSeed(input.data(), input.size(), seed);
+    XXH128_canonical_t canonical;
+    XXH128_canonicalFromHash(&canonical, hash);
+    static constexpr auto kLen = sizeof(canonical.digest);
+    result.resize(kLen);
+    std::memcpy(result.data(), canonical.digest, kLen);
+  }
+};
+
 /// md5(varbinary) → varbinary
 template <typename T>
 struct Md5Function {

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -26,6 +26,10 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "xxhash64"});
   registerFunction<XxHash64Function, Varbinary, Varbinary, int64_t>(
       {prefix + "xxhash64"});
+  registerFunction<XxHash128Function, Varbinary, Varbinary>(
+      {prefix + "xxhash128"});
+  registerFunction<XxHash128Function, Varbinary, Varbinary, int64_t>(
+      {prefix + "xxhash128"});
   registerFunction<Md5Function, Varbinary, Varbinary>({prefix + "md5"});
   registerFunction<Murmur3X64_128Function, Varbinary, Varbinary>(
       {prefix + "murmur3_x64_128"});

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -329,6 +329,44 @@ TEST_F(BinaryFunctionsTest, xxhash64WithSeed) {
   EXPECT_NE(hexToDec("26C7827D889F6DA3"), xxhash64WithSeed("hello", 1224));
 }
 
+TEST_F(BinaryFunctionsTest, xxhash128) {
+  const auto xxhash128 = [&](std::optional<std::string> value) {
+    return evaluateOnce<std::string>(
+        "xxhash128(c0)", VARBINARY(), std::move(value));
+  };
+
+  // Expected values are the big-endian canonical XXH3-128 digests produced by
+  // an independent oracle (the python xxhash library, seed 0).
+  EXPECT_EQ(std::nullopt, xxhash128(std::nullopt));
+  EXPECT_EQ(hexToDec("99AA06D3014798D86001C324468D497F"), xxhash128(""));
+  EXPECT_EQ(hexToDec("B5E9C1AD071B3E7FC779CFAA5E523818"), xxhash128("hello"));
+  EXPECT_EQ(hexToDec("94372AC63DEA37F1AB9234526989923A"), xxhash128("hashme"));
+  EXPECT_EQ(hexToDec("7C7419479B8CDDC1C5856B4F436BE4D2"), xxhash128("ABC "));
+  EXPECT_EQ(
+      hexToDec("82D9F70AEB974C48565E705734E91277"), xxhash128("1234567890"));
+  EXPECT_EQ(
+      hexToDec("58C6C309BC8AFF4A9B9FF553A4AB0942"),
+      xxhash128("more_than_12_characters_string"));
+}
+
+TEST_F(BinaryFunctionsTest, xxhash128WithSeed) {
+  const auto xxhash128WithSeed = [&](std::optional<std::string> value,
+                                     std::optional<int64_t> seed) {
+    return evaluateOnce<std::string>(
+        "xxhash128(c0, c1)", {VARBINARY(), BIGINT()}, std::move(value), seed);
+  };
+
+  EXPECT_EQ(
+      hexToDec("B5E9C1AD071B3E7FC779CFAA5E523818"),
+      xxhash128WithSeed("hello", 0));
+  EXPECT_NE(
+      hexToDec("B5E9C1AD071B3E7FC779CFAA5E523818"),
+      xxhash128WithSeed("hello", 1));
+  EXPECT_EQ(
+      hexToDec("94372AC63DEA37F1AB9234526989923A"),
+      xxhash128WithSeed("hashme", 0));
+}
+
 TEST_F(BinaryFunctionsTest, fnv1_32) {
   const auto fnv1_32 = [&](std::optional<std::string> arg) {
     return evaluateOnce<int32_t>("fnv1_32(c0)", VARBINARY(), arg);


### PR DESCRIPTION
Summary:

Adds xxhash128(varbinary) and xxhash128(varbinary, bigint), returning the
XXH3 128-bit hash as the 16-byte big-endian canonical representation
(XXH128_canonicalFromHash), mirroring the existing xxhash64. There is no
existing 128-bit xxhash in Presto/Velox.

Full open-source availability is gated on a companion prestodb/presto
registration (the same situation as the seeded xxhash64(varbinary, bigint)),
so both signatures are added to the expression fuzzer skip-list until that
lands.

Reviewed By: pedroerp

Differential Revision: D115043392
