### PR TITLE
fix(hive): Round-trip all FileProperties in split serde (#18481)

### DIFF
--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -18,6 +18,7 @@ velox_add_library(
   CacheTTLController.cpp
   FileHandle.cpp
   FileIds.cpp
+  FileProperties.cpp
   ScanTracker.cpp
   SsdCache.cpp
   SsdFile.cpp

--- a/velox/common/caching/FileProperties.cpp
+++ b/velox/common/caching/FileProperties.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/FileProperties.h"
+
+namespace facebook::velox {
+
+folly::dynamic FileProperties::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["fileSize"] =
+      fileSize.has_value() ? folly::dynamic(fileSize.value()) : nullptr;
+  obj["modificationTime"] = modificationTime.has_value()
+      ? folly::dynamic(modificationTime.value())
+      : nullptr;
+  obj["readRangeHint"] = readRangeHint.has_value()
+      ? folly::dynamic(readRangeHint.value())
+      : nullptr;
+  obj["extraFileInfo"] =
+      extraFileInfo == nullptr ? nullptr : folly::dynamic(*extraFileInfo);
+
+  folly::dynamic fileReadOpsObj = folly::dynamic::object;
+  for (const auto& [key, value] : fileReadOps) {
+    fileReadOpsObj[key] = value;
+  }
+  obj["fileReadOps"] = fileReadOpsObj;
+
+  return obj;
+}
+
+namespace {
+std::optional<int64_t> optionalInt(const folly::dynamic& obj, const char* key) {
+  const auto& value = obj.getDefault(key, nullptr);
+  return value.isNull() ? std::nullopt : std::optional<int64_t>(value.asInt());
+}
+} // namespace
+
+// static
+FileProperties FileProperties::create(const folly::dynamic& obj) {
+  FileProperties properties;
+  properties.fileSize = optionalInt(obj, "fileSize");
+  properties.modificationTime = optionalInt(obj, "modificationTime");
+  properties.readRangeHint = optionalInt(obj, "readRangeHint");
+
+  const auto& extraFileInfoObj = obj.getDefault("extraFileInfo", nullptr);
+  if (!extraFileInfoObj.isNull()) {
+    properties.extraFileInfo =
+        std::make_shared<std::string>(extraFileInfoObj.asString());
+  }
+
+  const auto& fileReadOpsObj = obj.getDefault("fileReadOps", nullptr);
+  if (!fileReadOpsObj.isNull()) {
+    for (const auto& [key, value] : fileReadOpsObj.items()) {
+      properties.fileReadOps[key.asString()] = value.asString();
+    }
+  }
+
+  return properties;
+}
+
+} // namespace facebook::velox

--- a/velox/common/caching/FileProperties.h
+++ b/velox/common/caching/FileProperties.h
@@ -21,6 +21,7 @@
 #include <optional>
 
 #include <folly/container/F14Map.h>
+#include <folly/dynamic.h>
 
 namespace facebook::velox {
 
@@ -34,7 +35,16 @@ struct FileProperties {
   std::optional<int64_t> readRangeHint{std::nullopt};
   std::shared_ptr<std::string> extraFileInfo{nullptr};
   folly::F14FastMap<std::string, std::string> fileReadOps{};
+
+  /// Non-owning pointer to the statistics of the data source that opened the
+  /// file. Set locally by the reader at open time, so 'serialize()' skips it.
   io::IoStatistics* ioStatistics{nullptr};
+
+  folly::dynamic serialize() const;
+
+  /// Reads what 'serialize()' wrote. Absent keys fall back to the member
+  /// default.
+  static FileProperties create(const folly::dynamic& obj);
 };
 
 } // namespace facebook::velox

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -89,14 +89,7 @@ folly::dynamic HiveConnectorSplit::serialize() const {
   obj["infoColumns"] = infoColumnsObj;
 
   if (properties.has_value()) {
-    folly::dynamic propertiesObj = folly::dynamic::object;
-    propertiesObj["fileSize"] = properties->fileSize.has_value()
-        ? folly::dynamic(properties->fileSize.value())
-        : nullptr;
-    propertiesObj["modificationTime"] = properties->modificationTime.has_value()
-        ? folly::dynamic(properties->modificationTime.value())
-        : nullptr;
-    obj["properties"] = propertiesObj;
+    obj["properties"] = properties->serialize();
   }
 
   if (rowIdProperties.has_value()) {
@@ -173,13 +166,7 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
   std::optional<FileProperties> properties = std::nullopt;
   const auto& propertiesObj = obj.getDefault("properties", nullptr);
   if (propertiesObj != nullptr) {
-    properties = FileProperties{
-        .fileSize = propertiesObj["fileSize"].isNull()
-            ? std::nullopt
-            : std::optional(propertiesObj["fileSize"].asInt()),
-        .modificationTime = propertiesObj["modificationTime"].isNull()
-            ? std::nullopt
-            : std::optional(propertiesObj["modificationTime"].asInt())};
+    properties = FileProperties::create(propertiesObj);
   }
 
   std::optional<RowIdProperties> rowIdProperties = std::nullopt;

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -105,6 +105,17 @@ class HiveConnectorSerDeTest : public exec::test::HiveConnectorTestBase {
       ASSERT_EQ(
           split.properties->modificationTime,
           clone->properties->modificationTime);
+      ASSERT_EQ(
+          split.properties->readRangeHint, clone->properties->readRangeHint);
+      if (split.properties->extraFileInfo != nullptr) {
+        ASSERT_NE(clone->properties->extraFileInfo, nullptr);
+        ASSERT_EQ(
+            *split.properties->extraFileInfo,
+            *clone->properties->extraFileInfo);
+      } else {
+        ASSERT_EQ(clone->properties->extraFileInfo, nullptr);
+      }
+      ASSERT_EQ(split.properties->fileReadOps, clone->properties->fileReadOps);
     } else {
       ASSERT_FALSE(clone->properties.has_value());
     }
@@ -270,7 +281,11 @@ TEST_F(HiveConnectorSerDeTest, hiveConnectorSplit) {
   const std::unordered_map<std::string, std::string> infoColumns{
       {"c0", "0"}, {"c1", "1"}};
   FileProperties fileProperties{
-      .fileSize = 2048, .modificationTime = std::nullopt};
+      .fileSize = 2048,
+      .modificationTime = std::nullopt,
+      .readRangeHint = std::nullopt,
+      .extraFileInfo = nullptr,
+      .fileReadOps = {}};
   const auto properties = std::optional<FileProperties>(fileProperties);
   RowIdProperties rowIdProperties{
       .metadataVersion = 2, .partitionId = 3, .tableGuid = "test"};
@@ -317,6 +332,37 @@ TEST_F(HiveConnectorSerDeTest, hiveConnectorSplit) {
   handles.push_back(makeColumnHandle("c0", INTEGER(), {}));
   split3.bucketConversion = {16, 2, std::move(handles)};
   testSerde(split3);
+}
+
+TEST_F(HiveConnectorSerDeTest, hiveConnectorSplitFileProperties) {
+  std::string descriptor;
+  for (int i = 0; i < 256; ++i) {
+    descriptor.push_back(static_cast<char>(i));
+  }
+
+  auto split = HiveConnectorSplit(
+      "testSerde", "/testSerde/p", dwio::common::FileFormat::DWRF);
+  split.properties = FileProperties{
+      .fileSize = 2048,
+      .modificationTime = 1024,
+      .readRangeHint = 4096,
+      .extraFileInfo = std::make_shared<std::string>(descriptor),
+      .fileReadOps = {{"o0", "0"}, {"o1", "1"}}};
+  testSerde(split);
+
+  // A producer that predates these keys omits them rather than writing nulls.
+  auto obj = split.serialize();
+  obj["properties"].erase("readRangeHint");
+  obj["properties"].erase("extraFileInfo");
+  obj["properties"].erase("fileReadOps");
+
+  const auto clone = ISerializable::deserialize<HiveConnectorSplit>(obj);
+  ASSERT_TRUE(clone->properties.has_value());
+  EXPECT_EQ(clone->properties->fileSize, 2048);
+  EXPECT_EQ(clone->properties->modificationTime, 1024);
+  EXPECT_FALSE(clone->properties->readRangeHint.has_value());
+  EXPECT_EQ(clone->properties->extraFileInfo, nullptr);
+  EXPECT_TRUE(clone->properties->fileReadOps.empty());
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

`HiveConnectorSplit::serialize()` wrote only `fileSize` and `modificationTime` out of `properties`, dropping `extraFileInfo`, `readRangeHint` and `fileReadOps`. An engine that ships splits to its workers as JSON loses them, so a split that carried a pre-resolved file descriptor on the coordinator reaches the worker with `properties->extraFileInfo == nullptr` and the file system opens the file by name instead.

Serialize the three missing fields, encoding `extraFileInfo` the same way the split's existing top-level `extraFileInfo` is encoded. `create()` reads the new keys defensively, so a split serialized by a producer that predates them still deserializes.

Reviewed By: arhimondr

Differential Revision: D115531582


