### PR TITLE
build: Annotate BaseVector/FlatVector/ComplexVector/BiasVector borrow accessors with [[clang::lifetimebound]] (#18473)

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include <fmt/format.h>
+#include <folly/CppAttributes.h>
 #include <folly/Format.h>
 #include <folly/Range.h>
 #include <folly/container/F14Map.h>
@@ -234,7 +235,7 @@ class BaseVector {
   /// this on first access. For ConstantVector, this method returns a BufferPtr
   /// of only size 1. For DictionaryVector, this method returns a BufferPtr for
   /// only nulls in the top-level layer.
-  const BufferPtr& nulls() const {
+  const BufferPtr& nulls() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return nulls_;
   }
 
@@ -713,7 +714,7 @@ class BaseVector {
 
   static const VectorPtr& loadedVectorShared(const VectorPtr& vector);
 
-  virtual const BufferPtr& values() const {
+  virtual const BufferPtr& values() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     VELOX_UNSUPPORTED("Only flat vectors have a values buffer");
   }
 

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/CppAttributes.h>
 #include <folly/dynamic.h>
 
 #include "velox/common/base/SimdUtil.h"
@@ -151,7 +152,8 @@ class BiasVector : public SimpleVector<T> {
    * this vector. This is used during execution to process over the subset of
    * values when possible.
    */
-  inline const BufferPtr& values() const override {
+  inline const BufferPtr& values() const
+      [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] override {
     return values_;
   }
 

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/CppAttributes.h>
 #include <folly/container/F14Map.h>
 #include <folly/hash/Hash.h>
 #include <glog/logging.h>
@@ -111,7 +112,7 @@ class RowVector : public BaseVector {
   void appendNulls(vector_size_t numberOfRows);
 
   /// Get the child vector at a given offset.
-  VectorPtr& childAt(column_index_t index) {
+  VectorPtr& childAt(column_index_t index) [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     VELOX_CHECK_LT(
         index,
         childrenSize_,
@@ -120,7 +121,8 @@ class RowVector : public BaseVector {
     return children_[index];
   }
 
-  const VectorPtr& childAt(column_index_t index) const {
+  const VectorPtr& childAt(column_index_t index) const
+      [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     VELOX_CHECK_LT(
         index,
         childrenSize_,
@@ -131,19 +133,22 @@ class RowVector : public BaseVector {
 
   /// Returns child vector for the specified field name. Throws if field with
   /// specified name doesn't exist.
-  VectorPtr& childAt(const std::string& name) {
+  VectorPtr& childAt(const std::string& name)
+      [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return children_[type_->asRow().getChildIdx(name)];
   }
 
-  const VectorPtr& childAt(const std::string& name) const {
+  const VectorPtr& childAt(const std::string& name) const
+      [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return children_[type_->asRow().getChildIdx(name)];
   }
 
-  std::vector<VectorPtr>& children() {
+  std::vector<VectorPtr>& children() [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return children_;
   }
 
-  const std::vector<VectorPtr>& children() const {
+  const std::vector<VectorPtr>& children() const
+      [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return children_;
   }
 
@@ -331,11 +336,11 @@ class RowVector : public BaseVector {
 struct ArrayVectorBase : BaseVector {
   ArrayVectorBase(const ArrayVectorBase&) = delete;
 
-  const BufferPtr& offsets() const {
+  const BufferPtr& offsets() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return offsets_;
   }
 
-  const BufferPtr& sizes() const {
+  const BufferPtr& sizes() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return sizes_;
   }
 
@@ -504,11 +509,11 @@ class ArrayVector : public ArrayVectorBase {
 
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
-  const VectorPtr& elements() const {
+  const VectorPtr& elements() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return elements_;
   }
 
-  VectorPtr& elements() {
+  VectorPtr& elements() [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return elements_;
   }
 
@@ -643,19 +648,19 @@ class MapVector : public ArrayVectorBase {
 
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
-  const VectorPtr& mapKeys() const {
+  const VectorPtr& mapKeys() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return keys_;
   }
 
-  VectorPtr& mapKeys() {
+  VectorPtr& mapKeys() [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return keys_;
   }
 
-  const VectorPtr& mapValues() const {
+  const VectorPtr& mapValues() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return values_;
   }
 
-  VectorPtr& mapValues() {
+  VectorPtr& mapValues() [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return values_;
   }
 

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/CppAttributes.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include <folly/dynamic.h>
@@ -136,7 +137,7 @@ class FlatVector final : public SimpleVector<T> {
   /// Returns a smart pointer holding the values for
   /// this vector. This is used during execution to process over the subset of
   /// values when possible.
-  const BufferPtr& values() const override {
+  const BufferPtr& values() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] override {
     return values_;
   }
 
@@ -421,7 +422,8 @@ class FlatVector final : public SimpleVector<T> {
   /// by StringView's. It is safe to share these among multiple vectors. These
   /// buffers are append only. It is allowed to append data, but it is
   /// prohibited to modify already written data.
-  const std::vector<BufferPtr>& stringBuffers() const {
+  const std::vector<BufferPtr>& stringBuffers() const
+      [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return stringBuffers_;
   }
 


### PR DESCRIPTION
Summary:

Annotates the borrow-into-*this accessors on velox
vector types so -Wdangling (fbcode is -Werror) catches dangling-borrow
use-after-free at compile time: binding a reference/pointer returned
from a temporary VectorPtr/BufferPtr-holding object and using it after
that temporary is destroyed.

All annotated methods return a reference into a member owned inline by
*this (not into a shared/refcounted external buffer, and not returned
by value) -- confirmed by inspection before annotating each one:

BaseVector.h (2 methods):
- nulls() const -> const BufferPtr& into nulls_
- values() const [virtual base] -> const BufferPtr& (overridden below)

FlatVector.h (2 methods):
- values() const [override] -> const BufferPtr& into values_
- stringBuffers() const -> const std::vector<BufferPtr>& into stringBuffers_

BiasVector.h (1 method, found via API-family sweep of values() overrides):
- values() const [override] -> const BufferPtr& into values_

ComplexVector.h (11 methods, RowVector/ArrayVectorBase/ArrayVector/MapVector):
- childAt(column_index_t) & / const& -> into children_[index]
- childAt(const std::string&) & / const& -> into children_[idx]
- children() & / const& -> into children_
- offsets() const& -> into offsets_
- sizes() const& -> into sizes_
- elements() & / const& -> into elements_
- mapKeys() & / const& -> into keys_
- mapValues() & / const& -> into values_

Excluded (own-buffer / by-value / type-erased -- would misfire):
raw-pointer accessors (rawNulls/rawOffsets/etc, not references),
DecodedVector (flattens through wrappers, CSA-scope not lifetimebound),
loadedVector() (returns `this`, not a member borrow).

Uses the portable [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] macro
(folly/CppAttributes.h) for GCC/OSS-safety, matching the proxygen
probe (D112316687). Added the `//folly:cpp_attributes` BUCK dep to
velox_vector's exported_deps (single target covers all 4 headers).
Velox has no xplat mirror (OSS-exported single copy).

Differential Revision: D115252058


