### PR TITLE
feat: Deletion-vector codec: bound Roaring64 positions and conform to Puffin (#18520)

### DIFF
--- a/velox/connectors/hive/iceberg/DeletionVectorFormat.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorFormat.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -34,5 +35,26 @@ inline constexpr size_t kDeletionVectorMagicSize = 4;
 // magic + bitmap in the deletion-vector-v1 frame.
 inline constexpr size_t kDeletionVectorLengthSize = 4;
 inline constexpr size_t kDeletionVectorCrcSize = 4;
+
+/// Largest Roaring64 group key (the high 32 bits of a position) the Iceberg
+/// deletion-vector format can represent.
+///
+/// Iceberg's RoaringPositionBitmap stores the key as a signed 32-bit int and
+/// caps it one below Integer.MAX_VALUE, so a spec-compliant reader cannot load
+/// a larger key back. Keys at or above 2^31 are worse still: `key << 32`
+/// shifts into the sign bit of the int64 position and yields a negative row
+/// ordinal. Both the writer (via DeletionVectorWriter::kMaxPosition) and the
+/// reader enforce this so neither can accept a blob the other would reject.
+inline constexpr uint32_t kMaxRoaring64GroupKey = 2'147'483'646;
+
+/// Puffin container format constants, shared by the deletion-vector writer
+/// (which emits the footer) and the reader (which parses it when the manifest
+/// carries no blob offset). Magic is "PFA1" and brackets both the file and the
+/// footer payload.
+inline constexpr char kPuffinMagic[] = {'\x50', '\x46', '\x41', '\x31'};
+inline constexpr size_t kPuffinMagicSize = 4;
+
+/// Blob type of an Iceberg V3 deletion vector inside a Puffin file.
+inline constexpr char kDeletionVectorBlobType[] = "deletion-vector-v1";
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
 
+#include <folly/json.h>
 #include <folly/lang/Bits.h>
 #include <zlib.h>
 
@@ -39,6 +40,146 @@ uint32_t readBigEndian32(const char* data) {
   uint32_t value;
   std::memcpy(&value, data, sizeof(value));
   return folly::Endian::big(value);
+}
+
+uint32_t readLittleEndian32(const char* data) {
+  uint32_t value;
+  std::memcpy(&value, data, sizeof(value));
+  return folly::Endian::little(value);
+}
+
+// Byte range of a blob inside a Puffin file.
+struct BlobLocation {
+  uint64_t offset;
+  uint64_t length;
+};
+
+// Reads the Puffin magic that both opens the file and brackets the footer.
+bool startsWithPuffinMagic(ReadFile& file) {
+  if (file.size() < kPuffinMagicSize) {
+    return false;
+  }
+  std::string magic(kPuffinMagicSize, '\0');
+  file.pread(0, kPuffinMagicSize, magic.data());
+  return std::string_view(magic) ==
+      std::string_view(kPuffinMagic, kPuffinMagicSize);
+}
+
+// Locates the deletion-vector blob by parsing the Puffin footer, for files
+// whose manifest entry carried no blob offset or length. The footer is:
+//   Magic FooterPayload FooterPayloadSize Flags Magic
+// with FooterPayloadSize and Flags each 4 bytes little-endian, read backwards
+// from end of file. 'referencedDataFile' disambiguates when the file holds
+// vectors for several data files; an empty value requires a single candidate.
+BlobLocation locateBlobFromPuffinFooter(
+    ReadFile& file,
+    const std::string& referencedDataFile) {
+  // FooterPayloadSize + Flags + trailing Magic.
+  constexpr uint64_t kTrailerSize = 4 + 4 + kPuffinMagicSize;
+  // Leading Magic and the Magic that opens the footer bracket any payload.
+  constexpr uint64_t kMinFileSize = kTrailerSize + 2 * kPuffinMagicSize;
+
+  const uint64_t fileSize = file.size();
+  VELOX_CHECK_GE(
+      fileSize,
+      kMinFileSize,
+      "Puffin file is too small to contain a footer: {} bytes.",
+      fileSize);
+
+  std::string trailer(kTrailerSize, '\0');
+  file.pread(fileSize - kTrailerSize, kTrailerSize, trailer.data());
+  const std::string_view puffinMagic(kPuffinMagic, kPuffinMagicSize);
+  VELOX_CHECK_EQ(
+      std::string_view(trailer).substr(8),
+      puffinMagic,
+      "Puffin file does not end with the expected magic.");
+
+  const uint32_t flags = readLittleEndian32(trailer.data() + 4);
+  // Bit 0 of the first flag byte marks a compressed footer payload. Deletion
+  // vectors are always written uncompressed, so this is unreachable for files
+  // we produce and unsupported for files we do not.
+  VELOX_CHECK_EQ(
+      flags & 1u, 0u, "Compressed Puffin footer payloads are not supported.");
+
+  // payloadOffset must leave room for the leading magic and the magic that
+  // opens the footer, so payloadSize + kMinFileSize must fit within the file.
+  const uint64_t payloadSize = readLittleEndian32(trailer.data());
+  VELOX_CHECK_LE(
+      payloadSize + kMinFileSize,
+      fileSize,
+      "Puffin footer payload size {} does not fit in a {}-byte file.",
+      payloadSize,
+      fileSize);
+
+  const uint64_t payloadOffset = fileSize - kTrailerSize - payloadSize;
+  std::string footerMagic(kPuffinMagicSize, '\0');
+  file.pread(
+      payloadOffset - kPuffinMagicSize, kPuffinMagicSize, footerMagic.data());
+  VELOX_CHECK_EQ(
+      std::string_view(footerMagic),
+      puffinMagic,
+      "Puffin footer payload is not preceded by the expected magic.");
+
+  std::string payload(payloadSize, '\0');
+  file.pread(payloadOffset, payloadSize, payload.data());
+
+  folly::dynamic footer;
+  try {
+    footer = folly::parseJson(payload);
+  } catch (const std::exception& e) {
+    VELOX_FAIL("Failed to parse Puffin footer payload: {}", e.what());
+  }
+
+  const auto* blobs = footer.get_ptr("blobs");
+  VELOX_CHECK(
+      blobs != nullptr && blobs->isArray(),
+      "Puffin footer has no \"blobs\" array.");
+
+  std::optional<BlobLocation> found;
+  for (const auto& blob : *blobs) {
+    const auto* type = blob.get_ptr("type");
+    if (type == nullptr || !type->isString() ||
+        type->asString() != kDeletionVectorBlobType) {
+      continue;
+    }
+    if (!referencedDataFile.empty()) {
+      const auto* properties = blob.get_ptr("properties");
+      const auto* referenced = properties == nullptr
+          ? nullptr
+          : properties->get_ptr("referenced-data-file");
+      if (referenced == nullptr || !referenced->isString() ||
+          referenced->asString() != referencedDataFile) {
+        continue;
+      }
+    }
+    const auto* offset = blob.get_ptr("offset");
+    const auto* length = blob.get_ptr("length");
+    VELOX_CHECK(
+        offset != nullptr && offset->isInt() && length != nullptr &&
+            length->isInt(),
+        "Puffin blob metadata is missing a numeric offset or length.");
+    // Both are widened to uint64_t below, where a negative value would wrap to
+    // a huge offset. The file-bounds check downstream would still reject it,
+    // but only after reporting an absurd number, so reject it here instead.
+    VELOX_CHECK_GE(
+        offset->asInt(), 0, "Puffin blob metadata has a negative offset.");
+    VELOX_CHECK_GE(
+        length->asInt(), 0, "Puffin blob metadata has a negative length.");
+    VELOX_CHECK(
+        !found.has_value(),
+        "Puffin file has multiple deletion vectors and no referenced data "
+        "file to disambiguate them.");
+    found = BlobLocation{
+        static_cast<uint64_t>(offset->asInt()),
+        static_cast<uint64_t>(length->asInt())};
+  }
+
+  VELOX_CHECK(
+      found.has_value(),
+      "Puffin footer has no deletion-vector blob for data file: {}",
+      referencedDataFile.empty() ? std::string_view{"(unspecified)"}
+                                 : std::string_view{referencedDataFile});
+  return found.value();
 }
 
 // Unwraps the Iceberg deletion-vector-v1 blob frame
@@ -120,12 +261,16 @@ void DeletionVectorReader::loadBitmap() {
   uint64_t blobLength = dvFile_.contentLength > 0
       ? static_cast<uint64_t>(dvFile_.contentLength)
       : dvFile_.fileSizeInBytes;
+  bool haveBlobLocation = dvFile_.contentLength > 0;
 
   if (dvFile_.contentLength == 0) {
+    bool haveOffset = false;
+    bool haveLength = false;
     if (auto it = dvFile_.lowerBounds.find(kDvOffsetFieldId);
         it != dvFile_.lowerBounds.end()) {
       try {
         blobOffset = std::stoull(it->second);
+        haveOffset = true;
       } catch (const std::exception& e) {
         VELOX_FAIL(
             "Failed to parse DV blob offset from bounds map: {}", e.what());
@@ -135,11 +280,16 @@ void DeletionVectorReader::loadBitmap() {
         it != dvFile_.upperBounds.end()) {
       try {
         blobLength = std::stoull(it->second);
+        haveLength = true;
       } catch (const std::exception& e) {
         VELOX_FAIL(
             "Failed to parse DV blob length from bounds map: {}", e.what());
       }
     }
+    // A legacy bounds-map location is usable only when both offset and length
+    // are present. A partial entry falls through to Puffin-footer parsing
+    // rather than unframing at a wrong offset/length.
+    haveBlobLocation = haveOffset && haveLength;
   }
 
   // Pass the connector config (e.g. hive.manifold.* credentials) so
@@ -156,6 +306,17 @@ void DeletionVectorReader::loadBitmap() {
       readFile, "Failed to open deletion vector file: {}", dvFile_.filePath);
 
   auto fileSize = readFile->size();
+
+  // Nothing in the manifest located the blob. A Puffin file describes its own
+  // blobs, so parse the footer rather than guessing. Non-Puffin inputs keep
+  // the legacy whole-file behaviour, which is how raw roaring blobs are read.
+  if (!haveBlobLocation && startsWithPuffinMagic(*readFile)) {
+    const auto location =
+        locateBlobFromPuffinFooter(*readFile, dvFile_.referencedDataFile);
+    blobOffset = location.offset;
+    blobLength = location.length;
+  }
+
   VELOX_CHECK_LE(
       blobOffset,
       fileSize,
@@ -231,6 +392,13 @@ void DeletionVectorReader::deserializeRoaring64Bitmap(std::string_view data) {
     std::memcpy(&highBits, ptr, sizeof(uint32_t));
     highBits = folly::Endian::little(highBits);
     ptr += sizeof(uint32_t);
+
+    VELOX_CHECK_LE(
+        highBits,
+        kMaxRoaring64GroupKey,
+        "Roaring64Bitmap group key exceeds the maximum the Iceberg "
+        "deletion-vector format can represent: {}",
+        highBits);
 
     int64_t highBitsOffset = static_cast<int64_t>(highBits) << 32;
 

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -40,15 +40,19 @@ constexpr size_t kBitmapContainerBytes = 8'192;
 constexpr size_t kBitmapContainerWords = 1'024;
 
 // Puffin file format constants (per Iceberg spec). Magic is "PFA1".
-constexpr char kPuffinMagic[] = {'\x50', '\x46', '\x41', '\x31'};
-constexpr size_t kPuffinMagicSize = 4;
 constexpr uint32_t kPuffinFooterFlags = 0;
 
 // Puffin blob metadata constants (per Iceberg V3 deletion vector spec).
-constexpr char kDeletionVectorBlobType[] = "deletion-vector-v1";
-constexpr char kCompressionCodecNone[] = "none";
-// Iceberg spec: source-field-id for whole-row deletes is INT_MAX - 1.
-constexpr int32_t kWholeRowDeleteFieldId = 2'147'483'646;
+// The blob's "fields" list names the row-position metadata column
+// (MetadataColumns.ROW_POSITION, INT_MAX - 2), matching Iceberg's own
+// BaseDVFileWriter. Note this is not the positional-delete file's "pos"
+// column (INT_MAX - 102), which IcebergMetadataColumns uses for a different
+// purpose.
+constexpr int32_t kRowPositionFieldId = 2'147'483'645;
+// A deletion vector is written before its snapshot is assigned, so Iceberg
+// records -1 for both. The fields are required by readers regardless.
+constexpr int64_t kUnassignedSnapshotId = -1;
+constexpr int64_t kUnassignedSequenceNumber = -1;
 
 void writeLittleEndian(std::string& out, uint16_t val) {
   val = folly::Endian::little(val);
@@ -159,6 +163,12 @@ void serializeContainerData(
 
 void DeletionVectorWriter::addDeletedPosition(int64_t position) {
   VELOX_CHECK_GE(position, 0, "Deleted position must be non-negative.");
+  VELOX_CHECK_LE(
+      position,
+      kMaxPosition,
+      "Deleted position exceeds the maximum the Iceberg deletion-vector "
+      "format can represent: {}",
+      position);
   positions_.push_back(position);
 }
 
@@ -257,14 +267,17 @@ std::pair<uint64_t, uint64_t> writePuffinFile(
   uint64_t blobOffset = kPuffinMagicSize;
   uint64_t blobLength = framedBlob.size();
 
-  folly::dynamic blobMeta = folly::dynamic::object(
-      "type", kDeletionVectorBlobType)(
-      "fields",
-      folly::dynamic::array(
-          folly::dynamic::object("source-field-id", kWholeRowDeleteFieldId)));
+  folly::dynamic blobMeta =
+      folly::dynamic::object("type", kDeletionVectorBlobType)(
+          "fields", folly::dynamic::array(kRowPositionFieldId));
+  blobMeta["snapshot-id"] = kUnassignedSnapshotId;
+  blobMeta["sequence-number"] = kUnassignedSequenceNumber;
   blobMeta["offset"] = blobOffset;
   blobMeta["length"] = blobLength;
-  blobMeta["compression-codec"] = kCompressionCodecNone;
+  // Uncompressed blobs omit "compression-codec": Iceberg's FileMetadataParser
+  // writes the field only for a non-null codec, and PuffinCompressionCodec
+  // .forName() has no "none" entry, so emitting it literally would make a
+  // spec-compliant reader throw.
 
   folly::dynamic properties = folly::dynamic::object;
   properties["referenced-data-file"] = referencedDataFile;

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
+
 namespace facebook::velox::memory {
 class MemoryPool;
 } // namespace facebook::velox::memory
@@ -52,9 +54,25 @@ namespace facebook::velox::connector::hive::iceberg {
 ///   std::string blob = writer.serialize();
 class DeletionVectorWriter {
  public:
+  /// Largest position the Iceberg deletion-vector format can represent.
+  ///
+  /// Iceberg's RoaringPositionBitmap derives this as
+  /// `toPosition(MAX_KEY, Integer.MIN_VALUE)`, i.e.
+  /// `(key << 32) | (pos32 & 0xFFFFFFFF)` with `key = 2147483646`, and rejects
+  /// anything above it. The binding constraint is the Roaring64 group key: it
+  /// is read back as a signed 32-bit int, so a key at or above 2^31 would
+  /// deserialize as negative and be rejected by spec-compliant readers.
+  /// Matching the bound here means we never write a blob Iceberg cannot read.
+  static constexpr int64_t kMaxPosition = 9'223'372'030'412'324'864LL;
+
+  static_assert(
+      (kMaxPosition >> 32) == kMaxRoaring64GroupKey,
+      "Writer position bound and reader group-key bound must agree.");
+
   DeletionVectorWriter() = default;
 
-  /// Adds a deleted row position (0-based file row offset).
+  /// Adds a deleted row position (0-based file row offset). The position must
+  /// be in [0, kMaxPosition].
   void addDeletedPosition(int64_t position);
 
   /// Adds multiple deleted row positions.

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -20,6 +20,8 @@
 
 #include <fstream>
 
+#include <folly/json.h>
+#include <folly/lang/Bits.h>
 #include <gtest/gtest.h>
 #include <zlib.h>
 
@@ -93,6 +95,201 @@ std::string serializeRoaringBitmapNoRun(const std::vector<int64_t>& positions) {
     }
   }
 
+  return data;
+}
+
+// Serializes a roaring bitmap in the portable no-run format, encoding any
+// block whose cardinality exceeds 4096 as a 1024-word bitset container rather
+// than an array container. 'serializeRoaringBitmapNoRun' above always emits
+// array containers, so it cannot produce this encoding — which is the one
+// Iceberg and DeletionVectorWriter use for dense blocks.
+std::string serializeRoaringBitmapWithBitsetContainer(
+    const std::vector<int64_t>& positions) {
+  constexpr uint32_t kMaxArrayContainerCardinality = 4'096;
+  constexpr uint32_t kBitmapContainerBytes = 8'192;
+  constexpr uint32_t kCookie = 12'346;
+
+  std::map<uint16_t, std::vector<uint16_t>> containers;
+  for (auto position : positions) {
+    containers[static_cast<uint16_t>(position >> 16)].push_back(
+        static_cast<uint16_t>(position & 0xFFFF));
+  }
+  for (auto& [key, values] : containers) {
+    std::sort(values.begin(), values.end());
+  }
+
+  const auto numContainers = static_cast<uint32_t>(containers.size());
+  std::string data;
+  data.append(reinterpret_cast<const char*>(&kCookie), 4);
+  data.append(reinterpret_cast<const char*>(&numContainers), 4);
+
+  for (const auto& [key, values] : containers) {
+    const auto cardMinus1 = static_cast<uint16_t>(values.size() - 1);
+    data.append(reinterpret_cast<const char*>(&key), 2);
+    data.append(reinterpret_cast<const char*>(&cardMinus1), 2);
+  }
+
+  uint32_t offset = 4 + 4 + numContainers * 4 + numContainers * 4;
+  for (const auto& [key, values] : containers) {
+    data.append(reinterpret_cast<const char*>(&offset), 4);
+    offset += values.size() <= kMaxArrayContainerCardinality
+        ? static_cast<uint32_t>(values.size()) * 2
+        : kBitmapContainerBytes;
+  }
+
+  for (const auto& [key, values] : containers) {
+    if (values.size() <= kMaxArrayContainerCardinality) {
+      for (auto value : values) {
+        data.append(reinterpret_cast<const char*>(&value), 2);
+      }
+    } else {
+      std::vector<uint64_t> words(1'024, 0);
+      for (auto value : values) {
+        words[value / 64] |= (1ULL << (value % 64));
+      }
+      for (auto word : words) {
+        data.append(reinterpret_cast<const char*>(&word), 8);
+      }
+    }
+  }
+  return data;
+}
+
+// Wraps serialized 32-bit roaring bitmaps in the Roaring64 envelope:
+// [numGroups: uint64] then, per group, [highBits: uint32][32-bit bitmap].
+// Reaching group N+1 requires the reader to advance exactly past group N's
+// container data, so multi-group inputs exercise that skip arithmetic.
+std::string wrapInRoaring64(
+    const std::vector<std::pair<uint32_t, std::string>>& groups) {
+  std::string data;
+  const auto numGroups = static_cast<uint64_t>(groups.size());
+  data.append(reinterpret_cast<const char*>(&numGroups), 8);
+  for (const auto& [highBits, bitmap] : groups) {
+    data.append(reinterpret_cast<const char*>(&highBits), 4);
+    data.append(bitmap);
+  }
+  return data;
+}
+
+// Serializes a roaring bitmap whose containers may each use a different
+// encoding, which none of the helpers above can express: the no-run helpers
+// pick array vs bitset purely by cardinality, and the run helper makes every
+// container run-encoded.
+//
+// Iceberg's own test suite carries an "all container types" case; this builds
+// an equivalent bitmap from scratch so the reader is exercised against array,
+// run, and bitset containers coexisting in one blob.
+struct ContainerSpec {
+  enum class Encoding { kArray, kRun, kBitset };
+
+  uint16_t key{0};
+  Encoding encoding{Encoding::kArray};
+  // Values within the container's 64K block, sorted. For kRun these are still
+  // the expanded values; the runs are derived from them.
+  std::vector<uint16_t> values;
+};
+
+// Collapses sorted values into (start, lengthMinus1) runs.
+std::vector<std::pair<uint16_t, uint16_t>> toRuns(
+    const std::vector<uint16_t>& values) {
+  std::vector<std::pair<uint16_t, uint16_t>> runs;
+  for (size_t i = 0; i < values.size();) {
+    size_t j = i;
+    while (j + 1 < values.size() && values[j + 1] == values[j] + 1) {
+      ++j;
+    }
+    runs.emplace_back(values[i], static_cast<uint16_t>(j - i));
+    i = j + 1;
+  }
+  return runs;
+}
+
+std::string serializeRoaringBitmapMixed(
+    const std::vector<ContainerSpec>& containers) {
+  constexpr uint32_t kSerialCookieWithRuns = 12'347;
+  constexpr uint32_t kRunContainersNoOffsetThreshold = 4;
+  constexpr size_t kBitmapContainerBytes = 8'192;
+
+  const auto numContainers = static_cast<uint32_t>(containers.size());
+  // This helper always emits the run-bearing cookie and a run bitmap, even
+  // when no container is actually run-encoded, so readers always take the
+  // "runs present" branch. The offset section must follow the same rule or the
+  // two sides disagree on the header size.
+  const bool hasRunContainers = true;
+
+  std::string data;
+  const uint32_t cookie = kSerialCookieWithRuns | ((numContainers - 1) << 16);
+  data.append(reinterpret_cast<const char*>(&cookie), 4);
+
+  // Run bitmap: bit i marks container i as run-encoded, LSB-first.
+  const uint32_t runBitmapBytes = (numContainers + 7) / 8;
+  std::vector<uint8_t> runBitmap(runBitmapBytes, 0);
+  for (uint32_t i = 0; i < numContainers; ++i) {
+    if (containers[i].encoding == ContainerSpec::Encoding::kRun) {
+      runBitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+    }
+  }
+  data.append(reinterpret_cast<const char*>(runBitmap.data()), runBitmapBytes);
+
+  for (const auto& spec : containers) {
+    const auto cardMinus1 = static_cast<uint16_t>(spec.values.size() - 1);
+    data.append(reinterpret_cast<const char*>(&spec.key), 2);
+    data.append(reinterpret_cast<const char*>(&cardMinus1), 2);
+  }
+
+  const auto containerBytes = [&](const ContainerSpec& spec) -> uint32_t {
+    switch (spec.encoding) {
+      case ContainerSpec::Encoding::kArray:
+        return static_cast<uint32_t>(spec.values.size()) * 2;
+      case ContainerSpec::Encoding::kBitset:
+        return kBitmapContainerBytes;
+      case ContainerSpec::Encoding::kRun:
+        return 2 + 4 * static_cast<uint32_t>(toRuns(spec.values).size());
+    }
+    return 0;
+  };
+
+  // The offset section is omitted for run-bearing bitmaps below the threshold.
+  const bool hasOffsetSection =
+      !hasRunContainers || numContainers >= kRunContainersNoOffsetThreshold;
+  if (hasOffsetSection) {
+    uint32_t offset =
+        4 + runBitmapBytes + 4 * numContainers + 4 * numContainers;
+    for (const auto& spec : containers) {
+      data.append(reinterpret_cast<const char*>(&offset), 4);
+      offset += containerBytes(spec);
+    }
+  }
+
+  for (const auto& spec : containers) {
+    switch (spec.encoding) {
+      case ContainerSpec::Encoding::kArray:
+        for (auto value : spec.values) {
+          data.append(reinterpret_cast<const char*>(&value), 2);
+        }
+        break;
+      case ContainerSpec::Encoding::kRun: {
+        const auto runs = toRuns(spec.values);
+        const auto numRuns = static_cast<uint16_t>(runs.size());
+        data.append(reinterpret_cast<const char*>(&numRuns), 2);
+        for (auto [start, lengthMinus1] : runs) {
+          data.append(reinterpret_cast<const char*>(&start), 2);
+          data.append(reinterpret_cast<const char*>(&lengthMinus1), 2);
+        }
+        break;
+      }
+      case ContainerSpec::Encoding::kBitset: {
+        std::vector<uint64_t> words(1'024, 0);
+        for (auto value : spec.values) {
+          words[value / 64] |= (1ULL << (value % 64));
+        }
+        for (auto word : words) {
+          data.append(reinterpret_cast<const char*>(&word), 8);
+        }
+        break;
+      }
+    }
+  }
   return data;
 }
 
@@ -227,6 +424,87 @@ std::vector<uint64_t> expandRuns(
 }
 
 // Writes binary data to a temp file and returns the path.
+// Builds a Puffin file around 'blob'. Layout per the Puffin spec:
+//   Magic | blob | Magic | footerPayload | payloadSize(4B LE) | flags(4B LE)
+//   | Magic
+// Built by hand rather than via writePuffinFile so the tests can produce
+// footers a spec-compliant writer never would.
+constexpr std::string_view kPuffinMagic{"PFA1"};
+
+std::string wrapInPuffinFile(
+    const std::string& blob,
+    const folly::dynamic& footer,
+    uint32_t flags = 0) {
+  const auto appendLittleEndian32 = [](std::string& out, uint32_t value) {
+    const uint32_t little = folly::Endian::little(value);
+    out.append(reinterpret_cast<const char*>(&little), sizeof(little));
+  };
+
+  const std::string footerJson = folly::toJson(footer);
+  std::string file;
+  file.append(kPuffinMagic);
+  file.append(blob);
+  file.append(kPuffinMagic);
+  file.append(footerJson);
+  appendLittleEndian32(file, static_cast<uint32_t>(footerJson.size()));
+  appendLittleEndian32(file, flags);
+  file.append(kPuffinMagic);
+  return file;
+}
+
+// Builds a Puffin footer describing one deletion-vector-v1 blob.
+folly::dynamic makeDvBlobMeta(
+    uint64_t blobOffset,
+    uint64_t blobLength,
+    const std::string& referencedDataFile = "") {
+  folly::dynamic blobMeta =
+      folly::dynamic::object("type", "deletion-vector-v1")(
+          "fields", folly::dynamic::array(2'147'483'645));
+  blobMeta["snapshot-id"] = -1;
+  blobMeta["sequence-number"] = -1;
+  blobMeta["offset"] = blobOffset;
+  blobMeta["length"] = blobLength;
+  if (!referencedDataFile.empty()) {
+    blobMeta["properties"] =
+        folly::dynamic::object("referenced-data-file", referencedDataFile);
+  }
+  return blobMeta;
+}
+
+folly::dynamic makeDvFooter(
+    uint64_t blobOffset,
+    uint64_t blobLength,
+    const std::string& referencedDataFile = "") {
+  return folly::dynamic::object(
+      "blobs",
+      folly::dynamic::array(
+          makeDvBlobMeta(blobOffset, blobLength, referencedDataFile)));
+}
+
+// Creates a DV delete file that carries no blob location at all: no typed
+// contentOffset/contentLength and no legacy bounds map. The reader must fall
+// back to the Puffin footer.
+IcebergDeleteFile makeFooterLocatedDvFile(
+    const std::string& filePath,
+    uint64_t recordCount,
+    uint64_t fileSize,
+    const std::string& referencedDataFile = "") {
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      filePath,
+      dwio::common::FileFormat::DWRF,
+      recordCount,
+      fileSize,
+      /*equalityFieldIds=*/{},
+      /*lowerBounds=*/{},
+      /*upperBounds=*/{},
+      /*dataSequenceNumber=*/0,
+      /*contentOffset=*/0,
+      /*contentLength=*/0);
+  dvFile.referencedDataFile = referencedDataFile;
+  return dvFile;
+}
+
 std::shared_ptr<TempFilePath> writeDvFile(const std::string& bitmapData) {
   auto tempFile = TempFilePath::create();
   // Write directly via C++ streams since TempFilePath already creates the
@@ -263,6 +541,38 @@ IcebergDeleteFile makeDvDeleteFile(
       /*dataSequenceNumber=*/0,
       /*contentOffset=*/static_cast<int64_t>(blobOffset),
       /*contentLength=*/contentLength);
+}
+
+// Creates a DV delete file that locates its blob through the legacy
+// bounds-map encoding instead of the typed 'contentOffset'/'contentLength'
+// fields. Leaving 'contentLength' at 0 is what selects that fallback.
+IcebergDeleteFile makeLegacyBoundsDvFile(
+    const std::string& filePath,
+    uint64_t recordCount,
+    uint64_t fileSize,
+    const std::optional<std::string>& blobOffset,
+    const std::optional<std::string>& blobLength) {
+  std::unordered_map<int32_t, std::string> lowerBounds;
+  std::unordered_map<int32_t, std::string> upperBounds;
+  if (blobOffset.has_value()) {
+    lowerBounds[DeletionVectorReader::kDvOffsetFieldId] = *blobOffset;
+  }
+  if (blobLength.has_value()) {
+    upperBounds[DeletionVectorReader::kDvLengthFieldId] = *blobLength;
+  }
+
+  return IcebergDeleteFile(
+      FileContent::kDeletionVector,
+      filePath,
+      dwio::common::FileFormat::DWRF,
+      recordCount,
+      fileSize,
+      /*equalityFieldIds=*/{},
+      lowerBounds,
+      upperBounds,
+      /*dataSequenceNumber=*/0,
+      /*contentOffset=*/0,
+      /*contentLength=*/0);
 }
 
 // Extracts which bits are set in a bitmap buffer.
@@ -521,6 +831,136 @@ TEST_F(DeletionVectorReaderTest, runContainersWithOffsetHeader) {
   EXPECT_TRUE(reader.noMoreData());
 }
 
+TEST_F(DeletionVectorReaderTest, bitsetContainer) {
+  // 5000 deletes inside a single 64K block exceeds the 4096 array-container
+  // threshold, so the block is stored as a 1024-word bitset. The reader picks
+  // the container encoding from the cardinality, so this is the only shape
+  // that exercises its bitset branch.
+  std::vector<int64_t> positions;
+  positions.reserve(5'000);
+  for (int64_t i = 0; i < 5'000; ++i) {
+    positions.push_back(i * 2);
+  }
+
+  auto bitmapData = serializeRoaringBitmapWithBitsetContainer(positions);
+  auto tempFile = writeDvFile(bitmapData);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+
+  const uint64_t numRows = 10'000;
+  auto bitmap = allocateBitmap(numRows);
+  reader.readDeletePositions(0, numRows, bitmap);
+
+  std::vector<uint64_t> expected;
+  expected.reserve(positions.size());
+  for (auto position : positions) {
+    expected.push_back(static_cast<uint64_t>(position));
+  }
+  EXPECT_EQ(getSetBits(bitmap, numRows), expected);
+  EXPECT_TRUE(reader.noMoreData());
+}
+
+TEST_F(DeletionVectorReaderTest, bitsetContainerMixedWithArrayContainer) {
+  // A dense block followed by a sparse one. The reader must advance exactly
+  // 8192 bytes past the bitset before reading the array container, so a wrong
+  // stride here corrupts the second block rather than failing outright.
+  std::vector<int64_t> positions;
+  positions.reserve(4'100);
+  for (int64_t i = 0; i < 4'100; ++i) {
+    positions.push_back(i);
+  }
+  positions.push_back(65'536 + 7);
+  positions.push_back(65'536 + 9);
+
+  auto bitmapData = serializeRoaringBitmapWithBitsetContainer(positions);
+  auto tempFile = writeDvFile(bitmapData);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+
+  std::vector<int64_t> expected(positions.begin(), positions.end());
+  std::sort(expected.begin(), expected.end());
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
+TEST_F(DeletionVectorReaderTest, runContainersAcrossRoaring64Groups) {
+  // Run containers wrapped in a Roaring64 envelope. Existing run-container
+  // coverage uses the bare 32-bit format, which returns before the 64-bit
+  // group loop; only a multi-group input exercises the logic that skips past
+  // a run container to locate the next group's header.
+  const std::vector<
+      std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>
+      lowGroupRuns = {{0, {{10, 4}, {100, 2}}}};
+  const std::vector<
+      std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>
+      highGroupRuns = {{0, {{20, 1}}}};
+
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapWithRuns(lowGroupRuns)},
+       {1, serializeRoaringBitmapWithRuns(highGroupRuns)}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  std::vector<int64_t> expected;
+  for (auto position : expandRuns(lowGroupRuns)) {
+    expected.push_back(static_cast<int64_t>(position));
+  }
+  // Group 1 positions live at highBits 1, i.e. offset 2^32.
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  for (auto position : expandRuns(highGroupRuns)) {
+    expected.push_back(kHighGroupBase + static_cast<int64_t>(position));
+  }
+  std::sort(expected.begin(), expected.end());
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
+TEST_F(
+    DeletionVectorReaderTest,
+    arrayAndBitsetContainersAcrossRoaring64Groups) {
+  // The multi-group skip arithmetic differs per container encoding: an array
+  // container advances by 2 bytes per value while a bitset always advances by
+  // a fixed 8192. Pair a sparse group with a dense one so both strides must be
+  // right for the second group's header to be found.
+  std::vector<int64_t> denseGroupPositions;
+  denseGroupPositions.reserve(4'200);
+  for (int64_t i = 0; i < 4'200; ++i) {
+    denseGroupPositions.push_back(i);
+  }
+
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapWithBitsetContainer({3, 11, 65'536 + 4})},
+       {1, serializeRoaringBitmapWithBitsetContainer(denseGroupPositions)}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  std::vector<int64_t> expected = {3, 11, 65'536 + 4};
+  for (auto position : denseGroupPositions) {
+    expected.push_back(kHighGroupBase + position);
+  }
+  std::sort(expected.begin(), expected.end());
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
 TEST_F(DeletionVectorReaderTest, largePositionsMultipleContainers) {
   // Positions spanning two containers: one in container 0 (key=0), one in
   // container 1 (key=1, i.e. pos >= 65536).
@@ -566,6 +1006,168 @@ TEST_F(DeletionVectorReaderTest, blobOffset) {
   auto setBits = getSetBits(bitmap, 20);
   EXPECT_EQ(setBits, (std::vector<uint64_t>{3, 7, 11}));
   EXPECT_TRUE(reader.noMoreData());
+}
+
+TEST_F(DeletionVectorReaderTest, locatesBlobFromPuffinFooterWhenOffsetsAbsent) {
+  // With no typed contentOffset/contentLength and no legacy bounds map, the
+  // reader used to fall back to treating the whole file -- leading magic and
+  // footer included -- as the blob, which cannot parse. A Puffin file is
+  // self-describing, so its footer is the authoritative fallback.
+  const std::vector<int64_t> positions = {3, 7, 42, 100};
+  const auto blob = serializeRoaringBitmapNoRun(positions);
+  const auto file = wrapInPuffinFile(blob, makeDvFooter(4, blob.size()));
+  auto tempFile = writeDvFile(file);
+
+  auto dvFile = makeFooterLocatedDvFile(
+      tempFile->getPath(), positions.size(), file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, puffinFooterSelectsBlobByReferencedDataFile) {
+  // One Puffin file can hold vectors for several data files. The referenced
+  // data file, not blob order, decides which one applies to this split.
+  const std::vector<int64_t> wantedPositions = {5, 9};
+  const std::vector<int64_t> otherPositions = {1, 2, 3};
+  const auto otherBlob = serializeRoaringBitmapNoRun(otherPositions);
+  const auto wantedBlob = serializeRoaringBitmapNoRun(wantedPositions);
+
+  const uint64_t otherOffset = 4;
+  const uint64_t wantedOffset = otherOffset + otherBlob.size();
+  folly::dynamic footer = folly::dynamic::object(
+      "blobs",
+      folly::dynamic::array(
+          makeDvBlobMeta(otherOffset, otherBlob.size(), "/data/other.parquet"),
+          makeDvBlobMeta(
+              wantedOffset, wantedBlob.size(), "/data/wanted.parquet")));
+
+  const auto file = wrapInPuffinFile(otherBlob + wantedBlob, footer);
+  auto tempFile = writeDvFile(file);
+
+  auto dvFile = makeFooterLocatedDvFile(
+      tempFile->getPath(),
+      wantedPositions.size(),
+      file.size(),
+      "/data/wanted.parquet");
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), wantedPositions);
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsAmbiguousPuffinFileWithoutReference) {
+  // Two candidate vectors and nothing to choose between them: picking either
+  // would silently apply the wrong deletes to the scan.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  folly::dynamic footer = folly::dynamic::object(
+      "blobs",
+      folly::dynamic::array(
+          makeDvBlobMeta(4, blob.size()), makeDvBlobMeta(4, blob.size())));
+
+  const auto file = wrapInPuffinFile(blob, footer);
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin file has multiple deletion vectors and no referenced data file");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterWithNoMatchingBlob) {
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  const auto file = wrapInPuffinFile(
+      blob, makeDvFooter(4, blob.size(), "/data/other.parquet"));
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(
+      tempFile->getPath(), 1, file.size(), "/data/wanted.parquet");
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin footer has no deletion-vector blob for data file");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterWithNoBlobs) {
+  // A structurally valid footer that declares no blobs at all. Iceberg allows
+  // an empty Puffin file; for a delete file it means there is nothing to read,
+  // which must be an error rather than an empty (silently no-op) vector.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  const auto file = wrapInPuffinFile(
+      blob, folly::dynamic::object("blobs", folly::dynamic::array()));
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin footer has no deletion-vector blob for data file");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterWithNegativeOffset) {
+  // JSON integers are signed, but the blob location is carried as uint64_t.
+  // A negative offset must be rejected where it is read, not allowed to wrap
+  // into a huge unsigned value and be reported as an absurd out-of-range read.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  auto footer = makeDvFooter(4, blob.size());
+  footer["blobs"][0]["offset"] = -8;
+  const auto file = wrapInPuffinFile(blob, footer);
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(), "Puffin blob metadata has a negative offset");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFileWithoutTrailingMagic) {
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  auto file = wrapInPuffinFile(blob, makeDvFooter(4, blob.size()));
+  file.replace(file.size() - 4, 4, "XXXX");
+
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin file does not end with the expected magic");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsPuffinFooterPayloadSizeBeyondFile) {
+  // A payload size larger than the file would make the payload offset
+  // underflow into a huge unsigned read.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  auto file = wrapInPuffinFile(blob, makeDvFooter(4, blob.size()));
+  const uint32_t absurdSize = folly::Endian::little(uint32_t{1} << 30);
+  file.replace(
+      file.size() - 12,
+      4,
+      std::string(reinterpret_cast<const char*>(&absurdSize), 4));
+
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Puffin footer payload size 1073741824 does not fit");
+}
+
+TEST_F(DeletionVectorReaderTest, rejectsCompressedPuffinFooter) {
+  // Bit 0 of the flags marks a compressed footer payload. Deletion vectors are
+  // always uncompressed, so reject rather than hand zstd bytes to the parser.
+  const auto blob = serializeRoaringBitmapNoRun({1});
+  const auto file =
+      wrapInPuffinFile(blob, makeDvFooter(4, blob.size()), /*flags=*/1);
+
+  auto tempFile = writeDvFile(file);
+  auto dvFile = makeFooterLocatedDvFile(tempFile->getPath(), 1, file.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Compressed Puffin footer payloads are not supported");
 }
 
 TEST_F(DeletionVectorReaderTest, constructorRejectsWrongContentType) {
@@ -706,4 +1308,271 @@ TEST_F(DeletionVectorReaderTest, invalidBitmapBadCookie) {
   VELOX_ASSERT_THROW(
       reader.readDeletePositions(0, 10, bitmap),
       "Unknown roaring bitmap cookie");
+}
+
+TEST_F(DeletionVectorReaderTest, legacyBoundsMapLocatesBlob) {
+  // Callers that predate the typed contentOffset/contentLength fields encode
+  // the blob's location in the delete file's bounds maps instead. Prefix the
+  // bitmap with padding so a wrong offset cannot accidentally still parse.
+  const std::vector<int64_t> positions = {2, 9, 70'000};
+  const std::string padding(16, '\xAB');
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(padding + bitmapData);
+
+  auto dvFile = makeLegacyBoundsDvFile(
+      tempFile->getPath(),
+      positions.size(),
+      padding.size() + bitmapData.size(),
+      std::to_string(padding.size()),
+      std::to_string(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, legacyBoundsMapRejectsNonNumericOffset) {
+  auto bitmapData = serializeRoaringBitmapNoRun({1});
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeLegacyBoundsDvFile(
+      tempFile->getPath(),
+      1,
+      bitmapData.size(),
+      "not-a-number",
+      std::to_string(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(), "Failed to parse DV blob offset");
+}
+
+TEST_F(DeletionVectorReaderTest, legacyBoundsMapRejectsNonNumericLength) {
+  auto bitmapData = serializeRoaringBitmapNoRun({1});
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeLegacyBoundsDvFile(
+      tempFile->getPath(), 1, bitmapData.size(), "0", "not-a-number");
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(), "Failed to parse DV blob length");
+}
+
+TEST_F(DeletionVectorReaderTest, emptyBitmapYieldsNoDeletes) {
+  // A container-less bitmap is structurally valid but selects nothing. The
+  // reader must return an empty position list rather than misparse the
+  // header, and a subsequent read must leave the delete bitmap untouched.
+  auto bitmapData = serializeRoaringBitmapNoRun({});
+  auto tempFile = writeDvFile(bitmapData);
+
+  // recordCount must be positive to construct a reader at all, so this also
+  // covers metadata that disagrees with the blob's actual contents.
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(), 1, static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_TRUE(reader.deletedPositions().empty());
+
+  auto bitmap = allocateBitmap(64);
+  reader.readDeletePositions(0, 64, bitmap);
+  EXPECT_TRUE(getSetBits(bitmap, 64).empty());
+}
+
+TEST_F(DeletionVectorReaderTest, emptyGroupInRoaring64IsSkipped) {
+  // A Roaring64 group carrying no containers contributes nothing, but the
+  // reader must still step over its header to reach the following group.
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapNoRun({})},
+       {1, serializeRoaringBitmapNoRun({6, 12})}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  const std::vector<int64_t> expected = {
+      kHighGroupBase + 6, kHighGroupBase + 12};
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
+}
+
+TEST_F(DeletionVectorReaderTest, skipsPositionsBeforeRequestedRange) {
+  // Reading a batch that starts past earlier deletes must advance the cursor
+  // over them instead of mapping them into the batch-relative bitmap. This is
+  // the path a split beginning at a nonzero row offset takes.
+  const std::vector<int64_t> positions = {1, 50};
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+
+  // Batch covers absolute rows [10, 60): position 1 is behind it, 50 lands at
+  // batch-relative index 40.
+  auto bitmap = allocateBitmap(50);
+  reader.readDeletePositions(10, 50, bitmap);
+
+  EXPECT_EQ(getSetBits(bitmap, 50), (std::vector<uint64_t>{40}));
+}
+
+// The roaring serialization format is defined as little-endian. Readers that
+// take a caller-configured buffer have to assert its byte order explicitly,
+// because a big-endian-configured buffer would silently decode garbage.
+//
+// There is no equivalent footgun here — the reader takes raw bytes and
+// applies an explicit folly::Endian::little conversion to every field, so the
+// interpretation is fixed regardless of caller or host. What is worth pinning
+// is the observable behavior that check exists to produce: bytes serialized
+// big-endian must be rejected, not silently misread.
+//
+// They are, though via a different guard than one might expect. The
+// byte-swapped cookie (0x3A300000) matches neither serial cookie, so the blob
+// is treated as the 64-bit format; the byte-swapped group count is then
+// absurd and trips the Roaring64 sanity limit. The assertion below pins that
+// whole chain, so a future change that loosens either the cookie check or the
+// group limit cannot start silently accepting byte-swapped input.
+TEST_F(DeletionVectorReaderTest, rejectsBigEndianSerializedBitmap) {
+  auto appendBigEndian32 = [](std::string& out, uint32_t value) {
+    const char bytes[4] = {
+        static_cast<char>((value >> 24) & 0xFF),
+        static_cast<char>((value >> 16) & 0xFF),
+        static_cast<char>((value >> 8) & 0xFF),
+        static_cast<char>(value & 0xFF)};
+    out.append(bytes, sizeof(bytes));
+  };
+
+  // The same empty 32-bit bitmap serializeRoaringBitmapNoRun({}) produces,
+  // but with both header words written big-endian.
+  std::string bigEndianBitmap;
+  appendBigEndian32(bigEndianBitmap, 12'346);
+  appendBigEndian32(bigEndianBitmap, 0);
+
+  auto tempFile = writeDvFile(bigEndianBitmap);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(), 1, static_cast<uint64_t>(bigEndianBitmap.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  VELOX_ASSERT_THROW(
+      reader.deletedPositions(),
+      "Roaring64Bitmap group count exceeds sanity limit");
+}
+
+TEST_F(DeletionVectorReaderTest, enforcesRoaring64GroupKeyBound) {
+  // Iceberg caps the Roaring64 group key at 2147483646 because readers load it
+  // back as a signed 32-bit int. A key at or above 2^31 would shift into the
+  // sign bit of `key << 32` and surface as a negative row position.
+  // DeletionVectorWriter already refuses to produce such a blob; the reader
+  // must reject one written by anything else rather than emit garbage.
+  const auto readPositions = [&](uint32_t groupKey) {
+    auto bitmapData =
+        wrapInRoaring64({{groupKey, serializeRoaringBitmapNoRun({5})}});
+    auto tempFile = writeDvFile(bitmapData);
+    auto dvFile = makeDvDeleteFile(
+        tempFile->getPath(), 1, static_cast<uint64_t>(bitmapData.size()));
+    DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+    return reader.deletedPositions();
+  };
+
+  constexpr uint32_t kMaxGroupKey = 2'147'483'646;
+  EXPECT_EQ(
+      readPositions(kMaxGroupKey),
+      (std::vector<int64_t>{(int64_t{kMaxGroupKey} << 32) + 5}));
+
+  VELOX_ASSERT_THROW(
+      readPositions(kMaxGroupKey + 1),
+      "Roaring64Bitmap group key exceeds the maximum the Iceberg "
+      "deletion-vector format can represent");
+}
+
+// The scenarios below mirror the shapes Iceberg's own position-index tests
+// cover. The bitmaps are built here rather than taken from anywhere, so they
+// exercise the same encodings without depending on external fixtures.
+
+TEST_F(DeletionVectorReaderTest, smallAlternatingValues) {
+  // Sparse odd positions in a single array container — the simplest shape a
+  // real deletion vector takes.
+  const std::vector<int64_t> positions = {1, 3, 5, 7, 9};
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, smallAndLargeValuesPast31Bits) {
+  // Two array containers far apart, the second past 2^31. The container key
+  // there is 32767, so a reader that sign-extends the 16-bit key or the
+  // resulting offset lands on a negative position.
+  const std::vector<int64_t> positions = {
+      100, 101, 2'147'483'747, 2'147'483'748};
+  auto bitmapData = serializeRoaringBitmapNoRun(positions);
+  auto tempFile = writeDvFile(bitmapData);
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      positions.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), positions);
+}
+
+TEST_F(DeletionVectorReaderTest, allContainerEncodingsInOneBitmap) {
+  // Array, run, and bitset containers coexisting in a single bitmap, wrapped
+  // in a second Roaring64 group. Each encoding advances the read cursor by a
+  // different rule, so the reader has to switch strategies three times and
+  // still land on the next group's header.
+  //
+  // Three containers with runs present also puts this below the threshold at
+  // which the offset section is written, exercising the no-offset path.
+  std::vector<uint16_t> denseValues;
+  denseValues.reserve(5'000);
+  for (uint16_t i = 0; i < 5'000; ++i) {
+    denseValues.push_back(static_cast<uint16_t>(i * 2));
+  }
+
+  const std::vector<ContainerSpec> lowGroup = {
+      {/*key=*/0, ContainerSpec::Encoding::kArray, {5, 7}},
+      {/*key=*/1, ContainerSpec::Encoding::kRun, {1, 2, 3, 4}},
+      {/*key=*/2, ContainerSpec::Encoding::kBitset, denseValues},
+  };
+  const std::vector<ContainerSpec> highGroup = {
+      {/*key=*/0, ContainerSpec::Encoding::kArray, {9}},
+  };
+
+  auto bitmapData = wrapInRoaring64(
+      {{0, serializeRoaringBitmapMixed(lowGroup)},
+       {1, serializeRoaringBitmapMixed(highGroup)}});
+  auto tempFile = writeDvFile(bitmapData);
+
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+  std::vector<int64_t> expected = {5, 7};
+  for (int64_t i = 1; i <= 4; ++i) {
+    expected.push_back(65'536 + i);
+  }
+  for (auto value : denseValues) {
+    expected.push_back(131'072 + value);
+  }
+  expected.push_back(kHighGroupBase + 9);
+  std::sort(expected.begin(), expected.end());
+
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(),
+      expected.size(),
+      static_cast<uint64_t>(bitmapData.size()));
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  EXPECT_EQ(reader.deletedPositions(), expected);
 }

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -18,10 +18,14 @@
 
 #include <fstream>
 
+#include <folly/json.h>
+#include <folly/lang/Bits.h>
 #include <gtest/gtest.h>
 #include <zlib.h>
 
 #include <cstring>
+#include <limits>
+#include <random>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -71,6 +75,50 @@ class DeletionVectorWriterTest : public ::testing::Test {
   BufferPtr allocateBitmap(uint64_t numBits) {
     auto numBytes = bits::nbytes(numBits);
     return AlignedBuffer::allocate<uint8_t>(numBytes, pool_.get(), 0);
+  }
+
+  /// Serializes 'positions', reads the blob back through
+  /// DeletionVectorReader, and returns every position the reader recovered.
+  ///
+  /// Prefer this over verifyRoundTrip for inputs spanning a wide range:
+  /// verifyRoundTrip walks the whole [0, maxPos] space one batch at a time,
+  /// which is impractical once positions reach into the 2^32 range.
+  std::vector<int64_t> roundTrip(const std::vector<int64_t>& positions) {
+    DeletionVectorWriter writer;
+    writer.addDeletedPositions(positions);
+    const auto blobData = writer.serialize();
+
+    auto tempFile = TempFilePath::create();
+    {
+      std::ofstream out(
+          tempFile->getPath(), std::ios::binary | std::ios::trunc);
+      out.write(blobData.data(), static_cast<std::streamsize>(blobData.size()));
+    }
+
+    IcebergDeleteFile dvFile(
+        FileContent::kDeletionVector,
+        tempFile->getPath(),
+        dwio::common::FileFormat::DWRF,
+        writer.numDistinctPositions(),
+        static_cast<uint64_t>(blobData.size()),
+        /*equalityFieldIds=*/{},
+        /*lowerBounds=*/{},
+        /*upperBounds=*/{},
+        /*dataSequenceNumber=*/0,
+        /*contentOffset=*/0,
+        /*contentLength=*/static_cast<int64_t>(blobData.size()));
+
+    DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+    return reader.deletedPositions();
+  }
+
+  /// Returns 'positions' sorted and de-duplicated — what a round trip through
+  /// a roaring bitmap is expected to yield, since the bitmap is a set.
+  static std::vector<int64_t> sortedUnique(std::vector<int64_t> positions) {
+    std::sort(positions.begin(), positions.end());
+    positions.erase(
+        std::unique(positions.begin(), positions.end()), positions.end());
+    return positions;
   }
 
   /// Writes serialized bitmap to a temp file, reads it back with
@@ -257,6 +305,105 @@ TEST_F(DeletionVectorWriterTest, fourOrMoreContainersWithOffsets) {
   verifyRoundTrip(positions, 5 * 65536 + 100);
 }
 
+// Decodes the Puffin footer of a file written by writePuffinFile and returns
+// the parsed footer JSON. Layout per the Puffin spec:
+//   Magic Blob... Footer
+//   Footer := Magic FooterPayload FooterPayloadSize Flags Magic
+// with FooterPayloadSize and Flags each a 4-byte little-endian value. The
+// trailer is located from the end of the file so nothing here depends on the
+// writer's own offset arithmetic.
+namespace {
+folly::dynamic readPuffinFooter(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  const std::string bytes(
+      (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+  constexpr size_t kMagicSize = 4;
+  constexpr size_t kTrailerSize = kMagicSize + 4 + 4;
+  EXPECT_GE(bytes.size(), kMagicSize + kTrailerSize);
+  EXPECT_EQ(bytes.substr(0, kMagicSize), "PFA1") << "missing leading magic";
+  EXPECT_EQ(bytes.substr(bytes.size() - kMagicSize), "PFA1")
+      << "missing trailing magic";
+
+  const auto readLittleEndian32 = [&](size_t offset) {
+    uint32_t value;
+    std::memcpy(&value, bytes.data() + offset, sizeof(value));
+    return folly::Endian::little(value);
+  };
+
+  const size_t flagsOffset = bytes.size() - kMagicSize - 4;
+  const size_t sizeOffset = flagsOffset - 4;
+  EXPECT_EQ(readLittleEndian32(flagsOffset), 0u)
+      << "flags must be 0: an uncompressed footer payload is bit 0";
+
+  const uint32_t payloadSize = readLittleEndian32(sizeOffset);
+  const size_t payloadOffset = sizeOffset - payloadSize;
+  EXPECT_EQ(bytes.substr(payloadOffset - kMagicSize, kMagicSize), "PFA1")
+      << "footer payload must be preceded by magic";
+
+  return folly::parseJson(bytes.substr(payloadOffset, payloadSize));
+}
+} // namespace
+
+TEST_F(DeletionVectorWriterTest, puffinFooterIsSpecCompliant) {
+  // Nothing in our own read path parses the Puffin footer --
+  // DeletionVectorReader locates the blob from the manifest's contentOffset --
+  // so the footer is written blind. Other Iceberg engines do parse it, and
+  // FileMetadataParser.blobMetadataFromJson treats type, fields, snapshot-id,
+  // sequence-number, offset and length as required, reading fields as a list
+  // of integers. A footer that omits or mistypes any of them makes the whole
+  // deletion vector unreadable outside Velox.
+  DeletionVectorWriter writer;
+  writer.addDeletedPositions({3, 7, 42, 100});
+  const auto blobData = writer.serialize();
+
+  auto tempDir = TempDirectoryPath::create();
+  const std::string puffinPath =
+      std::string(tempDir->getPath()) + "/footer.puffin";
+  auto sink = dwio::common::FileSink::create(
+      "file:" + puffinPath, {.pool = pool_.get()});
+  auto [blobOffset, blobLength] = writePuffinFile(
+      *sink,
+      *pool_,
+      blobData,
+      "/data/test-data-file.parquet",
+      /*cardinality=*/4);
+  sink->close();
+
+  const auto footer = readPuffinFooter(puffinPath);
+  ASSERT_TRUE(footer.isObject());
+  ASSERT_TRUE(footer["blobs"].isArray());
+  ASSERT_EQ(footer["blobs"].size(), 1);
+  const auto& blob = footer["blobs"][0];
+
+  EXPECT_EQ(blob["type"].asString(), "deletion-vector-v1");
+
+  // Iceberg's BaseDVFileWriter sets this to the single row-position metadata
+  // column ID, as a list of plain integers.
+  constexpr int64_t kRowPositionFieldId = 2'147'483'645;
+  ASSERT_TRUE(blob["fields"].isArray()) << "fields must be a list";
+  ASSERT_EQ(blob["fields"].size(), 1);
+  ASSERT_TRUE(blob["fields"][0].isInt())
+      << "fields entries must be integers, not objects";
+  EXPECT_EQ(blob["fields"][0].asInt(), kRowPositionFieldId);
+
+  // Required by the parser even though a freshly written DV has no snapshot
+  // assigned yet; Iceberg writes -1 for both.
+  ASSERT_TRUE(blob.count("snapshot-id")) << "snapshot-id is required";
+  ASSERT_TRUE(blob.count("sequence-number")) << "sequence-number is required";
+  EXPECT_EQ(blob["snapshot-id"].asInt(), -1);
+  EXPECT_EQ(blob["sequence-number"].asInt(), -1);
+
+  EXPECT_EQ(blob["offset"].asInt(), static_cast<int64_t>(blobOffset));
+  EXPECT_EQ(blob["length"].asInt(), static_cast<int64_t>(blobLength));
+
+  const auto& properties = blob["properties"];
+  EXPECT_EQ(
+      properties["referenced-data-file"].asString(),
+      "/data/test-data-file.parquet");
+  EXPECT_EQ(properties["cardinality"].asString(), "4");
+}
+
 TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {
   DeletionVectorWriter writer;
   writer.addDeletedPositions({3, 7, 42, 100});
@@ -304,6 +451,55 @@ TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {
       {},
       lowerBounds,
       upperBounds);
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+
+  auto bitmap = allocateBitmap(200);
+  reader.readDeletePositions(0, 200, bitmap);
+
+  auto setBits = getSetBits(bitmap, 200);
+  EXPECT_EQ(setBits, (std::vector<uint64_t>{3, 7, 42, 100}));
+}
+
+// Reads a writePuffinFile output back with NO bounds-map location, so the
+// reader must parse the Puffin footer (locateBlobFromPuffinFooter) to find the
+// blob. Unlike puffinFileRoundTrip -- which supplies explicit offset/length and
+// therefore skips the footer parser -- this exercises the writer's footer
+// layout against the reader's backwards footer parse, catching any drift in
+// trailer size, magic placement, or payload-size/flags encoding.
+TEST_F(DeletionVectorWriterTest, puffinFooterFallbackRoundTrip) {
+  DeletionVectorWriter writer;
+  writer.addDeletedPositions({3, 7, 42, 100});
+  auto blobData = writer.serialize();
+
+  auto tempDir = TempDirectoryPath::create();
+  const std::string puffinPath =
+      std::string(tempDir->getPath()) + "/test-dv-footer.puffin";
+  auto sink = dwio::common::FileSink::create(
+      "file:" + puffinPath, {.pool = pool_.get()});
+  VELOX_CHECK_NOT_NULL(sink);
+  writePuffinFile(
+      *sink,
+      *pool_,
+      blobData,
+      "/data/test-data-file.parquet",
+      /*cardinality=*/4);
+  sink->close();
+
+  std::ifstream in(puffinPath, std::ios::binary | std::ios::ate);
+  auto fileSize = static_cast<uint64_t>(in.tellg());
+
+  // Empty bounds maps: with no offset/length the reader falls through to
+  // Puffin-footer parsing and selects the single deletion-vector blob.
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      puffinPath,
+      dwio::common::FileFormat::DWRF,
+      4,
+      fileSize,
+      {},
+      {},
+      {});
 
   DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
@@ -400,4 +596,124 @@ TEST_F(DeletionVectorWriterTest, mixed32And64BitPositions) {
       8'589'934'592LL,
   };
   verifyRoundTrip(positions, 2'048);
+}
+
+/// Verifies that duplicate positions collapse in the cardinality reported for
+/// the DV blob. Seeding a writer from an existing deletion vector and then
+/// adding overlapping new deletes makes 'positions_' hold duplicates, so
+/// 'numPositions' overcounts and only 'numDistinctPositions' matches the
+/// cardinality Iceberg expects in the blob metadata.
+TEST_F(DeletionVectorWriterTest, numDistinctPositionsIgnoresDuplicates) {
+  DeletionVectorWriter writer;
+  writer.addDeletedPositions({7, 3, 7, 1, 3, 3});
+
+  EXPECT_EQ(writer.numPositions(), 6);
+  EXPECT_EQ(writer.numDistinctPositions(), 3);
+}
+
+// Randomized round trips across sparse, dense, and mixed position sets.
+// Hand-built fixtures only exercise the container shapes we thought to write
+// down; random inputs cross the array/bitset thresholds and 64-bit group
+// boundaries in combinations we did not enumerate.
+//
+// Seeds are fixed so a failure is reproducible, and reported on failure so a
+// counterexample can be replayed directly.
+TEST_F(DeletionVectorWriterTest, randomSparsePositionsRoundTrip) {
+  // Few positions spread over a wide 64-bit range: many container keys across
+  // several Roaring64 groups, each holding a small array container.
+  constexpr uint64_t kSeed = 0x1234'5678'9ABC'DEF0ULL;
+  constexpr int kNumPositions = 2'000;
+  constexpr int64_t kRange = int64_t{1} << 34;
+
+  std::mt19937_64 rng(kSeed);
+  std::uniform_int_distribution<int64_t> positionDist(0, kRange - 1);
+
+  std::vector<int64_t> positions;
+  positions.reserve(kNumPositions);
+  for (int i = 0; i < kNumPositions; ++i) {
+    positions.push_back(positionDist(rng));
+  }
+
+  EXPECT_EQ(roundTrip(positions), sortedUnique(positions)) << "seed=" << kSeed;
+}
+
+TEST_F(DeletionVectorWriterTest, randomDensePositionsRoundTrip) {
+  // Enough positions inside one 64K block to exceed the 4096 array-container
+  // threshold, so the block serializes as a bitset. Deliberately includes
+  // duplicates: the bitmap is a set, so they must collapse.
+  constexpr uint64_t kSeed = 0x0FED'CBA9'8765'4321ULL;
+  constexpr int kNumDraws = 30'000;
+  constexpr int64_t kBlockBase = int64_t{7} << 16;
+
+  std::mt19937_64 rng(kSeed);
+  std::uniform_int_distribution<int64_t> offsetDist(0, 65'535);
+
+  std::vector<int64_t> positions;
+  positions.reserve(kNumDraws);
+  for (int i = 0; i < kNumDraws; ++i) {
+    positions.push_back(kBlockBase + offsetDist(rng));
+  }
+
+  const auto expected = sortedUnique(positions);
+  ASSERT_GT(expected.size(), 4'096)
+      << "draws should exceed the array-container threshold";
+  EXPECT_EQ(roundTrip(positions), expected) << "seed=" << kSeed;
+}
+
+TEST_F(DeletionVectorWriterTest, randomMixedPositionsRoundTrip) {
+  // Dense block, sparse scatter, and a contiguous run in one bitmap, split
+  // across two Roaring64 groups. This is the shape most likely to expose an
+  // offset or stride error, because the reader must step over containers of
+  // different encodings to find the next one.
+  constexpr uint64_t kSeed = 0x2468'ACE0'1357'9BDFULL;
+  constexpr int64_t kHighGroupBase = int64_t{1} << 32;
+
+  std::mt19937_64 rng(kSeed);
+  std::vector<int64_t> positions;
+
+  // Dense block in group 0.
+  std::uniform_int_distribution<int64_t> denseDist(0, 65'535);
+  for (int i = 0; i < 20'000; ++i) {
+    positions.push_back(denseDist(rng));
+  }
+  // Sparse scatter across group 0's upper blocks.
+  std::uniform_int_distribution<int64_t> sparseDist(65'536, (int64_t{1} << 31));
+  for (int i = 0; i < 500; ++i) {
+    positions.push_back(sparseDist(rng));
+  }
+  // Contiguous run in group 1.
+  for (int64_t i = 0; i < 3'000; ++i) {
+    positions.push_back(kHighGroupBase + 1'000 + i);
+  }
+  // Sparse scatter in group 1.
+  for (int i = 0; i < 200; ++i) {
+    positions.push_back(kHighGroupBase + sparseDist(rng));
+  }
+
+  EXPECT_EQ(roundTrip(positions), sortedUnique(positions)) << "seed=" << kSeed;
+}
+
+// The Roaring64 group key is read back as a signed 32-bit int, so a position
+// whose high word reaches 2^31 would deserialize as a negative key and be
+// rejected by spec-compliant readers. Failing at insert time keeps us from
+// writing a blob Iceberg cannot read.
+TEST_F(DeletionVectorWriterTest, rejectsPositionsOutsideRepresentableRange) {
+  DeletionVectorWriter writer;
+
+  VELOX_ASSERT_THROW(writer.addDeletedPosition(-1), "must be non-negative");
+  VELOX_ASSERT_THROW(
+      writer.addDeletedPosition(DeletionVectorWriter::kMaxPosition + 1),
+      "exceeds the maximum");
+  VELOX_ASSERT_THROW(
+      writer.addDeletedPosition(std::numeric_limits<int64_t>::max()),
+      "exceeds the maximum");
+
+  // None of the rejected positions were recorded.
+  EXPECT_EQ(writer.numPositions(), 0);
+
+  // The bound itself is representable and round-trips.
+  writer.addDeletedPosition(DeletionVectorWriter::kMaxPosition);
+  EXPECT_EQ(
+      roundTrip({DeletionVectorWriter::kMaxPosition}),
+      std::vector<int64_t>{DeletionVectorWriter::kMaxPosition});
 }


### PR DESCRIPTION
Summary:

Base of a two-way split of the Velox Iceberg work; the reader integration,
field-id resolution, and partition handling stay on top in D115027212. This
diff is the self-contained deletion-vector codec (fbcode/velox only).

- Bound representable positions: derive the Roaring64 group-key ceiling and the
  max position from a single kMaxRoaring64GroupKey in DeletionVectorFormat.h,
  tied by static_assert, so the writer cannot emit a blob other engines cannot
  read and the reader cannot produce negative ordinals from an unchecked shift.
- Puffin conformance (Apache Iceberg 1.10.1): read/write the Puffin footer per
  FileMetadataParser -- integer "fields" list, ROW_POSITION (_pos) field id,
  required "snapshot-id"/"sequence-number", footer parsed backwards from EOF
  with the blob selected by referenced data file; gated on the Puffin magic so
  raw roaring blobs keep prior behaviour. Shared constants live in
  DeletionVectorFormat.h so reader and writer agree by construction.
- Coverage: randomized sparse/dense/mixed round trips through writer and reader
  with fixed, printed seeds.

Reviewed By: srsuryadev

Differential Revision: D116083632


