### PR TITLE
fix(iceberg): Field id based matching for equality delete columns

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -211,15 +211,44 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
     return fieldIds;
   }
 
+  // Equality-delete columns absent from the user's projection have no
+  // IcebergColumnHandle and would otherwise get a sentinel field ID. Collect
+  // their real Iceberg field IDs via resolveEqualityColumns() — the single
+  // authoritative path for field-ID→name resolution — so the Parquet reader
+  // can locate those columns physically. This is purely additive: it only
+  // fills slots where handleByName has no entry.
+  std::unordered_map<std::string, int32_t> equalityFieldIdByName;
+  for (const auto& deleteFile : icebergSplit_->deleteFiles) {
+    if (deleteFile.content != FileContent::kEqualityDeletes ||
+        deleteFile.recordCount == 0 || deleteFile.equalityFieldIds.empty()) {
+      continue;
+    }
+    if (shouldSkipBySequenceNumber(
+            deleteFile.dataSequenceNumber,
+            icebergSplit_->dataSequenceNumber,
+            /*isEqualityDelete=*/true)) {
+      continue;
+    }
+
+    auto [names, types] = resolveEqualityColumns(deleteFile);
+    for (size_t i = 0; i < names.size(); ++i) {
+      equalityFieldIdByName.emplace(names[i], deleteFile.equalityFieldIds[i]);
+    }
+  }
+
   fieldIds.reserve(dataColumns->size());
   int32_t sentinelFieldId = -1;
   for (size_t i = 0; i < dataColumns->size(); ++i) {
-    auto it = handleByName.find(dataColumns->nameOf(static_cast<uint32_t>(i)));
+    const auto& colName = dataColumns->nameOf(static_cast<uint32_t>(i));
+    auto it = handleByName.find(colName);
     if (it != handleByName.end()) {
       fieldIds.push_back(it->second->field());
     } else if (dataColumnFieldIds != nullptr && !dataColumnFieldIds->empty()) {
       fieldIds.push_back(
           dwio::common::ParquetFieldId{dataColumnFieldIds->at(i), {}});
+    } else if (auto eqIt = equalityFieldIdByName.find(colName);
+               eqIt != equalityFieldIdByName.end()) {
+      fieldIds.push_back(dwio::common::ParquetFieldId{eqIt->second, {}});
     } else {
       fieldIds.push_back(dwio::common::ParquetFieldId{sentinelFieldId--, {}});
     }

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -172,7 +172,13 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     )
   endif()
 
-  add_executable(velox_hive_iceberg_equality_delete_test EqualityDeleteFileReaderTest.cpp Main.cpp)
+  add_executable(
+    velox_hive_iceberg_equality_delete_test
+    EqualityDeleteFileReaderTest.cpp
+    IcebergTestBase.cpp
+    Main.cpp
+  )
+  velox_add_test_headers(velox_hive_iceberg_equality_delete_test IcebergTestBase.h)
   add_test(velox_hive_iceberg_equality_delete_test velox_hive_iceberg_equality_delete_test)
 
   target_link_libraries(
@@ -181,8 +187,18 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_hive_iceberg_splitreader
     velox_exec_test_lib
     velox_dwio_common_test_utils
+    velox_vector_fuzzer
     GTest::gtest
+    GTest::gtest_main
   )
+
+  if(VELOX_ENABLE_PARQUET)
+    target_link_libraries(
+      velox_hive_iceberg_equality_delete_test
+      velox_dwio_parquet_reader
+      velox_dwio_parquet_writer
+    )
+  endif()
 
   add_executable(velox_hive_iceberg_deletion_vector_writer_test DeletionVectorWriterTest.cpp)
   add_test(

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -16,218 +16,195 @@
 
 #include <gtest/gtest.h>
 
-#include "velox/common/file/FileSystems.h"
-#include "velox/common/testutil/TempDirectoryPath.h"
-#include "velox/connectors/ConnectorRegistry.h"
-#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
-#include "velox/connectors/hive/iceberg/IcebergConnector.h"
-#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
-#include "velox/connectors/hive/iceberg/IcebergSplit.h"
-#include "velox/dwio/common/Writer.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
-#include "velox/exec/tests/utils/PlanBuilder.h"
 
-namespace facebook::velox::connector::hive::iceberg {
+namespace facebook::velox::connector::hive::iceberg::test {
 
-using namespace facebook::velox::exec::test;
+using exec::test::assertEqualResults;
+using exec::test::AssertQueryBuilder;
 
-namespace {
+// ---------------------------------------------------------------------------
+// FileWriteMode — parameterizes file format and whether iceberg.id field IDs
+// are stamped in the written files.
+//
+// Valid combinations:
+//   {DWRF,    withFieldIds=false}  — plain DWRF, positional-fallback path
+//   {DWRF,    withFieldIds=true }  — DWRF with iceberg.id attrs, kFieldId path
+//   {PARQUET, withFieldIds=true }  — Parquet with field IDs (only valid mode)
+// ---------------------------------------------------------------------------
+struct FileWriteMode {
+  dwio::common::FileFormat format;
+  bool withFieldIds;
 
-const std::string kIcebergConnectorId = "test-iceberg-eq-delete";
+  std::string toString() const {
+    const std::string fmt =
+        format == dwio::common::FileFormat::PARQUET ? "Parquet" : "Dwrf";
+    return fmt + (withFieldIds ? "_FieldId" : "_Positional");
+  }
+};
 
-} // namespace
-
-/// End-to-end tests for equality deletes via the IcebergSplitReader.
-/// These tests write DWRF data files and delete files, then execute
-/// table scans verifying that matching rows are filtered out.
-class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
+// ---------------------------------------------------------------------------
+// EqualityDeleteFileReaderTest
+//
+// Non-parameterized base fixture.  Partition-column and evolved-schema tests
+// live here as TEST_F.  The parameterized class inherits this.
+// ---------------------------------------------------------------------------
+class EqualityDeleteFileReaderTest : public IcebergTestBase {
  protected:
-  void SetUp() override {
-    HiveConnectorTestBase::SetUp();
-    IcebergConnectorFactory icebergFactory;
-    auto icebergConnector = icebergFactory.newConnector(
-        kIcebergConnectorId,
-        std::make_shared<config::ConfigBase>(
-            std::unordered_map<std::string, std::string>()),
-        ioExecutor_.get());
-    connector::ConnectorRegistry::global().insert(
-        icebergConnector->connectorId(), icebergConnector);
-  }
-
-  void TearDown() override {
-    connector::ConnectorRegistry::global().erase(kIcebergConnectorId);
-    HiveConnectorTestBase::TearDown();
-  }
-
-  uint64_t getFileSize(const std::string& path) {
-    return filesystems::getFileSystem(path, nullptr)
-        ->openFileForRead(path)
-        ->size();
-  }
-
-  /// Writes a DWRF data file containing the given vectors.
-  std::shared_ptr<common::testutil::TempFilePath> writeDataFile(
+  /// Writes a file in the format described by 'mode'. When
+  /// Writes a file according to 'mode':
+  ///   DWRF  + withFieldIds=false  — plain DWRF, no iceberg.id attributes
+  ///                                  (positional fallback in DwrfReader)
+  ///   DWRF  + withFieldIds=true   — DWRF with iceberg.id footer attributes
+  ///                                  (kFieldId / renameByFieldId path)
+  ///   PARQUET + withFieldIds=true — Parquet with field_id metadata stamped
+  ///                                  (kParquetFieldId path)
+  ///   PARQUET + withFieldIds=false— Parquet without field_id metadata;
+  ///                                  buildFieldIds() returns empty so
+  ///                                  kParquetFieldId is not activated and the
+  ///                                  reader uses kPosition (ordinal binding).
+  std::shared_ptr<common::testutil::TempFilePath> writeFile(
       const std::vector<RowVectorPtr>& data,
-      const std::vector<int32_t>& fieldIds = {}) {
-    auto file = common::testutil::TempFilePath::create();
-    if (fieldIds.empty()) {
-      writeToFile(file->getPath(), data);
-      return file;
+      const std::vector<int32_t>& fieldIds,
+      const FileWriteMode& mode) {
+    if (mode.format == dwio::common::FileFormat::PARQUET) {
+#ifdef VELOX_ENABLE_PARQUET
+      // Pass fieldIds only when the mode wants them stamped; empty vector means
+      // no field_id metadata in the Parquet schema -> kPosition mode.
+      return writeParquetFile(
+          data, mode.withFieldIds ? fieldIds : std::vector<int32_t>{});
+#else
+      VELOX_FAIL("Parquet support is not enabled");
+#endif
     }
-
-    VELOX_CHECK_EQ(data.front()->type()->size(), fieldIds.size());
-    dwio::common::WriterOptions options;
-    auto dwrfOptions = std::make_shared<dwrf::DwrfWriterOptions>();
-    for (uint32_t i = 0; i < fieldIds.size(); ++i) {
-      dwrfOptions->schemaAttributes[i + 1] = {
-          {"iceberg.id", std::to_string(fieldIds[i])}};
-    }
-    options.formatSpecificOptions = std::move(dwrfOptions);
-    options.schema = data.front()->type();
-    options.memoryPool = rootPool_.get();
-
-    auto fs = filesystems::getFileSystem(file->getPath(), {});
-    auto writeFile = fs->openFileForWrite(
-        file->getPath(),
-        {.shouldCreateParentDirectories = true,
-         .shouldThrowOnFileAlreadyExists = false});
-    auto sink = std::make_unique<dwio::common::WriteFileSink>(
-        std::move(writeFile), file->getPath());
-    dwrf::Writer writer{std::move(sink), options};
-    for (const auto& vector : data) {
-      writer.write(vector);
-    }
-    writer.close();
-    return file;
+    return mode.withFieldIds ? writeDwrfFileWithFieldIds(data, fieldIds)
+                             : writeDataFile(data);
   }
 
-  /// Writes a DWRF delete file containing the equality delete rows.
-  std::shared_ptr<common::testutil::TempFilePath> writeEqDeleteFile(
-      const std::vector<RowVectorPtr>& deleteData) {
-    auto file = common::testutil::TempFilePath::create();
-    writeToFile(file->getPath(), deleteData);
-    return file;
-  }
-
-  /// Creates splits with equality delete files attached.
-  std::vector<std::shared_ptr<ConnectorSplit>> makeSplits(
-      const std::string& dataFilePath,
-      const std::vector<IcebergDeleteFile>& deleteFiles = {},
-      int64_t dataSequenceNumber = 0) {
-    return makeSplits(
-        dataFilePath,
-        /*partitionKeys=*/{},
-        deleteFiles,
-        dataSequenceNumber);
-  }
-
-  /// Creates splits with equality delete files and partition keys attached.
-  /// Use this overload to exercise the equality-delete augmentation for
-  /// partition columns missing from the user's projection.
-  ///
-  /// 'partitionKeys' is the raw name-keyed map that carries every partition
-  /// field under its derived 'PartitionField.name()'.
-  /// 'identityPartitionKeys' is the field-ID-keyed map that carries only
-  /// fields the partition spec explicitly marks as the identity transform;
-  /// only these may be substituted for a read of the source column.
+  /// Creates splits for the data file using the format in 'mode', attaching
+  /// delete files and (optionally) partition keys.
   std::vector<std::shared_ptr<ConnectorSplit>> makeSplits(
       const std::string& dataFilePath,
       const std::unordered_map<std::string, std::optional<std::string>>&
           partitionKeys,
-      const std::vector<IcebergDeleteFile>& deleteFiles,
+      const FileWriteMode& mode,
+      const std::vector<IcebergDeleteFile>& deleteFiles = {},
       int64_t dataSequenceNumber = 0,
       const std::unordered_map<int32_t, std::optional<std::string>>&
           identityPartitionKeys = {}) {
-    auto fileSize = getFileSize(dataFilePath);
-    return {std::make_shared<HiveIcebergSplit>(
-        kIcebergConnectorId,
+    fileFormat_ = mode.format; // makeIcebergSplits uses fileFormat_
+    return makeIcebergSplits(
         dataFilePath,
-        dwio::common::FileFormat::DWRF,
-        0,
-        fileSize,
-        partitionKeys,
-        std::nullopt,
-        std::unordered_map<std::string, std::string>{},
-        nullptr,
-        /*cacheable=*/true,
         deleteFiles,
-        std::unordered_map<std::string, std::string>{},
-        std::nullopt,
+        partitionKeys,
+        /*splitCount=*/1,
+        /*infoColumns=*/{},
         dataSequenceNumber,
-        identityPartitionKeys)};
+        identityPartitionKeys);
   }
 
-  /// Builds a table scan plan node with the given schema.
-  core::PlanNodePtr makeTableScanPlan(const RowTypePtr& rowType) {
-    return makeTableScanPlan(rowType, rowType);
-  }
-
-  /// Builds a table scan plan node with separate output and table column
-  /// schemas. Use this when the user's projection ('outputType') does not
-  /// contain every column referenced by an equality delete file
-  /// ('dataColumns' must contain the full table schema so the equality
-  /// column resolution can map field IDs to names).
-  core::PlanNodePtr makeTableScanPlan(
-      const RowTypePtr& outputType,
-      const RowTypePtr& dataColumns) {
-    return PlanBuilder()
-        .startTableScan(kIcebergConnectorId)
-        .outputType(outputType)
-        .dataColumns(dataColumns)
-        .endTableScan()
-        .planNode();
-  }
-
-  /// Builds a table scan whose full table schema uses explicit Iceberg field
-  /// IDs. Only projected columns receive column handles, matching production
-  /// plans where equality-delete columns may be otherwise unreferenced.
-  core::PlanNodePtr makeTableScanPlan(
-      const RowTypePtr& outputType,
-      const RowTypePtr& dataColumns,
-      const std::vector<int32_t>& dataColumnFieldIds) {
-    VELOX_CHECK_EQ(dataColumns->size(), dataColumnFieldIds.size());
-
-    ColumnHandleMap assignments;
-    for (auto i = 0; i < outputType->size(); ++i) {
-      const auto& name = outputType->nameOf(i);
-      const auto dataColumnIndex = dataColumns->getChildIdx(name);
-      assignments.emplace(
-          name,
-          std::make_shared<IcebergColumnHandle>(
-              name,
-              FileColumnHandle::ColumnType::kRegular,
-              outputType->childAt(i),
-              parquet::ParquetFieldId{
-                  dataColumnFieldIds[dataColumnIndex], {}}));
-    }
-
-    auto tableHandle = std::make_shared<HiveTableHandle>(
-        kIcebergConnectorId,
-        "iceberg_table",
-        common::SubfieldFilters{},
-        /*remainingFilter=*/nullptr,
-        dataColumns,
-        /*indexColumns=*/std::vector<std::string>{},
-        /*tableParameters=*/std::unordered_map<std::string, std::string>{},
-        /*filterColumnHandles=*/std::vector<HiveColumnHandlePtr>{},
-        /*sampleRate=*/1.0,
-        /*dbName=*/"",
-        dataColumnFieldIds);
-
-    return PlanBuilder()
-        .startTableScan(kIcebergConnectorId)
-        .outputType(outputType)
-        .assignments(assignments)
-        .tableHandle(std::move(tableHandle))
-        .endTableScan()
-        .planNode();
+  /// Builds an IcebergDeleteFile descriptor.
+  IcebergDeleteFile makeDeleteFile(
+      const std::string& path,
+      const std::vector<int32_t>& equalityFieldIds,
+      dwio::common::FileFormat format,
+      int64_t recordCount = 2,
+      int64_t deleteSeqNum = 0) {
+    return IcebergDeleteFile(
+        FileContent::kEqualityDeletes,
+        path,
+        format,
+        recordCount,
+        getFileSize(path),
+        equalityFieldIds,
+        /*lowerBounds=*/{},
+        /*upperBounds=*/{},
+        deleteSeqNum);
   }
 };
 
+// ---------------------------------------------------------------------------
+// EqualityDeleteFileReaderTestP — parameterized over FileWriteMode.
+//
+// Every TEST_P runs three times:
+//   1. Dwrf_Positional — DWRF, no field IDs     (kPosition fallback)
+//   2. Dwrf_FieldId    — DWRF, iceberg.id attrs (kFieldId path)
+//   3. Parquet_FieldId — Parquet field_id       (kParquetFieldId path)
+// ---------------------------------------------------------------------------
+class EqualityDeleteFileReaderTestP
+    : public EqualityDeleteFileReaderTest,
+      public ::testing::WithParamInterface<FileWriteMode> {
+ protected:
+  void SetUp() override {
+#ifndef VELOX_ENABLE_PARQUET
+    if (GetParam().format == dwio::common::FileFormat::PARQUET) {
+      GTEST_SKIP() << "Parquet support not enabled";
+    }
+#endif
+    EqualityDeleteFileReaderTest::SetUp();
+    fileFormat_ = GetParam().format;
+  }
+
+  std::shared_ptr<common::testutil::TempFilePath> writeDataFileP(
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<int32_t>& fieldIds) {
+    return writeFile(data, fieldIds, GetParam());
+  }
+
+  std::vector<std::shared_ptr<ConnectorSplit>> makeSplitsP(
+      const std::string& dataFilePath,
+      const std::vector<IcebergDeleteFile>& deleteFiles = {},
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          partitionKeys = {}) {
+    return makeSplits(
+        dataFilePath,
+        partitionKeys,
+        GetParam(),
+        deleteFiles,
+        dataSequenceNumber,
+        {});
+  }
+};
+
+// Three FileWriteMode combinations:
+//
+//   Dwrf_Positional {DWRF, false}   — no iceberg.id attributes; DwrfReader
+//                                     falls back to positional name mapping.
+//
+//   Dwrf_FieldId    {DWRF, true}    — "iceberg.id" footer attributes;
+//                                     DwrfReader uses renameByFieldId.
+//
+//   Parquet_FieldId {PARQUET, true} — Parquet field_id metadata present;
+//                                     IcebergSplitReader activates
+//                                     kParquetFieldId mapping.
+//
+// {PARQUET, false} does not work end-to-end: without field IDs,
+// buildFieldIds() returns empty, IcebergSplitReader does not set a fileSchema
+// on baseReaderOpts_, and the Parquet reader has no requested-type to match
+// positions against — physical columns cannot be bound to the scan-spec names,
+// yielding all-null output.  All production Iceberg Parquet files carry field
+// IDs; this combination is therefore not a valid use case.
+INSTANTIATE_TEST_SUITE_P(
+    Formats,
+    EqualityDeleteFileReaderTestP,
+    ::testing::Values(
+        FileWriteMode{dwio::common::FileFormat::DWRF, /*withFieldIds=*/false},
+        FileWriteMode{dwio::common::FileFormat::DWRF, /*withFieldIds=*/true},
+        FileWriteMode{
+            dwio::common::FileFormat::PARQUET,
+            /*withFieldIds=*/true}),
+    [](const ::testing::TestParamInfo<FileWriteMode>& info) {
+      return info.param.toString();
+    });
+
+// ===========================================================================
+// Parameterized tests
+// ===========================================================================
+
 /// Verifies that base rows matching the equality delete file are removed.
-TEST_F(EqualityDeleteFileReaderTest, basicSingleColumnDelete) {
+TEST_P(EqualityDeleteFileReaderTestP, basicSingleColumnDelete) {
   auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
 
   auto baseData = makeRowVector(
@@ -237,26 +214,16 @@ TEST_F(EqualityDeleteFileReaderTest, basicSingleColumnDelete) {
           makeFlatVector<std::string>(
               {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
       });
-  auto dataFile = writeDataFile({baseData});
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
 
-  // Delete rows where id == 3 or id == 7.
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({3, 7}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({3, 7})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
 
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1}); // field ID 1 = column 0 = "id"
+  auto icebergDeleteFile =
+      makeDeleteFile(eqDeleteFile->getPath(), {1}, GetParam().format);
 
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(rowType);
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(rowType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
   auto expected = makeRowVector(
@@ -265,65 +232,11 @@ TEST_F(EqualityDeleteFileReaderTest, basicSingleColumnDelete) {
           makeFlatVector<int64_t>({0, 1, 2, 4, 5, 6, 8, 9}),
           makeFlatVector<std::string>({"a", "b", "c", "e", "f", "g", "i", "j"}),
       });
-
   assertEqualResults({expected}, {result});
 }
 
-/// Regression test for the bug where IcebergSplitReader fails with
-/// "Column not found in row: <name>" when an equality-delete column is not
-/// part of the user's projection. The reader must augment its scan spec to
-/// physically read the equality-delete column, apply the delete, and then
-/// project the column away from the output before returning to the operator.
-TEST_F(EqualityDeleteFileReaderTest, equalityColumnNotInProjection) {
-  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
-  // The user only selects 'value'. The equality delete is on 'id', which is
-  // NOT in the projection — this is the case that previously failed.
-  auto outputType = ROW({"value"}, {VARCHAR()});
-
-  auto baseData = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-          makeFlatVector<std::string>(
-              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  // Delete rows where id == 3 or id == 7.
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({3, 7}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1}); // field ID 1 = column 0 = "id"
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(outputType, tableType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // The 'id' column must not appear in the output; only 'value' is projected.
-  // Rows with id=3 ("d") and id=7 ("h") are removed by the equality delete.
-  auto expected = makeRowVector(
-      {"value"},
-      {
-          makeFlatVector<std::string>({"a", "b", "c", "e", "f", "g", "i", "j"}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that two equality-delete files referencing the SAME column not in
-/// the user's projection only augment 'scanSpec_' once. Exercises the
-/// de-duplication branch in 'IcebergSplitReader::prepareSplit'.
-TEST_F(EqualityDeleteFileReaderTest, multipleDeleteFilesSameMissingColumn) {
+/// Regression test: equality-delete column absent from the user's projection.
+TEST_P(EqualityDeleteFileReaderTestP, equalityColumnNotInProjection) {
   auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
   auto outputType = ROW({"value"}, {VARCHAR()});
 
@@ -334,60 +247,61 @@ TEST_F(EqualityDeleteFileReaderTest, multipleDeleteFilesSameMissingColumn) {
           makeFlatVector<std::string>(
               {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
       });
-  auto dataFile = writeDataFile({baseData});
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
 
-  // Two delete files, both targeting 'id' (which is NOT in the projection).
-  auto deleteData1 = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({2, 5}),
-      });
-  auto eqDeleteFile1 = writeEqDeleteFile({deleteData1});
-  IcebergDeleteFile icebergDeleteFile1(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile1->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile1->getPath()),
-      /*equalityFieldIds=*/{1});
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({3, 7})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
 
-  auto deleteData2 = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({0, 9}),
-      });
-  auto eqDeleteFile2 = writeEqDeleteFile({deleteData2});
-  IcebergDeleteFile icebergDeleteFile2(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile2->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile2->getPath()),
-      /*equalityFieldIds=*/{1});
+  auto icebergDeleteFile =
+      makeDeleteFile(eqDeleteFile->getPath(), {1}, GetParam().format);
 
-  auto splits =
-      makeSplits(dataFile->getPath(), {icebergDeleteFile1, icebergDeleteFile2});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
-  // Rows with id=0, 2, 5, 9 are removed (across both delete files).
   auto expected = makeRowVector(
       {"value"},
-      {
-          makeFlatVector<std::string>({"b", "d", "e", "g", "h", "i"}),
-      });
-
+      {makeFlatVector<std::string>({"a", "b", "c", "e", "f", "g", "i", "j"})});
   assertEqualResults({expected}, {result});
 }
 
-/// Verifies a multi-column equality-delete file where some columns ARE in the
-/// user's projection and some are NOT. Both must end up in the read output for
-/// the equality probe to succeed, while only the projected columns appear in
-/// the operator-visible result.
-TEST_F(EqualityDeleteFileReaderTest, equalityMixedInAndOutOfProjection) {
+/// Two delete files targeting the same column not in the projection.
+TEST_P(EqualityDeleteFileReaderTestP, multipleDeleteFilesSameMissingColumn) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          makeFlatVector<std::string>(
+              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData1 = makeRowVector({"id"}, {makeFlatVector<int64_t>({2, 5})});
+  auto eqDeleteFile1 = writeDataFileP({deleteData1}, {1});
+  auto icebergDeleteFile1 =
+      makeDeleteFile(eqDeleteFile1->getPath(), {1}, GetParam().format);
+
+  auto deleteData2 = makeRowVector({"id"}, {makeFlatVector<int64_t>({0, 9})});
+  auto eqDeleteFile2 = writeDataFileP({deleteData2}, {1});
+  auto icebergDeleteFile2 =
+      makeDeleteFile(eqDeleteFile2->getPath(), {1}, GetParam().format);
+
+  auto splits = makeSplitsP(
+      dataFile->getPath(), {icebergDeleteFile1, icebergDeleteFile2});
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"}, {makeFlatVector<std::string>({"b", "d", "e", "g", "h", "i"})});
+  assertEqualResults({expected}, {result});
+}
+
+/// Multi-column equality delete: some delete columns in projection, some not.
+TEST_P(EqualityDeleteFileReaderTestP, equalityMixedInAndOutOfProjection) {
   auto tableType = ROW({"a", "b", "c"}, {INTEGER(), VARCHAR(), BIGINT()});
-  // User selects only 'b' and 'c'. 'a' is referenced by the equality delete
-  // but not part of the projection.
   auto outputType = ROW({"b", "c"}, {VARCHAR(), BIGINT()});
 
   auto baseData = makeRowVector(
@@ -397,54 +311,508 @@ TEST_F(EqualityDeleteFileReaderTest, equalityMixedInAndOutOfProjection) {
           makeFlatVector<std::string>({"x", "y", "z", "x", "y"}),
           makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
       });
-  auto dataFile = writeDataFile({baseData});
+  auto dataFile = writeDataFileP({baseData}, {1, 2, 3});
 
-  // Delete rows where (a=2, b="y") -- removes row 1.
-  // Also (a=1, b="y") -- no match (row with a=1 has b="x").
+  // Delete (a=2, b="y") => row 1; (a=1, b="y") => no match.
   auto deleteData = makeRowVector(
       {"a", "b"},
       {
           makeFlatVector<int32_t>({2, 1}),
           makeFlatVector<std::string>({"y", "y"}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1, 2});
 
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      3,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1, 2}); // field IDs 1,2 = columns "a","b"
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {1, 2}, GetParam().format, /*recordCount=*/3);
 
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
-  // Row 1 (a=2, b="y", c=20) is deleted. The remaining rows project to
-  // (b, c).
   auto expected = makeRowVector(
       {"b", "c"},
       {
           makeFlatVector<std::string>({"x", "z", "x", "y"}),
           makeFlatVector<int64_t>({10, 30, 40, 50}),
       });
-
   assertEqualResults({expected}, {result});
 }
 
-/// Verifies that an equality delete on a partition column that IS in the data
-/// file (Iceberg-style) but NOT in the user's projection works correctly. The
-/// augmentation should set the partition value as a constant; the file-read
-/// path should then leave the constant in place because the column is present
-/// in 'fileType'.
+/// Filter-only column upgrade: 'id' in WHERE but not SELECT, also the
+/// equality-delete column.
+TEST_P(EqualityDeleteFileReaderTestP, equalityFilterOnlyColumnNotInProjection) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          makeFlatVector<std::string>(
+              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({4, 8})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  auto icebergDeleteFile =
+      makeDeleteFile(eqDeleteFile->getPath(), {1}, GetParam().format);
+
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  // WHERE id >= 3 => {3,4,5,6,7,8,9}; delete id=4,8 => {3,5,6,7,9}.
+  auto plan = makeIcebergTableScanPlan(
+      outputType, tableType, {}, /*subfieldFilters=*/{"id >= 3"});
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"}, {makeFlatVector<std::string>({"d", "f", "g", "h", "j"})});
+  assertEqualResults({expected}, {result});
+}
+
+/// Multi-column equality delete: both columns must match simultaneously.
+TEST_P(EqualityDeleteFileReaderTestP, multiColumnDelete) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({3}),
+          makeFlatVector<std::string>({"c"}),
+      });
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1, 2});
+
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {1, 2}, GetParam().format, /*recordCount=*/1);
+
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"}, {makeFlatVector<std::string>({"a", "b", "d", "e"})});
+  assertEqualResults({expected}, {result});
+}
+
+/// Two separate delete files both apply (multi-reader path).
+TEST_P(EqualityDeleteFileReaderTestP, twoDeleteFiles) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          makeFlatVector<std::string>(
+              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData1 = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 5})});
+  auto eqDeleteFile1 = writeDataFileP({deleteData1}, {1});
+  auto icebergDelete1 =
+      makeDeleteFile(eqDeleteFile1->getPath(), {1}, GetParam().format);
+
+  auto deleteData2 = makeRowVector({"id"}, {makeFlatVector<int64_t>({3, 8})});
+  auto eqDeleteFile2 = writeDataFileP({deleteData2}, {1});
+  auto icebergDelete2 =
+      makeDeleteFile(eqDeleteFile2->getPath(), {1}, GetParam().format);
+
+  auto splits =
+      makeSplitsP(dataFile->getPath(), {icebergDelete1, icebergDelete2});
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // Deleted: 1,3,5,8. Surviving: 0,2,4,6,7,9.
+  auto expected = makeRowVector(
+      {"value"}, {makeFlatVector<std::string>({"a", "c", "e", "g", "h", "j"})});
+  assertEqualResults({expected}, {result});
+}
+
+/// No rows match the delete — all rows survive.
+TEST_P(EqualityDeleteFileReaderTestP, noMatchingDeletes) {
+  auto rowType = ROW({"id"}, {BIGINT()});
+
+  auto baseData = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  auto dataFile = writeDataFileP({baseData}, {1});
+
+  auto deleteData =
+      makeRowVector({"id"}, {makeFlatVector<int64_t>({100, 200})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  auto icebergDeleteFile =
+      makeDeleteFile(eqDeleteFile->getPath(), {1}, GetParam().format);
+
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  assertEqualResults(
+      {makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 2, 3})})}, {result});
+}
+
+/// Every row is deleted.
+TEST_P(EqualityDeleteFileReaderTestP, allRowsDeleted) {
+  auto rowType = ROW({"id"}, {BIGINT()});
+
+  auto baseData = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  auto dataFile = writeDataFileP({baseData}, {1});
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {1}, GetParam().format, /*recordCount=*/3);
+
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  EXPECT_EQ(result->size(), 0);
+}
+
+/// VARCHAR column equality delete.
+TEST_P(EqualityDeleteFileReaderTestP, stringColumnDelete) {
+  auto rowType = ROW({"name", "age"}, {VARCHAR(), INTEGER()});
+
+  auto baseData = makeRowVector(
+      {"name", "age"},
+      {
+          makeFlatVector<std::string>({"alice", "bob", "charlie", "dave"}),
+          makeFlatVector<int32_t>({25, 30, 35, 40}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData =
+      makeRowVector({"name"}, {makeFlatVector<std::string>({"bob", "dave"})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  auto icebergDeleteFile =
+      makeDeleteFile(eqDeleteFile->getPath(), {1}, GetParam().format);
+
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"name", "age"},
+      {
+          makeFlatVector<std::string>({"alice", "charlie"}),
+          makeFlatVector<int32_t>({25, 35}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies equality deletes after a field has been dropped, leaving sparse
+/// top-level field IDs.
+TEST_F(EqualityDeleteFileReaderTest, nonSequentialEqualityFieldId) {
+  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
+  const std::vector<int32_t> fieldIds{1, 3};
+
+  auto baseData = makeRowVector(
+      {"id", "dropped", "category"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
+          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
+      });
+  auto dataFile = writeDwrfFileWithFieldIds({baseData}, {1, 2, 3});
+
+  auto deleteData = makeRowVector(
+      {"category"},
+      {
+          makeFlatVector<std::string>({"B"}),
+      });
+  auto eqDeleteFile = writeDataFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{3});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      {},
+      {dwio::common::FileFormat::DWRF, false},
+      {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(tableType, tableType, fieldIds);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "category"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4}),
+          makeFlatVector<std::string>({"A", "A", "C"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    nonSequentialEqualityFieldIdNotInProjection) {
+  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"id"}, {BIGINT()});
+  const std::vector<int32_t> fieldIds{1, 3};
+
+  auto baseData = makeRowVector(
+      {"id", "dropped", "category"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
+          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
+      });
+  auto dataFile = writeDwrfFileWithFieldIds({baseData}, {1, 2, 3});
+
+  auto deleteData = makeRowVector(
+      {"category"},
+      {
+          makeFlatVector<std::string>({"B"}),
+      });
+  auto eqDeleteFile = writeDataFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{3});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/{},
+      {dwio::common::FileFormat::DWRF, false},
+      {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(outputType, tableType, fieldIds);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies the ordinal fallback on a non-first column when full-schema field
+/// IDs are unavailable.
+TEST_P(EqualityDeleteFileReaderTestP, deleteOnSecondColumn) {
+  auto rowType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "category"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData =
+      makeRowVector({"category"}, {makeFlatVector<std::string>({"B"})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {2});
+
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {2}, GetParam().format, /*recordCount=*/1);
+
+  auto splits = makeSplitsP(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "category"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4}),
+          makeFlatVector<std::string>({"A", "A", "C"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// Delete applies when deleteSeqNum > dataSeqNum.
+TEST_P(EqualityDeleteFileReaderTestP, sequenceNumberDeleteApplies) {
+  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({2, 4})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  // deleteSeqNum=5 > dataSeqNum=3 => applies.
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {1}, GetParam().format, 2, /*deleteSeqNum=*/5);
+
+  auto splits = makeSplitsP(
+      dataFile->getPath(), {icebergDeleteFile}, /*dataSequenceNumber=*/3);
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 3, 5}),
+          makeFlatVector<std::string>({"a", "c", "e"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// Delete skipped when deleteSeqNum <= dataSeqNum.
+TEST_P(EqualityDeleteFileReaderTestP, sequenceNumberDeleteSkipped) {
+  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  // deleteSeqNum=2 <= dataSeqNum=5 => skipped.
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {1}, GetParam().format, 3, /*deleteSeqNum=*/2);
+
+  auto splits = makeSplitsP(
+      dataFile->getPath(), {icebergDeleteFile}, /*dataSequenceNumber=*/5);
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// Delete skipped when deleteSeqNum == dataSeqNum (edge case of <=).
+TEST_P(EqualityDeleteFileReaderTestP, sequenceNumberEqualSkipped) {
+  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  // deleteSeqNum=5 == dataSeqNum=5 => skipped.
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {1}, GetParam().format, 3, /*deleteSeqNum=*/5);
+
+  auto splits = makeSplitsP(
+      dataFile->getPath(), {icebergDeleteFile}, /*dataSequenceNumber=*/5);
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// deleteSeqNum=0 disables filtering — delete always applies.
+TEST_P(EqualityDeleteFileReaderTestP, sequenceNumberZeroAlwaysApplies) {
+  auto rowType = ROW({"id"}, {BIGINT()});
+
+  auto baseData = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  auto dataFile = writeDataFileP({baseData}, {1});
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({2})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+
+  // deleteSeqNum=0 => filtering disabled, applies despite dataSeqNum=10.
+  auto icebergDeleteFile = makeDeleteFile(
+      eqDeleteFile->getPath(), {1}, GetParam().format, 1, /*deleteSeqNum=*/0);
+
+  auto splits = makeSplitsP(
+      dataFile->getPath(), {icebergDeleteFile}, /*dataSequenceNumber=*/10);
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  assertEqualResults(
+      {makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 3})})}, {result});
+}
+
+/// Only delete files with higher sequence numbers than the data file apply.
+TEST_P(EqualityDeleteFileReaderTestP, mixedSequenceNumbers) {
+  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
+      });
+  auto dataFile = writeDataFileP({baseData}, {1, 2});
+
+  // seqNum=10 > dataSeqNum=5 => applied.
+  auto deleteData1 = makeRowVector({"id"}, {makeFlatVector<int64_t>({2})});
+  auto eqDeleteFile1 = writeDataFileP({deleteData1}, {1});
+  auto icebergDeleteFile1 = makeDeleteFile(
+      eqDeleteFile1->getPath(), {1}, GetParam().format, 1, /*deleteSeqNum=*/10);
+
+  // seqNum=3 <= dataSeqNum=5 => skipped.
+  auto deleteData2 = makeRowVector({"id"}, {makeFlatVector<int64_t>({4})});
+  auto eqDeleteFile2 = writeDataFileP({deleteData2}, {1});
+  auto icebergDeleteFile2 = makeDeleteFile(
+      eqDeleteFile2->getPath(), {1}, GetParam().format, 1, /*deleteSeqNum=*/3);
+
+  auto splits = makeSplitsP(
+      dataFile->getPath(),
+      {icebergDeleteFile1, icebergDeleteFile2},
+      /*dataSequenceNumber=*/5);
+  auto plan = makeIcebergTableScanPlan(rowType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // id=2 deleted; id=4 survives.
+  auto expected = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4, 5}),
+          makeFlatVector<std::string>({"a", "c", "d", "e"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+// ===========================================================================
+// Non-parameterized tests -- partition columns and evolved schema (DWRF only).
+// ===========================================================================
+
+/// Equality delete on a partition column in the data file but not projected.
 TEST_F(
     EqualityDeleteFileReaderTest,
     equalityPartitionColumnInFileNotInProjection) {
   auto tableType = ROW({"part", "value"}, {INTEGER(), VARCHAR()});
   auto outputType = ROW({"value"}, {VARCHAR()});
 
-  // Data file contains both 'part' and 'value', all rows in partition 2.
   auto baseData = makeRowVector(
       {"part", "value"},
       {
@@ -459,7 +827,7 @@ TEST_F(
           makeFlatVector<int32_t>({2, 2}),
           makeFlatVector<std::string>({"b", "d"}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFile({deleteData});
 
   IcebergDeleteFile icebergDeleteFile(
       FileContent::kEqualityDeletes,
@@ -471,32 +839,27 @@ TEST_F(
 
   auto splits = makeSplits(
       dataFile->getPath(),
-      /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
+      /*partitionKeys=*/{},
+      {dwio::common::FileFormat::DWRF, false},
       {icebergDeleteFile},
       /*dataSequenceNumber=*/0,
       // Source field ID 1 ('part') is an explicit identity partition field.
       /*identityPartitionKeys=*/{{1, std::optional<std::string>{"2"}}});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
-  auto expected = makeRowVector(
-      {"value"},
-      {
-          makeFlatVector<std::string>({"a", "c"}),
-      });
-
-  assertEqualResults({expected}, {result});
+  assertEqualResults(
+      {makeRowVector({"value"}, {makeFlatVector<std::string>({"a", "c"})})},
+      {result});
 }
 
-/// Same as above but the partition value does NOT match the equality-delete
-/// value, so no rows should be removed.
+/// Same as above but partition value does not match -- no rows deleted.
 TEST_F(
     EqualityDeleteFileReaderTest,
     equalityPartitionColumnNonMatchingPartition) {
   auto tableType = ROW({"part", "value"}, {INTEGER(), VARCHAR()});
   auto outputType = ROW({"value"}, {VARCHAR()});
 
-  // Data file holds rows in partition 2.
   auto baseData = makeRowVector(
       {"part", "value"},
       {
@@ -505,14 +868,13 @@ TEST_F(
       });
   auto dataFile = writeDataFile({baseData});
 
-  // Delete (part=99, value="b"). No file row matches part=99.
   auto deleteData = makeRowVector(
       {"part", "value"},
       {
           makeFlatVector<int32_t>({99}),
           makeFlatVector<std::string>({"b"}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFile({deleteData});
 
   IcebergDeleteFile icebergDeleteFile(
       FileContent::kEqualityDeletes,
@@ -524,26 +886,21 @@ TEST_F(
 
   auto splits = makeSplits(
       dataFile->getPath(),
-      /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
+      /*partitionKeys=*/{},
+      {dwio::common::FileFormat::DWRF, false},
       {icebergDeleteFile},
       /*dataSequenceNumber=*/0,
       /*identityPartitionKeys=*/{{1, std::optional<std::string>{"2"}}});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
-  auto expected = makeRowVector(
-      {"value"},
-      {
-          makeFlatVector<std::string>({"a", "b", "c"}),
-      });
-
-  assertEqualResults({expected}, {result});
+  assertEqualResults(
+      {makeRowVector(
+          {"value"}, {makeFlatVector<std::string>({"a", "b", "c"})})},
+      {result});
 }
 
-/// Multi-column equality delete where ONE column is a partition column not in
-/// the projection and ANOTHER is a regular data column not in the projection.
-/// Both must be augmented; the partition column gets a constant value, the
-/// regular column is read from the file.
+/// One partition column + one regular column, both absent from the projection.
 TEST_F(
     EqualityDeleteFileReaderTest,
     equalityMixedPartitionAndRegularNotInProjection) {
@@ -551,7 +908,6 @@ TEST_F(
       ROW({"part", "id", "value"}, {INTEGER(), BIGINT(), VARCHAR()});
   auto outputType = ROW({"value"}, {VARCHAR()});
 
-  // Data file contains all three columns, all rows in partition 7.
   auto baseData = makeRowVector(
       {"part", "id", "value"},
       {
@@ -561,14 +917,13 @@ TEST_F(
       });
   auto dataFile = writeDataFile({baseData});
 
-  // Delete (part=7, id=20) and (part=7, id=40). Should remove "b" and "d".
   auto deleteData = makeRowVector(
       {"part", "id"},
       {
           makeFlatVector<int32_t>({7, 7}),
           makeFlatVector<int64_t>({20, 40}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFile({deleteData});
 
   IcebergDeleteFile icebergDeleteFile(
       FileContent::kEqualityDeletes,
@@ -576,40 +931,31 @@ TEST_F(
       dwio::common::FileFormat::DWRF,
       2,
       getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1, 2}); // field IDs 1,2 = part, id
+      /*equalityFieldIds=*/{1, 2});
 
   auto splits = makeSplits(
       dataFile->getPath(),
-      /*partitionKeys=*/{{"part", std::optional<std::string>{"7"}}},
+      {},
+      {dwio::common::FileFormat::DWRF, false},
       {icebergDeleteFile},
       /*dataSequenceNumber=*/0,
       /*identityPartitionKeys=*/{{1, std::optional<std::string>{"7"}}});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
-  auto expected = makeRowVector(
-      {"value"},
-      {
-          makeFlatVector<std::string>({"a", "c"}),
-      });
-
-  assertEqualResults({expected}, {result});
+  assertEqualResults(
+      {makeRowVector({"value"}, {makeFlatVector<std::string>({"a", "c"})})},
+      {result});
 }
 
-/// Verifies equality delete on a DATE partition column not in projection.
-/// Iceberg encodes DATE partition values as days-since-epoch (e.g. "19345").
-/// This exercises the type-derived 'isDaysSinceEpoch' flag in
-/// 'configureEqualityDeleteColumns' — for DATE columns the partition string
-/// must be parsed as an integer day count, NOT as an ISO-8601 date string.
+/// DATE partition column not in projection (days-since-epoch encoding).
 TEST_F(
     EqualityDeleteFileReaderTest,
     equalityDatePartitionColumnNotInProjection) {
   auto tableType = ROW({"part_date", "value"}, {DATE(), VARCHAR()});
   auto outputType = ROW({"value"}, {VARCHAR()});
 
-  // 19345 days since 1970-01-01 == 2022-12-22. All file rows belong to that
-  // partition.
-  constexpr int32_t kPartitionDays = 19345;
+  constexpr int32_t kPartitionDays = 19345; // 2022-12-22
   auto baseData = makeRowVector(
       {"part_date", "value"},
       {
@@ -619,14 +965,13 @@ TEST_F(
       });
   auto dataFile = writeDataFile({baseData});
 
-  // Delete (part_date=19345, value="b").
   auto deleteData = makeRowVector(
       {"part_date", "value"},
       {
           makeFlatVector<int32_t>({kPartitionDays}, DATE()),
           makeFlatVector<std::string>({"b"}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFile({deleteData});
 
   IcebergDeleteFile icebergDeleteFile(
       FileContent::kEqualityDeletes,
@@ -638,23 +983,18 @@ TEST_F(
 
   auto splits = makeSplits(
       dataFile->getPath(),
-      /*partitionKeys=*/
-      {{"part_date",
-        std::optional<std::string>{std::to_string(kPartitionDays)}}},
+      /*partitionKeys=*/{},
+      {dwio::common::FileFormat::DWRF, false},
       {icebergDeleteFile},
       /*dataSequenceNumber=*/0,
       /*identityPartitionKeys=*/
       {{1, std::optional<std::string>{std::to_string(kPartitionDays)}}});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
-  auto expected = makeRowVector(
-      {"value"},
-      {
-          makeFlatVector<std::string>({"a", "c"}),
-      });
-
-  assertEqualResults({expected}, {result});
+  assertEqualResults(
+      {makeRowVector({"value"}, {makeFlatVector<std::string>({"a", "c"})})},
+      {result});
 }
 
 /// Regression for transformed partition fields whose derived partition-field
@@ -687,7 +1027,7 @@ TEST_F(
       {
           makeFlatVector<int64_t>({20}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFile({deleteData});
 
   IcebergDeleteFile icebergDeleteFile(
       FileContent::kEqualityDeletes,
@@ -702,11 +1042,12 @@ TEST_F(
       // The bucket ordinal, stored under a name that collides with the
       // source column.
       /*partitionKeys=*/{{"id", std::optional<std::string>{"2"}}},
+      {dwio::common::FileFormat::DWRF, false},
       {icebergDeleteFile},
       /*dataSequenceNumber=*/0,
       // 'bucket[4]' is not identity, so nothing is substitutable.
       /*identityPartitionKeys=*/{});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
   // Only the physically matching row is deleted. Substituting the bucket
@@ -744,7 +1085,7 @@ TEST_F(EqualityDeleteFileReaderTest, equalityVoidPartitionNotInProjection) {
       {
           makeNullableFlatVector<int64_t>({std::nullopt}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFile({deleteData});
 
   IcebergDeleteFile icebergDeleteFile(
       FileContent::kEqualityDeletes,
@@ -757,11 +1098,12 @@ TEST_F(EqualityDeleteFileReaderTest, equalityVoidPartitionNotInProjection) {
   auto splits = makeSplits(
       dataFile->getPath(),
       /*partitionKeys=*/{{"id", std::nullopt}},
+      {dwio::common::FileFormat::DWRF, false},
       {icebergDeleteFile},
       /*dataSequenceNumber=*/0,
       // 'void' is not identity, so its null is not substitutable.
       /*identityPartitionKeys=*/{});
-  auto plan = makeTableScanPlan(outputType, tableType);
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
   auto expected = makeRowVector(
@@ -773,95 +1115,15 @@ TEST_F(EqualityDeleteFileReaderTest, equalityVoidPartitionNotInProjection) {
   assertEqualResults({expected}, {result});
 }
 
-/// Exercises the filter-only column upgrade path in
-/// 'configureEqualityDeleteColumns'. The equality-delete column 'id' is
-/// referenced by a WHERE predicate (so the planner installs a scan-spec
-/// child with 'projectOut=false') but is NOT in the user's SELECT
-/// projection. The augmentation must upgrade the existing scan-spec child
-/// from filter-only to 'projectOut=true' and assign a non-conflicting
-/// channel so the equality-delete reader can probe by name.
-TEST_F(EqualityDeleteFileReaderTest, equalityFilterOnlyColumnNotInProjection) {
-  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
-  auto outputType = ROW({"value"}, {VARCHAR()});
-
-  auto baseData = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-          makeFlatVector<std::string>(
-              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  // Equality delete removes id == 4 and id == 8.
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({4, 8}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1}); // field ID 1 = "id"
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  // WHERE id >= 3 keeps rows {3,4,5,6,7,8,9} from the file; the equality
-  // delete then removes id=4 and id=8, leaving values {d->skipped} no, we
-  // expect surviving values for ids {3,5,6,7,9}, projected as 'value' only.
-  auto plan = PlanBuilder()
-                  .startTableScan(kIcebergConnectorId)
-                  .outputType(outputType)
-                  .dataColumns(tableType)
-                  .subfieldFilter("id >= 3")
-                  .endTableScan()
-                  .planNode();
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  auto expected = makeRowVector(
-      {"value"},
-      {
-          makeFlatVector<std::string>({"d", "f", "g", "h", "j"}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Regression test for the schema-evolution +
-/// partition-column-not-in-projection scenario surfaced by the Presto Iceberg
-/// integration test 'testEqualityDeleteWithPartitionColumnMissingInSelect'.
-///
-/// Setup (mirrors the Presto test for the older data file):
-///   - Full table schema: (a, b, c, d) with a, c, d as partition columns.
-///   - The data file under test was written BEFORE 'd' was added, so it
-///     physically contains only (a, b, c).
-///   - User projection: (a, b, d). 'd' must be NULL-filled (not in file);
-///     'c' is NOT in the projection but IS referenced by the equality
-///     delete and IS the file's identity-partition column.
-///
-/// The equality delete (a=6, c=2, b=1006) targets the file row
-/// (6, '1006', 2). The augmentation must:
-///   1. Add 'c' to 'scanSpec_' / 'readerOutputType_' so the eq-delete
-///      probe can find it by name.
-///   2. Leave 'd' alone — 'd' is in the user projection and gets the
-///      standard schema-evolution NULL-fill from 'adaptColumns'.
-///   3. Honour the existing partition-key constant on 'c' regardless of
-///      whether the file physically contains 'c'.
+/// Schema evolution + partition column not in projection (Presto regression).
 TEST_F(
     EqualityDeleteFileReaderTest,
     equalityPartitionColumnNotInProjectionWithEvolvedSchema) {
-  // Full evolved table schema (after 'ALTER TABLE ADD COLUMN d').
   auto tableType =
       ROW({"a", "b", "c", "d"}, {INTEGER(), VARCHAR(), INTEGER(), VARCHAR()});
-  // User selects 'a', 'b', 'd'. Note 'c' is NOT projected.
   auto outputType = ROW({"a", "b", "d"}, {INTEGER(), VARCHAR(), VARCHAR()});
 
-  // Data file contains only (a, b, c) — written before 'd' was added.
-  // Both rows are in the (a=6, c=2) partition.
+  // Data file was written before 'd' was added -- contains only (a, b, c).
   auto baseData = makeRowVector(
       {"a", "b", "c"},
       {
@@ -871,8 +1133,6 @@ TEST_F(
       });
   auto dataFile = writeDataFile({baseData});
 
-  // Equality delete on (a, b, c) with values (6, '1006', 2). Field IDs
-  // are in field-id order = [1, 2, 3].
   auto deleteData = makeRowVector(
       {"a", "b", "c"},
       {
@@ -880,7 +1140,7 @@ TEST_F(
           makeFlatVector<std::string>({"1006"}),
           makeFlatVector<int32_t>({2}),
       });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+  auto eqDeleteFile = writeDataFile({deleteData});
 
   IcebergDeleteFile icebergDeleteFile(
       FileContent::kEqualityDeletes,
@@ -892,16 +1152,15 @@ TEST_F(
 
   auto splits = makeSplits(
       dataFile->getPath(),
-      /*partitionKeys=*/
       {{"a", std::optional<std::string>{"6"}},
        {"c", std::optional<std::string>{"2"}}},
-      {icebergDeleteFile});
-  auto plan = makeTableScanPlan(outputType, tableType);
+      {dwio::common::FileFormat::DWRF, false},
+      {icebergDeleteFile},
+      0);
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
-  // Row (6, '1006', 2) is deleted by the equality delete; (6, '1009', 2)
-  // survives. 'd' is NULL because the data file was written before 'd'
-  // was added.
+  // (6,'1006',2) deleted; (6,'1009',2) survives. 'd' is NULL-filled.
   auto expected = makeRowVector(
       {"a", "b", "d"},
       {
@@ -909,576 +1168,7 @@ TEST_F(
           makeFlatVector<std::string>({"1009"}),
           makeNullableFlatVector<std::string>({std::nullopt}),
       });
-
   assertEqualResults({expected}, {result});
 }
 
-/// Verifies multi-column equality deletes (both columns must match).
-TEST_F(EqualityDeleteFileReaderTest, multiColumnDelete) {
-  auto rowType = ROW({"a", "b", "c"}, {INTEGER(), VARCHAR(), BIGINT()});
-
-  auto baseData = makeRowVector(
-      {"a", "b", "c"},
-      {
-          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
-          makeFlatVector<std::string>({"x", "y", "z", "x", "y"}),
-          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  // Delete rows where (a=2, b="y") — matches row index 1.
-  // Also (a=5, b="y") — matches row index 4.
-  // But (a=1, b="y") — no match (a=1 has b="x").
-  auto deleteData = makeRowVector(
-      {"a", "b"},
-      {
-          makeFlatVector<int32_t>({2, 5, 1}),
-          makeFlatVector<std::string>({"y", "y", "y"}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      3,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1, 2}); // field IDs 1,2 = columns "a","b"
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // Rows 0, 2, 3 survive (rows 1 and 4 deleted).
-  auto expected = makeRowVector(
-      {"a", "b", "c"},
-      {
-          makeFlatVector<int32_t>({1, 3, 4}),
-          makeFlatVector<std::string>({"x", "z", "x"}),
-          makeFlatVector<int64_t>({10, 30, 40}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that when no rows match, all rows survive.
-TEST_F(EqualityDeleteFileReaderTest, noMatchingDeletes) {
-  auto rowType = ROW({"id"}, {BIGINT()});
-
-  auto baseData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  // Delete file has values not present in base data.
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({100, 200}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1});
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  auto expected = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that all rows are deleted when every base row matches.
-TEST_F(EqualityDeleteFileReaderTest, allRowsDeleted) {
-  auto rowType = ROW({"id"}, {BIGINT()});
-
-  auto baseData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      3,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1});
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  EXPECT_EQ(result->size(), 0);
-}
-
-/// Verifies equality deletes with VARCHAR columns.
-TEST_F(EqualityDeleteFileReaderTest, stringColumnDelete) {
-  auto rowType = ROW({"name", "age"}, {VARCHAR(), INTEGER()});
-
-  auto baseData = makeRowVector(
-      {"name", "age"},
-      {
-          makeFlatVector<std::string>({"alice", "bob", "charlie", "dave"}),
-          makeFlatVector<int32_t>({25, 30, 35, 40}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  // Delete rows where name is "bob" or "dave".
-  auto deleteData = makeRowVector(
-      {"name"},
-      {
-          makeFlatVector<std::string>({"bob", "dave"}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1}); // field ID 1 = "name"
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  auto expected = makeRowVector(
-      {"name", "age"},
-      {
-          makeFlatVector<std::string>({"alice", "charlie"}),
-          makeFlatVector<int32_t>({25, 35}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies equality deletes after a field has been dropped, leaving sparse
-/// top-level field IDs.
-TEST_F(EqualityDeleteFileReaderTest, nonSequentialEqualityFieldId) {
-  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
-  const std::vector<int32_t> fieldIds{1, 3};
-
-  auto baseData = makeRowVector(
-      {"id", "dropped", "category"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
-          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
-      });
-  auto dataFile = writeDataFile({baseData}, {1, 2, 3});
-
-  auto deleteData = makeRowVector(
-      {"category"},
-      {
-          makeFlatVector<std::string>({"B"}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      1,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{3});
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(tableType, tableType, fieldIds);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  auto expected = makeRowVector(
-      {"id", "category"},
-      {
-          makeFlatVector<int64_t>({1, 3, 4}),
-          makeFlatVector<std::string>({"A", "A", "C"}),
-      });
-  assertEqualResults({expected}, {result});
-}
-
-TEST_F(
-    EqualityDeleteFileReaderTest,
-    nonSequentialEqualityFieldIdNotInProjection) {
-  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
-  auto outputType = ROW({"id"}, {BIGINT()});
-  const std::vector<int32_t> fieldIds{1, 3};
-
-  auto baseData = makeRowVector(
-      {"id", "dropped", "category"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
-          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
-      });
-  auto dataFile = writeDataFile({baseData}, {1, 2, 3});
-
-  auto deleteData = makeRowVector(
-      {"category"},
-      {
-          makeFlatVector<std::string>({"B"}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      1,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{3});
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(outputType, tableType, fieldIds);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  auto expected = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 3, 4}),
-      });
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies the ordinal fallback on a non-first column when full-schema field
-/// IDs are unavailable.
-TEST_F(EqualityDeleteFileReaderTest, deleteOnSecondColumn) {
-  auto rowType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
-
-  auto baseData = makeRowVector(
-      {"id", "category"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  // Delete rows where category == "B".
-  auto deleteData = makeRowVector(
-      {"category"},
-      {
-          makeFlatVector<std::string>({"B"}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      1,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{2}); // field ID 2 = column 1 = "category"
-
-  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // Rows with category="B" (indices 1,4) deleted.
-  auto expected = makeRowVector(
-      {"id", "category"},
-      {
-          makeFlatVector<int64_t>({1, 3, 4}),
-          makeFlatVector<std::string>({"A", "A", "C"}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that equality deletes apply when the delete file has a higher
-/// sequence number than the data file (per the Iceberg V2+ spec).
-TEST_F(EqualityDeleteFileReaderTest, sequenceNumberDeleteApplies) {
-  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
-
-  auto baseData = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-          makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({2, 4}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  // Delete file has sequence number 5, data file has sequence number 3.
-  // Since deleteSeq (5) > dataSeq (3), the delete should apply.
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1},
-      /*lowerBounds=*/{},
-      /*upperBounds=*/{},
-      /*dataSequenceNumber=*/5);
-
-  auto splits = makeSplits(
-      dataFile->getPath(),
-      {icebergDeleteFile},
-      /*dataSequenceNumber=*/3);
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // Rows with id=2 and id=4 are deleted.
-  auto expected = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 3, 5}),
-          makeFlatVector<std::string>({"a", "c", "e"}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that equality deletes are skipped when the delete file has a
-/// lower or equal sequence number compared to the data file.
-TEST_F(EqualityDeleteFileReaderTest, sequenceNumberDeleteSkipped) {
-  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
-
-  auto baseData = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-          makeFlatVector<std::string>({"a", "b", "c"}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  // Delete file has sequence number 2, data file has sequence number 5.
-  // Since deleteSeq (2) <= dataSeq (5), the delete should be skipped.
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      3,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1},
-      /*lowerBounds=*/{},
-      /*upperBounds=*/{},
-      /*dataSequenceNumber=*/2);
-
-  auto splits = makeSplits(
-      dataFile->getPath(),
-      {icebergDeleteFile},
-      /*dataSequenceNumber=*/5);
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // All rows survive because the delete file is skipped.
-  auto expected = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-          makeFlatVector<std::string>({"a", "b", "c"}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that equality deletes are skipped when the delete file has the
-/// same sequence number as the data file (edge case of the <= check).
-TEST_F(EqualityDeleteFileReaderTest, sequenceNumberEqualSkipped) {
-  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
-
-  auto baseData = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-          makeFlatVector<std::string>({"a", "b", "c"}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  // Delete file and data file have the same sequence number (5).
-  // Since deleteSeq (5) <= dataSeq (5), the delete should be skipped.
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      3,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1},
-      /*lowerBounds=*/{},
-      /*upperBounds=*/{},
-      /*dataSequenceNumber=*/5);
-
-  auto splits = makeSplits(
-      dataFile->getPath(),
-      {icebergDeleteFile},
-      /*dataSequenceNumber=*/5);
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // All rows survive because the delete file is skipped (equal seq#).
-  auto expected = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-          makeFlatVector<std::string>({"a", "b", "c"}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that when either sequence number is 0 (unassigned/legacy V1),
-/// the delete file is always applied (filtering is disabled).
-TEST_F(EqualityDeleteFileReaderTest, sequenceNumberZeroAlwaysApplies) {
-  auto rowType = ROW({"id"}, {BIGINT()});
-
-  auto baseData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  auto deleteData = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({2}),
-      });
-  auto eqDeleteFile = writeEqDeleteFile({deleteData});
-
-  // Delete file has sequence number 0 (legacy), data file has sequence 10.
-  // Since deleteSeq is 0, filtering is disabled and the delete applies.
-  IcebergDeleteFile icebergDeleteFile(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile->getPath(),
-      dwio::common::FileFormat::DWRF,
-      1,
-      getFileSize(eqDeleteFile->getPath()),
-      /*equalityFieldIds=*/{1},
-      /*lowerBounds=*/{},
-      /*upperBounds=*/{},
-      /*dataSequenceNumber=*/0);
-
-  auto splits = makeSplits(
-      dataFile->getPath(),
-      {icebergDeleteFile},
-      /*dataSequenceNumber=*/10);
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // Row id=2 is deleted because sequence number filtering is disabled.
-  auto expected = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({1, 3}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-/// Verifies that when multiple delete files have different sequence numbers,
-/// only those with higher sequence numbers than the data file are applied.
-TEST_F(EqualityDeleteFileReaderTest, mixedSequenceNumbers) {
-  auto rowType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
-
-  auto baseData = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-          makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
-      });
-  auto dataFile = writeDataFile({baseData});
-
-  // First delete file: seqNum=10 (higher than data seqNum=5) → applied.
-  auto deleteData1 = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({2}),
-      });
-  auto eqDeleteFile1 = writeEqDeleteFile({deleteData1});
-  IcebergDeleteFile icebergDeleteFile1(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile1->getPath(),
-      dwio::common::FileFormat::DWRF,
-      1,
-      getFileSize(eqDeleteFile1->getPath()),
-      /*equalityFieldIds=*/{1},
-      /*lowerBounds=*/{},
-      /*upperBounds=*/{},
-      /*dataSequenceNumber=*/10);
-
-  // Second delete file: seqNum=3 (lower than data seqNum=5) → skipped.
-  auto deleteData2 = makeRowVector(
-      {"id"},
-      {
-          makeFlatVector<int64_t>({4}),
-      });
-  auto eqDeleteFile2 = writeEqDeleteFile({deleteData2});
-  IcebergDeleteFile icebergDeleteFile2(
-      FileContent::kEqualityDeletes,
-      eqDeleteFile2->getPath(),
-      dwio::common::FileFormat::DWRF,
-      1,
-      getFileSize(eqDeleteFile2->getPath()),
-      /*equalityFieldIds=*/{1},
-      /*lowerBounds=*/{},
-      /*upperBounds=*/{},
-      /*dataSequenceNumber=*/3);
-
-  auto splits = makeSplits(
-      dataFile->getPath(),
-      {icebergDeleteFile1, icebergDeleteFile2},
-      /*dataSequenceNumber=*/5);
-  auto plan = makeTableScanPlan(rowType);
-  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
-
-  // Only id=2 is deleted (from delete file 1 with seqNum=10).
-  // id=4 survives because delete file 2 (seqNum=3) is skipped.
-  auto expected = makeRowVector(
-      {"id", "value"},
-      {
-          makeFlatVector<int64_t>({1, 3, 4, 5}),
-          makeFlatVector<std::string>({"a", "c", "d", "e"}),
-      });
-
-  assertEqualResults({expected}, {result});
-}
-
-// TODO: Add a Parquet-format equality delete test. Currently all equality
-// delete tests use DWRF because writeToFile() (from HiveConnectorTestBase)
-// only supports DWRF. Adding a Parquet test requires adding Parquet writer
-// dependencies to this test target's BUCK file and a Parquet write helper.
-
-} // namespace facebook::velox::connector::hive::iceberg
+} // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -333,7 +333,9 @@ std::vector<std::shared_ptr<ConnectorSplit>> IcebergTestBase::makeIcebergSplits(
         partitionKeys,
     uint32_t splitCount,
     const std::unordered_map<std::string, std::string>& infoColumns,
-    int64_t dataSequenceNumber) {
+    int64_t dataSequenceNumber,
+    const std::unordered_map<int32_t, std::optional<std::string>>&
+        identityPartitionKeys) {
   VELOX_CHECK_GT(splitCount, 0);
   std::vector<std::shared_ptr<ConnectorSplit>> splits;
   const auto fileSize = getFileSize(dataFilePath);
@@ -350,6 +352,7 @@ std::vector<std::shared_ptr<ConnectorSplit>> IcebergTestBase::makeIcebergSplits(
                             .deleteFiles(deleteFiles)
                             .infoColumns(infoColumns)
                             .dataSequenceNumber(dataSequenceNumber)
+                            .identityPartitionKeys(identityPartitionKeys)
                             .build());
   }
 
@@ -366,6 +369,177 @@ IcebergTestBase::makeIcebergSplitWithInfoColumns(
       dataFilePath, deleteFiles, {}, 1, infoColumns, dataSequenceNumber);
   VELOX_CHECK_EQ(splits.size(), 1);
   return splits.front();
+}
+
+std::shared_ptr<common::testutil::TempFilePath> IcebergTestBase::writeDataFile(
+    const std::vector<RowVectorPtr>& data) {
+  auto file = common::testutil::TempFilePath::create();
+  writeToFile(file->getPath(), data);
+  return file;
+}
+
+std::shared_ptr<common::testutil::TempFilePath>
+IcebergTestBase::writeDwrfFileWithFieldIds(
+    const std::vector<RowVectorPtr>& data,
+    const std::vector<int32_t>& icebergFieldIds) {
+  VELOX_CHECK(!data.empty());
+  const uint32_t numCols = data[0]->type()->size();
+  VELOX_CHECK_EQ(icebergFieldIds.size(), numCols);
+
+  // Build schemaAttributes: DWRF pre-order node 0 is the root struct (no
+  // iceberg.id); nodes 1..numCols are the top-level columns.
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      attrs;
+  for (uint32_t i = 0; i < numCols; ++i) {
+    attrs[i + 1] = {{"iceberg.id", std::to_string(icebergFieldIds[i])}};
+  }
+
+  auto file = common::testutil::TempFilePath::create();
+  auto fs = filesystems::getFileSystem(file->getPath(), {});
+  auto writeFile = fs->openFileForWrite(
+      file->getPath(),
+      {.shouldCreateParentDirectories = true,
+       .shouldThrowOnFileAlreadyExists = false});
+  auto sink = std::make_unique<dwio::common::WriteFileSink>(
+      std::move(writeFile), file->getPath());
+  dwio::common::WriterOptions writerOptions;
+  auto dwrfOptions = std::make_shared<dwrf::DwrfWriterOptions>();
+  dwrfOptions->schemaAttributes = std::move(attrs);
+  writerOptions.formatSpecificOptions = dwrfOptions;
+  writerOptions.schema = data[0]->type();
+  auto childPool =
+      rootPool_->addAggregateChild("writeDwrfFileWithFieldIds.writer");
+  writerOptions.memoryPool = childPool.get();
+  dwrf::Writer writer{std::move(sink), writerOptions};
+  for (const auto& batch : data) {
+    writer.write(batch);
+  }
+  writer.close();
+  return file;
+}
+
+#ifdef VELOX_ENABLE_PARQUET
+std::shared_ptr<common::testutil::TempFilePath>
+IcebergTestBase::writeParquetFile(
+    const std::vector<RowVectorPtr>& data,
+    const std::vector<int32_t>& icebergFieldIds) {
+  VELOX_CHECK(!data.empty());
+  auto file = common::testutil::TempFilePath::create();
+  auto writeFile =
+      std::make_unique<LocalWriteFile>(file->getPath(), true, false);
+  auto sink = std::make_unique<dwio::common::WriteFileSink>(
+      std::move(writeFile), file->getPath());
+  dwio::common::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  parquet::ParquetWriterOptions parquetOptions;
+  if (!icebergFieldIds.empty()) {
+    VELOX_CHECK_EQ(icebergFieldIds.size(), data[0]->type()->size());
+    parquetOptions.parquetFieldIds.reserve(icebergFieldIds.size());
+    for (int32_t id : icebergFieldIds) {
+      parquetOptions.parquetFieldIds.push_back(parquet::ParquetFieldId{id, {}});
+    }
+  }
+  writerOptions.formatSpecificOptions =
+      std::make_shared<parquet::ParquetWriterOptions>(
+          std::move(parquetOptions));
+  auto writer = std::make_unique<parquet::Writer>(
+      std::move(sink), writerOptions, asRowType(data[0]->type()));
+  for (const auto& batch : data) {
+    writer->write(batch);
+  }
+  writer->close();
+  return file;
+}
+#endif // VELOX_ENABLE_PARQUET
+
+core::PlanNodePtr IcebergTestBase::makeIcebergTableScanPlan(
+    const RowTypePtr& outputType,
+    const RowTypePtr& dataColumns,
+    const std::vector<int32_t>& dataColumnFieldIds,
+    const std::vector<std::string>& subfieldFilters,
+    const std::string& remainingFilter) {
+  VELOX_CHECK_NOT_NULL(dataColumns);
+
+  // Build IcebergColumnHandle assignments for each output-projected column.
+  // The Iceberg field ID is taken from dataColumnFieldIds when available,
+  // otherwise it defaults to the 1-based ordinal position in dataColumns.
+  connector::ColumnHandleMap assignments;
+  assignments.reserve(outputType->size());
+  for (uint32_t i = 0; i < outputType->size(); ++i) {
+    const auto& name = outputType->nameOf(i);
+    const auto& type = outputType->childAt(i);
+    auto tableIdx = dataColumns->getChildIdxIfExists(name);
+    VELOX_CHECK(
+        tableIdx.has_value(),
+        "Output column '{}' not found in dataColumns.",
+        name);
+    const int32_t fieldId = !dataColumnFieldIds.empty()
+        ? dataColumnFieldIds[*tableIdx]
+        : static_cast<int32_t>(*tableIdx + 1);
+    assignments.emplace(
+        name,
+        std::make_shared<IcebergColumnHandle>(
+            name,
+            FileColumnHandle::ColumnType::kRegular,
+            type,
+            parquet::ParquetFieldId{fieldId, {}}));
+  }
+
+  // Build filter-only IcebergColumnHandles for columns referenced by pushed-
+  // down filters but absent from the output projection. These are needed so
+  // buildIcebergHandleByName() can resolve their Iceberg field IDs and
+  // configureEqualityDeleteColumns() can promote them to projected columns
+  // when they also serve as equality-delete keys.
+  std::vector<HiveColumnHandlePtr> filterHandles;
+  if (!subfieldFilters.empty() || !remainingFilter.empty()) {
+    for (uint32_t i = 0; i < dataColumns->size(); ++i) {
+      const auto& name = dataColumns->nameOf(i);
+      if (assignments.count(name)) {
+        continue; // Already in the output projection.
+      }
+      // Include this column as a filter handle if any subfield filter names it.
+      bool usedInFilter = std::any_of(
+          subfieldFilters.begin(),
+          subfieldFilters.end(),
+          [&name](const std::string& f) {
+            return f.find(name) != std::string::npos;
+          });
+      // Also include it if it appears in the remainingFilter expression.
+      if (!usedInFilter && !remainingFilter.empty()) {
+        usedInFilter = remainingFilter.find(name) != std::string::npos;
+      }
+      if (!usedInFilter) {
+        continue;
+      }
+      const auto& type = dataColumns->childAt(i);
+      const int32_t fieldId = !dataColumnFieldIds.empty()
+          ? dataColumnFieldIds[i]
+          : static_cast<int32_t>(i + 1);
+      filterHandles.push_back(
+          std::make_shared<IcebergColumnHandle>(
+              name,
+              FileColumnHandle::ColumnType::kRegular,
+              type,
+              parquet::ParquetFieldId{fieldId, {}}));
+    }
+  }
+
+  return exec::test::PlanBuilder()
+      .startTableScan(kIcebergConnectorId)
+      .outputType(outputType)
+      .dataColumns(dataColumns)
+      .subfieldFilters(subfieldFilters)
+      .remainingFilter(remainingFilter)
+      .dataColumnFieldIds(dataColumnFieldIds)
+      .filterColumnHandles(std::move(filterHandles))
+      .assignments(assignments)
+      .endTableScan()
+      .planNode();
+}
+
+core::PlanNodePtr IcebergTestBase::makeIcebergTableScanPlan(
+    const RowTypePtr& rowType) {
+  return makeIcebergTableScanPlan(rowType, rowType);
 }
 
 ColumnHandleMap IcebergTestBase::makeColumnHandles(

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -25,14 +25,21 @@
 #include <vector>
 
 #include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #ifdef VELOX_ENABLE_PARQUET
+#include "velox/common/file/LocalFile.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
+#include "velox/dwio/parquet/writer/Writer.h"
 #endif
 
 namespace facebook::velox::connector::hive::iceberg::test {
@@ -86,7 +93,9 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
           partitionKeys = {},
       uint32_t splitCount = 1,
       const std::unordered_map<std::string, std::string>& infoColumns = {},
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<int32_t, std::optional<std::string>>&
+          identityPartitionKeys = {});
 
   /// Creates one Iceberg connector split for a full data file with info
   /// columns.
@@ -95,6 +104,41 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
       const std::unordered_map<std::string, std::string>& infoColumns,
       const std::vector<IcebergDeleteFile>& deleteFiles = {},
       int64_t dataSequenceNumber = 0);
+
+  /// Writes a DWRF data file with no iceberg.id footer attributes.
+  /// The DWRF reader falls back to positional name mapping for these files.
+  std::shared_ptr<common::testutil::TempFilePath> writeDataFile(
+      const std::vector<RowVectorPtr>& data);
+
+  /// Writes a DWRF file stamping "iceberg.id" footer attributes on each
+  /// top-level column. 'icebergFieldIds[i]' is the Iceberg field ID for the
+  /// i-th column; DWRF pre-order node IDs: 0=root, 1=first column, etc.
+  std::shared_ptr<common::testutil::TempFilePath> writeDwrfFileWithFieldIds(
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<int32_t>& icebergFieldIds);
+
+#ifdef VELOX_ENABLE_PARQUET
+  /// Writes a Parquet file. 'icebergFieldIds[i]' is stamped as the Parquet
+  /// field ID for column i so the reader resolves columns by field ID under
+  /// kParquetFieldId mode. Pass an empty vector to omit field IDs.
+  std::shared_ptr<common::testutil::TempFilePath> writeParquetFile(
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<int32_t>& icebergFieldIds = {});
+#endif
+
+  /// Builds an Iceberg table scan plan.
+  /// Field IDs are derived from each output column's 1-based position in
+  /// 'dataColumns' (the full table schema), which is the authoritative source
+  /// for Iceberg field IDs regardless of file format or projection.
+  core::PlanNodePtr makeIcebergTableScanPlan(
+      const RowTypePtr& outputType,
+      const RowTypePtr& dataColumns,
+      const std::vector<int32_t>& dataColumnFieldIds = {},
+      const std::vector<std::string>& subfieldFilters = {},
+      const std::string& remainingFilter = "");
+
+  /// Convenience overload: outputType == dataColumns (full-projection scan).
+  core::PlanNodePtr makeIcebergTableScanPlan(const RowTypePtr& rowType);
 
   /// Creates Hive column handles for all columns in 'rowType', marking
   /// specified columns as partition keys.

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -391,7 +391,10 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
         dataColumns_,
         indexColumns_,
         /*tableParameters=*/std::unordered_map<std::string, std::string>{},
-        filterColumnHandles_);
+        filterColumnHandles_,
+        sampleRate_,
+        /*dbName=*/"",
+        dataColumnFieldIds_);
   }
   core::PlanNodePtr result = std::make_shared<core::TableScanNode>(
       id, outputType_, tableHandle_, assignments_);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -127,6 +127,8 @@ class PlanBuilder {
   static constexpr const std::string_view kTpchDefaultConnectorId{"test-tpch"};
   static constexpr const std::string_view kTpcdsDefaultConnectorId{
       "test-tpcds"};
+  static constexpr const std::string_view kIcebergDefaultConnectorId{
+      "test-iceberg"};
 
   ///
   /// TableScan
@@ -348,6 +350,16 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param dataColumnFieldIds Iceberg field IDs aligned positionally to
+    /// dataColumns(). An empty vector means field IDs are unavailable. When
+    /// set, these are forwarded into the HiveTableHandle so Iceberg readers
+    /// can resolve columns by Iceberg field ID rather than by ordinal position.
+    TableScanBuilder& dataColumnFieldIds(
+        std::vector<int32_t> dataColumnFieldIds) {
+      dataColumnFieldIds_ = std::move(dataColumnFieldIds);
+      return *this;
+    }
+
     /// Stop the TableScanBuilder.
     PlanBuilder& endTableScan() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -366,6 +378,7 @@ class PlanBuilder {
     double sampleRate_{1.0};
     RowTypePtr dataColumns_;
     std::vector<std::string> indexColumns_;
+    std::vector<int32_t> dataColumnFieldIds_;
     std::vector<connector::hive::HiveColumnHandlePtr> filterColumnHandles_;
     std::unordered_map<std::string, std::string> columnAliases_;
     connector::ConnectorTableHandlePtr tableHandle_;


### PR DESCRIPTION
This PR fixes an issue with Iceberg field id based matching when equality deletes are present in the table. `IcebergSplitReader::buildFieldIds()` method was only checking the `columnHandles_` and when the equality delete columns are not in projection, the returned `fieldIds` vector was missing the equality delete columns field ids.

This PR fixes two issues:

1) In buildFieldIds() method, now we add the equality delete columns' field ids if they are present.
2) The tests in EqualityDeleteFileReaderTest.cpp are using existing PlanBuilder methods to create table scans which were using `HiveColumnHandle`. Because of which `buildFieldIds` was getting bypassed entirely. Added a new `PlanBuilder::icebergTableScan()` method to use `IcebergColumnHandle`.

All tests in EqualityDeleteFileReaderTest.cpp were using DWRF format only. Added a test to reproduce this issue by adding a PARQUET format test. I ran the test without the fix and verified that this reproduces the exact issue.

Though this is common for both DWRF and PARQUET formats, the problem manifested only for PARQUET.  This is because
 1) DWRF's `kFieldId` mode has an explicit fallback to use `updateColumnNamesFromTableSchema` mapping when the file has no `iceberg.id` attributes, which our tests won't write when writing DWRF test data file.
2) Parquet's `kParquetFieldId` mode has no such fallback — it strictly matches by physical field_id metadata, so a sentinel -1 silently produces null rather than falling back to name-based resolution. The bug is latent in the Parquet path only because DWRF masks it with its fallback.

Java native E2E tests at https://github.com/prestodb/presto/pull/28335 which currently fail but pass with this fix applied.