### PR TITLE
refactor(hive): Add PartitionValue::toString for partition naming (#18533)

### DIFF
--- a/velox/connectors/hive/HivePartitionName.cpp
+++ b/velox/connectors/hive/HivePartitionName.cpp
@@ -16,8 +16,8 @@
 
 #include "velox/connectors/hive/HivePartitionName.h"
 #include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/PartitionValue.h"
 #include "velox/dwio/catalog/fbhive/FileUtils.h"
-#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -25,61 +25,31 @@ using namespace facebook::velox::dwio::catalog::fbhive;
 
 namespace {
 
-template <typename T>
-std::string formatDecimal(T value, const TypePtr& type) {
-  const auto& [p, s] = getDecimalPrecisionScale(*type);
-  const auto& maxSize = DecimalUtil::maxStringViewSize(p, s);
-  std::string buffer(maxSize, '\0');
-  const auto& actualSize =
-      DecimalUtil::castToString(value, s, maxSize, buffer.data());
-  buffer.resize(actualSize);
-  return buffer;
+// The writer names every partition in the default timezone, with ISO dates.
+std::string toPartitionString(const Variant& value, const TypePtr& type) {
+  return PartitionValue::toString(
+      value,
+      *type,
+      PartitionValue::TimestampMode::kLocalTime,
+      PartitionValue::DateMode::kIsoString);
 }
 
 } // namespace
 
 std::string HivePartitionName::toName(int32_t value, const TypePtr& type) {
-  if (type->isDate()) {
-    return DateType::toIso8601(value);
-  }
-  return fmt::to_string(value);
+  return toPartitionString(Variant(value), type);
 }
 
 std::string HivePartitionName::toName(int64_t value, const TypePtr& type) {
-  if (type->isShortDecimal()) {
-    return formatDecimal(value, type);
-  }
-  return fmt::to_string(value);
+  return toPartitionString(Variant(value), type);
 }
 
 std::string HivePartitionName::toName(int128_t value, const TypePtr& type) {
-  if (type->isLongDecimal()) {
-    return formatDecimal(value, type);
-  }
-  return fmt::to_string(value);
+  return toPartitionString(Variant(value), type);
 }
 
 std::string HivePartitionName::toName(Timestamp value, const TypePtr& type) {
-  value.toTimezone(Timestamp::defaultTimezone());
-  TimestampToStringOptions options;
-  options.dateTimeSeparator = ' ';
-  // Set the precision to milliseconds, and enable the skipTrailingZeros match
-  // the timestamp precision and truncation behavior of Presto.
-  options.precision = TimestampPrecision::kMilliseconds;
-  options.skipTrailingZeros = true;
-
-  auto result = value.toString(options);
-
-  // Presto's java.sql.Timestamp.toString() always keeps at least one decimal
-  // place even when all fractional seconds are zero.
-  // If skipTrailingZeros removed all fractional digits, add back ".0" to match
-  // Presto's behavior.
-  if (auto dotPos = result.find_last_of('.'); dotPos == std::string::npos) {
-    // No decimal point found, add ".0"
-    result += ".0";
-  }
-
-  return result;
+  return toPartitionString(Variant(value), type);
 }
 
 std::string HivePartitionName::partitionName(

--- a/velox/connectors/hive/HivePartitionName.h
+++ b/velox/connectors/hive/HivePartitionName.h
@@ -48,11 +48,9 @@ class HivePartitionName {
   /// instead of raw integer value.
   static std::string toName(int128_t value, const TypePtr& type);
 
-  /// Format Timestamp partition values. Specialized to:
-  /// 1. Convert to default timezone
-  /// 2. Use space as date-time separator (not 'T')
-  /// 3. Use millisecond precision with trailing zeros skipped
-  /// 4. Always keep at least ".0" for fractional seconds (Presto compatibility)
+  /// Format Timestamp partition values. Rendered by PartitionValue::toString,
+  /// which shifts a plain TIMESTAMP to the default timezone and leaves a
+  /// TIMESTAMP_UTC as it stands.
   static std::string toName(Timestamp value, const TypePtr& type);
 
   /// Build partition key-value pairs from partition values.

--- a/velox/connectors/hive/PartitionValue.cpp
+++ b/velox/connectors/hive/PartitionValue.cpp
@@ -28,6 +28,68 @@
 namespace facebook::velox::connector::hive {
 namespace {
 
+template <typename T>
+std::string formatDecimal(T value, const Type& type) {
+  const auto [precision, scale] = getDecimalPrecisionScale(type);
+  const auto maxSize = DecimalUtil::maxStringViewSize(precision, scale);
+  std::string buffer(maxSize, '\0');
+  buffer.resize(
+      DecimalUtil::castToString(value, scale, maxSize, buffer.data()));
+  return buffer;
+}
+
+std::string timestampToString(Timestamp value) {
+  static const TimestampToStringOptions kOptions{
+      .precision = TimestampPrecision::kMilliseconds,
+      .skipTrailingZeros = true,
+      .dateTimeSeparator = ' ',
+  };
+  auto result = value.toString(kOptions);
+  // Presto's java.sql.Timestamp.toString() always keeps one decimal place, so
+  // a whole second is named "...:56.0" and must be matched as such.
+  if (result.find_last_of('.') == std::string::npos) {
+    result += ".0";
+  }
+  return result;
+}
+
+template <TypeKind kind>
+std::string toStringImpl(
+    const Variant& value,
+    const Type& type,
+    PartitionValue::TimestampMode timestampMode,
+    PartitionValue::DateMode dateMode) {
+  using NativeType = typename TypeTraits<kind>::NativeType;
+
+  if (type.isDate()) {
+    const auto days = value.value<TypeKind::INTEGER>();
+    return dateMode == PartitionValue::DateMode::kDaysSinceEpoch
+        ? fmt::to_string(days)
+        : DateType::toIso8601(days);
+  }
+
+  if constexpr (
+      std::is_same_v<NativeType, int64_t> ||
+      std::is_same_v<NativeType, int128_t>) {
+    if (type.isDecimal()) {
+      return formatDecimal(value.value<kind>(), type);
+    }
+  }
+
+  if constexpr (std::is_same_v<NativeType, StringView>) {
+    return value.value<kind>();
+  } else if constexpr (kind == TypeKind::TIMESTAMP) {
+    auto timestamp = value.value<TypeKind::TIMESTAMP>();
+    if (type.equivalent(*TIMESTAMP()) &&
+        timestampMode == PartitionValue::TimestampMode::kLocalTime) {
+      timestamp.toTimezone(Timestamp::defaultTimezone());
+    }
+    return timestampToString(timestamp);
+  } else {
+    return fmt::to_string(value.value<kind>());
+  }
+}
+
 template <TypeKind kind>
 Variant fromStringImpl(
     std::string_view value,
@@ -73,6 +135,17 @@ Variant fromStringImpl(
 }
 
 } // namespace
+
+// static
+std::string PartitionValue::toString(
+    const Variant& value,
+    const Type& type,
+    TimestampMode timestampMode,
+    DateMode dateMode) {
+  VELOX_USER_CHECK(!value.isNull(), "A null partition value has no string");
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      toStringImpl, type.kind(), value, type, timestampMode, dateMode);
+}
 
 // static
 Variant PartitionValue::fromString(

--- a/velox/connectors/hive/PartitionValue.h
+++ b/velox/connectors/hive/PartitionValue.h
@@ -50,6 +50,17 @@ class PartitionValue {
     kDaysSinceEpoch,
   };
 
+  /// Converts 'value' to the text a partition is named with. 'value' must be
+  /// non-null. A TIMESTAMP is rendered with millisecond precision, trailing
+  /// zeros dropped, and at least one fractional digit, as Presto's
+  /// java.sql.Timestamp.toString() does. A TIMESTAMP_UTC is never shifted; a
+  /// plain TIMESTAMP follows 'timestampMode', and a DATE follows 'dateMode'.
+  static std::string toString(
+      const Variant& value,
+      const Type& type,
+      TimestampMode timestampMode,
+      DateMode dateMode);
+
   /// 'value' must be non-null. Accepted input per type:
   /// - BOOLEAN: t, f, 1, 0, true or false, case-insensitively.
   /// - TINYINT, SMALLINT, INTEGER, BIGINT: an integer, range-checked against

--- a/velox/connectors/hive/tests/HivePartitionNameTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionNameTest.cpp
@@ -175,6 +175,33 @@ TEST_F(HivePartitionNameTest, partitionNameForNull) {
   }
 }
 
+TEST_F(HivePartitionNameTest, shortDecimalPartitionValueFormatting) {
+  RowVectorPtr input = makeRowVector(
+      {"short_decimal_col"},
+      {makeFlatVector<int64_t>(std::vector<int64_t>{1234}, DECIMAL(10, 2))});
+
+  std::vector<column_index_t> partitionChannels{0};
+  EXPECT_EQ(
+      FileUtils::makePartName(
+          extractPartitionKeyValues(input, partitionChannels), true),
+      "short_decimal_col=12.34");
+}
+
+// A TIMESTAMP_UTC column reaches this path, and unlike a plain TIMESTAMP it is
+// named as it stands rather than in the default timezone.
+TEST_F(HivePartitionNameTest, timestampUtcPartitionValueIsNotShifted) {
+  RowVectorPtr input = makeRowVector(
+      {"ts"},
+      {makeFlatVector<Timestamp>(
+          std::vector<Timestamp>{Timestamp(0, 0)}, TIMESTAMP_UTC())});
+
+  std::vector<column_index_t> partitionChannels{0};
+  EXPECT_EQ(
+      FileUtils::makePartName(
+          extractPartitionKeyValues(input, partitionChannels), true),
+      "ts=1970-01-01 00%3A00%3A00.0");
+}
+
 TEST_F(HivePartitionNameTest, timestampPartitionValueFormatting) {
   // Test timestamp partition value formatting to match Presto's
   // java.sql.Timestamp.toString() behavior: removes trailing zeros but keeps at

--- a/velox/connectors/hive/tests/PartitionValueTest.cpp
+++ b/velox/connectors/hive/tests/PartitionValueTest.cpp
@@ -112,6 +112,89 @@ TEST(PartitionValueTest, timestampModes) {
       unshifted);
 }
 
+std::string toPartitionString(
+    const Variant& value,
+    const TypePtr& type,
+    TimestampMode timestampMode = TimestampMode::kUtc,
+    DateMode dateMode = DateMode::kIsoString) {
+  return PartitionValue::toString(value, *type, timestampMode, dateMode);
+}
+
+// A whole second is named with one fractional digit, so a filter matching a
+// partition has to render it the same way.
+TEST(PartitionValueTest, toStringNamesPartitions) {
+  const auto wholeSecond = parseTimestamp("2020-01-01 12:34:56");
+  EXPECT_EQ(
+      toPartitionString(Variant(wholeSecond), TIMESTAMP()),
+      "2020-01-01 12:34:56.0");
+  EXPECT_EQ(
+      toPartitionString(
+          Variant(parseTimestamp("2020-01-01 12:34:56.123")), TIMESTAMP()),
+      "2020-01-01 12:34:56.123");
+
+  EXPECT_EQ(toPartitionString(Variant(18'263), DATE()), "2020-01-02");
+  EXPECT_EQ(
+      toPartitionString(
+          Variant(18'263),
+          DATE(),
+          TimestampMode::kUtc,
+          DateMode::kDaysSinceEpoch),
+      "18263");
+
+  EXPECT_EQ(
+      toPartitionString(Variant(int64_t{1'234}), DECIMAL(10, 2)), "12.34");
+  EXPECT_EQ(toPartitionString(Variant(true), BOOLEAN()), "true");
+  EXPECT_EQ(toPartitionString(Variant(std::string("us")), VARCHAR()), "us");
+}
+
+// Shifting a TIMESTAMP_UTC, as naming a plain TIMESTAMP does, would not
+// survive fromString(), which leaves this type unshifted.
+TEST(PartitionValueTest, toStringLeavesTimestampUtcUnshifted) {
+  const auto timestamp = parseTimestamp("2020-01-01 12:34:56");
+  EXPECT_EQ(
+      PartitionValue::toString(
+          Variant(timestamp),
+          *TIMESTAMP_UTC(),
+          TimestampMode::kLocalTime,
+          DateMode::kIsoString),
+      "2020-01-01 12:34:56.0");
+  EXPECT_EQ(
+      toVariant(
+          "2020-01-01 12:34:56", TIMESTAMP_UTC(), TimestampMode::kLocalTime)
+          .value<TypeKind::TIMESTAMP>(),
+      timestamp);
+}
+
+TEST(PartitionValueTest, toStringRejectsNull) {
+  VELOX_ASSERT_USER_THROW(
+      toPartitionString(Variant::null(TypeKind::BIGINT), BIGINT()),
+      "A null partition value has no string");
+}
+
+TEST(PartitionValueTest, namingRoundTripsForEveryType) {
+  const std::vector<std::pair<Variant, TypePtr>> cases{
+      {Variant(true), BOOLEAN()},
+      {Variant(int8_t{-1}), TINYINT()},
+      {Variant(int16_t{-2}), SMALLINT()},
+      {Variant(int32_t{-3}), INTEGER()},
+      {Variant(int64_t{-4}), BIGINT()},
+      {Variant(1.25f), REAL()},
+      {Variant(2.5), DOUBLE()},
+      {Variant(std::string("us")), VARCHAR()},
+      {Variant(18'263), DATE()},
+      {Variant(int64_t{1'234}), DECIMAL(10, 2)},
+      {Variant(HugeInt::parse("1234567890123456789012")), DECIMAL(25, 2)},
+      {Variant(parseTimestamp("2020-01-01 12:34:56")), TIMESTAMP()},
+      {Variant(parseTimestamp("2020-01-01 12:34:56.123")), TIMESTAMP()},
+  };
+
+  for (const auto& [value, type] : cases) {
+    const auto named = PartitionValue::toString(
+        value, *type, TimestampMode::kUtc, DateMode::kIsoString);
+    EXPECT_EQ(toVariant(named, type), value) << "for " << type->toString();
+  }
+}
+
 TEST(PartitionValueTest, filterOnConvertedValue) {
   const common::BigintRange bigintRange(10, 20, /*nullAllowed=*/false);
   EXPECT_TRUE(applyFilter(bigintRange, toVariant("15", BIGINT())));


### PR DESCRIPTION
Summary:

The Metastore identifies a partition by the text it was named with, so a query filtering on a partition column has to reproduce that text exactly. The code that names partitions and the code that builds partition filters must therefore agree on how a typed value becomes a string.

`HivePartitionName::toName` was the only definition of that conversion, and it was shaped for the writer: it always converts a TIMESTAMP to the default timezone. A reader building a filter has to honor the interpretation the value already carries, so it could not reuse `toName` and had to reimplement the formatting instead, leaving a copy free to drift from the original.

This adds `PartitionValue::toString`, the counterpart to the existing `fromString`, taking the same `TimestampMode` and `DateMode` so a caller chooses the interpretation rather than inheriting the writer's. The formatting moves out of `HivePartitionName.cpp` into `PartitionValue.cpp`: decimal scaling, DATE rendering as either an ISO string or a day count, and timestamp rendering at millisecond precision with trailing zeros dropped and one fractional digit kept. All four `toName` overloads now delegate through a single helper. The generic template that formats the remaining types is unchanged.

Naming itself is unchanged except for `TIMESTAMP_UTC`, which is no longer shifted to the default timezone. `toName` shifted it unconditionally while `fromString` does not undo that, so such a partition could not be matched by its own name.

Differential Revision: D116108773


