### PR TITLE
fix(s3): Default the S3 region to aws-global for AWS

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
@@ -87,16 +87,11 @@ S3Config::S3Config(
 }
 
 std::optional<std::string> S3Config::endpointRegion() const {
-  auto region = config_.find(Keys::kEndpointRegion)->second;
-  if (!region.has_value()) {
-    // If region is not set, try inferring from the endpoint value for AWS
-    // endpoints.
-    auto endpointValue = endpoint();
-    if (endpointValue.has_value()) {
-      region = parseAWSStandardRegionName(endpointValue.value());
-    }
+  auto region = configuredEndpointRegion();
+  if (region.has_value()) {
+    return region;
   }
-  return region;
+  return defaultRegionForEndpoint(endpoint().value_or(""));
 }
 
 size_t S3Config::minPartSize() const {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -25,6 +25,12 @@ class ConfigBase;
 
 namespace facebook::velox::filesystems {
 
+/// Region used for AWS when none is configured and none can be inferred from
+/// the endpoint. The SDK signs this as us-east-1, but unlike a literal region
+/// it also lets AWSClient::AttemptExhaustively re-sign for the region a 301
+/// PermanentRedirect names, instead of failing a cross-region request.
+inline constexpr const char* kS3AwsGlobalRegion = "aws-global";
+
 /// Build config required to initialize an S3FileSystem instance.
 /// All hive.s3 options can be set on a per-bucket basis.
 /// The bucket-specific option is set by replacing the hive.s3. prefix on an
@@ -155,7 +161,18 @@ class S3Config {
     return config_.find(Keys::kEndpoint)->second;
   }
 
-  /// The S3 storage endpoint region.
+  /// The region as explicitly configured via hive.s3.endpoint.region, with no
+  /// derivation from the endpoint. Callers that must distinguish an operator's
+  /// deliberate choice from a derived default use this rather than
+  /// endpointRegion().
+  std::optional<std::string> configuredEndpointRegion() const {
+    return config_.find(Keys::kEndpointRegion)->second;
+  }
+
+  /// The S3 storage endpoint region. Falls back to the region named in the
+  /// endpoint host, then, only when the endpoint is an AWS one, to
+  /// kS3AwsGlobalRegion. Returns nullopt for other endpoints so that the SDK
+  /// resolves the region from the environment, a profile, or IMDS as before.
   std::optional<std::string> endpointRegion() const;
 
   /// Access key to use.

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -244,7 +244,7 @@ class S3FileSystem::Impl {
     }
 
     if (s3Config_->endpointRegion().has_value()) {
-      clientConfig.region = s3Config_->endpointRegion().value();
+      clientConfig.region = awsString(s3Config_->endpointRegion().value());
     }
 
     if (s3Config_->useProxyFromEnv()) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
@@ -22,6 +22,7 @@
 #include "folly/IPAddress.h"
 #include "re2/re2.h"
 
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
 
 namespace facebook::velox::filesystems {
@@ -169,22 +170,63 @@ std::optional<folly::Uri> S3ProxyConfigurationBuilder::build() {
   return proxyUri;
 }
 
+namespace {
+// The assumption is that an AWS endpoint ends with ".amazonaws.com" or
+// ".amazonaws.com/". That means for AWS we don't expect a port in the endpoint.
+const std::string_view kAmazonHostSuffix{".amazonaws.com"};
+
+std::string_view withoutTrailingSlash(std::string_view endpoint) {
+  if (!endpoint.empty() && endpoint.back() == '/') {
+    endpoint.remove_suffix(1);
+  }
+  return endpoint;
+}
+} // namespace
+
+bool isAWSEndpoint(std::string_view endpoint) {
+  endpoint = withoutTrailingSlash(endpoint);
+  // A shorter endpoint underflows the subtraction below to npos, which rfind
+  // also returns when the suffix is absent, so the match would pass.
+  if (endpoint.size() <= kAmazonHostSuffix.size()) {
+    return false;
+  }
+  return endpoint.rfind(kAmazonHostSuffix) ==
+      endpoint.size() - kAmazonHostSuffix.size();
+}
+
+std::optional<std::string> defaultRegionForEndpoint(std::string_view endpoint) {
+  if (endpoint.empty()) {
+    // No endpoint means AWS. Returning a region keeps the SDK from silently
+    // picking us-east-1, or the EC2 instance's own region, for a bucket that
+    // may live elsewhere.
+    return std::string(kS3AwsGlobalRegion);
+  }
+  auto region = parseAWSStandardRegionName(endpoint);
+  if (region.has_value()) {
+    return region;
+  }
+  // An AWS endpoint whose host names no region, e.g. 's3.amazonaws.com'. For
+  // anything else return nullopt and leave the region to the SDK, which honors
+  // AWS_REGION, the active profile, and IMDS. Note that aws-imds-enabled cannot
+  // stand in for this test: it is a permission to query IMDS rather than
+  // evidence that the peer is AWS, it defaults to true off EC2 where no IMDS
+  // exists, and a region it does yield is the instance's, not the bucket's. A
+  // DNS alias fronting AWS falls here too and needs hive.s3.endpoint.region
+  // configured explicitly.
+  return isAWSEndpoint(endpoint)
+      ? std::optional<std::string>(kS3AwsGlobalRegion)
+      : std::nullopt;
+}
+
 std::optional<std::string> parseAWSStandardRegionName(
     std::string_view endpoint) {
-  // The assumption is that the endpoint ends with
-  // ".amazonaws.com" or ".amazonaws.com/". That means for AWS we don't
-  // expect a port in the endpoint.
-  const std::string_view kAmazonHostSuffix = ".amazonaws.com";
-  auto index = endpoint.size() - kAmazonHostSuffix.size();
-  // Handle the case where the endpoint ends in a trailing slash.
-  if (!endpoint.empty() && endpoint.back() == '/') {
-    index--;
-  }
-  if (endpoint.rfind(kAmazonHostSuffix) != index) {
+  if (!isAWSEndpoint(endpoint)) {
     return std::nullopt;
   }
+  endpoint = withoutTrailingSlash(endpoint);
   // Remove the kAmazonHostSuffix.
-  std::string_view endpointPrefix = endpoint.substr(0, index);
+  std::string_view endpointPrefix =
+      endpoint.substr(0, endpoint.size() - kAmazonHostSuffix.size());
   const re2::RE2 pattern("^(?:.+\\.)?s3[-.]([a-z0-9-]+)$");
   std::string region;
   if (re2::RE2::FullMatch(endpointPrefix, pattern, &region)) {
@@ -192,7 +234,7 @@ std::optional<std::string> parseAWSStandardRegionName(
     return region;
   }
 
-  index = endpointPrefix.rfind('.');
+  auto index = endpointPrefix.rfind('.');
   if (index != std::string::npos) {
     // endpointPrefix was 'service.[region]'.
     return std::string(endpointPrefix.substr(index + 1));

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -194,6 +194,17 @@ std::string getHttpProxyEnvVar();
 std::string getHttpsProxyEnvVar();
 std::string getNoProxyEnvVar();
 
+// True if the endpoint host is an '.amazonaws.com' one. A DNS alias fronting
+// AWS is not recognized as such.
+// The endpoint may contain a trailing '/' that is handled.
+bool isAWSEndpoint(std::string_view endpoint);
+
+// Region to use for an endpoint when none is configured: the region named in
+// the endpoint host, else kS3AwsGlobalRegion when the endpoint is an AWS one or
+// is absent, else nullopt to leave the region to the SDK. An empty endpoint
+// counts as absent, which implies AWS.
+std::optional<std::string> defaultRegionForEndpoint(std::string_view endpoint);
+
 // Adopted from the AWS Java SDK
 // Endpoint can be 'service.[region].amazonaws.com' or
 // 'bucket.s3-[region].amazonaws.com' or bucket.s3.[region].amazonaws.com'

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
@@ -30,7 +30,7 @@ TEST(S3ConfigTest, defaultConfig) {
   ASSERT_EQ(s3Config.useSSL(), true);
   ASSERT_EQ(s3Config.useInstanceCredentials(), false);
   ASSERT_EQ(s3Config.endpoint(), std::nullopt);
-  ASSERT_EQ(s3Config.endpointRegion(), std::nullopt);
+  ASSERT_EQ(s3Config.endpointRegion(), kS3AwsGlobalRegion);
   ASSERT_EQ(s3Config.accessKey(), std::nullopt);
   ASSERT_EQ(s3Config.secretKey(), std::nullopt);
   ASSERT_EQ(s3Config.iamRole(), std::nullopt);
@@ -40,6 +40,60 @@ TEST(S3ConfigTest, defaultConfig) {
   ASSERT_EQ(s3Config.bucket(), "");
   ASSERT_EQ(s3Config.useIMDS(), true);
   ASSERT_EQ(s3Config.minPartSize(), 10485760);
+}
+
+TEST(S3ConfigTest, endpointRegionDefaultsToAwsGlobal) {
+  auto configFor = [](std::unordered_map<std::string, std::string> values) {
+    return S3Config(
+        "", std::make_shared<config::ConfigBase>(std::move(values)));
+  };
+
+  // Neither endpoint nor region set: AWS is implied, since the S3-compatible
+  // backends all require an endpoint.
+  ASSERT_EQ(configFor({}).endpointRegion(), kS3AwsGlobalRegion);
+
+  // A configured region wins, with or without an endpoint.
+  ASSERT_EQ(
+      configFor({{S3Config::baseConfigKey(S3Config::Keys::kEndpointRegion),
+                  "us-west-2"}})
+          .endpointRegion(),
+      "us-west-2");
+  ASSERT_EQ(
+      configFor({{S3Config::baseConfigKey(S3Config::Keys::kEndpoint),
+                  "s3.us-east-1.amazonaws.com"},
+                 {S3Config::baseConfigKey(S3Config::Keys::kEndpointRegion),
+                  "us-west-2"}})
+          .endpointRegion(),
+      "us-west-2");
+
+  // Region inferred from an AWS endpoint host.
+  ASSERT_EQ(
+      configFor({{S3Config::baseConfigKey(S3Config::Keys::kEndpoint),
+                  "bucket.s3.us-west-2.amazonaws.com"}})
+          .endpointRegion(),
+      "us-west-2");
+
+  // An AWS endpoint host that names no region.
+  ASSERT_EQ(
+      configFor({{S3Config::baseConfigKey(S3Config::Keys::kEndpoint),
+                  "s3.amazonaws.com"}})
+          .endpointRegion(),
+      kS3AwsGlobalRegion);
+
+  // A DNS alias fronting AWS is indistinguishable from a non-AWS backend, so
+  // the SDK resolves the region. Configure the region explicitly for these.
+  ASSERT_EQ(
+      configFor({{S3Config::baseConfigKey(S3Config::Keys::kEndpoint),
+                  "my-alias.internal.example.com"}})
+          .endpointRegion(),
+      std::nullopt);
+
+  // Non-AWS backend.
+  ASSERT_EQ(
+      configFor({{S3Config::baseConfigKey(S3Config::Keys::kEndpoint),
+                  "10.0.0.1:9000"}})
+          .endpointRegion(),
+      std::nullopt);
 }
 
 TEST(S3ConfigTest, overrideConfig) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 
 #include "gtest/gtest.h"
 
@@ -127,6 +128,33 @@ TEST(S3UtilTest, isDomainExcludedFromProxy) {
   }
 }
 
+TEST(S3UtilTest, isAWSEndpoint) {
+  EXPECT_TRUE(isAWSEndpoint("s3.amazonaws.com"));
+  EXPECT_TRUE(isAWSEndpoint("s3.amazonaws.com/"));
+  EXPECT_TRUE(isAWSEndpoint("bucket.s3.us-west-2.amazonaws.com"));
+  EXPECT_FALSE(isAWSEndpoint("my-alias.internal.example.com"));
+  EXPECT_FALSE(isAWSEndpoint("foo.a3-region.amazon.com"));
+  EXPECT_FALSE(isAWSEndpoint("10.0.0.1:9000"));
+  EXPECT_FALSE(isAWSEndpoint(""));
+  // The suffix alone is not a host under it.
+  EXPECT_FALSE(isAWSEndpoint("amazonaws.com"));
+  EXPECT_FALSE(isAWSEndpoint(".amazonaws.com"));
+}
+
+TEST(S3UtilTest, defaultRegionForEndpoint) {
+  // An absent endpoint implies AWS, and so does an empty one: an empty
+  // hive.s3.endpoint is no endpoint override at all.
+  EXPECT_EQ(defaultRegionForEndpoint(""), kS3AwsGlobalRegion);
+  EXPECT_EQ(defaultRegionForEndpoint("s3.amazonaws.com"), kS3AwsGlobalRegion);
+  EXPECT_EQ(
+      defaultRegionForEndpoint("bucket.s3.us-west-2.amazonaws.com"),
+      "us-west-2");
+  // Left to the SDK, which honors AWS_REGION, the profile, and IMDS.
+  EXPECT_EQ(defaultRegionForEndpoint("10.0.0.1:9000"), std::nullopt);
+  EXPECT_EQ(
+      defaultRegionForEndpoint("my-alias.internal.example.com"), std::nullopt);
+}
+
 TEST(S3UtilTest, parseAWSRegion) {
   // bucket.s3.[region]
   EXPECT_EQ(
@@ -146,6 +174,15 @@ TEST(S3UtilTest, parseAWSRegion) {
       parseAWSStandardRegionName("foo.a3-region.amazon.com"), std::nullopt);
   EXPECT_EQ(parseAWSStandardRegionName(""), std::nullopt);
   EXPECT_EQ(parseAWSStandardRegionName("velox"), std::nullopt);
+  // Endpoints shorter than ".amazonaws.com" are not AWS hosts. A 13-character
+  // one underflows the suffix offset to npos, which rfind also returns when the
+  // suffix is absent.
+  EXPECT_EQ(parseAWSStandardRegionName("10.0.0.1:9000"), std::nullopt);
+  EXPECT_EQ(parseAWSStandardRegionName("s3.foo.com:80"), std::nullopt);
+  EXPECT_EQ(parseAWSStandardRegionName("10.0.0.1:9000/"), std::nullopt);
+  EXPECT_EQ(parseAWSStandardRegionName("minio:9000"), std::nullopt);
+  EXPECT_EQ(parseAWSStandardRegionName("amazonaws.com"), std::nullopt);
+  EXPECT_EQ(parseAWSStandardRegionName(".amazonaws.com"), std::nullopt);
 }
 
 TEST(S3UtilTest, isIpExcludedFromProxy) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1200,9 +1200,10 @@ Nimble Options (prefix ``hive.nimble.``)
      - The S3 storage endpoint server. This can be used to connect to an S3-compatible storage system instead of AWS.
    * - hive.s3.endpoint.region
      - string
-     - us-east-1
-     - The S3 storage endpoint server region. Default is set by the AWS SDK. If not configured, region will be attempted
-       to be parsed from the hive.s3.endpoint value.
+     - ``aws-global`` for AWS
+     - The S3 storage endpoint server region. If not configured, the region is parsed from the hive.s3.endpoint value.
+       For AWS it then falls back to ``aws-global``, which allows access to a bucket in any region. For other endpoints
+       the region is left to the AWS SDK, which resolves it from the environment, the active profile, or IMDS.
    * - hive.s3.path-style-access
      - bool
      - false

--- a/velox/docs/develop/connectors.rst
+++ b/velox/docs/develop/connectors.rst
@@ -122,6 +122,32 @@ This is the behavior when the proxy settings are enabled:
 5. Use . or \*. to indicate domain suffix matching, e.g. `.foobar.com` will
    match `test.foobar.com` or `foo.foobar.com`.
 
+S3 Storage adapter region
+*************************
+
+The region used to sign requests is resolved in this order:
+
+1. `hive.s3.endpoint.region`, if configured.
+2. The region named in the `hive.s3.endpoint` host, e.g.
+   `bucket.s3.us-west-2.amazonaws.com`.
+3. ``aws-global``, if the endpoint is an AWS one or no endpoint is configured.
+4. Otherwise the region is left unset and the AWS SDK resolves it from
+   `AWS_REGION`, the active profile, or IMDS.
+
+``aws-global`` signs as `us-east-1`, but unlike a literal region it lets the SDK
+re-sign for the region a `301 PermanentRedirect` names, so a bucket in another
+region succeeds rather than failing. The SDK does not cache the bucket region,
+so this costs a round trip per request. Configure `hive.s3.endpoint.region`
+when the region is known.
+
+Step 4 covers S3-compatible backends and DNS aliases fronting AWS, which are
+indistinguishable from each other by hostname. Set `hive.s3.endpoint.region` to
+``aws-global`` for an alias that needs cross-region access.
+
+Note that `hive.s3.aws-imds-enabled` does not participate in this: it only
+permits the SDK to query IMDS, and it defaults to true even where no IMDS
+exists. A region IMDS does return is the EC2 instance's, not the bucket's.
+
 HDFS Storage adapter
 ********************
 


### PR DESCRIPTION
When neither hive.s3.endpoint.region nor a region-bearing endpoint host is
configured, S3FileSystem left ClientConfiguration::region unset, so the AWS
SDK resolved it itself: the EC2 instance's region via IMDS, or the hardcoded
us-east-1 fallback. For a bucket in another region S3 answers 301
PermanentRedirect carrying the correct region, but the SDK's region-correction
retry in AWSClient::AttemptExhaustively only fires when the configured region
is "aws-global", so the request failed instead of being re-signed.

Fall back to aws-global in S3Config::endpointRegion when the endpoint is an AWS
one, or when no endpoint is configured, which also implies AWS. It signs as
us-east-1 (Aws::Region::ComputeSignerRegion), so behavior is unchanged for
same-region access, but it enables the SDK's redirect handling.

For any other endpoint keep returning nullopt so the region stays unset and the
SDK resolves it as before from AWS_REGION, the active profile, or IMDS.
Overriding it with aws-global would change the signing region of S3-compatible
backends that never send a redirect. A DNS alias fronting AWS is
indistinguishable from those by hostname and needs the region configured
explicitly.

hive.s3.aws-imds-enabled deliberately does not gate this. It is a permission to
query IMDS rather than evidence that the peer is AWS, it defaults to true off
EC2 where no IMDS exists, and a region IMDS does return is the instance's, not
the bucket's, which is the case that fails.

Also fix a size_t underflow in parseAWSStandardRegionName: for an endpoint
shorter than ".amazonaws.com" the size difference wrapped to npos, which is
what rfind also returns when the suffix is absent, so non-AWS endpoints such
as "10.0.0.1:9000" were reported as region "1:9000". The suffix check moves
into isAWSEndpoint, which endpointRegion also uses.