### PR TITLE
fix(exec): Detach preloadingSplits_ under the task lock in Task::terminate

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2181,8 +2181,18 @@ BlockingReason Task::getSplitOrFuture(
     auto& splitsState = getPlanNodeSplitsStateLocked(planNodeId);
     auto* splitsStore = getOrCreateSplitsStoreLocked(splitsState, splitGroupId);
     const auto numQueuedBefore = taskStats_.numQueuedTableScanSplits;
+    // Stop arming new preloads once the task is no longer running. Otherwise a
+    // driver that is already on thread can register a split in
+    // 'preloadingSplits_' after Task::terminate() has detached it, leaving the
+    // data source unclosed. The split then keeps the task alive through the
+    // shared_ptr<Task> that TableScan::preload() captures into the AsyncSource,
+    // deferring task destruction until the queued IO job runs.
     notBlocked = splitsStore->nextSplit(
-        driverId, maxPreloadSplits, preload, split, future);
+        driverId,
+        isRunningLocked() ? maxPreloadSplits : 0,
+        preload,
+        split,
+        future);
     // Wake status waiters when the scan split queue drains while more splits
     // may still arrive, so a coordinator can refill before the task starves.
     // Once noMoreSplits has been signaled there is nothing left to refill, so
@@ -2207,6 +2217,11 @@ bool Task::testingHasDriverWaitForSplit() const {
     }
   }
   return false;
+}
+
+size_t Task::testingNumPreloadingSplits() const {
+  std::lock_guard<std::timed_mutex> l(mutex_);
+  return preloadingSplits_.size();
 }
 
 std::shared_ptr<ScaledScanController> Task::getScaledScanControllerLocked(
@@ -2681,6 +2696,8 @@ ContinueFuture Task::terminate(TaskState terminalState) {
   EventCompletionNotifier stateChangeNotifier;
   std::vector<ContinuePromise> barrierPromises;
   std::vector<std::shared_ptr<ExchangeClient>> exchangeClients;
+  folly::F14FastSet<std::shared_ptr<connector::ConnectorSplit>>
+      preloadingSplits;
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
     if (taskStats_.executionEndTimeMs == 0) {
@@ -2742,6 +2759,12 @@ ContinueFuture Task::terminate(TaskState terminalState) {
       }
     }
     exchangeClients.swap(exchangeClients_);
+    // Detach the preloading splits while holding the lock. Driver threads
+    // mutate 'preloadingSplits_' under 'mutex_' from SplitsStore::getSplit(),
+    // so iterating the member outside the lock races with a rehash that frees
+    // the table storage. The data sources are closed below, outside the lock,
+    // because AsyncSource::close() can block on an in-flight prepare().
+    preloadingSplits.swap(preloadingSplits_);
 
     barrierPromises.swap(barrierFinishPromises_);
     // Clear the barrier flag to ensure underBarrier() returns false after task
@@ -2856,10 +2879,9 @@ ContinueFuture Task::terminate(TaskState terminalState) {
     bridge->cancel();
   }
 
-  for (auto split : preloadingSplits_) {
+  for (const auto& split : preloadingSplits) {
     split->dataSource->close();
   }
-  preloadingSplits_.clear();
 
   for (auto& barrierPromise : barrierPromises) {
     barrierPromise.setValue();

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -854,6 +854,10 @@ class Task : public std::enable_shared_from_this<Task> {
   /// split.
   bool testingHasDriverWaitForSplit() const;
 
+  /// Returns the number of preloading splits still registered with the task.
+  /// Acquires 'mutex_', so it must not be called while the caller holds it.
+  size_t testingNumPreloadingSplits() const;
+
   /// Returns true if all the splits have finished.
   bool testingAllSplitsFinished();
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1825,6 +1825,95 @@ TEST_F(TableScanTest, preloadingSplitClose) {
   latch.wait();
 }
 
+TEST_F(TableScanTest, preloadingSplitsDetachedOnTerminate) {
+  auto filePaths = makeFilePaths(100);
+  auto vectors = makeVectors(100, 100);
+  for (int32_t i = 0; i < vectors.size(); i++) {
+    writeToFile(filePaths[i]->getPath(), vectors[i]);
+  }
+  createDuckDbTable(vectors);
+
+  auto* executors = ioExecutor_.get();
+  folly::Latch latch(executors->numThreads());
+  std::vector<folly::Baton<>> batons(executors->numThreads());
+  // Block every IO thread so preloaded splits never become ready and stay
+  // registered with the task until it terminates.
+  for (auto& baton : batons) {
+    executors->add([&]() {
+      baton.wait();
+      latch.count_down();
+    });
+  }
+
+  // Sampled where terminate() has released the task lock for the last time.
+  // Stays -1 if terminate() never ran.
+  std::atomic<int64_t> numPreloadingSplitsOnTerminate{-1};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Task::terminate",
+      std::function<void(Task*)>([&](Task* task) {
+        numPreloadingSplitsOnTerminate = task->testingNumPreloadingSplits();
+      }));
+
+  auto task = assertQuery(tableScanNode(), filePaths, "SELECT * FROM tmp", 2);
+  auto stats = getTableScanRuntimeStats(task);
+  // Verify that split preloading is enabled, otherwise the check below passes
+  // vacuously.
+  ASSERT_GT(stats.at("preloadedSplits").sum, 1);
+
+  // terminate() must detach 'preloadingSplits_' while holding the task lock.
+  // Driver threads insert into the same set under that lock from
+  // SplitsStore::getSplit(), so anything left here would be iterated unlocked
+  // and can be freed by a concurrent rehash.
+  EXPECT_EQ(numPreloadingSplitsOnTerminate.load(), 0);
+
+  task.reset();
+  // Clean blocking items in the IO thread pool.
+  for (auto& baton : batons) {
+    baton.post();
+  }
+  latch.wait();
+}
+
+TEST_F(TableScanTest, noSplitPreloadAfterTaskTerminated) {
+  auto filePaths = makeFilePaths(4);
+  auto vectors = makeVectors(4, 100);
+  for (int32_t i = 0; i < vectors.size(); i++) {
+    writeToFile(filePaths[i]->getPath(), vectors[i]);
+  }
+
+  CursorParameters params;
+  params.planNode = tableScanNode(ROW({}, {}));
+  auto cursor = TaskCursor::create(params);
+  const auto& task = cursor->task();
+  const auto scanNodeId = params.planNode->id();
+  for (const auto& filePath : filePaths) {
+    task->addSplit(scanNodeId, makeHiveSplit(filePath->getPath()));
+  }
+
+  task->requestCancel().wait();
+
+  // A driver that is already on thread can reach getSplitOrFuture() after
+  // terminate() has detached 'preloadingSplits_'. Preloading must not arm once
+  // the task has stopped running, otherwise the split is registered with
+  // nothing left to close its data source.
+  bool preloadCalled{false};
+  exec::Split split;
+  auto future = ContinueFuture::makeEmpty();
+  task->getSplitOrFuture(
+      /*driverId=*/0,
+      kUngroupedGroupId,
+      scanNodeId,
+      /*maxPreloadSplits=*/2,
+      [&](const std::shared_ptr<connector::ConnectorSplit>&) {
+        preloadCalled = true;
+      },
+      split,
+      future);
+
+  EXPECT_FALSE(preloadCalled);
+  EXPECT_EQ(task->testingNumPreloadingSplits(), 0);
+}
+
 TEST_F(TableScanTest, waitForSplit) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(10, 1'000);


### PR DESCRIPTION
Fixes #18444.

`Task::terminate()` iterated and cleared `preloadingSplits_` with no lock held,
while driver threads insert into and erase from the same `folly::F14FastSet`
under `mutex_` via `SplitsStore::getSplit()`. An insert that crosses the load
factor reallocates and frees the table storage under the iterating thread. The
`clear()` is itself an unsynchronized write, so the access races in both
directions.

The race dates to #8181, but stayed latent because `checkPreload()` was gated on
`allPrefetchIssued()` and ran after `getSplit()`, leaving the set almost always
empty. #15460 moved `checkPreload()` ahead of `getSplit()` and dropped that gate,
so preloading arms from the first split of every scan and the set churns for a
task's whole life. #18444 has the full analysis and the production stacks.

## Changes

Swap the set into a local inside the existing critical section, mirroring how
`exchangeClients` is already drained in the same function. Two constraints shape
this. Closing has to stay outside the lock, because `AsyncSource::close()` blocks
waiting on an in-flight `prepare()` and holding `mutex_` across that would stall
every driver on the task. The member also has to stay in place rather than being
reseated or destroyed, since `SplitsStore` holds a raw pointer to it
(`TaskStructs.h:146`); a swap keeps the address valid, so a late insert writes
into a live, empty container instead of freed memory.

Stop arming preloads in `getSplitOrFuture()` once the task is no longer running.
Without this, a driver already on thread can still register a split after
`terminate()` detached the set. That does not crash, but the data source is never
closed, and because `TableScan::preload()` captures a `shared_ptr<Task>` into the
`AsyncSource` item maker, the split forms a `Task -> preloadingSplits_ -> split ->
AsyncSource -> itemMaker_ -> Task` cycle that defers task destruction and memory
pool release until the queued IO job runs. That is the condition reported in
#8198. With `maxPreloadSplits` at 0 the preload scan in `SplitsStore::getSplit()`
is skipped, so nothing can register after termination begins.

`isRunningLocked()` is the lock-free variant and is called from inside the
existing `lock_guard`, which also keeps the check atomic with the `nextSplit()`
call.

## Tests

`preloadingSplitsDetachedOnTerminate` blocks every IO thread so preloaded splits
never become ready and stay registered, then samples `preloadingSplits_` from the
`Task::terminate` TestValue hook, which fires after the last unlock. It asserts
`preloadedSplits > 1` first so it cannot pass vacuously if preloading stops
engaging.

`noSplitPreloadAfterTaskTerminated` cancels a task with splits still queued, then
calls `getSplitOrFuture()` with a non-zero `maxPreloadSplits` and a preload
function that records whether it ran. Without the guard the split is preloaded
and registered; with it, neither happens.

Neither test reproduces the original interleaving, which would need TSAN. They
pin the two invariants that make the interleaving impossible: the set is detached
under the lock, and nothing can re-register after termination starts.

## Verification status

`velox/exec/Task.cpp` passes `-fsyntax-only` against my local configure. I was not
able to complete a full build and run the tests locally, so please treat the test
file in particular as unverified until CI reports. Happy to iterate on whatever
comes back.
