### PR TITLE
fix(ci): Only force UV_TOOL_BIN_DIR when installing uv (fixes #18463)

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -437,8 +437,15 @@ function install_hdfs_deps {
 }
 
 function install_uv {
-  export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
-  export UV_INSTALL_DIR=${UV_INSTALL_DIR:-"$UV_TOOL_BIN_DIR"}
+  # Default the uv tool/install dirs to INSTALL_PREFIX only when it is writable.
+  # On bare CI runners INSTALL_PREFIX (/usr/local) is root-owned, so a non-sudo
+  # `uv tool install` cannot symlink there and fails with "Permission denied";
+  # leaving these unset lets uv use its writable default (~/.local/bin).
+  # Container images set UV_TOOL_BIN_DIR via ENV, which is preserved here.
+  if [[ -w "$INSTALL_PREFIX/bin" ]]; then
+    export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
+    export UV_INSTALL_DIR="${UV_INSTALL_DIR:-$UV_TOOL_BIN_DIR}"
+  fi
   if command -v uv >/dev/null 2>&1; then
     echo "uv is already installed."
   else


### PR DESCRIPTION
## Summary

The Breeze `Ubuntu GPU debug` job (and any other bare-runner job that installs cmake via `uv`) fails during dependency setup:

```
+ uv tool install --force cmake==4.3.2
error: Failed to install executable
  Caused by: failed to symlink file from /usr/local/bin/ccmake ... Permission denied (os error 13)
...
cmake: command not found
```

Example failing run: https://github.com/facebookincubator/velox/actions/runs/31403075119/job/93502796302

## Root cause

These jobs run on bare runners where `uv` is preinstalled (via `astral-sh/setup-uv`) and `INSTALL_PREFIX` defaults to `/usr/local` (root-owned). The non-sudo `uv tool install` cannot symlink into `/usr/local/bin`, so `cmake` never lands on `PATH`.

This regressed in #18428, which made `install_uv` export

```sh
export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
export UV_INSTALL_DIR=${UV_INSTALL_DIR:-"$UV_TOOL_BIN_DIR"}
```

unconditionally, so the tool bin dir is forced to the root-owned `/usr/local/bin` even when uv is already present. Previously (uv-already-installed path) these were left unset and uv used its writable default (`~/.local/bin`).

## Fix

Keep the exports unconditional (as #18428 intended, so `uv tool update-shell` still runs with them set), but guard the `INSTALL_PREFIX/bin` default on that directory being writable:

```sh
if [[ -w "$INSTALL_PREFIX/bin" ]]; then
  export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
  export UV_INSTALL_DIR="${UV_INSTALL_DIR:-$UV_TOOL_BIN_DIR}"
fi
```

Behavior in the three cases:
- **Bare runner** (`/usr/local/bin` root-owned): guard is false, so `UV_TOOL_BIN_DIR` stays unset and `uv tool install` uses its writable default `~/.local/bin`. Fixed.
- **Container image** (sets `UV_TOOL_BIN_DIR` via `ENV`): the value is preserved regardless, and `/usr/local/bin` is writable as root anyway. Unchanged.
- **Privileged local run** (writable `/usr/local/bin`): still defaults to `$INSTALL_PREFIX/bin`, preserving the original intent.

The unconditional `uv tool update-shell` from #18428 is retained.

## Test plan

Note: `breeze.yml`'s path filter lists `scripts/setup-ubuntu.sh` and `scripts/setup-helper-functions.sh` but not `scripts/setup-common.sh` (which this PR edits), so this PR does not auto-trigger the `Ubuntu GPU debug` job. Validation is done on a scratch branch that also touches a triggering path so the GPU job runs with this fix; the `Install Dependencies` step then installs cmake without the `/usr/local/bin` permission error.

Fixes #18463.
