### PR TITLE
fix: Track row size for min_by/max_by with non-numeric accumulators (#18522)

### DIFF
--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <optional>
+
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/functions/lib/CheckNestedNulls.h"
@@ -118,9 +120,21 @@ class MinMaxByAggregateBase : public exec::Aggregate {
       bool throwOnNestedNulls = false)
       : exec::Aggregate(resultType), throwOnNestedNulls_(throwOnNestedNulls) {}
 
+  /// True when either accumulator stores its payload out of line in the
+  /// HashStringAllocator, i.e. when the value or comparison type is not
+  /// numeric. Such a group can hold arbitrarily more than
+  /// accumulatorFixedWidthSize().
+  static constexpr bool kUsesVariableWidthAccumulator =
+      std::is_same_v<ValueAccumulatorType, SingleValueAccumulator> ||
+      std::is_same_v<ComparisonAccumulatorType, SingleValueAccumulator>;
+
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(ValueAccumulatorType) + sizeof(ComparisonAccumulatorType) +
         sizeof(bool);
+  }
+
+  bool isFixedSize() const override {
+    return !kUsesVariableWidthAccumulator;
   }
 
   void addRawInput(
@@ -551,6 +565,16 @@ class MinMaxByAggregateBase : public exec::Aggregate {
     if (mayUpdate(
             comparisonValue(group), decodedComparisons, index, isFirstValue)) {
       valueIsNull(group) = isValueNull;
+      // A SingleValueAccumulator writes the value into the HashStringAllocator
+      // and keeps only a Position in the row, so without this the row's
+      // variable-length size stays at zero however large the value is. That
+      // size feeds result-set caps and, in particular, the spill batch sizing
+      // in Spiller::extractSpillVector. Follows the same compile-time guarded
+      // shape as SimpleAggregateAdapter.
+      std::optional<RowSizeTracker<char, uint32_t>> tracker;
+      if constexpr (kUsesVariableWidthAccumulator) {
+        tracker.emplace(group[Aggregate::rowSizeOffset_], *allocator_);
+      }
       if (LIKELY(!isValueNull)) {
         store<T>(value(group), decodedValues, index, allocator_);
       }

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1569,4 +1569,44 @@ void AggregationTestBase::testFailingAggregations(
         expectedMessage);
   }
 }
+
+uint32_t aggregateAndReadRowSize(
+    memory::MemoryPool* pool,
+    const std::string& name,
+    const TypePtr& valueType,
+    const VectorPtr& values,
+    const VectorPtr& comparisons) {
+  core::QueryConfig queryConfig({});
+  auto fn = exec::Aggregate::create(
+      name,
+      core::AggregationNode::Step::kSingle,
+      std::vector<TypePtr>{valueType, comparisons->type()},
+      valueType,
+      queryConfig);
+
+  HashStringAllocator stringAllocator{pool};
+  fn->setAllocator(&stringAllocator);
+
+  const int32_t rowSizeOffset = bits::nbytes(1);
+  int32_t offset = rowSizeOffset + sizeof(uint32_t);
+  offset = bits::roundUp(offset, fn->accumulatorAlignmentSize());
+  fn->setOffsets(
+      offset,
+      exec::RowContainer::nullByte(0),
+      exec::RowContainer::nullMask(0),
+      exec::RowContainer::initializedByte(0),
+      exec::RowContainer::initializedMask(0),
+      rowSizeOffset);
+
+  const auto size = values->size();
+  std::vector<char> group(offset + fn->accumulatorFixedWidthSize());
+  std::vector<char*> groups(size, group.data());
+  std::vector<vector_size_t> indices{0};
+  fn->initializeNewGroups(groups.data(), indices);
+
+  SelectivityVector rows{size};
+  fn->addRawInput(groups.data(), rows, {values, comparisons}, false);
+
+  return *reinterpret_cast<uint32_t*>(group.data() + rowSizeOffset);
+}
 } // namespace facebook::velox::functions::aggregate::test

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h
@@ -287,4 +287,15 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::unordered_map<std::string, std::string>& config);
 };
 
+/// Runs 'name' over a single group of ('values', 'comparisons') in a row laid
+/// out by hand, and returns the variable-length size the aggregate tracked for
+/// that row. Zero means the aggregate never moved the row size counter, which
+/// for an accumulator holding out-of-line bytes is the bug this measures.
+uint32_t aggregateAndReadRowSize(
+    memory::MemoryPool* pool,
+    const std::string& name,
+    const TypePtr& valueType,
+    const VectorPtr& values,
+    const VectorPtr& comparisons);
+
 } // namespace facebook::velox::functions::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -16,7 +16,9 @@
 
 #include <fmt/format.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/Aggregate.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/RowContainer.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
@@ -1139,6 +1141,110 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
     testing::ValuesIn(getTestParams()));
 
 class MinMaxByComplexTypes : public AggregationTestBase {};
+
+TEST_F(MinMaxByComplexTypes, trackRowSize) {
+  // A non-numeric value is held in the HashStringAllocator by
+  // SingleValueAccumulator, with only a Position in the row, so the row's
+  // variable-length size must be tracked. Untracked, RowContainer::rowSize()
+  // reports just the fixed part and Spiller::extractSpillVector sizes its
+  // batches from a number that can be orders of magnitude too small.
+  auto comparisons = makeFlatVector<int64_t>({5, 4, 3, 2, 1});
+
+  // Strings well past the inline StringView limit, so the payload really is
+  // out of line.
+  auto strings = makeFlatVector<StringView>({
+      "a string comfortably longer than the inlined limit 1"_sv,
+      "a string comfortably longer than the inlined limit 2"_sv,
+      "a string comfortably longer than the inlined limit 3"_sv,
+      "a string comfortably longer than the inlined limit 4"_sv,
+      "a string comfortably longer than the inlined limit 5"_sv,
+  });
+  auto arrays = makeArrayVector<int64_t>({
+      {1, 2, 3},
+      {4, 5},
+      {6},
+      {7, 8, 9, 10},
+      {11},
+  });
+  // Numeric value and comparison: the accumulator is genuinely fixed size, so
+  // nothing should be tracked and no tracker should be constructed. This is
+  // also what shows the counter is only ever moved by the tracker.
+  auto numbers = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+
+  // Bound the tracked size rather than just requiring it to be non-zero, so a
+  // garbage or uninitialised read fails too. The lower bound is the payload the
+  // accumulator must be holding; the upper bound is every candidate value plus
+  // room for allocator headers, since a comparison that keeps improving stores
+  // each value in turn. Deliberately loose: this pins the order of magnitude,
+  // not HashStringAllocator's block layout.
+  constexpr uint32_t kAllocatorSlack = 1024;
+  const uint32_t stringBytes =
+      strings->as<FlatVector<StringView>>()->valueAt(0).size();
+  const uint32_t allStringBytes = stringBytes * strings->size();
+  // Each array element is an int64 plus per-element serde overhead.
+  constexpr uint32_t kArrayBytes = 11 * sizeof(int64_t);
+
+  // min_by and max_by share MinMaxByAggregateBase but reach the store through
+  // opposite comparator outcomes, so exercise both.
+  for (const auto& name : {"min_by", "max_by"}) {
+    SCOPED_TRACE(name);
+    const auto varcharSize =
+        aggregateAndReadRowSize(pool(), name, VARCHAR(), strings, comparisons);
+    EXPECT_GE(varcharSize, stringBytes);
+    EXPECT_LE(varcharSize, allStringBytes + kAllocatorSlack);
+
+    const auto arraySize = aggregateAndReadRowSize(
+        pool(), name, ARRAY(BIGINT()), arrays, comparisons);
+    EXPECT_GE(arraySize, sizeof(int64_t));
+    EXPECT_LE(arraySize, kArrayBytes + kAllocatorSlack);
+
+    EXPECT_EQ(
+        aggregateAndReadRowSize(pool(), name, BIGINT(), numbers, comparisons),
+        0);
+  }
+}
+
+// The tracker above can only write a size because RowContainer reserved a slot
+// for it, and it reserves one only for an accumulator that reports itself as
+// not fixed size. Check that a real container does so, since
+// aggregateAndReadRowSize lays the row out by hand and would keep passing even
+// if the accumulator claimed to be fixed size.
+TEST_F(MinMaxByComplexTypes, rowContainerReservesRowSize) {
+  core::QueryConfig queryConfig({});
+  for (const auto& name : {"min_by", "max_by"}) {
+    SCOPED_TRACE(name);
+    for (const auto& valueType :
+         std::vector<TypePtr>{VARCHAR(), ARRAY(BIGINT()), BIGINT()}) {
+      SCOPED_TRACE(valueType->toString());
+      auto fn = exec::Aggregate::create(
+          name,
+          core::AggregationNode::Step::kSingle,
+          std::vector<TypePtr>{valueType, BIGINT()},
+          valueType,
+          queryConfig);
+      std::vector<exec::Accumulator> accumulators;
+      accumulators.emplace_back(fn.get(), valueType);
+      exec::RowContainer container(
+          {BIGINT()},
+          /*nullableKeys=*/false,
+          accumulators,
+          /*dependentTypes=*/std::vector<TypePtr>{},
+          /*hasNext=*/false,
+          /*isJoinBuild=*/false,
+          /*hasProbedFlag=*/false,
+          /*hasCountFlag=*/false,
+          /*hasNormalizedKey=*/false,
+          /*useListRowIndex=*/false,
+          pool());
+      // A numeric accumulator holds everything inline, so it needs no slot.
+      if (valueType->isFixedWidth()) {
+        EXPECT_EQ(container.rowSizeOffset(), 0);
+      } else {
+        EXPECT_NE(container.rowSizeOffset(), 0);
+      }
+    }
+  }
+}
 
 TEST_F(MinMaxByComplexTypes, array) {
   auto data = makeRowVector({

--- a/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/RowContainer.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
@@ -57,6 +59,47 @@ TEST_F(MinMaxByAggregateTest, minBy) {
   })};
 
   testAggregations(vectors, {}, {"spark_min_by(c0, c1)"}, expected);
+}
+
+TEST_F(MinMaxByAggregateTest, trackRowSize) {
+  // Spark registers min_by/max_by on the same MinMaxByAggregateBase as Presto
+  // but with its own comparator, so it instantiates different specializations.
+  // A non-numeric value lives in the HashStringAllocator behind a
+  // SingleValueAccumulator, and the row's variable-length size must grow with
+  // it or Spiller::extractSpillVector sizes spill batches from a number that
+  // is orders of magnitude too small.
+  auto comparisons = makeFlatVector<int32_t>({5, 4, 3, 2, 1});
+
+  auto arrays = makeArrayVector<int64_t>({
+      {1, 2, 3},
+      {4, 5},
+      {6},
+      {7, 8, 9, 10},
+      {11},
+  });
+  // Numeric value and comparison: the accumulator is genuinely fixed size, so
+  // nothing is tracked. This is also what shows the counter is only ever moved
+  // by the tracker.
+  auto numbers = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
+
+  // Bound the tracked size rather than just requiring it to be non-zero, so a
+  // garbage or uninitialised read fails too. Loose on purpose: the upper bound
+  // covers every candidate value plus allocator headers, since a comparison
+  // that keeps improving stores each value in turn.
+  constexpr uint32_t kAllocatorSlack = 1024;
+  constexpr uint32_t kArrayBytes = 11 * sizeof(int64_t);
+
+  for (const auto& name : {"spark_min_by", "spark_max_by"}) {
+    SCOPED_TRACE(name);
+    const auto arraySize = aggregateAndReadRowSize(
+        pool(), name, ARRAY(BIGINT()), arrays, comparisons);
+    EXPECT_GE(arraySize, sizeof(int64_t));
+    EXPECT_LE(arraySize, kArrayBytes + kAllocatorSlack);
+
+    EXPECT_EQ(
+        aggregateAndReadRowSize(pool(), name, INTEGER(), numbers, comparisons),
+        0);
+  }
 }
 
 TEST_F(MinMaxByAggregateTest, arrayCompare) {


### PR DESCRIPTION
Summary:

`min_by`/`max_by` over a non-numeric value or comparison type stores the payload
in the `HashStringAllocator` via `SingleValueAccumulator`, keeping only a
`HashStringAllocator::Position` in the row. The aggregate never overrode
`isFixedSize()` and never called `Aggregate::trackRowSize()`, so
`row[rowSizeOffset_]` stayed at zero no matter how large the value was and
`RowContainer::rowSize()` reported only the fixed part.

`Aggregate.h` states the contract and names the consequence: an accumulator that
can exceed `accumulatorFixedWidthSize()` must return false from `isFixedSize()`
and track its footprint, because "the size is relevant for keeping caps on
result set and spilling batch sizes with skewed data."

Measured in a problematic query with large row type payloads

```
SpillDiagnostic extract: rows=64 estimatedRowSizeBytes=2752
                         estimateFlatSizeBytes=27693024
                         targetBatchRows=64 targetBatchBytes=262144
SpillDiagnostic extract: rows=1  estimatedRowSizeBytes=43   ...
```

- `rowSize()` reports **43 bytes/row**; the row really holds **432,704 bytes**
  (423 KiB). A **10,063x** under-report.
- `SpillerBase::extractSpillVector` bounds a chunk by `rowSize()` against
  `kTargetBatchBytes` (256 KiB). 64 rows consume 1.05% of that budget, so the
  byte cap never binds and it always takes the full `kTargetBatchRows` of 64.
- Only 0.6 rows actually fit in 256 KiB, so the correct chunk is the 1-row
  minimum.
- Downstream, each spill batch reached 11.9-24.4 MB against a
  `spill_write_buffer_size` of 1 MiB, and the process-wide 
  pool was exhausted by a
  handful of concurrent spillers, failing 8 KB allocations with
  `MEM_ALLOC_ERROR` and killing tasks.

Fix: declare the variable-width case and track it. `updateValues` is the single
choke point -- all eleven update paths funnel through it and it has the group
pointer -- and `store<>()` is the only caller of
`SingleValueAccumulator::write`, so one tracker there covers every write. The
extract paths only read and are untouched.

`kUsesVariableWidthAccumulator` is `constexpr`, so the numeric specializations
keep `isFixedSize() == true` and compile the tracker away entirely; only the
`SingleValueAccumulator` instantiations pay for it. This matches
`ArrayAggAggregate`, the sample implementation `Aggregate.h` points to.

Note this base is in `functions/lib`, so it is shared: Presto's and Spark's
`min_by`/`max_by` are both affected and both fixed.

Reviewed By: kgpai

Differential Revision: D116063948


