### PR TITLE
fix(presto-serializer): Deserialize nested OPAQUE columns (#18532)

### DIFF
--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -248,6 +248,9 @@ void readStructNullsColumns(
           {TypeKind::TIMESTAMP, &readStructNulls<Timestamp>},
           {TypeKind::VARCHAR, &readStructNulls<StringView>},
           {TypeKind::VARBINARY, &readStructNulls<StringView>},
+          // Opaque values are serialized as strings, so the column uses the
+          // same VARIABLE_WIDTH framing as VARCHAR and VARBINARY.
+          {TypeKind::OPAQUE, &readStructNulls<StringView>},
           {TypeKind::ARRAY, &readArrayVectorStructNulls},
           {TypeKind::MAP, &readMapVectorStructNulls},
           {TypeKind::ROW, &readRowVectorStructNulls},

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1593,6 +1593,36 @@ TEST_P(PrestoSerializerTest, opaqueBatchVectorSerializer) {
   assertEqualVectors(inputRowVector, deserialized);
 }
 
+TEST_P(PrestoSerializerTest, opaqueNestedInRowBatchVectorSerializer) {
+  OpaqueType::registerSerialization<Foo>(
+      "Foo", Foo::serialize, Foo::deserialize);
+  auto opaqueVector = makeFlatVector<std::shared_ptr<void>>(
+      3,
+      [](vector_size_t row) { return Foo::create(row + 10); },
+      [](vector_size_t row) { return row == 1; },
+      OPAQUE<Foo>());
+  // Nesting the opaque column inside an inner row makes deserialization run the
+  // struct-nulls pass, which dispatches through a reader table separate from
+  // the one used to read values. The null inner row is omitted from the child
+  // by the serializer, so deserialization has to restore the gap.
+  auto innerRow = makeRowVector({opaqueVector});
+  innerRow->setNull(0, true);
+  auto inputRowVector = makeRowVector({innerRow});
+  auto rowType = asRowType(inputRowVector->type());
+
+  for (const bool nullsFirst : {false, true}) {
+    SCOPED_TRACE(fmt::format("nullsFirst: {}", nullsFirst));
+    serializer::presto::PrestoVectorSerde::PrestoOptions serdeOptions;
+    serdeOptions.nullsFirst = nullsFirst;
+
+    std::ostringstream out;
+    serializeBatch(inputRowVector, &out, &serdeOptions);
+
+    auto deserialized = deserialize(rowType, out.str(), &serdeOptions);
+    assertEqualVectors(inputRowVector, deserialized);
+  }
+}
+
 TEST_P(PrestoSerializerTest, opaqueInteractiveVectorSerializer) {
   OpaqueType::registerSerialization<Foo>(
       "Foo", Foo::serialize, Foo::deserialize);


### PR DESCRIPTION
Summary:

Deserializing a row that nests an OPAQUE column inside another row throws:

    Column reader for type OPAQUE is missing

The Presto deserializer keeps two type-keyed reader tables: one to read values, and one for the struct-nulls pass that restores rows the serializer omitted under a null parent. OPAQUE was registered in the first table only. Opaque values are written as strings, so `readStructNulls<StringView>` already skips the exact layout `read<OpaqueType>` consumes, and registering it there is enough.

The struct-nulls pass only runs when `nullsFirst` is false and the row has a nested struct. The existing opaque tests place the opaque column directly under the top-level row, so the pass never ran and the gap went unnoticed. This only widens support: the path threw unconditionally before, so no working deserialization changes behaviour.

Reviewed By: kagamiori

Differential Revision: D116382713


