### PR TITLE
feat(filter): Add FilterKind `kUserDefined`

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -55,6 +55,7 @@ const auto& filterKindNames() {
       {FilterKind::kHugeintValuesUsingHashTable, "HugeintValuesUsingHashTable"},
       {FilterKind::kBigintValuesUsingBloomFilter,
        "BigintValuesUsingBloomFilter"},
+      {FilterKind::kUnknown, "Unknown"},
   };
   return kNames;
 }
@@ -1615,6 +1616,8 @@ std::unique_ptr<Filter> MultiRange::mergeWith(const Filter* other) const {
         return std::make_unique<MultiRange>(std::move(merged), bothNullAllowed);
       }
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -1659,6 +1662,8 @@ std::unique_ptr<Filter> BoolValue::mergeWith(const Filter* other) const {
 
       return nullOrFalse(bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -1878,6 +1883,8 @@ std::unique_ptr<Filter> BigintRange::mergeWith(const Filter* other) const {
           std::make_unique<common::BigintRange>(lower_, upper_, false));
       return combineRangesAndNegatedValues(rangeList, vals, bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -1904,6 +1911,8 @@ std::unique_ptr<Filter> TimestampRange::mergeWith(const Filter* other) const {
 
       return nullOrFalse(bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2031,6 +2040,8 @@ std::unique_ptr<Filter> NegatedBigintRange::mergeWith(
           negatedValuesToRanges(rejectedValues),
           bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2090,6 +2101,8 @@ std::unique_ptr<Filter> BigintValuesUsingHashTable::mergeWith(
     case FilterKind::kNegatedBigintValuesUsingHashTable: {
       return mergeWith(min_, max_, other);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2210,6 +2223,8 @@ std::unique_ptr<Filter> BigintValuesUsingBitmask::mergeWith(
     case FilterKind::kNegatedBigintValuesUsingHashTable: {
       return mergeWith(min_, max_, other);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2264,6 +2279,8 @@ std::unique_ptr<Filter> NegatedBigintValuesUsingHashTable::mergeWith(
     case FilterKind::kNegatedBigintValuesUsingBitmask: {
       return other->mergeWith(this);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2308,6 +2325,8 @@ std::unique_ptr<Filter> NegatedBigintValuesUsingBitmask::mergeWith(
       return combineNegatedBigintLists(
           values(), otherBitmask->values(), bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2381,6 +2400,8 @@ std::unique_ptr<Filter> BigintMultiRange::mergeWith(const Filter* other) const {
       bool bothNullAllowed = nullAllowed_ && other->testNull();
       return combineRangesAndNegatedValues(ranges_, rejects, bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2445,6 +2466,8 @@ std::unique_ptr<Filter> BigintValuesUsingBloomFilter::mergeWith(
       // correctness.  We can do so if we think merging will not improve
       // performance.
       return other->clone();
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_FAIL("Cannot merge {} with {}", kindName(), other->kindName());
   }
@@ -2530,7 +2553,8 @@ std::unique_ptr<Filter> BytesRange::mergeWith(const Filter* other) const {
           upperExclusive,
           bothNullAllowed);
     }
-
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2554,6 +2578,8 @@ std::unique_ptr<Filter> NegatedBytesRange::mergeWith(
       // these cases are likely to end up as a MultiRange anyway
       return other->mergeWith(toMultiRange().get());
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2665,6 +2691,8 @@ std::unique_ptr<Filter> BytesValues::mergeWith(const Filter* other) const {
       return std::make_unique<BytesValues>(
           std::move(newValues), bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }
@@ -2769,6 +2797,8 @@ std::unique_ptr<Filter> NegatedBytesValues::mergeWith(
               false));
       return std::make_unique<MultiRange>(std::move(ranges), bothNullAllowed);
     }
+    case FilterKind::kUnknown:
+      return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
   }

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -55,7 +55,7 @@ const auto& filterKindNames() {
       {FilterKind::kHugeintValuesUsingHashTable, "HugeintValuesUsingHashTable"},
       {FilterKind::kBigintValuesUsingBloomFilter,
        "BigintValuesUsingBloomFilter"},
-      {FilterKind::kUnknown, "Unknown"},
+      {FilterKind::kUserDefined, "UserDefined"},
   };
   return kNames;
 }
@@ -139,7 +139,7 @@ void Filter::registerSerDe() {
 
 folly::dynamic Filter::serializeBase() const {
   folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = kindName();
+  obj["name"] = serializedName();
   obj["nullAllowed"] = nullAllowed_;
   return obj;
 }
@@ -758,7 +758,7 @@ BigintValuesUsingBitmask::BigintValuesUsingBitmask(
     int64_t max,
     const std::vector<int64_t>& values,
     bool nullAllowed)
-    : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingBitmask),
+    : BuiltInFilter(true, nullAllowed, FilterKind::kBigintValuesUsingBitmask),
       min_(min),
       max_(max) {
   VELOX_CHECK_LT(
@@ -810,7 +810,7 @@ BigintValuesUsingHashTable::BigintValuesUsingHashTable(
     int64_t max,
     const std::vector<int64_t>& values,
     bool nullAllowed)
-    : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingHashTable),
+    : BuiltInFilter(true, nullAllowed, FilterKind::kBigintValuesUsingHashTable),
       min_(min),
       max_(max),
       values_(values) {
@@ -914,7 +914,10 @@ HugeintValuesUsingHashTable::HugeintValuesUsingHashTable(
     const int128_t& max,
     const std::vector<int128_t>& values,
     const bool nullAllowed)
-    : Filter(true, nullAllowed, FilterKind::kHugeintValuesUsingHashTable),
+    : BuiltInFilter(
+          true,
+          nullAllowed,
+          FilterKind::kHugeintValuesUsingHashTable),
       min_(min),
       max_(max) {
   VELOX_CHECK(!values.empty(), "values must not be empty");
@@ -959,7 +962,10 @@ NegatedBigintValuesUsingBitmask::NegatedBigintValuesUsingBitmask(
     int64_t max,
     const std::vector<int64_t>& values,
     bool nullAllowed)
-    : Filter(true, nullAllowed, FilterKind::kNegatedBigintValuesUsingBitmask),
+    : BuiltInFilter(
+          true,
+          nullAllowed,
+          FilterKind::kNegatedBigintValuesUsingBitmask),
       min_(min),
       max_(max) {
   VELOX_CHECK_LE(
@@ -993,7 +999,7 @@ NegatedBigintValuesUsingHashTable::NegatedBigintValuesUsingHashTable(
     int64_t max,
     const std::vector<int64_t>& values,
     bool nullAllowed)
-    : Filter(
+    : BuiltInFilter(
           true,
           nullAllowed,
           FilterKind::kNegatedBigintValuesUsingHashTable) {
@@ -1140,7 +1146,7 @@ std::unique_ptr<Filter> createNegatedBigintValues(
 BigintMultiRange::BigintMultiRange(
     std::vector<std::unique_ptr<BigintRange>> ranges,
     bool nullAllowed)
-    : Filter(true, nullAllowed, FilterKind::kBigintMultiRange),
+    : BuiltInFilter(true, nullAllowed, FilterKind::kBigintMultiRange),
       ranges_(std::move(ranges)) {
   VELOX_CHECK(!ranges_.empty(), "ranges is empty");
   VELOX_CHECK_GT(ranges_.size(), 1, "should contain at least 2 ranges.");
@@ -1616,7 +1622,7 @@ std::unique_ptr<Filter> MultiRange::mergeWith(const Filter* other) const {
         return std::make_unique<MultiRange>(std::move(merged), bothNullAllowed);
       }
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -1662,7 +1668,7 @@ std::unique_ptr<Filter> BoolValue::mergeWith(const Filter* other) const {
 
       return nullOrFalse(bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -1883,7 +1889,7 @@ std::unique_ptr<Filter> BigintRange::mergeWith(const Filter* other) const {
           std::make_unique<common::BigintRange>(lower_, upper_, false));
       return combineRangesAndNegatedValues(rangeList, vals, bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -1911,7 +1917,7 @@ std::unique_ptr<Filter> TimestampRange::mergeWith(const Filter* other) const {
 
       return nullOrFalse(bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2040,7 +2046,7 @@ std::unique_ptr<Filter> NegatedBigintRange::mergeWith(
           negatedValuesToRanges(rejectedValues),
           bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2101,7 +2107,7 @@ std::unique_ptr<Filter> BigintValuesUsingHashTable::mergeWith(
     case FilterKind::kNegatedBigintValuesUsingHashTable: {
       return mergeWith(min_, max_, other);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2223,7 +2229,7 @@ std::unique_ptr<Filter> BigintValuesUsingBitmask::mergeWith(
     case FilterKind::kNegatedBigintValuesUsingHashTable: {
       return mergeWith(min_, max_, other);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2279,7 +2285,7 @@ std::unique_ptr<Filter> NegatedBigintValuesUsingHashTable::mergeWith(
     case FilterKind::kNegatedBigintValuesUsingBitmask: {
       return other->mergeWith(this);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2325,7 +2331,7 @@ std::unique_ptr<Filter> NegatedBigintValuesUsingBitmask::mergeWith(
       return combineNegatedBigintLists(
           values(), otherBitmask->values(), bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2400,7 +2406,7 @@ std::unique_ptr<Filter> BigintMultiRange::mergeWith(const Filter* other) const {
       bool bothNullAllowed = nullAllowed_ && other->testNull();
       return combineRangesAndNegatedValues(ranges_, rejects, bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2466,7 +2472,7 @@ std::unique_ptr<Filter> BigintValuesUsingBloomFilter::mergeWith(
       // correctness.  We can do so if we think merging will not improve
       // performance.
       return other->clone();
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_FAIL("Cannot merge {} with {}", kindName(), other->kindName());
@@ -2553,7 +2559,7 @@ std::unique_ptr<Filter> BytesRange::mergeWith(const Filter* other) const {
           upperExclusive,
           bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2578,7 +2584,7 @@ std::unique_ptr<Filter> NegatedBytesRange::mergeWith(
       // these cases are likely to end up as a MultiRange anyway
       return other->mergeWith(toMultiRange().get());
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2691,7 +2697,7 @@ std::unique_ptr<Filter> BytesValues::mergeWith(const Filter* other) const {
       return std::make_unique<BytesValues>(
           std::move(newValues), bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();
@@ -2797,7 +2803,7 @@ std::unique_ptr<Filter> NegatedBytesValues::mergeWith(
               false));
       return std::make_unique<MultiRange>(std::move(ranges), bothNullAllowed);
     }
-    case FilterKind::kUnknown:
+    case FilterKind::kUserDefined:
       return other->mergeWith(this);
     default:
       VELOX_UNREACHABLE();

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -54,6 +54,7 @@ enum class FilterKind {
   kTimestampRange,
   kHugeintValuesUsingHashTable,
   kBigintValuesUsingBloomFilter,
+  kUnknown,
 };
 
 VELOX_DECLARE_ENUM_NAME(FilterKind);
@@ -1748,6 +1749,8 @@ class FloatingPointRange final : public AbstractRange {
             upperExclusive,
             bothNullAllowed);
       }
+      case FilterKind::kUnknown:
+        return other->mergeWith(this);
       default:
         VELOX_UNREACHABLE();
     }

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -54,7 +54,8 @@ enum class FilterKind {
   kTimestampRange,
   kHugeintValuesUsingHashTable,
   kBigintValuesUsingBloomFilter,
-  kUnknown,
+  /// Filter implemented outside Velox using the UserDefinedFilter API.
+  kUserDefined,
 };
 
 VELOX_DECLARE_ENUM_NAME(FilterKind);
@@ -91,6 +92,9 @@ class Filter : public velox::ISerializable {
   std::string_view kindName() const {
     return FilterKindName::toName(kind_);
   }
+
+  /// Stable name used to select the deserializer.
+  virtual std::string_view serializedName() const = 0;
 
   bool is(FilterKind kind) const {
     return kind_ == kind;
@@ -328,10 +332,32 @@ class Filter : public velox::ISerializable {
   const FilterKind kind_;
 };
 
-/// TODO Check if this filter is needed. This should not be passed down.
-class AlwaysFalse final : public Filter {
+/// Base class for filters implemented by Velox.
+class BuiltInFilter : public Filter {
+ protected:
+  BuiltInFilter(bool deterministic, bool nullAllowed, FilterKind kind)
+      : Filter(deterministic, nullAllowed, kind) {}
+
  public:
-  AlwaysFalse() : Filter(true, false, FilterKind::kAlwaysFalse) {}
+  std::string_view serializedName() const final {
+    return kindName();
+  }
+};
+
+/// Base class for filters implemented outside Velox.
+class UserDefinedFilter : public Filter {
+ protected:
+  UserDefinedFilter(bool deterministic, bool nullAllowed)
+      : Filter(deterministic, nullAllowed, FilterKind::kUserDefined) {}
+
+ public:
+  virtual std::string_view serializedName() const override = 0;
+};
+
+/// TODO Check if this filter is needed. This should not be passed down.
+class AlwaysFalse final : public BuiltInFilter {
+ public:
+  AlwaysFalse() : BuiltInFilter(true, false, FilterKind::kAlwaysFalse) {}
 
   folly::dynamic serialize() const override;
 
@@ -416,9 +442,9 @@ class AlwaysFalse final : public Filter {
 };
 
 /// TODO Check if this filter is needed. This should not be passed down.
-class AlwaysTrue final : public Filter {
+class AlwaysTrue final : public BuiltInFilter {
  public:
-  AlwaysTrue() : Filter(true, true, FilterKind::kAlwaysTrue) {}
+  AlwaysTrue() : BuiltInFilter(true, true, FilterKind::kAlwaysTrue) {}
 
   std::unique_ptr<Filter> clone(
       std::optional<bool> nullAllowed = std::nullopt) const final {
@@ -503,9 +529,9 @@ class AlwaysTrue final : public Filter {
 };
 
 /// Returns true if the value is null. Supports all data types.
-class IsNull final : public Filter {
+class IsNull final : public BuiltInFilter {
  public:
-  IsNull() : Filter(true, true, FilterKind::kIsNull) {}
+  IsNull() : BuiltInFilter(true, true, FilterKind::kIsNull) {}
 
   folly::dynamic serialize() const override;
 
@@ -591,9 +617,9 @@ class IsNull final : public Filter {
 };
 
 /// Returns true if the value is not null. Supports all data types.
-class IsNotNull final : public Filter {
+class IsNotNull final : public BuiltInFilter {
  public:
-  IsNotNull() : Filter(true, false, FilterKind::kIsNotNull) {}
+  IsNotNull() : BuiltInFilter(true, false, FilterKind::kIsNotNull) {}
 
   folly::dynamic serialize() const override;
 
@@ -680,13 +706,14 @@ class IsNotNull final : public Filter {
 
 /// Tests whether boolean value is true or false or integral value is zero or
 /// not. Support boolean and integral data types.
-class BoolValue final : public Filter {
+class BoolValue final : public BuiltInFilter {
  public:
   /// @param value The boolean value that passes the filter. If true, integral
   /// values that are not zero are passing as well.
   /// @param nullAllowed Null values are passing the filter if true.
   BoolValue(bool value, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kBoolValue), value_(value) {}
+      : BuiltInFilter(true, nullAllowed, FilterKind::kBoolValue),
+        value_(value) {}
 
   folly::dynamic serialize() const override;
 
@@ -733,13 +760,13 @@ class BoolValue final : public Filter {
 /// ranges, e.g. c >= 10, c <= 34, c BETWEEN 10 and 34. Open ranges can be
 /// implemented by using the value to the left or right of the end of the range,
 /// e.g. a < 10 is equivalent to a <= 9.
-class BigintRange final : public Filter {
+class BigintRange final : public BuiltInFilter {
  public:
   /// @param lower Lower end of the range, inclusive.
   /// @param upper Upper end of the range, inclusive.
   /// @param nullAllowed Null values are passing the filter if true.
   BigintRange(int64_t lower, int64_t upper, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kBigintRange),
+      : BuiltInFilter(true, nullAllowed, FilterKind::kBigintRange),
         lower_(lower),
         upper_(upper),
         lower32_(std::max<int64_t>(lower, std::numeric_limits<int32_t>::min())),
@@ -855,13 +882,13 @@ class BigintRange final : public Filter {
   const bool inInt16Range_;
 };
 
-class NegatedBigintRange final : public Filter {
+class NegatedBigintRange final : public BuiltInFilter {
  public:
   /// @param lower Lowest value in the rejected range, inclusive.
   /// @param upper Highest value in the range, inclusive.
   /// @param nullAllowed Null values are passing the filter if true.
   NegatedBigintRange(int64_t lower, int64_t upper, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kNegatedBigintRange),
+      : BuiltInFilter(true, nullAllowed, FilterKind::kNegatedBigintRange),
         nonNegated_(std::make_unique<BigintRange>(lower, upper, !nullAllowed)) {
   }
 
@@ -928,13 +955,13 @@ class NegatedBigintRange final : public Filter {
   std::unique_ptr<BigintRange> nonNegated_;
 };
 
-class HugeintRange final : public Filter {
+class HugeintRange final : public BuiltInFilter {
  public:
   /// @param lower Lowest value in the rejected range, inclusive.
   /// @param upper Highest value in the range, inclusive.
   /// @param nullAllowed Null values are passing the filter if true.
   HugeintRange(const int128_t& lower, const int128_t& upper, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kHugeintRange),
+      : BuiltInFilter(true, nullAllowed, FilterKind::kHugeintRange),
         lower_(lower),
         upper_(upper) {}
 
@@ -992,7 +1019,7 @@ class HugeintRange final : public Filter {
 
 /// IN-list filter for integral data types. Implemented as a hash table. Good
 /// for large number of values that do not fit within a small range.
-class BigintValuesUsingHashTable final : public Filter {
+class BigintValuesUsingHashTable final : public BuiltInFilter {
  public:
   /// @param min Minimum value.
   /// @param max Maximum value.
@@ -1008,7 +1035,7 @@ class BigintValuesUsingHashTable final : public Filter {
   BigintValuesUsingHashTable(
       const BigintValuesUsingHashTable& other,
       bool nullAllowed)
-      : Filter(true, nullAllowed, other.kind()),
+      : BuiltInFilter(true, nullAllowed, other.kind()),
         min_(other.min_),
         max_(other.max_),
         hashTable_(other.hashTable_),
@@ -1173,7 +1200,7 @@ class BigintValuesUsingHashTable final : public Filter {
 };
 
 /// IN-list filter for int128_t data type, implemented as a hash table.
-class HugeintValuesUsingHashTable final : public Filter {
+class HugeintValuesUsingHashTable final : public BuiltInFilter {
  public:
   HugeintValuesUsingHashTable(
       const int128_t& min,
@@ -1184,7 +1211,7 @@ class HugeintValuesUsingHashTable final : public Filter {
   HugeintValuesUsingHashTable(
       const HugeintValuesUsingHashTable& other,
       bool nullAllowed)
-      : Filter(true, nullAllowed, other.kind()),
+      : BuiltInFilter(true, nullAllowed, other.kind()),
         min_(other.min_),
         max_(other.max_),
         values_(other.values_) {}
@@ -1229,7 +1256,7 @@ class HugeintValuesUsingHashTable final : public Filter {
 
 /// IN-list filter for integral data types. Implemented as a bitmask. Offers
 /// better performance than the hash table when the range of values is small.
-class BigintValuesUsingBitmask final : public Filter {
+class BigintValuesUsingBitmask final : public BuiltInFilter {
  public:
   /// @param min Minimum value.
   /// @param max Maximum value.
@@ -1245,7 +1272,7 @@ class BigintValuesUsingBitmask final : public Filter {
   BigintValuesUsingBitmask(
       const BigintValuesUsingBitmask& other,
       bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingBitmask),
+      : BuiltInFilter(true, nullAllowed, FilterKind::kBigintValuesUsingBitmask),
         bitmask_(other.bitmask_),
         min_(other.min_),
         max_(other.max_) {}
@@ -1296,14 +1323,17 @@ class BigintValuesUsingBitmask final : public Filter {
   const int64_t max_;
 };
 
-class BigintValuesUsingBloomFilter final : public Filter {
+class BigintValuesUsingBloomFilter final : public BuiltInFilter {
  public:
   static int64_t numBlocks(int64_t capacity) {
     return SplitBlockBloomFilter::numBlocks(capacity, 0.01);
   }
 
   BigintValuesUsingBloomFilter(int64_t capacity, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingBloomFilter),
+      : BuiltInFilter(
+            true,
+            nullAllowed,
+            FilterKind::kBigintValuesUsingBloomFilter),
         blocks_(numBlocks(capacity)),
         filter_(blocks_) {}
 
@@ -1367,7 +1397,10 @@ class BigintValuesUsingBloomFilter final : public Filter {
   BigintValuesUsingBloomFilter(
       bool nullAllowed,
       std::vector<SplitBlockBloomFilter::Block> blocks)
-      : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingBloomFilter),
+      : BuiltInFilter(
+            true,
+            nullAllowed,
+            FilterKind::kBigintValuesUsingBloomFilter),
         blocks_(std::move(blocks)),
         filter_(blocks_) {}
 
@@ -1377,7 +1410,7 @@ class BigintValuesUsingBloomFilter final : public Filter {
 
 // NOT IN-list filter for integral data types. Implemented as a hash table. Good
 // for large number of rejected values that do not fit within a small range.
-class NegatedBigintValuesUsingHashTable final : public Filter {
+class NegatedBigintValuesUsingHashTable final : public BuiltInFilter {
  public:
   /// @param min Minimum rejected value.
   /// @param max Maximum rejected value.
@@ -1393,7 +1426,7 @@ class NegatedBigintValuesUsingHashTable final : public Filter {
   NegatedBigintValuesUsingHashTable(
       const NegatedBigintValuesUsingHashTable& other,
       bool nullAllowed)
-      : Filter(true, nullAllowed, other.kind()),
+      : BuiltInFilter(true, nullAllowed, other.kind()),
         nonNegated_(
             std::make_unique<BigintValuesUsingHashTable>(*other.nonNegated_)) {}
 
@@ -1462,7 +1495,7 @@ class NegatedBigintValuesUsingHashTable final : public Filter {
 
 /// NOT IN-list filter for integral data types. Implemented as a bitmask. Offers
 /// better performance than the hash table when the range of values is small.
-class NegatedBigintValuesUsingBitmask final : public Filter {
+class NegatedBigintValuesUsingBitmask final : public BuiltInFilter {
  public:
   /// @param min Minimum REJECTED value.
   /// @param max Maximum REJECTED value.
@@ -1477,7 +1510,7 @@ class NegatedBigintValuesUsingBitmask final : public Filter {
   NegatedBigintValuesUsingBitmask(
       const NegatedBigintValuesUsingBitmask& other,
       bool nullAllowed)
-      : Filter(true, nullAllowed, other.kind()),
+      : BuiltInFilter(true, nullAllowed, other.kind()),
         min_(other.min_),
         max_(other.max_),
         nonNegated_(
@@ -1529,7 +1562,7 @@ class NegatedBigintValuesUsingBitmask final : public Filter {
 };
 
 /// Base class for range filters on floating point and string data types.
-class AbstractRange : public Filter {
+class AbstractRange : public BuiltInFilter {
  public:
   bool lowerUnbounded() const {
     return lowerUnbounded_;
@@ -1557,7 +1590,7 @@ class AbstractRange : public Filter {
       bool upperExclusive,
       bool nullAllowed,
       FilterKind kind)
-      : Filter(true, nullAllowed, kind),
+      : BuiltInFilter(true, nullAllowed, kind),
         lowerUnbounded_(lowerUnbounded),
         lowerExclusive_(lowerUnbounded ? true : lowerExclusive),
         upperUnbounded_(upperUnbounded),
@@ -1749,7 +1782,7 @@ class FloatingPointRange final : public AbstractRange {
             upperExclusive,
             bothNullAllowed);
       }
-      case FilterKind::kUnknown:
+      case FilterKind::kUserDefined:
         return other->mergeWith(this);
       default:
         VELOX_UNREACHABLE();
@@ -2056,7 +2089,7 @@ class BytesRange final : public AbstractRange {
 };
 
 // Negated range filter for strings
-class NegatedBytesRange final : public Filter {
+class NegatedBytesRange final : public BuiltInFilter {
  public:
   /// @param lower Lower end of the rejected range.
   /// @param lowerUnbounded True if lower end is "negative infinity" in which
@@ -2077,7 +2110,7 @@ class NegatedBytesRange final : public Filter {
       bool upperUnbounded,
       bool upperExclusive,
       bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kNegatedBytesRange) {
+      : BuiltInFilter(true, nullAllowed, FilterKind::kNegatedBytesRange) {
     nonNegated_ = std::make_unique<BytesRange>(
         std::move(lower),
         lowerUnbounded,
@@ -2089,7 +2122,7 @@ class NegatedBytesRange final : public Filter {
   }
 
   NegatedBytesRange(const NegatedBytesRange& other, bool nullAllowed)
-      : Filter(true, nullAllowed, other.kind()),
+      : BuiltInFilter(true, nullAllowed, other.kind()),
         nonNegated_(std::make_unique<BytesRange>(*other.nonNegated_)) {}
 
   folly::dynamic serialize() const override;
@@ -2178,7 +2211,7 @@ class NegatedBytesRange final : public Filter {
 /// Open ranges can be implemented by using the value to the left
 /// or right of the end of the range, e.g. a < timestamp '2023-07-19
 /// 17:00:00.777' is equivalent to a <= timestamp '2023-07-19 17:00:00.776'.
-class TimestampRange : public Filter {
+class TimestampRange : public BuiltInFilter {
  public:
   /// @param lower Lower end of the range, inclusive.
   /// @param upper Upper end of the range, inclusive.
@@ -2187,7 +2220,7 @@ class TimestampRange : public Filter {
       const Timestamp& lower,
       const Timestamp& upper,
       bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kTimestampRange),
+      : BuiltInFilter(true, nullAllowed, FilterKind::kTimestampRange),
         lower_(lower),
         upper_(upper),
         singleValue_(lower_ == upper) {}
@@ -2252,13 +2285,13 @@ class TimestampRange : public Filter {
 };
 
 /// IN-list filter for string data type.
-class BytesValues final : public Filter {
+class BytesValues final : public BuiltInFilter {
  public:
   /// @param values List of values that pass the filter. Must contain at least
   /// one entry.
   /// @param nullAllowed Null values are passing the filter if true.
   BytesValues(const std::vector<std::string>& values, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kBytesValues) {
+      : BuiltInFilter(true, nullAllowed, FilterKind::kBytesValues) {
     VELOX_CHECK(!values.empty(), "values must not be empty");
 
     for (const auto& value : values) {
@@ -2271,7 +2304,7 @@ class BytesValues final : public Filter {
   }
 
   BytesValues(const BytesValues& other, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kBytesValues),
+      : BuiltInFilter(true, nullAllowed, FilterKind::kBytesValues),
         lower_(other.lower_),
         upper_(other.upper_),
         values_(other.values_),
@@ -2322,7 +2355,7 @@ class BytesValues final : public Filter {
 /// Represents a combination of two of more range filters on integral types with
 /// OR semantics. The filter passes if at least one of the contained filters
 /// passes.
-class BigintMultiRange final : public Filter {
+class BigintMultiRange final : public BuiltInFilter {
  public:
   /// @param ranges List of range filters. Must contain at least two entries.
   /// Ranges must be sorted in ascending order and must not overlap.
@@ -2361,19 +2394,19 @@ class BigintMultiRange final : public Filter {
 };
 
 /// NOT IN-list filter for string data type.
-class NegatedBytesValues final : public Filter {
+class NegatedBytesValues final : public BuiltInFilter {
  public:
   /// @param values List of values that fail the filter. Must contain at least
   /// one entry.
   /// @param nullAllowed Null values are passing the filter if true.
   NegatedBytesValues(const std::vector<std::string>& values, bool nullAllowed)
-      : Filter(true, nullAllowed, FilterKind::kNegatedBytesValues) {
+      : BuiltInFilter(true, nullAllowed, FilterKind::kNegatedBytesValues) {
     VELOX_CHECK(!values.empty(), "values must not be empty");
     nonNegated_ = std::make_unique<BytesValues>(values, !nullAllowed);
   }
 
   NegatedBytesValues(const NegatedBytesValues& other, bool nullAllowed)
-      : Filter(true, nullAllowed, other.kind()),
+      : BuiltInFilter(true, nullAllowed, other.kind()),
         nonNegated_(std::make_unique<BytesValues>(*other.nonNegated_)) {}
 
   folly::dynamic serialize() const override;
@@ -2420,7 +2453,7 @@ class NegatedBytesValues final : public Filter {
 /// Represents a combination of two of more filters with
 /// OR semantics. The filter passes if at least one of the contained filters
 /// passes.
-class MultiRange final : public Filter {
+class MultiRange final : public BuiltInFilter {
  public:
   /// @param ranges List of range filters. Must contain at least two entries.
   /// All entries must support the same data types.
@@ -2432,7 +2465,7 @@ class MultiRange final : public Filter {
       std::vector<std::unique_ptr<Filter>> filters,
       bool nullAllowed,
       bool nanAllowed = false)
-      : Filter(true, nullAllowed, FilterKind::kMultiRange),
+      : BuiltInFilter(true, nullAllowed, FilterKind::kMultiRange),
         filters_(std::move(filters)) {}
 
   folly::dynamic serialize() const override;

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1693,9 +1693,13 @@ void testMergeWithBytes(Filter* left, Filter* right) {
   }
 }
 
-class MyFilter final : public Filter {
+class MyFilter final : public UserDefinedFilter {
  public:
-  MyFilter() : Filter(true, false, FilterKind::kUnknown) {}
+  MyFilter() : UserDefinedFilter(true, false) {}
+
+  std::string_view serializedName() const final {
+    return "MyFilter";
+  }
 
   std::unique_ptr<Filter> clone(
       std::optional<bool> /*nullAllowed*/ = std::nullopt) const final {
@@ -1703,11 +1707,11 @@ class MyFilter final : public Filter {
   }
 
   bool testingEquals(const Filter& other) const final {
-    return other.kind() == FilterKind::kUnknown;
+    return other.kind() == FilterKind::kUserDefined;
   }
 
   folly::dynamic serialize() const final {
-    return folly::dynamic::object();
+    return serializeBase();
   }
 
   std::unique_ptr<Filter> mergeWith(const Filter* other) const final {
@@ -1735,7 +1739,9 @@ TEST(FilterTest, mergeWithUntyped) {
   }
 }
 
-TEST(FilterTest, mergeWithUnknown) {
+TEST(FilterTest, mergeWithUserDefined) {
+  EXPECT_EQ(MyFilter().serialize()["name"], "MyFilter");
+
   std::vector<std::unique_ptr<Filter>> filters;
   filters.push_back(std::make_unique<BoolValue>(true, false));
   filters.push_back(between(1, 10));

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1692,6 +1692,36 @@ void testMergeWithBytes(Filter* left, Filter* right) {
         << ", merged: " << merged->toString();
   }
 }
+
+class MyFilter final : public Filter {
+ public:
+  MyFilter() : Filter(true, false, FilterKind::kUnknown) {}
+
+  std::unique_ptr<Filter> clone(
+      std::optional<bool> /*nullAllowed*/ = std::nullopt) const final {
+    return std::make_unique<MyFilter>();
+  }
+
+  bool testingEquals(const Filter& other) const final {
+    return other.kind() == FilterKind::kUnknown;
+  }
+
+  folly::dynamic serialize() const final {
+    return folly::dynamic::object();
+  }
+
+  std::unique_ptr<Filter> mergeWith(const Filter* other) const final {
+    lastMergedFilterKind_ = other->kind();
+    return other->clone();
+  }
+
+  std::optional<FilterKind> lastMergedFilterKind() const {
+    return lastMergedFilterKind_;
+  }
+
+ private:
+  mutable std::optional<FilterKind> lastMergedFilterKind_;
+};
 } // namespace
 
 TEST(FilterTest, mergeWithUntyped) {
@@ -1702,6 +1732,34 @@ TEST(FilterTest, mergeWithUntyped) {
     for (const auto& right : filters) {
       testMergeWithUntyped(left.get(), right.get());
     }
+  }
+}
+
+TEST(FilterTest, mergeWithUnknown) {
+  std::vector<std::unique_ptr<Filter>> filters;
+  filters.push_back(std::make_unique<BoolValue>(true, false));
+  filters.push_back(between(1, 10));
+  filters.push_back(betweenDouble(1, 10));
+  filters.push_back(
+      std::make_unique<TimestampRange>(
+          Timestamp(1, 0), Timestamp(10, 0), false));
+  filters.push_back(between("a", "z"));
+
+  std::vector<std::unique_ptr<Filter>> ranges;
+  ranges.push_back(betweenDouble(1, 10));
+  ranges.push_back(betweenDouble(20, 30));
+  filters.push_back(std::make_unique<MultiRange>(std::move(ranges), false));
+
+  for (const auto& filter : filters) {
+    MyFilter unknownRight;
+    auto merged = filter->mergeWith(&unknownRight);
+    EXPECT_EQ(unknownRight.lastMergedFilterKind(), filter->kind());
+    EXPECT_EQ(merged->kind(), filter->kind());
+
+    MyFilter unknownLeft;
+    auto reverseMerged = unknownLeft.mergeWith(filter.get());
+    EXPECT_EQ(unknownLeft.lastMergedFilterKind(), filter->kind());
+    EXPECT_EQ(reverseMerged->kind(), filter->kind());
   }
 }
 


### PR DESCRIPTION
Currently, Velox has the public API `ExprToSubfieldFilterParser`, which allows users to register their own filter-pushdown logic for user expressions. However, the FilterKind list now only matches the built-in Filter implementations under `velox/type/Filter{.h/.cpp}`, which is not extensible to user. The patch adds a new FilterKind `kUserDefined`,  to help downstream users to create their own filter implementations, and push them into Velox scan through the registered `ExprToSubfieldFilterParser`.

For example, user will be able to add filter implementations in their own code:

```cpp
class MyFilter final : public UserDefinedFilter {
 public:
  MyFilter() : Filter(true, false, FilterKind::kUnknown) {}

  std::string_view serializedName() const final {
    return "MyFilter";
  }
  // ...
};
```

and translate `my_filter` function call to it in the user filter parser:

```cpp
class MyFilterParser final : public ExprToSubfieldFilterParser {
 public:
  std::optional<std::pair<Subfield, std::unique_ptr<Filter>>>
  leafCallToSubfieldFilter(const CallTypedExpr& call, ExpressionEvaluator*, bool) override {
    if (call.name() == "my_filter") {
      return std::make_pair(subfield, std::make_unique<MyFilter>());
    }
    return std::nullopt;
  }
  // ...
};

```

Related: https://github.com/facebookincubator/velox/issues/18084