### PR TITLE
fix: Parquet column reader options initialization order

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -336,9 +336,8 @@ DwrfRowReader::DwrfRowReader(
     makeProjectedNodes(*getReader().schemaWithId(), *projectedNodes_);
   }
 
-  // Configure reader options before calling 'getUnitLoader()'.
-  // Construction is single-threaded, and the unit loader is created only
-  // after 'columnReaderOptions_' has been initialized.
+  // Keep this before 'getUnitLoader()': it copies 'columnReaderOptions_' into
+  // every DwrfUnit, which then uses the copy to build its column readers.
   columnReaderOptions_ = dwio::common::makeColumnReaderOptions(
       readerBaseShared()->readerOptions());
   unitLoader_ = getUnitLoader();

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1553,6 +1553,8 @@ class ParquetRowReader::Impl {
       : pool_{readerBase->getMemoryPool()},
         readerBase_{readerBase},
         options_{options},
+        columnReaderOptions_{
+            dwio::common::makeColumnReaderOptions(readerBase_->options())},
         rowGroups_{*readerBase_->thriftFileMetaData().row_groups()},
         nextRowGroupIdsIdx_{0},
         currentRowGroupPtr_{nullptr},
@@ -1598,9 +1600,6 @@ class ParquetRowReader::Impl {
       // table scan.
       advanceToNextRowGroup();
     }
-
-    columnReaderOptions_ =
-        dwio::common::makeColumnReaderOptions(readerBase_->options());
   }
 
   void filterRowGroups() {
@@ -1785,7 +1784,7 @@ class ParquetRowReader::Impl {
   memory::MemoryPool& pool_;
   const std::shared_ptr<ReaderBase> readerBase_;
   const dwio::common::RowReaderOptions options_;
-  dwio::common::ColumnReaderOptions columnReaderOptions_;
+  const dwio::common::ColumnReaderOptions columnReaderOptions_;
 
   // All row groups from file metadata.
   std::vector<thrift::RowGroup>& rowGroups_;

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -248,6 +248,35 @@ TEST_F(ParquetReaderTest, parquetFieldIdColumnMapping) {
       *leafPool_);
 }
 
+TEST_F(ParquetReaderTest, nestedNameColumnMapping) {
+  auto data = makeRowVector(
+      {"nested"},
+      {makeRowVector(
+          // Make positional and name-based mapping disagree.
+          {"padding", "present"},
+          {makeFlatVector<int32_t>({10, 20, 30}),
+           makeFlatVector<int32_t>({1, 2, 3})})});
+  auto* sink = write(data);
+
+  const auto outputNestedType = ROW({"present", "missing"}, INTEGER());
+  const auto outputType = ROW("nested", outputNestedType);
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setFileSchema(outputType);
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kName);
+
+  auto readerBundle =
+      readerBuilder(*sink, outputType).options(readerOptions).build();
+  auto expected = makeRowVector(
+      {"nested"},
+      {makeRowVector(
+          {"present", "missing"},
+          {makeFlatVector<int32_t>({1, 2, 3}),
+           makeNullableFlatVector<int32_t>(
+               {std::nullopt, std::nullopt, std::nullopt})})});
+  assertReadWithReaderAndExpected(
+      outputType, *readerBundle.rowReader, expected, *leafPool_);
+}
+
 TEST_F(ParquetReaderTest, parseEmptyNestedList) {
   // parse_empty_nested_list.parquet holds 1,000 rows of the following data:
   //


### PR DESCRIPTION
Previously, `ParquetColumnReader::build()` received a default-constructed
`ColumnReaderOptions`, so nested column readers could not observe the
correct name-based mapping mode when name-based mapping was enabled.

This PR fixes Parquet row reader construction so `columnReaderOptions_` is 
initialized from `makeColumnReaderOptions(readerBase_->options())` before 
building the column reader tree.