### PR TITLE
fix(parquet): Flatten nested constant-of-complex before Arrow export

### DIFF
--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1922,6 +1922,63 @@ TEST_F(ParquetWriterTest, flatComplexWithEncodedDescendantFlattens) {
   assertFlattenedRoundTrip(makeRowVector({structColumn, arrayColumn}));
 }
 
+// Verifies that a flat complex column whose descendant is a CONSTANT wrapping a
+// non-flat (complex) vector is flattened before Arrow export. The constant
+// analogue of flatComplexWithEncodedDescendantFlattens:
+// descendantNeedsFlatten() recurses into ARRAY/MAP/ROW children and must
+// flatten a nested constant-of-complex. Otherwise it reaches the
+// Velox-to-Arrow bridge's flattenConstant path, which supports only constants
+// over flat scalar values, and export fails with "An unsupported nested
+// encoding was found".
+TEST_F(ParquetWriterTest, flatComplexWithConstantOfComplexDescendantFlattens) {
+  constexpr vector_size_t kSize = 500;
+  constexpr int kInnerSize = 10;
+
+  // Builds a CONSTANT wrapping a dictionary over an ARRAY<INTEGER>, so the
+  // constant's wrapped vector is non-flat (ARRAY) -- the same shape as
+  // constantWrappingDictionaryFlattens, but here nested inside a flat complex
+  // column rather than at the top level. Builds fresh vectors on each call:
+  // flattening a complex vector rewrites its children in place, so the expected
+  // (flattened) output must not alias the written input.
+  auto makeConstantOfComplex = [&](vector_size_t size) {
+    auto innerArray = makeArrayVector<int32_t>(
+        kInnerSize,
+        [](auto row) { return row % 3 + 1; },
+        [](auto row) { return static_cast<int32_t>(row); });
+    auto dictOfArray = makeDictionaryColumn(
+        kInnerSize, innerArray, [](auto row) { return row; });
+    auto constVector = BaseVector::wrapInConstant(size, 0, dictOfArray);
+    EXPECT_EQ(constVector->encoding(), VectorEncoding::Simple::CONSTANT);
+    EXPECT_FALSE(constVector->wrappedVector()->isFlatEncoding());
+    return constVector;
+  };
+
+  std::vector<vector_size_t> offsets(kSize);
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    offsets[i] = i;
+  }
+
+  // A flat ROW column and a flat ARRAY column, each carrying a
+  // constant-of-complex descendant.
+  auto data = makeRowVector(
+      {makeRowVector({makeConstantOfComplex(kSize)}),
+       makeArrayVector(offsets, makeConstantOfComplex(kSize))});
+  ASSERT_EQ(data->childAt(0)->encoding(), VectorEncoding::Simple::ROW);
+  ASSERT_EQ(data->childAt(1)->encoding(), VectorEncoding::Simple::ARRAY);
+
+  // Build the expected output from independent vectors, then flatten them.
+  // assertFlattenedRoundTrip() cannot be used here: its flatten() helper
+  // rewrites the input's children in place, which would pre-flatten 'data' and
+  // mask the regression (the writer would never see the nested constant).
+  VectorPtr expectedStruct = makeRowVector({makeConstantOfComplex(kSize)});
+  VectorPtr expectedArray =
+      makeArrayVector(offsets, makeConstantOfComplex(kSize));
+  BaseVector::flattenVector(expectedStruct);
+  BaseVector::flattenVector(expectedArray);
+
+  assertRoundTrip(data, makeRowVector({expectedStruct, expectedArray}));
+}
+
 // Verifies selective per-column flattening: a dict-of-dict column (must
 // flatten) alongside a passthrough dictionary column (must NOT flatten).
 // With blanket flattening, both would be materialized. With selective

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -633,33 +633,45 @@ void Writer::setMemoryReclaimers() {
 
 namespace {
 
-// Returns true if 'vector' or any of its descendants is dictionary-encoded.
-// Used to detect dictionary encoding nested inside a top-level complex column
-// (ARRAY/MAP/ROW). Constant descendants are exported densely by the Arrow
-// bridge (flattenConstant=true) and therefore do not need to be checked here.
-bool hasDictionaryDescendant(const VectorPtr& vector) {
+// Returns true if 'vector' or any of its descendants must be flattened before
+// Arrow export. Used to detect encodings nested inside a top-level complex
+// column (ARRAY/MAP/ROW) that the Velox-to-Arrow bridge cannot export:
+//   - A dictionary-encoded descendant would be exported as an Arrow
+//     DictionaryArray, which is only safe for top-level scalar columns.
+//   - A constant wrapping a non-flat vector (constant-of-complex or
+//     constant-of-dictionary) reaches the bridge's flattenConstant path, which
+//     only supports constants over flat scalar values and otherwise fails with
+//     "An unsupported nested encoding was found".
+bool descendantNeedsFlatten(const VectorPtr& vector) {
   if (vector == nullptr) {
     return false;
   }
   switch (vector->encoding()) {
     case VectorEncoding::Simple::DICTIONARY:
       return true;
+    case VectorEncoding::Simple::CONSTANT:
+      // Mirror the top-level constant handling in childNeedsFlatten(): a
+      // constant over a non-flat vector must be flattened, while a constant
+      // over a flat scalar (or a null constant with no value vector) is
+      // exported densely and needs no flattening.
+      return vector->valueVector() != nullptr &&
+          !vector->wrappedVector()->isFlatEncoding();
     case VectorEncoding::Simple::ROW: {
       const auto* row = vector->asUnchecked<RowVector>();
       for (const auto& child : row->children()) {
-        if (hasDictionaryDescendant(child)) {
+        if (descendantNeedsFlatten(child)) {
           return true;
         }
       }
       return false;
     }
     case VectorEncoding::Simple::ARRAY:
-      return hasDictionaryDescendant(
+      return descendantNeedsFlatten(
           vector->asUnchecked<ArrayVector>()->elements());
     case VectorEncoding::Simple::MAP: {
       const auto* map = vector->asUnchecked<MapVector>();
-      return hasDictionaryDescendant(map->mapKeys()) ||
-          hasDictionaryDescendant(map->mapValues());
+      return descendantNeedsFlatten(map->mapKeys()) ||
+          descendantNeedsFlatten(map->mapValues());
     }
     default:
       return false;
@@ -710,12 +722,13 @@ bool childNeedsFlatten(const VectorPtr& child) {
       return true;
     }
   } else if (!child->type()->isPrimitiveType()) {
-    // A flat complex column (ARRAY/MAP/ROW) is not itself flattened, but the
-    // Velox-to-Arrow bridge exports dictionary-encoded descendants as Arrow
-    // DictionaryArrays (flattenDictionary=false). Dictionary passthrough is
-    // only safe for top-level scalar VARCHAR/VARBINARY columns, so flatten the
-    // whole column if any descendant is dictionary-encoded.
-    return hasDictionaryDescendant(child);
+    // A flat complex column (ARRAY/MAP/ROW) is not itself flattened, but a
+    // dictionary- or constant-encoded descendant would break Arrow export:
+    // dictionary passthrough is only safe for top-level scalar
+    // VARCHAR/VARBINARY columns, and the bridge cannot flatten a nested
+    // constant over a complex vector. Flatten the whole column if any
+    // descendant requires it.
+    return descendantNeedsFlatten(child);
   }
   return false;
 }


### PR DESCRIPTION
## Description

facebookincubator/velox#17986 replaced blanket flattening in the Parquet writer
with selective flattening (`flattenDictionary=false`, dictionary passthrough).
It added a detector (`hasDictionaryDescendant()`) to find encodings nested
inside a flat top-level complex column (ARRAY/MAP/ROW) and flatten only the
columns that need it.

That detector recurses through ROW/ARRAY/MAP and returns `true` on DICTIONARY,
but its `default` case returns `false` — so it **skips CONSTANT descendants**.
A CONSTANT wrapping a non-flat vector (constant-of-complex, or
constant-of-dictionary) nested inside a flat complex column is therefore not
flattened.

The Parquet writer exports with `flattenConstant = true` (`Writer.h`), so at
export the nested constant is routed to the Velox-to-Arrow bridge's
`exportFlattenedVector()`, which supports only constants over flat scalar
values:

```cpp
VELOX_CHECK(
    vec.valueVector() == nullptr || vec.wrappedVector()->isFlatEncoding(),
    "An unsupported nested encoding was found.");
```

`wrappedVector()` peels the constant (and any dictionary) down to the innermost
vector; for a constant-of-complex that is an ARRAY/MAP/ROW, whose
`isFlatEncoding()` is false, so the write aborts with `An unsupported nested
encoding was found`.

Note the asymmetry: `childNeedsFlatten()` already handles a **top-level**
constant-of-non-flat (it flattens when `!child->wrappedVector()->isFlatEncoding()`),
but the nested detector did not — so only the *nested-inside-complex* case
regressed.

Surfaced when advancing the pinned Velox in Apache Gluten, which writes complex
columns containing constant-encoded descendants.

## Fix

Rename `hasDictionaryDescendant()` to `descendantNeedsFlatten()` (it no longer
detects only dictionaries) and add a CONSTANT case that mirrors the existing
top-level handling in `childNeedsFlatten()`: a constant needs flattening iff it
has a value vector and its wrapped (fully peeled) vector is not flat. Constants
with no value vector (dense null constants) or wrapping a flat scalar are
exported densely and need no flattening.

## Test

Added `ParquetWriterTest.flatComplexWithConstantOfComplexDescendantFlattens` —
the constant analogue of the existing `flatComplexWithEncodedDescendantFlattens`
(nested dictionary) and `constantWrappingDictionaryFlattens` (top-level
constant). It writes a flat ROW column and a flat ARRAY column that each carry a
constant-of-complex descendant, and asserts the data round-trips flattened. The
expected output is built from independent vectors, since flattening a complex
vector rewrites its children in place. The test fails on `main` with `An
unsupported nested encoding was found` and passes with this fix.

cc @iemejia @rui-mo @majetideepak
