### PR TITLE
fix(ci): Format ArrayJoin benchmark target

### DIFF
--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -35,14 +35,8 @@ add_executable(velox_functions_prestosql_benchmarks_array_contains ArrayContains
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_contains ArrayPositionBasic.h)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_contains ${BENCHMARK_DEPENDENCIES})
 
-add_executable(
-  velox_functions_prestosql_benchmarks_array_join
-  ArrayJoinBenchmark.cpp
-)
-target_link_libraries(
-  velox_functions_prestosql_benchmarks_array_join
-  ${BENCHMARK_DEPENDENCIES}
-)
+add_executable(velox_functions_prestosql_benchmarks_array_join ArrayJoinBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_array_join ${BENCHMARK_DEPENDENCIES})
 
 add_executable(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.cpp)
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.h)


### PR DESCRIPTION
Summary: Format the new `velox_functions_prestosql_benchmarks_array_join` executable and link declarations consistently with the surrounding Gersemi-formatted CMake targets. This fixes the Velox formatting validation triggered by the recently added benchmark.

Differential Revision: D115242942


