### PR TITLE
fix(ci): Bump Ubuntu tzdata pin to the currently published build (fixes #18440)

### DIFF
--- a/scripts/docker/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/docker/ubuntu-22.04-cpp.dockerfile
@@ -11,14 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# tzdata is pinned to a known-good version so docker rebuilds (any time
-# scripts/docker/*.dockerfile or scripts/setup-*.sh changes) don't
+# tzdata is pinned to an exact version so docker rebuilds (any time
+# scripts/docker/*.dockerfile or scripts/setup-*.sh changes) do not
 # silently bump tzdata in the image. See issue #17522 for the bug class
-# this prevents — version mismatch between OS tzdata and consumers'
-# bundled tzdb code can produce silent 1-hour offsets in TIMESTAMP
-# WITH TIME ZONE values. To bump intentionally: change the default and
-# rebuild locally to confirm before merging.
-ARG UBUNTU_TZDATA_VERSION=2026a-0ubuntu0.22.04.1
+# this prevents: a version mismatch between OS tzdata and consumers'
+# bundled tzdb code can produce silent one hour offsets in TIMESTAMP
+# WITH TIME ZONE values.
+#
+# Ubuntu keeps only the latest build of tzdata in the jammy pockets, so an
+# exact pin is purged once Canonical publishes a newer build, which then
+# fails the image bake with "Version ... not found" (issue #18440). Track
+# the build currently published for 22.04. The Presto source of truth
+# fuzzers, the tz sensitive consumer from #17522, run on the centos9 and
+# presto-java images and are governed by CENTOS_TZDATA_VERSION, not this
+# pin, so this version can move independently. To bump: set it to the
+# current 22.04 build and rebuild to confirm before merging.
+ARG UBUNTU_TZDATA_VERSION=2026c-0ubuntu0.22.04.1
 
 ARG base=ubuntu:22.04
 FROM ${base}

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -35,14 +35,8 @@ add_executable(velox_functions_prestosql_benchmarks_array_contains ArrayContains
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_contains ArrayPositionBasic.h)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_contains ${BENCHMARK_DEPENDENCIES})
 
-add_executable(
-  velox_functions_prestosql_benchmarks_array_join
-  ArrayJoinBenchmark.cpp
-)
-target_link_libraries(
-  velox_functions_prestosql_benchmarks_array_join
-  ${BENCHMARK_DEPENDENCIES}
-)
+add_executable(velox_functions_prestosql_benchmarks_array_join ArrayJoinBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_array_join ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.cpp)
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.h)


### PR DESCRIPTION
## Summary

The `Build & Push Docker Images` workflow fails at the bake step because the Ubuntu image pins an exact `tzdata` apt version that Ubuntu has since purged from its mirrors.

Failing run (PR #18194): https://github.com/facebookincubator/velox/actions/runs/31194302781/job/92918701450

```
E: Version '2026a-0ubuntu0.22.04.1' for 'tzdata' was not found
ERROR: process "apt-get install -y --allow-downgrades tzdata=${UBUNTU_TZDATA_VERSION}" ... exit code: 100
buildx bake failed
```

## Root cause

`scripts/docker/ubuntu-22.04-cpp.dockerfile` pinned `UBUNTU_TZDATA_VERSION=2026a-0ubuntu0.22.04.1` and installed it with an exact match. Ubuntu keeps only the latest build of a package in the `jammy-updates`/`jammy-security` pockets, so once Canonical published a newer build the pinned exact version was removed from the archive and the exact-match install started failing with exit code 100.

## Fix

Bump `UBUNTU_TZDATA_VERSION` to `2026c-0ubuntu0.22.04.1`, the build currently published for 22.04 (confirmed in both jammy-updates and jammy-security via Launchpad).

Design notes:
- The pin is kept **exact** to preserve the deterministic-tzdata behavior introduced in #17522 (avoids silent OS-vs-consumer tzdb mismatches that caused 1-hour offsets in `TIMESTAMP WITH TIME ZONE`).
- The tz-sensitive consumer from #17522, the Presto source-of-truth fuzzers, run on the `centos9`/`presto-java` images and are governed by `CENTOS_TZDATA_VERSION` (left unchanged at `2026a`). The Ubuntu image is not used by those fuzzers, so this pin can move independently without affecting fuzzer tz consistency.

## Additional: unrelated pre-commit fix folded in

pre-commit CI runs gersemi with `--all-files`, so any pre-existing formatting drift in the tree fails every PR (not just this one). #18361 (landed 2026-08-06) introduced a multi-line `add_executable`/`target_link_libraries` in `velox/functions/prestosql/benchmarks/CMakeLists.txt` that gersemi 0.21.0 collapses to single lines. That drift was failing pre-commit here despite being unrelated to the tzdata change, so the gersemi-formatted version is included in this PR to unblock it (second commit).

## Test plan

`docker.yml` runs on `pull_request` when `scripts/docker/*.dockerfile` changes, so this PR triggers the `Build ubuntu Image on amd64` bake, which exercises the tzdata fix directly. pre-commit exercises the gersemi fix.

Fixes #18440.
