### PR TITLE
feat: Resolve Iceberg delete field IDs and narrow test matrices

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -286,19 +286,26 @@ HiveTableHandle::HiveTableHandle(
     const std::unordered_map<std::string, std::string>& tableParameters,
     std::vector<HiveColumnHandlePtr> filterColumnHandles,
     double sampleRate,
-    std::string dbName)
+    std::string dbName,
+    std::vector<int32_t> dataColumnFieldIds)
     : FileTableHandle(std::move(connectorId)),
       tableName_(tableName),
       subfieldFilters_(std::move(subfieldFilters)),
       remainingFilter_(remainingFilter),
       sampleRate_(sampleRate),
       dataColumns_(dataColumns),
+      dataColumnFieldIds_(std::move(dataColumnFieldIds)),
       indexColumns_(std::move(indexColumns)),
       tableParameters_(tableParameters),
       filterColumnHandles_(std::move(filterColumnHandles)),
       dbName_(std::move(dbName)) {
   VELOX_CHECK_GT(sampleRate_, 0.0, "Sample rate must be positive");
   VELOX_CHECK_LE(sampleRate_, 1.0, "Sample rate must not exceed 1.0");
+  VELOX_CHECK(
+      dataColumnFieldIds_.empty() ||
+          (dataColumns_ != nullptr &&
+           dataColumnFieldIds_.size() == dataColumns_->size()),
+      "Data column field IDs must be empty or aligned to data columns");
 }
 
 HiveTableHandle::HiveTableHandle(
@@ -404,6 +411,13 @@ folly::dynamic HiveTableHandle::serialize() const {
   if (dataColumns_) {
     obj["dataColumns"] = dataColumns_->serialize();
   }
+  if (!dataColumnFieldIds_.empty()) {
+    folly::dynamic dataColumnFieldIds = folly::dynamic::array;
+    for (const auto fieldId : dataColumnFieldIds_) {
+      dataColumnFieldIds.push_back(fieldId);
+    }
+    obj["dataColumnFieldIds"] = std::move(dataColumnFieldIds);
+  }
   folly::dynamic tableParameters = folly::dynamic::object;
   for (const auto& param : tableParameters_) {
     tableParameters[param.first] = param.second;
@@ -463,6 +477,14 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     dataColumns = ISerializable::deserialize<RowType>(it->second, context);
   }
 
+  std::vector<int32_t> dataColumnFieldIds;
+  if (auto it = obj.find("dataColumnFieldIds"); it != obj.items().end()) {
+    dataColumnFieldIds.reserve(it->second.size());
+    for (const auto& fieldId : it->second) {
+      dataColumnFieldIds.push_back(fieldId.asInt());
+    }
+  }
+
   std::unordered_map<std::string, std::string> tableParameters{};
   const auto& tableParametersObj = obj["tableParameters"];
   for (const auto& key : tableParametersObj.keys()) {
@@ -500,7 +522,8 @@ ConnectorTableHandlePtr HiveTableHandle::create(
       tableParameters,
       std::move(filterColumnHandles),
       sampleRate,
-      std::move(dbName));
+      std::move(dbName),
+      std::move(dataColumnFieldIds));
 }
 
 void HiveTableHandle::registerSerDe() {

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -188,7 +188,8 @@ class HiveTableHandle : public FileTableHandle {
       const std::unordered_map<std::string, std::string>& tableParameters = {},
       std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
       double sampleRate = 1.0,
-      std::string dbName = "");
+      std::string dbName = "",
+      std::vector<int32_t> dataColumnFieldIds = {});
 
   /// Legacy constructor without indexColumns parameter for backward
   /// compatibility.
@@ -234,6 +235,12 @@ class HiveTableHandle : public FileTableHandle {
     return dataColumns_;
   }
 
+  /// Returns Iceberg field IDs aligned positionally to dataColumns(). An empty
+  /// vector means field IDs are unavailable.
+  const std::vector<int32_t>& dataColumnFieldIds() const {
+    return dataColumnFieldIds_;
+  }
+
   /// Returns the names of the index columns for the table.
   const std::vector<std::string>& indexColumns() const {
     return indexColumns_;
@@ -275,6 +282,7 @@ class HiveTableHandle : public FileTableHandle {
   const core::TypedExprPtr remainingFilter_;
   const double sampleRate_;
   const RowTypePtr dataColumns_;
+  const std::vector<int32_t> dataColumnFieldIds_;
   const std::vector<std::string> indexColumns_;
   const std::unordered_map<std::string, std::string> tableParameters_;
   const std::vector<HiveColumnHandlePtr> filterColumnHandles_;

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -34,7 +34,9 @@ HiveIcebergSplit::HiveIcebergSplit(
     bool cacheable,
     const std::unordered_map<std::string, std::string>& infoColumns,
     std::optional<FileProperties> properties,
-    int64_t dataSequenceNumber)
+    int64_t dataSequenceNumber,
+    const std::unordered_map<int32_t, std::optional<std::string>>&
+        identityPartitionKeys)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -52,7 +54,8 @@ HiveIcebergSplit::HiveIcebergSplit(
           properties,
           std::nullopt,
           std::nullopt),
-      dataSequenceNumber(dataSequenceNumber) {
+      dataSequenceNumber(dataSequenceNumber),
+      identityPartitionKeys(identityPartitionKeys) {
   // TODO: Deserialize _extraFileInfo to get deleteFiles;
 }
 
@@ -72,7 +75,9 @@ HiveIcebergSplit::HiveIcebergSplit(
     std::vector<IcebergDeleteFile> deletes,
     const std::unordered_map<std::string, std::string>& infoColumns,
     std::optional<FileProperties> properties,
-    int64_t dataSequenceNumber)
+    int64_t dataSequenceNumber,
+    const std::unordered_map<int32_t, std::optional<std::string>>&
+        identityPartitionKeys)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -91,7 +96,8 @@ HiveIcebergSplit::HiveIcebergSplit(
           std::nullopt,
           std::nullopt),
       deleteFiles(std::move(deletes)),
-      dataSequenceNumber(dataSequenceNumber) {}
+      dataSequenceNumber(dataSequenceNumber),
+      identityPartitionKeys(identityPartitionKeys) {}
 
 std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
   return std::make_shared<HiveIcebergSplit>(
@@ -108,6 +114,7 @@ std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
       deleteFiles_,
       infoColumns_,
       std::nullopt,
-      dataSequenceNumber_);
+      dataSequenceNumber_,
+      identityPartitionKeys_);
 }
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -37,6 +37,21 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   /// sequence number filtering.
   int64_t dataSequenceNumber{0};
 
+  /// Partition values keyed by the Iceberg *source* column field ID, for
+  /// partition fields the serialized spec explicitly marks as the 'identity'
+  /// transform. Only an identity value equals the source column's value, so
+  /// only these entries may be substituted for a read of the source column.
+  ///
+  /// Transformed fields (bucket, truncate, day, void) are never present, even
+  /// when their derived partition-field name happens to collide with a source
+  /// column name. An empty map means no identity provenance was available and
+  /// callers must read source columns from the data file.
+  ///
+  /// Distinct from the inherited name-keyed 'partitionKeys', which carries
+  /// every partition field under its derived 'PartitionField.name()' and
+  /// therefore cannot prove a transform is identity.
+  std::unordered_map<int32_t, std::optional<std::string>> identityPartitionKeys;
+
   HiveIcebergSplit(
       const std::string& connectorId,
       const std::string& filePath,
@@ -51,7 +66,9 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       bool cacheable = true,
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<int32_t, std::optional<std::string>>&
+          identityPartitionKeys = {});
 
   // For tests only
   HiveIcebergSplit(
@@ -69,7 +86,9 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       std::vector<IcebergDeleteFile> deletes = {},
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<int32_t, std::optional<std::string>>&
+          identityPartitionKeys = {});
 };
 
 /// Builds Iceberg splits with named parameters.
@@ -124,6 +143,14 @@ class IcebergSplitBuilder {
     return *this;
   }
 
+  /// Sets identity-transform partition values keyed by source field ID. See
+  /// 'HiveIcebergSplit::identityPartitionKeys'.
+  IcebergSplitBuilder& identityPartitionKeys(
+      const std::unordered_map<int32_t, std::optional<std::string>>& keys) {
+    identityPartitionKeys_ = keys;
+    return *this;
+  }
+
   std::shared_ptr<HiveIcebergSplit> build() const;
 
  private:
@@ -136,6 +163,8 @@ class IcebergSplitBuilder {
   std::unordered_map<std::string, std::string> infoColumns_;
   std::vector<IcebergDeleteFile> deleteFiles_;
   int64_t dataSequenceNumber_{0};
+  std::unordered_map<int32_t, std::optional<std::string>>
+      identityPartitionKeys_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -192,14 +192,22 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
     const {
   std::vector<dwio::common::ParquetFieldId> fieldIds;
   const auto& dataColumns = tableHandle_->dataColumns();
-  if (dataColumns == nullptr || columnHandles_ == nullptr) {
+  if (dataColumns == nullptr) {
     return fieldIds;
   }
+
+  const auto* hiveTableHandle =
+      dynamic_cast<const HiveTableHandle*>(tableHandle_.get());
+  const auto* dataColumnFieldIds = hiveTableHandle != nullptr
+      ? &hiveTableHandle->dataColumnFieldIds()
+      : nullptr;
+
   // Column handles are keyed by output alias; index them by the underlying
   // data-column name so we can align to dataColumns() order.
   const auto handleByName =
       buildIcebergHandleByName(columnHandles_.get(), tableHandle_.get());
-  if (handleByName.empty()) {
+  if (handleByName.empty() &&
+      (dataColumnFieldIds == nullptr || dataColumnFieldIds->empty())) {
     return fieldIds;
   }
 
@@ -209,6 +217,9 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
     auto it = handleByName.find(dataColumns->nameOf(static_cast<uint32_t>(i)));
     if (it != handleByName.end()) {
       fieldIds.push_back(it->second->field());
+    } else if (dataColumnFieldIds != nullptr && !dataColumnFieldIds->empty()) {
+      fieldIds.push_back(
+          dwio::common::ParquetFieldId{dataColumnFieldIds->at(i), {}});
     } else {
       fieldIds.push_back(dwio::common::ParquetFieldId{sentinelFieldId--, {}});
     }
@@ -411,23 +422,25 @@ void IcebergSplitReader::prepareSplit(
     return;
   }
 
-  // Inject a row-number column when filters, random-skip, or positional
+  // Inject a row-number column when filters, random-skip, or row-skipping
   // deletes make the output-to-file-position mapping non-contiguous.
   // Check split metadata rather than positionalDeleteFileReaders_ because
   // the row reader must be configured before delete files are opened. Both
   // _row_id and $target_table_row_id need accurate file-absolute positions,
-  // so request injection when either is projected.
-  const bool hasPositionalDeletes = std::any_of(
+  // so request injection when either is projected. Deletion vectors skip rows
+  // exactly like V2 positional deletes and must be counted here too.
+  const bool hasRowSkippingDeletes = std::any_of(
       icebergSplit_->deleteFiles.begin(),
       icebergSplit_->deleteFiles.end(),
       [](const IcebergDeleteFile& deleteFile) {
-        return deleteFile.content == FileContent::kPositionalDeletes &&
+        return (deleteFile.content == FileContent::kPositionalDeletes ||
+                deleteFile.content == FileContent::kDeletionVector) &&
             deleteFile.recordCount > 0;
       });
   useRowNumberColumn_ = (rowIdOutputIndex_.has_value() ||
                          targetTableRowIdOutputIndex_.has_value()) &&
       (scanSpec_->hasFilter() || baseReaderOpts_.randomSkip() != nullptr ||
-       hasPositionalDeletes);
+       hasRowSkippingDeletes);
   if (useRowNumberColumn_) {
     dwio::common::RowNumberColumnInfo rowNumInfo;
     rowNumInfo.insertPosition = readerOutputType_->size();
@@ -566,7 +579,7 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
   std::vector<std::string> extraNames;
   std::vector<TypePtr> extraTypes;
   const auto& deleteFiles = icebergSplit_->deleteFiles;
-  const auto& splitPartitionKeys = icebergSplit_->partitionKeys;
+  const auto& identityPartitionKeys = icebergSplit_->identityPartitionKeys;
 
   for (const auto& deleteFile : deleteFiles) {
     if (deleteFile.content != FileContent::kEqualityDeletes ||
@@ -612,14 +625,21 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
           static_cast<column_index_t>(
               readerOutputType_->size() + extraEqualityColumns.size()));
 
-      // For partition columns set the partition value directly as a constant
-      // on the scan-spec child. This is independent of whether the data file
-      // contains the partition column physically. With the constant set
-      // up-front, 'adaptColumns' does not need any special-case logic for
-      // augmented partition columns and the read does not depend on the
-      // writer's choice of including the partition column in the file.
-      auto partitionIt = splitPartitionKeys.find(name);
-      if (partitionIt != splitPartitionKeys.end()) {
+      // Substitute the partition value for the source column only when the
+      // Iceberg partition spec explicitly marks this equality field's source
+      // column as an identity partition field. Identity is the only transform
+      // whose stored partition value equals the source column value; a
+      // bucket, truncate, or temporal value is a transform result, and a
+      // 'void' value is always null while keeping the source column's name.
+      // Keying by the delete file's own Iceberg field ID (rather than by
+      // column name) also keeps this correct across column renames.
+      //
+      // Anything else -- a transformed field, a spec that could not be
+      // parsed, or a split with no identity metadata at all -- leaves no
+      // constant installed, so the column is read from the data file.
+      const auto identityIt =
+          identityPartitionKeys.find(deleteFile.equalityFieldIds[i]);
+      if (identityIt != identityPartitionKeys.end()) {
         // Iceberg encodes DATE partition values as the integer number of
         // days since the Unix epoch (e.g. "19345"). The standard
         // 'setPartitionValue' helper learns this from the planner-supplied
@@ -630,7 +650,7 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
         const bool isDaysSinceEpoch = equalityColumnTypes[i]->isDate();
         auto constant = newConstantFromString(
             equalityColumnTypes[i],
-            partitionIt->second,
+            identityIt->second,
             connectorQueryCtx_->memoryPool(),
             fileConfig_->readTimestampPartitionValueAsLocalTime(
                 connectorQueryCtx_->sessionProperties()),
@@ -677,18 +697,35 @@ IcebergSplitReader::resolveEqualityColumns(
       "Iceberg equality delete file '{}' cannot be processed because "
       "table data columns are not available in HiveTableHandle.",
       deleteFile.filePath);
-  for (const auto& eqFieldId : deleteFile.equalityFieldIds) {
-    // Field IDs are 1-based sequential for non-evolved schemas.
-    auto colIdx = static_cast<uint32_t>(eqFieldId - 1);
+  std::unordered_map<int32_t, uint32_t> columnIndexByFieldId;
+  if (const auto* hiveTableHandle =
+          dynamic_cast<const HiveTableHandle*>(tableHandle_.get())) {
+    const auto& dataColumnFieldIds = hiveTableHandle->dataColumnFieldIds();
+    columnIndexByFieldId.reserve(dataColumnFieldIds.size());
+    for (uint32_t i = 0; i < dataColumnFieldIds.size(); ++i) {
+      columnIndexByFieldId.emplace(dataColumnFieldIds[i], i);
+    }
+  }
+
+  for (const auto& equalityFieldId : deleteFile.equalityFieldIds) {
+    VELOX_CHECK_GT(
+        equalityFieldId,
+        0,
+        "Equality delete field ID must be positive: {}",
+        equalityFieldId);
+    const auto fieldIdIt = columnIndexByFieldId.find(equalityFieldId);
+    // Older plans and tests may not carry full-schema field IDs. Preserve the
+    // legacy ordinal lookup when metadata is unavailable or incomplete.
+    const auto columnIndex = fieldIdIt != columnIndexByFieldId.end()
+        ? fieldIdIt->second
+        : static_cast<uint32_t>(equalityFieldId - 1);
     VELOX_CHECK_LT(
-        colIdx,
+        columnIndex,
         dataColumns->size(),
-        "Equality delete field ID {} out of range. This may indicate "
-        "schema evolution with non-sequential field IDs, which is "
-        "not yet supported.",
-        eqFieldId);
-    equalityColumnNames.push_back(dataColumns->nameOf(colIdx));
-    equalityColumnTypes.push_back(dataColumns->childAt(colIdx));
+        "Equality delete field ID cannot be resolved against table columns: {}",
+        equalityFieldId);
+    equalityColumnNames.push_back(dataColumns->nameOf(columnIndex));
+    equalityColumnTypes.push_back(dataColumns->childAt(columnIndex));
   }
   return {std::move(equalityColumnNames), std::move(equalityColumnTypes)};
 }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -66,9 +66,10 @@ class IcebergSplitReader : public FileSplitReader {
 
   // Builds the requested-schema field-id trees, one per top-level column,
   // aligned to tableHandle_->dataColumns(). Projected and filter-only Iceberg
-  // handles provide field IDs. Data columns without an Iceberg handle get a
+  // handles provide field IDs. Data columns without an Iceberg handle fall back
+  // to the table handle's full-schema field IDs when available, otherwise a
   // negative sentinel id that matches no physical field. Returns empty when no
-  // Iceberg handles are available.
+  // Iceberg handles and no full-schema field IDs are available.
   std::vector<dwio::common::ParquetFieldId> buildFieldIds() const;
 
   /// Adapts the data file schema to match the table schema expected by the
@@ -130,20 +131,22 @@ class IcebergSplitReader : public FileSplitReader {
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
 
-  // Resolves the equality field IDs of an equality-delete file to the
-  // corresponding column names and types in the table schema. In Iceberg,
-  // field IDs for top-level columns are assigned sequentially starting from
-  // 1, matching the column order in the table schema.
+  // Resolves equality-delete field IDs to column names and types using the
+  // table handle's full-schema field IDs. Falls back to the legacy one-based
+  // ordinal mapping when those IDs are unavailable or incomplete.
   std::pair<std::vector<std::string>, std::vector<TypePtr>>
   resolveEqualityColumns(const IcebergDeleteFile& deleteFile) const;
 
   // Discovers equality-delete columns that are not in the user's projection
   // and augments 'scanSpec_' and 'readerOutputType_' so they are physically
-  // read and made available in the output RowVector. For partition columns
-  // the partition value is set as a constant on the scan-spec child so the
-  // augmentation works regardless of whether the data file physically
-  // contains the partition column. Augmented columns are appended at the end
-  // of 'readerOutputType_' so the upstream FileDataSource's positional
+  // read and made available in the output RowVector. When the split proves
+  // the column's Iceberg field ID belongs to an identity partition field
+  // (see 'HiveIcebergSplit::identityPartitionKeys'), the partition value is
+  // set as a constant on the scan-spec child so the augmentation works
+  // regardless of whether the data file physically contains the column;
+  // every other column, including one partitioned by a transform, is read
+  // from the file. Augmented columns are appended at the end of
+  // 'readerOutputType_' so the upstream FileDataSource's positional
   // projection naturally drops them from the operator output.
   void configureEqualityDeleteColumns();
 

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -19,9 +19,12 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/dwio/common/Writer.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -66,9 +69,37 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
 
   /// Writes a DWRF data file containing the given vectors.
   std::shared_ptr<common::testutil::TempFilePath> writeDataFile(
-      const std::vector<RowVectorPtr>& data) {
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<int32_t>& fieldIds = {}) {
     auto file = common::testutil::TempFilePath::create();
-    writeToFile(file->getPath(), data);
+    if (fieldIds.empty()) {
+      writeToFile(file->getPath(), data);
+      return file;
+    }
+
+    VELOX_CHECK_EQ(data.front()->type()->size(), fieldIds.size());
+    dwio::common::WriterOptions options;
+    auto dwrfOptions = std::make_shared<dwrf::DwrfWriterOptions>();
+    for (uint32_t i = 0; i < fieldIds.size(); ++i) {
+      dwrfOptions->schemaAttributes[i + 1] = {
+          {"iceberg.id", std::to_string(fieldIds[i])}};
+    }
+    options.formatSpecificOptions = std::move(dwrfOptions);
+    options.schema = data.front()->type();
+    options.memoryPool = rootPool_.get();
+
+    auto fs = filesystems::getFileSystem(file->getPath(), {});
+    auto writeFile = fs->openFileForWrite(
+        file->getPath(),
+        {.shouldCreateParentDirectories = true,
+         .shouldThrowOnFileAlreadyExists = false});
+    auto sink = std::make_unique<dwio::common::WriteFileSink>(
+        std::move(writeFile), file->getPath());
+    dwrf::Writer writer{std::move(sink), options};
+    for (const auto& vector : data) {
+      writer.write(vector);
+    }
+    writer.close();
     return file;
   }
 
@@ -95,12 +126,20 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
   /// Creates splits with equality delete files and partition keys attached.
   /// Use this overload to exercise the equality-delete augmentation for
   /// partition columns missing from the user's projection.
+  ///
+  /// 'partitionKeys' is the raw name-keyed map that carries every partition
+  /// field under its derived 'PartitionField.name()'.
+  /// 'identityPartitionKeys' is the field-ID-keyed map that carries only
+  /// fields the partition spec explicitly marks as the identity transform;
+  /// only these may be substituted for a read of the source column.
   std::vector<std::shared_ptr<ConnectorSplit>> makeSplits(
       const std::string& dataFilePath,
       const std::unordered_map<std::string, std::optional<std::string>>&
           partitionKeys,
       const std::vector<IcebergDeleteFile>& deleteFiles,
-      int64_t dataSequenceNumber = 0) {
+      int64_t dataSequenceNumber = 0,
+      const std::unordered_map<int32_t, std::optional<std::string>>&
+          identityPartitionKeys = {}) {
     auto fileSize = getFileSize(dataFilePath);
     return {std::make_shared<HiveIcebergSplit>(
         kIcebergConnectorId,
@@ -116,7 +155,8 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
         deleteFiles,
         std::unordered_map<std::string, std::string>{},
         std::nullopt,
-        dataSequenceNumber)};
+        dataSequenceNumber,
+        identityPartitionKeys)};
   }
 
   /// Builds a table scan plan node with the given schema.
@@ -136,6 +176,51 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
         .startTableScan(kIcebergConnectorId)
         .outputType(outputType)
         .dataColumns(dataColumns)
+        .endTableScan()
+        .planNode();
+  }
+
+  /// Builds a table scan whose full table schema uses explicit Iceberg field
+  /// IDs. Only projected columns receive column handles, matching production
+  /// plans where equality-delete columns may be otherwise unreferenced.
+  core::PlanNodePtr makeTableScanPlan(
+      const RowTypePtr& outputType,
+      const RowTypePtr& dataColumns,
+      const std::vector<int32_t>& dataColumnFieldIds) {
+    VELOX_CHECK_EQ(dataColumns->size(), dataColumnFieldIds.size());
+
+    ColumnHandleMap assignments;
+    for (auto i = 0; i < outputType->size(); ++i) {
+      const auto& name = outputType->nameOf(i);
+      const auto dataColumnIndex = dataColumns->getChildIdx(name);
+      assignments.emplace(
+          name,
+          std::make_shared<IcebergColumnHandle>(
+              name,
+              FileColumnHandle::ColumnType::kRegular,
+              outputType->childAt(i),
+              parquet::ParquetFieldId{
+                  dataColumnFieldIds[dataColumnIndex], {}}));
+    }
+
+    auto tableHandle = std::make_shared<HiveTableHandle>(
+        kIcebergConnectorId,
+        "iceberg_table",
+        common::SubfieldFilters{},
+        /*remainingFilter=*/nullptr,
+        dataColumns,
+        /*indexColumns=*/std::vector<std::string>{},
+        /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+        /*filterColumnHandles=*/std::vector<HiveColumnHandlePtr>{},
+        /*sampleRate=*/1.0,
+        /*dbName=*/"",
+        dataColumnFieldIds);
+
+    return PlanBuilder()
+        .startTableScan(kIcebergConnectorId)
+        .outputType(outputType)
+        .assignments(assignments)
+        .tableHandle(std::move(tableHandle))
         .endTableScan()
         .planNode();
   }
@@ -387,7 +472,10 @@ TEST_F(
   auto splits = makeSplits(
       dataFile->getPath(),
       /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      // Source field ID 1 ('part') is an explicit identity partition field.
+      /*identityPartitionKeys=*/{{1, std::optional<std::string>{"2"}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -437,7 +525,9 @@ TEST_F(
   auto splits = makeSplits(
       dataFile->getPath(),
       /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      /*identityPartitionKeys=*/{{1, std::optional<std::string>{"2"}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -491,7 +581,9 @@ TEST_F(
   auto splits = makeSplits(
       dataFile->getPath(),
       /*partitionKeys=*/{{"part", std::optional<std::string>{"7"}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      /*identityPartitionKeys=*/{{1, std::optional<std::string>{"7"}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -549,7 +641,10 @@ TEST_F(
       /*partitionKeys=*/
       {{"part_date",
         std::optional<std::string>{std::to_string(kPartitionDays)}}},
-      {icebergDeleteFile});
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      /*identityPartitionKeys=*/
+      {{1, std::optional<std::string>{std::to_string(kPartitionDays)}}});
   auto plan = makeTableScanPlan(outputType, tableType);
   auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
 
@@ -557,6 +652,122 @@ TEST_F(
       {"value"},
       {
           makeFlatVector<std::string>({"a", "c"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Regression for transformed partition fields whose derived partition-field
+/// name collides with a real source column name.
+///
+/// A partition field may be named anything, so a 'bucket[4]' field on source
+/// column 'id' can itself be named "id". The split's name-keyed
+/// 'partitionKeys' then maps "id" to the *bucket ordinal*, not to any row's
+/// 'id'. Substituting that value for the source column would corrupt the
+/// equality-delete probe. Only a field the spec marks 'identity' may be
+/// substituted, and no identity metadata is supplied here, so the reader must
+/// read the physical 'id' column from the data file.
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    equalityBucketPartitionNameCollisionNotInProjection) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<std::string>({"a", "b", "c", "d"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Equality delete removes the row whose physical id is 20.
+  auto deleteData = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({20}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      // The bucket ordinal, stored under a name that collides with the
+      // source column.
+      /*partitionKeys=*/{{"id", std::optional<std::string>{"2"}}},
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      // 'bucket[4]' is not identity, so nothing is substitutable.
+      /*identityPartitionKeys=*/{});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // Only the physically matching row is deleted. Substituting the bucket
+  // ordinal would make every row's id 2 and delete nothing.
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "c", "d"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Regression for the 'void' transform, which always stores a null partition
+/// value and — unlike bucket/truncate/temporal — keeps the source column's
+/// name by default. A name-keyed lookup therefore finds an entry for "id"
+/// and would install a constant null over every row, making the null
+/// equality-delete key match everything. With identity metadata absent, the
+/// physical non-null 'id' values must survive instead.
+TEST_F(EqualityDeleteFileReaderTest, equalityVoidPartitionNotInProjection) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // The delete key is null, matching the null the void transform stores.
+  auto deleteData = makeRowVector(
+      {"id"},
+      {
+          makeNullableFlatVector<int64_t>({std::nullopt}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/{{"id", std::nullopt}},
+      {icebergDeleteFile},
+      /*dataSequenceNumber=*/0,
+      // 'void' is not identity, so its null is not substitutable.
+      /*identityPartitionKeys=*/{});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "b", "c"}),
       });
 
   assertEqualResults({expected}, {result});
@@ -865,7 +1076,94 @@ TEST_F(EqualityDeleteFileReaderTest, stringColumnDelete) {
   assertEqualResults({expected}, {result});
 }
 
-/// Verifies equality deletes on a non-first column (field ID 2).
+/// Verifies equality deletes after a field has been dropped, leaving sparse
+/// top-level field IDs.
+TEST_F(EqualityDeleteFileReaderTest, nonSequentialEqualityFieldId) {
+  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
+  const std::vector<int32_t> fieldIds{1, 3};
+
+  auto baseData = makeRowVector(
+      {"id", "dropped", "category"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
+          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
+      });
+  auto dataFile = writeDataFile({baseData}, {1, 2, 3});
+
+  auto deleteData = makeRowVector(
+      {"category"},
+      {
+          makeFlatVector<std::string>({"B"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{3});
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeTableScanPlan(tableType, tableType, fieldIds);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "category"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4}),
+          makeFlatVector<std::string>({"A", "A", "C"}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    nonSequentialEqualityFieldIdNotInProjection) {
+  auto tableType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"id"}, {BIGINT()});
+  const std::vector<int32_t> fieldIds{1, 3};
+
+  auto baseData = makeRowVector(
+      {"id", "dropped", "category"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
+          makeFlatVector<std::string>({"A", "B", "A", "C", "B"}),
+      });
+  auto dataFile = writeDataFile({baseData}, {1, 2, 3});
+
+  auto deleteData = makeRowVector(
+      {"category"},
+      {
+          makeFlatVector<std::string>({"B"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{3});
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType, fieldIds);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({1, 3, 4}),
+      });
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies the ordinal fallback on a non-first column when full-schema field
+/// IDs are unavailable.
 TEST_F(EqualityDeleteFileReaderTest, deleteOnSecondColumn) {
   auto rowType = ROW({"id", "category"}, {BIGINT(), VARCHAR()});
 

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorReadTest.cpp
@@ -21,7 +21,12 @@
 
 #include <folly/Singleton.h>
 
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/dwrf/reader/ReaderBase.h"
+#include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
@@ -114,6 +119,124 @@ TEST_F(IcebergDeletionVectorReadTest, deletionVectorFiltersDeletedRowsInScan) {
   auto expected =
       makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7})});
   exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(expected);
+}
+
+// A deletion vector removes rows from the scan output, so an output row's
+// index no longer matches its position in the data file. _row_id must still
+// report file-absolute positions.
+//
+// The row-number column that carries those positions used to be injected only
+// for V2 positional delete files, so a split whose only delete file was a V3
+// deletion vector fell back to deriving positions from the output index. A
+// DELETE with no WHERE clause hit this: with no filter to force the row-number
+// column on, the rewritten deletion vector recorded 0..N-1 instead of the true
+// positions and left the trailing rows of the file undeleted.
+TEST_F(IcebergDeletionVectorReadTest, rowIdIsFileAbsoluteWithDeletionVector) {
+  auto dataFile = TempFilePath::create();
+  writeToFile(
+      dataFile->getPath(),
+      {makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40, 50})})});
+
+  auto [puffinDir, dvFile] = writeDeletionVector(dataFile->getPath(), {1, 3});
+
+  const std::unordered_map<std::string, std::string> infoColumns{
+      {IcebergMetadataColumn::kFirstRowIdInfoColumn, "200"},
+      {IcebergMetadataColumn::kDataSequenceNumberInfoColumn, "42"}};
+
+  const std::vector<std::string> outputNames{
+      "c0", "_row_id", "_last_updated_sequence_number"};
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(
+                      ROW({outputNames[0], outputNames[1], outputNames[2]},
+                          {BIGINT(), BIGINT(), BIGINT()}))
+                  .dataColumns(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+
+  // Positions 1 and 3 are deleted, so the surviving rows keep file positions
+  // 0, 2 and 4 and _row_id is firstRowId plus those positions.
+  auto expected = makeRowVector(
+      outputNames,
+      {
+          makeFlatVector<int64_t>({10, 30, 50}),
+          makeFlatVector<int64_t>({200, 202, 204}),
+          makeFlatVector<int64_t>({42, 42, 42}),
+      });
+  exec::test::AssertQueryBuilder(plan)
+      .splits({makeIcebergSplitWithInfoColumns(
+          dataFile->getPath(), infoColumns, {dvFile})})
+      .assertResults(expected);
+}
+
+// Deletion-vector positions are absolute row ordinals in the base data file,
+// while a split's 'start'/'length' are a byte range over that file. This
+// pins down the conversion between those two coordinate systems for a split
+// that begins at a nonzero byte offset.
+//
+// IcebergSplitReader resolves the two by asking the format reader, not by
+// arithmetic on the byte offset: after creating the row reader it sets
+// 'splitOffset_ = baseRowReader_->nextRowNumber()', which for DWRF/ORC is the
+// cumulative row count of the preceding stripes (row groups for Parquet), and
+// each batch then recovers its absolute range as
+// 'splitOffset_ + baseReadOffset_'. A DV position preceding the split must be
+// ignored rather than shifted onto a row this split actually reads.
+TEST_F(IcebergDeletionVectorReadTest, deletionVectorAppliesToNonZeroByteSplit) {
+  // Two DWRF stripes of five rows each: values 0..4 then 5..9, where each
+  // value equals its absolute row position.
+  auto dataFile = TempFilePath::create();
+  writeToFile(
+      dataFile->getPath(),
+      {
+          makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})}),
+          makeRowVector({makeFlatVector<int64_t>({5, 6, 7, 8, 9})}),
+      },
+      std::make_shared<dwrf::Config>(),
+      []() {
+        return std::make_unique<dwrf::LambdaFlushPolicy>([]() { return true; });
+      });
+
+  auto readFile = filesystems::getFileSystem(dataFile->getPath(), nullptr)
+                      ->openFileForRead(dataFile->getPath());
+  const uint64_t fileSize = readFile->size();
+  dwio::common::ReaderOptions readerOptions{pool()};
+  auto reader = std::make_unique<dwrf::ReaderBase>(
+      readerOptions,
+      std::make_unique<dwio::common::BufferedInput>(
+          std::shared_ptr<ReadFile>(std::move(readFile)), *pool()));
+  reader->loadCache();
+
+  // The premise of the test: the second stripe really does start at a nonzero
+  // byte offset and at absolute row 5, so the byte offset and the row offset
+  // are different numbers and cannot be confused for one another.
+  ASSERT_EQ(reader->footer().stripesSize(), 2);
+  const uint64_t secondStripeByteOffset = reader->footer().stripes(1).offset();
+  ASSERT_GT(secondStripeByteOffset, 0);
+  ASSERT_EQ(reader->footer().stripes(0).numberOfRows(), 5);
+
+  // Absolute data-file positions: 1 lives in the first stripe and is outside
+  // this split, 7 is the third row of the second stripe.
+  auto [puffinDir, dvFile] = writeDeletionVector(dataFile->getPath(), {1, 7});
+
+  auto split = IcebergSplitBuilder(dataFile->getPath())
+                   .connectorId(test::kIcebergConnectorId)
+                   .fileFormat(fileFormat_)
+                   .start(secondStripeByteOffset)
+                   .length(fileSize - secondStripeByteOffset)
+                   .deleteFiles({dvFile})
+                   .build();
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+
+  // Position 7 is removed from the second stripe. Position 1 precedes the
+  // split and must not delete anything; in particular it must not be
+  // misread as the second row of this split (value 6).
+  auto expected = makeRowVector({makeFlatVector<int64_t>({5, 6, 8, 9})});
+  exec::test::AssertQueryBuilder(plan).splits({split}).assertResults(expected);
 }
 
 } // namespace

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
@@ -684,3 +684,125 @@ TEST_F(IcebergDeletionVectorSinkTest, dictionaryWrappedRowIdStructFlatPath) {
       pool_.get());
   EXPECT_EQ(deleted, (std::vector<uint64_t>{1, 3}));
 }
+
+TEST_F(IcebergDeletionVectorSinkTest, rejectsUnsupportedInputType) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  // Neither the flat (file_path, pos) shape nor a ROW whose first two fields
+  // are (VARCHAR, BIGINT), so the sink cannot locate the row-id.
+  VELOX_ASSERT_USER_THROW(
+      IcebergDeletionVectorSink(
+          ROW({"a", "b"}, {BIGINT(), BIGINT()}),
+          handle,
+          connectorQueryCtx_.get(),
+          connector::CommitStrategy::kNoCommit,
+          hiveConfig_),
+      "IcebergDeletionVectorSink expects a two-column (file_path, pos) input");
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, appendDataIgnoresNullAndEmptyPages) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  sink.appendData(nullptr);
+  sink.appendData(makePositionDeleteRows({}, {}));
+
+  // Neither page created per-file state, so nothing is written.
+  EXPECT_TRUE(sink.finish());
+  EXPECT_TRUE(sink.close().empty());
+  EXPECT_EQ(sink.stats().numWrittenFiles, 0u);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, rowIdStructSkipsNullRowId) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+  const std::string dataFile = tempDir->getPath() + "/A.parquet";
+
+  IcebergDeletionVectorSink sink(
+      ROW({"$row_id"},
+          {ROW(
+              {"_file", "_pos", "_spec_id", "partition_data"},
+              {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()})}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  // A null row-id carries no (file_path, pos) to delete and must be skipped
+  // rather than dereferenced.
+  auto page = makeRowIdStructDeletePage(
+      dataFile, {10, 20, 30}, {0, 1, 2}, /*filePathConstant=*/true);
+  auto rowIdWithNull = page->childAt(0);
+  rowIdWithNull->setNull(1, true);
+
+  sink.appendData(page);
+  EXPECT_TRUE(sink.finish());
+
+  auto messages = sink.close();
+  ASSERT_EQ(messages.size(), 1);
+  const auto parsed = folly::parseJson(messages[0]);
+  // Positions 10 and 30 survive; the null row at index 1 contributes nothing.
+  EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 2);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, finishAndAbortAreIdempotent) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  sink.appendData(
+      makePositionDeleteRows({tempDir->getPath() + "/A.parquet"}, {5}));
+
+  EXPECT_TRUE(sink.finish());
+  const auto statsAfterFirstFinish = sink.stats();
+
+  // A second finish() must not re-write the Puffin file or duplicate the
+  // commit message.
+  EXPECT_TRUE(sink.finish());
+  EXPECT_EQ(
+      sink.stats().numWrittenFiles, statsAfterFirstFinish.numWrittenFiles);
+  EXPECT_EQ(sink.close().size(), 1);
+
+  // abort() after finish() is a no-op rather than clearing committed state.
+  sink.abort();
+  sink.abort();
+  EXPECT_EQ(sink.close().size(), 1);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, puffinPathFallsBackToTargetPath) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  // A data-file name with no '/' has no parent directory to co-locate with,
+  // so the Puffin lands in the location handle's target path instead.
+  sink.appendData(makePositionDeleteRows({"bare-name.parquet"}, {1}));
+  EXPECT_TRUE(sink.finish());
+
+  auto messages = sink.close();
+  ASSERT_EQ(messages.size(), 1);
+  const auto parsed = folly::parseJson(messages[0]);
+  const auto puffinPath = parsed["path"].asString();
+  EXPECT_EQ(puffinPath.rfind(tempDir->getPath() + "/dv-", 0), 0)
+      << "puffin path should sit under the target path: " << puffinPath;
+}

--- a/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
@@ -240,6 +240,128 @@ TEST_F(IcebergDwrfInsertTest, partitioned) {
   exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
 }
 
+/// IcebergFileNameGenerator participates in plan serialization
+/// (IcebergConnector::registerSerDe registers it), so its serialize /
+/// deserialize / toString methods are reachable from any serialized plan even
+/// though the write tests never round-trip a plan.
+TEST_F(IcebergDwrfInsertTest, fileNameGeneratorSerDeRoundTrip) {
+  IcebergFileNameGenerator::registerSerDe();
+
+  const IcebergFileNameGenerator generator;
+  EXPECT_EQ(generator.toString(), "IcebergFileNameGenerator");
+
+  const auto serialized = generator.serialize();
+  EXPECT_EQ(serialized["name"].asString(), "IcebergFileNameGenerator");
+
+  const auto deserialized =
+      IcebergFileNameGenerator::deserialize(serialized, /*context=*/nullptr);
+  ASSERT_NE(deserialized, nullptr);
+  EXPECT_EQ(deserialized->toString(), generator.toString());
+}
+
+/// Exercises writer file rotation. FileDataSink rotates once a writer's
+/// current file reaches 'maxTargetFileBytes', which HiveDataSink derives from
+/// the format-specific max-target-file-size setting (0 = unlimited, the
+/// default, so no other test reaches this path). IcebergDataSink overrides
+/// rotateWriter() to capture per-file statistics before the writer is reset;
+/// without rotation coverage that override and the post-rotation null-writer
+/// handling in closeInternal() never run.
+TEST_F(IcebergDwrfInsertTest, writerRotationProducesMultipleFiles) {
+  // 1 byte forces a rotation after essentially every batch.
+  setConnectorSessionProperty(
+      connector::hive::HiveConfig::kOrcMaxTargetFileSizeSession, "1B");
+
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 3, 50);
+
+  const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+  const auto commitTasks = dataSink->close();
+
+  // Rotation means one unpartitioned writer emits several files, each with its
+  // own commit task and its own record count.
+  ASSERT_GT(commitTasks.size(), 1)
+      << "expected rotation to split the write across multiple files";
+  EXPECT_EQ(listFiles(dataPath).size(), commitTasks.size());
+
+  int64_t totalRecords = 0;
+  for (const auto& task : commitTasks) {
+    const auto taskJson = folly::parseJson(task);
+    const auto records = taskJson["metrics"]["recordCount"].asInt();
+    // Per-file counts are deltas, not the running total, so none may be zero
+    // and they must sum to the rows written.
+    EXPECT_GT(records, 0);
+    totalRecords += records;
+  }
+  EXPECT_EQ(totalRecords, 3 * 50);
+
+  // The rotated files still read back as the original data.
+  auto splits = createSplitsForDirectory(dataPath);
+  ASSERT_EQ(splits.size(), commitTasks.size());
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+}
+
+/// Partition values are serialized into the commit message by a per-type
+/// dispatch. VARBINARY and TIMESTAMP take dedicated specializations —
+/// base64-encoding and micros-since-epoch respectively — that the BIGINT and
+/// VARCHAR partition tests never reach.
+TEST_F(IcebergDwrfInsertTest, varbinaryPartitionValue) {
+  auto rowType = ROW({"c1", "c2"}, {VARBINARY(), BIGINT()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 1, 20);
+
+  std::vector<test::PartitionField> partitionTransforms = {
+      {0, TransformType::kIdentity, std::nullopt}};
+  const auto dataSink =
+      createDataSinkAndAppendData(vectors, dataPath, partitionTransforms);
+  const auto commitTasks = dataSink->close();
+  ASSERT_GT(commitTasks.size(), 0);
+
+  for (const auto& task : commitTasks) {
+    const auto taskJson = folly::parseJson(task);
+    ASSERT_GT(taskJson.count("partitionDataJson"), 0);
+    const auto partitionData =
+        folly::parseJson(taskJson["partitionDataJson"].asString());
+    ASSERT_EQ(partitionData["partitionValues"].size(), 1);
+    // Binary partition values are base64 strings, never raw bytes.
+    const auto& value = partitionData["partitionValues"][0];
+    EXPECT_TRUE(value.isString() || value.isNull());
+  }
+}
+
+TEST_F(IcebergDwrfInsertTest, timestampPartitionValue) {
+  auto rowType = ROW({"c1", "c2"}, {TIMESTAMP(), BIGINT()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 1, 20);
+
+  std::vector<test::PartitionField> partitionTransforms = {
+      {0, TransformType::kIdentity, std::nullopt}};
+  const auto dataSink =
+      createDataSinkAndAppendData(vectors, dataPath, partitionTransforms);
+  const auto commitTasks = dataSink->close();
+  ASSERT_GT(commitTasks.size(), 0);
+
+  for (const auto& task : commitTasks) {
+    const auto taskJson = folly::parseJson(task);
+    ASSERT_GT(taskJson.count("partitionDataJson"), 0);
+    const auto partitionData =
+        folly::parseJson(taskJson["partitionDataJson"].asString());
+    ASSERT_EQ(partitionData["partitionValues"].size(), 1);
+    // Iceberg stores timestamps as micros since epoch, so the serialized
+    // partition value must be an integer rather than a formatted string.
+    const auto& value = partitionData["partitionValues"][0];
+    EXPECT_TRUE(value.isInt() || value.isNull());
+  }
+}
+
 /// Regression test for the isPartitioned() guard added to ensureWriter().
 /// Without the guard, calling ensureWriter() on a non-partitioned table
 /// invoked makeCommitPartitionValue(), which dereferences

--- a/velox/connectors/hive/iceberg/tests/IcebergMergeSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergMergeSinkTest.cpp
@@ -468,6 +468,42 @@ TEST_F(IcebergMergeSinkTest, dataInputTypeNamesComeFromHandleNotSource) {
 
 // VELOX_ENABLE_PARQUET guard removed: rely on the iceberg_connector
 // target's unconditional Parquet writer dependency.
+TEST_F(IcebergMergeSinkTest, appendDataIgnoresNullAndEmptyPages) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  // Neither page carries rows, so neither sub-sink is driven and no operation
+  // byte is validated.
+  sink->appendData(nullptr);
+  sink->appendData(makeInput(
+      /*ids=*/std::vector<std::optional<int64_t>>{},
+      /*names=*/std::vector<std::optional<std::string>>{},
+      /*operations=*/std::vector<int8_t>{},
+      /*filePaths=*/std::vector<std::optional<std::string>>{},
+      /*positions=*/std::vector<std::optional<int64_t>>{},
+      /*insertFromUpdate=*/std::vector<int8_t>{}));
+
+  EXPECT_TRUE(sink->finish());
+  EXPECT_TRUE(sink->close().empty());
+}
+
+TEST_F(IcebergMergeSinkTest, abortIsIdempotent) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  sink->appendData(makeInput(
+      /*ids=*/{1},
+      /*names=*/{{std::string("a")}},
+      /*operations=*/{IMS::kInsertOperationNumber},
+      /*filePaths=*/{std::nullopt},
+      /*positions=*/{std::nullopt},
+      /*insertFromUpdate=*/{0}));
+
+  // The second abort must not re-enter the sub-sinks, which are not safe to
+  // abort twice.
+  sink->abort();
+  sink->abort();
+}
 
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1391,6 +1391,94 @@ TEST_F(IcebergReadTest, targetTableRowIdSynthesis) {
       .assertResults({expected});
 }
 
+// Info columns arrive as strings on the split and are parsed at read time.
+// A value the coordinator could not have produced means the split metadata is
+// corrupt, so the reader must fail loudly rather than silently substituting a
+// default: $first_row_id and $data_sequence_number both feed V3 row lineage,
+// and a wrong value there mislabels every row in the file.
+class IcebergInfoColumnValidationTest : public IcebergReadTest {
+ protected:
+  // Runs a scan of a single BIGINT column with 'infoColumns' attached to the
+  // split, projecting 'outputType' (which decides whether the row-lineage or
+  // MERGE row-id parsing paths run at all).
+  void assertScanFails(
+      const std::unordered_map<std::string, std::string>& infoColumns,
+      const RowTypePtr& outputType,
+      const std::string& expectedMessage) {
+    std::vector<RowVectorPtr> inputVectors = {
+        makeRowVector({"c0"}, {makeFlatVector<int64_t>({10, 20, 30})})};
+    auto dataFilePath = TempFilePath::create();
+    writeToFile(dataFilePath->getPath(), inputVectors);
+
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(outputType)
+                    .dataColumns(ROW({"c0"}, {BIGINT()}))
+                    .endTableScan()
+                    .planNode();
+
+    VELOX_ASSERT_THROW(
+        exec::test::AssertQueryBuilder(plan)
+            .splits({makeIcebergSplitWithInfoColumns(
+                dataFilePath->getPath(), infoColumns)})
+            .copyResults(pool()),
+        expectedMessage);
+  }
+
+  // Projecting _row_id is what makes the reader parse $first_row_id.
+  RowTypePtr rowLineageOutputType() const {
+    return ROW(
+        {"c0", IcebergMetadataColumn::kRowIdColumnName}, {BIGINT(), BIGINT()});
+  }
+
+  // Projecting $target_table_row_id is what makes the reader parse $spec_id.
+  RowTypePtr targetRowIdOutputType() const {
+    return ROW(
+        {"c0", IcebergMetadataColumn::kTargetTableRowIdColumnName},
+        {BIGINT(),
+         ROW({"file_path", "row_position", "spec_id", "partition_data"},
+             {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()})});
+  }
+};
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNonNumericFirstRowId) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "not-a-number"}},
+      rowLineageOutputType(),
+      "Invalid $first_row_id value in split info columns");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNegativeFirstRowId) {
+  // Parses cleanly but is out of range: row ids are file-absolute offsets.
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "-1"}},
+      rowLineageOutputType(),
+      "First row ID must be non-negative");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNonNumericDataSequenceNumber) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "0"},
+       {IcebergMetadataColumn::kDataSequenceNumberInfoColumn, "abc"}},
+      rowLineageOutputType(),
+      "Invalid $data_sequence_number value in split info columns");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNegativeDataSequenceNumber) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kFirstRowIdInfoColumn, "0"},
+       {IcebergMetadataColumn::kDataSequenceNumberInfoColumn, "-5"}},
+      rowLineageOutputType(),
+      "Data sequence number must be non-negative");
+}
+
+TEST_F(IcebergInfoColumnValidationTest, rejectsNonNumericSpecId) {
+  assertScanFails(
+      {{IcebergMetadataColumn::kSpecIdInfoColumn, "spec-seven"}},
+      targetRowIdOutputType(),
+      "Invalid $spec_id value in split info columns");
+}
+
 TEST_F(IcebergReadTest, flatMapAsStruct) {
   // Write a DWRF file with a MAP<BIGINT, DOUBLE> column.
   auto mapType = MAP(BIGINT(), DOUBLE());

--- a/velox/connectors/hive/tests/TableHandleTest.cpp
+++ b/velox/connectors/hive/tests/TableHandleTest.cpp
@@ -101,6 +101,40 @@ TEST(TableHandleTest, hiveTableHandleDbName) {
   ASSERT_TRUE(cloneNoDb->dbName().empty());
 }
 
+TEST(TableHandleTest, hiveTableHandleDataColumnFieldIds) {
+  Type::registerSerDe();
+  connector::hive::HiveTableHandle::registerSerDe();
+
+  const auto dataColumns = ROW({"a", "c"}, {BIGINT(), VARCHAR()});
+  const std::vector<int32_t> fieldIds{1, 3};
+  auto handle = std::make_shared<connector::hive::HiveTableHandle>(
+      "test-connector",
+      "test_table",
+      common::SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      dataColumns,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/
+      std::vector<connector::hive::HiveColumnHandlePtr>{},
+      /*sampleRate=*/1.0,
+      /*dbName=*/"",
+      fieldIds);
+
+  EXPECT_EQ(handle->dataColumnFieldIds(), fieldIds);
+
+  auto serialized = handle->serialize();
+  auto clone = ISerializable::deserialize<connector::hive::HiveTableHandle>(
+      serialized, /*context=*/nullptr);
+  EXPECT_EQ(clone->dataColumnFieldIds(), fieldIds);
+
+  serialized.erase("dataColumnFieldIds");
+  auto legacyClone =
+      ISerializable::deserialize<connector::hive::HiveTableHandle>(
+          serialized, /*context=*/nullptr);
+  EXPECT_TRUE(legacyClone->dataColumnFieldIds().empty());
+}
+
 TEST(TableHandleTest, hiveTableHandleIndexSupport) {
   // Test HiveTableHandle without index columns.
   auto tableHandleWithoutIndex =


### PR DESCRIPTION
Summary:
Resolve Iceberg equality-delete columns using stable schema field IDs instead of assuming IDs are one-based ordinals. Carry aligned top-level IDs through HiveTableHandle serialization, populate them from Prestissimo tableSchemaJson, and use them for DWRF/ORC reads including unprojected equality columns while preserving compatibility fallback behavior.

Also split Nimble parameterized tests into focused fixtures so non-legacy, cache-only, FSST, and metadata-reuse cases instantiate only supported configurations instead of skipping unsupported combinations at runtime.

Reviewed By: srsuryadev

Differential Revision: D115027212


