### PR TITLE
feat(cudf): Add byte target for CudfBatchConcat

### DIFF
--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -18,6 +18,7 @@
 
 #include <cudf/types.hpp>
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -45,6 +46,9 @@ struct CudfConfig {
   static constexpr const char* kCudfLogFallback{"cudf.log_fallback"};
   static constexpr const char* kCudfBatchSizeMinThreshold{
       "cudf.batch_size_min_threshold"};
+  /// Minimum buffered GPU byte target for CudfBatchConcat.
+  static constexpr const char* kCudfBatchSizeMinBytes{
+      "cudf.batch_size_min_bytes"};
   static constexpr const char* kCudfBatchSizeMaxThreshold{
       "cudf.batch_size_max_threshold"};
   static constexpr const char* kCudfConcatOptimizationEnabled{
@@ -110,15 +114,19 @@ struct CudfConfig {
   /// Whether to insert CudfBatchConcat operators before supported Cudf
   /// operators.
   /// This can improve performance by reducing the number of cuda kernel
-  /// launches on addInput of certain operators by collecting a minimum number
-  /// of rows before concatenating and passing on to the next operator.
-  /// This batch size is determined by batchSizeMinThreshold and
-  /// batchSizeMaxThreshold
+  /// launches on addInput of certain operators. Inputs are collected until
+  /// batchSizeMinBytes is reached, or batchSizeMinThreshold otherwise.
+  /// batchSizeMaxThreshold limits the rows in a concatenated batch.
   bool concatOptimizationEnabled{false};
 
-  /// Minimum rows to accumulate before GPU-side concatenation in
-  /// `CudfBatchConcat` (default 100k).
+  /// Minimum rows to accumulate before GPU-side concatenation when
+  /// batchSizeMinBytes is not configured. This is also the fallback target for
+  /// zero-column vectors, which have no GPU buffers to count (default 100k).
   int32_t batchSizeMinThreshold{100000};
+
+  /// Optional minimum GPU byte target for concatenation, measured by
+  /// CudfVector::estimateFlatSize(). When unset, batchSizeMinThreshold applies.
+  std::optional<uint64_t> batchSizeMinBytes;
 
   /// Maximum rows allowed in a concatenated batch (user configurable).
   /// When not set, cuDF's own `size_type::max()` is used.

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -126,6 +126,17 @@ struct CudfConfig {
 
   /// Optional minimum GPU byte target for concatenation, measured by
   /// CudfVector::estimateFlatSize(). When unset, batchSizeMinThreshold applies.
+  ///
+  /// This bounds the buffered input, not peak GPU usage. Peak is roughly twice
+  /// the target, because the buffered inputs stay resident while
+  /// cudf::concatenate builds the output. Setting batchSizeMaxThreshold adds
+  /// more, since the whole split output set is held until it drains
+  /// downstream.
+  ///
+  /// Keep the target well under 2 GiB when string columns are present, unless
+  /// LIBCUDF_LARGE_STRINGS_ENABLED is set: cuDF rejects a strings column whose
+  /// character data exceeds the 32-bit offset limit, and batchSizeMaxThreshold
+  /// caps rows rather than bytes.
   std::optional<uint64_t> batchSizeMinBytes;
 
   /// Maximum rows allowed in a concatenated batch (user configurable).

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -41,9 +41,8 @@ RowTypePtr getConcatOutputType(
   return planNode->sources()[0]->outputType();
 }
 
-// Resolves the byte target for an output carrying 'numColumns' columns.
-// Zero-column vectors own no GPU buffers to measure, so they have no byte
-// target and fall back to counting rows.
+// Returns the configured byte target, or nullopt for a zero-column output,
+// which owns no GPU buffers to measure.
 std::optional<uint64_t> getBatchSizeMinBytes(size_t numColumns) {
   if (numColumns == 0) {
     return std::nullopt;
@@ -81,7 +80,6 @@ CudfBatchConcat::CudfBatchConcat(
           NvtxMethodFlag::kAll,
           std::nullopt,
           planNode),
-      driverCtx_(driverCtx),
       targetBytes_(getBatchSizeMinBytes(outputType_->size())),
       targetRows_(getBatchSizeMinRows()) {}
 
@@ -178,6 +176,7 @@ void CudfBatchConcat::doClose() {
   while (!outputQueue_.empty()) {
     outputQueue_.pop();
   }
+  currentBytes_ = 0;
   currentNumRows_ = 0;
   Operator::close();
 }

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -144,11 +144,16 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     }
 
     // Keep a below-target final table buffered while more input can arrive.
+    // Only a split leaves a genuine partial tail. A lone output already met the
+    // target on the input side, and re-buffering it would concatenate it a
+    // second time: byte estimates are not additive, because concatenating
+    // merges the inputs' null masks and drops all but one string offset entry,
+    // so the output can measure less than the inputs it came from.
     auto& last = outputVectors.back();
     const auto numRows = static_cast<size_t>(last->size());
     const auto lastBytes =
         usesRowFallback() ? uint64_t{0} : last->estimateFlatSize();
-    const auto retainLast = !noMoreInput_ &&
+    const auto retainLast = !noMoreInput_ && outputVectors.size() > 1 &&
         (usesRowFallback() ? numRows < targetRows_
                            : lastBytes < targetBytes_.value());
 

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -41,7 +41,13 @@ RowTypePtr getConcatOutputType(
   return planNode->sources()[0]->outputType();
 }
 
-std::optional<uint64_t> getBatchSizeMinBytes() {
+// Resolves the byte target for an output carrying 'numColumns' columns.
+// Zero-column vectors own no GPU buffers to measure, so they have no byte
+// target and fall back to counting rows.
+std::optional<uint64_t> getBatchSizeMinBytes(size_t numColumns) {
+  if (numColumns == 0) {
+    return std::nullopt;
+  }
   const auto targetBytes = CudfConfig::getInstance().batchSizeMinBytes;
   if (targetBytes.has_value()) {
     VELOX_CHECK_GT(
@@ -76,9 +82,8 @@ CudfBatchConcat::CudfBatchConcat(
           std::nullopt,
           planNode),
       driverCtx_(driverCtx),
-      targetBytes_(getBatchSizeMinBytes()),
-      usesRowFallback_(!targetBytes_.has_value() || outputType_->size() == 0),
-      targetRows_(usesRowFallback_ ? getBatchSizeMinRows() : 0) {}
+      targetBytes_(getBatchSizeMinBytes(outputType_->size())),
+      targetRows_(getBatchSizeMinRows()) {}
 
 void CudfBatchConcat::doAddInput(RowVectorPtr input) {
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
@@ -88,13 +93,8 @@ void CudfBatchConcat::doAddInput(RowVectorPtr input) {
     return;
   }
 
-  if (usesRowFallback_) {
-    const auto inputRows = static_cast<size_t>(cudfVector->size());
-    VELOX_CHECK_LE(
-        inputRows,
-        std::numeric_limits<size_t>::max() - currentNumRows_,
-        "CudfBatchConcat buffered row count overflow");
-    currentNumRows_ += inputRows;
+  if (usesRowFallback()) {
+    currentNumRows_ += cudfVector->size();
   } else {
     const auto inputBytes = cudfVector->estimateFlatSize();
     VELOX_CHECK_LE(
@@ -149,14 +149,14 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     auto& last = outputVectors.back();
     const auto numRows = static_cast<size_t>(last->size());
     const auto lastBytes =
-        usesRowFallback_ ? uint64_t{0} : last->estimateFlatSize();
+        usesRowFallback() ? uint64_t{0} : last->estimateFlatSize();
     const auto retainLast = !noMoreInput_ &&
-        (usesRowFallback_ ? numRows < targetRows_
-                          : lastBytes < targetBytes_.value());
+        (usesRowFallback() ? numRows < targetRows_
+                           : lastBytes < targetBytes_.value());
 
     if (retainLast) {
       currentBytes_ = lastBytes;
-      currentNumRows_ = usesRowFallback_ ? numRows : 0;
+      currentNumRows_ = usesRowFallback() ? numRows : 0;
       buffer_.push_back(std::move(last));
     } else {
       outputQueue_.push(std::move(last));

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -20,6 +20,7 @@
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
+#include <limits>
 #include <utility>
 
 namespace facebook::velox::cudf_velox {
@@ -40,6 +41,24 @@ RowTypePtr getConcatOutputType(
   return planNode->sources()[0]->outputType();
 }
 
+std::optional<uint64_t> getBatchSizeMinBytes() {
+  const auto targetBytes = CudfConfig::getInstance().batchSizeMinBytes;
+  if (targetBytes.has_value()) {
+    VELOX_CHECK_GT(
+        targetBytes.value(),
+        0,
+        "cuDF BatchConcat minimum byte target must be positive");
+  }
+  return targetBytes;
+}
+
+size_t getBatchSizeMinRows() {
+  const auto targetRows = CudfConfig::getInstance().batchSizeMinThreshold;
+  VELOX_CHECK_GT(
+      targetRows, 0, "cuDF BatchConcat minimum row target must be positive");
+  return static_cast<size_t>(targetRows);
+}
+
 } // namespace
 
 CudfBatchConcat::CudfBatchConcat(
@@ -57,7 +76,9 @@ CudfBatchConcat::CudfBatchConcat(
           std::nullopt,
           planNode),
       driverCtx_(driverCtx),
-      targetRows_(CudfConfig::getInstance().batchSizeMinThreshold) {}
+      targetBytes_(getBatchSizeMinBytes()),
+      usesRowFallback_(!targetBytes_.has_value() || outputType_->size() == 0),
+      targetRows_(usesRowFallback_ ? getBatchSizeMinRows() : 0) {}
 
 void CudfBatchConcat::doAddInput(RowVectorPtr input) {
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
@@ -67,8 +88,21 @@ void CudfBatchConcat::doAddInput(RowVectorPtr input) {
     return;
   }
 
-  // Push input cudf table to buffer
-  currentNumRows_ += cudfVector->size();
+  if (usesRowFallback_) {
+    const auto inputRows = static_cast<size_t>(cudfVector->size());
+    VELOX_CHECK_LE(
+        inputRows,
+        std::numeric_limits<size_t>::max() - currentNumRows_,
+        "CudfBatchConcat buffered row count overflow");
+    currentNumRows_ += inputRows;
+  } else {
+    const auto inputBytes = cudfVector->estimateFlatSize();
+    VELOX_CHECK_LE(
+        inputBytes,
+        std::numeric_limits<uint64_t>::max() - currentBytes_,
+        "CudfBatchConcat buffered byte count overflow");
+    currentBytes_ += inputBytes;
+  }
   buffer_.push_back(std::move(cudfVector));
 }
 
@@ -80,8 +114,8 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     return output;
   }
 
-  // Merge tables if there are enough rows
-  if (!buffer_.empty() && (currentNumRows_ >= targetRows_ || noMoreInput_)) {
+  // Merge tables once the active target is reached.
+  if (!buffer_.empty() && (targetReached() || noMoreInput_)) {
     // Concatenating a single column-bearing input only materializes a copy of
     // the same table. Pass it through unchanged. Zero-column inputs still need
     // the batching helper below to preserve their row count and enforce the
@@ -89,6 +123,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     if (buffer_.size() == 1 && outputType_->size() > 0) {
       auto output = std::move(buffer_.front());
       buffer_.clear();
+      currentBytes_ = 0;
       currentNumRows_ = 0;
       return output;
     }
@@ -102,6 +137,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
         outputStream,
         get_output_mr());
 
+    currentBytes_ = 0;
     currentNumRows_ = 0;
     VELOX_CHECK_GT(outputVectors.size(), 0);
 
@@ -109,13 +145,18 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
       outputQueue_.push(std::move(*it));
     }
 
-    // If last table is a smaller batch and we still expect more input and keep
-    // it in buffer.
+    // Keep a below-target final table buffered while more input can arrive.
     auto& last = outputVectors.back();
-    auto rowCount = last->size();
+    const auto numRows = static_cast<size_t>(last->size());
+    const auto lastBytes =
+        usesRowFallback_ ? uint64_t{0} : last->estimateFlatSize();
+    const auto retainLast = !noMoreInput_ &&
+        (usesRowFallback_ ? numRows < targetRows_
+                          : lastBytes < targetBytes_.value());
 
-    if (!noMoreInput_ && rowCount < targetRows_) {
-      currentNumRows_ = rowCount;
+    if (retainLast) {
+      currentBytes_ = lastBytes;
+      currentNumRows_ = usesRowFallback_ ? numRows : 0;
       buffer_.push_back(std::move(last));
     } else {
       outputQueue_.push(std::move(last));

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -22,6 +22,8 @@
 
 #include "velox/exec/Operator.h"
 
+#include <cstdint>
+#include <optional>
 #include <queue>
 
 namespace facebook::velox::cudf_velox {
@@ -34,8 +36,7 @@ class CudfBatchConcat : public CudfOperatorBase {
       std::shared_ptr<const core::PlanNode> planNode);
 
   bool needsInput() const override {
-    return !noMoreInput_ && outputQueue_.empty() &&
-        currentNumRows_ < targetRows_;
+    return !noMoreInput_ && outputQueue_.empty() && !targetReached();
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -50,10 +51,35 @@ class CudfBatchConcat : public CudfOperatorBase {
   void doClose() override;
 
  private:
+  // Returns true when the active byte or row target is met.
+  bool targetReached() const {
+    return usesRowFallback_ ? currentNumRows_ >= targetRows_
+                            : currentBytes_ >= targetBytes_.value();
+  }
+
+  // Driver context associated with this operator.
   exec::DriverCtx* const driverCtx_;
+
+  // Input vectors awaiting concatenation.
   std::vector<CudfVectorPtr> buffer_;
+
+  // Concatenated vectors ready for downstream consumption.
   std::queue<CudfVectorPtr> outputQueue_;
+
+  // Estimated GPU bytes currently held in buffer_.
+  uint64_t currentBytes_{0};
+
+  // Estimated GPU byte target for column-bearing vectors, when configured.
+  const std::optional<uint64_t> targetBytes_;
+
+  // Whether logical rows are used because no byte target is configured or the
+  // vectors have no GPU columns.
+  const bool usesRowFallback_{false};
+
+  // Logical rows currently buffered while the row target is active.
   size_t currentNumRows_{0};
+
+  // Logical row target used while the row fallback is active.
   const size_t targetRows_{0};
 };
 

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -63,9 +63,6 @@ class CudfBatchConcat : public CudfOperatorBase {
                              : currentBytes_ >= targetBytes_.value();
   }
 
-  // Driver context associated with this operator.
-  exec::DriverCtx* const driverCtx_;
-
   // Input vectors awaiting concatenation.
   std::vector<CudfVectorPtr> buffer_;
 
@@ -78,10 +75,7 @@ class CudfBatchConcat : public CudfOperatorBase {
   // Logical rows currently buffered while the row fallback is active.
   size_t currentNumRows_{0};
 
-  // Estimated GPU byte target. Empty when the row fallback is active, that is
-  // when no byte target is configured or the output has no GPU columns. Both
-  // targets are resolved from the config alone, so neither depends on the
-  // other's position in this declaration list.
+  // Estimated GPU byte target. Empty while usesRowFallback() applies.
   const std::optional<uint64_t> targetBytes_;
 
   // Logical row target used while the row fallback is active.

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -51,10 +51,16 @@ class CudfBatchConcat : public CudfOperatorBase {
   void doClose() override;
 
  private:
+  // Returns true when buffering is measured in logical rows, which happens
+  // when no byte target is configured or the output has no GPU columns.
+  bool usesRowFallback() const {
+    return !targetBytes_.has_value();
+  }
+
   // Returns true when the active byte or row target is met.
   bool targetReached() const {
-    return usesRowFallback_ ? currentNumRows_ >= targetRows_
-                            : currentBytes_ >= targetBytes_.value();
+    return usesRowFallback() ? currentNumRows_ >= targetRows_
+                             : currentBytes_ >= targetBytes_.value();
   }
 
   // Driver context associated with this operator.
@@ -69,15 +75,14 @@ class CudfBatchConcat : public CudfOperatorBase {
   // Estimated GPU bytes currently held in buffer_.
   uint64_t currentBytes_{0};
 
-  // Estimated GPU byte target for column-bearing vectors, when configured.
-  const std::optional<uint64_t> targetBytes_;
-
-  // Whether logical rows are used because no byte target is configured or the
-  // vectors have no GPU columns.
-  const bool usesRowFallback_{false};
-
-  // Logical rows currently buffered while the row target is active.
+  // Logical rows currently buffered while the row fallback is active.
   size_t currentNumRows_{0};
+
+  // Estimated GPU byte target. Empty when the row fallback is active, that is
+  // when no byte target is configured or the output has no GPU columns. Both
+  // targets are resolved from the config alone, so neither depends on the
+  // other's position in this declaration list.
+  const std::optional<uint64_t> targetBytes_;
 
   // Logical row target used while the row fallback is active.
   const size_t targetRows_{0};

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -387,8 +387,11 @@ void CudfConfig::initialize(
     outputMemoryResource = config[kCudfOutputMr];
   }
   if (config.find(kCudfBatchSizeMinThreshold) != config.end()) {
-    batchSizeMinThreshold =
+    const auto targetRows =
         folly::to<int32_t>(config[kCudfBatchSizeMinThreshold]);
+    VELOX_USER_CHECK_GT(
+        targetRows, 0, "cuDF BatchConcat minimum row target must be positive");
+    batchSizeMinThreshold = targetRows;
   }
   if (config.find(kCudfBatchSizeMinBytes) != config.end()) {
     const auto targetBytes =

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -32,6 +32,7 @@
 #include "velox/experimental/cudf/expression/JitExpression.h"
 
 #include "folly/Conv.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/Values.h"
@@ -388,6 +389,15 @@ void CudfConfig::initialize(
   if (config.find(kCudfBatchSizeMinThreshold) != config.end()) {
     batchSizeMinThreshold =
         folly::to<int32_t>(config[kCudfBatchSizeMinThreshold]);
+  }
+  if (config.find(kCudfBatchSizeMinBytes) != config.end()) {
+    const auto targetBytes =
+        folly::to<uint64_t>(config[kCudfBatchSizeMinBytes]);
+    VELOX_USER_CHECK_GT(
+        targetBytes,
+        0,
+        "cuDF BatchConcat minimum byte target must be positive");
+    batchSizeMinBytes = targetBytes;
   }
   if (config.find(kCudfBatchSizeMaxThreshold) != config.end()) {
     batchSizeMaxThreshold =

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -77,22 +77,22 @@ class CudfBatchConcatTest : public OperatorTestBase {
     OperatorTestBase::TearDown();
   }
 
-  void updateCudfConfig(
+  void updateCudfConfig(int32_t min, std::optional<int32_t> max) {
+    auto& config = CudfConfig::getInstance();
+    config.batchSizeMinBytes.reset();
+    config.batchSizeMinThreshold = min;
+    config.batchSizeMaxThreshold = max;
+  }
+
+  // Configures a byte target. 'zeroColumnMinRows' is the row target that a
+  // zero-column output falls back to.
+  void updateCudfByteConfig(
       uint64_t minBytes,
       std::optional<int32_t> maxRows,
       int32_t zeroColumnMinRows = 100'000) {
     auto& config = CudfConfig::getInstance();
     config.batchSizeMinBytes = minBytes;
     config.batchSizeMinThreshold = zeroColumnMinRows;
-    config.batchSizeMaxThreshold = maxRows;
-  }
-
-  // Configures the default mode, where no byte target is set and buffering is
-  // measured in rows.
-  void updateCudfRowConfig(int32_t minRows, std::optional<int32_t> maxRows) {
-    auto& config = CudfConfig::getInstance();
-    config.batchSizeMinBytes.reset();
-    config.batchSizeMinThreshold = minRows;
     config.batchSizeMaxThreshold = maxRows;
   }
 
@@ -177,7 +177,7 @@ class CudfBatchConcatTest : public OperatorTestBase {
 } // namespace
 
 TEST_F(CudfBatchConcatTest, singleColumnBearingInputPassesThrough) {
-  updateCudfRowConfig(/*minRows=*/4, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/4, /*max=*/std::nullopt);
 
   auto input = makeRowVector({makeFlatSequence<int64_t>(0, 4)});
   auto plan = PlanBuilder()
@@ -218,7 +218,7 @@ TEST_F(
   const auto targetBytes =
       std::max(small->estimateFlatSize(), tail->estimateFlatSize()) + 1;
   ASSERT_LT(targetBytes, large->estimateFlatSize());
-  updateCudfConfig(
+  updateCudfByteConfig(
       /*minBytes=*/targetBytes, /*maxRows=*/std::nullopt);
   auto plan = createAggregationPlan(smallInput);
   auto task = createTask(plan);
@@ -263,7 +263,7 @@ TEST_F(CudfBatchConcatTest, singleOutputBatchIsNotRebuffered) {
   auto first = toCudfVector(input, kReportedBytes);
   auto second = toCudfVector(input, kReportedBytes);
 
-  updateCudfConfig(
+  updateCudfByteConfig(
       /*minBytes=*/2 * kReportedBytes, /*maxRows=*/std::nullopt);
   auto plan = createAggregationPlan(input);
   auto task = createTask(plan);
@@ -292,8 +292,7 @@ TEST_F(CudfBatchConcatTest, usesRowTargetWhenByteTargetIsNotConfigured) {
   auto first = toCudfVector(input, 1'000'000);
   auto second = toCudfVector(input, 1'000'000);
 
-  updateCudfRowConfig(
-      /*minRows=*/2 * kRowsPerBatch, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/2 * kRowsPerBatch, /*max=*/std::nullopt);
 
   auto plan = createAggregationPlan(input);
   auto task = createTask(plan);
@@ -317,7 +316,7 @@ TEST_F(CudfBatchConcatTest, rejectsZeroByteTarget) {
   auto plan = createAggregationPlan(input);
   auto task = createTask(plan);
   DriverCtx driverCtx(task, 0, 0, 0, 0);
-  updateCudfConfig(/*minBytes=*/0, /*maxRows=*/std::nullopt);
+  updateCudfByteConfig(/*minBytes=*/0, /*maxRows=*/std::nullopt);
 
   VELOX_ASSERT_THROW(
       CudfBatchConcat(0, &driverCtx, plan),
@@ -328,7 +327,7 @@ TEST_F(CudfBatchConcatTest, rejectsBufferedByteOverflow) {
   auto input = makeRowVector({makeFlatVector<int64_t>({1})});
   auto first = toCudfVector(input, std::numeric_limits<uint64_t>::max() - 1);
   auto second = toCudfVector(input, 2);
-  updateCudfConfig(
+  updateCudfByteConfig(
       /*minBytes=*/std::numeric_limits<uint64_t>::max(),
       /*maxRows=*/std::nullopt);
 
@@ -355,10 +354,10 @@ TEST_F(CudfBatchConcatTest, zeroColumnVectorsUseRowFallback) {
       std::nullopt);
   auto first = toCudfVector(input);
   auto second = toCudfVector(input);
-  auto tail = toCudfVector(input);
   ASSERT_EQ(first->estimateFlatSize(), 0);
 
-  updateCudfConfig(
+  // A one-byte target would flush on the first input if bytes were counted.
+  updateCudfByteConfig(
       /*minBytes=*/1,
       /*maxRows=*/std::nullopt,
       /*zeroColumnMinRows=*/2 * kRowsPerBatch);
@@ -373,19 +372,9 @@ TEST_F(CudfBatchConcatTest, zeroColumnVectorsUseRowFallback) {
 
   concat.addInput(second);
   EXPECT_FALSE(concat.needsInput());
-  auto fullBatch = concat.getOutput();
-  ASSERT_NE(fullBatch, nullptr);
-  EXPECT_EQ(fullBatch->size(), 2 * kRowsPerBatch);
-  EXPECT_EQ(fullBatch->estimateFlatSize(), 0);
-
-  concat.addInput(tail);
-  EXPECT_TRUE(concat.needsInput());
-  EXPECT_EQ(concat.getOutput(), nullptr);
-  concat.noMoreInput();
-  auto tailBatch = concat.getOutput();
-  ASSERT_NE(tailBatch, nullptr);
-  EXPECT_EQ(tailBatch->size(), kRowsPerBatch);
-  EXPECT_TRUE(concat.isFinished());
+  auto output = concat.getOutput();
+  ASSERT_NE(output, nullptr);
+  EXPECT_EQ(output->size(), 2 * kRowsPerBatch);
   concat.close();
 }
 
@@ -395,7 +384,7 @@ TEST_F(CudfBatchConcatTest, concatReducesBatchesBeforeAggregation) {
   // 6 batches of 10 rows each = 60 rows total.
   // With min threshold 30, concat should accumulate ~3 batches before flushing,
   // producing fewer output batches than the 6 it received.
-  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -447,7 +436,7 @@ TEST_F(CudfBatchConcatTest, concatFlushesMidStreamAtByteTarget) {
   const auto batchBytes = toCudfVector(vectors[0])->estimateFlatSize();
   ASSERT_GT(batchBytes, 0u);
   const auto targetBytes = 3 * batchBytes;
-  updateCudfConfig(
+  updateCudfByteConfig(
       /*minBytes=*/targetBytes, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
@@ -479,7 +468,7 @@ TEST_F(CudfBatchConcatTest, concatFlushesMidStreamAtByteTarget) {
 // Verifies that CudfBatchConcat is not inserted when the optimization is
 // disabled, even when aggregation is present.
 TEST_F(CudfBatchConcatTest, concatNotInsertedWhenDisabled) {
-  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = false;
 
   std::vector<RowVectorPtr> vectors;
@@ -510,10 +499,10 @@ TEST_F(CudfBatchConcatTest, concatNotInsertedWhenDisabled) {
       << "CudfBatchConcat should not be present when optimization is disabled";
 }
 
-// When the threshold exceeds total input bytes, concat accumulates all batches
+// When the threshold exceeds total input rows, concat accumulates all batches
 // and flushes them as a single merged batch on noMoreInput.
 TEST_F(CudfBatchConcatTest, concatMergesAllOnFlushWithHighThreshold) {
-  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/100000, /*max=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -552,7 +541,7 @@ TEST_F(CudfBatchConcatTest, concatMergesAllOnFlushWithHighThreshold) {
 
 // Verifies correctness with grouped aggregation (non-global) and concat.
 TEST_F(CudfBatchConcatTest, concatWithGroupedAggregation) {
-  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -588,7 +577,7 @@ TEST_F(CudfBatchConcatTest, concatWithGroupedAggregation) {
 }
 
 TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
-  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   auto data = makeRowVector({
@@ -623,7 +612,7 @@ TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
 // Verifies that CudfBatchConcat is inserted before the hash join probe and
 // correctly handles the 2-source HashJoinNode plan node.
 TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
-  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   // Probe side: 6 batches of 10 rows each.
@@ -680,7 +669,7 @@ TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
 }
 
 TEST_F(CudfBatchConcatTest, rightJoinCollectsMatchedRowsFromPeerProbes) {
-  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> probeVectors;
@@ -726,7 +715,7 @@ TEST_F(CudfBatchConcatTest, rightJoinCollectsMatchedRowsFromPeerProbes) {
 }
 
 TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
-  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/20);
+  updateCudfConfig(/*min=*/30, /*max=*/20);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -763,7 +752,7 @@ TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
 }
 
 TEST_F(CudfBatchConcatTest, singleZeroColumnBatchSplitsAtMaxThreshold) {
-  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/20);
+  updateCudfConfig(/*min=*/30, /*max=*/20);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   auto data = makeRowVector({makeFlatSequence<int64_t>(0, 30)});

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -177,31 +177,18 @@ class CudfBatchConcatTest : public OperatorTestBase {
 } // namespace
 
 TEST_F(CudfBatchConcatTest, singleColumnBearingInputPassesThrough) {
-  updateCudfConfig(/*minBytes=*/1, /*maxRows=*/std::nullopt);
+  updateCudfRowConfig(/*minRows=*/4, /*maxRows=*/std::nullopt);
 
   auto input = makeRowVector({makeFlatSequence<int64_t>(0, 4)});
   auto plan = PlanBuilder()
                   .values({input})
                   .singleAggregation({}, {"sum(c0)"})
                   .planNode();
-
-  core::PlanFragment planFragment;
-  planFragment.planNode = plan;
-  auto task = Task::create(
-      "CudfBatchConcatTest_singleColumnBearingInputPassesThrough",
-      std::move(planFragment),
-      0,
-      core::QueryCtx::create(executor_.get()),
-      Task::ExecutionMode::kParallel);
+  auto task = createTask(plan);
   DriverCtx driverCtx(task, 0, 0, 0, 0);
   CudfBatchConcat concat(0, &driverCtx, plan);
 
-  auto stream = cudfGlobalStreamPool().get_stream();
-  auto table = with_arrow::toCudfTable(
-      input, pool(), stream, cudf::get_current_device_resource_ref());
-  auto cudfInput = std::make_shared<CudfVector>(
-      pool(), input->type(), input->size(), std::move(table), stream);
-
+  auto cudfInput = toCudfVector(input);
   concat.addInput(cudfInput);
   auto output = concat.getOutput();
 
@@ -263,6 +250,7 @@ TEST_F(
   ASSERT_NE(tailBatch, nullptr);
   EXPECT_EQ(tailBatch->size(), kRowsPerBatch);
   EXPECT_TRUE(concat.isFinished());
+  concat.close();
 }
 
 TEST_F(CudfBatchConcatTest, usesRowTargetWhenByteTargetIsNotConfigured) {
@@ -288,6 +276,7 @@ TEST_F(CudfBatchConcatTest, usesRowTargetWhenByteTargetIsNotConfigured) {
   auto output = concat.getOutput();
   ASSERT_NE(output, nullptr);
   EXPECT_EQ(output->size(), 2 * kRowsPerBatch);
+  concat.close();
 }
 
 TEST_F(CudfBatchConcatTest, rejectsZeroByteTarget) {
@@ -319,6 +308,7 @@ TEST_F(CudfBatchConcatTest, rejectsBufferedByteOverflow) {
   ASSERT_TRUE(concat.needsInput());
   VELOX_ASSERT_THROW(
       concat.addInput(second), "CudfBatchConcat buffered byte count overflow");
+  concat.close();
 }
 
 TEST_F(CudfBatchConcatTest, zeroColumnVectorsUseRowFallback) {
@@ -363,6 +353,7 @@ TEST_F(CudfBatchConcatTest, zeroColumnVectorsUseRowFallback) {
   ASSERT_NE(tailBatch, nullptr);
   EXPECT_EQ(tailBatch->size(), kRowsPerBatch);
   EXPECT_TRUE(concat.isFinished());
+  concat.close();
 }
 
 // Verifies that CudfBatchConcat is inserted before aggregation and reduces

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -87,6 +87,15 @@ class CudfBatchConcatTest : public OperatorTestBase {
     config.batchSizeMaxThreshold = maxRows;
   }
 
+  // Configures the default mode, where no byte target is set and buffering is
+  // measured in rows.
+  void updateCudfRowConfig(int32_t minRows, std::optional<int32_t> maxRows) {
+    auto& config = CudfConfig::getInstance();
+    config.batchSizeMinBytes.reset();
+    config.batchSizeMinThreshold = minRows;
+    config.batchSizeMaxThreshold = maxRows;
+  }
+
   CudfVectorPtr toCudfVector(
       const RowVectorPtr& input,
       std::optional<uint64_t> estimatedSizeBytes = std::nullopt) {
@@ -262,10 +271,8 @@ TEST_F(CudfBatchConcatTest, usesRowTargetWhenByteTargetIsNotConfigured) {
   auto first = toCudfVector(input, 1'000'000);
   auto second = toCudfVector(input, 1'000'000);
 
-  auto& config = CudfConfig::getInstance();
-  config.batchSizeMinBytes = {};
-  config.batchSizeMinThreshold = 2 * kRowsPerBatch;
-  config.batchSizeMaxThreshold.reset();
+  updateCudfRowConfig(
+      /*minRows=*/2 * kRowsPerBatch, /*maxRows=*/std::nullopt);
 
   auto plan = createAggregationPlan(input);
   auto task = createTask(plan);
@@ -362,8 +369,9 @@ TEST_F(CudfBatchConcatTest, zeroColumnVectorsUseRowFallback) {
 // the number of batches reaching the aggregation operator.
 TEST_F(CudfBatchConcatTest, concatReducesBatchesBeforeAggregation) {
   // 6 batches of 10 rows each = 60 rows total.
-  // A byte target above their combined size merges them on noMoreInput.
-  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
+  // With min threshold 30, concat should accumulate ~3 batches before flushing,
+  // producing fewer output batches than the 6 it received.
+  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -399,6 +407,49 @@ TEST_F(CudfBatchConcatTest, concatReducesBatchesBeforeAggregation) {
       << "CudfBatchConcat should have received all 6 input batches";
   EXPECT_LT(concatStats.outputVectors, concatStats.inputVectors)
       << "CudfBatchConcat should produce fewer output batches than input";
+}
+
+// Verifies that a byte target below the total input size flushes mid-stream
+// rather than holding everything until noMoreInput.
+TEST_F(CudfBatchConcatTest, concatFlushesMidStreamAtByteTarget) {
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < 6; ++i) {
+    vectors.push_back(makeRowVector({makeFlatSequence<int64_t>(i * 10, 10)}));
+  }
+  createDuckDbTable(vectors);
+
+  // Derive the target from a measured vector so it does not drift when cuDF
+  // allocation changes. Three batches per flush leaves several output batches.
+  const auto batchBytes = toCudfVector(vectors[0])->estimateFlatSize();
+  ASSERT_GT(batchBytes, 0u);
+  const auto targetBytes = 3 * batchBytes;
+  updateCudfConfig(
+      /*minBytes=*/targetBytes, /*maxRows=*/std::nullopt);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  auto generator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId aggNodeId;
+
+  auto plan = PlanBuilder(generator)
+                  .addNode([&](auto id, auto pool) {
+                    return createFragmentedSource(vectors, generator);
+                  })
+                  .singleAggregation({}, {"sum(c0)"})
+                  .capturePlanNodeId(aggNodeId)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .maxDrivers(1)
+                  .assertResults("SELECT sum(c0) FROM tmp");
+
+  auto* concatStats = getConcatStats(task, aggNodeId);
+  ASSERT_NE(concatStats, nullptr);
+  EXPECT_EQ(concatStats->inputVectors, 6);
+  EXPECT_GT(concatStats->outputVectors, 1)
+      << "A byte target below the total input size should flush mid-stream";
+  EXPECT_LT(concatStats->outputVectors, concatStats->inputVectors)
+      << "CudfBatchConcat should still reduce the number of batches";
 }
 
 // Verifies that CudfBatchConcat is not inserted when the optimization is

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -253,6 +253,39 @@ TEST_F(
   concat.close();
 }
 
+// Verifies that a flush producing one batch emits it rather than buffering it
+// again. Byte estimates are not additive across concatenation, so the single
+// output can measure below the target that the inputs already met.
+TEST_F(CudfBatchConcatTest, singleOutputBatchIsNotRebuffered) {
+  constexpr vector_size_t kRowsPerBatch = 10;
+  constexpr uint64_t kReportedBytes = 1'000'000;
+  auto input = makeRowVector({makeFlatSequence<int64_t>(0, kRowsPerBatch)});
+  auto first = toCudfVector(input, kReportedBytes);
+  auto second = toCudfVector(input, kReportedBytes);
+
+  updateCudfConfig(
+      /*minBytes=*/2 * kReportedBytes, /*maxRows=*/std::nullopt);
+  auto plan = createAggregationPlan(input);
+  auto task = createTask(plan);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  CudfBatchConcat concat(0, &driverCtx, plan);
+
+  concat.addInput(first);
+  EXPECT_TRUE(concat.needsInput());
+  concat.addInput(second);
+  EXPECT_FALSE(concat.needsInput());
+
+  auto output = concat.getOutput();
+  ASSERT_NE(output, nullptr)
+      << "A single concatenated batch must be emitted, not buffered again";
+  EXPECT_EQ(output->size(), 2 * kRowsPerBatch);
+
+  const auto targetBytes = CudfConfig::getInstance().batchSizeMinBytes.value();
+  EXPECT_LT(output->estimateFlatSize(), targetBytes)
+      << "The concatenated batch measures below the target it already met";
+  concat.close();
+}
+
 TEST_F(CudfBatchConcatTest, usesRowTargetWhenByteTargetIsNotConfigured) {
   constexpr vector_size_t kRowsPerBatch = 10;
   auto input = makeRowVector({makeFlatSequence<int64_t>(0, kRowsPerBatch)});
@@ -555,10 +588,7 @@ TEST_F(CudfBatchConcatTest, concatWithGroupedAggregation) {
 }
 
 TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
-  updateCudfConfig(
-      /*minBytes=*/1,
-      /*maxRows=*/std::nullopt,
-      /*zeroColumnMinRows=*/30);
+  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   auto data = makeRowVector({
@@ -696,8 +726,7 @@ TEST_F(CudfBatchConcatTest, rightJoinCollectsMatchedRowsFromPeerProbes) {
 }
 
 TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
-  updateCudfConfig(
-      /*minBytes=*/1, /*maxRows=*/20, /*zeroColumnMinRows=*/30);
+  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/20);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -734,8 +763,7 @@ TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
 }
 
 TEST_F(CudfBatchConcatTest, singleZeroColumnBatchSplitsAtMaxThreshold) {
-  updateCudfConfig(
-      /*minBytes=*/1, /*maxRows=*/20, /*zeroColumnMinRows=*/30);
+  updateCudfRowConfig(/*minRows=*/30, /*maxRows=*/20);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   auto data = makeRowVector({makeFlatSequence<int64_t>(0, 30)});

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -20,15 +20,44 @@
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/Driver.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+
+#include <algorithm>
+#include <limits>
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::cudf_velox;
+
+namespace {
+
+class EstimatedSizeCudfVector final : public CudfVector {
+ public:
+  EstimatedSizeCudfVector(
+      memory::MemoryPool* pool,
+      TypePtr type,
+      vector_size_t size,
+      std::unique_ptr<cudf::table>&& table,
+      rmm::cuda_stream_view stream,
+      uint64_t estimatedSizeBytes)
+      : CudfVector(pool, type, size, std::move(table), stream),
+        estimatedSizeBytes_(estimatedSizeBytes) {}
+
+  uint64_t estimateFlatSize() const override {
+    return estimatedSizeBytes_;
+  }
+
+ private:
+  const uint64_t estimatedSizeBytes_;
+};
 
 class CudfBatchConcatTest : public OperatorTestBase {
  protected:
@@ -39,15 +68,66 @@ class CudfBatchConcatTest : public OperatorTestBase {
   }
 
   void TearDown() override {
-    CudfConfig::getInstance().concatOptimizationEnabled = false;
+    auto& config = CudfConfig::getInstance();
+    config.concatOptimizationEnabled = false;
+    config.batchSizeMinThreshold = 100'000;
+    config.batchSizeMinBytes.reset();
+    config.batchSizeMaxThreshold.reset();
     cudf_velox::unregisterCudf();
     OperatorTestBase::TearDown();
   }
 
-  void updateCudfConfig(int32_t min, std::optional<int32_t> max) {
+  void updateCudfConfig(
+      uint64_t minBytes,
+      std::optional<int32_t> maxRows,
+      int32_t zeroColumnMinRows = 100'000) {
     auto& config = CudfConfig::getInstance();
-    config.batchSizeMinThreshold = min;
-    config.batchSizeMaxThreshold = max;
+    config.batchSizeMinBytes = minBytes;
+    config.batchSizeMinThreshold = zeroColumnMinRows;
+    config.batchSizeMaxThreshold = maxRows;
+  }
+
+  CudfVectorPtr toCudfVector(
+      const RowVectorPtr& input,
+      std::optional<uint64_t> estimatedSizeBytes = std::nullopt) {
+    auto stream = cudfGlobalStreamPool().get_stream();
+    std::unique_ptr<cudf::table> table;
+    if (input->childrenSize() == 0) {
+      table = std::make_unique<cudf::table>();
+    } else {
+      table =
+          with_arrow::toCudfTable(input, pool_.get(), stream, get_output_mr());
+    }
+
+    if (estimatedSizeBytes.has_value()) {
+      return std::make_shared<EstimatedSizeCudfVector>(
+          pool_.get(),
+          input->type(),
+          input->size(),
+          std::move(table),
+          stream,
+          estimatedSizeBytes.value());
+    }
+    return std::make_shared<CudfVector>(
+        pool_.get(), input->type(), input->size(), std::move(table), stream);
+  }
+
+  core::PlanNodePtr createAggregationPlan(const RowVectorPtr& input) {
+    return PlanBuilder()
+        .values({input})
+        .singleAggregation({}, {"count(*)"})
+        .planNode();
+  }
+
+  std::shared_ptr<Task> createTask(const core::PlanNodePtr& planNode) {
+    core::PlanFragment planFragment;
+    planFragment.planNode = planNode->sources().front();
+    return Task::create(
+        "CudfBatchConcatTest",
+        std::move(planFragment),
+        0,
+        core::QueryCtx::create(driverExecutor_.get()),
+        Task::ExecutionMode::kParallel);
   }
 
   template <typename T>
@@ -85,8 +165,10 @@ class CudfBatchConcatTest : public OperatorTestBase {
   }
 };
 
+} // namespace
+
 TEST_F(CudfBatchConcatTest, singleColumnBearingInputPassesThrough) {
-  updateCudfConfig(/*min=*/4, /*max=*/std::nullopt);
+  updateCudfConfig(/*minBytes=*/1, /*maxRows=*/std::nullopt);
 
   auto input = makeRowVector({makeFlatSequence<int64_t>(0, 4)});
   auto plan = PlanBuilder()
@@ -120,13 +202,168 @@ TEST_F(CudfBatchConcatTest, singleColumnBearingInputPassesThrough) {
   concat.close();
 }
 
+TEST_F(
+    CudfBatchConcatTest,
+    flushesByEstimatedGpuBytesAndRetainsTailUntilNoMoreInput) {
+  constexpr vector_size_t kRowsPerBatch = 10;
+  auto smallInput = makeRowVector({makeFlatVector<std::string>(
+      kRowsPerBatch, [](auto /*row*/) { return "x"; })});
+  auto largeInput = makeRowVector({makeFlatVector<std::string>(
+      kRowsPerBatch, [](auto /*row*/) { return std::string(4'096, 'y'); })});
+  auto tailInput = makeRowVector({makeFlatVector<std::string>(
+      kRowsPerBatch, [](auto /*row*/) { return "z"; })});
+
+  auto small = toCudfVector(smallInput);
+  auto large = toCudfVector(largeInput);
+  auto tail = toCudfVector(tailInput);
+  ASSERT_LT(small->estimateFlatSize(), large->estimateFlatSize());
+  ASSERT_LT(tail->estimateFlatSize(), large->estimateFlatSize());
+
+  const auto targetBytes =
+      std::max(small->estimateFlatSize(), tail->estimateFlatSize()) + 1;
+  ASSERT_LT(targetBytes, large->estimateFlatSize());
+  updateCudfConfig(
+      /*minBytes=*/targetBytes, /*maxRows=*/std::nullopt);
+  auto plan = createAggregationPlan(smallInput);
+  auto task = createTask(plan);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  CudfBatchConcat concat(0, &driverCtx, plan);
+
+  ASSERT_TRUE(concat.needsInput());
+  concat.addInput(small);
+  EXPECT_TRUE(concat.needsInput());
+  EXPECT_EQ(concat.getOutput(), nullptr);
+
+  concat.addInput(large);
+  EXPECT_FALSE(concat.needsInput());
+  auto fullBatch = concat.getOutput();
+  ASSERT_NE(fullBatch, nullptr);
+  EXPECT_EQ(fullBatch->size(), 2 * kRowsPerBatch);
+  EXPECT_GE(
+      fullBatch->estimateFlatSize(),
+      CudfConfig::getInstance().batchSizeMinBytes.value());
+
+  ASSERT_TRUE(concat.needsInput());
+  concat.addInput(tail);
+  EXPECT_TRUE(concat.needsInput());
+  EXPECT_EQ(concat.getOutput(), nullptr);
+  EXPECT_FALSE(concat.isFinished());
+
+  concat.noMoreInput();
+  auto tailBatch = concat.getOutput();
+  ASSERT_NE(tailBatch, nullptr);
+  EXPECT_EQ(tailBatch->size(), kRowsPerBatch);
+  EXPECT_TRUE(concat.isFinished());
+}
+
+TEST_F(CudfBatchConcatTest, usesRowTargetWhenByteTargetIsNotConfigured) {
+  constexpr vector_size_t kRowsPerBatch = 10;
+  auto input = makeRowVector({makeFlatSequence<int64_t>(0, kRowsPerBatch)});
+  auto first = toCudfVector(input, 1'000'000);
+  auto second = toCudfVector(input, 1'000'000);
+
+  auto& config = CudfConfig::getInstance();
+  config.batchSizeMinBytes = {};
+  config.batchSizeMinThreshold = 2 * kRowsPerBatch;
+  config.batchSizeMaxThreshold.reset();
+
+  auto plan = createAggregationPlan(input);
+  auto task = createTask(plan);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  CudfBatchConcat concat(0, &driverCtx, plan);
+
+  concat.addInput(first);
+  EXPECT_TRUE(concat.needsInput());
+  EXPECT_EQ(concat.getOutput(), nullptr);
+
+  concat.addInput(second);
+  EXPECT_FALSE(concat.needsInput());
+  auto output = concat.getOutput();
+  ASSERT_NE(output, nullptr);
+  EXPECT_EQ(output->size(), 2 * kRowsPerBatch);
+}
+
+TEST_F(CudfBatchConcatTest, rejectsZeroByteTarget) {
+  auto input = makeRowVector({makeFlatVector<int64_t>({1})});
+  auto plan = createAggregationPlan(input);
+  auto task = createTask(plan);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  updateCudfConfig(/*minBytes=*/0, /*maxRows=*/std::nullopt);
+
+  VELOX_ASSERT_THROW(
+      CudfBatchConcat(0, &driverCtx, plan),
+      "cuDF BatchConcat minimum byte target must be positive");
+}
+
+TEST_F(CudfBatchConcatTest, rejectsBufferedByteOverflow) {
+  auto input = makeRowVector({makeFlatVector<int64_t>({1})});
+  auto first = toCudfVector(input, std::numeric_limits<uint64_t>::max() - 1);
+  auto second = toCudfVector(input, 2);
+  updateCudfConfig(
+      /*minBytes=*/std::numeric_limits<uint64_t>::max(),
+      /*maxRows=*/std::nullopt);
+
+  auto plan = createAggregationPlan(input);
+  auto task = createTask(plan);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  CudfBatchConcat concat(0, &driverCtx, plan);
+
+  concat.addInput(first);
+  ASSERT_TRUE(concat.needsInput());
+  VELOX_ASSERT_THROW(
+      concat.addInput(second), "CudfBatchConcat buffered byte count overflow");
+}
+
+TEST_F(CudfBatchConcatTest, zeroColumnVectorsUseRowFallback) {
+  constexpr vector_size_t kRowsPerBatch = 10;
+  auto input = std::make_shared<RowVector>(
+      pool_.get(),
+      ROW({}, {}),
+      BufferPtr(nullptr),
+      kRowsPerBatch,
+      std::vector<VectorPtr>{},
+      std::nullopt);
+  auto first = toCudfVector(input);
+  auto second = toCudfVector(input);
+  auto tail = toCudfVector(input);
+  ASSERT_EQ(first->estimateFlatSize(), 0);
+
+  updateCudfConfig(
+      /*minBytes=*/1,
+      /*maxRows=*/std::nullopt,
+      /*zeroColumnMinRows=*/2 * kRowsPerBatch);
+  auto plan = createAggregationPlan(input);
+  auto task = createTask(plan);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  CudfBatchConcat concat(0, &driverCtx, plan);
+
+  concat.addInput(first);
+  EXPECT_TRUE(concat.needsInput());
+  EXPECT_EQ(concat.getOutput(), nullptr);
+
+  concat.addInput(second);
+  EXPECT_FALSE(concat.needsInput());
+  auto fullBatch = concat.getOutput();
+  ASSERT_NE(fullBatch, nullptr);
+  EXPECT_EQ(fullBatch->size(), 2 * kRowsPerBatch);
+  EXPECT_EQ(fullBatch->estimateFlatSize(), 0);
+
+  concat.addInput(tail);
+  EXPECT_TRUE(concat.needsInput());
+  EXPECT_EQ(concat.getOutput(), nullptr);
+  concat.noMoreInput();
+  auto tailBatch = concat.getOutput();
+  ASSERT_NE(tailBatch, nullptr);
+  EXPECT_EQ(tailBatch->size(), kRowsPerBatch);
+  EXPECT_TRUE(concat.isFinished());
+}
+
 // Verifies that CudfBatchConcat is inserted before aggregation and reduces
 // the number of batches reaching the aggregation operator.
 TEST_F(CudfBatchConcatTest, concatReducesBatchesBeforeAggregation) {
   // 6 batches of 10 rows each = 60 rows total.
-  // With min threshold 30, concat should accumulate ~3 batches before flushing,
-  // producing fewer output batches than the 6 it received.
-  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  // A byte target above their combined size merges them on noMoreInput.
+  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -167,7 +404,7 @@ TEST_F(CudfBatchConcatTest, concatReducesBatchesBeforeAggregation) {
 // Verifies that CudfBatchConcat is not inserted when the optimization is
 // disabled, even when aggregation is present.
 TEST_F(CudfBatchConcatTest, concatNotInsertedWhenDisabled) {
-  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = false;
 
   std::vector<RowVectorPtr> vectors;
@@ -198,10 +435,10 @@ TEST_F(CudfBatchConcatTest, concatNotInsertedWhenDisabled) {
       << "CudfBatchConcat should not be present when optimization is disabled";
 }
 
-// When the threshold exceeds total input rows, concat accumulates all batches
+// When the threshold exceeds total input bytes, concat accumulates all batches
 // and flushes them as a single merged batch on noMoreInput.
 TEST_F(CudfBatchConcatTest, concatMergesAllOnFlushWithHighThreshold) {
-  updateCudfConfig(/*min=*/100000, /*max=*/std::nullopt);
+  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -240,7 +477,7 @@ TEST_F(CudfBatchConcatTest, concatMergesAllOnFlushWithHighThreshold) {
 
 // Verifies correctness with grouped aggregation (non-global) and concat.
 TEST_F(CudfBatchConcatTest, concatWithGroupedAggregation) {
-  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -276,7 +513,10 @@ TEST_F(CudfBatchConcatTest, concatWithGroupedAggregation) {
 }
 
 TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
-  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  updateCudfConfig(
+      /*minBytes=*/1,
+      /*maxRows=*/std::nullopt,
+      /*zeroColumnMinRows=*/30);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   auto data = makeRowVector({
@@ -311,7 +551,7 @@ TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
 // Verifies that CudfBatchConcat is inserted before the hash join probe and
 // correctly handles the 2-source HashJoinNode plan node.
 TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
-  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   // Probe side: 6 batches of 10 rows each.
@@ -368,7 +608,7 @@ TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
 }
 
 TEST_F(CudfBatchConcatTest, rightJoinCollectsMatchedRowsFromPeerProbes) {
-  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  updateCudfConfig(/*minBytes=*/1'048'576, /*maxRows=*/std::nullopt);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> probeVectors;
@@ -414,7 +654,8 @@ TEST_F(CudfBatchConcatTest, rightJoinCollectsMatchedRowsFromPeerProbes) {
 }
 
 TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
-  updateCudfConfig(/*min=*/30, /*max=*/20);
+  updateCudfConfig(
+      /*minBytes=*/1, /*maxRows=*/20, /*zeroColumnMinRows=*/30);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   std::vector<RowVectorPtr> vectors;
@@ -451,7 +692,8 @@ TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
 }
 
 TEST_F(CudfBatchConcatTest, singleZeroColumnBatchSplitsAtMaxThreshold) {
-  updateCudfConfig(/*min=*/30, /*max=*/20);
+  updateCudfConfig(
+      /*minBytes=*/1, /*maxRows=*/20, /*zeroColumnMinRows=*/30);
   CudfConfig::getInstance().concatOptimizationEnabled = true;
 
   auto data = makeRowVector({makeFlatSequence<int64_t>(0, 30)});

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -55,6 +55,26 @@ TEST(ConfigTest, cudfConfig) {
   ASSERT_EQ(config.batchSizeMinBytes.value(), 2'147'483'648);
 }
 
+TEST(ConfigTest, rejectsZeroBatchSizeMinThreshold) {
+  CudfConfig config;
+  std::unordered_map<std::string, std::string> options = {
+      {CudfConfig::kCudfBatchSizeMinThreshold, "0"}};
+
+  VELOX_ASSERT_USER_THROW(
+      config.initialize(std::move(options)),
+      "cuDF BatchConcat minimum row target must be positive");
+}
+
+TEST(ConfigTest, rejectsNegativeBatchSizeMinThreshold) {
+  CudfConfig config;
+  std::unordered_map<std::string, std::string> options = {
+      {CudfConfig::kCudfBatchSizeMinThreshold, "-5"}};
+
+  VELOX_ASSERT_USER_THROW(
+      config.initialize(std::move(options)),
+      "cuDF BatchConcat minimum row target must be positive");
+}
+
 TEST(ConfigTest, rejectsZeroBatchSizeMinBytes) {
   CudfConfig config;
   std::unordered_map<std::string, std::string> options = {

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -16,9 +16,21 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+#include <folly/Conv.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+
 namespace facebook::velox::cudf_velox::test {
+
+TEST(ConfigTest, batchConcatThresholdDefaults) {
+  CudfConfig config;
+  EXPECT_EQ(config.batchSizeMinThreshold, 100'000);
+  EXPECT_FALSE(config.batchSizeMinBytes);
+}
 
 TEST(ConfigTest, cudfConfig) {
   std::unordered_map<std::string, std::string> options = {
@@ -27,7 +39,9 @@ TEST(ConfigTest, cudfConfig) {
       {CudfConfig::kCudfMemoryResource, "arena"},
       {CudfConfig::kCudfMemoryPercent, "25"},
       {CudfConfig::kCudfFunctionNamePrefix, "presto"},
-      {CudfConfig::kCudfAllowCpuFallback, "false"}};
+      {CudfConfig::kCudfAllowCpuFallback, "false"},
+      {CudfConfig::kCudfBatchSizeMinThreshold, "123456"},
+      {CudfConfig::kCudfBatchSizeMinBytes, "2147483648"}};
 
   CudfConfig config;
   config.initialize(std::move(options));
@@ -37,5 +51,36 @@ TEST(ConfigTest, cudfConfig) {
   ASSERT_EQ(config.memoryPercent, 25);
   ASSERT_EQ(config.functionNamePrefix, "presto");
   ASSERT_EQ(config.allowCpuFallback, false);
+  ASSERT_EQ(config.batchSizeMinThreshold, 123'456);
+  ASSERT_EQ(config.batchSizeMinBytes.value(), 2'147'483'648);
+}
+
+TEST(ConfigTest, rejectsZeroBatchSizeMinBytes) {
+  CudfConfig config;
+  std::unordered_map<std::string, std::string> options = {
+      {CudfConfig::kCudfBatchSizeMinBytes, "0"}};
+
+  VELOX_ASSERT_USER_THROW(
+      config.initialize(std::move(options)),
+      "cuDF BatchConcat minimum byte target must be positive");
+}
+
+TEST(ConfigTest, parsesMaximumBatchSizeMinBytes) {
+  CudfConfig config;
+  std::unordered_map<std::string, std::string> options = {
+      {CudfConfig::kCudfBatchSizeMinBytes, "18446744073709551615"}};
+
+  config.initialize(std::move(options));
+
+  EXPECT_EQ(
+      config.batchSizeMinBytes.value(), std::numeric_limits<uint64_t>::max());
+}
+
+TEST(ConfigTest, rejectsBatchSizeMinBytesOverflow) {
+  CudfConfig config;
+  std::unordered_map<std::string, std::string> options = {
+      {CudfConfig::kCudfBatchSizeMinBytes, "18446744073709551616"}};
+
+  EXPECT_THROW(config.initialize(std::move(options)), folly::ConversionError);
 }
 } // namespace facebook::velox::cudf_velox::test

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -19,10 +19,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 
-#include <folly/Conv.h>
 #include <gtest/gtest.h>
-
-#include <limits>
 
 namespace facebook::velox::cudf_velox::test {
 
@@ -55,52 +52,21 @@ TEST(ConfigTest, cudfConfig) {
   ASSERT_EQ(config.batchSizeMinBytes.value(), 2'147'483'648);
 }
 
-TEST(ConfigTest, rejectsZeroBatchSizeMinThreshold) {
-  CudfConfig config;
-  std::unordered_map<std::string, std::string> options = {
-      {CudfConfig::kCudfBatchSizeMinThreshold, "0"}};
+TEST(ConfigTest, rejectsNonPositiveBatchConcatTargets) {
+  auto initialize = [](const char* key, const char* value) {
+    CudfConfig config;
+    config.initialize({{key, value}});
+  };
 
   VELOX_ASSERT_USER_THROW(
-      config.initialize(std::move(options)),
+      initialize(CudfConfig::kCudfBatchSizeMinThreshold, "0"),
       "cuDF BatchConcat minimum row target must be positive");
-}
-
-TEST(ConfigTest, rejectsNegativeBatchSizeMinThreshold) {
-  CudfConfig config;
-  std::unordered_map<std::string, std::string> options = {
-      {CudfConfig::kCudfBatchSizeMinThreshold, "-5"}};
-
   VELOX_ASSERT_USER_THROW(
-      config.initialize(std::move(options)),
+      initialize(CudfConfig::kCudfBatchSizeMinThreshold, "-5"),
       "cuDF BatchConcat minimum row target must be positive");
-}
-
-TEST(ConfigTest, rejectsZeroBatchSizeMinBytes) {
-  CudfConfig config;
-  std::unordered_map<std::string, std::string> options = {
-      {CudfConfig::kCudfBatchSizeMinBytes, "0"}};
-
   VELOX_ASSERT_USER_THROW(
-      config.initialize(std::move(options)),
+      initialize(CudfConfig::kCudfBatchSizeMinBytes, "0"),
       "cuDF BatchConcat minimum byte target must be positive");
 }
 
-TEST(ConfigTest, parsesMaximumBatchSizeMinBytes) {
-  CudfConfig config;
-  std::unordered_map<std::string, std::string> options = {
-      {CudfConfig::kCudfBatchSizeMinBytes, "18446744073709551615"}};
-
-  config.initialize(std::move(options));
-
-  EXPECT_EQ(
-      config.batchSizeMinBytes.value(), std::numeric_limits<uint64_t>::max());
-}
-
-TEST(ConfigTest, rejectsBatchSizeMinBytesOverflow) {
-  CudfConfig config;
-  std::unordered_map<std::string, std::string> options = {
-      {CudfConfig::kCudfBatchSizeMinBytes, "18446744073709551616"}};
-
-  EXPECT_THROW(config.initialize(std::move(options)), folly::ConversionError);
-}
 } // namespace facebook::velox::cudf_velox::test


### PR DESCRIPTION
## Summary
- Adds an optional `cudf.batch_size_min_bytes` target so rebatching can be bounded by estimated GPU data size instead of row count.
- Preserves the existing row threshold when the byte target is absent and for zero-column vectors.
- Keeps retained-tail accounting consistent with the active target and rejects invalid targets or counter overflow.
- Adds coverage for byte-triggered flushing, legacy fallback, zero-column inputs, configuration parsing, and overflow paths.