### PR TITLE
feat(fuzzer): Run TableEvolutionFuzzer query shapes against an existing file

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -16,10 +16,13 @@
 
 #include "velox/exec/tests/TableEvolutionFuzzer.h"
 #include "velox/common/config/Config.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/ReaderFactory.h"
 #include "velox/dwio/common/tests/utils/FilterGenerator.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/exec/Cursor.h"
@@ -52,6 +55,35 @@ DEFINE_bool(
     "aren't thrown and the process isn't killed in the process of cleaning "
     "up after failures. Therefore, results are not compared when this is "
     "enabled. Note that this option only works in debug builds.");
+
+DEFINE_int64(
+    input_file_max_bytes,
+    0,
+    "When reading an existing file, cap every scan to this many bytes from the "
+    "start of it. Zero reads the whole file. Both plans and the sample read get "
+    "the same range, so the comparison is unaffected.\n"
+    "This bounds work only as far as split granularity allows: a format that "
+    "takes a whole stripe whenever its start falls inside the range still reads "
+    "that entire stripe, so on a file with few large stripes it may reduce "
+    "nothing. Measured on one 588MB production Nimble file it did not.");
+
+DEFINE_int32(
+    input_file_query_shapes,
+    4,
+    "Number of query shapes run per call when reading an existing file. Kept "
+    "well below the count used for generated files: there is no expensive "
+    "write to amortize here, and a caller loops until its own deadline, so "
+    "this is the granularity at which that deadline can be honoured. Each "
+    "shape scans the whole file twice, which on a production file is not "
+    "cheap.");
+
+DEFINE_int32(
+    input_file_sample_rows,
+    100'000,
+    "When running query shapes against an existing file, the number of rows "
+    "read from it to generate subfield filters from. Only the values matter -- "
+    "the reference row set the generator narrows is discarded -- so a bounded "
+    "prefix keeps a large production file from being read whole.");
 
 DEFINE_int32(
     aggregation_pushdown_frequency,
@@ -943,6 +975,125 @@ void TableEvolutionFuzzer::run() {
   }
 }
 
+RowTypePtr TableEvolutionFuzzer::readInputFileSchema(
+    const InputFile& inputFile) const {
+  dwio::common::ReaderOptions readerOptions(config_.pool);
+  readerOptions.setFileFormat(inputFile.format);
+  auto uniqueReadFile = filesystems::getFileSystem(inputFile.path, nullptr)
+                            ->openFileForRead(inputFile.path);
+  std::shared_ptr<ReadFile> readFile{std::move(uniqueReadFile)};
+  auto input = std::make_unique<dwio::common::BufferedInput>(
+      readFile, readerOptions.memoryPool());
+  auto readerFactory = dwio::common::getReaderFactory(inputFile.format);
+  VELOX_CHECK_NOT_NULL(
+      readerFactory,
+      "No reader factory registered for the format of {}",
+      inputFile.path);
+  auto reader = readerFactory->createReader(std::move(input), readerOptions);
+  VELOX_CHECK_NOT_NULL(reader, "Could not open {}", inputFile.path);
+  return reader->rowType();
+}
+
+std::pair<std::vector<Split>, std::vector<Split>>
+TableEvolutionFuzzer::makeInputFileSplits(const InputFile& inputFile) const {
+  auto makeSplit = [&] { return Split(makeInputFileSplit(inputFile)); };
+  std::vector<Split> actualSplits;
+  std::vector<Split> expectedSplits;
+  actualSplits.push_back(makeSplit());
+  expectedSplits.push_back(makeSplit());
+  return {std::move(actualSplits), std::move(expectedSplits)};
+}
+
+std::shared_ptr<connector::hive::HiveConnectorSplit>
+TableEvolutionFuzzer::makeInputFileSplit(const InputFile& inputFile) const {
+  const uint64_t length = FLAGS_input_file_max_bytes > 0
+      ? static_cast<uint64_t>(FLAGS_input_file_max_bytes)
+      : std::numeric_limits<uint64_t>::max();
+  return std::make_shared<connector::hive::HiveConnectorSplit>(
+      connectorId(), inputFile.path, inputFile.format, /*start=*/0, length);
+}
+
+RowVectorPtr TableEvolutionFuzzer::readInputFileSample(
+    const InputFile& inputFile,
+    const RowTypePtr& schema,
+    int32_t maxRows) const {
+  CursorParameters params;
+  params.serialExecution = true;
+  params.planNode = PlanBuilder().tableScan(schema).planNode();
+
+  auto cursor = TaskCursor::create(params);
+  // Same range the plan scans use, so the values the filters are built from
+  // come from the rows those scans will actually see.
+  cursor->task()->addSplit("0", Split(makeInputFileSplit(inputFile)));
+  cursor->task()->noMoreSplits("0");
+
+  std::vector<RowVectorPtr> batches;
+  int32_t rows = 0;
+  while (rows < maxRows && cursor->moveNext()) {
+    auto batch = cursor->current();
+    rows += batch->size();
+    // Copy: the cursor reuses its output vector across calls.
+    batches.push_back(
+        std::static_pointer_cast<RowVector>(
+            BaseVector::copy(*batch, config_.pool)));
+  }
+  // Unconditional: stopping at maxRows leaves the task running, and cancelling
+  // one that already reached the end of its splits is a no-op.
+  cursor->task()->requestCancel().wait();
+
+  VELOX_CHECK(!batches.empty(), "Input file {} has no rows", inputFile.path);
+  return fuzzer::mergeRowVectors(batches, config_.pool);
+}
+
+void TableEvolutionFuzzer::runOnInputFile(const InputFile& inputFile) {
+  inputFile_ = &inputFile;
+  SCOPE_EXIT {
+    inputFile_ = nullptr;
+  };
+
+  const auto schema = readInputFileSchema(inputFile);
+  VELOX_CHECK_GT(
+      schema->size(), 0, "Input file {} has no columns", inputFile.path);
+  LOG(INFO) << "Input file " << inputFile.path << " schema "
+            << schema->toString();
+
+  const RowVectorPtr finalExpectedData =
+      readInputFileSample(inputFile, schema, FLAGS_input_file_sample_rows);
+
+  // One setup, matching the file: no evolution, no bucketing. Both plans then
+  // read the same splits and the comparison isolates the plan difference.
+  std::vector<Setup> testSetups{
+      Setup{schema, /*log2BucketCount=*/0, inputFile.format}};
+  const std::vector<column_index_t> bucketColumnIndices;
+
+  // Flatmap-as-struct reading needs the key sets the writer observed, which
+  // are only collected while writing. Left empty, so map columns are read as
+  // maps.
+  const folly::F14FastMap<int, folly::F14FastSet<std::string>>
+      globalMapColumnKeys;
+  const std::vector<int> globallyConsistentColumnIndexVector;
+
+  const fuzzer::ExpressionFuzzer::FuzzedExpressionData noRemainingFilters;
+  const std::unordered_map<std::string, std::string> noColumnNameMapping;
+  const std::vector<std::vector<RowVectorPtr>> noWriteResults;
+
+  auto executor = folly::getGlobalCPUExecutor();
+  for (int shape = 0; shape < FLAGS_input_file_query_shapes; ++shape) {
+    VLOG(1) << "Running query shape " << shape;
+    runQueryShape(
+        noWriteResults,
+        testSetups,
+        bucketColumnIndices,
+        finalExpectedData,
+        globalMapColumnKeys,
+        globallyConsistentColumnIndexVector,
+        /*shouldGenerateRemainingFilters=*/false,
+        noRemainingFilters,
+        noColumnNameMapping,
+        *executor);
+  }
+}
+
 void TableEvolutionFuzzer::runQueryShape(
     const std::vector<std::vector<RowVectorPtr>>& writeResults,
     const std::vector<Setup>& testSetups,
@@ -973,8 +1124,12 @@ void TableEvolutionFuzzer::runQueryShape(
     VLOG(1) << "selectedBucket=" << *selectedBucket;
   }
 
-  auto [actualSplits, expectedSplits] = createScanSplitsFromWriteResults(
-      writeResults, testSetups, bucketColumnIndices, selectedBucket);
+  // There are no write results to rebuild from when running against a file
+  // that was not written here; both plans read that one file.
+  auto [actualSplits, expectedSplits] = inputFile_ != nullptr
+      ? makeInputFileSplits(*inputFile_)
+      : createScanSplitsFromWriteResults(
+            writeResults, testSetups, bucketColumnIndices, selectedBucket);
 
   // Step 5: Setup scan tasks with filters and optional aggregation pushdown
   auto rowType = testSetups.back().schema;

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -30,6 +30,10 @@
 #include <unordered_set>
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
 
+namespace facebook::velox::connector::hive {
+struct HiveConnectorSplit;
+}
+
 namespace facebook::velox::exec::test {
 
 class TableEvolutionFuzzer {
@@ -120,6 +124,27 @@ class TableEvolutionFuzzer {
       const folly::F14FastSet<std::string>& droppedColumns);
 
   void run();
+
+  /// An already written file to run query shapes against, in place of one this
+  /// fuzzer generates and writes.
+  struct InputFile {
+    std::string path;
+    dwio::common::FileFormat format;
+  };
+
+  /// Runs the same query shapes as run(), but against 'inputFile'.
+  ///
+  /// The schema comes from the file, so there is nothing to evolve and no
+  /// write. Both the pushdown plan and the reference plan read that one file,
+  /// which narrows the comparison to the plan difference alone -- run() varies
+  /// the files as well, so a mismatch there does not say which axis caused it.
+  /// The flip side is that a decode bug returning the same wrong value to both
+  /// plans cannot be caught here.
+  ///
+  /// Remaining filters are not generated: the expression fuzzer invents columns
+  /// and relies on schema evolution to add them, which a fixed file schema
+  /// cannot accommodate.
+  void runOnInputFile(const InputFile& inputFile);
 
   virtual ~TableEvolutionFuzzer() = default;
 
@@ -266,8 +291,31 @@ class TableEvolutionFuzzer {
       const std::unordered_map<std::string, std::string>& columnNameMapping,
       folly::Executor& executor);
 
+  /// Opens 'inputFile' far enough to read its schema.
+  RowTypePtr readInputFileSchema(const InputFile& inputFile) const;
+
+  /// Scans up to 'maxRows' rows of 'inputFile' with no filters, for subfield
+  /// filter generation to pick bounds from. A bounded prefix is enough: the
+  /// generator narrows a reference row set as a byproduct and this consumer
+  /// discards it, so only the values that shape the filters matter.
+  RowVectorPtr readInputFileSample(
+      const InputFile& inputFile,
+      const RowTypePtr& schema,
+      int32_t maxRows) const;
+
+  /// One split over 'inputFile', honouring --input_file_max_bytes.
+  std::shared_ptr<connector::hive::HiveConnectorSplit> makeInputFileSplit(
+      const InputFile& inputFile) const;
+
+  /// Both plans read the same file, so the two split vectors are identical.
+  std::pair<std::vector<Split>, std::vector<Split>> makeInputFileSplits(
+      const InputFile& inputFile) const;
+
   const Config config_;
   VectorFuzzer vectorFuzzer_;
+  /// Set only for the duration of runOnInputFile, which makes runQueryShape
+  /// build its splits from the file rather than from write results.
+  const InputFile* inputFile_ = nullptr;
   unsigned currentSeed_;
   FuzzerGenerator rng_;
   /// Per-query-shape read-side connector session properties for the pushdown


### PR DESCRIPTION
Summary:
Adds `TableEvolutionFuzzer::runOnInputFile`, which runs the same query
shapes as `run()` against a file the fuzzer did not write, plus
`--input_file_path` / `--input_file_format` on the Nimble runner to reach
it.

This is the C++ half of running the fuzzer's query shapes over production
data in the validation service. The service samples a file and hands over
its path; nothing is generated and nothing is written.

**Why an existing file collapses the oracle, usefully.**
`createScanSplitsFromWriteResults` writes two files per evolution:
`writeResults[2*i]` in that setup's own schema, format and bucket count,
and `writeResults[2*i+1]` in the final schema. So `run()` normally differs
on two axes at once -- the files *and* the plan -- and a mismatch does not
say which caused it. With one setup the guard
`if (i < config_.evolutionCount - 1)` is false, expected falls back to the
same files as actual, and the comparison isolates the plan difference:

    actual:   TableScan(pushdown) -> [Aggregation]
    expected: TableScan -> Project -> [Aggregation]

The tradeoff is that both plans read the same bytes, so a decode bug
returning the same wrong value to both cannot be caught here. The
validation service's checksum stages cover that axis; this is
complementary to them, not a replacement.

**What it does.** Reads the schema from the file, scans a bounded prefix
(`--input_file_sample_rows`, default 100k) for subfield filter generation
to pick bounds from, builds one `Setup` matching the file, and runs the
usual `kQueryShapesPerFile` shapes. A bounded prefix is sound here because
the generator's narrowed reference row set is a byproduct this consumer
discards -- `hitRows` is written at `TableEvolutionFuzzer.cpp:467` and
never read -- so only the values that shape the filters matter.

**Deliberately out of scope for this diff**, both noted in the header:

- Remaining filters are off. The expression fuzzer invents columns and
  relies on schema evolution to add them, which a fixed file schema cannot
  accommodate. Generating them over the file's own columns is a follow-up.
- Flatmap-as-struct reading is off. It needs the key sets the writer
  observed, which are only collected while writing, so map columns are read
  as maps.

Reviewed By: xiaoxmeng

Differential Revision: D116018650


