### PR TITLE
fix(cuDF): Fix cuDF local exchange memory accounting

### DIFF
--- a/velox/experimental/cudf/benchmarks/CudfTpchBenchmark.cpp
+++ b/velox/experimental/cudf/benchmarks/CudfTpchBenchmark.cpp
@@ -54,6 +54,11 @@ DEFINE_int32(
     100000,
     "Preferred output batch size in rows for cudf operators.");
 
+DEFINE_uint64(
+    cudf_local_exchange_buffer_size,
+    1UL << 30,
+    "Maximum buffered bytes per local exchange before applying backpressure.");
+
 DEFINE_bool(velox_cudf_table_scan, true, "Enable cuDF table scan");
 
 DEFINE_string(
@@ -103,6 +108,8 @@ void CudfTpchBenchmark::initialize() {
 
   queryConfigs_[facebook::velox::cudf_velox::CudfFromVelox::kGpuBatchSizeRows] =
       std::to_string(FLAGS_cudf_gpu_batch_size_rows);
+  queryConfigs_[core::QueryConfig::kMaxLocalExchangeBufferSize] =
+      std::to_string(FLAGS_cudf_local_exchange_buffer_size);
 }
 
 std::shared_ptr<config::ConfigBase>

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -27,12 +27,23 @@
 #include <cudf/copying.hpp>
 #include <cudf/partitioning.hpp>
 
+#include <limits>
+
 namespace facebook::velox::cudf_velox {
 
 namespace {
 template <class... Deriveds, class Base>
 bool isAnyOf(const Base* p) {
   return ((dynamic_cast<const Deriveds*>(p) != nullptr) || ...);
+}
+
+int64_t retainedBytes(const CudfVector& vector) {
+  const auto bytes = vector.retainedSize();
+  VELOX_CHECK_LE(
+      bytes,
+      std::numeric_limits<int64_t>::max(),
+      "CudfVector is too large for local exchange byte accounting");
+  return static_cast<int64_t>(bytes);
 }
 } // namespace
 
@@ -171,8 +182,8 @@ void CudfLocalPartition::enqueuePartition(
   }
 
   ContinueFuture future;
-  auto blockingReason =
-      queues_[partitionIndex]->enqueue(cudfVector, cudfVector->size(), &future);
+  auto blockingReason = queues_[partitionIndex]->enqueue(
+      cudfVector, retainedBytes(*cudfVector), &future);
   if (blockingReason != exec::BlockingReason::kNotBlocked) {
     blockingReasons_.push_back(blockingReason);
     futures_.push_back(std::move(future));
@@ -257,7 +268,7 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
     // Single partition case.
     ContinueFuture future;
     auto blockingReason =
-        queues_[0]->enqueue(input, input->retainedSize(), &future);
+        queues_[0]->enqueue(input, retainedBytes(*cudfVector), &future);
     if (blockingReason != exec::BlockingReason::kNotBlocked) {
       blockingReasons_.push_back(blockingReason);
       futures_.push_back(std::move(future));

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -179,6 +179,23 @@ class CudfVectorTest : public ::testing::Test, public VectorTestBase {
   }
 };
 
+TEST_F(CudfVectorTest, retainedSizeReportsDeviceStorage) {
+  TestCudaStream stream;
+  auto table =
+      makeTable(stream.view(), cudf::get_current_device_resource_ref());
+  stream.view().synchronize();
+
+  CudfVector vector(
+      pool_.get(),
+      ROW({"c0"}, {INTEGER()}),
+      table->num_rows(),
+      std::move(table),
+      stream.view());
+
+  EXPECT_EQ(vector.estimateFlatSize(), 4 * sizeof(int32_t));
+  EXPECT_EQ(vector.retainedSize(), vector.estimateFlatSize());
+}
+
 TEST_F(CudfVectorTest, rebindOwnedTableDeallocationStream) {
   TestCudaStream allocationStream;
   TestCudaStream targetStream;

--- a/velox/experimental/cudf/tests/LocalPartitionTest.cpp
+++ b/velox/experimental/cudf/tests/LocalPartitionTest.cpp
@@ -476,5 +476,39 @@ TEST_F(LocalPartitionTest, roundRobinDistributionVerification) {
   ASSERT_EQ(partitionCounts[2], 1);
 }
 
+TEST_F(LocalPartitionTest, gpuBytesTriggerBackpressure) {
+  std::vector<RowVectorPtr> vectors = {makeRowVector(
+      {makeFlatSequence<int64_t>(0, 1'024),
+       makeFlatSequence<int64_t>(0, 1'024)})};
+  createDuckDbTable(vectors);
+
+  for (const int32_t numDrivers : {1, 2}) {
+    SCOPED_TRACE(fmt::format("numDrivers: {}", numDrivers));
+    core::PlanNodeId localPartitionId;
+    auto plan = PlanBuilder()
+                    .values(vectors)
+                    .partialAggregation({"c0"}, {"max(c1)"})
+                    .localPartition({"c0"})
+                    .capturePlanNodeId(localPartitionId)
+                    .finalAggregation()
+                    .planNode();
+
+    auto task =
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .maxDrivers(numDrivers)
+            .config(
+                core::QueryConfig::kMaxLocalExchangePartitionCount, numDrivers)
+            .config(core::QueryConfig::kMaxLocalExchangeBufferSize, 4'096)
+            .assertResults("SELECT c0, max(c1) FROM tmp GROUP BY c0");
+
+    const auto stats = exec::toPlanStats(task->taskStats());
+    ASSERT_GT(
+        stats.at(localPartitionId)
+            .customStats.at("blockedWaitForConsumerTimes")
+            .sum,
+        0);
+  }
+}
+
 } // namespace
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -217,4 +217,9 @@ uint64_t CudfVector::estimateFlatSize() const {
   return flatSize_;
 }
 
+uint64_t CudfVector::retainedSizeImpl(
+    uint64_t& /*totalStringBufferSize*/) const {
+  return flatSize_;
+}
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/vector/CudfVector.h
+++ b/velox/experimental/cudf/vector/CudfVector.h
@@ -82,6 +82,8 @@ class CudfVector : public RowVector {
   uint64_t estimateFlatSize() const override;
 
  private:
+  uint64_t retainedSizeImpl(uint64_t& totalStringBufferSize) const override;
+
   // Storage for either an owned table or packed table.
   // Only one is active at a time - using variant enforces this at compile time.
   using TableStorage = std::variant<


### PR DESCRIPTION
CudfLocalPartition was providing the wrong estimates about vector byte size to the queue and as a result the backpressure wasn't working for the single partition case and working with the wrong estimate for the multiple partitioned case. This fixes the issue.