### PR TITLE
fix(spark): Enable ANSI-compliant cast from BOOLEAN to DECIMAL

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -396,7 +396,7 @@ Invalid examples
   SELECT cast(cast(-100 as bigint) as decimal(17, 16)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
 
 From decimal types
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 *(ANSI compliant)*
 
@@ -460,6 +460,36 @@ Invalid examples
   SELECT cast(cast(1e38 as double) as decimal(20, 2)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Result overflows
   SELECT cast(cast('inf' as double) as decimal(38, 2)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value is not finite
   SELECT cast(cast('nan' as double) as decimal(38, 2)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value is not finite
+
+From boolean
+^^^^^^^^^^^^
+
+*(ANSI compliant)*
+
+Casting a boolean to a decimal of given precision and scale is allowed.
+``true`` becomes 1 and ``false`` becomes 0.
+
+When ANSI mode is enabled, casting a value that overflows the target precision
+and scale throws an error. Otherwise, such casts return NULL. Only ``true`` can
+overflow, and only when the target has no integer digits (precision equals
+scale), since 1 cannot be represented there. ``false`` becomes 0, which fits any
+precision and scale.
+
+Valid examples
+
+::
+
+  SELECT cast(true as decimal(6, 2)); -- 1.00
+  SELECT cast(false as decimal(6, 2)); -- 0.00
+  SELECT cast(true as decimal(20, 10)); -- 1.0000000000
+  SELECT cast(false as decimal(1, 1)); -- 0.0
+
+Invalid examples
+
+::
+
+  SELECT cast(true as decimal(1, 1)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
+  SELECT cast(true as decimal(38, 38)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
 
 Cast to Varbinary
 -----------------

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -132,6 +132,9 @@ bool SparkCastCallToSpecialForm::isAnsiSupported(
     if (fromType->isReal() || fromType->isDouble()) {
       return true;
     }
+    if (fromType->isBoolean()) {
+      return true;
+    }
   }
 
   if (toType->isTimestamp() && (fromType->isReal() || fromType->isDouble())) {

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1311,13 +1311,6 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
     // False becomes zero, which fits any precision and scale.
     testCast<bool, int64_t>(BOOLEAN(), DECIMAL(1, 1), {false}, {0});
     testCast<bool, int128_t>(BOOLEAN(), DECIMAL(38, 38), {false}, {0});
-
-    // Nulls are preserved.
-    testCast<bool, int64_t>(
-        BOOLEAN(),
-        DECIMAL(6, 2),
-        {true, std::nullopt, false},
-        {100, std::nullopt, 0});
   }
 
   void testDecimalToDecimal() {

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1285,6 +1285,41 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
             DECIMAL(20, 10)));
   }
 
+  // Valid bool-to-decimal cases. Results are identical regardless of ANSI
+  // mode, so they are shared between the ANSI ON and ANSI OFF tests.
+  void testBoolToDecimal() {
+    auto input =
+        makeFlatVector<bool>({true, false, false, true, true, true, false});
+    // Bool to short decimal.
+    testCast(
+        input,
+        makeFlatVector<int64_t>({100, 0, 0, 100, 100, 100, 0}, DECIMAL(6, 2)));
+
+    // Bool to long decimal.
+    testCast(
+        input,
+        makeFlatVector<int128_t>(
+            {10'000'000'000,
+             0,
+             0,
+             10'000'000'000,
+             10'000'000'000,
+             10'000'000'000,
+             0},
+            DECIMAL(20, 10)));
+
+    // False becomes zero, which fits any precision and scale.
+    testCast<bool, int64_t>(BOOLEAN(), DECIMAL(1, 1), {false}, {0});
+    testCast<bool, int128_t>(BOOLEAN(), DECIMAL(38, 38), {false}, {0});
+
+    // Nulls are preserved.
+    testCast<bool, int64_t>(
+        BOOLEAN(),
+        DECIMAL(6, 2),
+        {true, std::nullopt, false},
+        {100, std::nullopt, 0});
+  }
+
   void testDecimalToDecimal() {
     // Short to short, scale up.
     auto shortFlat =
@@ -2608,6 +2643,24 @@ TEST_F(SparkCastExprTestAnsiOn, decimalToDecimal) {
   testOverflowThrow();
 }
 
+TEST_F(SparkCastExprTestAnsiOn, boolToDecimal) {
+  // Regular cases produce the same results regardless of ANSI mode.
+  testBoolToDecimal();
+
+  // Under ANSI ON, true overflows a target with no integer digits
+  // (precision == scale), because 1 cannot be represented there.
+  testThrow<bool>(
+      BOOLEAN(),
+      DECIMAL(1, 1),
+      {true},
+      "Cannot cast BOOLEAN 'true' to DECIMAL(1, 1)");
+  testThrow<bool>(
+      BOOLEAN(),
+      DECIMAL(38, 38),
+      {true},
+      "Cannot cast BOOLEAN 'true' to DECIMAL(38, 38)");
+}
+
 TEST_F(SparkCastExprTestAnsiOn, doubleToDecimal) {
   // Regular cases produce the same results regardless of ANSI mode.
   testDoubleToDecimal();
@@ -2858,6 +2911,16 @@ TEST_F(SparkCastExprTestAnsiOff, integralToDecimal) {
   testOverflowNull.operator()<int16_t>();
   testOverflowNull.operator()<int32_t>();
   testOverflowNull.operator()<int64_t>();
+}
+
+TEST_F(SparkCastExprTestAnsiOff, boolToDecimal) {
+  // Regular cases produce the same results regardless of ANSI mode.
+  testBoolToDecimal();
+
+  // Under ANSI OFF, the same overflowing inputs return NULL instead of
+  // throwing.
+  testCast<bool, int64_t>(BOOLEAN(), DECIMAL(1, 1), {true}, {std::nullopt});
+  testCast<bool, int128_t>(BOOLEAN(), DECIMAL(38, 38), {true}, {std::nullopt});
 }
 
 TEST_F(SparkCastExprTestAnsiOff, doubleToDecimal) {


### PR DESCRIPTION
Adds ANSI mode support for casting BOOLEAN to DECIMAL in Spark SQL functions, aligning Velox with Spark: when ANSI mode is on, values that overflow the target precision/scale throw; when ANSI mode is off (or for try_cast), they return NULL. 

Overflow can only happen for ``true``, when the target decimal type has no integer digits (precision equals scale).

Update docs for this support.

Tests
Ported from `CastExprTest.cpp` (Presto cast behavior). Shared valid cases live in `testBoolToDecimal()`; overflow cases are split between the ANSI-on test (expects a throw) and the ANSI-off test (expects NULL).

Spark code [link](https://github.com/apache/spark/blob/4b4a2f7b69d555a2b28a130092f7d75411cb4c49/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L1384).