### PR TITLE
refactor(test): Rename outputType to targetColumns

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -408,9 +408,10 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
   auto upstreamNode = planBuilder_.planNode();
   VELOX_CHECK_NOT_NULL(upstreamNode, "TableWrite cannot be the source node");
 
-  // If outputType wasn't explicit specified, fallback to use the output of the
-  // upstream operator.
-  auto outputType = outputType_ ? outputType_ : upstreamNode->outputType();
+  // If targetColumns wasn't explicit specified, fallback to use the output of
+  // the upstream operator.
+  auto targetColumns =
+      targetColumns_ ? targetColumns_ : upstreamNode->outputType();
 
   // If insertHandle_ is not specified, build a HiveInsertTableHandle along with
   // columnHandles, bucketProperty and locationHandle.
@@ -418,8 +419,8 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
     // Create column handles.
     std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
         columnHandles;
-    for (auto i = 0; i < outputType->size(); ++i) {
-      const auto column = outputType->nameOf(i);
+    for (auto i = 0; i < targetColumns->size(); ++i) {
+      const auto column = targetColumns->nameOf(i);
       const bool isPartitionKey =
           std::find(partitionBy_.begin(), partitionBy_.end(), column) !=
           partitionBy_.end();
@@ -429,8 +430,8 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
               isPartitionKey
                   ? connector::hive::FileColumnHandle::ColumnType::kPartitionKey
                   : connector::hive::FileColumnHandle::ColumnType::kRegular,
-              outputType->childAt(i),
-              outputType->childAt(i)));
+              targetColumns->childAt(i),
+              targetColumns->childAt(i)));
     }
 
     auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
@@ -442,7 +443,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
     std::shared_ptr<HiveBucketProperty> bucketProperty;
     if (bucketCount_ != 0) {
       bucketProperty = buildHiveBucketProperty(
-          outputType, bucketCount_, bucketedBy_, sortBy_);
+          targetColumns, bucketCount_, bucketedBy_, sortBy_);
     }
 
     auto hiveHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
@@ -468,7 +469,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
     for (const auto& partitionBy : partitionBy_) {
       groupingKeys.push_back(
           std::make_shared<core::FieldAccessTypedExpr>(
-              outputType->findChild(partitionBy), partitionBy));
+              targetColumns->findChild(partitionBy), partitionBy));
     }
     columnStatsSpec = core::ColumnStatsSpec(
         std::move(groupingKeys),
@@ -478,8 +479,8 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
   }
   const auto writeNode = std::make_shared<core::TableWriteNode>(
       id,
-      outputType,
-      outputType->names(),
+      targetColumns,
+      targetColumns->names(),
       columnStatsSpec,
       insertHandle_,
       false,
@@ -806,7 +807,7 @@ PlanBuilder& PlanBuilder::tableWrite(
   return TableWriterBuilder(*this)
       .outputDirectoryPath(outputDirectoryPath)
       .outputFileName(outputFileName)
-      .outputType(schema)
+      .targetColumns(schema)
       .partitionBy(partitionBy)
       .bucketCount(bucketCount)
       .bucketedBy(bucketedBy)

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -504,11 +504,11 @@ class PlanBuilder {
    public:
     explicit TableWriterBuilder(PlanBuilder& builder) : planBuilder_(builder) {}
 
-    /// @param outputType The schema that will be written to the output file. It
-    /// may reference a subset or change the order of columns from the input
-    /// (upstream operator output).
-    TableWriterBuilder& outputType(RowTypePtr outputType) {
-      outputType_ = std::move(outputType);
+    /// @param targetColumns The target table's columns, in the order they are
+    /// written to the output file. It may reference a subset or change the
+    /// order of columns from the input (upstream operator output).
+    TableWriterBuilder& targetColumns(RowTypePtr targetColumns) {
+      targetColumns_ = std::move(targetColumns);
       return *this;
     }
 
@@ -629,7 +629,7 @@ class PlanBuilder {
     core::PlanNodePtr build(core::PlanNodeId id);
 
     PlanBuilder& planBuilder_;
-    RowTypePtr outputType_;
+    RowTypePtr targetColumns_;
     std::string outputDirectoryPath_;
     std::string outputFileName_;
     std::string connectorId_{kHiveDefaultConnectorId};

--- a/velox/python/plan_builder/PyPlanBuilder.cpp
+++ b/velox/python/plan_builder/PyPlanBuilder.cpp
@@ -72,7 +72,7 @@ PyPlanBuilder& PyPlanBuilder::tableWrite(
     if (outputRowSchema == nullptr) {
       throw std::runtime_error("Output schema must be a ROW().");
     }
-    builder.outputType(outputRowSchema);
+    builder.targetColumns(outputRowSchema);
   }
 
   if (!outputFile && !outputPath) {

--- a/velox/python/plan_builder/PyPlanBuilder.cpp
+++ b/velox/python/plan_builder/PyPlanBuilder.cpp
@@ -16,8 +16,6 @@
 
 #include "velox/python/plan_builder/PyPlanBuilder.h"
 
-#include <folly/executors/GlobalExecutor.h>
-#include <pybind11/stl.h>
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
@@ -29,8 +27,6 @@
 #include "velox/tpch/gen/TpchGen.h"
 
 namespace facebook::velox::py {
-
-namespace py = pybind11;
 
 PyPlanNode::PyPlanNode(
     core::PlanNodePtr planNode,


### PR DESCRIPTION
`PlanBuilder::TableWriterBuilder::outputType()` sets the columns of the target table. Those columns become `TableWriteNode`'s `columns` and `columnNames`. But `TableWriteNode::outputType()` is a different schema: the write metadata columns `rows`, `fragments`, and `commitcontext`. Reading a table-write plan, one name meant two unrelated things. The setter and its field are now `targetColumns()` and `targetColumns_`.

Deleted the unused include and alias in PyPlanBuilder.cpp