### PR TITLE
test(dwrf): Use the ArenaCreate shim in TestBinaryStreamReader (#18442)

### DIFF
--- a/velox/dwio/dwrf/test/TestBinaryStreamReader.cpp
+++ b/velox/dwio/dwrf/test/TestBinaryStreamReader.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/io/IoStatistics.h"
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/reader/BinaryStreamReader.h"
@@ -74,7 +75,7 @@ auto createFooter(
     google::protobuf::Arena& arena,
     uint32_t strideLen,
     const std::string& schema) {
-  auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
+  auto footer = ArenaCreate<proto::Footer>(&arena);
   footer->set_rowindexstride(strideLen);
   auto type = HiveTypeParser().parse(schema);
   FooterWriteWrapper wrapper{footer};


### PR DESCRIPTION
Summary:

protobuf 32.1 removes `Arena::CreateMessage<T>()`. The previous version of this diff rewrote the call site to `Arena::Create<T>(&arena)` on the premise that the two are equivalent under 3.20.3. They are not.

Under 3.20.3, `Arena::Create` deliberately treats `T` as a black box (contract comment at `third-party/protobuf/3.20.3/protobuf/src/google/protobuf/arena.h:297-311`, implementation at `:699-714`): it placement-news `T()` into arena storage *without* threading the arena pointer into the message, then registers a destructor. The message reports `GetArena() == nullptr` while living in arena memory. Only in 32.1 does `Create` branch on `is_arena_constructable<T>` and route messages to `DoCreateMessage` (`third-party/protobuf/32.1/src/src/google/protobuf/arena.h:198-226`).

The practical effect here: `createFooter()`'s footer stops propagating the arena, so `add_statistics()` / `mutable_encryption()` / `add_stripes()` sub-allocations land on the heap instead of the arena. Not a crash — nothing takes ownership of the footer — but it diverges from production, which builds its footer with `ArenaCreate` (`velox/dwio/dwrf/writer/WriterBase.h:111`), and it would silently flip back at the 32.1 cutover.

Use the existing version-guarded shim `velox::dwio::common::ArenaCreate` (`velox/dwio/common/Arena.h`, added for this break in D85457019) instead. `velox_dwrf_binary_stream_reader_test` gains an explicit `//velox/dwio/common:velox_dwio_common` dep for the header.

Reviewed By: itamaro

Differential Revision: D115225025


