### PR TITLE
feat: Add Spark convert_timezone function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -23,6 +23,18 @@ These functions support TIMESTAMP and DATE input types.
         SELECT add_months('2015-01-30', -2); -- '2014-11-30'
         SELECT add_months('2015-03-31', -1); -- '2015-02-28'
 
+.. spark:function:: convert_timezone([sourceTz, ]targetTz, sourceTs) -> timestamp_utc
+
+    Converts ``sourceTs`` from the ``sourceTz`` time zone to ``targetTz``. If
+    ``sourceTz`` is omitted, the session time zone is used as the source time
+    zone. ::
+
+        SELECT convert_timezone('Europe/Brussels', 'America/Los_Angeles', TIMESTAMP_NTZ '2021-12-06 00:00:00'); -- 2021-12-05 15:00:00
+
+    Under session timezone ``America/Los_Angeles``: ::
+
+        SELECT convert_timezone('Europe/Brussels', TIMESTAMP_NTZ '2021-12-05 15:00:00'); -- 2021-12-06 00:00:00
+
 .. spark:function:: date_add(start_date, num_days) -> date
 
     Returns the date that is ``num_days`` after ``start_date``. According to the inputs,

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -70,6 +70,7 @@ velox_add_library(
   CharVarcharUtils.h
   Comparisons.h
   ConcatWs.h
+  ConvertTimezone.h
   DateTimeFunctions.h
   DecimalArithmetic.h
   DecimalCeil.h

--- a/velox/functions/sparksql/ConvertTimezone.h
+++ b/velox/functions/sparksql/ConvertTimezone.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/QueryConfig.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/sparksql/TimestampUtils.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// Converts a timestamp from one time zone to another: interprets the input
+/// as local time in the source zone, resolves it to a UTC instant, then
+/// re-expresses that instant as local time in the target zone. The
+/// 2-argument overload uses the session timezone as the source.
+template <typename T>
+struct ConvertTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Caches the target timezone when constant.
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* targetTz,
+      const arg_type<TimestampUtc>* /*sourceTs*/) {
+    auto sessionTzName = config.sessionTimezone();
+    if (!sessionTzName.empty()) {
+      sessionTimeZone_ = tz::locateZone(sessionTzName);
+    }
+    if (targetTz) {
+      targetTimeZone_ = tz::locateZone(std::string_view(*targetTz), false);
+    }
+  }
+
+  // Caches the source and target timezones when constant.
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Varchar>* sourceTz,
+      const arg_type<Varchar>* targetTz,
+      const arg_type<TimestampUtc>* /*sourceTs*/) {
+    if (sourceTz) {
+      sourceTimeZone_ = tz::locateZone(std::string_view(*sourceTz), false);
+    }
+    if (targetTz) {
+      targetTimeZone_ = tz::locateZone(std::string_view(*targetTz), false);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampUtc>& result,
+      const arg_type<Varchar>& targetTz,
+      const arg_type<TimestampUtc>& sourceTs) {
+    const auto* target = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(targetTz), false);
+    VELOX_USER_CHECK_NOT_NULL(target, "Unknown time zone: '{}'", targetTz);
+    convert(result, sessionTimeZone_, target, sourceTs);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampUtc>& result,
+      const arg_type<Varchar>& sourceTz,
+      const arg_type<Varchar>& targetTz,
+      const arg_type<TimestampUtc>& sourceTs) {
+    const auto* source = sourceTimeZone_ != nullptr
+        ? sourceTimeZone_
+        : tz::locateZone(std::string_view(sourceTz), false);
+    VELOX_USER_CHECK_NOT_NULL(source, "Unknown time zone: '{}'", sourceTz);
+    const auto* target = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(targetTz), false);
+    VELOX_USER_CHECK_NOT_NULL(target, "Unknown time zone: '{}'", targetTz);
+    convert(result, source, target, sourceTs);
+  }
+
+ private:
+  static void convert(
+      out_type<TimestampUtc>& result,
+      const tz::TimeZone* sourceTimeZone,
+      const tz::TimeZone* targetTimeZone,
+      const arg_type<TimestampUtc>& sourceTs) {
+    result = sourceTs;
+    toGMTWithGapCorrection(result, *sourceTimeZone);
+    result.toTimezone(*targetTimeZone);
+  }
+
+  // Defaults to GMT when no session timezone is configured. Velox has no
+  // OS-local-timezone detection to match Spark's own default (the JVM's
+  // local zone), so GMT is used as a deterministic fallback.
+  const tz::TimeZone* sessionTimeZone_{tz::locateZone(0)};
+  const tz::TimeZone* sourceTimeZone_{nullptr};
+  const tz::TimeZone* targetTimeZone_{nullptr};
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/DateTimeFunctions.h"
+#include "velox/functions/sparksql/ConvertTimezone.h"
 #include "velox/functions/sparksql/DateTimeFunctions.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -29,6 +30,17 @@ void registerDatetimeFunctions(const std::string& prefix) {
       {prefix + "to_utc_timestamp"});
   registerFunction<FromUtcTimestampFunction, Timestamp, Timestamp, Varchar>(
       {prefix + "from_utc_timestamp"});
+  registerFunction<
+      ConvertTimezoneFunction,
+      TimestampUtc,
+      Varchar,
+      TimestampUtc>({prefix + "convert_timezone"});
+  registerFunction<
+      ConvertTimezoneFunction,
+      TimestampUtc,
+      Varchar,
+      Varchar,
+      TimestampUtc>({prefix + "convert_timezone"});
   registerFunction<UnixDateFunction, int32_t, Date>({prefix + "unix_date"});
   registerFunction<UnixSecondsFunction, int64_t, Timestamp>(
       {prefix + "unix_seconds"});

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
   CharTypeWriteSideCheckTest.cpp
   ComparisonsTest.cpp
   ConcatWsTest.cpp
+  ConvertTimezoneTest.cpp
   DateTimeFunctionsTest.cpp
   DecimalArithmeticTest.cpp
   DecimalCompareTest.cpp

--- a/velox/functions/sparksql/tests/ConvertTimezoneTest.cpp
+++ b/velox/functions/sparksql/tests/ConvertTimezoneTest.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ConvertTimezoneTest : public SparkFunctionBaseTest {
+ protected:
+  void setQueryTimeZone(const std::string& timeZone) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+    });
+  }
+
+  std::optional<Timestamp> convertTimezone(
+      const std::string& sourceTz,
+      const std::string& targetTz,
+      const std::string& tsStr) {
+    auto ts = std::make_optional(parseTimestamp(tsStr));
+    return evaluateOnce<Timestamp>(
+        "convert_timezone(c0, c1, c2)",
+        {VARCHAR(), VARCHAR(), TIMESTAMP_UTC()},
+        std::make_optional(sourceTz),
+        std::make_optional(targetTz),
+        ts);
+  }
+
+  std::optional<Timestamp> convertTimezone(
+      const std::string& targetTz,
+      const std::string& tsStr) {
+    auto ts = std::make_optional(parseTimestamp(tsStr));
+    return evaluateOnce<Timestamp>(
+        "convert_timezone(c0, c1)",
+        {VARCHAR(), TIMESTAMP_UTC()},
+        std::make_optional(targetTz),
+        ts);
+  }
+
+  // For calls needing a nullable argument or a raw Timestamp not
+  // expressible as a parseable date string.
+  std::optional<Timestamp> evalConvertTimezoneNullable(
+      std::optional<std::string> sourceTz,
+      std::optional<std::string> targetTz,
+      std::optional<Timestamp> ts) {
+    return evaluateOnce<Timestamp>(
+        "convert_timezone(c0, c1, c2)",
+        {VARCHAR(), VARCHAR(), TIMESTAMP_UTC()},
+        std::move(sourceTz),
+        std::move(targetTz),
+        ts);
+  }
+};
+
+TEST_F(ConvertTimezoneTest, basicConversion) {
+  EXPECT_EQ(
+      parseTimestamp("2021-12-05 15:00:00"),
+      convertTimezone(
+          "Europe/Brussels", "America/Los_Angeles", "2021-12-06 00:00:00"));
+}
+
+TEST_F(ConvertTimezoneTest, sessionTimezoneAsSource) {
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(
+      parseTimestamp("2021-12-06 00:00:00"),
+      convertTimezone("Europe/Brussels", "2021-12-05 15:00:00"));
+}
+
+TEST_F(ConvertTimezoneTest, constantTimezoneArgs) {
+  // Timezone names as SQL literals are constant-folded, exercising the
+  // initialize()-time caching path instead of the per-row fallback.
+  const auto evalConvertTimezoneLiteral = [&](const std::string& functionCall,
+                                              std::optional<Timestamp> ts) {
+    return evaluateOnce<Timestamp>(functionCall, {TIMESTAMP_UTC()}, ts);
+  };
+
+  auto ts = std::make_optional(parseTimestamp("2021-12-06 00:00:00"));
+  EXPECT_EQ(
+      parseTimestamp("2021-12-05 15:00:00"),
+      evalConvertTimezoneLiteral(
+          "convert_timezone('Europe/Brussels', 'America/Los_Angeles', c0)",
+          ts));
+
+  setQueryTimeZone("America/Los_Angeles");
+  auto ts2 = std::make_optional(parseTimestamp("2021-12-05 15:00:00"));
+  EXPECT_EQ(
+      parseTimestamp("2021-12-06 00:00:00"),
+      evalConvertTimezoneLiteral(
+          "convert_timezone('Europe/Brussels', c0)", ts2));
+}
+
+// 1941-12-25 in Hong Kong: clocks jumped from HKWT (UTC+8) to JST (UTC+9),
+// making midnight nonexistent. Spark adjusts to 00:30:00 JST, which is
+// 1941-12-24 15:30:00 UTC.
+TEST_F(ConvertTimezoneTest, timezoneGapCorrection) {
+  auto result = evalConvertTimezoneNullable(
+      std::make_optional<std::string>("Asia/Hong_Kong"),
+      std::make_optional<std::string>("UTC"),
+      std::make_optional(Timestamp(-884'217'600, 0)));
+  EXPECT_EQ(Timestamp(-884'248'200, 0), result);
+}
+
+TEST_F(ConvertTimezoneTest, unknownTimezone) {
+  VELOX_ASSERT_THROW(
+      convertTimezone("Asia/Ooty", "UTC", "2021-12-06 00:00:00"),
+      "Unknown time zone: 'Asia/Ooty'");
+  VELOX_ASSERT_THROW(
+      convertTimezone("UTC", "Asia/Ooty", "2021-12-06 00:00:00"),
+      "Unknown time zone: 'Asia/Ooty'");
+  VELOX_ASSERT_THROW(
+      convertTimezone("Asia/Ooty", "2021-12-06 00:00:00"),
+      "Unknown time zone: 'Asia/Ooty'");
+}
+
+TEST_F(ConvertTimezoneTest, nullPropagation) {
+  EXPECT_EQ(
+      std::nullopt,
+      evalConvertTimezoneNullable(
+          std::optional<std::string>(std::nullopt),
+          std::make_optional<std::string>("UTC"),
+          std::make_optional(parseTimestamp("2021-12-06 00:00:00"))));
+  EXPECT_EQ(
+      std::nullopt,
+      evalConvertTimezoneNullable(
+          std::make_optional<std::string>("UTC"),
+          std::optional<std::string>(std::nullopt),
+          std::make_optional(parseTimestamp("2021-12-06 00:00:00"))));
+  EXPECT_EQ(
+      std::nullopt,
+      evalConvertTimezoneNullable(
+          std::make_optional<std::string>("UTC"),
+          std::make_optional<std::string>("UTC"),
+          std::optional<Timestamp>(std::nullopt)));
+}
+
+TEST_F(ConvertTimezoneTest, sameSourceAndTargetTimezone) {
+  EXPECT_EQ(
+      parseTimestamp("2015-01-24 05:30:00"),
+      convertTimezone("Asia/Riyadh", "Asia/Riyadh", "2015-01-24 05:30:00"));
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Adds `convert_timezone([sourceTz, ]targetTz, sourceTs`) converts a timestamp from one time zone to another. If `sourceTz` is omitted, the session time zone is used. Returns `TIMESTAMP_UTC`.

Similar pattern to` make_timestamp_ntz/make_timestamp ` see #18014.
