### PR TITLE
docs: Update Spark function documents

### DIFF
--- a/velox/docs/functions/spark/coverage.rst
+++ b/velox/docs/functions/spark/coverage.rst
@@ -16,6 +16,7 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(2) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(3) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(2) {background-color: #6BA81E;}
@@ -45,8 +46,10 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(13) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(14) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(15) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(1) {background-color: #6BA81E;}
@@ -60,8 +63,10 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(2) {background-color: #6BA81E;}
@@ -72,6 +77,8 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(22) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(23) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(23) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(3) {background-color: #6BA81E;}
@@ -86,12 +93,15 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(26) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
@@ -106,6 +116,7 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(32) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(1) {background-color: #6BA81E;}
@@ -150,8 +161,10 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(45) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(46) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(3) {background-color: #6BA81E;}
@@ -160,6 +173,7 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(50) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(51) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(3) {background-color: #6BA81E;}
@@ -175,9 +189,11 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(57) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(58) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(60) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(2) {background-color: #6BA81E;}
@@ -198,6 +214,7 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     table.coverage tr:nth-child(68) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(69) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(4) {background-color: #6BA81E;}
     </style>
 
@@ -210,7 +227,7 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     =====================================================================================================================================================================================================================  ==  =========================================  ==  =========================================
     :spark:func:`abs`                          count_if                                   inline                                     nvl                                        :spark:func:`sqrt`                             any                                            cume_dist
     :spark:func:`acos`                         count_min_sketch                           inline_outer                               nvl2                                       stack                                          approx_count_distinct                          :spark:func:`dense_rank`
-    :spark:func:`acosh`                        covar_pop                                  input_file_block_length                    octet_length                               std                                            approx_percentile                              first_value
+    :spark:func:`acosh`                        covar_pop                                  input_file_block_length                    octet_length                               std                                            :spark:func:`approx_percentile`                first_value
     :spark:func:`add_months`                   covar_samp                                 input_file_block_start                     or                                         stddev                                         array_agg                                      lag
     :spark:func:`aggregate`                    :spark:func:`crc32`                        input_file_name                            :spark:func:`overlay`                      stddev_pop                                     :spark:func:`avg`                              last_value
     and                                        cume_dist                                  :spark:func:`instr`                        parse_url                                  stddev_samp                                    bit_and                                        lead
@@ -221,26 +238,26 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     :spark:func:`array_contains`               current_timezone                           java_method                                :spark:func:`pmod`                         :spark:func:`substring`                        :spark:func:`collect_list`                     :spark:func:`row_number`
     :spark:func:`array_distinct`               current_user                               :spark:func:`json_array_length`            posexplode                                 :spark:func:`substring_index`                  :spark:func:`collect_set`
     :spark:func:`array_except`                 date                                       :spark:func:`json_object_keys`             posexplode_outer                           sum                                            :spark:func:`corr`
-    :spark:func:`array_intersect`              :spark:func:`date_add`                     json_tuple                                 position                                   tan                                            count
-    :spark:func:`array_join`                   :spark:func:`date_format`                  kurtosis                                   positive                                   tanh                                           count_if
+    :spark:func:`array_intersect`              :spark:func:`date_add`                     json_tuple                                 position                                   :spark:func:`tan`                              count
+    :spark:func:`array_join`                   :spark:func:`date_format`                  kurtosis                                   positive                                   :spark:func:`tanh`                             count_if
     :spark:func:`array_max`                    :spark:func:`date_from_unix_date`          lag                                        pow                                        timestamp                                      count_min_sketch
     :spark:func:`array_min`                    date_part                                  last                                       :spark:func:`power`                        :spark:func:`timestamp_micros`                 covar_pop
     :spark:func:`array_position`               :spark:func:`date_sub`                     :spark:func:`last_day`                     printf                                     :spark:func:`timestamp_millis`                 :spark:func:`covar_samp`
-    :spark:func:`array_remove`                 :spark:func:`date_trunc`                   last_value                                 :spark:func:`quarter`                      timestamp_seconds                              every
-    :spark:func:`array_repeat`                 :spark:func:`datediff`                     lcase                                      radians                                    tinyint                                        :spark:func:`first`
+    :spark:func:`array_remove`                 :spark:func:`date_trunc`                   last_value                                 :spark:func:`quarter`                      :spark:func:`timestamp_seconds`                every
+    :spark:func:`array_repeat`                 :spark:func:`datediff`                     lcase                                      :spark:func:`radians`                      tinyint                                        :spark:func:`first`
     :spark:func:`array_sort`                   :spark:func:`day`                          lead                                       :spark:func:`raise_error`                  to_csv                                         first_value
     :spark:func:`array_union`                  :spark:func:`dayofmonth`                   :spark:func:`least`                        :spark:func:`rand`                         to_date                                        grouping
-    arrays_overlap                             :spark:func:`dayofweek`                    :spark:func:`left`                         randn                                      to_json                                        grouping_id
+    arrays_overlap                             :spark:func:`dayofweek`                    :spark:func:`left`                         :spark:func:`randn`                        :spark:func:`to_json`                          grouping_id
     :spark:func:`arrays_zip`                   :spark:func:`dayofyear`                    :spark:func:`length`                       :spark:func:`random`                       to_timestamp                                   histogram_numeric
     :spark:func:`ascii`                        decimal                                    :spark:func:`levenshtein`                  range                                      :spark:func:`to_unix_timestamp`                :spark:func:`kurtosis`
     :spark:func:`asin`                         decode                                     :spark:func:`like`                         rank                                       :spark:func:`to_utc_timestamp`                 :spark:func:`last`
-    :spark:func:`asinh`                        :spark:func:`degrees`                      ln                                         reflect                                    :spark:func:`transform`                        last_value
+    :spark:func:`asinh`                        :spark:func:`degrees`                      :spark:func:`ln`                           reflect                                    :spark:func:`transform`                        last_value
     assert_true                                dense_rank                                 :spark:func:`locate`                       regexp                                     transform_keys                                 :spark:func:`max`
-    :spark:func:`atan`                         div                                        :spark:func:`log`                          :spark:func:`regexp_extract`               transform_values                               :spark:func:`max_by`
+    :spark:func:`atan`                         :spark:func:`div`                          :spark:func:`log`                          :spark:func:`regexp_extract`               :spark:func:`transform_values`                 :spark:func:`max_by`
     :spark:func:`atan2`                        double                                     :spark:func:`log10`                        :spark:func:`regexp_extract_all`           :spark:func:`translate`                        mean
     :spark:func:`atanh`                        e                                          :spark:func:`log1p`                        regexp_like                                :spark:func:`trim`                             :spark:func:`min`
     avg                                        :spark:func:`element_at`                   :spark:func:`log2`                         :spark:func:`regexp_replace`               :spark:func:`trunc`                            :spark:func:`min_by`
-    base64                                     elt                                        :spark:func:`lower`                        :spark:func:`repeat`                       try_add                                        percentile
+    :spark:func:`base64`                       elt                                        :spark:func:`lower`                        :spark:func:`repeat`                       try_add                                        percentile
     :spark:func:`between`                      encode                                     :spark:func:`lpad`                         :spark:func:`replace`                      try_divide                                     percentile_approx
     bigint                                     every                                      :spark:func:`ltrim`                        :spark:func:`reverse`                      typeof                                         regr_avgx
     :spark:func:`bin`                          :spark:func:`exists`                       :spark:func:`make_date`                    right                                      ucase                                          regr_avgy
@@ -253,21 +270,21 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     bit_xor                                    :spark:func:`filter`                       :spark:func:`map_entries`                  schema_of_csv                              :spark:func:`unix_timestamp`                   stddev_pop
     bool_and                                   :spark:func:`find_in_set`                  :spark:func:`map_filter`                   schema_of_json                             :spark:func:`upper`                            :spark:func:`stddev_samp`
     bool_or                                    first                                      :spark:func:`map_from_arrays`              :spark:func:`second`                       :spark:func:`uuid`                             :spark:func:`sum`
-    boolean                                    first_value                                map_from_entries                           sentences                                  var_pop                                        try_avg
-    bround                                     :spark:func:`flatten`                      :spark:func:`map_keys`                     sequence                                   var_samp                                       try_sum
+    boolean                                    first_value                                :spark:func:`map_from_entries`             sentences                                  var_pop                                        try_avg
+    bround                                     :spark:func:`flatten`                      :spark:func:`map_keys`                     :spark:func:`sequence`                     var_samp                                       try_sum
     btrim                                      float                                      :spark:func:`map_values`                   session_window                             variance                                       var_pop
     cardinality                                :spark:func:`floor`                        :spark:func:`map_zip_with`                 sha                                        version                                        :spark:func:`var_samp`
     case                                       :spark:func:`forall`                       max                                        :spark:func:`sha1`                         :spark:func:`weekday`                          :spark:func:`variance`
-    cast                                       format_number                              max_by                                     :spark:func:`sha2`                         weekofyear
+    cast                                       :spark:func:`format_number`                max_by                                     :spark:func:`sha2`                         weekofyear
     :spark:func:`cbrt`                         format_string                              :spark:func:`md5`                          :spark:func:`shiftleft`                    when
     :spark:func:`ceil`                         from_csv                                   mean                                       :spark:func:`shiftright`                   :spark:func:`width_bucket`
     ceiling                                    from_json                                  min                                        shiftrightunsigned                         window
     char                                       :spark:func:`from_unixtime`                min_by                                     :spark:func:`shuffle`                      xpath
     char_length                                :spark:func:`from_utc_timestamp`           :spark:func:`minute`                       :spark:func:`sign`                         xpath_boolean
     character_length                           :spark:func:`get_json_object`              mod                                        signum                                     xpath_double
-    :spark:func:`chr`                          getbit                                     :spark:func:`monotonically_increasing_id`  sin                                        xpath_float
+    :spark:func:`chr`                          getbit                                     :spark:func:`monotonically_increasing_id`  :spark:func:`sin`                          xpath_float
     coalesce                                   :spark:func:`greatest`                     :spark:func:`month`                        :spark:func:`sinh`                         xpath_int
-    collect_list                               grouping                                   months_between                             :spark:func:`size`                         xpath_long
+    collect_list                               grouping                                   :spark:func:`months_between`               :spark:func:`size`                         xpath_long
     collect_set                                grouping_id                                named_struct                               skewness                                   xpath_number
     :spark:func:`concat`                       :spark:func:`hash`                         nanvl                                      :spark:func:`slice`                        xpath_short
     concat_ws                                  :spark:func:`hex`                          negative                                   smallint                                   xpath_string
@@ -276,5 +293,5 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     :spark:func:`cos`                          if                                         now                                        :spark:func:`soundex`                      :spark:func:`zip_with`
     :spark:func:`cosh`                         ifnull                                     nth_value                                  space
     :spark:func:`cot`                          :spark:func:`in`                           ntile                                      :spark:func:`spark_partition_id`
-    count                                      initcap                                    nullif                                     :spark:func:`split`
+    count                                      :spark:func:`initcap`                      nullif                                     :spark:func:`split`
     =========================================  =========================================  =========================================  =========================================  =========================================  ==  =========================================  ==  =========================================

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -314,6 +314,6 @@ Decimal Special Forms
 
 .. spark:function:: make_decimal(x[, nullOnOverflow]) -> decimal
 
-    Create ``decimal`` of requsted precision and scale from an unscaled bigint value ``x``.
+    Create ``decimal`` of requested precision and scale from an unscaled bigint value ``x``.
     By default, the value of ``nullOnOverflow`` is true, and null will be returned when ``x`` is too large for the result precision.
     Otherwise, exception will be thrown when ``x`` overflows.

--- a/velox/docs/functions/spark/regexp.rst
+++ b/velox/docs/functions/spark/regexp.rst
@@ -5,10 +5,10 @@ Regular Expression Functions
 Regular expression functions use RE2 as the regex engine. RE2 is fast, but
 supports only a subset of PCRE syntax and in particular does not support
 backtracking and associated features (e.g. back references).
-Java and RE2 regex output can diverage and users should be cautious that
+Java and RE2 regex output can diverge and users should be cautious that
 the patterns they are using perform similarly between RE2 and Java.
 For example, character class unions, intersections, and differences
-``([a[b]], [a&&[b]], [a&&[^b]])`` are intepreted as a single character class
+``([a[b]], [a&&[b]], [a&&[^b]])`` are interpreted as a single character class
 that contain ``[, &, and ^`` rather than union, intersection, or
 difference of the character classes.
 

--- a/velox/docs/spark_functions.rst
+++ b/velox/docs/spark_functions.rst
@@ -65,80 +65,89 @@ for :doc:`all <functions/spark/coverage>` functions.
     :widths: auto
     :class: rows
 
-    ===========================================  ===========================================  ===========================================  ==  ===========================================  ==  ===========================================
-    Scalar Functions                                                                                                                           Aggregate Functions                              Window Functions
-    =====================================================================================================================================  ==  ===========================================  ==  ===========================================
-    :spark:func:`abs`                            :spark:func:`divide_deny_precision_loss`     :spark:func:`not`                                :spark:func:`avg`                                :spark:func:`dense_rank`
-    :spark:func:`acos`                           :spark:func:`doy`                            :spark:func:`overlay`                            :spark:func:`bit_xor`                            :spark:func:`nth_value`
-    :spark:func:`acosh`                          :spark:func:`element_at`                     :spark:func:`pmod`                               :spark:func:`bloom_filter_agg`                   :spark:func:`ntile`
-    :spark:func:`add`                            :spark:func:`empty2null`                     :spark:func:`power`                              :spark:func:`collect_list`                       :spark:func:`rank`
-    :spark:func:`add_deny_precision_loss`        :spark:func:`endswith`                       :spark:func:`quarter`                            :spark:func:`collect_set`                        :spark:func:`row_number`
-    :spark:func:`add_months`                     :spark:func:`equalnullsafe`                  :spark:func:`raise_error`                        :spark:func:`corr`
-    :spark:func:`aggregate`                      :spark:func:`equalto`                        :spark:func:`rand`                               :spark:func:`covar_samp`
-    :spark:func:`array`                          :spark:func:`exists`                         :spark:func:`random`                             :spark:func:`first`
-    :spark:func:`array_append`                   :spark:func:`exp`                            :spark:func:`regexp_extract`                     :spark:func:`first_ignore_null`
-    :spark:func:`array_compact`                  :spark:func:`expm1`                          :spark:func:`regexp_extract_all`                 :spark:func:`kurtosis`
-    :spark:func:`array_contains`                 :spark:func:`factorial`                      :spark:func:`regexp_replace`                     :spark:func:`last`
-    :spark:func:`array_distinct`                 :spark:func:`filter`                         :spark:func:`remainder`                          :spark:func:`last_ignore_null`
-    :spark:func:`array_except`                   :spark:func:`find_in_set`                    :spark:func:`repeat`                             :spark:func:`max`
-    :spark:func:`array_insert`                   :spark:func:`flatten`                        :spark:func:`replace`                            :spark:func:`max_by`
-    :spark:func:`array_intersect`                :spark:func:`floor`                          :spark:func:`reverse`                            :spark:func:`min`
-    :spark:func:`array_join`                     :spark:func:`forall`                         :spark:func:`rint`                               :spark:func:`min_by`
-    :spark:func:`array_max`                      :spark:func:`from_unixtime`                  :spark:func:`rlike`                              :spark:func:`mode`
-    :spark:func:`array_min`                      :spark:func:`from_utc_timestamp`             :spark:func:`round`                              :spark:func:`regr_replacement`
-    :spark:func:`array_position`                 :spark:func:`get`                            :spark:func:`rpad`                               :spark:func:`skewness`
-    :spark:func:`array_prepend`                  :spark:func:`get_json_object`                :spark:func:`rtrim`                              :spark:func:`stddev`
-    :spark:func:`array_remove`                   :spark:func:`get_timestamp`                  :spark:func:`sec`                                :spark:func:`stddev_samp`
-    :spark:func:`array_repeat`                   :spark:func:`greaterthan`                    :spark:func:`second`                             :spark:func:`sum`
-    :spark:func:`array_sort`                     :spark:func:`greaterthanorequal`             :spark:func:`sha1`                               :spark:func:`var_samp`
-    :spark:func:`array_union`                    :spark:func:`greatest`                       :spark:func:`sha2`                               :spark:func:`variance`
-    :spark:func:`arrays_zip`                     :spark:func:`hash`                           :spark:func:`shiftleft`
-    :spark:func:`ascii`                          :spark:func:`hash_with_seed`                 :spark:func:`shiftright`
-    :spark:func:`asin`                           :spark:func:`hex`                            :spark:func:`shuffle`
-    :spark:func:`asinh`                          :spark:func:`hour`                           :spark:func:`sign`
-    :spark:func:`atan`                           :spark:func:`hypot`                          :spark:func:`sinh`
-    :spark:func:`atan2`                          :spark:func:`in`                             :spark:func:`size`
-    :spark:func:`atanh`                          :spark:func:`instr`                          :spark:func:`slice`
-    :spark:func:`between`                        :spark:func:`isnan`                          :spark:func:`sort_array`
-    :spark:func:`bin`                            :spark:func:`isnotnull`                      :spark:func:`soundex`
-    :spark:func:`bit_count`                      :spark:func:`isnull`                         :spark:func:`spark_partition_id`
-    :spark:func:`bit_get`                        :spark:func:`json_array_length`              :spark:func:`split`
-    :spark:func:`bit_length`                     :spark:func:`json_object_keys`               :spark:func:`sqrt`
-    :spark:func:`bitwise_and`                    :spark:func:`last_day`                       :spark:func:`startswith`
-    :spark:func:`bitwise_not`                    :spark:func:`least`                          :spark:func:`str_to_map`
-    :spark:func:`bitwise_or`                     :spark:func:`left`                           :spark:func:`substring`
-    :spark:func:`bitwise_xor`                    :spark:func:`length`                         :spark:func:`substring_index`
-    :spark:func:`cbrt`                           :spark:func:`lessthan`                       :spark:func:`subtract`
-    :spark:func:`ceil`                           :spark:func:`lessthanorequal`                :spark:func:`subtract_deny_precision_loss`
-    :spark:func:`checked_add`                    :spark:func:`levenshtein`                    :spark:func:`timestamp_micros`
-    :spark:func:`checked_divide`                 :spark:func:`like`                           :spark:func:`timestamp_millis`
-    :spark:func:`checked_multiply`               :spark:func:`locate`                         :spark:func:`to_unix_timestamp`
-    :spark:func:`checked_subtract`               :spark:func:`log`                            :spark:func:`to_utc_timestamp`
-    :spark:func:`chr`                            :spark:func:`log10`                          :spark:func:`transform`
-    :spark:func:`concat`                         :spark:func:`log1p`                          :spark:func:`translate`
-    :spark:func:`contains`                       :spark:func:`log2`                           :spark:func:`trim`
-    :spark:func:`conv`                           :spark:func:`lower`                          :spark:func:`trunc`
-    :spark:func:`cos`                            :spark:func:`lpad`                           :spark:func:`unaryminus`
-    :spark:func:`cosh`                           :spark:func:`ltrim`                          :spark:func:`unbase64`
-    :spark:func:`cot`                            :spark:func:`luhn_check`                     :spark:func:`unhex`
-    :spark:func:`crc32`                          :spark:func:`make_date`                      :spark:func:`unix_date`
-    :spark:func:`csc`                            :spark:func:`make_timestamp`                 :spark:func:`unix_micros`
-    :spark:func:`date_add`                       :spark:func:`make_ym_interval`               :spark:func:`unix_millis`
-    :spark:func:`date_format`                    :spark:func:`map`                            :spark:func:`unix_seconds`
-    :spark:func:`date_from_unix_date`            :spark:func:`map_concat`                     :spark:func:`unix_timestamp`
-    :spark:func:`date_sub`                       :spark:func:`map_entries`                    :spark:func:`unscaled_value`
-    :spark:func:`date_trunc`                     :spark:func:`map_filter`                     :spark:func:`upper`
-    :spark:func:`datediff`                       :spark:func:`map_from_arrays`                :spark:func:`url_decode`
-    :spark:func:`day`                            :spark:func:`map_keys`                       :spark:func:`url_encode`
-    :spark:func:`dayofmonth`                     :spark:func:`map_values`                     :spark:func:`uuid`
-    :spark:func:`dayofweek`                      :spark:func:`map_zip_with`                   :spark:func:`varchar_type_write_side_check`
-    :spark:func:`dayofyear`                      :spark:func:`mask`                           :spark:func:`week_of_year`
-    :spark:func:`decimal_equalto`                :spark:func:`md5`                            :spark:func:`weekday`
-    :spark:func:`decimal_greaterthan`            :spark:func:`might_contain`                  :spark:func:`width_bucket`
-    :spark:func:`decimal_greaterthanorequal`     :spark:func:`minute`                         :spark:func:`xxhash64`
-    :spark:func:`decimal_lessthan`               :spark:func:`monotonically_increasing_id`    :spark:func:`xxhash64_with_seed`
-    :spark:func:`decimal_lessthanorequal`        :spark:func:`month`                          :spark:func:`year`
-    :spark:func:`decimal_notequalto`             :spark:func:`multiply`                       :spark:func:`year_of_week`
-    :spark:func:`degrees`                        :spark:func:`multiply_deny_precision_loss`   :spark:func:`zip_with`
-    :spark:func:`divide`                         :spark:func:`next_day`
-    ===========================================  ===========================================  ===========================================  ==  ===========================================  ==  ===========================================
+    ==================================================  ==================================================  ==================================================  ==  ==================================================  ==  ==================================================
+    Scalar Functions                                                                                                                                                Aggregate Functions                                     Window Functions
+    ==========================================================================================================================================================  ==  ==================================================  ==  ==================================================
+    :spark:func:`abs`                                   :spark:func:`divide`                                :spark:func:`radians`                                   :spark:func:`approx_percentile`                         :spark:func:`dense_rank`
+    :spark:func:`acos`                                  :spark:func:`divide_deny_precision_loss`            :spark:func:`raise_error`                               :spark:func:`avg`                                       :spark:func:`nth_value`
+    :spark:func:`acosh`                                 :spark:func:`element_at`                            :spark:func:`rand`                                      :spark:func:`bit_xor`                                   :spark:func:`ntile`
+    :spark:func:`add`                                   :spark:func:`empty2null`                            :spark:func:`randn`                                     :spark:func:`bitmap_construct_agg`                      :spark:func:`rank`
+    :spark:func:`add_deny_precision_loss`               :spark:func:`endswith`                              :spark:func:`random`                                    :spark:func:`bitmap_or_agg`                             :spark:func:`row_number`
+    :spark:func:`add_months`                            :spark:func:`equalnullsafe`                         :spark:func:`randstr`                                   :spark:func:`bloom_filter_agg`
+    :spark:func:`aggregate`                             :spark:func:`equalto`                               :spark:func:`read_side_padding`                         :spark:func:`collect_list`
+    :spark:func:`array`                                 :spark:func:`exists`                                :spark:func:`regexp_extract`                            :spark:func:`collect_set`
+    :spark:func:`array_append`                          :spark:func:`exp`                                   :spark:func:`regexp_extract_all`                        :spark:func:`corr`
+    :spark:func:`array_compact`                         :spark:func:`expm1`                                 :spark:func:`regexp_instr`                              :spark:func:`covar_samp`
+    :spark:func:`array_contains`                        :spark:func:`factorial`                             :spark:func:`regexp_replace`                            :spark:func:`first`
+    :spark:func:`array_distinct`                        :spark:func:`filter`                                :spark:func:`remainder`                                 :spark:func:`first_ignore_null`
+    :spark:func:`array_except`                          :spark:func:`find_in_set`                           :spark:func:`repeat`                                    :spark:func:`kurtosis`
+    :spark:func:`array_insert`                          :spark:func:`flatten`                               :spark:func:`replace`                                   :spark:func:`last`
+    :spark:func:`array_intersect`                       :spark:func:`floor`                                 :spark:func:`reverse`                                   :spark:func:`last_ignore_null`
+    :spark:func:`array_join`                            :spark:func:`forall`                                :spark:func:`rint`                                      :spark:func:`max`
+    :spark:func:`array_max`                             :spark:func:`format_number`                         :spark:func:`rlike`                                     :spark:func:`max_by`
+    :spark:func:`array_min`                             :spark:func:`from_unixtime`                         :spark:func:`round`                                     :spark:func:`min`
+    :spark:func:`array_position`                        :spark:func:`from_utc_timestamp`                    :spark:func:`rpad`                                      :spark:func:`min_by`
+    :spark:func:`array_prepend`                         :spark:func:`get`                                   :spark:func:`rtrim`                                     :spark:func:`mode`
+    :spark:func:`array_remove`                          :spark:func:`get_json_object`                       :spark:func:`sec`                                       :spark:func:`regr_replacement`
+    :spark:func:`array_repeat`                          :spark:func:`get_timestamp`                         :spark:func:`second`                                    :spark:func:`skewness`
+    :spark:func:`array_sort`                            :spark:func:`greaterthan`                           :spark:func:`sequence`                                  :spark:func:`stddev`
+    :spark:func:`array_sort_desc`                       :spark:func:`greaterthanorequal`                    :spark:func:`sha1`                                      :spark:func:`stddev_samp`
+    :spark:func:`array_union`                           :spark:func:`greatest`                              :spark:func:`sha2`                                      :spark:func:`sum`
+    :spark:func:`arrays_zip`                            :spark:func:`hash`                                  :spark:func:`shiftleft`                                 :spark:func:`var_samp`
+    :spark:func:`ascii`                                 :spark:func:`hash_with_seed`                        :spark:func:`shiftright`                                :spark:func:`variance`
+    :spark:func:`asin`                                  :spark:func:`hex`                                   :spark:func:`shuffle`
+    :spark:func:`asinh`                                 :spark:func:`hour`                                  :spark:func:`sign`
+    :spark:func:`assert_not_null`                       :spark:func:`hypot`                                 :spark:func:`sin`
+    :spark:func:`atan`                                  :spark:func:`initcap`                               :spark:func:`sinh`
+    :spark:func:`atan2`                                 :spark:func:`instr`                                 :spark:func:`size`
+    :spark:func:`atanh`                                 :spark:func:`isnan`                                 :spark:func:`slice`
+    :spark:func:`base64`                                :spark:func:`isnotnull`                             :spark:func:`sort_array`
+    :spark:func:`between`                               :spark:func:`isnull`                                :spark:func:`soundex`
+    :spark:func:`bin`                                   :spark:func:`json_array_length`                     :spark:func:`spark_partition_id`
+    :spark:func:`bit_count`                             :spark:func:`json_object_keys`                      :spark:func:`split`
+    :spark:func:`bit_get`                               :spark:func:`last_day`                              :spark:func:`sqrt`
+    :spark:func:`bit_length`                            :spark:func:`least`                                 :spark:func:`startswith`
+    :spark:func:`bitwise_and`                           :spark:func:`left`                                  :spark:func:`str_to_map`
+    :spark:func:`bitwise_not`                           :spark:func:`length`                                :spark:func:`substring`
+    :spark:func:`bitwise_or`                            :spark:func:`lessthan`                              :spark:func:`substring_index`
+    :spark:func:`bitwise_xor`                           :spark:func:`lessthanorequal`                       :spark:func:`subtract`
+    :spark:func:`cbrt`                                  :spark:func:`levenshtein`                           :spark:func:`subtract_deny_precision_loss`
+    :spark:func:`ceil`                                  :spark:func:`like`                                  :spark:func:`tan`
+    :spark:func:`char_type_write_side_check`            :spark:func:`ln`                                    :spark:func:`tanh`
+    :spark:func:`checked_add`                           :spark:func:`locate`                                :spark:func:`timestamp_micros`
+    :spark:func:`checked_add_deny_precision_loss`       :spark:func:`log`                                   :spark:func:`timestamp_millis`
+    :spark:func:`checked_div`                           :spark:func:`log10`                                 :spark:func:`timestamp_seconds`
+    :spark:func:`checked_divide`                        :spark:func:`log1p`                                 :spark:func:`timestampadd`
+    :spark:func:`checked_multiply`                      :spark:func:`log2`                                  :spark:func:`timestampdiff`
+    :spark:func:`checked_multiply_deny_precision_loss`  :spark:func:`lower`                                 :spark:func:`to_json`
+    :spark:func:`checked_subtract`                      :spark:func:`lpad`                                  :spark:func:`to_pretty_string`
+    :spark:func:`checked_subtract_deny_precision_loss`  :spark:func:`ltrim`                                 :spark:func:`to_unix_timestamp`
+    :spark:func:`chr`                                   :spark:func:`luhn_check`                            :spark:func:`to_utc_timestamp`
+    :spark:func:`concat`                                :spark:func:`make_date`                             :spark:func:`transform`
+    :spark:func:`contains`                              :spark:func:`make_timestamp`                        :spark:func:`transform_values`
+    :spark:func:`conv`                                  :spark:func:`make_ym_interval`                      :spark:func:`translate`
+    :spark:func:`cos`                                   :spark:func:`map`                                   :spark:func:`trim`
+    :spark:func:`cosh`                                  :spark:func:`map_concat`                            :spark:func:`trunc`
+    :spark:func:`cot`                                   :spark:func:`map_entries`                           :spark:func:`unaryminus`
+    :spark:func:`crc32`                                 :spark:func:`map_filter`                            :spark:func:`unbase64`
+    :spark:func:`csc`                                   :spark:func:`map_from_arrays`                       :spark:func:`unhex`
+    :spark:func:`date_add`                              :spark:func:`map_from_entries`                      :spark:func:`unix_date`
+    :spark:func:`date_format`                           :spark:func:`map_keys`                              :spark:func:`unix_micros`
+    :spark:func:`date_from_unix_date`                   :spark:func:`map_values`                            :spark:func:`unix_millis`
+    :spark:func:`date_sub`                              :spark:func:`map_zip_with`                          :spark:func:`unix_seconds`
+    :spark:func:`date_trunc`                            :spark:func:`mask`                                  :spark:func:`unix_timestamp`
+    :spark:func:`datediff`                              :spark:func:`md5`                                   :spark:func:`unscaled_value`
+    :spark:func:`day`                                   :spark:func:`might_contain`                         :spark:func:`upper`
+    :spark:func:`dayname`                               :spark:func:`minute`                                :spark:func:`url_decode`
+    :spark:func:`dayofmonth`                            :spark:func:`monotonically_increasing_id`           :spark:func:`url_encode`
+    :spark:func:`dayofweek`                             :spark:func:`month`                                 :spark:func:`uuid`
+    :spark:func:`dayofyear`                             :spark:func:`monthname`                             :spark:func:`varchar_type_write_side_check`
+    :spark:func:`decimal_equalto`                       :spark:func:`months_between`                        :spark:func:`week_of_year`
+    :spark:func:`decimal_greaterthan`                   :spark:func:`multiply`                              :spark:func:`weekday`
+    :spark:func:`decimal_greaterthanorequal`            :spark:func:`multiply_deny_precision_loss`          :spark:func:`width_bucket`
+    :spark:func:`decimal_lessthan`                      :spark:func:`next_day`                              :spark:func:`xxhash64`
+    :spark:func:`decimal_lessthanorequal`               :spark:func:`overlay`                               :spark:func:`xxhash64_with_seed`
+    :spark:func:`decimal_notequalto`                    :spark:func:`pmod`                                  :spark:func:`year`
+    :spark:func:`degrees`                               :spark:func:`power`                                 :spark:func:`year_of_week`
+    :spark:func:`div`                                   :spark:func:`quarter`                               :spark:func:`zip_with`
+    ==================================================  ==================================================  ==================================================  ==  ==================================================  ==  ==================================================

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -518,7 +518,7 @@ struct WidthBucketFunction {
       double bound2,
       int64_t numBuckets) {
     // NULL would be returned if the input arguments don't follow conditions
-    // list belows:
+    // listed below:
     // - `numBuckets` must be greater than zero and be less than Long.MaxValue.
     // - `value`, `bound1`, and `bound2` cannot be NaN.
     // - `bound1` bound cannot equal `bound2`.

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -414,7 +414,7 @@ struct FromUtcTimestampFunction {
   const tz::TimeZone* timeZone_{nullptr};
 };
 
-/// Converts date string to Timestmap type.
+/// Converts date string to Timestamp type.
 template <typename T>
 struct GetTimestampFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/DecimalArithmetic.cpp
+++ b/velox/functions/sparksql/DecimalArithmetic.cpp
@@ -203,7 +203,7 @@ struct DecimalAddSubtractBase {
       bool& overflow) {
     VELOX_DCHECK(
         (a < 0 && b > 0) || (a > 0 && b < 0),
-        "One positve and one negative value are expected in addLargeOpposite.");
+        "One positive and one negative value are expected in addLargeOpposite.");
 
     // Separate whole and fraction parts.
     const auto [aWhole, aFraction] = getWholeAndFraction<A>(a, aScale);

--- a/velox/functions/sparksql/DecimalUtil.h
+++ b/velox/functions/sparksql/DecimalUtil.h
@@ -109,7 +109,7 @@ class DecimalUtil {
     return value;
   }
 
-  /// Returns the minumum number of leading zeros after scaling up two inputs
+  /// Returns the minimum number of leading zeros after scaling up two inputs
   /// for certain scales. Inputs are decimal values of bigint or hugeint type.
   template <typename A, typename B>
   inline static uint32_t

--- a/velox/functions/sparksql/RegexFunctions.cpp
+++ b/velox/functions/sparksql/RegexFunctions.cpp
@@ -35,9 +35,9 @@ void ensureRegexIsConstant(
 // REGEXP_REPLACE(string, pattern, overwrite, position) → string
 //
 // If a string has a substring that matches the given pattern, replace
-// the match in the string wither overwrite and return the string. If
+// the match in the string with overwrite and return the string. If
 // optional parameter position is provided, only make replacements
-// after that positon in the string (1 indexed).
+// after that position in the string (1 indexed).
 //
 // If position <= 0, throw error.
 // If position > length string, return string.

--- a/velox/functions/sparksql/RegexFunctions.h
+++ b/velox/functions/sparksql/RegexFunctions.h
@@ -61,14 +61,14 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
     const core::QueryConfig& config);
 
 /// Full implementation of RegexReplace found in SparkSQL only,
-/// due to semantic mismatches betweeen Spark and Presto
+/// due to semantic mismatches between Spark and Presto
 /// regexp_replace(string, pattern, overwrite) → string
 /// regexp_replace(string, pattern, overwrite, position) → string
 ///
 /// If a string has a substring that matches the given pattern, replace
 /// the match in the string with overwrite and return the string. If
 /// optional parameter position is provided, only make replacements
-/// after that positon in the string (1 indexed).
+/// after that position in the string (1 indexed).
 ///
 /// If position <= 0, throw error.
 /// If position > length string, return string.

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -18,6 +18,7 @@
 #include "folly/ssl/OpenSSLHash.h"
 
 #include <string>
+#include "velox/expression/StringWriter.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/lib/string/StringCore.h"

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1183,7 +1183,7 @@ struct ConvFunction {
       toChars(result, unsignedValue, toBase, resultSize);
     }
 
-    // Converts to uppper case, consistent with Spark.
+    // Converts to upper case, consistent with Spark.
     if (std::abs(toBase) > 10) {
       toUpper(result.data(), result.size());
     }

--- a/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
@@ -298,7 +298,7 @@ TEST_F(CollectSetAggregateTest, unknownType) {
   });
   testAggregations({data}, {}, {"collect_set(c0, true)"}, {}, {expected});
 
-  // The grouping key is of UNKONWN type.
+  // The grouping key is of UNKNOWN type.
   expected = makeRowVector({
       makeNullConstant(TypeKind::UNKNOWN, 1),
       makeArrayVectorFromJson<int32_t>({"[]"}),

--- a/velox/functions/sparksql/registration/RegisterComparison.cpp
+++ b/velox/functions/sparksql/registration/RegisterComparison.cpp
@@ -74,7 +74,7 @@ void registerCompareFunctions(const std::string& prefix) {
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, double, double, double>(
       {prefix + "between"});
-  // Decimal comapre functions.
+  // Decimal compare functions.
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_decimal_gt, prefix + "decimal_greaterthan");
   VELOX_REGISTER_VECTOR_FUNCTION(

--- a/velox/functions/sparksql/tests/ArrayInsertTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayInsertTest.cpp
@@ -246,7 +246,7 @@ TEST_F(ArrayInsertTest, nullInputs) {
   auto expected = makeArrayVectorFromJson<int64_t>({"null"});
   testExpression("array_insert(c0, 1, 1, false)", {arrays}, expected);
 
-  // Null postition.
+  // Null position.
   arrays = makeArrayVectorFromJson<int64_t>({"[1, 1]"});
   expected = makeArrayVectorFromJson<int64_t>({"null"});
   testExpression(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -1508,7 +1508,7 @@ TEST_F(DateTimeFunctionsTest, trunc) {
 
   // Date(19576) is 2023-08-07, which is Monday, should return Monday.
   EXPECT_EQ(19576, trunc(19576, "week"));
-  // Date(19579) is 2023-08-10, Thur, should return Monday.
+  // Date(19579) is 2023-08-10, Thursday, should return Monday.
   EXPECT_EQ(19576, trunc(19579, "week"));
   // Date(18297) is 2020-02-05.
   EXPECT_EQ(18293, trunc(18297, "month"));

--- a/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
+++ b/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
@@ -172,7 +172,7 @@ TEST_F(GetJsonObjectTest, nullResult) {
   EXPECT_EQ(getJsonObject(R"({"hello": "3.5"})", "$."), std::nullopt);
   // The first char is not '$'.
   EXPECT_EQ(getJsonObject(R"({"hello": "3.5"})", ".hello"), std::nullopt);
-  // Constains '$' not in the first position.
+  // Contains '$' not in the first position.
   EXPECT_EQ(getJsonObject(R"({"hello": "3.5"})", "$.$hello"), std::nullopt);
 
   // Invalid ending character.

--- a/velox/functions/sparksql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/sparksql/tests/MapFromEntriesTest.cpp
@@ -147,7 +147,7 @@ TEST_F(MapFromEntriesTest, unknownInputs) {
 }
 
 TEST_F(MapFromEntriesTest, nullRowEntriesWithSmallerChildren) {
-  // Row vector is of size 3, childrens are of size 2 since row 2 is null.
+  // Row vector is of size 3, children are of size 2 since row 2 is null.
   auto rowVector = makeRowVector(
       {makeNullableFlatVector<int32_t>({std::nullopt, 2}),
        makeFlatVector<int32_t>({1, 2})});


### PR DESCRIPTION
- Update the coverage map and function list for Spark functions.
The new map and list are generated by running `velox_sparksql_coverage`.
- Fix typos in the sparksql functions.

Last update (in July 2025): https://github.com/facebookincubator/velox/commit/dd864ddaa8793bb4745fe2894ed8bc268390704f.