### PR TITLE
feat(spark): Switch to `SplitBlockBloomFilter` implementation in bloom filter functions

### DIFF
--- a/velox/functions/sparksql/MightContain.h
+++ b/velox/functions/sparksql/MightContain.h
@@ -15,9 +15,11 @@
  */
 #pragma once
 
+#include <cstring>
 #include <optional>
+#include <vector>
 
-#include "velox/common/base/BloomFilter.h"
+#include "velox/common/base/SplitBlockBloomFilter.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/functions/Macros.h"
 
@@ -36,22 +38,40 @@ struct BloomFilterMightContainFunction {
       return;
     }
 
-    VELOX_USER_CHECK_GE(
-        serialized->size(),
-        BloomFilterView::kSerializedHeaderSize,
-        "Serialized BloomFilter is too small: {}",
+    VELOX_USER_CHECK_GT(
+        serialized->size(), 0, "Serialized split-block Bloom filter is empty");
+    VELOX_USER_CHECK_EQ(
+        serialized->size() % sizeof(SplitBlockBloomFilter::Block),
+        0,
+        "Invalid serialized split-block Bloom filter size: {}",
         serialized->size());
-    bloomFilterView_.emplace(serialized->data());
+    using Block = SplitBlockBloomFilter::Block;
+    const auto numBlocks =
+        static_cast<int32_t>(serialized->size() / sizeof(Block));
+    const auto* serializedBlocks = serialized->data();
+    Block* blocks;
+    if (reinterpret_cast<uintptr_t>(serializedBlocks) % alignof(Block) == 0) {
+      // Reuse aligned serialized blocks without copying.
+      blocks = reinterpret_cast<Block*>(const_cast<char*>(serializedBlocks));
+    } else {
+      // Copy unaligned serialized blocks into aligned storage.
+      ownedBlocks_.resize(numBlocks);
+      std::memcpy(
+          ownedBlocks_.data(), serializedBlocks, numBlocks * sizeof(Block));
+      blocks = ownedBlocks_.data();
+    }
+    bloomFilter_.emplace(std::span<Block>(blocks, numBlocks));
   }
 
   FOLLY_ALWAYS_INLINE void
   call(bool& result, const arg_type<Varbinary>&, const int64_t& input) {
-    result = bloomFilterView_.has_value() &&
-        bloomFilterView_->mayContain(folly::hasher<int64_t>()(input));
+    result = bloomFilter_.has_value() &&
+        bloomFilter_->mayContain(folly::hasher<int64_t>()(input));
   }
 
  private:
-  std::optional<BloomFilterView> bloomFilterView_;
+  std::vector<SplitBlockBloomFilter::Block> ownedBlocks_;
+  std::optional<SplitBlockBloomFilter> bloomFilter_;
 };
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -16,7 +16,13 @@
 
 #include "velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
 
+#include <cstring>
+#include <optional>
+
+#include <folly/lang/Bits.h>
+
 #include "velox/common/base/BloomFilter.h"
+#include "velox/common/base/SplitBlockBloomFilter.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/sparksql/SparkQueryConfig.h"
@@ -29,36 +35,66 @@ using functions::sparksql::SparkQueryConfig;
 namespace {
 
 struct BloomFilterAccumulator {
+  using Block = SplitBlockBloomFilter::Block;
+  using BlockAllocator = AlignedStlAllocator<Block, alignof(Block)>;
+
   explicit BloomFilterAccumulator(HashStringAllocator* allocator)
-      : bloomFilter{StlAllocator<uint64_t>(allocator)} {}
+      : blocks{BlockAllocator(allocator)} {}
 
   int32_t serializedSize() const {
-    return bloomFilter.serializedSize();
+    return static_cast<int32_t>(blocks.size() * sizeof(Block));
   }
 
   void serialize(char* output) const {
-    return bloomFilter.serialize(output);
+    std::memcpy(output, blocks.data(), blocks.size() * sizeof(Block));
   }
 
-  void mergeWith(StringView& serialized) {
-    bloomFilter.merge(serialized.data());
+  void mergeWith(const StringView& serialized) {
+    VELOX_USER_CHECK_GT(
+        serialized.size(), 0, "Serialized split-block Bloom filter is empty");
+    VELOX_USER_CHECK_EQ(
+        serialized.size() % sizeof(Block),
+        0,
+        "Invalid serialized split-block Bloom filter size: {}",
+        serialized.size());
+    const auto numBlocks =
+        static_cast<int32_t>(serialized.size() / sizeof(Block));
+    if (blocks.empty()) {
+      init(numBlocks);
+    } else {
+      VELOX_USER_CHECK_EQ(
+          blocks.size(),
+          numBlocks,
+          "Cannot merge split-block Bloom filters of different sizes");
+    }
+
+    for (int64_t i = 0; i < numBlocks; ++i) {
+      for (int32_t j = 0; j < xsimd::batch<uint32_t>::size; ++j) {
+        const auto offset = i * sizeof(Block) + j * sizeof(uint32_t);
+        blocks[i].data[j] |=
+            folly::loadUnaligned<uint32_t>(serialized.data() + offset);
+      }
+    }
   }
 
   bool initialized() const {
-    return bloomFilter.isSet();
+    return !blocks.empty();
   }
 
-  void init(int32_t capacity) {
-    if (!bloomFilter.isSet()) {
-      bloomFilter.reset(capacity);
+  void init(int32_t numBlocks) {
+    if (blocks.empty()) {
+      VELOX_CHECK_GT(numBlocks, 0);
+      blocks.resize(numBlocks);
+      bloomFilter.emplace(blocks);
     }
   }
 
   void insert(int64_t value) {
-    bloomFilter.insert(folly::hasher<int64_t>()(value));
+    bloomFilter->insert(folly::hasher<int64_t>()(value));
   }
 
-  BloomFilter<StlAllocator<uint64_t>> bloomFilter;
+  std::vector<Block, BlockAllocator> blocks;
+  std::optional<SplitBlockBloomFilter> bloomFilter;
 };
 
 class BloomFilterAggAggregate : public exec::Aggregate {
@@ -95,7 +131,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
     decodeArguments(rows, args);
-    computeCapacity();
+    const auto numBlocks = this->numBlocks();
     auto mayHaveNulls = decodedRaw_.mayHaveNulls();
     rows.applyToSelected([&](vector_size_t row) {
       if (mayHaveNulls) {
@@ -104,7 +140,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       auto group = groups[row];
       auto tracker = trackRowSize(group);
       auto accumulator = value<BloomFilterAccumulator>(group);
-      accumulator->init(capacity_);
+      accumulator->init(numBlocks);
       accumulator->insert(decodedRaw_.valueAt<int64_t>(row));
     });
   }
@@ -134,10 +170,10 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
     decodeArguments(rows, args);
-    computeCapacity();
+    const auto numBlocks = this->numBlocks();
     auto tracker = trackRowSize(group);
     auto accumulator = value<BloomFilterAccumulator>(group);
-    accumulator->init(capacity_);
+    accumulator->init(numBlocks);
     if (decodedRaw_.isConstantMapping()) {
       // All values are same, just do for the first.
       checkBloomFilterNotNull(decodedRaw_, 0);
@@ -211,6 +247,14 @@ class BloomFilterAggAggregate : public exec::Aggregate {
     }
   }
 
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto* group : groups) {
+      if (isInitialized(group)) {
+        value<BloomFilterAccumulator>(group)->~BloomFilterAccumulator();
+      }
+    }
+  }
+
  private:
   void decodeArguments(
       const SelectivityVector& rows,
@@ -235,11 +279,10 @@ class BloomFilterAggAggregate : public exec::Aggregate {
     }
   }
 
-  void computeCapacity() {
-    if (capacity_ == kMissingArgument) {
-      int64_t numBits = std::min(numBits_, maxNumBits_);
-      capacity_ = numBits / 16;
-    }
+  int32_t numBlocks() const {
+    const int64_t numBits = std::min(numBits_, maxNumBits_);
+    return static_cast<int32_t>(std::max<int64_t>(
+        1, numBits / (8 * sizeof(SplitBlockBloomFilter::Block))));
   }
 
   int32_t getTotalSize(char** groups, int32_t numGroups) const {
@@ -290,7 +333,6 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
   int64_t estimatedNumItems_ = kMissingArgument;
   int64_t numBits_ = kMissingArgument;
-  int32_t capacity_ = kMissingArgument;
 };
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -32,70 +32,68 @@ namespace facebook::velox::functions::aggregate::sparksql {
 
 using functions::sparksql::SparkQueryConfig;
 
-namespace {
+BloomFilterAccumulator::BloomFilterAccumulator(HashStringAllocator* allocator)
+    : blocks_{BlockAllocator(allocator)} {}
 
-struct BloomFilterAccumulator {
-  using Block = SplitBlockBloomFilter::Block;
-  using BlockAllocator = AlignedStlAllocator<Block, alignof(Block)>;
+int32_t BloomFilterAccumulator::serializedSize() const {
+  return static_cast<int32_t>(blocks_.size() * sizeof(Block));
+}
 
-  explicit BloomFilterAccumulator(HashStringAllocator* allocator)
-      : blocks{BlockAllocator(allocator)} {}
+void BloomFilterAccumulator::serialize(char* output) const {
+  std::memcpy(output, blocks_.data(), blocks_.size() * sizeof(Block));
+}
 
-  int32_t serializedSize() const {
-    return static_cast<int32_t>(blocks.size() * sizeof(Block));
-  }
-
-  void serialize(char* output) const {
-    std::memcpy(output, blocks.data(), blocks.size() * sizeof(Block));
-  }
-
-  void mergeWith(const StringView& serialized) {
-    VELOX_USER_CHECK_GT(
-        serialized.size(), 0, "Serialized split-block Bloom filter is empty");
+void BloomFilterAccumulator::merge(const StringView& serialized) {
+  VELOX_USER_CHECK_GT(
+      serialized.size(), 0, "Serialized split-block Bloom filter is empty");
+  VELOX_USER_CHECK_EQ(
+      serialized.size() % sizeof(Block),
+      0,
+      "Invalid serialized split-block Bloom filter size: {}",
+      serialized.size());
+  const auto numBlocks =
+      static_cast<int32_t>(serialized.size() / sizeof(Block));
+  if (blocks_.empty()) {
+    init(numBlocks);
+  } else {
     VELOX_USER_CHECK_EQ(
-        serialized.size() % sizeof(Block),
-        0,
-        "Invalid serialized split-block Bloom filter size: {}",
-        serialized.size());
-    const auto numBlocks =
-        static_cast<int32_t>(serialized.size() / sizeof(Block));
-    if (blocks.empty()) {
-      init(numBlocks);
-    } else {
-      VELOX_USER_CHECK_EQ(
-          blocks.size(),
-          numBlocks,
-          "Cannot merge split-block Bloom filters of different sizes");
-    }
+        blocks_.size(),
+        numBlocks,
+        "Cannot merge split-block Bloom filters of different sizes");
+  }
 
-    for (int64_t i = 0; i < numBlocks; ++i) {
-      for (int32_t j = 0; j < xsimd::batch<uint32_t>::size; ++j) {
-        const auto offset = i * sizeof(Block) + j * sizeof(uint32_t);
-        blocks[i].data[j] |=
-            folly::loadUnaligned<uint32_t>(serialized.data() + offset);
-      }
+  for (int64_t i = 0; i < numBlocks; ++i) {
+    for (int32_t j = 0; j < xsimd::batch<uint32_t>::size; ++j) {
+      const auto offset = i * sizeof(Block) + j * sizeof(uint32_t);
+      blocks_[i].data[j] |=
+          folly::loadUnaligned<uint32_t>(serialized.data() + offset);
     }
   }
+}
 
-  bool initialized() const {
-    return !blocks.empty();
+bool BloomFilterAccumulator::initialized() const {
+  return !blocks_.empty();
+}
+
+void BloomFilterAccumulator::init(int32_t numBlocks) {
+  if (blocks_.empty()) {
+    VELOX_CHECK_GT(numBlocks, 0);
+    blocks_.resize(numBlocks);
+    bloomFilter_.emplace(blocks_);
   }
+}
 
-  void init(int32_t numBlocks) {
-    if (blocks.empty()) {
-      VELOX_CHECK_GT(numBlocks, 0);
-      blocks.resize(numBlocks);
-      bloomFilter.emplace(blocks);
-    }
-  }
+void BloomFilterAccumulator::insert(int64_t value) {
+  VELOX_DCHECK(bloomFilter_.has_value());
+  bloomFilter_->insert(folly::hasher<int64_t>()(value));
+}
 
-  void insert(int64_t value) {
-    bloomFilter->insert(folly::hasher<int64_t>()(value));
-  }
+const SplitBlockBloomFilter* BloomFilterAccumulator::bloomFilter() const {
+  VELOX_CHECK(bloomFilter_.has_value());
+  return &bloomFilter_.value();
+}
 
-  std::vector<Block, BlockAllocator> blocks;
-  std::optional<SplitBlockBloomFilter> bloomFilter;
-};
+namespace {
 
 class BloomFilterAggAggregate : public exec::Aggregate {
  public:
@@ -160,7 +158,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       auto tracker = trackRowSize(group);
       auto serialized = decodedIntermediate_.valueAt<StringView>(row);
       auto accumulator = value<BloomFilterAccumulator>(group);
-      accumulator->mergeWith(serialized);
+      accumulator->merge(serialized);
     });
   }
 
@@ -203,7 +201,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
         return;
       }
       auto serialized = decodedIntermediate_.valueAt<StringView>(row);
-      accumulator->mergeWith(serialized);
+      accumulator->merge(serialized);
     });
   }
 

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
@@ -16,11 +16,43 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <vector>
 
+#include "velox/common/base/SplitBlockBloomFilter.h"
+#include "velox/common/memory/HashStringAllocator.h"
 #include "velox/exec/AggregateUtil.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
+
+class BloomFilterAccumulator {
+ public:
+  explicit BloomFilterAccumulator(HashStringAllocator* allocator);
+
+  int32_t serializedSize() const;
+
+  void serialize(char* output) const;
+
+  void merge(const StringView& serialized);
+
+  bool initialized() const;
+
+  void init(int32_t numBlocks);
+
+  void insert(int64_t value);
+
+  SplitBlockBloomFilter* bloomFilter();
+
+  const SplitBlockBloomFilter* bloomFilter() const;
+
+ private:
+  using Block = SplitBlockBloomFilter::Block;
+  using BlockAllocator = AlignedStlAllocator<Block, alignof(Block)>;
+
+  std::vector<Block, BlockAllocator> blocks_;
+  std::optional<SplitBlockBloomFilter> bloomFilter_;
+};
 
 exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
     const std::string& name,

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/common/base/BloomFilter.h"
+#include "velox/common/base/SplitBlockBloomFilter.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -35,15 +35,20 @@ class BloomFilterAggAggregateTest
     registerAggregateFunctions("");
   }
 
-  VectorPtr getSerializedBloomFilter(int32_t capacity) {
-    BloomFilter bloomFilter;
-    bloomFilter.reset(capacity);
+  static int32_t numBlocksForBits(int64_t numBits) {
+    return static_cast<int32_t>(std::max<int64_t>(
+        1, numBits / (8 * sizeof(SplitBlockBloomFilter::Block))));
+  }
+
+  VectorPtr getSerializedBloomFilter(int32_t numBlocks) {
+    std::vector<SplitBlockBloomFilter::Block> blocks(numBlocks);
+    SplitBlockBloomFilter bloomFilter(blocks);
     for (auto i = 0; i < 9; ++i) {
       bloomFilter.insert(folly::hasher<int64_t>()(i));
     }
-    std::string data;
-    data.resize(bloomFilter.serializedSize());
-    bloomFilter.serialize(data.data());
+    std::string data(
+        reinterpret_cast<const char*>(blocks.data()),
+        blocks.size() * sizeof(SplitBlockBloomFilter::Block));
     return makeConstant(StringView(data), 1, VARBINARY());
   }
 };
@@ -52,7 +57,7 @@ class BloomFilterAggAggregateTest
 TEST_F(BloomFilterAggAggregateTest, basic) {
   auto vectors = {makeRowVector({makeFlatVector<int64_t>(
       100, [](vector_size_t row) { return row % 9; })})};
-  auto expected = {makeRowVector({getSerializedBloomFilter(11)})};
+  auto expected = {makeRowVector({getSerializedBloomFilter(1)})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expected);
 }
 
@@ -60,14 +65,16 @@ TEST_F(BloomFilterAggAggregateTest, bloomFilterAggArgument) {
   auto vectors = {makeRowVector({makeFlatVector<int64_t>(
       100, [](vector_size_t row) { return row % 9; })})};
 
-  auto expected1 = {makeRowVector({getSerializedBloomFilter(13)})};
+  auto expected1 = {makeRowVector({getSerializedBloomFilter(1)})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0, 6)"}, expected1);
 
-  auto expected2 = {makeRowVector({getSerializedBloomFilter(524'288)})};
+  auto expected2 = {
+      makeRowVector({getSerializedBloomFilter(numBlocksForBits(8'388'608))})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0)"}, expected2);
 
   // Max bits case: bloom filter is at its largest possible size.
-  auto expected3 = {makeRowVector({getSerializedBloomFilter(4'194'304)})};
+  auto expected3 = {
+      makeRowVector({getSerializedBloomFilter(numBlocksForBits(67'108'864))})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0, 10000000)"}, expected3);
 }
 
@@ -91,7 +98,7 @@ TEST_F(BloomFilterAggAggregateTest, config) {
   auto vector = {makeRowVector({makeFlatVector<int64_t>(
       100, [](vector_size_t row) { return row % 9; })})};
   std::vector<RowVectorPtr> expected = {
-      makeRowVector({getSerializedBloomFilter(100)})};
+      makeRowVector({getSerializedBloomFilter(numBlocksForBits(1'600))})};
 
   // This config will decide the bloom filter capacity, the expected value is
   // the serialized bloom filter, it should be consistent.

--- a/velox/functions/sparksql/tests/MightContainTest.cpp
+++ b/velox/functions/sparksql/tests/MightContainTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/functions/sparksql/MightContain.h"
-#include "velox/common/base/BloomFilter.h"
+#include "velox/common/base/SplitBlockBloomFilter.h"
 #include "velox/core/Expressions.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
@@ -55,15 +55,14 @@ class MightContainTest : public SparkFunctionBaseTest {
   }
 
   std::string getSerializedBloomFilter(int32_t kSize) {
-    BloomFilter bloomFilter;
-    bloomFilter.reset(kSize);
+    std::vector<SplitBlockBloomFilter::Block> blocks(1);
+    SplitBlockBloomFilter bloomFilter(blocks);
     for (auto i = 0; i < kSize; ++i) {
       bloomFilter.insert(folly::hasher<int64_t>()(i));
     }
-    std::string data;
-    data.resize(bloomFilter.serializedSize());
-    bloomFilter.serialize(data.data());
-    return data;
+    return std::string(
+        reinterpret_cast<const char*>(blocks.data()),
+        blocks.size() * sizeof(SplitBlockBloomFilter::Block));
   }
 };
 


### PR DESCRIPTION
The patch modifies Spark function `bloom_filter_agg` and `might_contain`, to switch the internal bloom filter implementation from `BloomFilter` to `SplitBlockBloomFilter`, since `SplitBlockBloomFilter` can be pushed down as subfield filter with minimal effort while `BloomFilter` doesn't have subfield filter support.`SplitBlockBloomFilter` also supposedly provides better performance compared to `BloomFilter` since it's simd-friendly.

