### PR TITLE
feat(connector): Let file systems report per-operation IO counters (#18475)

### DIFF
--- a/velox/common/caching/FileHandle.cpp
+++ b/velox/common/caching/FileHandle.cpp
@@ -59,6 +59,7 @@ std::unique_ptr<FileHandle> FileHandleGenerator::operator()(
       options.readRangeHint = properties->readRangeHint;
       options.extraFileInfo = properties->extraFileInfo;
       options.fileReadOps = properties->fileReadOps;
+      options.ioStatistics = properties->ioStatistics;
     }
     const auto& filename = key.filename;
     fileHandle->file = filesystems::getFileSystem(filename, properties_)

--- a/velox/common/caching/FileProperties.h
+++ b/velox/common/caching/FileProperties.h
@@ -17,11 +17,16 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 #include <folly/container/F14Map.h>
 
 namespace facebook::velox {
+
+namespace io {
+class IoStatistics;
+}
 
 struct FileProperties {
   std::optional<int64_t> fileSize;
@@ -29,6 +34,7 @@ struct FileProperties {
   std::optional<int64_t> readRangeHint{std::nullopt};
   std::shared_ptr<std::string> extraFileInfo{nullptr};
   folly::F14FastMap<std::string, std::string> fileReadOps{};
+  io::IoStatistics* ioStatistics{nullptr};
 };
 
 } // namespace facebook::velox

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -28,6 +28,9 @@ namespace facebook::velox {
 namespace config {
 class ConfigBase;
 }
+namespace io {
+class IoStatistics;
+}
 class IoStats;
 class ReadFile;
 class WriteFile;
@@ -77,6 +80,12 @@ struct FileOptions {
       std::nullopt};
 
   IoStats* stats{nullptr};
+
+  /// Per-operation counters, keyed by operation name, unlike 'stats' above
+  /// which has no operation dimension. Non-owning: a file system may retain
+  /// this and record into it on every read, so it must outlive any file opened
+  /// with these options.
+  io::IoStatistics* ioStatistics{nullptr};
 
   /// A raw string that client can encode as anything they want to describe the
   /// file. For example, extraFileInfo can contain serialized file descriptors

--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -85,6 +85,24 @@ inline void addIoLatencyMetric(
   }
 }
 
+void addOperationStatsToRuntimeStats(
+    io::IoStatistics& ioStats,
+    std::unordered_map<std::string, RuntimeMetric>& res) {
+  for (const auto& [operation, counters] : ioStats.operationStats()) {
+    const auto add = [&](std::string_view counter, uint64_t value) {
+      if (value == 0) {
+        return;
+      }
+      res[fmt::format("storage.{}.{}", operation, counter)] =
+          RuntimeMetric(value, RuntimeCounter::Unit::kNone);
+    };
+    add("requestCount", counters.requestCount);
+    add("localThrottleCount", counters.localThrottleCount);
+    add("globalThrottleCount", counters.globalThrottleCount);
+    add("resourceThrottleCount", counters.resourceThrottleCount);
+  }
+}
+
 void addIoStatsToRuntimeStats(
     io::IoStatistics& ioStats,
     std::string_view prefix,
@@ -684,6 +702,8 @@ FileDataSource::getRuntimeStats() {
       res.emplace(key, value);
     }
   }
+
+  addOperationStatsToRuntimeStats(*dataIoStats_, res);
   return res;
 }
 

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -289,6 +289,12 @@ void FileSplitReader::createReader(
   if (!tableHandle_->name().empty()) {
     fileProperties.fileReadOps[kTableNameKey] = tableHandle_->name();
   }
+  // Per-operation counters are attributed to the data source that opened the
+  // file, so they are only meaningful while file handles are not reused across
+  // data sources. A cached handle would both outlive these statistics and
+  // report one data source's reads against another's.
+  fileProperties.ioStatistics =
+      fileHandleFactory_->maxSize() == 0 ? dataIoStats_.get() : nullptr;
 
   try {
     fileHandleCachePtr = fileHandleFactory_->generate(


### PR DESCRIPTION
Summary:

`FileOptions` carries only `IoStats`, a free-form name-to-metric map with no
operation dimension. A file system that tracks counters per operation -- request
and throttle counts keyed by `open`, `size` or a read variant -- has no way to
report them to the connector.

Carry an optional `io::IoStatistics` alongside it. `FileSplitReader` populates it
from the data source's existing statistics, and whatever a file system records is
exported as `storage.<operation>.<counter>` runtime stats on the TableScan node.

Supplied only when file handles are not cached (`FileHandleFactory::maxSize() == 0`).
A cached handle is shared across data sources and outlives the one that opened it,
so it would both dangle and report one data source's reads against another's. Since the file handle cache is enabled by default, this is effectively opt-in: a deployment that wants per-operation counters must set num_cached_file_handles to 0

Optional and default-null, so behavior is unchanged for any file system that
does not read it.

Reviewed By: apurva-meta

Differential Revision: D115530427


