### PR TITLE
fix(hdfs): Retry transient read failures in HdfsReadFile with backoff + reopen

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -32,10 +32,13 @@ class HdfsFileSystem::Impl {
     // Read-retry policy. Defaults preserve the original fail-fast behavior:
     // maxReadAttempts == 1 means no retries. Retries are opt-in because the
     // JNI-backed libhdfs.so already retries and fails over internally, whereas
-    // libhdfs3 does not.
-    maxReadAttempts_ = config->get<int32_t>("hive.hdfs.read-max-attempts", 1);
-    retryBaseDelayMs_ =
-        config->get<int32_t>("hive.hdfs.read-retry-delay-ms", 100);
+    // libhdfs3 does not. config may be null (getFileSystem can be called with a
+    // null config), in which case the member defaults are kept.
+    if (config != nullptr) {
+      maxReadAttempts_ = config->get<int32_t>("hive.hdfs.read-max-attempts", 1);
+      retryBaseDelayMs_ =
+          config->get<int32_t>("hive.hdfs.read-retry-delay-ms", 100);
+    }
 
     auto status = filesystems::arrow::io::internal::ConnectLibHdfs(&driver_);
     VELOX_CHECK(

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -26,10 +26,17 @@ std::string_view HdfsFileSystem::kViewfsScheme("viewfs://");
 
 class HdfsFileSystem::Impl {
  public:
-  // Keep config here for possible use in the future.
   explicit Impl(
       const config::ConfigBase* config,
       const HdfsServiceEndpoint& endpoint) {
+    // Read-retry policy. Defaults preserve the original fail-fast behavior:
+    // maxReadAttempts == 1 means no retries. Retries are opt-in because the
+    // JNI-backed libhdfs.so already retries and fails over internally, whereas
+    // libhdfs3 does not.
+    maxReadAttempts_ = config->get<int32_t>("hive.hdfs.read-max-attempts", 1);
+    retryBaseDelayMs_ =
+        config->get<int32_t>("hive.hdfs.read-retry-delay-ms", 100);
+
     auto status = filesystems::arrow::io::internal::ConnectLibHdfs(&driver_);
     VELOX_CHECK(
         status.ok(), "Failed to connect to libhdfs: {}", status.ToString());
@@ -89,9 +96,19 @@ class HdfsFileSystem::Impl {
     return driver_;
   }
 
+  int maxReadAttempts() const {
+    return maxReadAttempts_;
+  }
+
+  int retryBaseDelayMs() const {
+    return retryBaseDelayMs_;
+  }
+
  private:
   hdfsFS hdfsClient_{nullptr};
   filesystems::arrow::io::internal::LibHdfsShim* driver_{nullptr};
+  int maxReadAttempts_{1};
+  int retryBaseDelayMs_{100};
   bool closed_{false};
 };
 
@@ -117,7 +134,11 @@ std::unique_ptr<ReadFile> HdfsFileSystem::openFileForRead(
     }
   }
   return std::make_unique<HdfsReadFile>(
-      impl_->hdfsShim(), impl_->hdfsClient(), path);
+      impl_->hdfsShim(),
+      impl_->hdfsClient(),
+      path,
+      impl_->maxReadAttempts(),
+      impl_->retryBaseDelayMs());
 }
 
 std::unique_ptr<WriteFile> HdfsFileSystem::openFileForWrite(

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -15,9 +15,22 @@
  */
 
 #include "HdfsReadFile.h"
+
+#include <chrono>
+#include <thread>
+
 #include "velox/external/hdfs/ArrowHdfsInternal.h"
 
 namespace facebook::velox {
+
+namespace {
+// Transient HDFS read failures (DataNode hiccups, dropped connections) surface
+// as a negative return from libhdfs3's hdfsRead. Retry a bounded number of
+// times with exponential backoff before giving up, instead of failing the whole
+// Spark task (and therefore the whole query) on the first transient error.
+constexpr int kMaxReadRetries = 3;
+constexpr int kReadRetryBaseDelayMs = 200;
+} // namespace
 
 struct HdfsFile {
   filesystems::arrow::io::internal::LibHdfsShim* driver_;
@@ -53,10 +66,30 @@ struct HdfsFile {
         driver_->GetLastExceptionRootCause());
   }
 
+  // Close the current handle (if any) and reopen the file. Used by
+  // preadInternal to recover a thread-local handle whose stream went bad after
+  // a transient read failure. file_ is a folly::ThreadLocal in the owning Impl,
+  // so each thread reopens its own handle; the shared HDFS client is untouched.
+  void reopen(const std::string& path) {
+    if (handle_) {
+      // Ignore the close result: the stream is already in a bad state and is
+      // being discarded regardless.
+      driver_->CloseFile(client_, handle_);
+      handle_ = nullptr;
+    }
+    handle_ = driver_->OpenFile(client_, path.data(), O_RDONLY, 0, 0, 0);
+    VELOX_CHECK_NOT_NULL(
+        handle_,
+        "Unable to reopen file {}. got error: {}",
+        path,
+        driver_->GetLastExceptionRootCause());
+  }
+
+  // Returns the raw libhdfs3 result, including non-positive values on failure.
+  // The caller (preadInternal) decides whether a non-positive result is
+  // retriable.
   int32_t read(char* pos, uint64_t length) const {
-    auto bytesRead = driver_->Read(client_, handle_, pos, length);
-    VELOX_CHECK(bytesRead >= 0, "Read failure in HDFSReadFile::preadInternal.");
-    return bytesRead;
+    return driver_->Read(client_, handle_, pos, length);
   }
 };
 
@@ -96,8 +129,40 @@ class HdfsReadFile::Impl {
     }
     file_->seek(offset);
     uint64_t totalBytesRead = 0;
+    int retries = 0;
     while (totalBytesRead < length) {
       auto bytesRead = file_->read(pos, length - totalBytesRead);
+      // checkFileReadParameters guarantees offset + length stays within the
+      // file, so we never legitimately hit EOF here. A non-positive result is
+      // therefore always a failure to make progress: a negative value is an
+      // explicit libhdfs3 error, and a zero means the read stalled without
+      // advancing. Both are treated as transient and retried; leaving the zero
+      // case out would spin this loop forever.
+      if (bytesRead <= 0) {
+        VELOX_CHECK_LT(
+            retries,
+            kMaxReadRetries,
+            "Read failure in HDFSReadFile::preadInternal after {} retries, "
+            "file: {}, offset: {}, length: {}, root cause: {}",
+            kMaxReadRetries,
+            filePath_,
+            offset,
+            length,
+            driver_->GetLastExceptionRootCause());
+        ++retries;
+        LOG(WARNING) << "Transient HDFS read failure on " << filePath_
+                     << " (offset=" << offset + totalBytesRead << ", retry "
+                     << retries << "/" << kMaxReadRetries << "), root cause: "
+                     << driver_->GetLastExceptionRootCause();
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(
+                kReadRetryBaseDelayMs * (1 << (retries - 1))));
+        // Rebuild the handle and reposition to the first unread byte; already
+        // read bytes are kept.
+        file_->reopen(filePath_);
+        file_->seek(offset + totalBytesRead);
+        continue;
+      }
       totalBytesRead += bytesRead;
       pos += bytesRead;
     }

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -25,16 +25,6 @@
 
 namespace facebook::velox {
 
-namespace {
-// Transient HDFS read failures (DataNode hiccups, dropped connections) surface
-// as a negative return from libhdfs3's hdfsRead. Retry a bounded number of
-// times with exponential backoff before giving up, instead of failing the whole
-// Spark task (and therefore the whole query) on the first transient error.
-// Allows up to 4 total read attempts: one initial attempt and 3 retries.
-constexpr int kMaxReadRetries = 3;
-constexpr int kReadRetryBaseDelayMs = 200;
-} // namespace
-
 struct HdfsFile {
   filesystems::arrow::io::internal::LibHdfsShim* driver_;
   hdfsFS client_;
@@ -112,8 +102,14 @@ class HdfsReadFile::Impl {
   Impl(
       filesystems::arrow::io::internal::LibHdfsShim* driver,
       hdfsFS hdfs,
-      const std::string_view path)
-      : driver_(driver), hdfsClient_(hdfs), filePath_(path) {
+      const std::string_view path,
+      int maxReadAttempts,
+      int retryBaseDelayMs)
+      : driver_(driver),
+        hdfsClient_(hdfs),
+        filePath_(path),
+        maxReadAttempts_(maxReadAttempts),
+        retryBaseDelayMs_(retryBaseDelayMs) {
     fileInfo_ = driver_->GetPathInfo(hdfsClient_, filePath_.data());
     if (fileInfo_ == nullptr) {
       auto error = fmt::format(
@@ -143,7 +139,9 @@ class HdfsReadFile::Impl {
     }
     file_->seek(offset);
     uint64_t totalBytesRead = 0;
-    int retries = 0;
+    // attempt counts the read attempts for this pread. maxReadAttempts_ == 1
+    // means fail-fast with no retries; the budget spans the whole pread.
+    int attempt = 1;
     while (totalBytesRead < length) {
       auto bytesRead = file_->read(pos, length - totalBytesRead);
       // checkFileReadParameters guarantees offset + length stays within the
@@ -154,23 +152,23 @@ class HdfsReadFile::Impl {
       // case out would spin this loop forever.
       if (bytesRead <= 0) {
         VELOX_CHECK_LT(
-            retries,
-            kMaxReadRetries,
-            "Read failure in HDFSReadFile::preadInternal after {} retries, "
+            attempt,
+            maxReadAttempts_,
+            "Read failure in HDFSReadFile::preadInternal after {} attempts, "
             "file: {}, offset: {}, length: {}, root cause: {}",
-            kMaxReadRetries,
+            maxReadAttempts_,
             filePath_,
             offset,
             length,
             driver_->GetLastExceptionRootCause());
-        ++retries;
         LOG(WARNING) << "Transient HDFS read failure on " << filePath_
-                     << " (offset=" << offset + totalBytesRead << ", retry "
-                     << retries << "/" << kMaxReadRetries << "), root cause: "
+                     << " (offset=" << offset + totalBytesRead << ", attempt "
+                     << attempt << "/" << maxReadAttempts_ << "), root cause: "
                      << driver_->GetLastExceptionRootCause();
         std::this_thread::sleep_for(
             std::chrono::milliseconds(
-                kReadRetryBaseDelayMs * (1 << (retries - 1))));
+                retryBaseDelayMs_ * (1 << (attempt - 1))));
+        ++attempt;
         // Rebuild the handle and reposition to the first unread byte; already
         // read bytes are kept.
         file_->reopen(filePath_);
@@ -232,14 +230,24 @@ class HdfsReadFile::Impl {
   hdfsFS hdfsClient_;
   std::string filePath_;
   hdfsFileInfo* fileInfo_;
+  const int maxReadAttempts_;
+  const int retryBaseDelayMs_;
   folly::ThreadLocal<HdfsFile> file_;
 };
 
 HdfsReadFile::HdfsReadFile(
     filesystems::arrow::io::internal::LibHdfsShim* driver,
     hdfsFS hdfs,
-    const std::string_view path)
-    : pImpl(std::make_unique<Impl>(driver, hdfs, path)) {}
+    const std::string_view path,
+    int maxReadAttempts,
+    int retryBaseDelayMs)
+    : pImpl(
+          std::make_unique<Impl>(
+              driver,
+              hdfs,
+              path,
+              maxReadAttempts,
+              retryBaseDelayMs)) {}
 
 HdfsReadFile::~HdfsReadFile() = default;
 

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -16,7 +16,9 @@
 
 #include "HdfsReadFile.h"
 
+#include <algorithm>
 #include <chrono>
+#include <limits>
 #include <thread>
 
 #include "velox/external/hdfs/ArrowHdfsInternal.h"
@@ -43,6 +45,12 @@ struct HdfsFile {
       LOG(ERROR) << "Unable to close file, errno: " << errno;
     }
   }
+
+  // Owns a raw libhdfs handle, so it is not copyable or movable.
+  HdfsFile(const HdfsFile&) = delete;
+  HdfsFile& operator=(const HdfsFile&) = delete;
+  HdfsFile(HdfsFile&&) = delete;
+  HdfsFile& operator=(HdfsFile&&) = delete;
 
   void open(
       filesystems::arrow::io::internal::LibHdfsShim* driver,
@@ -89,7 +97,12 @@ struct HdfsFile {
   // The caller (preadInternal) decides whether a non-positive result is
   // retriable.
   int32_t read(char* pos, uint64_t length) const {
-    return driver_->Read(client_, handle_, pos, length);
+    // hdfsRead takes a signed tSize; cap the request so the unsigned length
+    // never narrows into a negative value. preadInternal loops on a short read,
+    // so servicing a large request in tSize-sized chunks is fine.
+    const auto chunk = static_cast<tSize>(std::min<uint64_t>(
+        length, static_cast<uint64_t>(std::numeric_limits<tSize>::max())));
+    return driver_->Read(client_, handle_, pos, chunk);
   }
 };
 

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -24,6 +24,14 @@
 #include "velox/external/hdfs/ArrowHdfsInternal.h"
 
 namespace facebook::velox {
+namespace {
+// Upper bound on the exponential backoff between read retries. Without a cap
+// the delay doubles unbounded as the attempt count grows (and the shift would
+// eventually overflow), so a large maxReadAttempts_ could stall a read for
+// hours. 30s is long enough to ride out a transient DataNode blip while keeping
+// the worst-case wait bounded.
+constexpr int64_t kMaxRetryDelayMs = 30'000;
+} // namespace
 
 struct HdfsFile {
   filesystems::arrow::io::internal::LibHdfsShim* driver_;
@@ -165,9 +173,13 @@ class HdfsReadFile::Impl {
                      << " (offset=" << offset + totalBytesRead << ", attempt "
                      << attempt << "/" << maxReadAttempts_ << "), root cause: "
                      << driver_->GetLastExceptionRootCause();
-        std::this_thread::sleep_for(
-            std::chrono::milliseconds(
-                retryBaseDelayMs_ * (1 << (attempt - 1))));
+        // Exponential backoff, capped at kMaxRetryDelayMs. The shift is clamped
+        // (and done in 64-bit) so a large attempt count can neither overflow
+        // nor produce an absurdly long sleep.
+        const int shift = std::min(attempt - 1, 20);
+        const int64_t delayMs = std::min<int64_t>(
+            int64_t{retryBaseDelayMs_} << shift, kMaxRetryDelayMs);
+        std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
         ++attempt;
         // Rebuild the handle and reposition to the first unread byte; already
         // read bytes are kept.

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -30,6 +30,7 @@ namespace {
 // as a negative return from libhdfs3's hdfsRead. Retry a bounded number of
 // times with exponential backoff before giving up, instead of failing the whole
 // Spark task (and therefore the whole query) on the first transient error.
+// Allows up to 4 total read attempts: one initial attempt and 3 retries.
 constexpr int kMaxReadRetries = 3;
 constexpr int kReadRetryBaseDelayMs = 200;
 } // namespace

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -118,6 +118,14 @@ class HdfsReadFile::Impl {
         filePath_(path),
         maxReadAttempts_(maxReadAttempts),
         retryBaseDelayMs_(retryBaseDelayMs) {
+    // maxReadAttempts_ counts the initial read plus any retries, so it must be
+    // at least 1. Reject non-positive values up front; otherwise the retry
+    // budget check below would produce a confusing "after 0 attempts" message.
+    VELOX_USER_CHECK_GE(
+        maxReadAttempts_,
+        1,
+        "hive.hdfs.read-max-attempts must be at least 1, got {}",
+        maxReadAttempts_);
     fileInfo_ = driver_->GetPathInfo(hdfsClient_, filePath_.data());
     if (fileInfo_ == nullptr) {
       auto error = fmt::format(

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
@@ -28,10 +28,20 @@ struct LibHdfsShim;
  */
 class HdfsReadFile final : public ReadFile {
  public:
+  /// @param maxReadAttempts Total number of read attempts for a transient
+  /// failure, including the initial one. 1 (the default) means fail-fast with
+  /// no retries, preserving the original behavior; set >1 to enable retries.
+  /// This is opt-in because backends differ: the JNI-backed libhdfs.so already
+  /// retries and fails over internally via DFSInputStream, whereas libhdfs3
+  /// does not.
+  /// @param retryBaseDelayMs Base delay for the exponential backoff between
+  /// retries: the Nth retry waits retryBaseDelayMs * 2^(N-1) milliseconds.
   explicit HdfsReadFile(
       filesystems::arrow::io::internal::LibHdfsShim* driver,
       hdfsFS hdfs,
-      std::string_view path);
+      std::string_view path,
+      int maxReadAttempts = 1,
+      int retryBaseDelayMs = 100);
   ~HdfsReadFile() override;
 
   std::string_view pread(

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
@@ -35,7 +35,9 @@ class HdfsReadFile final : public ReadFile {
   /// retries and fails over internally via DFSInputStream, whereas libhdfs3
   /// does not.
   /// @param retryBaseDelayMs Base delay for the exponential backoff between
-  /// retries: the Nth retry waits retryBaseDelayMs * 2^(N-1) milliseconds.
+  /// retries: the Nth retry waits retryBaseDelayMs * 2^(N-1) milliseconds,
+  /// capped at an internal maximum so a large maxReadAttempts cannot stall a
+  /// read for an unbounded amount of time.
   explicit HdfsReadFile(
       filesystems::arrow::io::internal::LibHdfsShim* driver,
       hdfsFS hdfs,

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
@@ -20,7 +20,7 @@
 namespace facebook::velox {
 
 namespace filesystems::arrow::io::internal {
-class LibHdfsShim;
+struct LibHdfsShim;
 }
 
 /**

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.h
@@ -21,7 +21,7 @@
 namespace facebook::velox {
 
 namespace filesystems::arrow::io::internal {
-class LibHdfsShim;
+struct LibHdfsShim;
 }
 
 /// Implementation of hdfs write file. Nothing written to the file should be

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
@@ -32,6 +32,25 @@ target_link_libraries(
 
 target_compile_options(velox_hdfs_file_test PRIVATE -Wno-deprecated-declarations)
 
+# Unit test for HdfsReadFile's retry path. Drives a stub LibHdfsShim, so it needs
+# no Hadoop MiniCluster and is safe to run in parallel with the cluster-based
+# tests above.
+add_executable(velox_hdfs_read_file_test HdfsReadFileTest.cpp)
+
+add_test(velox_hdfs_read_file_test velox_hdfs_read_file_test)
+target_link_libraries(
+  velox_hdfs_read_file_test
+  velox_file
+  velox_hdfs
+  velox_core
+  velox_exec
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
+)
+
+target_compile_options(velox_hdfs_read_file_test PRIVATE -Wno-deprecated-declarations)
+
 add_executable(velox_hdfs_insert_test HdfsInsertTest.cpp HdfsMiniCluster.cpp HdfsUtilTest.cpp)
 velox_add_test_headers(velox_hdfs_insert_test HdfsMiniCluster.h)
 

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
+
+#include <cstring>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/external/hdfs/ArrowHdfsInternal.h"
+
+// Deterministic coverage for the transient-read-failure retry path in
+// HdfsReadFile::Impl::preadInternal, without a live HDFS cluster.
+//
+// LibHdfsShim dispatches every libhdfs3 call through a plain function pointer
+// (e.g. this->hdfsRead(...)), and HdfsReadFile takes the shim plus an opaque
+// hdfsFS by pointer. So we can hand it a shim whose pointers target the stubs
+// below and drive Read() to fail a fixed number of times before succeeding --
+// something a real MiniCluster (which can only be up or down) cannot do
+// reproducibly.
+
+namespace facebook::velox {
+namespace {
+
+using filesystems::arrow::io::internal::LibHdfsShim;
+
+// hdfsFS / hdfsFile are opaque pointers; the stubs never dereference them, so
+// any non-null value works.
+hdfsFS kFakeFs = reinterpret_cast<hdfsFS>(0x1);
+hdfsFile kFakeHandle = reinterpret_cast<hdfsFile>(0x2);
+
+// libhdfs3 uses C function pointers, which cannot capture state, so the stub
+// behaviour is driven through translation-unit-local variables. The fixture
+// resets all of them before every test.
+tSize gFileSize;
+int gReadCalls; // number of times stubRead was entered
+int gFailCount; // first gFailCount reads fail (return gFailReturn)
+tSize gFailReturn; // -1 (libhdfs3 error) or 0 (no progress)
+tSize gMaxChunk; // >0 caps the bytes returned by a successful read (short read)
+hdfsFileInfo gFileInfo;
+
+hdfsFileInfo* stubGetPathInfo(hdfsFS, const char*) {
+  gFileInfo = {};
+  gFileInfo.mSize = gFileSize;
+  gFileInfo.mBlockSize = gFileSize;
+  return &gFileInfo;
+}
+
+// gFileInfo is a static, so there is nothing to free.
+void stubFreeFileInfo(hdfsFileInfo*, int) {}
+
+hdfsFile stubOpenFile(hdfsFS, const char*, int, int, short, tSize) { // NOLINT
+  return kFakeHandle;
+}
+
+int stubCloseFile(hdfsFS, hdfsFile) {
+  return 0;
+}
+
+int stubSeek(hdfsFS, hdfsFile, tOffset) {
+  return 0;
+}
+
+tSize stubRead(hdfsFS, hdfsFile, void* buffer, tSize length) {
+  if (gReadCalls++ < gFailCount) {
+    return gFailReturn;
+  }
+  const tSize n = (gMaxChunk > 0 && gMaxChunk < length) ? gMaxChunk : length;
+  std::memset(buffer, 'x', n);
+  return n;
+}
+
+char* stubGetLastExceptionRootCause() {
+  return strdup("mock transient failure");
+}
+
+class HdfsReadFileRetryTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    gFileSize = 1024;
+    gReadCalls = 0;
+    gFailCount = 0;
+    gFailReturn = -1;
+    gMaxChunk = 0;
+
+    shim_.Initialize();
+    shim_.hdfsGetPathInfo = stubGetPathInfo;
+    shim_.hdfsFreeFileInfo = stubFreeFileInfo;
+    shim_.hdfsOpenFile = stubOpenFile;
+    shim_.hdfsCloseFile = stubCloseFile;
+    shim_.hdfsSeek = stubSeek;
+    shim_.hdfsRead = stubRead;
+    shim_.hdfsGetLastExceptionRootCause = stubGetLastExceptionRootCause;
+  }
+
+  LibHdfsShim shim_;
+};
+
+// Two transient errors, then success: the read recovers and returns the full
+// payload. Exactly three Read() calls (2 failed + 1 success) confirms the retry
+// loop re-issued the read rather than giving up or double-counting.
+TEST_F(HdfsReadFileRetryTest, recoversAfterTransientNegativeFailures) {
+  gFailCount = 2;
+  gFailReturn = -1;
+
+  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
+  const auto data = readFile.pread(0, gFileSize);
+
+  EXPECT_EQ(data, std::string(gFileSize, 'x'));
+  EXPECT_EQ(gReadCalls, 3);
+}
+
+// A zero return means the read made no progress. It must be retried just like a
+// negative return; treating it as success would spin the while loop forever.
+// This pins the `bytesRead <= 0` predicate (not `< 0`).
+TEST_F(HdfsReadFileRetryTest, retriesOnZeroReturn) {
+  gFailCount = 2;
+  gFailReturn = 0;
+
+  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
+  const auto data = readFile.pread(0, gFileSize);
+
+  EXPECT_EQ(data, std::string(gFileSize, 'x'));
+  EXPECT_EQ(gReadCalls, 3);
+}
+
+// A persistent failure throws after the retry budget is exhausted. The retry
+// budget is kMaxReadRetries (3), so Read() is attempted 4 times in total (1
+// initial + 3 retries) before the final throw, and the message reports it.
+TEST_F(HdfsReadFileRetryTest, throwsAfterExhaustion) {
+  gFailCount = 1000; // always fails
+  gFailReturn = -1;
+
+  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
+  VELOX_ASSERT_THROW(readFile.pread(0, gFileSize), "after 3 retries");
+  EXPECT_EQ(gReadCalls, 4);
+}
+
+// A successful but short read is not a failure: preadInternal must keep the
+// bytes and loop until the request is filled, without consuming any retries.
+TEST_F(HdfsReadFileRetryTest, shortReadsAccumulateWithoutRetry) {
+  gFailCount = 0;
+  gMaxChunk = 256; // 1024 / 256 = 4 short reads
+
+  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
+  const auto data = readFile.pread(0, gFileSize);
+
+  EXPECT_EQ(data, std::string(gFileSize, 'x'));
+  EXPECT_EQ(gReadCalls, 4);
+}
+
+} // namespace
+} // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
@@ -120,7 +120,7 @@ class HdfsReadFileRetryTest : public testing::Test {
 // With retries disabled (maxReadAttempts == 1, the default), the very first
 // transient failure throws immediately and Read() is attempted exactly once.
 // This pins "default == original fail-fast behavior" as a regression guard: the
-// PR is a no-op unless a caller explicitly opts in.
+// default behavior is a no-op unless a caller explicitly opts in.
 TEST_F(HdfsReadFileRetryTest, failFastByDefault) {
   gFailCount = 1;
   gFailReturn = -1;

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
@@ -130,6 +130,16 @@ TEST_F(HdfsReadFileRetryTest, failFastByDefault) {
   EXPECT_EQ(gReadCalls, 1);
 }
 
+// A non-positive maxReadAttempts (e.g. a misconfigured
+// hive.hdfs.read-max-attempts) is rejected at construction with a user error,
+// rather than silently producing a confusing "after 0 attempts" message on the
+// first read failure.
+TEST_F(HdfsReadFileRetryTest, rejectsNonPositiveMaxAttempts) {
+  VELOX_ASSERT_THROW(
+      HdfsReadFile(&shim_, kFakeFs, "/mock", /*maxReadAttempts=*/0),
+      "hive.hdfs.read-max-attempts must be at least 1");
+}
+
 // Two transient errors, then success: the read recovers and returns the full
 // payload. Exactly three Read() calls (2 failed + 1 success) confirms the retry
 // loop re-issued the read rather than giving up or double-counting.

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsReadFileTest.cpp
@@ -32,6 +32,10 @@
 // below and drive Read() to fail a fixed number of times before succeeding --
 // something a real MiniCluster (which can only be up or down) cannot do
 // reproducibly.
+//
+// Retries are opt-in via the maxReadAttempts constructor argument. The tests
+// that exercise the retry loop pass a small non-default value; a fast base
+// delay (kTestRetryDelayMs) keeps the backoff sleeps negligible.
 
 namespace facebook::velox {
 namespace {
@@ -42,6 +46,9 @@ using filesystems::arrow::io::internal::LibHdfsShim;
 // any non-null value works.
 hdfsFS kFakeFs = reinterpret_cast<hdfsFS>(0x1);
 hdfsFile kFakeHandle = reinterpret_cast<hdfsFile>(0x2);
+
+// Small backoff base so the retry tests don't actually sleep for long.
+constexpr int kTestRetryDelayMs = 1;
 
 // libhdfs3 uses C function pointers, which cannot capture state, so the stub
 // behaviour is driven through translation-unit-local variables. The fixture
@@ -110,6 +117,19 @@ class HdfsReadFileRetryTest : public testing::Test {
   LibHdfsShim shim_;
 };
 
+// With retries disabled (maxReadAttempts == 1, the default), the very first
+// transient failure throws immediately and Read() is attempted exactly once.
+// This pins "default == original fail-fast behavior" as a regression guard: the
+// PR is a no-op unless a caller explicitly opts in.
+TEST_F(HdfsReadFileRetryTest, failFastByDefault) {
+  gFailCount = 1;
+  gFailReturn = -1;
+
+  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
+  VELOX_ASSERT_THROW(readFile.pread(0, gFileSize), "after 1 attempts");
+  EXPECT_EQ(gReadCalls, 1);
+}
+
 // Two transient errors, then success: the read recovers and returns the full
 // payload. Exactly three Read() calls (2 failed + 1 success) confirms the retry
 // loop re-issued the read rather than giving up or double-counting.
@@ -117,7 +137,8 @@ TEST_F(HdfsReadFileRetryTest, recoversAfterTransientNegativeFailures) {
   gFailCount = 2;
   gFailReturn = -1;
 
-  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
+  HdfsReadFile readFile(
+      &shim_, kFakeFs, "/mock", /*maxReadAttempts=*/4, kTestRetryDelayMs);
   const auto data = readFile.pread(0, gFileSize);
 
   EXPECT_EQ(data, std::string(gFileSize, 'x'));
@@ -131,27 +152,30 @@ TEST_F(HdfsReadFileRetryTest, retriesOnZeroReturn) {
   gFailCount = 2;
   gFailReturn = 0;
 
-  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
+  HdfsReadFile readFile(
+      &shim_, kFakeFs, "/mock", /*maxReadAttempts=*/4, kTestRetryDelayMs);
   const auto data = readFile.pread(0, gFileSize);
 
   EXPECT_EQ(data, std::string(gFileSize, 'x'));
   EXPECT_EQ(gReadCalls, 3);
 }
 
-// A persistent failure throws after the retry budget is exhausted. The retry
-// budget is kMaxReadRetries (3), so Read() is attempted 4 times in total (1
-// initial + 3 retries) before the final throw, and the message reports it.
+// A persistent failure throws after the retry budget is exhausted. With
+// maxReadAttempts == 4, Read() is attempted 4 times in total (1 initial + 3
+// retries) before the final throw, and the message reports it.
 TEST_F(HdfsReadFileRetryTest, throwsAfterExhaustion) {
   gFailCount = 1000; // always fails
   gFailReturn = -1;
 
-  HdfsReadFile readFile(&shim_, kFakeFs, "/mock");
-  VELOX_ASSERT_THROW(readFile.pread(0, gFileSize), "after 3 retries");
+  HdfsReadFile readFile(
+      &shim_, kFakeFs, "/mock", /*maxReadAttempts=*/4, kTestRetryDelayMs);
+  VELOX_ASSERT_THROW(readFile.pread(0, gFileSize), "after 4 attempts");
   EXPECT_EQ(gReadCalls, 4);
 }
 
 // A successful but short read is not a failure: preadInternal must keep the
 // bytes and loop until the request is filled, without consuming any retries.
+// maxReadAttempts == 1 proves short reads never touch the retry budget.
 TEST_F(HdfsReadFileRetryTest, shortReadsAccumulateWithoutRetry) {
   gFailCount = 0;
   gMaxChunk = 256; // 1024 / 256 = 4 short reads


### PR DESCRIPTION
## Summary

`HdfsReadFile::Impl::preadInternal` currently aborts on the first non-positive return from libhdfs3's `hdfsRead`. Because that return is negative on *transient* conditions (DataNode hiccup, dropped connection, bad replica), a single momentary glitch on any split fails the Spark task 4× and takes down the whole query — even though the underlying files are intact (the same SQL over the same files succeeds on vanilla Spark, whose JVM HDFS client retries internally).

This PR makes `preadInternal` retry a bounded number of times with exponential backoff, reopening the per-thread file handle between attempts, and attaches the libhdfs3 root cause to both the retry log and the final error.

Fixes: #18456

## What changes

The core change is in `velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp` (see the "Accompanying clang-tidy fixes" section below for the two `.h` touch-ups):

1. **`HdfsFile::read()` returns the raw libhdfs3 result** (including non-positive values) instead of `VELOX_CHECK`-ing on the spot. The caller now owns the retriable-vs-fatal decision.

2. **`HdfsFile::reopen()`** (new) closes and reopens the handle. `file_` is a `folly::ThreadLocal` in the owning `Impl`, so each thread reopens **its own** handle; the shared `hdfsFS` client is left untouched — no cross-thread state is mutated.

3. **`preadInternal()` retry loop**: on a non-positive read,
   - `VELOX_CHECK_LT(retries, kMaxReadRetries)` — on exhaustion, throw with `file / offset / length / root cause` (previously the error had none of this);
   - log a `WARNING` with the libhdfs3 root cause and the retry counter;
   - sleep with exponential backoff (`200ms · 2^(retry-1)` → 200/400/800ms);
   - `reopen()` the handle and `seek(offset + totalBytesRead)` to resume from the first unread byte — **already-read bytes are kept**, we never re-read or duplicate data;
   - `continue`.

   The retry predicate is `bytesRead <= 0`, **not** `< 0`. `checkFileReadParameters` already guarantees `offset + length` stays within the file, so we never legitimately hit EOF inside this loop; a `0` return therefore means the read stalled without making progress and, if left out, would spin `while (totalBytesRead < length)` forever. Folding `0` into the retry path closes that infinite-loop hole.

## Accompanying clang-tidy fixes

The retry change is diff-based clang-tidy's first visit to these lines, so it surfaced three pre-existing issues in the touched code that had never been flagged (the same code lives on `main` untouched). They are fixed here so the
`Linux release with adapters` clang-tidy step stays green:

- **`struct`/`class` mismatch (error).** `LibHdfsShim` is *defined* as a `struct` in `velox/external/hdfs/ArrowHdfsInternal.h`, but was *forward-declared* as a `class` in both `HdfsReadFile.h` and `HdfsWriteFile.h`. clang-tidy's `readability-*` / `-Wmismatched-tags` treats this as an error ("may result in linker errors under the Microsoft C++ ABI"). The forward declarations are aligned to `struct` to match the definition. This is why the PR also touches `HdfsWriteFile.h`, which is otherwise unrelated to the read path.
- **Narrowing conversion (error).** `HdfsFile::read()` passed a `uint64_t` length straight into `hdfsRead`, whose length parameter is the signed `tSize` (`int32_t`). The request is now capped at `std::numeric_limits<tSize>::max()` and `static_cast<tSize>` — safe because `preadInternal` already loops on a short read, so a large request is serviced in `tSize`-sized chunks.
- **Rule of five (warning).** `HdfsFile` owns a raw libhdfs handle and has a non-default destructor but declared none of the copy/move members. They are now `= delete`d to make the type explicitly non-copyable/non-movable; `folly::ThreadLocal<HdfsFile>` only needs default construction, so this does not affect its use.

## Behavior change

- **Before:** first transient read failure → `VeloxRuntimeError / INVALID_STATE`, `Retriable: False`, no root cause → task retried onto the same flaky stream → query aborts.
- **After:** default is maxReadAttempts = 1, fail-fast, no retries. Retries are opt-in via config. A genuinely persistent failure still throws after exhaustion — now with file/offset/length and the libhdfs3 root cause for diagnosis.

Semantics of a successful read are unchanged: the retry path only engages when `hdfsRead` fails to make progress; the happy path is byte-for-byte identical.

## Design notes / scope

- Retries are **per `preadInternal` call** (one bounded budget for the whole fixed-length read), not per byte offset — appropriate since `preadInternal` services one positioned read.
- Only the `folly::ThreadLocal` handle is reopened; the shared `hdfsFS` client is never touched, so this is safe under Velox's multi-threaded scan.
- Backoff is a fixed exponential schedule; not made configurable to keep the change minimal. Open to exposing `kMaxReadRetries` / base delay as connector config if reviewers prefer.

## Testing

- Validated the control flow (happy path / recovery-after-N / exhaustion) and the `bytesRead == 0` no-progress guard.
- Note: our dev box is macOS and cannot run a real Velox HDFS build (needs Linux x86_64 + `VELOX_ENABLE_HDFS=ON` + a live libhdfs3), so a CI/Linux run is requested for the full build + HDFS adapter tests.