### PR TITLE
fix(expression): Widen conditional branches to a common type (#18511)

### DIFF
--- a/velox/expression/CaseExpr.cpp
+++ b/velox/expression/CaseExpr.cpp
@@ -487,46 +487,48 @@ TypePtr CaseCallToSpecialForm::resolveTypeWithCoercions(
     }
   }
 
+  // Records the coercion the first 'numClauses' THEN clauses need to reach
+  // 'type'. A clause already of that type needs none.
+  auto setThenCoercions = [&](size_t numClauses, const TypePtr& type) {
+    for (size_t i = 0; i < numClauses; i++) {
+      const auto index = 2 * i + 2;
+      coercions[index] = *argTypes[index] == *type ? nullptr : type;
+    }
+  };
+
   // Resolve the result type from THEN (and optional ELSE) clauses with
   // widening coercions, mirroring the logic in SwitchCallToSpecialForm.
   TypePtr resultType = argTypes[2];
   for (size_t i = 0; i < numCases; i++) {
     const auto& thenType = argTypes[2 * i + 2];
     if (*thenType != *resultType) {
-      if (coercer.coerce(thenType, resultType)) {
-        coercions[2 * i + 2] = resultType;
-      } else if (coercer.coerce(resultType, thenType)) {
-        resultType = thenType;
-        for (size_t j = 0; j < i; j++) {
-          coercions[2 * j + 2] = resultType;
-        }
-      } else {
-        VELOX_FAIL(
-            "All THEN clauses in case must have the same type. "
-            "Expected {}, but got {}.",
-            resultType->toString(),
-            thenType->toString());
-      }
+      const auto common = coercer.leastCommonSuperType(resultType, thenType);
+      VELOX_CHECK_NOT_NULL(
+          common,
+          "All THEN clauses in case must have the same type. "
+          "Expected {}, but got {}.",
+          resultType->toString(),
+          thenType->toString());
+
+      resultType = common;
+      setThenCoercions(i + 1, resultType);
     }
   }
 
   if (hasElse) {
     const auto& elseType = argTypes.back();
     if (*elseType != *resultType) {
-      if (coercer.coerce(elseType, resultType)) {
-        coercions.back() = resultType;
-      } else if (coercer.coerce(resultType, elseType)) {
-        resultType = elseType;
-        for (size_t i = 0; i < numCases; i++) {
-          coercions[2 * i + 2] = resultType;
-        }
-      } else {
-        VELOX_FAIL(
-            "ELSE clause in case must match THEN clause type. "
-            "Expected {}, but got {}.",
-            resultType->toString(),
-            elseType->toString());
-      }
+      const auto common = coercer.leastCommonSuperType(resultType, elseType);
+      VELOX_CHECK_NOT_NULL(
+          common,
+          "ELSE clause in case must match THEN clause type. "
+          "Expected {}, but got {}.",
+          resultType->toString(),
+          elseType->toString());
+
+      resultType = common;
+      setThenCoercions(numCases, resultType);
+      coercions.back() = *elseType == *resultType ? nullptr : resultType;
     }
   }
 

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -45,24 +45,24 @@ TypePtr resolveTypeInt(
       continue;
     }
 
-    if (allowedCoercions && coercer.coerce(argTypes[i], resultType)) {
-      coercions[i] = resultType;
-      continue;
-    }
+    // Inputs that coerce in neither direction, such as DECIMAL(8, 5) and
+    // INTEGER, still meet at a type that holds both.
+    const auto common = allowedCoercions
+        ? coercer.leastCommonSuperType(resultType, argTypes[i])
+        : nullptr;
 
-    if (allowedCoercions && coercer.coerce(resultType, argTypes[i])) {
-      resultType = argTypes[i];
-      for (auto j = 0; j < i; j++) {
-        coercions[j] = resultType;
-      }
-      continue;
-    }
-
-    VELOX_USER_CHECK(
-        *argTypes[0] == *argTypes[i],
+    VELOX_USER_CHECK_NOT_NULL(
+        common,
         "Inputs to coalesce must have the same type. Expected {}, but got {}.",
-        argTypes[0]->toString(),
+        resultType->toString(),
         argTypes[i]->toString());
+
+    resultType = common;
+
+    // An input already of the result type needs no coercion.
+    for (auto j = 0; j <= i; j++) {
+      coercions[j] = *argTypes[j] == *resultType ? nullptr : resultType;
+    }
   }
 
   return resultType;

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -252,9 +252,11 @@ TypePtr resolveTypeInt(
     coercions.resize(numArgs);
   }
 
+  // Records the coercion every then clause up to 'index' needs to reach
+  // 'type'. A clause already of that type needs none.
   auto setCoercionsUpTo = [&](int index, const TypePtr& type) {
     for (auto i = 1; i <= index; i += 2) {
-      coercions[i] = type;
+      coercions[i] = *argTypes[i] == *type ? nullptr : type;
     }
   };
 
@@ -268,18 +270,18 @@ TypePtr resolveTypeInt(
         "Condition of  SWITCH statement is not bool");
 
     if (*thenType != *resultType) {
-      if (allowedCoercions && coercer.coerce(thenType, resultType)) {
-        coercions[i * 2 + 1] = resultType;
-      } else if (allowedCoercions && coercer.coerce(resultType, thenType)) {
-        resultType = thenType;
-        setCoercionsUpTo(i * 2 - 1, resultType);
-      } else {
-        VELOX_FAIL(
-            "All then clauses of a SWITCH statement must have the same type. "
-            "Expected {}, but got {}.",
-            resultType->toString(),
-            thenType->toString());
-      }
+      const auto common = allowedCoercions
+          ? coercer.leastCommonSuperType(resultType, thenType)
+          : nullptr;
+      VELOX_CHECK_NOT_NULL(
+          common,
+          "All then clauses of a SWITCH statement must have the same type. "
+          "Expected {}, but got {}.",
+          resultType->toString(),
+          thenType->toString());
+
+      resultType = common;
+      setCoercionsUpTo(i * 2 + 1, resultType);
     }
   }
 
@@ -288,18 +290,19 @@ TypePtr resolveTypeInt(
     const auto& elseType = argTypes.back();
 
     if (*elseType != *resultType) {
-      if (allowedCoercions && coercer.coerce(elseType, resultType)) {
-        coercions.back() = resultType;
-      } else if (allowedCoercions && coercer.coerce(resultType, elseType)) {
-        resultType = elseType;
-        setCoercionsUpTo(numArgs - 2, resultType);
-      } else {
-        VELOX_FAIL(
-            "Else clause of a SWITCH statement must have the same type as 'then' clauses. "
-            "Expected {}, but got {}.",
-            resultType->toString(),
-            elseType->toString());
-      }
+      const auto common = allowedCoercions
+          ? coercer.leastCommonSuperType(resultType, elseType)
+          : nullptr;
+      VELOX_CHECK_NOT_NULL(
+          common,
+          "Else clause of a SWITCH statement must have the same type as 'then' clauses. "
+          "Expected {}, but got {}.",
+          resultType->toString(),
+          elseType->toString());
+
+      resultType = common;
+      setCoercionsUpTo(numArgs - 2, resultType);
+      coercions.back() = *elseType == *resultType ? nullptr : resultType;
     }
   }
 

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/IPAddressRegistration.h"
 #include "velox/functions/prestosql/types/IPPrefixRegistration.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/tests/RegistryTestUtil.h"
@@ -91,6 +92,8 @@ class FunctionRegistryTest : public testing::Test {
   FunctionRegistryTest() {
     registerTestFunctions();
     exec::registerFunctionCallToSpecialForms();
+    registerIPAddressType();
+    registerIPPrefixType();
   }
 
   void testResolveVectorFunction(
@@ -1048,7 +1051,21 @@ TEST_F(FunctionRegistryTest, resolveIfWithCoercions) {
   testSpecialFormNoCoercions(
       "if", {BOOLEAN(), INTEGER(), INTEGER()}, INTEGER());
 
+  // Neither branch coerces to the other: INTEGER widens to DECIMAL(10, 0),
+  // which does not fit DECIMAL(8, 5). Both widen to a decimal that holds
+  // either.
+  testSpecialFormCoercions(
+      "if",
+      {BOOLEAN(), DECIMAL(8, 5), INTEGER()},
+      DECIMAL(15, 5),
+      {nullptr, DECIMAL(15, 5), DECIMAL(15, 5)});
+
   testSpecialFormCannotResolve("if", {BOOLEAN(), INTEGER(), VARCHAR()});
+
+  // Custom types do not reconcile implicitly, matching Presto, which rejects
+  // "Result types for IF must be the same: ipprefix vs ipaddress". IPADDRESS
+  // has a cast rule to IPPREFIX, but it is not implicitly allowed.
+  testSpecialFormCannotResolve("if", {BOOLEAN(), IPPREFIX(), IPADDRESS()});
 }
 
 TEST_F(FunctionRegistryTest, resolveSwitchWithCoercions) {
@@ -1087,6 +1104,33 @@ TEST_F(FunctionRegistryTest, resolveSwitchWithCoercions) {
        BIGINT()},
       BIGINT(),
       {nullptr, BIGINT(), nullptr, BIGINT(), nullptr, BIGINT(), nullptr});
+
+  // Branches that meet only at a common decimal, as Presto resolves them.
+  testSpecialFormCoercions(
+      "switch",
+      {BOOLEAN(), DECIMAL(8, 5), BOOLEAN(), DECIMAL(12, 2), INTEGER()},
+      DECIMAL(15, 5),
+      {nullptr, DECIMAL(15, 5), nullptr, DECIMAL(15, 5), DECIMAL(15, 5)});
+}
+
+TEST_F(FunctionRegistryTest, resolveCaseWithCoercions) {
+  // subject, WHEN, THEN, WHEN, THEN, ELSE. The THEN clauses coerce in neither
+  // direction, so they and the ELSE meet at a common decimal.
+  testSpecialFormCoercions(
+      "case",
+      {INTEGER(),
+       INTEGER(),
+       DECIMAL(8, 5),
+       INTEGER(),
+       DECIMAL(12, 2),
+       INTEGER()},
+      DECIMAL(15, 5),
+      {nullptr,
+       nullptr,
+       DECIMAL(15, 5),
+       nullptr,
+       DECIMAL(15, 5),
+       DECIMAL(15, 5)});
 }
 
 TEST_F(FunctionRegistryTest, resolveCoalesceWithCoercions) {
@@ -1095,6 +1139,13 @@ TEST_F(FunctionRegistryTest, resolveCoalesceWithCoercions) {
 
   testSpecialFormCoercions(
       "coalesce", {BIGINT(), UNKNOWN()}, BIGINT(), {nullptr, BIGINT()});
+
+  // Inputs that coerce in neither direction meet at a common decimal.
+  testSpecialFormCoercions(
+      "coalesce",
+      {DECIMAL(8, 5), INTEGER()},
+      DECIMAL(15, 5),
+      {DECIMAL(15, 5), DECIMAL(15, 5)});
 
   testSpecialFormCoercions(
       "coalesce",
@@ -1274,7 +1325,6 @@ TEST_F(FunctionRegistryOverwriteTest, overwrite) {
 }
 
 TEST_F(FunctionRegistryTest, ipPrefixRegistration) {
-  registerIPPrefixType();
   registerFunction<IPPrefixFunc, IPPrefix, IPPrefix>({"ipprefix_func"});
 
   auto& simpleFunctions = exec::simpleFunctions();


### PR DESCRIPTION
Summary:

A conditional whose branches coerce in neither direction failed to resolve:

    SELECT IF(app_dau > 0, TRY_CAST(dau / app_dau AS DECIMAL(8, 5)), 0)

fails with:

    Else clause of a SWITCH statement must have the same type as 'then' clauses. Expected DECIMAL(8, 5), but got INTEGER.

INTEGER widens to DECIMAL(10, 0), which does not fit DECIMAL(8, 5), and DECIMAL(8, 5) does not fit INTEGER, so both directions were rejected. Presto widens both branches instead and answers DECIMAL(15, 5). This is how a production query that scales seven ratios into DECIMAL(8, 5) failed to plan.

`SwitchExpr`, `CoalesceExpr` and `CaseExpr` each tried to coerce one branch to the other's type and gave up when neither worked. They now ask `TypeCoercer::leastCommonSuperType`, which tries both directions first and falls back to the type that holds either. `CaseExpr` already resolved its subject and WHEN values that way; only its THEN and ELSE clauses did not.

A branch already of the result type records no coercion, as before.

Custom types still do not reconcile: their cast rules are not marked implicit, so `IF(c, ipprefix, ipaddress)` fails as it does in Presto.

Reviewed By: amitkdutta

Differential Revision: D115979786


