### PR TITLE
fix(ci): Accept the current Meta copyright line in the license header check

### DIFF
--- a/scripts/checks/license-header.py
+++ b/scripts/checks/license-header.py
@@ -119,6 +119,50 @@ file_types = OrderedDict(
     }
 )
 
+# Copyright lines that also count as an existing license header. The canonical
+# line lives in the header file passed via --header and is the one written into
+# files that have none. These variants are only recognised, never inserted, so
+# that code imported with an equally valid Meta copyright line is not given a
+# second header on top of the one it already carries.
+ALTERNATE_COPYRIGHT_LINES = [
+    " Copyright (c) Meta Platforms, Inc. and affiliates.",
+]
+
+
+def header_variants(header_text):
+    """Canonical header first, then the same header with each accepted
+    copyright line substituted for the first."""
+    return [header_text] + [
+        [line] + header_text[1:] for line in ALTERNATE_COPYRIGHT_LINES
+    ]
+
+
+def find_header(content, header_comment, args):
+    """Locate an existing license header, exactly or fuzzily. Returns the
+    (start, end) span of the match, or None."""
+    found = content.find(header_comment, 0, len(header_comment) + args.extra)
+    if found >= 0:
+        return found, found + len(header_comment)
+
+    # Look for a fuzzy match in the first 60 chars.
+    found = regex.search(
+        "(?be)(%s){e<=%d}" % (regex.escape(header_comment[0:60]), 6),
+        content[0 : 80 + args.extra],
+    )
+    if not found:
+        return None
+
+    # If the first 80 chars match, try harder for the rest of the header.
+    fuzzy = regex.compile(
+        "(?be)(%s){e<=%d}" % (regex.escape(header_comment), args.editdist)
+    )
+    found = fuzzy.search(content[0 : len(header_comment) + args.extra], found.start())
+    if not found:
+        return None
+
+    return found.start(), found.end()
+
+
 file_pattern = regex.compile(
     "|".join(
         [
@@ -169,6 +213,7 @@ def main():
             log_to = sys.stdout
 
     header_text = file_lines(args.header)
+    variants = header_variants(header_text)
 
     if len(args.files) == 1 and args.files[0] == "-":
         files = [file.strip() for file in sys.stdin.readlines()]
@@ -192,36 +237,20 @@ def main():
         start = 0
         end = 0
 
-        # Look for an exact substr match
-        #
-        found = content.find(header_comment, 0, len(header_comment) + args.extra)
-        if found >= 0:
+        # A file is licensed if it carries the canonical header or any accepted
+        # variant of it.
+        span = None
+        for variant in variants:
+            span = find_header(content, wrap.wrapper(variant, args), args)
+            if span:
+                break
+
+        if span:
             if not args.remove:
                 message(log_to, "OK   : " + filepath)
                 continue
 
-            start = found
-            end = found + len(header_comment)
-        else:
-            # Look for a fuzzy match in the first 60 chars
-            #
-            found = regex.search(
-                "(?be)(%s){e<=%d}" % (regex.escape(header_comment[0:60]), 6),
-                content[0 : 80 + args.extra],
-            )
-            if found:
-                fuzzy = regex.compile(
-                    "(?be)(%s){e<=%d}" % (regex.escape(header_comment), args.editdist)
-                )
-
-                # If the first 80 chars match - try harder for the rest of the header
-                #
-                found = fuzzy.search(
-                    content[0 : len(header_comment) + args.extra], found.start()
-                )
-                if found:
-                    start = found.start()
-                    end = found.end()
+            start, end = span
 
         if args.remove:
             if start == 0 and end == 0:


### PR DESCRIPTION
## Problem

`scripts/checks/license-header.py` recognises exactly one copyright line:

```
Copyright (c) Facebook, Inc. and its affiliates.
```

A file carrying the equally valid, and currently correct, Meta wording:

```
Copyright (c) Meta Platforms, Inc. and affiliates.
```

sits too far from that for the fuzzy matcher to reach. The gate is a
first-60-characters check with an edit distance of 6, and `Facebook, Inc. and
its` to `Meta Platforms, Inc. and` exceeds it, so the file is reported as
unlicensed.

The `-i` auto-fix that CI runs then **prepends a second header** instead of
recognising the one already present, leaving the file with two stacked license
blocks. That is a silent corruption rather than a fix.

This is about to matter in practice. The Nimble move in #18468 brings 643 files
using the newer wording; running the hook over them produces 632 files with
duplicated headers.

## Change

Recognise both lines. The canonical line still lives in
`scripts/checks/license.header` and remains the only one ever *written* into a
file that has no header. The alternative is recognised but never inserted, so no
existing file is rewritten.

The header search is factored into a `find_header()` helper so each accepted
variant can be tried in turn, which also removes a chunk of inline nesting from
`main()`.

Adding a further accepted wording later is now a one-line change to
`ALTERNATE_COPYRIGHT_LINES`.

## Verification

Against all 4800 tracked files the hook covers, in check mode:

| | result |
|---|---|
| before | 4723 OK, 77 Fix |
| after | 4723 OK, 77 Fix |

Output is byte-identical. The 77 are pre-existing and are covered by the hook's
`exclude` list in `.pre-commit-config.yaml`; they were passed here directly to
widen the comparison.

Behaviour on the three cases that matter:

| file | before | after |
|---|---|---|
| Meta wording | gains a 2nd copyright block | unchanged, 1 block |
| Facebook wording | unchanged, 1 block | unchanged, 1 block |
| no header | canonical header added | canonical header added |
