### PR TITLE
fix: Fix the stale make format command in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -116,7 +116,8 @@ or lightweight dependencies, use `add_executable` / `add_test`.
 ## Formatting
 
 ```bash
-make format  # format all changed files
+pre-commit run --files <paths>  # format/lint specific files
+pre-commit run --all-files      # sweep the whole repo
 ```
 
 ## Coding Style


### PR DESCRIPTION
The Makefile has no `format` target; `format-fix` and `format-check`
were removed in 7c73c1106 when the project moved to pre-commit.
`--files` is listed first because a bare `pre-commit run` only looks
at staged files, doing nothing for files just edited.