### PR TITLE
fix(cudf): Link Iceberg test with gmock

### DIFF
--- a/velox/experimental/cudf/tests/iceberg/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/iceberg/CMakeLists.txt
@@ -47,6 +47,7 @@ velox_add_cudf_test(
     velox_exec_test_lib
     velox_test_util
     fmt::fmt
+    gmock
   TIMEOUT 3000
 )
 


### PR DESCRIPTION
Link the cuDF Iceberg test with bundled gmock so its headers match bundled gtest.

If gmock is not specified, the system GMock 1.11 headers are used instead of the bundled GoogleTest 1.13. The mismatch breaks GPU builds while compiling `CudfIcebergFilterTransformTest.cpp`.

Regression introduced by #18400.

Failure logs look like:
```text
/usr/include/gmock/gmock-actions.h:687:27: error: expected identifier before '!' token
/usr/include/gmock/gmock-matchers.h:3565:50: error: 'GTEST_COMPILE_ASSERT_' was not declared in this scope
ninja: build stopped: subcommand failed.
```