### PR TITLE
feat: Conform to the Puffin and partition-spec formats, and extend coverage

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -286,19 +286,26 @@ HiveTableHandle::HiveTableHandle(
     const std::unordered_map<std::string, std::string>& tableParameters,
     std::vector<HiveColumnHandlePtr> filterColumnHandles,
     double sampleRate,
-    std::string dbName)
+    std::string dbName,
+    std::vector<int32_t> dataColumnFieldIds)
     : FileTableHandle(std::move(connectorId)),
       tableName_(tableName),
       subfieldFilters_(std::move(subfieldFilters)),
       remainingFilter_(remainingFilter),
       sampleRate_(sampleRate),
       dataColumns_(dataColumns),
+      dataColumnFieldIds_(std::move(dataColumnFieldIds)),
       indexColumns_(std::move(indexColumns)),
       tableParameters_(tableParameters),
       filterColumnHandles_(std::move(filterColumnHandles)),
       dbName_(std::move(dbName)) {
   VELOX_CHECK_GT(sampleRate_, 0.0, "Sample rate must be positive");
   VELOX_CHECK_LE(sampleRate_, 1.0, "Sample rate must not exceed 1.0");
+  VELOX_CHECK(
+      dataColumnFieldIds_.empty() ||
+          (dataColumns_ != nullptr &&
+           dataColumnFieldIds_.size() == dataColumns_->size()),
+      "Data column field IDs must be empty or aligned to data columns");
 }
 
 HiveTableHandle::HiveTableHandle(
@@ -404,6 +411,13 @@ folly::dynamic HiveTableHandle::serialize() const {
   if (dataColumns_) {
     obj["dataColumns"] = dataColumns_->serialize();
   }
+  if (!dataColumnFieldIds_.empty()) {
+    folly::dynamic dataColumnFieldIds = folly::dynamic::array;
+    for (const auto fieldId : dataColumnFieldIds_) {
+      dataColumnFieldIds.push_back(fieldId);
+    }
+    obj["dataColumnFieldIds"] = std::move(dataColumnFieldIds);
+  }
   folly::dynamic tableParameters = folly::dynamic::object;
   for (const auto& param : tableParameters_) {
     tableParameters[param.first] = param.second;
@@ -463,6 +477,14 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     dataColumns = ISerializable::deserialize<RowType>(it->second, context);
   }
 
+  std::vector<int32_t> dataColumnFieldIds;
+  if (auto it = obj.find("dataColumnFieldIds"); it != obj.items().end()) {
+    dataColumnFieldIds.reserve(it->second.size());
+    for (const auto& fieldId : it->second) {
+      dataColumnFieldIds.push_back(fieldId.asInt());
+    }
+  }
+
   std::unordered_map<std::string, std::string> tableParameters{};
   const auto& tableParametersObj = obj["tableParameters"];
   for (const auto& key : tableParametersObj.keys()) {
@@ -500,7 +522,8 @@ ConnectorTableHandlePtr HiveTableHandle::create(
       tableParameters,
       std::move(filterColumnHandles),
       sampleRate,
-      std::move(dbName));
+      std::move(dbName),
+      std::move(dataColumnFieldIds));
 }
 
 void HiveTableHandle::registerSerDe() {

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -188,7 +188,8 @@ class HiveTableHandle : public FileTableHandle {
       const std::unordered_map<std::string, std::string>& tableParameters = {},
       std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
       double sampleRate = 1.0,
-      std::string dbName = "");
+      std::string dbName = "",
+      std::vector<int32_t> dataColumnFieldIds = {});
 
   /// Legacy constructor without indexColumns parameter for backward
   /// compatibility.
@@ -234,6 +235,12 @@ class HiveTableHandle : public FileTableHandle {
     return dataColumns_;
   }
 
+  /// Returns Iceberg field IDs aligned positionally to dataColumns(). An empty
+  /// vector means field IDs are unavailable.
+  const std::vector<int32_t>& dataColumnFieldIds() const {
+    return dataColumnFieldIds_;
+  }
+
   /// Returns the names of the index columns for the table.
   const std::vector<std::string>& indexColumns() const {
     return indexColumns_;
@@ -275,6 +282,7 @@ class HiveTableHandle : public FileTableHandle {
   const core::TypedExprPtr remainingFilter_;
   const double sampleRate_;
   const RowTypePtr dataColumns_;
+  const std::vector<int32_t> dataColumnFieldIds_;
   const std::vector<std::string> indexColumns_;
   const std::unordered_map<std::string, std::string> tableParameters_;
   const std::vector<HiveColumnHandlePtr> filterColumnHandles_;

--- a/velox/connectors/hive/iceberg/DeletionVectorFormat.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorFormat.h
@@ -47,4 +47,14 @@ inline constexpr size_t kDeletionVectorCrcSize = 4;
 /// reader enforce this so neither can accept a blob the other would reject.
 inline constexpr uint32_t kMaxRoaring64GroupKey = 2'147'483'646;
 
+/// Puffin container format constants, shared by the deletion-vector writer
+/// (which emits the footer) and the reader (which parses it when the manifest
+/// carries no blob offset). Magic is "PFA1" and brackets both the file and the
+/// footer payload.
+inline constexpr char kPuffinMagic[] = {'\x50', '\x46', '\x41', '\x31'};
+inline constexpr size_t kPuffinMagicSize = 4;
+
+/// Blob type of an Iceberg V3 deletion vector inside a Puffin file.
+inline constexpr char kDeletionVectorBlobType[] = "deletion-vector-v1";
+
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/DeletionVectorFormat.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorFormat.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -34,5 +35,16 @@ inline constexpr size_t kDeletionVectorMagicSize = 4;
 // magic + bitmap in the deletion-vector-v1 frame.
 inline constexpr size_t kDeletionVectorLengthSize = 4;
 inline constexpr size_t kDeletionVectorCrcSize = 4;
+
+/// Largest Roaring64 group key (the high 32 bits of a position) the Iceberg
+/// deletion-vector format can represent.
+///
+/// Iceberg's RoaringPositionBitmap stores the key as a signed 32-bit int and
+/// caps it one below Integer.MAX_VALUE, so a spec-compliant reader cannot load
+/// a larger key back. Keys at or above 2^31 are worse still: `key << 32`
+/// shifts into the sign bit of the int64 position and yields a negative row
+/// ordinal. Both the writer (via DeletionVectorWriter::kMaxPosition) and the
+/// reader enforce this so neither can accept a blob the other would reject.
+inline constexpr uint32_t kMaxRoaring64GroupKey = 2'147'483'646;
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
 
+#include <folly/json.h>
 #include <folly/lang/Bits.h>
 #include <zlib.h>
 
@@ -39,6 +40,146 @@ uint32_t readBigEndian32(const char* data) {
   uint32_t value;
   std::memcpy(&value, data, sizeof(value));
   return folly::Endian::big(value);
+}
+
+uint32_t readLittleEndian32(const char* data) {
+  uint32_t value;
+  std::memcpy(&value, data, sizeof(value));
+  return folly::Endian::little(value);
+}
+
+// Byte range of a blob inside a Puffin file.
+struct BlobLocation {
+  uint64_t offset;
+  uint64_t length;
+};
+
+// Reads the Puffin magic that both opens the file and brackets the footer.
+bool startsWithPuffinMagic(ReadFile& file) {
+  if (file.size() < kPuffinMagicSize) {
+    return false;
+  }
+  std::string magic(kPuffinMagicSize, '\0');
+  file.pread(0, kPuffinMagicSize, magic.data());
+  return std::string_view(magic) ==
+      std::string_view(kPuffinMagic, kPuffinMagicSize);
+}
+
+// Locates the deletion-vector blob by parsing the Puffin footer, for files
+// whose manifest entry carried no blob offset or length. The footer is:
+//   Magic FooterPayload FooterPayloadSize Flags Magic
+// with FooterPayloadSize and Flags each 4 bytes little-endian, read backwards
+// from end of file. 'referencedDataFile' disambiguates when the file holds
+// vectors for several data files; an empty value requires a single candidate.
+BlobLocation locateBlobFromPuffinFooter(
+    ReadFile& file,
+    const std::string& referencedDataFile) {
+  // FooterPayloadSize + Flags + trailing Magic.
+  constexpr uint64_t kTrailerSize = 4 + 4 + kPuffinMagicSize;
+  // Leading Magic and the Magic that opens the footer bracket any payload.
+  constexpr uint64_t kMinFileSize = kTrailerSize + 2 * kPuffinMagicSize;
+
+  const uint64_t fileSize = file.size();
+  VELOX_CHECK_GE(
+      fileSize,
+      kMinFileSize,
+      "Puffin file is too small to contain a footer: {} bytes.",
+      fileSize);
+
+  std::string trailer(kTrailerSize, '\0');
+  file.pread(fileSize - kTrailerSize, kTrailerSize, trailer.data());
+  const std::string_view puffinMagic(kPuffinMagic, kPuffinMagicSize);
+  VELOX_CHECK_EQ(
+      std::string_view(trailer).substr(8),
+      puffinMagic,
+      "Puffin file does not end with the expected magic.");
+
+  const uint32_t flags = readLittleEndian32(trailer.data() + 4);
+  // Bit 0 of the first flag byte marks a compressed footer payload. Deletion
+  // vectors are always written uncompressed, so this is unreachable for files
+  // we produce and unsupported for files we do not.
+  VELOX_CHECK_EQ(
+      flags & 1u, 0u, "Compressed Puffin footer payloads are not supported.");
+
+  // payloadOffset must leave room for the leading magic and the magic that
+  // opens the footer, so payloadSize + kMinFileSize must fit within the file.
+  const uint64_t payloadSize = readLittleEndian32(trailer.data());
+  VELOX_CHECK_LE(
+      payloadSize + kMinFileSize,
+      fileSize,
+      "Puffin footer payload size {} does not fit in a {}-byte file.",
+      payloadSize,
+      fileSize);
+
+  const uint64_t payloadOffset = fileSize - kTrailerSize - payloadSize;
+  std::string footerMagic(kPuffinMagicSize, '\0');
+  file.pread(
+      payloadOffset - kPuffinMagicSize, kPuffinMagicSize, footerMagic.data());
+  VELOX_CHECK_EQ(
+      std::string_view(footerMagic),
+      puffinMagic,
+      "Puffin footer payload is not preceded by the expected magic.");
+
+  std::string payload(payloadSize, '\0');
+  file.pread(payloadOffset, payloadSize, payload.data());
+
+  folly::dynamic footer;
+  try {
+    footer = folly::parseJson(payload);
+  } catch (const folly::json::parse_error& e) {
+    VELOX_FAIL("Failed to parse Puffin footer payload: {}", e.what());
+  }
+
+  const auto* blobs = footer.get_ptr("blobs");
+  VELOX_CHECK(
+      blobs != nullptr && blobs->isArray(),
+      "Puffin footer has no \"blobs\" array.");
+
+  std::optional<BlobLocation> found;
+  for (const auto& blob : *blobs) {
+    const auto* type = blob.get_ptr("type");
+    if (type == nullptr || !type->isString() ||
+        type->asString() != kDeletionVectorBlobType) {
+      continue;
+    }
+    if (!referencedDataFile.empty()) {
+      const auto* properties = blob.get_ptr("properties");
+      const auto* referenced = properties == nullptr
+          ? nullptr
+          : properties->get_ptr("referenced-data-file");
+      if (referenced == nullptr || !referenced->isString() ||
+          referenced->asString() != referencedDataFile) {
+        continue;
+      }
+    }
+    const auto* offset = blob.get_ptr("offset");
+    const auto* length = blob.get_ptr("length");
+    VELOX_CHECK(
+        offset != nullptr && offset->isInt() && length != nullptr &&
+            length->isInt(),
+        "Puffin blob metadata is missing a numeric offset or length.");
+    // Both are widened to uint64_t below, where a negative value would wrap to
+    // a huge offset. The file-bounds check downstream would still reject it,
+    // but only after reporting an absurd number, so reject it here instead.
+    VELOX_CHECK_GE(
+        offset->asInt(), 0, "Puffin blob metadata has a negative offset.");
+    VELOX_CHECK_GE(
+        length->asInt(), 0, "Puffin blob metadata has a negative length.");
+    VELOX_CHECK(
+        !found.has_value(),
+        "Puffin file has multiple deletion vectors and no referenced data "
+        "file to disambiguate them.");
+    found = BlobLocation{
+        static_cast<uint64_t>(offset->asInt()),
+        static_cast<uint64_t>(length->asInt())};
+  }
+
+  VELOX_CHECK(
+      found.has_value(),
+      "Puffin footer has no deletion-vector blob for data file: {}",
+      referencedDataFile.empty() ? std::string_view{"(unspecified)"}
+                                 : std::string_view{referencedDataFile});
+  return found.value();
 }
 
 // Unwraps the Iceberg deletion-vector-v1 blob frame
@@ -120,6 +261,7 @@ void DeletionVectorReader::loadBitmap() {
   uint64_t blobLength = dvFile_.contentLength > 0
       ? static_cast<uint64_t>(dvFile_.contentLength)
       : dvFile_.fileSizeInBytes;
+  bool haveBlobLocation = dvFile_.contentLength > 0;
 
   if (dvFile_.contentLength == 0) {
     if (auto it = dvFile_.lowerBounds.find(kDvOffsetFieldId);
@@ -135,6 +277,7 @@ void DeletionVectorReader::loadBitmap() {
         it != dvFile_.upperBounds.end()) {
       try {
         blobLength = std::stoull(it->second);
+        haveBlobLocation = true;
       } catch (const std::exception& e) {
         VELOX_FAIL(
             "Failed to parse DV blob length from bounds map: {}", e.what());
@@ -156,6 +299,17 @@ void DeletionVectorReader::loadBitmap() {
       readFile, "Failed to open deletion vector file: {}", dvFile_.filePath);
 
   auto fileSize = readFile->size();
+
+  // Nothing in the manifest located the blob. A Puffin file describes its own
+  // blobs, so parse the footer rather than guessing. Non-Puffin inputs keep
+  // the legacy whole-file behaviour, which is how raw roaring blobs are read.
+  if (!haveBlobLocation && startsWithPuffinMagic(*readFile)) {
+    const auto location =
+        locateBlobFromPuffinFooter(*readFile, dvFile_.referencedDataFile);
+    blobOffset = location.offset;
+    blobLength = location.length;
+  }
+
   VELOX_CHECK_LE(
       blobOffset,
       fileSize,

--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -232,6 +232,13 @@ void DeletionVectorReader::deserializeRoaring64Bitmap(std::string_view data) {
     highBits = folly::Endian::little(highBits);
     ptr += sizeof(uint32_t);
 
+    VELOX_CHECK_LE(
+        highBits,
+        kMaxRoaring64GroupKey,
+        "Roaring64Bitmap group key exceeds the maximum the Iceberg "
+        "deletion-vector format can represent: {}",
+        highBits);
+
     int64_t highBitsOffset = static_cast<int64_t>(highBits) << 32;
 
     // Deserialize the 32-bit bitmap for this group.

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -159,6 +159,12 @@ void serializeContainerData(
 
 void DeletionVectorWriter::addDeletedPosition(int64_t position) {
   VELOX_CHECK_GE(position, 0, "Deleted position must be non-negative.");
+  VELOX_CHECK_LE(
+      position,
+      kMaxPosition,
+      "Deleted position exceeds the maximum the Iceberg deletion-vector "
+      "format can represent: {}",
+      position);
   positions_.push_back(position);
 }
 

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -40,15 +40,20 @@ constexpr size_t kBitmapContainerBytes = 8'192;
 constexpr size_t kBitmapContainerWords = 1'024;
 
 // Puffin file format constants (per Iceberg spec). Magic is "PFA1".
-constexpr char kPuffinMagic[] = {'\x50', '\x46', '\x41', '\x31'};
-constexpr size_t kPuffinMagicSize = 4;
 constexpr uint32_t kPuffinFooterFlags = 0;
 
 // Puffin blob metadata constants (per Iceberg V3 deletion vector spec).
-constexpr char kDeletionVectorBlobType[] = "deletion-vector-v1";
 constexpr char kCompressionCodecNone[] = "none";
-// Iceberg spec: source-field-id for whole-row deletes is INT_MAX - 1.
-constexpr int32_t kWholeRowDeleteFieldId = 2'147'483'646;
+// The blob's "fields" list names the row-position metadata column
+// (MetadataColumns.ROW_POSITION, INT_MAX - 2), matching Iceberg's own
+// BaseDVFileWriter. Note this is not the positional-delete file's "pos"
+// column (INT_MAX - 102), which IcebergMetadataColumns uses for a different
+// purpose.
+constexpr int32_t kRowPositionFieldId = 2'147'483'645;
+// A deletion vector is written before its snapshot is assigned, so Iceberg
+// records -1 for both. The fields are required by readers regardless.
+constexpr int64_t kUnassignedSnapshotId = -1;
+constexpr int64_t kUnassignedSequenceNumber = -1;
 
 void writeLittleEndian(std::string& out, uint16_t val) {
   val = folly::Endian::little(val);
@@ -263,11 +268,11 @@ std::pair<uint64_t, uint64_t> writePuffinFile(
   uint64_t blobOffset = kPuffinMagicSize;
   uint64_t blobLength = framedBlob.size();
 
-  folly::dynamic blobMeta = folly::dynamic::object(
-      "type", kDeletionVectorBlobType)(
-      "fields",
-      folly::dynamic::array(
-          folly::dynamic::object("source-field-id", kWholeRowDeleteFieldId)));
+  folly::dynamic blobMeta =
+      folly::dynamic::object("type", kDeletionVectorBlobType)(
+          "fields", folly::dynamic::array(kRowPositionFieldId));
+  blobMeta["snapshot-id"] = kUnassignedSnapshotId;
+  blobMeta["sequence-number"] = kUnassignedSequenceNumber;
   blobMeta["offset"] = blobOffset;
   blobMeta["length"] = blobLength;
   blobMeta["compression-codec"] = kCompressionCodecNone;

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
+
 namespace facebook::velox::memory {
 class MemoryPool;
 } // namespace facebook::velox::memory
@@ -52,9 +54,25 @@ namespace facebook::velox::connector::hive::iceberg {
 ///   std::string blob = writer.serialize();
 class DeletionVectorWriter {
  public:
+  /// Largest position the Iceberg deletion-vector format can represent.
+  ///
+  /// Iceberg's RoaringPositionBitmap derives this as
+  /// `toPosition(MAX_KEY, Integer.MIN_VALUE)`, i.e.
+  /// `(key << 32) | (pos32 & 0xFFFFFFFF)` with `key = 2147483646`, and rejects
+  /// anything above it. The binding constraint is the Roaring64 group key: it
+  /// is read back as a signed 32-bit int, so a key at or above 2^31 would
+  /// deserialize as negative and be rejected by spec-compliant readers.
+  /// Matching the bound here means we never write a blob Iceberg cannot read.
+  static constexpr int64_t kMaxPosition = 9'223'372'030'412'324'864LL;
+
+  static_assert(
+      (kMaxPosition >> 32) == kMaxRoaring64GroupKey,
+      "Writer position bound and reader group-key bound must agree.");
+
   DeletionVectorWriter() = default;
 
-  /// Adds a deleted row position (0-based file row offset).
+  /// Adds a deleted row position (0-based file row offset). The position must
+  /// be in [0, kMaxPosition].
   void addDeletedPosition(int64_t position);
 
   /// Adds multiple deleted row positions.

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -34,7 +34,9 @@ HiveIcebergSplit::HiveIcebergSplit(
     bool cacheable,
     const std::unordered_map<std::string, std::string>& infoColumns,
     std::optional<FileProperties> properties,
-    int64_t dataSequenceNumber)
+    int64_t dataSequenceNumber,
+    const std::unordered_map<int32_t, std::optional<std::string>>&
+        identityPartitionKeys)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -52,7 +54,8 @@ HiveIcebergSplit::HiveIcebergSplit(
           properties,
           std::nullopt,
           std::nullopt),
-      dataSequenceNumber(dataSequenceNumber) {
+      dataSequenceNumber(dataSequenceNumber),
+      identityPartitionKeys(identityPartitionKeys) {
   // TODO: Deserialize _extraFileInfo to get deleteFiles;
 }
 
@@ -72,7 +75,9 @@ HiveIcebergSplit::HiveIcebergSplit(
     std::vector<IcebergDeleteFile> deletes,
     const std::unordered_map<std::string, std::string>& infoColumns,
     std::optional<FileProperties> properties,
-    int64_t dataSequenceNumber)
+    int64_t dataSequenceNumber,
+    const std::unordered_map<int32_t, std::optional<std::string>>&
+        identityPartitionKeys)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -91,7 +96,8 @@ HiveIcebergSplit::HiveIcebergSplit(
           std::nullopt,
           std::nullopt),
       deleteFiles(std::move(deletes)),
-      dataSequenceNumber(dataSequenceNumber) {}
+      dataSequenceNumber(dataSequenceNumber),
+      identityPartitionKeys(identityPartitionKeys) {}
 
 std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
   return std::make_shared<HiveIcebergSplit>(
@@ -108,6 +114,7 @@ std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
       deleteFiles_,
       infoColumns_,
       std::nullopt,
-      dataSequenceNumber_);
+      dataSequenceNumber_,
+      identityPartitionKeys_);
 }
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -37,6 +37,21 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   /// sequence number filtering.
   int64_t dataSequenceNumber{0};
 
+  /// Partition values keyed by the Iceberg *source* column field ID, for
+  /// partition fields the serialized spec explicitly marks as the 'identity'
+  /// transform. Only an identity value equals the source column's value, so
+  /// only these entries may be substituted for a read of the source column.
+  ///
+  /// Transformed fields (bucket, truncate, day, void) are never present, even
+  /// when their derived partition-field name happens to collide with a source
+  /// column name. An empty map means no identity provenance was available and
+  /// callers must read source columns from the data file.
+  ///
+  /// Distinct from the inherited name-keyed 'partitionKeys', which carries
+  /// every partition field under its derived 'PartitionField.name()' and
+  /// therefore cannot prove a transform is identity.
+  std::unordered_map<int32_t, std::optional<std::string>> identityPartitionKeys;
+
   HiveIcebergSplit(
       const std::string& connectorId,
       const std::string& filePath,
@@ -51,7 +66,9 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       bool cacheable = true,
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<int32_t, std::optional<std::string>>&
+          identityPartitionKeys = {});
 
   // For tests only
   HiveIcebergSplit(
@@ -69,7 +86,9 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       std::vector<IcebergDeleteFile> deletes = {},
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<int32_t, std::optional<std::string>>&
+          identityPartitionKeys = {});
 };
 
 /// Builds Iceberg splits with named parameters.
@@ -124,6 +143,14 @@ class IcebergSplitBuilder {
     return *this;
   }
 
+  /// Sets identity-transform partition values keyed by source field ID. See
+  /// 'HiveIcebergSplit::identityPartitionKeys'.
+  IcebergSplitBuilder& identityPartitionKeys(
+      const std::unordered_map<int32_t, std::optional<std::string>>& keys) {
+    identityPartitionKeys_ = keys;
+    return *this;
+  }
+
   std::shared_ptr<HiveIcebergSplit> build() const;
 
  private:
@@ -136,6 +163,8 @@ class IcebergSplitBuilder {
   std::unordered_map<std::string, std::string> infoColumns_;
   std::vector<IcebergDeleteFile> deleteFiles_;
   int64_t dataSequenceNumber_{0};
+  std::unordered_map<int32_t, std::optional<std::string>>
+      identityPartitionKeys_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -166,9 +166,16 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
     const {
   std::vector<dwio::common::ParquetFieldId> fieldIds;
   const auto& dataColumns = tableHandle_->dataColumns();
-  if (dataColumns == nullptr || columnHandles_ == nullptr) {
+  if (dataColumns == nullptr) {
     return fieldIds;
   }
+
+  const auto* hiveTableHandle =
+      dynamic_cast<const HiveTableHandle*>(tableHandle_.get());
+  const auto* dataColumnFieldIds = hiveTableHandle != nullptr
+      ? &hiveTableHandle->dataColumnFieldIds()
+      : nullptr;
+
   // Column handles are keyed by output alias; index them by the underlying
   // data-column name so we can align to dataColumns() order.
   std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
@@ -178,8 +185,10 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
       handleByName.emplace(icebergHandle->name(), icebergHandle);
     }
   };
-  for (const auto& columnHandle : *columnHandles_) {
-    addIcebergHandle(columnHandle.second);
+  if (columnHandles_ != nullptr) {
+    for (const auto& columnHandle : *columnHandles_) {
+      addIcebergHandle(columnHandle.second);
+    }
   }
   // Remaining filters can add columns to the reader output that are not
   // projected by the table scan. Include those handles so filter-only columns
@@ -187,7 +196,8 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
   for (const auto& handle : tableHandle_->filterColumnHandles()) {
     addIcebergHandle(handle);
   }
-  if (handleByName.empty()) {
+  if (handleByName.empty() &&
+      (dataColumnFieldIds == nullptr || dataColumnFieldIds->empty())) {
     return fieldIds;
   }
 
@@ -197,6 +207,9 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
     auto it = handleByName.find(dataColumns->nameOf(static_cast<uint32_t>(i)));
     if (it != handleByName.end()) {
       fieldIds.push_back(it->second->field());
+    } else if (dataColumnFieldIds != nullptr && !dataColumnFieldIds->empty()) {
+      fieldIds.push_back(
+          dwio::common::ParquetFieldId{dataColumnFieldIds->at(i), {}});
     } else {
       fieldIds.push_back(dwio::common::ParquetFieldId{sentinelFieldId--, {}});
     }
@@ -671,18 +684,35 @@ IcebergSplitReader::resolveEqualityColumns(
       "Iceberg equality delete file '{}' cannot be processed because "
       "table data columns are not available in HiveTableHandle.",
       deleteFile.filePath);
-  for (const auto& eqFieldId : deleteFile.equalityFieldIds) {
-    // Field IDs are 1-based sequential for non-evolved schemas.
-    auto colIdx = static_cast<uint32_t>(eqFieldId - 1);
+  std::unordered_map<int32_t, uint32_t> columnIndexByFieldId;
+  if (const auto* hiveTableHandle =
+          dynamic_cast<const HiveTableHandle*>(tableHandle_.get())) {
+    const auto& dataColumnFieldIds = hiveTableHandle->dataColumnFieldIds();
+    columnIndexByFieldId.reserve(dataColumnFieldIds.size());
+    for (uint32_t i = 0; i < dataColumnFieldIds.size(); ++i) {
+      columnIndexByFieldId.emplace(dataColumnFieldIds[i], i);
+    }
+  }
+
+  for (const auto& equalityFieldId : deleteFile.equalityFieldIds) {
+    VELOX_CHECK_GT(
+        equalityFieldId,
+        0,
+        "Equality delete field ID must be positive: {}",
+        equalityFieldId);
+    const auto fieldIdIt = columnIndexByFieldId.find(equalityFieldId);
+    // Older plans and tests may not carry full-schema field IDs. Preserve the
+    // legacy ordinal lookup when metadata is unavailable or incomplete.
+    const auto columnIndex = fieldIdIt != columnIndexByFieldId.end()
+        ? fieldIdIt->second
+        : static_cast<uint32_t>(equalityFieldId - 1);
     VELOX_CHECK_LT(
-        colIdx,
+        columnIndex,
         dataColumns->size(),
-        "Equality delete field ID {} out of range. This may indicate "
-        "schema evolution with non-sequential field IDs, which is "
-        "not yet supported.",
-        eqFieldId);
-    equalityColumnNames.push_back(dataColumns->nameOf(colIdx));
-    equalityColumnTypes.push_back(dataColumns->childAt(colIdx));
+        "Equality delete field ID cannot be resolved against table columns: {}",
+        equalityFieldId);
+    equalityColumnNames.push_back(dataColumns->nameOf(columnIndex));
+    equalityColumnTypes.push_back(dataColumns->childAt(columnIndex));
   }
   return {std::move(equalityColumnNames), std::move(equalityColumnTypes)};
 }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -418,23 +418,25 @@ void IcebergSplitReader::prepareSplit(
     return;
   }
 
-  // Inject a row-number column when filters, random-skip, or positional
+  // Inject a row-number column when filters, random-skip, or row-skipping
   // deletes make the output-to-file-position mapping non-contiguous.
   // Check split metadata rather than positionalDeleteFileReaders_ because
   // the row reader must be configured before delete files are opened. Both
   // _row_id and $target_table_row_id need accurate file-absolute positions,
-  // so request injection when either is projected.
-  const bool hasPositionalDeletes = std::any_of(
+  // so request injection when either is projected. Deletion vectors skip rows
+  // exactly like V2 positional deletes and must be counted here too.
+  const bool hasRowSkippingDeletes = std::any_of(
       icebergSplit_->deleteFiles.begin(),
       icebergSplit_->deleteFiles.end(),
       [](const IcebergDeleteFile& deleteFile) {
-        return deleteFile.content == FileContent::kPositionalDeletes &&
+        return (deleteFile.content == FileContent::kPositionalDeletes ||
+                deleteFile.content == FileContent::kDeletionVector) &&
             deleteFile.recordCount > 0;
       });
   useRowNumberColumn_ = (rowIdOutputIndex_.has_value() ||
                          targetTableRowIdOutputIndex_.has_value()) &&
       (scanSpec_->hasFilter() || baseReaderOpts_.randomSkip() != nullptr ||
-       hasPositionalDeletes);
+       hasRowSkippingDeletes);
   if (useRowNumberColumn_) {
     dwio::common::RowNumberColumnInfo rowNumInfo;
     rowNumInfo.insertPosition = readerOutputType_->size();

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -573,7 +573,7 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
   std::vector<std::string> extraNames;
   std::vector<TypePtr> extraTypes;
   const auto& deleteFiles = icebergSplit_->deleteFiles;
-  const auto& splitPartitionKeys = icebergSplit_->partitionKeys;
+  const auto& identityPartitionKeys = icebergSplit_->identityPartitionKeys;
 
   for (const auto& deleteFile : deleteFiles) {
     if (deleteFile.content != FileContent::kEqualityDeletes ||
@@ -619,14 +619,21 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
           static_cast<column_index_t>(
               readerOutputType_->size() + extraEqualityColumns.size()));
 
-      // For partition columns set the partition value directly as a constant
-      // on the scan-spec child. This is independent of whether the data file
-      // contains the partition column physically. With the constant set
-      // up-front, 'adaptColumns' does not need any special-case logic for
-      // augmented partition columns and the read does not depend on the
-      // writer's choice of including the partition column in the file.
-      auto partitionIt = splitPartitionKeys.find(name);
-      if (partitionIt != splitPartitionKeys.end()) {
+      // Substitute the partition value for the source column only when the
+      // Iceberg partition spec explicitly marks this equality field's source
+      // column as an identity partition field. Identity is the only transform
+      // whose stored partition value equals the source column value; a
+      // bucket, truncate, or temporal value is a transform result, and a
+      // 'void' value is always null while keeping the source column's name.
+      // Keying by the delete file's own Iceberg field ID (rather than by
+      // column name) also keeps this correct across column renames.
+      //
+      // Anything else -- a transformed field, a spec that could not be
+      // parsed, or a split with no identity metadata at all -- leaves no
+      // constant installed, so the column is read from the data file.
+      const auto identityIt =
+          identityPartitionKeys.find(deleteFile.equalityFieldIds[i]);
+      if (identityIt != identityPartitionKeys.end()) {
         // Iceberg encodes DATE partition values as the integer number of
         // days since the Unix epoch (e.g. "19345"). The standard
         // 'setPartitionValue' helper learns this from the planner-supplied
@@ -637,7 +644,7 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
         const bool isDaysSinceEpoch = equalityColumnTypes[i]->isDate();
         auto constant = newConstantFromString(
             equalityColumnTypes[i],
-            partitionIt->second,
+            identityIt->second,
             connectorQueryCtx_->memoryPool(),
             fileConfig_->readTimestampPartitionValueAsLocalTime(
                 connectorQueryCtx_->sessionProperties()),

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -139,11 +139,14 @@ class IcebergSplitReader : public FileSplitReader {
 
   // Discovers equality-delete columns that are not in the user's projection
   // and augments 'scanSpec_' and 'readerOutputType_' so they are physically
-  // read and made available in the output RowVector. For partition columns
-  // the partition value is set as a constant on the scan-spec child so the
-  // augmentation works regardless of whether the data file physically
-  // contains the partition column. Augmented columns are appended at the end
-  // of 'readerOutputType_' so the upstream FileDataSource's positional
+  // read and made available in the output RowVector. When the split proves
+  // the column's Iceberg field ID belongs to an identity partition field
+  // (see 'HiveIcebergSplit::identityPartitionKeys'), the partition value is
+  // set as a constant on the scan-spec child so the augmentation works
+  // regardless of whether the data file physically contains the column;
+  // every other column, including one partitioned by a transform, is read
+  // from the file. Augmented columns are appended at the end of
+  // 'readerOutputType_' so the upstream FileDataSource's positional
   // projection naturally drops them from the operator output.
   void configureEqualityDeleteColumns();
 

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -66,9 +66,10 @@ class IcebergSplitReader : public FileSplitReader {
 
   // Builds the requested-schema field-id trees, one per top-level column,
   // aligned to tableHandle_->dataColumns(). Projected and filter-only Iceberg
-  // handles provide field IDs. Data columns without an Iceberg handle get a
+  // handles provide field IDs. Data columns without an Iceberg handle fall back
+  // to the table handle's full-schema field IDs when available, otherwise a
   // negative sentinel id that matches no physical field. Returns empty when no
-  // Iceberg handles are available.
+  // Iceberg handles and no full-schema field IDs are available.
   std::vector<dwio::common::ParquetFieldId> buildFieldIds() const;
 
   /// Adapts the data file schema to match the table schema expected by the
@@ -130,10 +131,9 @@ class IcebergSplitReader : public FileSplitReader {
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
 
-  // Resolves the equality field IDs of an equality-delete file to the
-  // corresponding column names and types in the table schema. In Iceberg,
-  // field IDs for top-level columns are assigned sequentially starting from
-  // 1, matching the column order in the table schema.
+  // Resolves equality-delete field IDs to column names and types using the
+  // table handle's full-schema field IDs. Falls back to the legacy one-based
+  // ordinal mapping when those IDs are unavailable or incomplete.
   std::pair<std::vector<std::string>, std::vector<TypePtr>>
   resolveEqualityColumns(const IcebergDeleteFile& deleteFile) const;
 

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -96,6 +96,79 @@ std::string serializeRoaringBitmapNoRun(const std::vector<int64_t>& positions) {
   return data;
 }
 
+// Serializes a roaring bitmap in the portable no-run format, encoding any
+// block whose cardinality exceeds 4096 as a 1024-word bitset container rather
+// than an array container. 'serializeRoaringBitmapNoRun' above always emits
+// array containers, so it cannot produce this encoding — which is the one
+// Iceberg and DeletionVectorWriter use for dense blocks.
+std::string serializeRoaringBitmapWithBitsetContainer(
+    const std::vector<int64_t>& positions) {
+  constexpr uint32_t kMaxArrayContainerCardinality = 4'096;
+  constexpr uint32_t kBitmapContainerBytes = 8'192;
+  constexpr uint32_t kCookie = 12'346;
+
+  std::map<uint16_t, std::vector<uint16_t>> containers;
+  for (auto position : positions) {
+    containers[static_cast<uint16_t>(position >> 16)].push_back(
+        static_cast<uint16_t>(position & 0xFFFF));
+  }
+  for (auto& [key, values] : containers) {
+    std::sort(values.begin(), values.end());
+  }
+
+  const auto numContainers = static_cast<uint32_t>(containers.size());
+  std::string data;
+  data.append(reinterpret_cast<const char*>(&kCookie), 4);
+  data.append(reinterpret_cast<const char*>(&numContainers), 4);
+
+  for (const auto& [key, values] : containers) {
+    const auto cardMinus1 = static_cast<uint16_t>(values.size() - 1);
+    data.append(reinterpret_cast<const char*>(&key), 2);
+    data.append(reinterpret_cast<const char*>(&cardMinus1), 2);
+  }
+
+  uint32_t offset = 4 + 4 + numContainers * 4 + numContainers * 4;
+  for (const auto& [key, values] : containers) {
+    data.append(reinterpret_cast<const char*>(&offset), 4);
+    offset += values.size() <= kMaxArrayContainerCardinality
+        ? static_cast<uint32_t>(values.size()) * 2
+        : kBitmapContainerBytes;
+  }
+
+  for (const auto& [key, values] : containers) {
+    if (values.size() <= kMaxArrayContainerCardinality) {
+      for (auto value : values) {
+        data.append(reinterpret_cast<const char*>(&value), 2);
+      }
+    } else {
+      std::vector<uint64_t> words(1'024, 0);
+      for (auto value : values) {
+        words[value / 64] |= (1ULL << (value % 64));
+      }
+      for (auto word : words) {
+        data.append(reinterpret_cast<const char*>(&word), 8);
+      }
+    }
+  }
+  return data;
+}
+
+// Wraps serialized 32-bit roaring bitmaps in the Roaring64 envelope:
+// [numGroups: uint64] then, per group, [highBits: uint32][32-bit bitmap].
+// Reaching group N+1 requires the reader to advance exactly past group N's
+// container data, so multi-group inputs exercise that skip arithmetic.
+std::string wrapInRoaring64(
+    const std::vector<std::pair<uint32_t, std::string>>& groups) {
+  std::string data;
+  const auto numGroups = static_cast<uint64_t>(groups.size());
+  data.append(reinterpret_cast<const char*>(&numGroups), 8);
+  for (const auto& [highBits, bitmap] : groups) {
+    data.append(reinterpret_cast<const char*>(&highBits), 4);
+    data.append(bitmap);
+  }
+  return data;
+}
+
 // Concatenates the deletion-vector-v1 magic bytes with a serialized roaring
 // bitmap. The frame's length prefix and CRC-32 both cover these bytes.
 std::string magicAndVectorBytes(const std::string& bitmap) {
@@ -263,6 +336,38 @@ IcebergDeleteFile makeDvDeleteFile(
       /*dataSequenceNumber=*/0,
       /*contentOffset=*/static_cast<int64_t>(blobOffset),
       /*contentLength=*/contentLength);
+}
+
+// Creates a DV delete file that locates its blob through the legacy
+// bounds-map encoding instead of the typed 'contentOffset'/'contentLength'
+// fields. Leaving 'contentLength' at 0 is what selects that fallback.
+IcebergDeleteFile makeLegacyBoundsDvFile(
+    const std::string& filePath,
+    uint64_t recordCount,
+    uint64_t fileSize,
+    const std::optional<std::string>& blobOffset,
+    const std::optional<std::string>& blobLength) {
+  std::unordered_map<int32_t, std::string> lowerBounds;
+  std::unordered_map<int32_t, std::string> upperBounds;
+  if (blobOffset.has_value()) {
+    lowerBounds[DeletionVectorReader::kDvOffsetFieldId] = *blobOffset;
+  }
+  if (blobLength.has_value()) {
+    upperBounds[DeletionVectorReader::kDvLengthFieldId] = *blobLength;
+  }
+
+  return IcebergDeleteFile(
+      FileContent::kDeletionVector,
+      filePath,
+      dwio::common::FileFormat::DWRF,
+      recordCount,
+      fileSize,
+      /*equalityFieldIds=*/{},
+      lowerBounds,
+      upperBounds,
+      /*dataSequenceNumber=*/0,
+      /*contentOffset=*/0,
+      /*contentLength=*/0);
 }
 
 // Extracts which bits are set in a bitmap buffer.
@@ -521,6 +626,136 @@ TEST_F(DeletionVectorReaderTest, runContainersWithOffsetHeader) {
   EXPECT_TRUE(reader.noMoreData());
 }
 
+TEST_F(DeletionVectorReaderTest, bitsetContainer) {
+  // 5000 deletes inside a single 64K block exceeds the 4096 array-container
+  // threshold, so the block is stored as a 1024-word bitset. The reader picks
+  // the container encoding from the cardinality, so this is the only shape
+  // that exercises its bitset branch.
+  std::vector<int64_t> positions;
+  positions.reserve(5'000);
+  for (int64_t i = 0; i < 5'000; ++i) {
+    positions.push_back(i * 2);
+  }
+
+  auto bitmapData = serializeRoaringBitmapWithBitsetContainer(positions);
+  auto tempFile = writeDvFile(bitmapData);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+
+  const uint64_t numRows = 10'000;
+  auto bitmap = allocateBitmap(numRows);
+  reader.readDeletePositions(0, numRows, bitmap);
+
+  std::vector<uint64_t> expected;
+  expected.reserve(positions.size());
+  for (auto position : positions) {
+    expected.push_back(static_cast<uint64_t>(position));
+  }
+  EXPECT_EQ(getSetBits(bitmap, numRows), expected);
+  EXPECT_TRUE(reader.noMoreData());
+}
+
+TEST_F(DeletionVectorReaderTest, bitsetContainerMixedWithArrayContainer) {
+  // A dense block followed by a sparse one. The reader must advance exactly
+  // 8192 bytes past the bitset before reading the array container, so a wrong
+  // stride here corrupts the second block rather than failing outright.
+  std::vector<int64_t> positions;
+  positions.reserve(4'100);
+  for (int64_t i = 0; i < 4'100; ++i) {
+    positions.push_back(i);
+  }
+  positions.push_back(65'536 + 7);
+  positions.push_back(65'536 + 9);
+
+  auto bitmapData = serializeRoaringBitmapWithBitsetContainer(positions);
+  auto tempFile = writeDvFile(bitmapData);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+
+  std::vector<int64_t> expected(positions.begin(), positions.end());
+  std::sort(expected.begin(), expected.end());
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
+TEST_F(DeletionVectorReaderTest, runContainersAcrossRoaring64Groups) {
+  // Run containers wrapped in a Roaring64 envelope. Existing run-container
+  // coverage uses the bare 32-bit format, which returns before the 64-bit
+  // group loop; only a multi-group input exercises the logic that skips past
+  // a run container to locate the next group's header.
+  const std::vector<
+      std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>
+      lowGroupRuns = {{0, {{10, 4}, {100, 2}}}};
+  const std::vector<
+      std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>
+      highGroupRuns = {{0, {{20, 1}}}};
+
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapWithRuns(lowGroupRuns)},
+       {1, serializeRoaringBitmapWithRuns(highGroupRuns)}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  std::vector<int64_t> expected;
+  for (auto position : expandRuns(lowGroupRuns)) {
+    expected.push_back(static_cast<int64_t>(position));
+  }
+  // Group 1 positions live at highBits 1, i.e. offset 2^32.
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  for (auto position : expandRuns(highGroupRuns)) {
+    expected.push_back(kHighGroupBase + static_cast<int64_t>(position));
+  }
+  std::sort(expected.begin(), expected.end());
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
+TEST_F(
+    DeletionVectorReaderTest,
+    arrayAndBitsetContainersAcrossRoaring64Groups) {
+  // The multi-group skip arithmetic differs per container encoding: an array
+  // container advances by 2 bytes per value while a bitset always advances by
+  // a fixed 8192. Pair a sparse group with a dense one so both strides must be
+  // right for the second group's header to be found.
+  std::vector<int64_t> denseGroupPositions;
+  denseGroupPositions.reserve(4'200);
+  for (int64_t i = 0; i < 4'200; ++i) {
+    denseGroupPositions.push_back(i);
+  }
+
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapWithBitsetContainer({3, 11, 65'536 + 4})},
+       {1, serializeRoaringBitmapWithBitsetContainer(denseGroupPositions)}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  std::vector<int64_t> expected = {3, 11, 65'536 + 4};
+  for (auto position : denseGroupPositions) {
+    expected.push_back(kHighGroupBase + position);
+  }
+  std::sort(expected.begin(), expected.end());
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
 TEST_F(DeletionVectorReaderTest, largePositionsMultipleContainers) {
   // Positions spanning two containers: one in container 0 (key=0), one in
   // container 1 (key=1, i.e. pos >= 65536).
@@ -706,4 +941,116 @@ TEST_F(DeletionVectorReaderTest, invalidBitmapBadCookie) {
   VELOX_ASSERT_THROW(
       reader.readDeletePositions(0, 10, bitmap),
       "Unknown roaring bitmap cookie");
+}
+
+TEST_F(DeletionVectorReaderTest, legacyBoundsMapLocatesBlob) {
+  // Callers that predate the typed contentOffset/contentLength fields encode
+  // the blob's location in the delete file's bounds maps instead. Prefix the
+  // bitmap with padding so a wrong offset cannot accidentally still parse.
+  const std::vector<int64_t> positions = {2, 9, 70'000};
+  const std::string padding(16, '\xAB');
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(padding + bitmapData);
+
+  auto dvFile = makeLegacyBoundsDvFile(
+      tempFile->getPath(),
+      positions.size(),
+      padding.size() + bitmapData.size(),
+      std::to_string(padding.size()),
+      std::to_string(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, legacyBoundsMapRejectsNonNumericOffset) {
+  auto bitmapData = serializeRoaringBitmapNoRun({1});
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeLegacyBoundsDvFile(
+      tempFile->getPath(),
+      1,
+      bitmapData.size(),
+      "not-a-number",
+      std::to_string(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(), "Failed to parse DV blob offset");
+}
+
+TEST_F(DeletionVectorReaderTest, legacyBoundsMapRejectsNonNumericLength) {
+  auto bitmapData = serializeRoaringBitmapNoRun({1});
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeLegacyBoundsDvFile(
+      tempFile->getPath(), 1, bitmapData.size(), "0", "not-a-number");
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(), "Failed to parse DV blob length");
+}
+
+TEST_F(DeletionVectorReaderTest, emptyBitmapYieldsNoDeletes) {
+  // A container-less bitmap is structurally valid but selects nothing. The
+  // reader must return an empty position list rather than misparse the
+  // header, and a subsequent read must leave the delete bitmap untouched.
+  auto bitmapData = serializeRoaringBitmapNoRun({});
+  auto tempFile = writeDvFile(bitmapData);
+
+  // recordCount must be positive to construct a reader at all, so this also
+  // covers metadata that disagrees with the blob's actual contents.
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(), 1, static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_TRUE(reader.deletedPositions().empty());
+
+  auto bitmap = allocateBitmap(64);
+  reader.readDeletePositions(0, 64, bitmap);
+  EXPECT_TRUE(getSetBits(bitmap, 64).empty());
+}
+
+TEST_F(DeletionVectorReaderTest, emptyGroupInRoaring64IsSkipped) {
+  // A Roaring64 group carrying no containers contributes nothing, but the
+  // reader must still step over its header to reach the following group.
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapNoRun({})},
+       {1, serializeRoaringBitmapNoRun({6, 12})}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  const std::vector<int64_t> expected = {
+      kHighGroupBase + 6, kHighGroupBase + 12};
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
+TEST_F(DeletionVectorReaderTest, skipsPositionsBeforeRequestedRange) {
+  // Reading a batch that starts past earlier deletes must advance the cursor
+  // over them instead of mapping them into the batch-relative bitmap. This is
+  // the path a split beginning at a nonzero row offset takes.
+  const std::vector<int64_t> positions = {1, 50};
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+
+  // Batch covers absolute rows [10, 60): position 1 is behind it, 50 lands at
+  // batch-relative index 40.
+  auto bitmap = allocateBitmap(50);
+  reader.readDeletePositions(10, 50, bitmap);
+
+  EXPECT_EQ(getSetBits(bitmap, 50), (std::vector<uint64_t>{40}));
 }

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -20,6 +20,8 @@
 
 #include <fstream>
 
+#include <folly/json.h>
+#include <folly/lang/Bits.h>
 #include <gtest/gtest.h>
 #include <zlib.h>
 
@@ -422,6 +424,87 @@ std::vector<uint64_t> expandRuns(
 }
 
 // Writes binary data to a temp file and returns the path.
+// Builds a Puffin file around 'blob'. Layout per the Puffin spec:
+//   Magic | blob | Magic | footerPayload | payloadSize(4B LE) | flags(4B LE)
+//   | Magic
+// Built by hand rather than via writePuffinFile so the tests can produce
+// footers a spec-compliant writer never would.
+constexpr std::string_view kPuffinMagic{"PFA1"};
+
+std::string wrapInPuffinFile(
+    const std::string& blob,
+    const folly::dynamic& footer,
+    uint32_t flags = 0) {
+  const auto appendLittleEndian32 = [](std::string& out, uint32_t value) {
+    const uint32_t little = folly::Endian::little(value);
+    out.append(reinterpret_cast<const char*>(&little), sizeof(little));
+  };
+
+  const std::string footerJson = folly::toJson(footer);
+  std::string file;
+  file.append(kPuffinMagic);
+  file.append(blob);
+  file.append(kPuffinMagic);
+  file.append(footerJson);
+  appendLittleEndian32(file, static_cast<uint32_t>(footerJson.size()));
+  appendLittleEndian32(file, flags);
+  file.append(kPuffinMagic);
+  return file;
+}
+
+// Builds a Puffin footer describing one deletion-vector-v1 blob.
+folly::dynamic makeDvBlobMeta(
+    uint64_t blobOffset,
+    uint64_t blobLength,
+    const std::string& referencedDataFile = "") {
+  folly::dynamic blobMeta =
+      folly::dynamic::object("type", "deletion-vector-v1")(
+          "fields", folly::dynamic::array(2'147'483'645));
+  blobMeta["snapshot-id"] = -1;
+  blobMeta["sequence-number"] = -1;
+  blobMeta["offset"] = blobOffset;
+  blobMeta["length"] = blobLength;
+  if (!referencedDataFile.empty()) {
+    blobMeta["properties"] =
+        folly::dynamic::object("referenced-data-file", referencedDataFile);
+  }
+  return blobMeta;
+}
+
+folly::dynamic makeDvFooter(
+    uint64_t blobOffset,
+    uint64_t blobLength,
+    const std::string& referencedDataFile = "") {
+  return folly::dynamic::object(
+      "blobs",
+      folly::dynamic::array(
+          makeDvBlobMeta(blobOffset, blobLength, referencedDataFile)));
+}
+
+// Creates a DV delete file that carries no blob location at all: no typed
+// contentOffset/contentLength and no legacy bounds map. The reader must fall
+// back to the Puffin footer.
+IcebergDeleteFile makeFooterLocatedDvFile(
+    const std::string& filePath,
+    uint64_t recordCount,
+    uint64_t fileSize,
+    const std::string& referencedDataFile = "") {
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      filePath,
+      dwio::common::FileFormat::DWRF,
+      recordCount,
+      fileSize,
+      /*equalityFieldIds=*/{},
+      /*lowerBounds=*/{},
+      /*upperBounds=*/{},
+      /*dataSequenceNumber=*/0,
+      /*contentOffset=*/0,
+      /*contentLength=*/0);
+  dvFile.referencedDataFile = referencedDataFile;
+  return dvFile;
+}
+
 std::shared_ptr<TempFilePath> writeDvFile(const std::string& bitmapData) {
   auto tempFile = TempFilePath::create();
   // Write directly via C++ streams since TempFilePath already creates the
@@ -923,6 +1006,168 @@ TEST_F(DeletionVectorReaderTest, blobOffset) {
   auto setBits = getSetBits(bitmap, 20);
   EXPECT_EQ(setBits, (std::vector<uint64_t>{3, 7, 11}));
   EXPECT_TRUE(reader.noMoreData());
+}
+
+TEST_F(DeletionVectorReaderTest, locatesBlobFromPuffinFooterWhenOffsetsAbsent) {
+  // With no typed contentOffset/contentLength and no legacy bounds map, the
+  // reader used to fall back to treating the whole file -- leading magic and
+  // footer included -- as the blob, which cannot parse. A Puffin file is
+  // self-describing, so its footer is the authoritative fallback.
+  const std::vector<int64_t> positions = {3, 7, 42, 100};
+  const auto blob = serializeRoaringBitmapNoRun(positions);
+  const auto file = wrapInPuffinFile(blob, makeDvFooter(4, blob.size()));
+  auto tempFile = writeDvFile(file);
+
+  auto dvFile = makeFooterLocatedDvFile(
+      tempFile->getPath(), positions.size(), file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, puffinFooterSelectsBlobByReferencedDataFile) {
+  // One Puffin file can hold vectors for several data files. The referenced
+  // data file, not blob order, decides which one applies to this split.
+  const std::vector<int64_t> wantedPositions = {5, 9};
+  const std::vector<int64_t> otherPositions = {1, 2, 3};
+  const auto otherBlob = serializeRoaringBitmapNoRun(otherPositions);
+  const auto wantedBlob = serializeRoaringBitmapNoRun(wantedPositions);
+
+  const uint64_t otherOffset = 4;
+  const uint64_t wantedOffset = otherOffset + otherBlob.size();
+  folly::dynamic footer = folly::dynamic::object(
+      "blobs",
+      folly::dynamic::array(
+          makeDvBlobMeta(otherOffset, otherBlob.size(), "/data/other.parquet"),
+          makeDvBlobMeta(
+              wantedOffset, wantedBlob.size(), "/data/wanted.parquet")));
+
+  const auto file = wrapInPuffinFile(otherBlob + wantedBlob, footer);
+  auto tempFile = writeDvFile(file);
+
+  auto dvFile = makeFooterLocatedDvFile(
+      tempFile->getPath(),
+      wantedPositions.size(),
+      file.size(),
+      "/data/wanted.parquet");
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), wantedPositions);
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsAmbiguousPuffinFileWithoutReference) {
+  // Two candidate vectors and nothing to choose between them: picking either
+  // would silently apply the wrong deletes to the scan.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  folly::dynamic footer = folly::dynamic::object(
+      "blobs",
+      folly::dynamic::array(
+          makeDvBlobMeta(4, blob.size()), makeDvBlobMeta(4, blob.size())));
+
+  const auto file = wrapInPuffinFile(blob, footer);
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin file has multiple deletion vectors and no referenced data file");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterWithNoMatchingBlob) {
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  const auto file = wrapInPuffinFile(
+      blob, makeDvFooter(4, blob.size(), "/data/other.parquet"));
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(
+      tempFile->getPath(), 1, file.size(), "/data/wanted.parquet");
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin footer has no deletion-vector blob for data file");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterWithNoBlobs) {
+  // A structurally valid footer that declares no blobs at all. Iceberg allows
+  // an empty Puffin file; for a delete file it means there is nothing to read,
+  // which must be an error rather than an empty (silently no-op) vector.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  const auto file = wrapInPuffinFile(
+      blob, folly::dynamic::object("blobs", folly::dynamic::array()));
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin footer has no deletion-vector blob for data file");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterWithNegativeOffset) {
+  // JSON integers are signed, but the blob location is carried as uint64_t.
+  // A negative offset must be rejected where it is read, not allowed to wrap
+  // into a huge unsigned value and be reported as an absurd out-of-range read.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  auto footer = makeDvFooter(4, blob.size());
+  footer["blobs"][0]["offset"] = -8;
+  const auto file = wrapInPuffinFile(blob, footer);
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(), "Puffin blob metadata has a negative offset");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFileWithoutTrailingMagic) {
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  auto file = wrapInPuffinFile(blob, makeDvFooter(4, blob.size()));
+  file.replace(file.size() - 4, 4, "XXXX");
+
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin file does not end with the expected magic");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterPayloadSizeBeyondFile) {
+  // A payload size larger than the file would make the payload offset
+  // underflow into a huge unsigned read.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  auto file = wrapInPuffinFile(blob, makeDvFooter(4, blob.size()));
+  const uint32_t absurdSize = folly::Endian::little(uint32_t{1} << 30);
+  file.replace(
+      file.size() - 12,
+      4,
+      std::string(reinterpret_cast<const char*>(&absurdSize), 4));
+
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin footer payload size 1073741824 does not fit");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsCompressedPuffinFooter) {
+  // Bit 0 of the flags marks a compressed footer payload. Deletion vectors are
+  // always uncompressed, so reject rather than hand zstd bytes to the parser.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  const auto file =
+      wrapInPuffinFile(blob, makeDvFooter(4, blob.size()), /*flags=*/1);
+
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Compressed Puffin footer payloads are not supported");
 }
 
 TEST_F(DeletionVectorReaderTest, constructorRejectsWrongContentType) {

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -169,6 +169,128 @@ std::string wrapInRoaring64(
   return data;
 }
 
+// Serializes a roaring bitmap whose containers may each use a different
+// encoding, which none of the helpers above can express: the no-run helpers
+// pick array vs bitset purely by cardinality, and the run helper makes every
+// container run-encoded.
+//
+// Iceberg's own test suite carries an "all container types" case; this builds
+// an equivalent bitmap from scratch so the reader is exercised against array,
+// run, and bitset containers coexisting in one blob.
+struct ContainerSpec {
+  enum class Encoding { kArray, kRun, kBitset };
+
+  uint16_t key{0};
+  Encoding encoding{Encoding::kArray};
+  // Values within the container's 64K block, sorted. For kRun these are still
+  // the expanded values; the runs are derived from them.
+  std::vector<uint16_t> values;
+};
+
+// Collapses sorted values into (start, lengthMinus1) runs.
+std::vector<std::pair<uint16_t, uint16_t>> toRuns(
+    const std::vector<uint16_t>& values) {
+  std::vector<std::pair<uint16_t, uint16_t>> runs;
+  for (size_t i = 0; i < values.size();) {
+    size_t j = i;
+    while (j + 1 < values.size() && values[j + 1] == values[j] + 1) {
+      ++j;
+    }
+    runs.emplace_back(values[i], static_cast<uint16_t>(j - i));
+    i = j + 1;
+  }
+  return runs;
+}
+
+std::string serializeRoaringBitmapMixed(
+    const std::vector<ContainerSpec>& containers) {
+  constexpr uint32_t kSerialCookieWithRuns = 12'347;
+  constexpr uint32_t kRunContainersNoOffsetThreshold = 4;
+  constexpr size_t kBitmapContainerBytes = 8'192;
+
+  const auto numContainers = static_cast<uint32_t>(containers.size());
+  // This helper always emits the run-bearing cookie and a run bitmap, even
+  // when no container is actually run-encoded, so readers always take the
+  // "runs present" branch. The offset section must follow the same rule or the
+  // two sides disagree on the header size.
+  const bool hasRunContainers = true;
+
+  std::string data;
+  const uint32_t cookie = kSerialCookieWithRuns | ((numContainers - 1) << 16);
+  data.append(reinterpret_cast<const char*>(&cookie), 4);
+
+  // Run bitmap: bit i marks container i as run-encoded, LSB-first.
+  const uint32_t runBitmapBytes = (numContainers + 7) / 8;
+  std::vector<uint8_t> runBitmap(runBitmapBytes, 0);
+  for (uint32_t i = 0; i < numContainers; ++i) {
+    if (containers[i].encoding == ContainerSpec::Encoding::kRun) {
+      runBitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+    }
+  }
+  data.append(reinterpret_cast<const char*>(runBitmap.data()), runBitmapBytes);
+
+  for (const auto& spec : containers) {
+    const auto cardMinus1 = static_cast<uint16_t>(spec.values.size() - 1);
+    data.append(reinterpret_cast<const char*>(&spec.key), 2);
+    data.append(reinterpret_cast<const char*>(&cardMinus1), 2);
+  }
+
+  const auto containerBytes = [&](const ContainerSpec& spec) -> uint32_t {
+    switch (spec.encoding) {
+      case ContainerSpec::Encoding::kArray:
+        return static_cast<uint32_t>(spec.values.size()) * 2;
+      case ContainerSpec::Encoding::kBitset:
+        return kBitmapContainerBytes;
+      case ContainerSpec::Encoding::kRun:
+        return 2 + 4 * static_cast<uint32_t>(toRuns(spec.values).size());
+    }
+    return 0;
+  };
+
+  // The offset section is omitted for run-bearing bitmaps below the threshold.
+  const bool hasOffsetSection =
+      !hasRunContainers || numContainers >= kRunContainersNoOffsetThreshold;
+  if (hasOffsetSection) {
+    uint32_t offset =
+        4 + runBitmapBytes + 4 * numContainers + 4 * numContainers;
+    for (const auto& spec : containers) {
+      data.append(reinterpret_cast<const char*>(&offset), 4);
+      offset += containerBytes(spec);
+    }
+  }
+
+  for (const auto& spec : containers) {
+    switch (spec.encoding) {
+      case ContainerSpec::Encoding::kArray:
+        for (auto value : spec.values) {
+          data.append(reinterpret_cast<const char*>(&value), 2);
+        }
+        break;
+      case ContainerSpec::Encoding::kRun: {
+        const auto runs = toRuns(spec.values);
+        const auto numRuns = static_cast<uint16_t>(runs.size());
+        data.append(reinterpret_cast<const char*>(&numRuns), 2);
+        for (auto [start, lengthMinus1] : runs) {
+          data.append(reinterpret_cast<const char*>(&start), 2);
+          data.append(reinterpret_cast<const char*>(&lengthMinus1), 2);
+        }
+        break;
+      }
+      case ContainerSpec::Encoding::kBitset: {
+        std::vector<uint64_t> words(1'024, 0);
+        for (auto value : spec.values) {
+          words[value / 64] |= (1ULL << (value % 64));
+        }
+        for (auto word : words) {
+          data.append(reinterpret_cast<const char*>(&word), 8);
+        }
+        break;
+      }
+    }
+  }
+  return data;
+}
+
 // Concatenates the deletion-vector-v1 magic bytes with a serialized roaring
 // bitmap. The frame's length prefix and CRC-32 both cover these bytes.
 std::string magicAndVectorBytes(const std::string& bitmap) {
@@ -1053,4 +1175,159 @@ TEST_F(DeletionVectorReaderTest, skipsPositionsBeforeRequestedRange) {
   reader.readDeletePositions(10, 50, bitmap);
 
   EXPECT_EQ(getSetBits(bitmap, 50), (std::vector<uint64_t>{40}));
+}
+
+// The roaring serialization format is defined as little-endian. Readers that
+// take a caller-configured buffer have to assert its byte order explicitly,
+// because a big-endian-configured buffer would silently decode garbage.
+//
+// There is no equivalent footgun here — the reader takes raw bytes and
+// applies an explicit folly::Endian::little conversion to every field, so the
+// interpretation is fixed regardless of caller or host. What is worth pinning
+// is the observable behavior that check exists to produce: bytes serialized
+// big-endian must be rejected, not silently misread.
+//
+// They are, though via a different guard than one might expect. The
+// byte-swapped cookie (0x3A300000) matches neither serial cookie, so the blob
+// is treated as the 64-bit format; the byte-swapped group count is then
+// absurd and trips the Roaring64 sanity limit. The assertion below pins that
+// whole chain, so a future change that loosens either the cookie check or the
+// group limit cannot start silently accepting byte-swapped input.
+TEST_F(DeletionVectorReaderTest, rejectsBigEndianSerializedBitmap) {
+  auto appendBigEndian32 = [](std::string& out, uint32_t value) {
+    const char bytes[4] = {
+        static_cast<char>((value >> 24) & 0xFF),
+        static_cast<char>((value >> 16) & 0xFF),
+        static_cast<char>((value >> 8) & 0xFF),
+        static_cast<char>(value & 0xFF)};
+    out.append(bytes, sizeof(bytes));
+  };
+
+  // The same empty 32-bit bitmap serializeRoaringBitmapNoRun({}) produces,
+  // but with both header words written big-endian.
+  std::string bigEndianBitmap;
+  appendBigEndian32(bigEndianBitmap, 12'346);
+  appendBigEndian32(bigEndianBitmap, 0);
+
+  auto tempFile = writeDvFile(bigEndianBitmap);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(), 1, static_cast<uint64_t>(bigEndianBitmap.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Roaring64Bitmap group count exceeds sanity limit");
+}
+
+TEST_F(DeletionVectorReaderTest, enforcesRoaring64GroupKeyBound) {
+  // Iceberg caps the Roaring64 group key at 2147483646 because readers load it
+  // back as a signed 32-bit int. A key at or above 2^31 would shift into the
+  // sign bit of `key << 32` and surface as a negative row position.
+  // DeletionVectorWriter already refuses to produce such a blob; the reader
+  // must reject one written by anything else rather than emit garbage.
+  const auto readPositions = [&](uint32_t groupKey) {
+    auto bitmapData =
+        wrapInRoaring64({{groupKey, serializeRoaringBitmapNoRun({5})}});
+    auto tempFile = writeDvFile(bitmapData);
+    auto dvFile = makeDvDeleteFile(
+        tempFile->getPath(), 1, static_cast<uint64_t>(bitmapData.size()));
+    DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+    return reader.deletedPositions();
+  };
+
+  constexpr uint32_t kMaxGroupKey = 2'147'483'646;
+  EXPECT_EQ(
+      readPositions(kMaxGroupKey),
+      (std::vector<int64_t>{(int64_t{kMaxGroupKey} << 32) + 5}));
+
+  VELOX_ASSERT_THROW(
+      readPositions(kMaxGroupKey + 1),
+      "Roaring64Bitmap group key exceeds the maximum the Iceberg "
+      "deletion-vector format can represent");
+}
+
+// The scenarios below mirror the shapes Iceberg's own position-index tests
+// cover. The bitmaps are built here rather than taken from anywhere, so they
+// exercise the same encodings without depending on external fixtures.
+
+TEST_F(DeletionVectorReaderTest, smallAlternatingValues) {
+  // Sparse odd positions in a single array container — the simplest shape a
+  // real deletion vector takes.
+  const std::vector<int64_t> positions = {1, 3, 5, 7, 9};
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, smallAndLargeValuesPast31Bits) {
+  // Two array containers far apart, the second past 2^31. The container key
+  // there is 32767, so a reader that sign-extends the 16-bit key or the
+  // resulting offset lands on a negative position.
+  const std::vector<int64_t> positions = {
+      100, 101, 2'147'483'747, 2'147'483'748};
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, allContainerEncodingsInOneBitmap) {
+  // Array, run, and bitset containers coexisting in a single bitmap, wrapped
+  // in a second Roaring64 group. Each encoding advances the read cursor by a
+  // different rule, so the reader has to switch strategies three times and
+  // still land on the next group's header.
+  //
+  // Three containers with runs present also puts this below the threshold at
+  // which the offset section is written, exercising the no-offset path.
+  std::vector<uint16_t> denseValues;
+  denseValues.reserve(5'000);
+  for (uint16_t i = 0; i < 5'000; ++i) {
+    denseValues.push_back(static_cast<uint16_t>(i * 2));
+  }
+
+  const std::vector<ContainerSpec> lowGroup = {
+      {/*key=*/0, ContainerSpec::Encoding::kArray, {5, 7}},
+      {/*key=*/1, ContainerSpec::Encoding::kRun, {1, 2, 3, 4}},
+      {/*key=*/2, ContainerSpec::Encoding::kBitset, denseValues},
+  };
+  const std::vector<ContainerSpec> highGroup = {
+      {/*key=*/0, ContainerSpec::Encoding::kArray, {9}},
+  };
+
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapMixed(lowGroup)},
+       {1, serializeRoaringBitmapMixed(highGroup)}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  std::vector<int64_t> expected = {5, 7};
+  for (int64_t i = 1; i <= 4; ++i) {
+    expected.push_back(65'536 + i);
+  }
+  for (auto value : denseValues) {
+    expected.push_back(131'072 + value);
+  }
+  expected.push_back(kHighGroupBase + 9);
+  std::sort(expected.begin(), expected.end());
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
 }

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -401,3 +401,16 @@ TEST_F(DeletionVectorWriterTest, mixed32And64BitPositions) {
   };
   verifyRoundTrip(positions, 2'048);
 }
+
+/// Verifies that duplicate positions collapse in the cardinality reported for
+/// the DV blob. Seeding a writer from an existing deletion vector and then
+/// adding overlapping new deletes makes 'positions_' hold duplicates, so
+/// 'numPositions' overcounts and only 'numDistinctPositions' matches the
+/// cardinality Iceberg expects in the blob metadata.
+TEST_F(DeletionVectorWriterTest, numDistinctPositionsIgnoresDuplicates) {
+  DeletionVectorWriter writer;
+  writer.addDeletedPositions({7, 3, 7, 1, 3, 3});
+
+  EXPECT_EQ(writer.numPositions(), 6);
+  EXPECT_EQ(writer.numDistinctPositions(), 3);
+}

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -18,6 +18,8 @@
 
 #include <fstream>
 
+#include <folly/json.h>
+#include <folly/lang/Bits.h>
 #include <gtest/gtest.h>
 #include <zlib.h>
 
@@ -301,6 +303,105 @@ TEST_F(DeletionVectorWriterTest, fourOrMoreContainersWithOffsets) {
     positions.push_back(static_cast<int64_t>(i) * 65536 + 42);
   }
   verifyRoundTrip(positions, 5 * 65536 + 100);
+}
+
+// Decodes the Puffin footer of a file written by writePuffinFile and returns
+// the parsed footer JSON. Layout per the Puffin spec:
+//   Magic Blob... Footer
+//   Footer := Magic FooterPayload FooterPayloadSize Flags Magic
+// with FooterPayloadSize and Flags each a 4-byte little-endian value. The
+// trailer is located from the end of the file so nothing here depends on the
+// writer's own offset arithmetic.
+namespace {
+folly::dynamic readPuffinFooter(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  const std::string bytes(
+      (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+  constexpr size_t kMagicSize = 4;
+  constexpr size_t kTrailerSize = kMagicSize + 4 + 4;
+  EXPECT_GE(bytes.size(), kMagicSize + kTrailerSize);
+  EXPECT_EQ(bytes.substr(0, kMagicSize), "PFA1") << "missing leading magic";
+  EXPECT_EQ(bytes.substr(bytes.size() - kMagicSize), "PFA1")
+      << "missing trailing magic";
+
+  const auto readLittleEndian32 = [&](size_t offset) {
+    uint32_t value;
+    std::memcpy(&value, bytes.data() + offset, sizeof(value));
+    return folly::Endian::little(value);
+  };
+
+  const size_t flagsOffset = bytes.size() - kMagicSize - 4;
+  const size_t sizeOffset = flagsOffset - 4;
+  EXPECT_EQ(readLittleEndian32(flagsOffset), 0u)
+      << "flags must be 0: an uncompressed footer payload is bit 0";
+
+  const uint32_t payloadSize = readLittleEndian32(sizeOffset);
+  const size_t payloadOffset = sizeOffset - payloadSize;
+  EXPECT_EQ(bytes.substr(payloadOffset - kMagicSize, kMagicSize), "PFA1")
+      << "footer payload must be preceded by magic";
+
+  return folly::parseJson(bytes.substr(payloadOffset, payloadSize));
+}
+} // namespace
+
+TEST_F(DeletionVectorWriterTest, puffinFooterIsSpecCompliant) {
+  // Nothing in our own read path parses the Puffin footer --
+  // DeletionVectorReader locates the blob from the manifest's contentOffset --
+  // so the footer is written blind. Other Iceberg engines do parse it, and
+  // FileMetadataParser.blobMetadataFromJson treats type, fields, snapshot-id,
+  // sequence-number, offset and length as required, reading fields as a list
+  // of integers. A footer that omits or mistypes any of them makes the whole
+  // deletion vector unreadable outside Velox.
+  DeletionVectorWriter writer;
+  writer.addDeletedPositions({3, 7, 42, 100});
+  const auto blobData = writer.serialize();
+
+  auto tempDir = TempDirectoryPath::create();
+  const std::string puffinPath =
+      std::string(tempDir->getPath()) + "/footer.puffin";
+  auto sink = dwio::common::FileSink::create(
+      "file:" + puffinPath, {.pool = pool_.get()});
+  auto [blobOffset, blobLength] = writePuffinFile(
+      *sink,
+      *pool_,
+      blobData,
+      "/data/test-data-file.parquet",
+      /*cardinality=*/4);
+  sink->close();
+
+  const auto footer = readPuffinFooter(puffinPath);
+  ASSERT_TRUE(footer.isObject());
+  ASSERT_TRUE(footer["blobs"].isArray());
+  ASSERT_EQ(footer["blobs"].size(), 1);
+  const auto& blob = footer["blobs"][0];
+
+  EXPECT_EQ(blob["type"].asString(), "deletion-vector-v1");
+
+  // Iceberg's BaseDVFileWriter sets this to the single row-position metadata
+  // column ID, as a list of plain integers.
+  constexpr int64_t kRowPositionFieldId = 2'147'483'645;
+  ASSERT_TRUE(blob["fields"].isArray()) << "fields must be a list";
+  ASSERT_EQ(blob["fields"].size(), 1);
+  ASSERT_TRUE(blob["fields"][0].isInt())
+      << "fields entries must be integers, not objects";
+  EXPECT_EQ(blob["fields"][0].asInt(), kRowPositionFieldId);
+
+  // Required by the parser even though a freshly written DV has no snapshot
+  // assigned yet; Iceberg writes -1 for both.
+  ASSERT_TRUE(blob.count("snapshot-id")) << "snapshot-id is required";
+  ASSERT_TRUE(blob.count("sequence-number")) << "sequence-number is required";
+  EXPECT_EQ(blob["snapshot-id"].asInt(), -1);
+  EXPECT_EQ(blob["sequence-number"].asInt(), -1);
+
+  EXPECT_EQ(blob["offset"].asInt(), static_cast<int64_t>(blobOffset));
+  EXPECT_EQ(blob["length"].asInt(), static_cast<int64_t>(blobLength));
+
+  const auto& properties = blob["properties"];
+  EXPECT_EQ(
+      properties["referenced-data-file"].asString(),
+      "/data/test-data-file.parquet");
+  EXPECT_EQ(properties["cardinality"].asString(), "4");
 }
 
 TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -22,6 +22,8 @@
 #include <zlib.h>
 
 #include <cstring>
+#include <limits>
+#include <random>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -71,6 +73,50 @@ class DeletionVectorWriterTest : public ::testing::Test {
   BufferPtr allocateBitmap(uint64_t numBits) {
     auto numBytes = bits::nbytes(numBits);
     return AlignedBuffer::allocate<uint8_t>(numBytes, pool_.get(), 0);
+  }
+
+  /// Serializes 'positions', reads the blob back through
+  /// DeletionVectorReader, and returns every position the reader recovered.
+  ///
+  /// Prefer this over verifyRoundTrip for inputs spanning a wide range:
+  /// verifyRoundTrip walks the whole [0, maxPos] space one batch at a time,
+  /// which is impractical once positions reach into the 2^32 range.
+  std::vector<int64_t> roundTrip(const std::vector<int64_t>& positions) {
+    DeletionVectorWriter writer;
+    writer.addDeletedPositions(positions);
+    const auto blobData = writer.serialize();
+
+    auto tempFile = TempFilePath::create();
+    {
+      std::ofstream out(
+          tempFile->getPath(), std::ios::binary | std::ios::trunc);
+      out.write(blobData.data(), static_cast<std::streamsize>(blobData.size()));
+    }
+
+    IcebergDeleteFile dvFile(
+        FileContent::kDeletionVector,
+        tempFile->getPath(),
+        dwio::common::FileFormat::DWRF,
+        writer.numDistinctPositions(),
+        static_cast<uint64_t>(blobData.size()),
+        /*equalityFieldIds=*/{},
+        /*lowerBounds=*/{},
+        /*upperBounds=*/{},
+        /*dataSequenceNumber=*/0,
+        /*contentOffset=*/0,
+        /*contentLength=*/static_cast<int64_t>(blobData.size()));
+
+    DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+    return reader.deletedPositions();
+  }
+
+  /// Returns 'positions' sorted and de-duplicated — what a round trip through
+  /// a roaring bitmap is expected to yield, since the bitmap is a set.
+  static std::vector<int64_t> sortedUnique(std::vector<int64_t> positions) {
+    std::sort(positions.begin(), positions.end());
+    positions.erase(
+        std::unique(positions.begin(), positions.end()), positions.end());
+    return positions;
   }
 
   /// Writes serialized bitmap to a temp file, reads it back with
@@ -413,4 +459,111 @@ TEST_F(DeletionVectorWriterTest, numDistinctPositionsIgnoresDuplicates) {
 
   EXPECT_EQ(writer.numPositions(), 6);
   EXPECT_EQ(writer.numDistinctPositions(), 3);
+}
+
+// Randomized round trips across sparse, dense, and mixed position sets.
+// Hand-built fixtures only exercise the container shapes we thought to write
+// down; random inputs cross the array/bitset thresholds and 64-bit group
+// boundaries in combinations we did not enumerate.
+//
+// Seeds are fixed so a failure is reproducible, and reported on failure so a
+// counterexample can be replayed directly.
+TEST_F(DeletionVectorWriterTest, randomSparsePositionsRoundTrip) {
+  // Few positions spread over a wide 64-bit range: many container keys across
+  // several Roaring64 groups, each holding a small array container.
+  constexpr uint64_t kSeed = 0x1234'5678'9ABC'DEF0ULL;
+  constexpr int kNumPositions = 2'000;
+  constexpr int64_t kRange = int64_t{1} << 34;
+
+  std::mt19937_64 rng(kSeed);
+  std::uniform_int_distribution<int64_t> positionDist(0, kRange - 1);
+
+  std::vector<int64_t> positions;
+  positions.reserve(kNumPositions);
+  for (int i = 0; i < kNumPositions; ++i) {
+    positions.push_back(positionDist(rng));
+  }
+
+  EXPECT_EQ(roundTrip(positions), sortedUnique(positions)) << "seed=" << kSeed;
+}
+
+TEST_F(DeletionVectorWriterTest, randomDensePositionsRoundTrip) {
+  // Enough positions inside one 64K block to exceed the 4096 array-container
+  // threshold, so the block serializes as a bitset. Deliberately includes
+  // duplicates: the bitmap is a set, so they must collapse.
+  constexpr uint64_t kSeed = 0x0FED'CBA9'8765'4321ULL;
+  constexpr int kNumDraws = 30'000;
+  constexpr int64_t kBlockBase = int64_t{7} << 16;
+
+  std::mt19937_64 rng(kSeed);
+  std::uniform_int_distribution<int64_t> offsetDist(0, 65'535);
+
+  std::vector<int64_t> positions;
+  positions.reserve(kNumDraws);
+  for (int i = 0; i < kNumDraws; ++i) {
+    positions.push_back(kBlockBase + offsetDist(rng));
+  }
+
+  const auto expected = sortedUnique(positions);
+  ASSERT_GT(expected.size(), 4'096)
+      << "draws should exceed the array-container threshold";
+  EXPECT_EQ(roundTrip(positions), expected) << "seed=" << kSeed;
+}
+
+TEST_F(DeletionVectorWriterTest, randomMixedPositionsRoundTrip) {
+  // Dense block, sparse scatter, and a contiguous run in one bitmap, split
+  // across two Roaring64 groups. This is the shape most likely to expose an
+  // offset or stride error, because the reader must step over containers of
+  // different encodings to find the next one.
+  constexpr uint64_t kSeed = 0x2468'ACE0'1357'9BDFULL;
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+
+  std::mt19937_64 rng(kSeed);
+  std::vector<int64_t> positions;
+
+  // Dense block in group 0.
+  std::uniform_int_distribution<int64_t> denseDist(0, 65'535);
+  for (int i = 0; i < 20'000; ++i) {
+    positions.push_back(denseDist(rng));
+  }
+  // Sparse scatter across group 0's upper blocks.
+  std::uniform_int_distribution<int64_t> sparseDist(65'536, (int64_t{1} << 31));
+  for (int i = 0; i < 500; ++i) {
+    positions.push_back(sparseDist(rng));
+  }
+  // Contiguous run in group 1.
+  for (int64_t i = 0; i < 3'000; ++i) {
+    positions.push_back(kHighGroupBase + 1'000 + i);
+  }
+  // Sparse scatter in group 1.
+  for (int i = 0; i < 200; ++i) {
+    positions.push_back(kHighGroupBase + sparseDist(rng));
+  }
+
+  EXPECT_EQ(roundTrip(positions), sortedUnique(positions)) << "seed=" << kSeed;
+}
+
+// The Roaring64 group key is read back as a signed 32-bit int, so a position
+// whose high word reaches 2^31 would deserialize as a negative key and be
+// rejected by spec-compliant readers. Failing at insert time keeps us from
+// writing a blob Iceberg cannot read.
+TEST_F(DeletionVectorWriterTest, rejectsPositionsOutsideRepresentableRange) {
+  DeletionVectorWriter writer;
+
+  VELOX_ASSERT_THROW(writer.addDeletedPosition(-1), "must be non-negative");
+  VELOX_ASSERT_THROW(
+      writer.addDeletedPosition(DeletionVectorWriter::kMaxPosition + 1),
+      "exceeds the maximum");
+  VELOX_ASSERT_THROW(
+      writer.addDeletedPosition(std::numeric_limits<int64_t>::max()),
+      "exceeds the maximum");
+
+  // None of the rejected positions were recorded.
+  EXPECT_EQ(writer.numPositions(), 0);
+
+  // The bound itself is representable and round-trips.
+  writer.addDeletedPosition(DeletionVectorWriter::kMaxPosition);
+  EXPECT_EQ(
+      roundTrip({DeletionVectorWriter::kMaxPosition}),
+      std::vector<int64_t>{DeletionVectorWriter::kMaxPosition});
 }

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -126,12 +126,20 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
   /// Creates splits with equality delete files and partition keys attached.
   /// Use this overload to exercise the equality-delete augmentation for
   /// partition columns missing from the user's projection.
+  ///
+  /// 'partitionKeys' is the raw name-keyed map that carries every partition
+  /// field under its derived 'PartitionField.name()'.
+  /// 'identityPartitionKeys' is the field-ID-keyed map that carries only
+  /// fields the partition spec explicitly marks as the identity transform;
+  /// only these may be substituted for a read of the source column.
   std::vector<std::shared_ptr<ConnectorSplit>> makeSplits(
       const std::string& dataFilePath,
       const std::unordered_map<std::string, std::optional<std::string>>&
           partitionKeys,
       const std::vector<IcebergDeleteFile>& deleteFiles,
-      int64_t dataSequenceNumber = 0) {
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<int32_t, std::optional<std::string>>&
+          identityPartitionKeys = {}) {
     auto fileSize = getFileSize(dataFilePath);
     return {std::make_shared<HiveIcebergSplit>(
         kIcebergConnectorId,
@@ -147,7 +155,8 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
         deleteFiles,
         std::unordered_map<std::string, std::string>{},
         std::nullopt,
-        dataSequenceNumber)};
+        dataSequenceNumber,
+        identityPartitionKeys)};
   }
 
   /// Builds a table scan plan node with the given schema.
@@ -463,7 +472,10 @@ TEST_F(
   auto splits = makeSplits(
       dataFile->getPath(),
       /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      // Source field ID 1 ('part') is an explicit identity partition field.
+      /*identityPartitionKeys=*/{{1, std::optional<std::string>{"2"}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -513,7 +525,9 @@ TEST_F(
   auto splits = makeSplits(
       dataFile->getPath(),
       /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      /*identityPartitionKeys=*/{{1, std::optional<std::string>{"2"}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -567,7 +581,9 @@ TEST_F(
   auto splits = makeSplits(
       dataFile->getPath(),
       /*partitionKeys=*/{{"part", std::optional<std::string>{"7"}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      /*identityPartitionKeys=*/{{1, std::optional<std::string>{"7"}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -625,7 +641,10 @@ TEST_F(
       /*partitionKeys=*/
       {{"part_date",
         std::optional<std::string>{std::to_string(kPartitionDays)}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      /*identityPartitionKeys=*/
+      {{1, std::optional<std::string>{std::to_string(kPartitionDays)}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -633,6 +652,122 @@ TEST_F(
       {"value"},
       {
           makeFlatVector<std::string>({"a", "c"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Regression for transformed partition fields whose derived partition-field
+/// name collides with a real source column name.
+///
+/// A partition field may be named anything, so a 'bucket[4]' field on source
+/// column 'id' can itself be named "id". The split's name-keyed
+/// 'partitionKeys' then maps "id" to the *bucket ordinal*, not to any row's
+/// 'id'. Substituting that value for the source column would corrupt the
+/// equality-delete probe. Only a field the spec marks 'identity' may be
+/// substituted, and no identity metadata is supplied here, so the reader must
+/// read the physical 'id' column from the data file.
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    equalityBucketPartitionNameCollisionNotInProjection) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<std::string>({"a", "b", "c", "d"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Equality delete removes the row whose physical id is 20.
+  auto deleteData = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({20}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      // The bucket ordinal, stored under a name that collides with the
+      // source column.
+      /*partitionKeys=*/{{"id", std::optional<std::string>{"2"}}},
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      // 'bucket[4]' is not identity, so nothing is substitutable.
+      /*identityPartitionKeys=*/{});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // Only the physically matching row is deleted. Substituting the bucket
+  // ordinal would make every row's id 2 and delete nothing.
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "c", "d"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Regression for the 'void' transform, which always stores a null partition
+/// value and — unlike bucket/truncate/temporal — keeps the source column's
+/// name by default. A name-keyed lookup therefore finds an entry for "id"
+/// and would install a constant null over every row, making the null
+/// equality-delete key match everything. With identity metadata absent, the
+/// physical non-null 'id' values must survive instead.
+TEST_F(EqualityDeleteFileReaderTest, equalityVoidPartitionNotInProjection) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // The delete key is null, matching the null the void transform stores.
+  auto deleteData = makeRowVector(
+      {"id"},
+      {
+          makeNullableFlatVector<int64_t>({std::nullopt}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/{{"id", std::nullopt}},
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      // 'void' is not identity, so its null is not substitutable.
+      /*identityPartitionKeys=*/{});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "b", "c"}),
       });
 
   assertEqualResults({expected}, {result});

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -19,9 +19,12 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/dwio/common/Writer.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -66,9 +69,37 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
 
   /// Writes a DWRF data file containing the given vectors.
   std::shared_ptr<common::testutil::TempFilePath> writeDataFile(
-      const std::vector<RowVectorPtr>& data) {
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<int32_t>& fieldIds = {}) {
     auto file = common::testutil::TempFilePath::create();
-    writeToFile(file->getPath(), data);
+    if (fieldIds.empty()) {
+      writeToFile(file->getPath(), data);
+      return file;
+    }
+
+    VELOX_CHECK_EQ(data.front()->type()->size(), fieldIds.size());
+    dwio::common::WriterOptions options;
+    auto dwrfOptions = std::make_shared<dwrf::DwrfWriterOptions>();
+    for (uint32_t i = 0; i < fieldIds.size(); ++i) {
+      dwrfOptions->schemaAttributes[i + 1] = {
+          {"iceberg.id", std::to_string(fieldIds[i])}};
+    }
+    options.formatSpecificOptions = std::move(dwrfOptions);
+    options.schema = data.front()->type();
+    options.memoryPool = rootPool_.get();
+
+    auto fs = filesystems::getFileSystem(file->getPath(), {});
+    auto writeFile = fs->openFileForWrite(
+        file->getPath(),
+        {.shouldCreateParentDirectories = true,
+         .shouldThrowOnFileAlreadyExists = false});
+    auto sink = std::make_unique<dwio::common::WriteFileSink>(
+        std::move(writeFile), file->getPath());
+    dwrf::Writer writer{std::move(sink), options};
+    for (const auto& vector : data) {
+      writer.write(vector);
+    }
+    writer.close();
     return file;
   }
 
@@ -136,6 +167,51 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
         .startTableScan(kIcebergConnectorId)
         .outputType(outputType)
         .dataColumns(dataColumns)
+        .endTableScan()
+        .planNode();
+  }
+
+  /// Builds a table scan whose full table schema uses explicit Iceberg field
+  /// IDs. Only projected columns receive column handles, matching production
+  /// plans where equality-delete columns may be otherwise unreferenced.
+  core::PlanNodePtr makeTableScanPlan(
+      const RowTypePtr& outputType,
+      const RowTypePtr& dataColumns,
+      const std::vector<int32_t>& dataColumnFieldIds) {
+    VELOX_CHECK_EQ(dataColumns->size(), dataColumnFieldIds.size());
+
+    ColumnHandleMap assignments;
+    for (auto i = 0; i < outputType->size(); ++i) {
+      const auto& name = outputType->nameOf(i);
+      const auto dataColumnIndex = dataColumns->getChildIdx(name);
+      assignments.emplace(
+          name,
+          std::make_shared<IcebergColumnHandle>(
+              name,
+              FileColumnHandle::ColumnType::kRegular,
+              outputType->childAt(i),
+              parquet::ParquetFieldId{
+                  dataColumnFieldIds[dataColumnIndex], {}}));
+    }
+
+    auto tableHandle = std::make_shared<HiveTableHandle>(
+        kIcebergConnectorId,
+        "iceberg_table",
+        common::SubfieldFilters{},
+        /*remainingFilter=*/nullptr,
+        dataColumns,
+        /*indexColumns=*/std::vector<std::string>{},
+        /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+        /*filterColumnHandles=*/std::vector<HiveColumnHandlePtr>{},
+        /*sampleRate=*/1.0,
+        /*dbName=*/"",
+        dataColumnFieldIds);
+
+    return PlanBuilder()
+        .startTableScan(kIcebergConnectorId)
+        .outputType(outputType)
+        .assignments(assignments)
+        .tableHandle(std::move(tableHandle))
         .endTableScan()
         .planNode();
   }
@@ -865,7 +941,94 @@ TEST_F(EqualityDeleteFileReaderTest, stringColumnDelete) {
   assertEqualResults({expected}, {result});
 }
 
-/// Verifies equality deletes on a non-first column (field ID 2).
+/// Verifies equality deletes after a field has been dropped, leaving sparse
+/// top-level field IDs.
+TEST_F(EqualityDeleteFileReaderTest, nonSequentialEqualityFieldId) {
+  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
+  const std::vector<int32_t> fieldIds{1, 3};
+
+  auto baseData = makeRowVector(
+      {"id", "dropped", "category"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
+          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
+      });
+  auto dataFile = writeDataFile({baseData}, {1, 2, 3});
+
+  auto deleteData = makeRowVector(
+      {"category"},
+      {
+          makeFlatVector<std::string>({"B"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{3});
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeTableScanPlan(tableType, tableType, fieldIds);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "category"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4}),
+          makeFlatVector<std::string>({"A", "A", "C"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    nonSequentialEqualityFieldIdNotInProjection) {
+  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"id"}, {BIGINT()});
+  const std::vector<int32_t> fieldIds{1, 3};
+
+  auto baseData = makeRowVector(
+      {"id", "dropped", "category"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
+          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
+      });
+  auto dataFile = writeDataFile({baseData}, {1, 2, 3});
+
+  auto deleteData = makeRowVector(
+      {"category"},
+      {
+          makeFlatVector<std::string>({"B"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{3});
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType, fieldIds);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies the ordinal fallback on a non-first column when full-schema field
+/// IDs are unavailable.
 TEST_F(EqualityDeleteFileReaderTest, deleteOnSecondColumn) {
   auto rowType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
 

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorReadTest.cpp
@@ -21,7 +21,12 @@
 
 #include <folly/Singleton.h>
 
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/dwrf/reader/ReaderBase.h"
+#include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
@@ -114,6 +119,124 @@ TEST_F(IcebergDeletionVectorReadTest, deletionVectorFiltersDeletedRowsInScan) {
   auto expected =
       makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7})});
   exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(expected);
+}
+
+// A deletion vector removes rows from the scan output, so an output row's
+// index no longer matches its position in the data file. _row_id must still
+// report file-absolute positions.
+//
+// The row-number column that carries those positions used to be injected only
+// for V2 positional delete files, so a split whose only delete file was a V3
+// deletion vector fell back to deriving positions from the output index. A
+// DELETE with no WHERE clause hit this: with no filter to force the row-number
+// column on, the rewritten deletion vector recorded 0..N-1 instead of the true
+// positions and left the trailing rows of the file undeleted.
+TEST_F(IcebergDeletionVectorReadTest, rowIdIsFileAbsoluteWithDeletionVector) {
+  auto dataFile = TempFilePath::create();
+  writeToFile(
+      dataFile->getPath(),
+      {makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40, 50})})});
+
+  auto [puffinDir, dvFile] = writeDeletionVector(dataFile->getPath(), {1, 3});
+
+  const std::unordered_map<std::string, std::string> infoColumns{
+      {IcebergMetadataColumn::kFirstRowIdInfoColumn, "200"},
+      {IcebergMetadataColumn::kDataSequenceNumberInfoColumn, "42"}};
+
+  const std::vector<std::string> outputNames{
+      "c0", "_row_id", "_last_updated_sequence_number"};
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(
+                      ROW({outputNames[0], outputNames[1], outputNames[2]},
+                          {BIGINT(), BIGINT(), BIGINT()}))
+                  .dataColumns(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+
+  // Positions 1 and 3 are deleted, so the surviving rows keep file positions
+  // 0, 2 and 4 and _row_id is firstRowId plus those positions.
+  auto expected = makeRowVector(
+      outputNames,
+      {
+          makeFlatVector<int64_t>({10, 30, 50}),
+          makeFlatVector<int64_t>({200, 202, 204}),
+          makeFlatVector<int64_t>({42, 42, 42}),
+      });
+  exec::test::AssertQueryBuilder(plan)
+      .splits({makeIcebergSplitWithInfoColumns(
+          dataFile->getPath(), infoColumns, {dvFile})})
+      .assertResults(expected);
+}
+
+// Deletion-vector positions are absolute row ordinals in the base data file,
+// while a split's 'start'/'length' are a byte range over that file. This
+// pins down the conversion between those two coordinate systems for a split
+// that begins at a nonzero byte offset.
+//
+// IcebergSplitReader resolves the two by asking the format reader, not by
+// arithmetic on the byte offset: after creating the row reader it sets
+// 'splitOffset_ = baseRowReader_->nextRowNumber()', which for DWRF/ORC is the
+// cumulative row count of the preceding stripes (row groups for Parquet), and
+// each batch then recovers its absolute range as
+// 'splitOffset_ + baseReadOffset_'. A DV position preceding the split must be
+// ignored rather than shifted onto a row this split actually reads.
+TEST_F(IcebergDeletionVectorReadTest, deletionVectorAppliesToNonZeroByteSplit) {
+  // Two DWRF stripes of five rows each: values 0..4 then 5..9, where each
+  // value equals its absolute row position.
+  auto dataFile = TempFilePath::create();
+  writeToFile(
+      dataFile->getPath(),
+      {
+          makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})}),
+          makeRowVector({makeFlatVector<int64_t>({5, 6, 7, 8, 9})}),
+      },
+      std::make_shared<dwrf::Config>(),
+      []() {
+        return std::make_unique<dwrf::LambdaFlushPolicy>([]() { return true; });
+      });
+
+  auto readFile = filesystems::getFileSystem(dataFile->getPath(), nullptr)
+                      ->openFileForRead(dataFile->getPath());
+  const uint64_t fileSize = readFile->size();
+  dwio::common::ReaderOptions readerOptions{pool()};
+  auto reader = std::make_unique<dwrf::ReaderBase>(
+      readerOptions,
+      std::make_unique<dwio::common::BufferedInput>(
+          std::shared_ptr<ReadFile>(std::move(readFile)), *pool()));
+  reader->loadCache();
+
+  // The premise of the test: the second stripe really does start at a nonzero
+  // byte offset and at absolute row 5, so the byte offset and the row offset
+  // are different numbers and cannot be confused for one another.
+  ASSERT_EQ(reader->footer().stripesSize(), 2);
+  const uint64_t secondStripeByteOffset = reader->footer().stripes(1).offset();
+  ASSERT_GT(secondStripeByteOffset, 0);
+  ASSERT_EQ(reader->footer().stripes(0).numberOfRows(), 5);
+
+  // Absolute data-file positions: 1 lives in the first stripe and is outside
+  // this split, 7 is the third row of the second stripe.
+  auto [puffinDir, dvFile] = writeDeletionVector(dataFile->getPath(), {1, 7});
+
+  auto split = IcebergSplitBuilder(dataFile->getPath())
+                   .connectorId(test::kIcebergConnectorId)
+                   .fileFormat(fileFormat_)
+                   .start(secondStripeByteOffset)
+                   .length(fileSize - secondStripeByteOffset)
+                   .deleteFiles({dvFile})
+                   .build();
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+
+  // Position 7 is removed from the second stripe. Position 1 precedes the
+  // split and must not delete anything; in particular it must not be
+  // misread as the second row of this split (value 6).
+  auto expected = makeRowVector({makeFlatVector<int64_t>({5, 6, 8, 9})});
+  exec::test::AssertQueryBuilder(plan).splits({split}).assertResults(expected);
 }
 
 } // namespace

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
@@ -684,3 +684,125 @@ TEST_F(IcebergDeletionVectorSinkTest, dictionaryWrappedRowIdStructFlatPath) {
       pool_.get());
   EXPECT_EQ(deleted, (std::vector<uint64_t>{1, 3}));
 }
+
+TEST_F(IcebergDeletionVectorSinkTest, rejectsUnsupportedInputType) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  // Neither the flat (file_path, pos) shape nor a ROW whose first two fields
+  // are (VARCHAR, BIGINT), so the sink cannot locate the row-id.
+  VELOX_ASSERT_USER_THROW(
+      IcebergDeletionVectorSink(
+          ROW({"a", "b"}, {BIGINT(), BIGINT()}),
+          handle,
+          connectorQueryCtx_.get(),
+          connector::CommitStrategy::kNoCommit,
+          hiveConfig_),
+      "IcebergDeletionVectorSink expects a two-column (file_path, pos) input");
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, appendDataIgnoresNullAndEmptyPages) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  sink.appendData(nullptr);
+  sink.appendData(makePositionDeleteRows({}, {}));
+
+  // Neither page created per-file state, so nothing is written.
+  EXPECT_TRUE(sink.finish());
+  EXPECT_TRUE(sink.close().empty());
+  EXPECT_EQ(sink.stats().numWrittenFiles, 0u);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, rowIdStructSkipsNullRowId) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+  const std::string dataFile = tempDir->getPath() + "/A.parquet";
+
+  IcebergDeletionVectorSink sink(
+      ROW({"$row_id"},
+          {ROW(
+              {"_file", "_pos", "_spec_id", "partition_data"},
+              {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()})}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  // A null row-id carries no (file_path, pos) to delete and must be skipped
+  // rather than dereferenced.
+  auto page = makeRowIdStructDeletePage(
+      dataFile, {10, 20, 30}, {0, 1, 2}, /*filePathConstant=*/true);
+  auto rowIdWithNull = page->childAt(0);
+  rowIdWithNull->setNull(1, true);
+
+  sink.appendData(page);
+  EXPECT_TRUE(sink.finish());
+
+  auto messages = sink.close();
+  ASSERT_EQ(messages.size(), 1);
+  const auto parsed = folly::parseJson(messages[0]);
+  // Positions 10 and 30 survive; the null row at index 1 contributes nothing.
+  EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 2);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, finishAndAbortAreIdempotent) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  sink.appendData(
+      makePositionDeleteRows({tempDir->getPath() + "/A.parquet"}, {5}));
+
+  EXPECT_TRUE(sink.finish());
+  const auto statsAfterFirstFinish = sink.stats();
+
+  // A second finish() must not re-write the Puffin file or duplicate the
+  // commit message.
+  EXPECT_TRUE(sink.finish());
+  EXPECT_EQ(
+      sink.stats().numWrittenFiles, statsAfterFirstFinish.numWrittenFiles);
+  EXPECT_EQ(sink.close().size(), 1);
+
+  // abort() after finish() is a no-op rather than clearing committed state.
+  sink.abort();
+  sink.abort();
+  EXPECT_EQ(sink.close().size(), 1);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, puffinPathFallsBackToTargetPath) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  // A data-file name with no '/' has no parent directory to co-locate with,
+  // so the Puffin lands in the location handle's target path instead.
+  sink.appendData(makePositionDeleteRows({"bare-name.parquet"}, {1}));
+  EXPECT_TRUE(sink.finish());
+
+  auto messages = sink.close();
+  ASSERT_EQ(messages.size(), 1);
+  const auto parsed = folly::parseJson(messages[0]);
+  const auto puffinPath = parsed["path"].asString();
+  EXPECT_EQ(puffinPath.rfind(tempDir->getPath() + "/dv-", 0), 0)
+      << "puffin path should sit under the target path: " << puffinPath;
+}

--- a/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
@@ -240,6 +240,128 @@ TEST_F(IcebergDwrfInsertTest, partitioned) {
   exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
 }
 
+/// IcebergFileNameGenerator participates in plan serialization
+/// (IcebergConnector::registerSerDe registers it), so its serialize /
+/// deserialize / toString methods are reachable from any serialized plan even
+/// though the write tests never round-trip a plan.
+TEST_F(IcebergDwrfInsertTest, fileNameGeneratorSerDeRoundTrip) {
+  IcebergFileNameGenerator::registerSerDe();
+
+  const IcebergFileNameGenerator generator;
+  EXPECT_EQ(generator.toString(), "IcebergFileNameGenerator");
+
+  const auto serialized = generator.serialize();
+  EXPECT_EQ(serialized["name"].asString(), "IcebergFileNameGenerator");
+
+  const auto deserialized =
+      IcebergFileNameGenerator::deserialize(serialized, /*context=*/nullptr);
+  ASSERT_NE(deserialized, nullptr);
+  EXPECT_EQ(deserialized->toString(), generator.toString());
+}
+
+/// Exercises writer file rotation. FileDataSink rotates once a writer's
+/// current file reaches 'maxTargetFileBytes', which HiveDataSink derives from
+/// the format-specific max-target-file-size setting (0 = unlimited, the
+/// default, so no other test reaches this path). IcebergDataSink overrides
+/// rotateWriter() to capture per-file statistics before the writer is reset;
+/// without rotation coverage that override and the post-rotation null-writer
+/// handling in closeInternal() never run.
+TEST_F(IcebergDwrfInsertTest, writerRotationProducesMultipleFiles) {
+  // 1 byte forces a rotation after essentially every batch.
+  setConnectorSessionProperty(
+      connector::hive::HiveConfig::kOrcMaxTargetFileSizeSession, "1B");
+
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 3, 50);
+
+  const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+  const auto commitTasks = dataSink->close();
+
+  // Rotation means one unpartitioned writer emits several files, each with its
+  // own commit task and its own record count.
+  ASSERT_GT(commitTasks.size(), 1)
+      << "expected rotation to split the write across multiple files";
+  EXPECT_EQ(listFiles(dataPath).size(), commitTasks.size());
+
+  int64_t totalRecords = 0;
+  for (const auto& task : commitTasks) {
+    const auto taskJson = folly::parseJson(task);
+    const auto records = taskJson["metrics"]["recordCount"].asInt();
+    // Per-file counts are deltas, not the running total, so none may be zero
+    // and they must sum to the rows written.
+    EXPECT_GT(records, 0);
+    totalRecords += records;
+  }
+  EXPECT_EQ(totalRecords, 3 * 50);
+
+  // The rotated files still read back as the original data.
+  auto splits = createSplitsForDirectory(dataPath);
+  ASSERT_EQ(splits.size(), commitTasks.size());
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+}
+
+/// Partition values are serialized into the commit message by a per-type
+/// dispatch. VARBINARY and TIMESTAMP take dedicated specializations —
+/// base64-encoding and micros-since-epoch respectively — that the BIGINT and
+/// VARCHAR partition tests never reach.
+TEST_F(IcebergDwrfInsertTest, varbinaryPartitionValue) {
+  auto rowType = ROW({"c1", "c2"}, {VARBINARY(), BIGINT()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 1, 20);
+
+  std::vector<test::PartitionField> partitionTransforms = {
+      {0, TransformType::kIdentity, std::nullopt}};
+  const auto dataSink =
+      createDataSinkAndAppendData(vectors, dataPath, partitionTransforms);
+  const auto commitTasks = dataSink->close();
+  ASSERT_GT(commitTasks.size(), 0);
+
+  for (const auto& task : commitTasks) {
+    const auto taskJson = folly::parseJson(task);
+    ASSERT_GT(taskJson.count("partitionDataJson"), 0);
+    const auto partitionData =
+        folly::parseJson(taskJson["partitionDataJson"].asString());
+    ASSERT_EQ(partitionData["partitionValues"].size(), 1);
+    // Binary partition values are base64 strings, never raw bytes.
+    const auto& value = partitionData["partitionValues"][0];
+    EXPECT_TRUE(value.isString() || value.isNull());
+  }
+}
+
+TEST_F(IcebergDwrfInsertTest, timestampPartitionValue) {
+  auto rowType = ROW({"c1", "c2"}, {TIMESTAMP(), BIGINT()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 1, 20);
+
+  std::vector<test::PartitionField> partitionTransforms = {
+      {0, TransformType::kIdentity, std::nullopt}};
+  const auto dataSink =
+      createDataSinkAndAppendData(vectors, dataPath, partitionTransforms);
+  const auto commitTasks = dataSink->close();
+  ASSERT_GT(commitTasks.size(), 0);
+
+  for (const auto& task : commitTasks) {
+    const auto taskJson = folly::parseJson(task);
+    ASSERT_GT(taskJson.count("partitionDataJson"), 0);
+    const auto partitionData =
+        folly::parseJson(taskJson["partitionDataJson"].asString());
+    ASSERT_EQ(partitionData["partitionValues"].size(), 1);
+    // Iceberg stores timestamps as micros since epoch, so the serialized
+    // partition value must be an integer rather than a formatted string.
+    const auto& value = partitionData["partitionValues"][0];
+    EXPECT_TRUE(value.isInt() || value.isNull());
+  }
+}
+
 /// Regression test for the isPartitioned() guard added to ensureWriter().
 /// Without the guard, calling ensureWriter() on a non-partitioned table
 /// invoked makeCommitPartitionValue(), which dereferences

--- a/velox/connectors/hive/iceberg/tests/IcebergMergeSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergMergeSinkTest.cpp
@@ -468,6 +468,42 @@ TEST_F(IcebergMergeSinkTest, dataInputTypeNamesComeFromHandleNotSource) {
 
 // VELOX_ENABLE_PARQUET guard removed: rely on the iceberg_connector
 // target's unconditional Parquet writer dependency.
+TEST_F(IcebergMergeSinkTest, appendDataIgnoresNullAndEmptyPages) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  // Neither page carries rows, so neither sub-sink is driven and no operation
+  // byte is validated.
+  sink->appendData(nullptr);
+  sink->appendData(makeInput(
+      /*ids=*/std::vector<std::optional<int64_t>>{},
+      /*names=*/std::vector<std::optional<std::string>>{},
+      /*operations=*/std::vector<int8_t>{},
+      /*filePaths=*/std::vector<std::optional<std::string>>{},
+      /*positions=*/std::vector<std::optional<int64_t>>{},
+      /*insertFromUpdate=*/std::vector<int8_t>{}));
+
+  EXPECT_TRUE(sink->finish());
+  EXPECT_TRUE(sink->close().empty());
+}
+
+TEST_F(IcebergMergeSinkTest, abortIsIdempotent) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  sink->appendData(makeInput(
+      /*ids=*/{1},
+      /*names=*/{{std::string("a")}},
+      /*operations=*/{IMS::kInsertOperationNumber},
+      /*filePaths=*/{std::nullopt},
+      /*positions=*/{std::nullopt},
+      /*insertFromUpdate=*/{0}));
+
+  // The second abort must not re-enter the sub-sinks, which are not safe to
+  // abort twice.
+  sink->abort();
+  sink->abort();
+}
 
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1389,6 +1389,94 @@ TEST_F(IcebergReadTest, targetTableRowIdSynthesis) {
       .assertResults({expected});
 }
 
+// Info columns arrive as strings on the split and are parsed at read time.
+// A value the coordinator could not have produced means the split metadata is
+// corrupt, so the reader must fail loudly rather than silently substituting a
+// default: $first_row_id and $data_sequence_number both feed V3 row lineage,
+// and a wrong value there mislabels every row in the file.
+class IcebergInfoColumnValidationTest : public IcebergReadTest {
+ protected:
+  // Runs a scan of a single BIGINT column with 'infoColumns' attached to the
+  // split, projecting 'outputType' (which decides whether the row-lineage or
+  // MERGE row-id parsing paths run at all).
+  void assertScanFails(
+      const std::unordered_map<std::string, std::string>& infoColumns,
+      const RowTypePtr& outputType,
+      const std::string& expectedMessage) {
+    std::vector<RowVectorPtr> inputVectors = {
+        makeRowVector({"c0"}, {makeFlatVector<int64_t>({10, 20, 30})})};
+    auto dataFilePath = TempFilePath::create();
+    writeToFile(dataFilePath->getPath(), inputVectors);
+
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(outputType)
+                    .dataColumns(ROW({"c0"}, {BIGINT()}))
+                    .endTableScan()
+                    .planNode();
+
+    VELOX_ASSERT_THROW(
+        exec::test::AssertQueryBuilder(plan)
+            .splits({makeIcebergSplitWithInfoColumns(
+                dataFilePath->getPath(), infoColumns)})
+            .copyResults(pool()),
+        expectedMessage);
+  }
+
+  // Projecting _row_id is what makes the reader parse $first_row_id.
+  RowTypePtr rowLineageOutputType() const {
+    return ROW(
+        {"c0", IcebergMetadataColumn::kRowIdColumnName}, {BIGINT(), BIGINT()});
+  }
+
+  // Projecting $target_table_row_id is what makes the reader parse $spec_id.
+  RowTypePtr targetRowIdOutputType() const {
+    return ROW(
+        {"c0", IcebergMetadataColumn::kTargetTableRowIdColumnName},
+        {BIGINT(),
+         ROW({"file_path", "row_position", "spec_id", "partition_data"},
+             {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()})});
+  }
+};
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNonNumericFirstRowId) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "not-a-number"}},
+      rowLineageOutputType(),
+      "Invalid $first_row_id value in split info columns");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNegativeFirstRowId) {
+  // Parses cleanly but is out of range: row ids are file-absolute offsets.
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "-1"}},
+      rowLineageOutputType(),
+      "First row ID must be non-negative");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNonNumericDataSequenceNumber) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "0"},
+       {IcebergMetadataColumn::kDataSequenceNumberInfoColumn, "abc"}},
+      rowLineageOutputType(),
+      "Invalid $data_sequence_number value in split info columns");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNegativeDataSequenceNumber) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "0"},
+       {IcebergMetadataColumn::kDataSequenceNumberInfoColumn, "-5"}},
+      rowLineageOutputType(),
+      "Data sequence number must be non-negative");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNonNumericSpecId) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kSpecIdInfoColumn, "spec-seven"}},
+      targetRowIdOutputType(),
+      "Invalid $spec_id value in split info columns");
+}
+
 TEST_F(IcebergReadTest, flatMapAsStruct) {
   // Write a DWRF file with a MAP<BIGINT, DOUBLE> column.
   auto mapType = MAP(BIGINT(), DOUBLE());

--- a/velox/connectors/hive/tests/TableHandleTest.cpp
+++ b/velox/connectors/hive/tests/TableHandleTest.cpp
@@ -101,6 +101,40 @@ TEST(TableHandleTest, hiveTableHandleDbName) {
   ASSERT_TRUE(cloneNoDb->dbName().empty());
 }
 
+TEST(TableHandleTest, hiveTableHandleDataColumnFieldIds) {
+  Type::registerSerDe();
+  connector::hive::HiveTableHandle::registerSerDe();
+
+  const auto dataColumns = ROW({"a", "c"}, {BIGINT(), VARCHAR()});
+  const std::vector<int32_t> fieldIds{1, 3};
+  auto handle = std::make_shared<connector::hive::HiveTableHandle>(
+      "test-connector",
+      "test_table",
+      common::SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      dataColumns,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/
+      std::vector<connector::hive::HiveColumnHandlePtr>{},
+      /*sampleRate=*/1.0,
+      /*dbName=*/"",
+      fieldIds);
+
+  EXPECT_EQ(handle->dataColumnFieldIds(), fieldIds);
+
+  auto serialized = handle->serialize();
+  auto clone = ISerializable::deserialize<connector::hive::HiveTableHandle>(
+      serialized, /*context=*/nullptr);
+  EXPECT_EQ(clone->dataColumnFieldIds(), fieldIds);
+
+  serialized.erase("dataColumnFieldIds");
+  auto legacyClone =
+      ISerializable::deserialize<connector::hive::HiveTableHandle>(
+          serialized, /*context=*/nullptr);
+  EXPECT_TRUE(legacyClone->dataColumnFieldIds().empty());
+}
+
 TEST(TableHandleTest, hiveTableHandleIndexSupport) {
   // Test HiveTableHandle without index columns.
   auto tableHandleWithoutIndex =


### PR DESCRIPTION
Summary:
Iceberg spec-conformance fixes found by diffing our behaviour against Apache
Iceberg 1.10.1, plus the read/write coverage that surfaced them.

Puffin blob metadata. Nothing on our side parsed a Puffin footer -
DeletionVectorReader located its blob from the manifest - so the footer
DeletionVectorWriter emits had never been read by anything, and three defects
had accumulated. Checked against FileMetadataParser.blobMetadataFromJson, which
requires type, fields, snapshot-id, sequence-number, offset and length, and
reads fields via getIntegerList:
  - "fields" was a list of objects rather than a list of integers.
  - The field ID named _file (INT_MAX - 1) instead of ROW_POSITION / _pos
    (INT_MAX - 2), which is what Iceberg BaseDVFileWriter uses. This is also
    distinct from the positional-delete "pos" column that
    IcebergMetadataColumns uses elsewhere.
  - "snapshot-id" and "sequence-number" were absent; both are required, and
    Iceberg writes -1 for a vector whose snapshot is not yet assigned.
Any one of these aborts the parse, so every Puffin deletion vector we wrote was
unreadable by Spark, Trino, or Java Presto. Velox never noticed because it
bypassed the footer.

Puffin footer parsing. With no typed contentOffset/contentLength and no legacy
bounds map, the reader treated the whole file - magic and footer included - as
the bitmap, which cannot parse. It now reads the footer backwards from end of
file and selects the blob by referenced-data-file, requiring a single candidate
when no name is given. Gated on the Puffin magic so raw roaring blobs keep the
previous behaviour. Puffin constants moved to DeletionVectorFormat.h so reader
and writer agree by construction.

Optional "field-id". parseIdentityPartitionKeys required "field-id" on every
spec field and rejected the whole spec otherwise, silently disabling identity
substitution. Iceberg PartitionSpecParser treats it as optional - V1 specs omit
it - and only name, transform and source-id are required.

Coverage: writer file rotation and typed partition values, malformed
info-column handling, the full non-identity transform matrix, and the Puffin
guards mirroring TestPuffinReader.

Differential Revision: D115365708


