### PR TITLE
refactor: Replace raw glog DCHECK with VELOX_DCHECK in velox/vector

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -954,7 +954,7 @@ class BaseVector {
 
   FOLLY_ALWAYS_INLINE static std::optional<int32_t>
   compareNulls(bool thisNull, bool otherNull, CompareFlags flags) {
-    DCHECK(thisNull || otherNull);
+    VELOX_DCHECK(thisNull || otherNull);
     switch (flags.nullHandlingMode) {
       case CompareFlags::NullHandlingMode::kNullAsIndeterminate:
         if (flags.equalsOnly) {

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -18,7 +18,6 @@
 
 #include <folly/container/F14Map.h>
 #include <folly/hash/Hash.h>
-#include <glog/logging.h>
 
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
@@ -377,7 +376,7 @@ struct ArrayVectorBase : BaseVector {
   /// are safe to write at index i, i.ex not shared, or not large enough.
   void
   setOffsetAndSize(vector_size_t i, vector_size_t offset, vector_size_t size) {
-    DCHECK_LT(i, BaseVector::length_);
+    VELOX_DCHECK_LT(i, BaseVector::length_);
     offsets_->asMutable<vector_size_t>()[i] = offset;
     sizes_->asMutable<vector_size_t>()[i] = size;
   }

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -257,7 +257,7 @@ void FlatVector<StringView>::copy(
       rows.applyToSelected([&](vector_size_t row) { setNull(row, true); });
     } else {
       rows.applyToSelected([&](vector_size_t row) {
-        auto sourceRow = toSourceRow ? toSourceRow[row] : row;
+        [[maybe_unused]] auto sourceRow = toSourceRow ? toSourceRow[row] : row;
         VELOX_DCHECK(source->isNullAt(sourceRow));
         setNull(row, true);
       });

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -253,12 +253,12 @@ void FlatVector<StringView>::copy(
   // Source can be of Unknown type, in that case it should have null values.
   if (source->typeKind() == TypeKind::UNKNOWN) {
     if (source->isConstantEncoding()) {
-      DCHECK(source->isNullAt(0));
+      VELOX_DCHECK(source->isNullAt(0));
       rows.applyToSelected([&](vector_size_t row) { setNull(row, true); });
     } else {
       rows.applyToSelected([&](vector_size_t row) {
         auto sourceRow = toSourceRow ? toSourceRow[row] : row;
-        DCHECK(source->isNullAt(sourceRow));
+        VELOX_DCHECK(source->isNullAt(sourceRow));
         setNull(row, true);
       });
     }

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -25,7 +25,6 @@
 #include <folly/Synchronized.h>
 #include <folly/container/F14Map.h>
 #include <folly/hash/Hash.h>
-#include <glog/logging.h>
 
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/FloatingPointUtil.h"
@@ -163,8 +162,9 @@ class SimpleVector : public BaseVector {
     // need to ensure it is loaded.
     loadedVector();
     other = other->loadedVector();
-    DCHECK(dynamic_cast<const SimpleVector<T>*>(other) != nullptr)
-        << "Attempting to compare vectors not of the same type";
+    VELOX_DCHECK_NOT_NULL(
+        dynamic_cast<const SimpleVector<T>*>(other),
+        "Attempting to compare vectors not of the same type");
     bool otherNull = other->isNullAt(otherIndex);
     bool thisNull = isNullAt(index);
 


### PR DESCRIPTION
CODING_STYLE.md endorses only the `VELOX_CHECK_*`/`VELOX_DCHECK_*` macros.
VELOX_DCHECK throws a catchable VeloxRuntimeError instead of aborting via
glog's LOG(FATAL), so these five assertions join Velox's error handling.
Both are compiled out under NDEBUG, so release behavior is unchanged.

SimpleVector.h used glog's streaming '<< message' form, which VELOX_DCHECK
does not support; it becomes VELOX_DCHECK_NOT_NULL with the message as an
argument. Neither SimpleVector.h nor ComplexVector.h references any glog
symbol now, so their orphaned #include <glog/logging.h> is dropped.

No functional changes.