### PR TITLE
DO NOT LAND - test(fuzzer): Break floor() to validate regression detection (#18443)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -258,6 +258,7 @@ jobs:
             -DVELOX_BUILD_SHARED=ON
             -DVELOX_BUILD_PYTHON_PACKAGE=ON
             -DVELOX_PYTHON_LEGACY_ONLY=ON
+            -DVELOX_ENABLE_LOCAL_RUNNER_SERVICE=ON
             ${{ inputs.extraCMakeFlags }}
         run: |
           make python-venv

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -754,6 +754,7 @@ jobs:
           set +e
           ./velox_expression_fuzzer_test \
                 --seed ${random_seed} \
+                --only floor \
                 --enable_variadic_signatures \
                 --velox_fuzzer_enable_complex_types \
                 --velox_fuzzer_enable_decimal_type \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -453,6 +453,149 @@ jobs:
           path: velox/_build/debug/lib/libvelox.so
           retention-days: ${{ env.RETENTION }}
 
+  compile-baseline-local-runner:
+    name: Build LocalRunnerService
+    if: ${{ github.repository == 'facebookincubator/velox' }}
+    runs-on: 32-core-ubuntu
+    container: ghcr.io/facebookincubator/velox-dev:centos9
+    timeout-minutes: 120
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      NUM_THREADS: ${{ inputs.numThreads || 32 }}
+      MAX_HIGH_MEM_JOBS: ${{ inputs.maxHighMemJobs || 8 }}
+      MAX_LINK_JOBS: ${{ inputs.maxLinkJobs || 6 }}
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+      BASELINE_DIR: ${{ github.workspace }}/baseline-local-runner
+      # Bump to invalidate every cached baseline binary. Required whenever
+      # EXTRA_CMAKE_FLAGS, the built target, or the container image changes,
+      # since none of those are part of the cache key.
+      BASELINE_CACHE_VERSION: v1
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: velox_main
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      # Resolves the commit the baseline is built from. On push this is the
+      # landed commit itself, not its parent: that commit is the merge base
+      # future PRs will resolve to, so building it here warms the cache for
+      # them.
+      - name: Get baseline commit
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_REF: ${{ inputs.ref || 'main' }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+        id: get-merge-base
+        run: |
+          source .github/scripts/gh-api-retry.sh
+          if [ '${{ github.event_name == 'push' }}' == "true" ]; then
+            head_main='${{ github.sha }}'
+          elif [ '${{ github.event_name == 'pull_request' }}' == "true" ]; then
+            head_main=$(gh_api -q '.merge_base_commit.sha' \
+              /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
+            )
+          else
+            # Resolve to an immutable SHA; a branch name would make the cache
+            # key mutable and serve a stale baseline forever.
+            head_main=$(gh_api -q '.sha' "/repos/facebookincubator/velox/commits/$INPUT_REF")
+          fi
+          echo "Determined SHA: $head_main"
+          echo "head_main=$head_main" >> $GITHUB_OUTPUT
+
+      # Exact-match key only, no restore-keys prefix fallback: restoring a
+      # binary built from a different commit would compare the contender
+      # against the wrong baseline and report phantom regressions.
+      - name: Restore baseline LocalRunnerService
+        uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        id: get-baseline
+        with:
+          path: ${{ env.BASELINE_DIR }}
+          key: local-runner-service-${{ env.BASELINE_CACHE_VERSION }}-${{ runner.arch }}-${{ steps.get-merge-base.outputs.head_main }}
+
+      - name: Restore ccache
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-baseline-local-runner-centos
+
+      - name: Fix git permissions
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        working-directory: ${{ github.workspace }}
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox_main
+
+      - name: Ensure Stash Dirs Exists
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        working-directory: ${{ github.workspace }}
+        run: mkdir -p '$CCACHE_DIR'
+
+      - name: Checkout Main
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.get-merge-base.outputs.head_main || 'main' }}
+          path: velox_main
+          persist-credentials: false
+
+      # Every step below that inherits working-directory: velox_main has to
+      # carry the cache-miss guard as well, since velox_main is not checked
+      # out on a hit.
+      - name: Zero Ccache Statistics
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        run: ccache -sz
+
+      - name: Build LocalRunnerService
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        env:
+          EXTRA_CMAKE_FLAGS: >
+            -DVELOX_ENABLE_ARROW=ON
+            -DVELOX_ENABLE_GEO=ON
+            -DVELOX_ENABLE_REMOTE_FUNCTIONS=ON
+            -DVELOX_ENABLE_LOCAL_RUNNER_SERVICE=ON
+            ${{ inputs.extraCMakeFlags }}
+        run: |
+          make cmake BUILD_DIR=debug BUILD_TYPE=Debug
+          cmake --build _build/debug -j ${NUM_THREADS} --target \
+            velox_local_runner_service_runner
+          mkdir -p "${BASELINE_DIR}"
+          cp _build/debug/velox/exec/fuzzer/velox_local_runner_service_runner \
+            "${BASELINE_DIR}/"
+
+      - name: Ccache after
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        run: ccache -s
+
+      - name: Save ccache
+        continue-on-error: true
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' && github.event_name != 'schedule' }}
+        uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-baseline-local-runner-centos
+
+      - name: Save baseline LocalRunnerService
+        if: ${{ steps.get-baseline.outputs.stash-hit != 'true' }}
+        uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        with:
+          path: ${{ env.BASELINE_DIR }}
+          key: local-runner-service-${{ env.BASELINE_CACHE_VERSION }}-${{ runner.arch }}-${{ steps.get-merge-base.outputs.head_main }}
+
+      - name: Upload baseline local runner service
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: baseline_local_runner_service_runner
+          path: ${{ env.BASELINE_DIR }}/velox_local_runner_service_runner
+          retention-days: ${{ env.RETENTION }}
+
   presto-fuzzer-run:
     name: Presto Fuzzer
     if: ${{ needs.compile.outputs.presto_bias  != 'true' }}
@@ -533,6 +676,113 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: presto-fuzzer-failure-artifacts
+          path: |
+            /tmp/fuzzer_repro
+
+  presto-fuzzer-with-local-runner-run:
+    name: Regression Fuzzer
+    runs-on: 4-core-ubuntu
+    container: ghcr.io/facebookincubator/velox-dev:centos9
+    needs: [compile, compile-baseline-local-runner]
+    timeout-minutes: 120
+    # Soft launch: this job is being monitored for signal quality and must not
+    # gate the workflow. Remove once the results are trusted.
+    continue-on-error: true
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        if: github.event_name == 'pull_request'
+        id: changes
+        with:
+          filters: |
+            presto:
+              - 'velox/expression/!(test)**'
+              - 'velox/exec/!(test)**'
+              - 'velox/common/!(test)**'
+              - 'velox/core/!(test)**'
+              - 'velox/vector/!(test)**'
+
+      - name: Set presto specific fuzzer duration
+        env:
+          pr_duration: ${{ steps.changes.outputs.presto == 'true' && 600 || 300 }}
+          other_duration: ${{ inputs.duration || (github.event_name == 'push' && 600 || 1200) }}
+          is_pr: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [ "$is_pr" == "true" ]; then
+            duration=$pr_duration
+          else
+            duration=$other_duration
+          fi
+
+          echo "DURATION=$duration" >> $GITHUB_ENV
+
+      - name: Download presto fuzzer
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: presto
+
+      - name: Download baseline local runner service
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: baseline_local_runner_service_runner
+
+      - name: Download libvelox
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: libvelox
+
+      - name: Run Regression Fuzzer
+        run: |
+          export LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH
+          mkdir -p /tmp/fuzzer_repro/logs/
+          chmod -R 777 /tmp/fuzzer_repro
+          chmod +x velox_expression_fuzzer_test
+          chmod +x velox_local_runner_service_runner
+          # Start LocalRunnerService in the background
+          ./velox_local_runner_service_runner > /tmp/fuzzer_repro/logs/local_runner_service.log 2>&1 &
+          LOCAL_RUNNER_PID=$!
+          # Stop the LocalRunnerService
+          trap 'kill $LOCAL_RUNNER_PID || true' EXIT
+          echo "Started LocalRunnerService with PID: ${LOCAL_RUNNER_PID}"
+          # Sleep for 10 seconds to allow service to start
+          sleep 10
+          random_seed=${RANDOM}
+          echo "Duration: $DURATION"
+          echo "Random seed: ${random_seed}"
+          # Soft launch: swallow the fuzzer's exit code so a real regression
+          # surfaces as a log annotation instead of a red check. Remove along
+          # with continue-on-error once the results are trusted.
+          set +e
+          ./velox_expression_fuzzer_test \
+                --seed ${random_seed} \
+                --enable_variadic_signatures \
+                --velox_fuzzer_enable_complex_types \
+                --velox_fuzzer_enable_decimal_type \
+                --lazy_vector_generation_ratio 0.2 \
+                --common_dictionary_wraps_generation_ratio=0.3 \
+                --velox_fuzzer_enable_column_reuse \
+                --velox_fuzzer_enable_expression_reuse \
+                --max_expression_trees_per_step 2 \
+                --retry_with_try \
+                --enable_dereference \
+                --duration_sec $DURATION \
+                --minloglevel=0 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/fuzzer_repro/logs \
+                --repro_persist_path=/tmp/fuzzer_repro \
+                --velox_runner_url=http://127.0.0.1:9091
+          fuzzer_status=$?
+          set -e
+          if [ "${fuzzer_status}" -eq 0 ]; then
+            echo -e "\n\nFuzzer run finished successfully."
+          else
+            echo "::warning title=Regression Fuzzer::Fuzzer exited with status ${fuzzer_status}. Soft launch: not failing the workflow. Check the run logs and the uploaded repro artifacts."
+          fi
+
+      - name: Archive production artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: presto-fuzzer-with-local-runner-failure-artifacts
           path: |
             /tmp/fuzzer_repro
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,11 @@ option(VELOX_ENABLE_NIMBLE "Enable Nimble support" OFF)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_GEO "Enable Geospatial support" ON)
 option(VELOX_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
+option(
+  VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  "Enable LocalRunnerService and VeloxQueryRunner for expression fuzzer regression testing"
+  OFF
+)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 option(VELOX_ENABLE_COMPRESSION_LZ4 "Enable Lz4 compression support." OFF)
 
@@ -711,9 +716,14 @@ if(${VELOX_BUILD_TESTING})
   velox_resolve_dependency(gRPC)
 endif()
 
-if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET)
-  # TODO: Move this to use resolve_dependency(). For some reason, FBThrift
-  # requires clients to explicitly install fizz and wangle.
+# FBThrift is required by remote functions and LocalRunnerService.
+if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET OR VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+  set(VELOX_NEEDS_FBTHRIFT ON)
+endif()
+
+# TODO: Move this to use resolve_dependency(). For some reason, FBThrift
+# requires clients to explicitly install fizz and wangle.
+if(VELOX_NEEDS_FBTHRIFT)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Generate Thrift library for LocalRunnerService early since velox_fuzzer_util
-# depends on it when VELOX_ENABLE_REMOTE_FUNCTIONS is enabled.
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# depends on it when VELOX_ENABLE_LOCAL_RUNNER_SERVICE is enabled.
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   include(FBThriftCppLibrary)
   add_fbthrift_cpp_library(
     local_runner_service_thrift
@@ -55,13 +55,12 @@ velox_add_test_headers(
   VeloxQueryRunner.h
 )
 
-# TODO Add VeloxQueryRunner to velox_fuzzer_util to support in
-# ExpressionFuzzerTest. More information can be found here:
-# https://github.com/facebookincubator/velox/issues/15414
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# VeloxQueryRunner requires LocalRunnerService thrift library
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   target_sources(velox_fuzzer_util PRIVATE VeloxQueryRunner.cpp)
   target_link_libraries(velox_fuzzer_util local_runner_service_thrift)
   target_include_directories(velox_fuzzer_util PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  target_compile_definitions(velox_fuzzer_util PUBLIC VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
 endif()
 
 target_link_libraries(
@@ -285,7 +284,7 @@ target_link_libraries(
 )
 
 # LocalRunnerService Library
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_library(velox_local_runner_service_lib LocalRunnerService.cpp)
   velox_add_test_headers(velox_local_runner_service_lib LocalRunnerService.h)
 

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(presto_sql_test presto_sql_test)
 target_link_libraries(presto_sql_test velox_fuzzer_util velox_presto_types)
 
 # LocalRunnerService Test (requires FBThrift support)
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_executable(local_runner_service_test LocalRunnerServiceTest.cpp)
   add_test(local_runner_service_test local_runner_service_test)
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -19,6 +19,9 @@
 
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+#include "velox/exec/fuzzer/VeloxQueryRunner.h"
+#endif
 #include "velox/expression/fuzzer/ArgTypesGenerator.h"
 #include "velox/expression/fuzzer/ArgValuesGenerators.h"
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
@@ -48,6 +51,16 @@ DEFINE_string(
     "Presto coordinator URI along with port. If set, we use Presto as the "
     "source of truth. Otherwise, use the Velox simplified expression evaluation. Example: "
     "--presto_url=http://127.0.0.1:8080");
+
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+DEFINE_string(
+    velox_runner_url,
+    "",
+    "URI for thrift requests to LocalRunnerService. If set, we use a "
+    "LocalRunnerService instance as the source of truth. Otherwise, use the "
+    "Velox simplified expression evaluation. Example: "
+    "--velox_runner_url=http://127.0.0.1:9091");
+#endif
 
 DEFINE_uint32(
     req_timeout_ms,
@@ -153,6 +166,8 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
         {"s2_cell_from_token",
          std::make_shared<S2CellTokenArgValuesGenerator>()}};
 
+const std::unordered_set<std::string> skipFunctionsLocalRunner{};
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
@@ -174,6 +189,7 @@ int main(int argc, char** argv) {
   std::shared_ptr<facebook::velox::memory::MemoryPool> rootPool{
       facebook::velox::memory::memoryManager()->addRootPool()};
   std::shared_ptr<ReferenceQueryRunner> referenceQueryRunner{nullptr};
+  const char* shouldAdjustTimestampToSessionTimezone{"true"};
 
   if (!FLAGS_presto_url.empty()) {
     // Add additional functions to skip since we are now querying Presto
@@ -187,6 +203,21 @@ int main(int argc, char** argv) {
         "expression_fuzzer",
         static_cast<std::chrono::milliseconds>(FLAGS_req_timeout_ms));
     LOG(INFO) << "Using Presto as the reference DB.";
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  } else if (!FLAGS_velox_runner_url.empty()) {
+    // LocalRunnerService sets only session_timezone on the reference side, so
+    // adjust_timestamp_to_session_timezone keeps its default of false there.
+    // The contender has to match it or timezone-less timestamp conversions
+    // differ by the session's UTC offset on every comparison.
+    shouldAdjustTimestampToSessionTimezone = "false";
+    skipFunctions.insert(
+        skipFunctionsLocalRunner.begin(), skipFunctionsLocalRunner.end());
+    referenceQueryRunner = std::make_shared<VeloxQueryRunner>(
+        rootPool.get(),
+        FLAGS_velox_runner_url,
+        std::chrono::milliseconds(FLAGS_req_timeout_ms));
+    LOG(INFO) << "Using LocalQueryRunner as the reference engine.";
+#endif
   }
   FuzzerRunner::runFromGtest(
       initialSeed,
@@ -194,7 +225,8 @@ int main(int argc, char** argv) {
       exprTransformers,
       {{facebook::velox::core::QueryConfig::kSessionTimezone,
         "America/Los_Angeles"},
-       {facebook::velox::core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+       {facebook::velox::core::QueryConfig::kAdjustTimestampToTimezone,
+        shouldAdjustTimestampToSessionTimezone},
        {facebook::velox::core::QueryConfig::kMinRowsForPeeling, "50"}},
       argTypesGenerators,
       argValuesGenerators,

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -249,7 +249,7 @@ struct FloorFunction {
     if constexpr (std::is_integral_v<TInput>) {
       result = a;
     } else {
-      result = floor(a);
+      result = floor(a) + 1;
     }
   }
 };


### PR DESCRIPTION
Summary:

Deliberately wrong `floor()` used to prove the regression fuzzer added below it actually detects a behavior change. This is a canary, not a fix. It must never land.

`floor()` now returns `floor(a) + 1` for negative inputs, so `floor(-2.5)` gives `-1` instead of `-2`. Positive inputs and the integral overload are untouched, which keeps the break narrow enough that the failure points at one function.

The contender build gets this change; the baseline LocalRunnerService is built from the merge base and does not. Any expression the fuzzer generates over a negative floating point value should therefore produce a result mismatch, and the Presto Fuzzer with Local Runner job should fail. If that job passes, the regression fuzzer is not doing its job and the wiring needs another look.

Differential Revision: D115238972


