### PR TITLE
fix(vector): Support OPAQUE vectors in saveVector/restoreVector

### DIFF
--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -324,9 +324,94 @@ bool isVarcharOrVarbinary(const BaseVector& vector) {
       vector.typeKind() == TypeKind::VARBINARY;
 }
 
+std::shared_ptr<const OpaqueType> asOpaqueType(const TypePtr& type) {
+  auto opaqueType = std::dynamic_pointer_cast<const OpaqueType>(type);
+  VELOX_CHECK_NOT_NULL(opaqueType, "Not an opaque type: {}", type->toString());
+  return opaqueType;
+}
+
+// An opaque value is a shared_ptr<void>, so its in-memory representation is a
+// pointer that means nothing once the process exits. Write the bytes produced
+// by the serializer registered for the type via
+// OpaqueType::registerSerialization instead, length-prefixed.
+void writeOpaqueValue(
+    const std::shared_ptr<void>& value,
+    const OpaqueType& type,
+    std::ostream& out) {
+  // Throws with a message naming the type when no serializer is registered.
+  const auto serialized = type.getSerializeFunc()(value);
+  write<int64_t>(static_cast<int64_t>(serialized.size()), out);
+  out.write(serialized.data(), static_cast<std::streamsize>(serialized.size()));
+}
+
+std::shared_ptr<void> readOpaqueValue(
+    const OpaqueType& type,
+    std::istream& in) {
+  const auto length = read<int64_t>(in);
+  VELOX_CHECK_GE(length, 0, "Invalid serialized opaque value size: {}", length);
+
+  std::string serialized(length, '\0');
+  in.read(serialized.data(), length);
+  // The deserializer is caller-supplied and may do anything with these bytes,
+  // so refuse truncated input rather than handing it a partial value.
+  VELOX_CHECK_EQ(
+      in.gcount(),
+      length,
+      "Truncated stream reading a serialized opaque value");
+
+  return type.getDeserializeFunc()(serialized);
+}
+
+// Null rows are recoverable from the nulls buffer written by writeFlatVector,
+// so they contribute no bytes here.
+void writeOpaqueValues(const BaseVector& vector, std::ostream& out) {
+  const auto opaqueType = asOpaqueType(vector.type());
+
+  // saveVector() dispatches on encoding, so a vector reaching writeFlatVector()
+  // is flat.
+  const auto* flat = vector.as<FlatVector<std::shared_ptr<void>>>();
+  VELOX_CHECK_NOT_NULL(flat);
+
+  for (vector_size_t i = 0; i < vector.size(); ++i) {
+    if (!vector.isNullAt(i)) {
+      writeOpaqueValue(flat->valueAt(i), *opaqueType, out);
+    }
+  }
+}
+
+VectorPtr readOpaqueVector(
+    const TypePtr& type,
+    vector_size_t size,
+    std::istream& in,
+    memory::MemoryPool* pool,
+    BufferPtr nulls) {
+  const auto opaqueType = asOpaqueType(type);
+
+  auto vector = std::make_shared<FlatVector<std::shared_ptr<void>>>(
+      pool,
+      type,
+      std::move(nulls),
+      size,
+      AlignedBuffer::allocate<std::shared_ptr<void>>(size, pool),
+      std::vector<BufferPtr>{});
+
+  const auto* rawNulls = vector->rawNulls();
+  for (vector_size_t i = 0; i < size; ++i) {
+    if (rawNulls == nullptr || !bits::isBitNull(rawNulls, i)) {
+      vector->set(i, readOpaqueValue(*opaqueType, in));
+    }
+  }
+  return vector;
+}
+
 void writeFlatVector(const BaseVector& vector, std::ostream& out) {
   // Nulls buffer.
   writeOptionalBuffer(vector.nulls(), out);
+
+  if (vector.typeKind() == TypeKind::OPAQUE) {
+    writeOpaqueValues(vector, out);
+    return;
+  }
 
   // Values buffer.
   if (isVarcharOrVarbinary(vector)) {
@@ -363,6 +448,10 @@ VectorPtr readFlatVector(
     memory::MemoryPool* pool) {
   // Nulls buffer.
   BufferPtr nulls = readOptionalBuffer(in, pool);
+
+  if (type->kind() == TypeKind::OPAQUE) {
+    return readOpaqueVector(type, size, in, pool, std::move(nulls));
+  }
 
   // Values buffer.
   BufferPtr values = readOptionalBuffer(in, pool);
@@ -414,6 +503,12 @@ void writeConstantVector(const BaseVector& vector, std::ostream& out) {
   if (baseVector) {
     saveVector(*baseVector, out);
     write<int32_t>(vector.as<ConstantVector<ComplexType>>()->index(), out);
+  } else if (vector.typeKind() == TypeKind::OPAQUE) {
+    // writeScalarConstant() would write the shared_ptr itself.
+    writeOpaqueValue(
+        vector.as<ConstantVector<std::shared_ptr<void>>>()->valueAt(0),
+        *asOpaqueType(vector.type()),
+        out);
   } else {
     VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
         writeScalarConstant, vector.typeKind(), vector, out);
@@ -463,6 +558,10 @@ VectorPtr readConstantVector(
 
   bool scalar = read<bool>(in);
   if (scalar) {
+    if (type->kind() == TypeKind::OPAQUE) {
+      return std::make_shared<ConstantVector<std::shared_ptr<void>>>(
+          pool, size, false, type, readOpaqueValue(*asOpaqueType(type), in));
+    }
     return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
         readConstant, type->kind(), type, size, pool, in);
   }

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -392,6 +392,150 @@ TEST_F(VectorSaverTest, flatIntervalDayTime) {
   testRoundTrip(opts, INTERVAL_DAY_TIME());
 }
 
+namespace {
+struct OpaqueValue {
+  explicit OpaqueValue(std::string payload) : payload{std::move(payload)} {}
+  std::string payload;
+};
+} // namespace
+
+// Opaque values are shared_ptr<void>, so no encoding can persist them by
+// copying their in-memory representation; every one of them has to go through
+// the serializer registered for the type. Kept in one fixture rather than split
+// across the flat/constant/dictionary groups because they share a registration.
+class OpaqueVectorSaverTest : public VectorSaverTest {
+ protected:
+  static void SetUpTestCase() {
+    VectorSaverTest::SetUpTestCase();
+    OpaqueType::registerSerialization<OpaqueValue>(
+        "vector_saver_test_opaque_value",
+        [](const std::shared_ptr<OpaqueValue>& value) {
+          return value->payload;
+        },
+        [](const std::string& serialized) {
+          return std::make_shared<OpaqueValue>(serialized);
+        });
+  }
+
+  VectorPtr makeOpaqueVector(
+      const std::vector<std::optional<std::string>>& payloads) {
+    auto vector = BaseVector::create<FlatVector<std::shared_ptr<void>>>(
+        OPAQUE<OpaqueValue>(),
+        static_cast<vector_size_t>(payloads.size()),
+        pool());
+    for (auto i = 0; i < static_cast<vector_size_t>(payloads.size()); ++i) {
+      if (payloads[i].has_value()) {
+        vector->set(i, std::make_shared<OpaqueValue>(*payloads[i]));
+      } else {
+        vector->setNull(i, true);
+      }
+    }
+    return vector;
+  }
+
+  static std::string payloadAt(const VectorPtr& vector, vector_size_t index) {
+    return std::static_pointer_cast<OpaqueValue>(
+               vector->as<SimpleVector<std::shared_ptr<void>>>()->valueAt(
+                   index))
+        ->payload;
+  }
+
+  void assertOpaquePayloads(
+      const VectorPtr& actual,
+      const std::vector<std::optional<std::string>>& expected) {
+    ASSERT_EQ(*actual->type(), *OPAQUE<OpaqueValue>());
+    ASSERT_EQ(actual->size(), static_cast<vector_size_t>(expected.size()));
+    for (auto i = 0; i < static_cast<vector_size_t>(expected.size()); ++i) {
+      if (!expected[i].has_value()) {
+        EXPECT_TRUE(actual->isNullAt(i)) << "at " << i;
+        continue;
+      }
+      ASSERT_FALSE(actual->isNullAt(i)) << "at " << i;
+      EXPECT_EQ(payloadAt(actual, i), *expected[i]) << "at " << i;
+    }
+  }
+};
+
+TEST_F(OpaqueVectorSaverTest, flatOpaque) {
+  const std::vector<std::optional<std::string>> payloads = {
+      "first", "second", "third"};
+  assertOpaquePayloads(takeRoundTrip(makeOpaqueVector(payloads)), payloads);
+}
+
+TEST_F(OpaqueVectorSaverTest, flatOpaqueWithNulls) {
+  const std::vector<std::optional<std::string>> payloads = {
+      "first", std::nullopt, "third", std::nullopt};
+  assertOpaquePayloads(takeRoundTrip(makeOpaqueVector(payloads)), payloads);
+}
+
+TEST_F(OpaqueVectorSaverTest, flatOpaqueEmptyAndEmbeddedNulls) {
+  const std::vector<std::optional<std::string>> payloads = {
+      "", std::string("with\0embedded", 13), "tail"};
+  assertOpaquePayloads(takeRoundTrip(makeOpaqueVector(payloads)), payloads);
+}
+
+// A constant with no base vector holds the value inline, so it needs the same
+// serde treatment as a flat vector's values.
+TEST_F(OpaqueVectorSaverTest, constantOpaque) {
+  auto vector = std::make_shared<ConstantVector<std::shared_ptr<void>>>(
+      pool(),
+      100,
+      false,
+      OPAQUE<OpaqueValue>(),
+      std::static_pointer_cast<void>(
+          std::make_shared<OpaqueValue>("constant payload")));
+
+  auto copy = takeRoundTrip(vector);
+  ASSERT_EQ(copy->encoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_EQ(*copy->type(), *OPAQUE<OpaqueValue>());
+  ASSERT_EQ(copy->size(), 100);
+  ASSERT_FALSE(copy->isNullAt(0));
+  EXPECT_EQ(payloadAt(copy, 0), "constant payload");
+}
+
+TEST_F(OpaqueVectorSaverTest, constantOpaqueNull) {
+  auto copy = takeRoundTrip(
+      BaseVector::createNullConstant(OPAQUE<OpaqueValue>(), 100, pool()));
+  ASSERT_EQ(copy->encoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_EQ(*copy->type(), *OPAQUE<OpaqueValue>());
+  EXPECT_TRUE(copy->isNullAt(0));
+}
+
+// A dictionary defers to its base vector, so the values are written once and
+// the indices select among them.
+TEST_F(OpaqueVectorSaverTest, dictionaryOpaque) {
+  auto base = makeOpaqueVector({"first", "second"});
+
+  auto indices = AlignedBuffer::allocate<vector_size_t>(4, pool());
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  rawIndices[0] = 1;
+  rawIndices[1] = 0;
+  rawIndices[2] = 1;
+  rawIndices[3] = 1;
+
+  auto copy = takeRoundTrip(
+      BaseVector::wrapInDictionary(nullptr, indices, 4, std::move(base)));
+  ASSERT_EQ(copy->encoding(), VectorEncoding::Simple::DICTIONARY);
+  assertOpaquePayloads(copy, {"second", "first", "second", "second"});
+}
+
+// registerSerialization allows a persistent name without serialize/deserialize
+// functions. The type then survives saveType, but its values cannot be written.
+// A fully unregistered type fails earlier, when the type itself is written.
+TEST_F(OpaqueVectorSaverTest, nameRegisteredWithoutValueSerdeFails) {
+  struct NameOnly {};
+  OpaqueType::registerSerialization<NameOnly>(
+      "vector_saver_test_name_only_opaque");
+
+  auto vector = BaseVector::create<FlatVector<std::shared_ptr<void>>>(
+      OPAQUE<NameOnly>(), 1, pool());
+  vector->set(0, std::make_shared<NameOnly>());
+
+  std::ostringstream out;
+  VELOX_ASSERT_THROW(
+      saveVector(*vector, out), "No serialization function registered");
+}
+
 TEST_F(VectorSaverTest, row) {
   auto opts = fuzzerOptions();
 


### PR DESCRIPTION
Summary:
`saveVector` cannot persist an OPAQUE vector under any encoding. Opaque values
are `std::shared_ptr<void>`, so their in-memory representation is a
process-local pointer, and both paths that reach a value write it verbatim:

- `writeFlatVector` writes `vector.values()` as raw bytes for every non-string
  type, so a buffer of pointers goes straight to the stream.
- `writeConstantVector` dispatches through
  `VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL`, which lists OPAQUE explicitly, so
  `writeScalarConstant<OPAQUE>` writes `sizeof(std::shared_ptr<void>)` bytes of
  the pointer itself.

Reading either back is worse than recovering a wrong value.
`readConstant<OPAQUE>` fills a `std::shared_ptr<void>` with bytes off the stream
and then owns it, so a fabricated control-block pointer gets decremented when
the vector dies. There is no mention of OPAQUE anywhere in `VectorSaver.cpp`
today.

`OpaqueType` already carries what is needed. `registerSerialization<T>()`
records a serialize/deserialize pair, and the *type* already round-trips through
its persistent name. Only the values were unhandled, so anything routing an
opaque vector through `saveVector` -- batch dumps, replay logging, debug capture
-- fails.

This adds `writeOpaqueValue`/`readOpaqueValue`, one length-prefixed value
framing, and routes both the flat and the constant path through it. DICTIONARY
and LAZY need no change: they defer to their base vector, which lands on the
flat path.

Null rows contribute no bytes. `writeFlatVector` persists the nulls buffer
immediately before the values, so the reader replays it to decide which rows to
consume -- the same contract every other type in this file uses. (V1 of this
diff wrote a per-row presence flag, which duplicated the nulls buffer.)

Framing is an `int64` length followed by the bytes, so payloads containing
embedded NULs survive. The reader rejects a negative length, matching the
existing `read<std::string>` helper, and rejects a short read: the deserializer
is caller-supplied and should not be handed a truncated value.

No other error handling is added. `OpaqueType::getSerializeFunc()` and
`getDeserializeFunc()` already `VELOX_CHECK` and throw naming the type, and a
type with no registered persistent name fails earlier still, when the type
itself is written.

Differential Revision: D115142536


