### PR TITLE
refactor(memory): Use VELOX_MEM_LOG in Memory and MemoryArbitrator

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -190,7 +190,7 @@ MemoryManager::~MemoryManager() {
     if (checkUsageLeak_) {
       VELOX_FAIL(errMsg);
     } else {
-      LOG(ERROR) << errMsg;
+      VELOX_MEM_LOG(ERROR) << errMsg;
     }
   }
 }

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -81,9 +81,10 @@ class NoopArbitrator : public MemoryArbitrator {
   explicit NoopArbitrator(const Config& config) : MemoryArbitrator(config) {
     VELOX_CHECK(config.kind.empty());
     if (config_.capacity != kMaxMemory) {
-      LOG(WARNING) << "Query memory capacity["
-                   << succinctBytes(config_.capacity) << "] is set for "
-                   << kind() << " arbitrator which has no capacity enforcement";
+      VELOX_MEM_LOG(WARNING)
+          << "Query memory capacity[" << succinctBytes(config_.capacity)
+          << "] is set for " << kind()
+          << " arbitrator which has no capacity enforcement";
     }
   }
 
@@ -543,15 +544,17 @@ ScopedReclaimedBytesRecorder::~ScopedReclaimedBytesRecorder() {
   }
   const int64_t reservedBytesAfterReclaim = pool_->reservedBytes();
   if (reservedBytesAfterReclaim > reservedBytesBeforeReclaim_) {
-    LOG(ERROR) << "Unexpected reserved bytes growth from " << pool_->name()
-               << ", root pool: " << pool_->root()->name()
-               << " after memory reclaim from "
-               << succinctBytes(reservedBytesBeforeReclaim_) << " to "
-               << succinctBytes(reservedBytesAfterReclaim)
-               << ", used: " << succinctBytes(pool_->usedBytes())
-               << ", reservation: " << succinctBytes(pool_->reservedBytes())
-               << ", root pool reservation: "
-               << succinctBytes(pool_->root()->reservedBytes());
+    VELOX_MEM_LOG(ERROR) << "Unexpected reserved bytes growth from "
+                         << pool_->name()
+                         << ", root pool: " << pool_->root()->name()
+                         << " after memory reclaim from "
+                         << succinctBytes(reservedBytesBeforeReclaim_) << " to "
+                         << succinctBytes(reservedBytesAfterReclaim)
+                         << ", used: " << succinctBytes(pool_->usedBytes())
+                         << ", reservation: "
+                         << succinctBytes(pool_->reservedBytes())
+                         << ", root pool reservation: "
+                         << succinctBytes(pool_->root()->reservedBytes());
   }
   *reclaimedBytes_ = reservedBytesBeforeReclaim_ - reservedBytesAfterReclaim;
 }


### PR DESCRIPTION
Both files are part of the memory subsystem, whose logs carry the "[MEM] "
prefix, but they still call glog's `LOG()` directly instead of `VELOX_MEM_LOG()`.
Filtering memory logs by "[MEM]" therefore silently drops their output.

Log message text is unchanged.