### PR TITLE
fix: Reject trailing date-time separator in Spark CAST(string as timestamp)

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -655,6 +655,9 @@ Invalid examples
 
   SELECT cast('INVALID' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
   SELECT cast('2012-Oct-01' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+  SELECT cast('2015-03-18T' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+
+A ``T`` date-time separator must be followed immediately by the time component.
 
 From boolean
 ^^^^^^^^^^^^

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -636,6 +636,8 @@ Casting from strings to timestamp uses Spark-compatible timestamp parsing.
 The parser accepts date-only values, both ``' '`` and ``'T'`` as date-time
 separators, fractional seconds, and leading or trailing spaces. Both ``' '``
 and ``'T'`` date-time separators must be followed immediately by a digit.
+Outer whitespace is trimmed before the parser runs, so a bare trailing
+separator such as ``"2015-03-18 "`` is handled as a date-only value.
 
 Casting from invalid strings returns NULL when ANSI mode is disabled and throws
 an error when ANSI mode is enabled.

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -634,8 +634,8 @@ From strings
 
 Casting from strings to timestamp uses Spark-compatible timestamp parsing.
 The parser accepts date-only values, both ``' '`` and ``'T'`` as date-time
-separators, fractional seconds, and leading or trailing spaces. A ``'T'``
-separator must be followed immediately by a digit.
+separators, fractional seconds, and leading or trailing spaces. Both ``' '``
+and ``'T'`` date-time separators must be followed immediately by a digit.
 
 Casting from invalid strings returns NULL when ANSI mode is disabled and throws
 an error when ANSI mode is enabled.
@@ -658,6 +658,7 @@ Invalid examples
   SELECT cast('2012-Oct-01' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
   SELECT cast('2015-03-18T' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
   SELECT cast('2015-03-18T 12:00:00' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+  SELECT cast('2015-03-18 Z' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
 
 From boolean
 ^^^^^^^^^^^^

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -634,7 +634,8 @@ From strings
 
 Casting from strings to timestamp uses Spark-compatible timestamp parsing.
 The parser accepts date-only values, both ``' '`` and ``'T'`` as date-time
-separators, fractional seconds, and leading or trailing spaces.
+separators, fractional seconds, and leading or trailing spaces. A ``'T'``
+separator must be followed immediately by a digit.
 
 Casting from invalid strings returns NULL when ANSI mode is disabled and throws
 an error when ANSI mode is enabled.
@@ -656,8 +657,7 @@ Invalid examples
   SELECT cast('INVALID' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
   SELECT cast('2012-Oct-01' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
   SELECT cast('2015-03-18T' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
-
-A ``T`` date-time separator must be followed immediately by the time component.
+  SELECT cast('2015-03-18T 12:00:00' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
 
 From boolean
 ^^^^^^^^^^^^

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -741,10 +741,7 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
     // sees the input. These must remain valid through the full cast path.
     testCast(
         makeFlatVector<std::string>(
-            {"2015-03-18 ",
-             "\t2015-03-18\n",
-             "2015-03-18\t",
-             "2015-03-18\n"},
+            {"2015-03-18 ", "\t2015-03-18\n", "2015-03-18\t", "2015-03-18\n"},
             VARCHAR()),
         makeFlatVector<Timestamp>(
             {Timestamp(1'426'636'800, 0),

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1829,18 +1829,26 @@ TEST_F(SparkCastExprTest, tryCastStringToTimestampInvalid) {
     auto input = makeRowVector({makeFlatVector<std::string>({
         "INVALID",
         "2012-Oct-01",
-        // SPARK-36286: trailing T with no time component is invalid.
+        // A trailing 'T' with no time component is invalid.
         "2015-03-18T",
-        // T followed by whitespace then end of string is invalid.
+        // 'T' followed by whitespace then end of string is invalid.
         "2015-03-18T ",
         "2015-03-18T\t",
         "2015-03-18T\n",
-        // T followed by whitespace then a valid time is still invalid:
-        // Spark requires time digits immediately after T.
+        // 'T' followed by whitespace then a valid time is still invalid:
+        // Spark requires time digits immediately after the separator.
         "2015-03-18T 12:00:00",
-        // T followed by a non-digit, non-time character is invalid.
+        // 'T' followed by a non-digit, non-time character is invalid.
         "2015-03-18TZ",
         "2015-03-18T+08:00",
+        // A space separator followed by a non-digit is invalid, matching
+        // Spark's grammar. Outer whitespace is trimmed by CastExpr, so
+        // these inputs reach the parser with the space separator intact.
+        "2015-03-18 Z",
+        "2015-03-18 +08:00",
+        "2015-03-18 UTC",
+        "2015-03-18  12:00:00",
+        "2015-03-18 x",
     })});
 
     auto result =

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -735,6 +735,23 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
             {"\n\f\r\t\n\x1f 2000-01-01 12:21:56\v\x1c\x1d\x1e"}, VARCHAR()),
         makeNullableFlatVector<Timestamp>(
             {Timestamp(946'729'316, 0)}, TIMESTAMP_UTC()));
+
+    // Outer whitespace trimming: trailing/leading spaces, tabs, and newlines
+    // around a date-only string are trimmed by CastExpr before the parser
+    // sees the input. These must remain valid through the full cast path.
+    testCast(
+        makeNullableFlatVector<std::string>(
+            {"2015-03-18 ",
+             "\t2015-03-18\n",
+             "2015-03-18\t",
+             "2015-03-18\n"},
+            VARCHAR()),
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(1'426'636'800, 0),
+             Timestamp(1'426'636'800, 0),
+             Timestamp(1'426'636'800, 0),
+             Timestamp(1'426'636'800, 0)},
+            TIMESTAMP_UTC()));
   }
 
   void testStringToDate() {
@@ -1852,16 +1869,24 @@ TEST_F(SparkCastExprTestAnsiOn, stringToTimestampInvalidThrows) {
 
   testInvalidTimestamp("INVALID");
   testInvalidTimestamp("2012-Oct-01");
-  // SPARK-36286: trailing T with no time component is invalid.
+  // A trailing 'T' with no time component is invalid.
   testInvalidTimestamp("2015-03-18T");
   testInvalidTimestamp("2015-03-18T ");
   testInvalidTimestamp("2015-03-18T\t");
   testInvalidTimestamp("2015-03-18T\n");
-  // T followed by whitespace then a valid time is still invalid.
+  // 'T' followed by whitespace then a valid time is still invalid.
   testInvalidTimestamp("2015-03-18T 12:00:00");
-  // T followed by a non-digit, non-time character is invalid.
+  // 'T' followed by a non-digit, non-time character is invalid.
   testInvalidTimestamp("2015-03-18TZ");
   testInvalidTimestamp("2015-03-18T+08:00");
+  // A space separator followed by a non-digit is invalid, matching Spark's
+  // grammar. Outer whitespace is trimmed by CastExpr, so these inputs reach
+  // the parser with the space separator intact.
+  testInvalidTimestamp("2015-03-18 Z");
+  testInvalidTimestamp("2015-03-18 +08:00");
+  testInvalidTimestamp("2015-03-18 UTC");
+  testInvalidTimestamp("2015-03-18  12:00:00");
+  testInvalidTimestamp("2015-03-18 x");
 }
 
 TEST_F(SparkCastExprTestAnsiOn, stringToTimestampUtc) {
@@ -2195,8 +2220,8 @@ TEST_F(SparkCastExprTestAnsiOff, stringToTimestamp) {
   testStringToTimestamp();
   testCast<std::string, Timestamp>(
       "timestamp", {"INVALID", "2012-Oct-01"}, {std::nullopt, std::nullopt});
-  // SPARK-36286: in non-ANSI mode, an invalid trailing-T string yields null
-  // rather than throwing. Covers the same set as the TRY and ANSI-ON tests.
+  // In non-ANSI mode, an invalid separator string yields null rather than
+  // throwing. Covers the same set as the ANSI-ON tests.
   testCast<std::string, Timestamp>(
       "timestamp",
       {"2015-03-18T",
@@ -2205,8 +2230,18 @@ TEST_F(SparkCastExprTestAnsiOff, stringToTimestamp) {
        "2015-03-18T\n",
        "2015-03-18T 12:00:00",
        "2015-03-18TZ",
-       "2015-03-18T+08:00"},
+       "2015-03-18T+08:00",
+       "2015-03-18 Z",
+       "2015-03-18 +08:00",
+       "2015-03-18 UTC",
+       "2015-03-18  12:00:00",
+       "2015-03-18 x"},
       {std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
        std::nullopt,
        std::nullopt,
        std::nullopt,

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -740,13 +740,13 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
     // around a date-only string are trimmed by CastExpr before the parser
     // sees the input. These must remain valid through the full cast path.
     testCast(
-        makeNullableFlatVector<std::string>(
+        makeFlatVector<std::string>(
             {"2015-03-18 ",
              "\t2015-03-18\n",
              "2015-03-18\t",
              "2015-03-18\n"},
             VARCHAR()),
-        makeNullableFlatVector<Timestamp>(
+        makeFlatVector<Timestamp>(
             {Timestamp(1'426'636'800, 0),
              Timestamp(1'426'636'800, 0),
              Timestamp(1'426'636'800, 0),

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1809,14 +1809,32 @@ TEST_F(SparkCastExprTest, tryCastStringToTimestampInvalid) {
   for (auto ansiEnabled : {false, true}) {
     setAnsiSupport(ansiEnabled);
 
-    auto input = makeRowVector(
-        {makeFlatVector<std::string>({"INVALID", "2012-Oct-01"})});
+    auto input = makeRowVector({makeFlatVector<std::string>({
+        "INVALID",
+        "2012-Oct-01",
+        // SPARK-36286: trailing T with no time component is invalid.
+        "2015-03-18T",
+        // T followed by whitespace then end of string is invalid.
+        "2015-03-18T ",
+        "2015-03-18T\t",
+        "2015-03-18T\n",
+        // T followed by whitespace then a valid time is still invalid:
+        // Spark requires time digits immediately after T.
+        "2015-03-18T 12:00:00",
+        // T followed by a non-digit, non-time character is invalid.
+        "2015-03-18TZ",
+        "2015-03-18T+08:00",
+    })});
 
     auto result =
         evaluate<SimpleVector<Timestamp>>("try_cast(c0 as timestamp)", input);
 
-    ASSERT_TRUE(result->isNullAt(0));
-    ASSERT_TRUE(result->isNullAt(1));
+    for (int i = 0; i < result->size(); ++i) {
+      ASSERT_TRUE(result->isNullAt(i))
+          << "Expected null at index " << i << " for input \""
+          << input->childAt(0)->as<SimpleVector<StringView>>()->valueAt(i)
+          << "\"";
+    }
   }
 }
 
@@ -1834,6 +1852,16 @@ TEST_F(SparkCastExprTestAnsiOn, stringToTimestampInvalidThrows) {
 
   testInvalidTimestamp("INVALID");
   testInvalidTimestamp("2012-Oct-01");
+  // SPARK-36286: trailing T with no time component is invalid.
+  testInvalidTimestamp("2015-03-18T");
+  testInvalidTimestamp("2015-03-18T ");
+  testInvalidTimestamp("2015-03-18T\t");
+  testInvalidTimestamp("2015-03-18T\n");
+  // T followed by whitespace then a valid time is still invalid.
+  testInvalidTimestamp("2015-03-18T 12:00:00");
+  // T followed by a non-digit, non-time character is invalid.
+  testInvalidTimestamp("2015-03-18TZ");
+  testInvalidTimestamp("2015-03-18T+08:00");
 }
 
 TEST_F(SparkCastExprTestAnsiOn, stringToTimestampUtc) {
@@ -2167,6 +2195,24 @@ TEST_F(SparkCastExprTestAnsiOff, stringToTimestamp) {
   testStringToTimestamp();
   testCast<std::string, Timestamp>(
       "timestamp", {"INVALID", "2012-Oct-01"}, {std::nullopt, std::nullopt});
+  // SPARK-36286: in non-ANSI mode, an invalid trailing-T string yields null
+  // rather than throwing. Covers the same set as the TRY and ANSI-ON tests.
+  testCast<std::string, Timestamp>(
+      "timestamp",
+      {"2015-03-18T",
+       "2015-03-18T ",
+       "2015-03-18T\t",
+       "2015-03-18T\n",
+       "2015-03-18T 12:00:00",
+       "2015-03-18TZ",
+       "2015-03-18T+08:00"},
+      {std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt});
 }
 
 TEST_F(SparkCastExprTestAnsiOff, stringToTimestampUtc) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -639,9 +639,8 @@ bool tryParseTimestampString(
   parseTimeSeparator(buf, pos, parseMode);
 
   // In Spark cast mode, a 'T' separator must be followed immediately by the
-  // time component. Preserve the existing space-separator behavior; this
-  // change is scoped specifically to 'T'. Known space-path divergences are
-  // tracked separately.
+  // time component. Space-separator behavior is outside the scope of this
+  // change.
   if (parseMode == TimestampParseMode::kSparkCast && pos > preSeparatorPos &&
       buf[preSeparatorPos] == 'T' &&
       (pos >= len || !characterIsDigit(buf[pos]))) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -635,7 +635,20 @@ bool tryParseTimestampString(
   }
 
   // Try to parse a time field.
+  size_t preSeparatorPos = pos;
   parseTimeSeparator(buf, pos, parseMode);
+
+  // In Spark cast mode, when a 'T' separator is consumed, the time component
+  // must begin immediately with a digit. Spark only trims the outer input
+  // boundaries, not internal whitespace after 'T', so any of
+  // "2015-03-18T", "2015-03-18T ", "2015-03-18T 12:00:00", "2015-03-18TZ"
+  // is invalid. A space separator (e.g. "2015-03-18 12:00:00") is unaffected
+  // because Spark allows whitespace there. Presto/ISO/Legacy are unaffected.
+  if (parseMode == TimestampParseMode::kSparkCast && pos > preSeparatorPos &&
+      buf[preSeparatorPos] == 'T' &&
+      (pos >= len || !characterIsDigit(buf[pos]))) {
+    return false;
+  }
 
   size_t timePos = 0;
   if (!tryParseTimeString(

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -635,15 +635,16 @@ bool tryParseTimestampString(
   }
 
   // Try to parse a time field.
-  size_t preSeparatorPos = pos;
+  const size_t preSeparatorPos = pos;
   parseTimeSeparator(buf, pos, parseMode);
 
-  // In Spark cast mode, a 'T' separator must be followed immediately by a
-  // digit. Spark applies the same rule after a ' ' separator, but it trims the
-  // input first while Velox does not, so guarding ' ' the same way here would
-  // reject "2015-03-18 ", which Spark accepts. The ' ' form is left alone.
+  // In Spark cast mode, once a date-time separator ('T' or ' ') is consumed,
+  // the time component must begin immediately with a digit. This mirrors
+  // Spark's grammar: a separator followed by a timezone, garbage, or end of
+  // input is rejected. Outer whitespace is trimmed earlier by CastExpr's
+  // removeWhiteSpaces, so a bare trailing separator like "2015-03-18 " never
+  // reaches this point (it is trimmed to "2015-03-18" and handled as a date).
   if (parseMode == TimestampParseMode::kSparkCast && pos > preSeparatorPos &&
-      buf[preSeparatorPos] == 'T' &&
       (pos >= len || !characterIsDigit(buf[pos]))) {
     return false;
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -641,9 +641,7 @@ bool tryParseTimestampString(
   // In Spark cast mode, once a date-time separator ('T' or ' ') is consumed,
   // the time component must begin immediately with a digit. This mirrors
   // Spark's grammar: a separator followed by a timezone, garbage, or end of
-  // input is rejected. Outer whitespace is trimmed earlier by CastExpr's
-  // removeWhiteSpaces, so a bare trailing separator like "2015-03-18 " never
-  // reaches this point (it is trimmed to "2015-03-18" and handled as a date).
+  // input is rejected.
   if (parseMode == TimestampParseMode::kSparkCast && pos > preSeparatorPos &&
       (pos >= len || !characterIsDigit(buf[pos]))) {
     return false;

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -638,12 +638,10 @@ bool tryParseTimestampString(
   size_t preSeparatorPos = pos;
   parseTimeSeparator(buf, pos, parseMode);
 
-  // In Spark cast mode, when a 'T' separator is consumed, the time component
-  // must begin immediately with a digit. Spark only trims the outer input
-  // boundaries, not internal whitespace after 'T', so any of
-  // "2015-03-18T", "2015-03-18T ", "2015-03-18T 12:00:00", "2015-03-18TZ"
-  // is invalid. A space separator (e.g. "2015-03-18 12:00:00") is unaffected
-  // because Spark allows whitespace there. Presto/ISO/Legacy are unaffected.
+  // In Spark cast mode, a 'T' separator must be followed immediately by the
+  // time component. Preserve the existing space-separator behavior; this
+  // change is scoped specifically to 'T'. Known space-path divergences are
+  // tracked separately.
   if (parseMode == TimestampParseMode::kSparkCast && pos > preSeparatorPos &&
       buf[preSeparatorPos] == 'T' &&
       (pos >= len || !characterIsDigit(buf[pos]))) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -638,9 +638,10 @@ bool tryParseTimestampString(
   size_t preSeparatorPos = pos;
   parseTimeSeparator(buf, pos, parseMode);
 
-  // In Spark cast mode, a 'T' separator must be followed immediately by the
-  // time component. Space-separator behavior is outside the scope of this
-  // change.
+  // In Spark cast mode, a 'T' separator must be followed immediately by a
+  // digit. Spark applies the same rule after a ' ' separator, but it trims the
+  // input first while Velox does not, so guarding ' ' the same way here would
+  // reject "2015-03-18 ", which Spark accepts. The ' ' form is left alone.
   if (parseMode == TimestampParseMode::kSparkCast && pos > preSeparatorPos &&
       buf[preSeparatorPos] == 'T' &&
       (pos >= len || !characterIsDigit(buf[pos]))) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -356,8 +356,9 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
         parseTimestampWithTimezone(invalid, TimestampParseMode::kSparkCast),
         parserError);
   }
-  // A space separator is unaffected: Spark trims the input, so a trailing
-  // space is equivalent to a date-only string.
+  // A space separator is unaffected by this change. A trailing space after
+  // a date-only string remains valid; known space-path divergences are
+  // tracked separately.
   EXPECT_EQ(
       Timestamp(1426636800, 0),
       parseTimestamp("2015-03-18 ", TimestampParseMode::kSparkCast));

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -339,6 +339,31 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
   VELOX_ASSERT_THROW(
       parseTimestamp("2000-01-01T 12:21:56", TimestampParseMode::kIso8601),
       parserError);
+  // In Spark cast mode a 'T' separator must be followed immediately by the
+  // time digits; anything else is invalid.
+  for (const auto& invalid :
+       {"2015-03-18T",
+        "2015-03-18T ",
+        "2015-03-18T\t",
+        "2015-03-18T\n",
+        "2015-03-18T 12:00:00",
+        "2015-03-18TZ",
+        "2015-03-18T+08:00"}) {
+    SCOPED_TRACE(invalid);
+    VELOX_ASSERT_THROW(
+        parseTimestamp(invalid, TimestampParseMode::kSparkCast), parserError);
+    VELOX_ASSERT_THROW(
+        parseTimestampWithTimezone(invalid, TimestampParseMode::kSparkCast),
+        parserError);
+  }
+  // A space separator is unaffected: Spark trims the input, so a trailing
+  // space is equivalent to a date-only string.
+  EXPECT_EQ(
+      Timestamp(1426636800, 0),
+      parseTimestamp("2015-03-18 ", TimestampParseMode::kSparkCast));
+  EXPECT_EQ(
+      Timestamp(1426680000, 0),
+      parseTimestamp("2015-03-18T12:00:00", TimestampParseMode::kSparkCast));
 
   // Parse timestamp with (broken) timezones.
   VELOX_ASSERT_THROW(

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -339,16 +339,21 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
   VELOX_ASSERT_THROW(
       parseTimestamp("2000-01-01T 12:21:56", TimestampParseMode::kIso8601),
       parserError);
-  // In Spark cast mode a 'T' separator must be followed immediately by the
-  // time digits; anything else is invalid.
+  // In Spark cast mode a 'T' separator must be followed immediately by a
+  // digit; anything else is invalid, including a 'T' after a year-only or
+  // year-month date, and whitespace between 'T' and an otherwise valid time.
   for (const auto& invalid :
        {"2015-03-18T",
         "2015-03-18T ",
         "2015-03-18T\t",
         "2015-03-18T\n",
         "2015-03-18T 12:00:00",
+        "2015-03-18T\t12:00:00",
         "2015-03-18TZ",
-        "2015-03-18T+08:00"}) {
+        "2015-03-18T+08:00",
+        "2015T",
+        "2015-03T",
+        "+2015-03-18T"}) {
     SCOPED_TRACE(invalid);
     VELOX_ASSERT_THROW(
         parseTimestamp(invalid, TimestampParseMode::kSparkCast), parserError);
@@ -356,14 +361,22 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
         parseTimestampWithTimezone(invalid, TimestampParseMode::kSparkCast),
         parserError);
   }
-  // A space separator is unaffected by this change. Space-separator behavior
-  // is outside the scope of this change.
+  // A space separator is unaffected by this change, and a 'T' followed
+  // directly by time digits still parses.
   EXPECT_EQ(
       Timestamp(1426636800, 0),
       parseTimestamp("2015-03-18 ", TimestampParseMode::kSparkCast));
   EXPECT_EQ(
       Timestamp(1426680000, 0),
       parseTimestamp("2015-03-18T12:00:00", TimestampParseMode::kSparkCast));
+  // Only kSparkCast is affected: a trailing 'T' still parses as a bare date
+  // under ISO 8601 and legacy cast.
+  EXPECT_EQ(
+      Timestamp(1426636800, 0),
+      parseTimestamp("2015-03-18T", TimestampParseMode::kIso8601));
+  EXPECT_EQ(
+      Timestamp(1426636800, 0),
+      parseTimestamp("2015-03-18T", TimestampParseMode::kLegacyCast));
 
   // Parse timestamp with (broken) timezones.
   VELOX_ASSERT_THROW(

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -356,9 +356,8 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
         parseTimestampWithTimezone(invalid, TimestampParseMode::kSparkCast),
         parserError);
   }
-  // A space separator is unaffected by this change. A trailing space after
-  // a date-only string remains valid; known space-path divergences are
-  // tracked separately.
+  // A space separator is unaffected by this change. Space-separator behavior
+  // is outside the scope of this change.
   EXPECT_EQ(
       Timestamp(1426636800, 0),
       parseTimestamp("2015-03-18 ", TimestampParseMode::kSparkCast));

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -339,9 +339,12 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
   VELOX_ASSERT_THROW(
       parseTimestamp("2000-01-01T 12:21:56", TimestampParseMode::kIso8601),
       parserError);
-  // In Spark cast mode a 'T' separator must be followed immediately by a
-  // digit; anything else is invalid, including a 'T' after a year-only or
-  // year-month date, and whitespace between 'T' and an otherwise valid time.
+  // In Spark cast mode, once a date-time separator ('T' or ' ') is consumed,
+  // the time component must begin immediately with a digit. A separator
+  // followed by a timezone, garbage, whitespace, or end of input is invalid.
+  // This applies to both 'T' and ' ' separators equally. Note: outer
+  // whitespace trimming is the responsibility of CastExpr, not the parser;
+  // at the parser level an untrimmed trailing separator is rejected.
   for (const auto& invalid :
        {"2015-03-18T",
         "2015-03-18T ",
@@ -351,6 +354,12 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
         "2015-03-18T\t12:00:00",
         "2015-03-18TZ",
         "2015-03-18T+08:00",
+        "2015-03-18 ",
+        "2015-03-18 Z",
+        "2015-03-18 +08:00",
+        "2015-03-18 UTC",
+        "2015-03-18  12:00:00",
+        "2015-03-18 x",
         "2015T",
         "2015-03T",
         "+2015-03-18T"}) {
@@ -361,11 +370,10 @@ TEST(DateTimeUtilTest, fromTimestampStringInvalid) {
         parseTimestampWithTimezone(invalid, TimestampParseMode::kSparkCast),
         parserError);
   }
-  // A space separator is unaffected by this change, and a 'T' followed
-  // directly by time digits still parses.
+  // A separator followed directly by valid time digits still parses.
   EXPECT_EQ(
-      Timestamp(1426636800, 0),
-      parseTimestamp("2015-03-18 ", TimestampParseMode::kSparkCast));
+      Timestamp(1426680000, 0),
+      parseTimestamp("2015-03-18 12:00:00", TimestampParseMode::kSparkCast));
   EXPECT_EQ(
       Timestamp(1426680000, 0),
       parseTimestamp("2015-03-18T12:00:00", TimestampParseMode::kSparkCast));


### PR DESCRIPTION
## Problem

Velox's Spark cast mode accepts `CAST('2015-03-18T' AS TIMESTAMP)` and returns
`2015-03-18 00:00:00`; Spark returns `NULL` (SPARK-36286). In Spark's parser, once the
date/time separator is consumed the next byte must be a digit — otherwise the hour segment
ends with zero digits and the final `isValidDigits` check fails. This rule applies to
both `'T'` and `' '` separators:

- https://github.com/apache/spark/blob/7c29c664cdc9321205a98a14858aaf8daaa19db2/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala#L455-L466
- https://github.com/apache/spark/blob/7c29c664cdc9321205a98a14858aaf8daaa19db2/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala#L528-L530

Also reported via https://github.com/apache/gluten/issues/8984.

## Change

In `tryParseTimestampString`, under `TimestampParseMode::kSparkCast` only, fail the parse
when a date-time separator (`'T'` or `' '`) has been consumed and the next character is not
a digit. This mirrors Spark's grammar, which requires the time component to begin
immediately after the separator. `kIso8601`, `kPrestoCast` and `kLegacyCast` reach no new
branch.

Outer whitespace is trimmed earlier by `CastExpr`'s `removeWhiteSpaces` (called at
`CastExpr-inl.h:218` before `castStringToTimestamp`), so a bare trailing separator like
`"2015-03-18 "` never reaches the parser — it is trimmed to `"2015-03-18"` and handled as a
date.

Every input where behavior changes moves from disagreeing with Spark to agreeing with it.
Representative cases, measured against Spark 3.5.5
`SparkDateTimeUtils.stringToTimestamp` at session timezone UTC:

| input | before | after | Spark 3.5.5 |
|---|---|---|---|
| `2015-03-18T` | `2015-03-18 00:00:00` | `NULL` | `NULL` |
| `2015-03-18T ` / `\t` / `\n` | `2015-03-18 00:00:00` | `NULL` | `NULL` |
| `2015-03-18T 12:00:00` | `2015-03-18 12:00:00` | `NULL` | `NULL` |
| `2015-03-18T\t12:00:00` | `2015-03-18 12:00:00` | `NULL` | `NULL` |
| `2015-03-18TZ` | `2015-03-18 00:00:00` UTC | `NULL` | `NULL` |
| `2015-03-18T+08:00` | `2015-03-17 16:00:00` | `NULL` | `NULL` |
| `2015T` | `2015-01-01 00:00:00` | `NULL` | `NULL` |
| `2015-03T` | `2015-03-01 00:00:00` | `NULL` | `NULL` |
| `+2015-03-18T` | `2015-03-18 00:00:00` | `NULL` | `NULL` |
| `2015-03-18 Z` | `2015-03-18 00:00:00` UTC | `NULL` | `NULL` |
| `2015-03-18 +08:00` | `2015-03-17 16:00:00` | `NULL` | `NULL` |
| `2015-03-18 UTC` | `2015-03-18 00:00:00` UTC | `NULL` | `NULL` |
| `2015-03-18  12:00:00` (two spaces) | `2015-03-18 12:00:00` | `NULL` | `NULL` |
| `2015-03-18 x` | `2015-03-18 00:00:00` | `NULL` | `NULL` |

The year-only and year-month forms reach the guard through the "no month" / "no day"
early returns in `tryParseDateString`, which leave `pos` on the `T`.

## Scope

The guard applies to both `'T'` and `' '` separators in `kSparkCast` mode. Outer
whitespace trimming is handled by `CastExpr`'s `removeWhiteSpaces` (which calls
`SparkCastHooks::removeWhiteSpaces`, a real trim via `trimUnicodeWhiteSpace`), so inputs
like `"2015-03-18 "` (trailing space), `"2015-03-18\t"`, or `"\t2015-03-18\n"` are trimmed
before the parser sees them and remain valid.

Hour-only time components (e.g. `"2015-03-18T12"`, `"2015-03-18 12"`) are accepted by
Spark but rejected by Velox due to a separate grammar difference in `tryParseTimeString`
(only `kIso8601` accepts hour-only). This is out of scope for this PR.

`CAST(... AS DATE)` is unchanged — `fromDateString` never calls
`tryParseTimestampString`.

## Tests

`TimestampConversionTest.fromTimestampStringInvalid`: invalid inputs through both
`fromTimestampString` and `fromTimestampWithTimezoneString`, covering both `'T'` and `' '`
separator cases; positive controls for `"2015-03-18 12:00:00"` and `"2015-03-18T12:00:00"`;
pins that `'2015-03-18T'` still parses as a bare date under `kIso8601` and `kLegacyCast`.
`SparkCastExprTest`: all three cast contracts — `try_cast` → null, ANSI off → null, ANSI on
→ throws — for both `'T'` and `' '` separator invalid cases. Outer whitespace trimming
tests in `testStringToTimestampUtc` verify that trailing/leading spaces, tabs, and newlines
around date-only strings remain valid through the full cast path.
