### PR TITLE
fix(cudf): Resolve filter columns to physical names

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -77,7 +77,7 @@ const std::string& resolvePhysicalColumnName(
   return it == physicalColumnNames.end() ? name : it->second;
 }
 
-// Resolves a physical column name against the logical table schema.
+// Resolves a physical column name into its index
 uint32_t resolveColumnIndex(const RowType& rowType, const std::string& name) {
   if (const auto childIndex = rowType.getChildIdxIfExists(name)) {
     return *childIndex;

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -37,10 +37,57 @@
 
 #include <cudf/stream_compaction.hpp>
 
+#include <folly/String.h>
+
 namespace facebook::velox::cudf_velox::connector::hive {
 
 using namespace facebook::velox::connector;
 using namespace facebook::velox::connector::hive;
+
+namespace {
+
+using PhysicalColumnNames = std::unordered_map<std::string, std::string>;
+
+// Builds a lookup from normalized logical names to physical file names.
+PhysicalColumnNames makePhysicalColumnNames(
+    const ColumnHandleMap& columnHandles,
+    const std::vector<HiveColumnHandlePtr>& filterColumnHandles) {
+  PhysicalColumnNames physicalColumnNames;
+  for (const auto& [logicalName, columnHandle] : columnHandles) {
+    auto* handle = static_cast<const HiveColumnHandle*>(columnHandle.get());
+    auto normalizedName = logicalName;
+    folly::toLowerAscii(normalizedName);
+    physicalColumnNames.emplace(std::move(normalizedName), handle->name());
+  }
+  for (const auto& handle : filterColumnHandles) {
+    auto normalizedName = handle->name();
+    folly::toLowerAscii(normalizedName);
+    physicalColumnNames.emplace(std::move(normalizedName), handle->name());
+  }
+  return physicalColumnNames;
+}
+
+// Resolves a logical column name to its physical file name.
+const std::string& resolvePhysicalColumnName(
+    const PhysicalColumnNames& physicalColumnNames,
+    const std::string& name) {
+  auto normalizedName = name;
+  folly::toLowerAscii(normalizedName);
+  const auto it = physicalColumnNames.find(normalizedName);
+  return it == physicalColumnNames.end() ? name : it->second;
+}
+
+// Resolves a physical column name against the logical table schema.
+uint32_t resolveColumnIndex(const RowType& rowType, const std::string& name) {
+  if (const auto childIndex = rowType.getChildIdxIfExists(name)) {
+    return *childIndex;
+  }
+  auto normalizedName = name;
+  folly::toLowerAscii(normalizedName);
+  return rowType.getChildIdx(normalizedName);
+}
+
+} // namespace
 
 CudfHiveDataSource::CudfHiveDataSource(
     const RowTypePtr& outputType,
@@ -61,6 +108,16 @@ CudfHiveDataSource::CudfHiveDataSource(
       outputType_(outputType),
       pool_(connectorQueryCtx->memoryPool()),
       expressionEvaluator_(connectorQueryCtx->expressionEvaluator()) {
+  tableHandle_ =
+      std::dynamic_pointer_cast<const hive::HiveTableHandle>(tableHandle);
+  VELOX_CHECK_NOT_NULL(
+      tableHandle_, "TableHandle must be an instance of HiveTableHandle");
+
+  // Presto logical names are lowercase, while Hive handles preserve the
+  // physical Parquet column names.
+  const auto physicalColumnNames = makePhysicalColumnNames(
+      columnHandles, tableHandle_->hiveFilterColumnHandles());
+
   // Set up column projection if needed
   auto readColumnTypes = outputType_->children();
   for (const auto& outputName : outputType_->names()) {
@@ -74,11 +131,6 @@ CudfHiveDataSource::CudfHiveDataSource(
     readColumnSet_.emplace(handle->name());
     readColumnNames_.emplace_back(handle->name());
   }
-
-  tableHandle_ =
-      std::dynamic_pointer_cast<const hive::HiveTableHandle>(tableHandle);
-  VELOX_CHECK_NOT_NULL(
-      tableHandle_, "TableHandle must be an instance of HiveTableHandle");
 
   // Copy subfield filters.
   for (const auto& [k, v] : tableHandle_->subfieldFilters()) {
@@ -98,9 +150,10 @@ CudfHiveDataSource::CudfHiveDataSource(
 
   // Add fields in the filter to the columns to read if not there
   for (const auto& [field, _] : subfieldFilters_) {
-    if (readColumnSet_.count(field.toString()) == 0) {
-      readColumnSet_.emplace(field.toString());
-      readColumnNames_.emplace_back(field.toString());
+    const auto& physicalName =
+        resolvePhysicalColumnName(physicalColumnNames, getColumnName(field));
+    if (readColumnSet_.emplace(physicalName).second) {
+      readColumnNames_.emplace_back(physicalName);
     }
   }
   // Optimize (rewrites + constant folding) the remaining filter before
@@ -123,9 +176,10 @@ CudfHiveDataSource::CudfHiveDataSource(
     // they reference. Read-column order does not affect results: the data
     // source projects its output to the requested output type.
     for (const auto& name : referencedInputFields(optimizedRemainingFilter_)) {
-      if (readColumnSet_.count(name) == 0) {
-        readColumnSet_.emplace(name);
-        readColumnNames_.emplace_back(name);
+      const auto& physicalName =
+          resolvePhysicalColumnName(physicalColumnNames, name);
+      if (readColumnSet_.emplace(physicalName).second) {
+        readColumnNames_.emplace_back(physicalName);
       }
     }
 
@@ -331,9 +385,10 @@ const RowTypePtr CudfHiveDataSource::getTableRowType() {
     std::vector<std::string> names;
     std::vector<TypePtr> types;
     for (const auto& name : readColumnNames_) {
-      auto parsedType = tableHandle_->dataColumns()->findChild(name);
-      names.emplace_back(std::move(name));
-      types.push_back(parsedType);
+      const auto childIndex =
+          resolveColumnIndex(*tableHandle_->dataColumns(), name);
+      names.emplace_back(tableHandle_->dataColumns()->nameOf(childIndex));
+      types.push_back(tableHandle_->dataColumns()->childAt(childIndex));
     }
     cachedTableRowType_ = ROW(std::move(names), std::move(types));
     return cachedTableRowType_;

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -553,6 +553,60 @@ TEST_F(TableScanTest, filterPushdown) {
 #endif
 }
 
+TEST_F(TableScanTest, mixedCasePhysicalColumnNames) {
+  auto vector = makeRowVector(
+      {"Filter_Col", "Value_Col"},
+      {makeFlatVector<std::string>({"a", "b", "c", "d"}),
+       makeFlatVector<std::string>({"a", "b", "c", "d"})});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), {vector});
+  createDuckDbTable({vector});
+
+  common::SubfieldFilters subfieldFilters =
+      common::test::SubfieldFiltersBuilder()
+          .add(
+              "filter_col",
+              std::make_unique<common::BytesRange>(
+                  "b",
+                  /*lowerUnbounded*/ false,
+                  /*lowerExclusive*/ false,
+                  "",
+                  /*upperUnbounded*/ true,
+                  /*upperExclusive*/ false,
+                  /*nullAllowed*/ false))
+          .build();
+  auto logicalRowType =
+      ROW({"filter_col", "value_col"}, {VARCHAR(), VARCHAR()});
+  auto filterColumnHandle =
+      facebook::velox::exec::test::HiveConnectorTestBase::regularColumn(
+          "Filter_Col", VARCHAR());
+  auto tableHandle =
+      std::make_shared<facebook::velox::connector::hive::HiveTableHandle>(
+          kCudfHiveConnectorId,
+          "parquet_table",
+          std::move(subfieldFilters),
+          nullptr,
+          logicalRowType,
+          std::vector<std::string>{},
+          std::unordered_map<std::string, std::string>{},
+          std::vector<facebook::velox::connector::hive::HiveColumnHandlePtr>{
+              filterColumnHandle});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(ROW({}, {}))
+                  .tableHandle(tableHandle)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .singleAggregation({}, {"sum(1)"})
+                  .planNode();
+
+  assertQuery(
+      plan, {filePath}, "SELECT count(*) FROM tmp WHERE Filter_Col >= 'b'");
+}
+
 // Disable this test and the one below for now, pending a CUDF fix.
 // simoneves 2/25/26
 // @TODO simoneves/mattgara re-enable once fixed.


### PR DESCRIPTION
Fixes #18447

Adds a previously-failing testcase in which we have an underlying file with mixed-case column names and a pushdown-able filter that is unable to resolve those column names.

This change moves the HiveCudfDataSource to resolve and normalize the logical column names in filters.
