### PR TITLE
refactor: Allow subclassing ConcurrentRuntimeStatWriter

### DIFF
--- a/velox/common/base/ConcurrentRuntimeStatWriter.h
+++ b/velox/common/base/ConcurrentRuntimeStatWriter.h
@@ -28,7 +28,7 @@ namespace facebook::velox {
 /// Accumulates runtime metrics by name behind a lock, and exposes a snapshot.
 /// Unlike writers that forward each sample to an owning operator, this one owns
 /// the values, so any number of threads may record into it concurrently.
-class ConcurrentRuntimeStatWriter final : public BaseRuntimeStatWriter {
+class ConcurrentRuntimeStatWriter : public BaseRuntimeStatWriter {
  public:
   /// Merges 'value' under 'name'. All samples under a name must share the same
   /// unit; a mismatched unit throws.


### PR DESCRIPTION
Summary:
A per-query stats collector that wants the same accumulate-by-name behavior currently has to hold a `ConcurrentRuntimeStatWriter` member and forward every method to it. Removing `final` lets it derive instead.

Copy and assignment go at the same time. The class is held by reference, so a copy silently detaches from the collector everyone else is writing to, and as a polymorphic base it would also allow slice-assignment through a base reference.

Differential Revision: D115817317


