### PR TITLE
fix(memory): Make the global arbitration thread name fully visible

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -355,7 +355,11 @@ void SharedArbitrator::setupGlobalArbitration(
                              ",", globalArbitrationSpillCapacityLimits_);
 
   globalArbitrationController_ = std::make_unique<std::thread>([&]() {
-    folly::setThreadName("GlobalArbitrationController");
+    // Thread names are truncated to 15 characters (Linux TASK_COMM_LEN - 1),
+    // so keep this name short enough to stay fully visible in top and pstack.
+    static constexpr std::string_view kThreadName{"ArbitrationMain"};
+    static_assert(kThreadName.size() <= 15);
+    folly::setThreadName(kThreadName);
     globalArbitrationMain();
   });
 }


### PR DESCRIPTION
In `top -H` and `pstack`, the global arbitration thread appeared as
`"GlobalArbitrati"`. Linux stores a thread name in 16 bytes including the
terminator (`TASK_COMM_LEN`), leaving 15 usable characters. The name it was
given was 27 characters long, so the tail was cut mid-word and `Controller`
never showed up. The loss was silent: the kernel rejects a too-long name
with `ERANGE`, but folly trims to the limit before calling
`pthread_setname_np` and reports success.

Name it `"ArbitrationMain"` instead, which fits in 15 characters and points
at the `globalArbitrationMain()` loop the thread runs. A `static_assert` on
the name length now breaks the build if a later rename exceeds the limit.