### PR TITLE
feat(spark): Add encode function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -115,17 +115,21 @@ String Functions
 
     Encodes the first argument into a binary using the provided ``charset``.
     Supported charsets (case-insensitive) are ``US-ASCII``, ``ISO-8859-1``,
-    ``UTF-8``, ``UTF-16BE``, ``UTF-16LE``, and ``UTF-16``. Common Java aliases
-    such as ``UTF8``, ``ASCII``, and ``LATIN1`` are also accepted. Throws an
-    exception when ``charset`` is not supported. When encoding to a single-byte
-    charset (``US-ASCII`` or ``ISO-8859-1``), characters outside the charset's
-    range are replaced with ``?``. ``UTF-16`` prepends a byte-order mark and
-    emits big-endian data. Malformed UTF-8 in ``string`` is normalized to the
-    replacement character ``U+FFFD`` before encoding. ::
+    ``UTF-8``, ``UTF-16BE``, ``UTF-16LE``, ``UTF-16``, and ``UTF-32``. Throws
+    an exception when ``charset`` is not supported or a character cannot be
+    represented by the selected charset. When ``spark.legacy_java_charsets`` is
+    enabled, additional Java-compatible charsets and aliases such as
+    ``windows-1252``, ``Shift_JIS``, ``UTF8``, and ``LATIN1`` are also
+    accepted. When ``spark.legacy_coding_error_action`` is enabled, unmappable
+    characters are replaced with ``?``. ``UTF-16`` prepends a big-endian
+    byte-order mark; ``UTF-32`` emits big-endian data without a byte-order mark.
+    Malformed UTF-8 in ``string`` is normalized to the replacement character
+    ``U+FFFD`` before encoding. ::
 
         SELECT encode('Spark SQL', 'UTF-8'); -- [53 70 61 72 6B 20 53 51 4C]
         SELECT encode('A', 'UTF-16BE'); -- [00 41]
         SELECT encode('A', 'UTF-16LE'); -- [41 00]
+        SELECT encode('A', 'UTF-32'); -- [00 00 00 41]
 
 .. spark:function:: endswith(left, right) -> boolean
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -111,6 +111,22 @@ String Functions
         SELECT empty2null(''); -- NULL
         SELECT empty2null('abc'); -- 'abc'
 
+.. spark:function:: encode(string, charset) -> varbinary
+
+    Encodes the first argument into a binary using the provided ``charset``.
+    Supported charsets (case-insensitive) are ``US-ASCII``, ``ISO-8859-1``,
+    ``UTF-8``, ``UTF-16BE``, ``UTF-16LE``, and ``UTF-16``. Common Java aliases
+    such as ``UTF8``, ``ASCII``, and ``LATIN1`` are also accepted. Throws an
+    exception when ``charset`` is not supported. When encoding to a single-byte
+    charset (``US-ASCII`` or ``ISO-8859-1``), characters outside the charset's
+    range are replaced with ``?``. ``UTF-16`` prepends a byte-order mark and
+    emits big-endian data. Malformed UTF-8 in ``string`` is normalized to the
+    replacement character ``U+FFFD`` before encoding. ::
+
+        SELECT encode('Spark SQL', 'UTF-8'); -- [53 70 61 72 6B 20 53 51 4C]
+        SELECT encode('A', 'UTF-16BE'); -- [00 41]
+        SELECT encode('A', 'UTF-16LE'); -- [41 00]
+
 .. spark:function:: endswith(left, right) -> boolean
 
     Returns true if 'left' ends with 'right'. Otherwise, returns false. ::

--- a/velox/functions/lib/Utf8Utils.cpp
+++ b/velox/functions/lib/Utf8Utils.cpp
@@ -202,6 +202,23 @@ tryGetUtf8CharLength(const char* input, int64_t size, int32_t& codePoint) {
   return -1;
 }
 
+int32_t decodeUtf8CodePointOrReplacement(
+    const char* input,
+    int64_t size,
+    int32_t& codePoint) {
+  const auto charLength = tryGetUtf8CharLength(input, size, codePoint);
+  if (charLength > 0) {
+    return charLength;
+  }
+
+  codePoint = 0xFFFD;
+  const auto invalidLength = -charLength;
+  if (invalidLength >= 2 && isMultipleInvalidSequences(input, 0)) {
+    return 1;
+  }
+  return invalidLength;
+}
+
 size_t replaceInvalidUTF8Characters(
     char* outputBuffer,
     const char* input,
@@ -222,15 +239,16 @@ size_t replaceInvalidUTF8Characters(
         outputIndex += charLength;
         inputIndex += charLength;
       } else {
+        const auto bytesConsumed = decodeUtf8CodePointOrReplacement(
+            input + inputIndex, len - inputIndex, codePoint);
         const auto& replacementCharacterString =
-            getInvalidUTF8ReplacementString(
-                input + inputIndex, len - inputIndex, -charLength);
+            kReplacementCharacterStrings[0];
         std::memcpy(
             outputBuffer + outputIndex,
             replacementCharacterString.data(),
             replacementCharacterString.size());
         outputIndex += replacementCharacterString.size();
-        inputIndex += -charLength;
+        inputIndex += bytesConsumed;
       }
     }
   }

--- a/velox/functions/lib/Utf8Utils.h
+++ b/velox/functions/lib/Utf8Utils.h
@@ -57,6 +57,14 @@ namespace facebook::velox::functions {
 int32_t
 tryGetUtf8CharLength(const char* input, int64_t size, int32_t& codePoint);
 
+/// Decodes the next UTF-8 code point, replacing malformed input with U+FFFD
+/// using Java's malformed-input grouping. Returns the number of input bytes
+/// consumed and always sets codePoint.
+int32_t decodeUtf8CodePointOrReplacement(
+    const char* input,
+    int64_t size,
+    int32_t& codePoint);
+
 /// Return the length in byte of the next UTF-8 encoded character at the
 /// beginning of `string`. If the beginning of `string` is not valid UTF-8
 /// encoding, return -1.

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -74,6 +74,7 @@ velox_add_library(
   DecimalArithmetic.h
   DecimalCeil.h
   DecimalUtil.h
+  EncodeFunction.h
   Factorial.h
   FormatNumber.h
   GetJsonObject.h

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -37,6 +37,7 @@ velox_add_library(
   DecimalArithmetic.cpp
   DecimalCeil.cpp
   DecimalCompare.cpp
+  EncodeFunction.cpp
   FilterFunction.cpp
   FormatNumber.cpp
   GetJsonObject.cpp
@@ -116,6 +117,7 @@ velox_link_libraries(
   velox_functions_spark_specialforms
   velox_functions_util
   Folly::folly
+  ICU::uc
   simdjson::simdjson
 )
 

--- a/velox/functions/sparksql/EncodeFunction.cpp
+++ b/velox/functions/sparksql/EncodeFunction.cpp
@@ -135,8 +135,10 @@ Status unmappableCharacter(const StringView& charset) {
 // Charset.forName, so Spark rejects them. Compare against ICU's canonical name
 // to catch every alias that maps to one of these converters.
 bool isJavaUnsupportedCharset(const char* canonicalName) {
+  // Entries must be upper case: equalsIgnoreCase upper-cases the candidate and
+  // compares it against these literals verbatim.
   static constexpr std::string_view kIcuOnlyCharsets[] = {
-      "UTF-7", "IMAP-mailbox-name", "BOCU-1", "SCSU"};
+      "UTF-7", "IMAP-MAILBOX-NAME", "BOCU-1", "SCSU"};
   const StringView name{canonicalName};
   for (const auto& unsupported : kIcuOnlyCharsets) {
     if (equalsIgnoreCase(name, unsupported)) {

--- a/velox/functions/sparksql/EncodeFunction.cpp
+++ b/velox/functions/sparksql/EncodeFunction.cpp
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/EncodeFunction.h"
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <unicode/ucnv.h>
+#include <unicode/ucnv_err.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/functions/lib/Utf8Utils.h"
+
+namespace facebook::velox::functions::sparksql::detail {
+namespace {
+
+constexpr char32_t kReplacementCodePoint = 0xFFFD;
+
+bool equalsIgnoreCase(const StringView& value, std::string_view expected) {
+  if (value.size() != expected.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < value.size(); ++i) {
+    const auto character = value.data()[i];
+    const auto upperCharacter = character >= 'a' && character <= 'z'
+        ? static_cast<char>(character - ('a' - 'A'))
+        : character;
+    if (upperCharacter != expected[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+size_t decodeCodePoint(
+    const char* input,
+    size_t inputSize,
+    size_t position,
+    char32_t& codePoint) {
+  int32_t decodedCodePoint;
+  const auto bytesConsumed = decodeUtf8CodePointOrReplacement(
+      input + position, inputSize - position, decodedCodePoint);
+  codePoint = static_cast<char32_t>(decodedCodePoint);
+  return bytesConsumed;
+}
+
+size_t utf8Length(char32_t codePoint) {
+  if (codePoint <= 0x7F) {
+    return 1;
+  }
+  if (codePoint <= 0x7FF) {
+    return 2;
+  }
+  if (codePoint <= 0xFFFF) {
+    return 3;
+  }
+  return 4;
+}
+
+size_t writeUtf8(char32_t codePoint, char* output) {
+  if (codePoint <= 0x7F) {
+    output[0] = static_cast<char>(codePoint);
+    return 1;
+  }
+  if (codePoint <= 0x7FF) {
+    output[0] = static_cast<char>(0xC0 | (codePoint >> 6));
+    output[1] = static_cast<char>(0x80 | (codePoint & 0x3F));
+    return 2;
+  }
+  if (codePoint <= 0xFFFF) {
+    output[0] = static_cast<char>(0xE0 | (codePoint >> 12));
+    output[1] = static_cast<char>(0x80 | ((codePoint >> 6) & 0x3F));
+    output[2] = static_cast<char>(0x80 | (codePoint & 0x3F));
+    return 3;
+  }
+  output[0] = static_cast<char>(0xF0 | (codePoint >> 18));
+  output[1] = static_cast<char>(0x80 | ((codePoint >> 12) & 0x3F));
+  output[2] = static_cast<char>(0x80 | ((codePoint >> 6) & 0x3F));
+  output[3] = static_cast<char>(0x80 | (codePoint & 0x3F));
+  return 4;
+}
+
+size_t writeUtf16(char32_t codePoint, char* output, bool bigEndian) {
+  auto writeUnit = [&](char16_t unit, char* destination) {
+    if (bigEndian) {
+      destination[0] = static_cast<char>((unit >> 8) & 0xFF);
+      destination[1] = static_cast<char>(unit & 0xFF);
+    } else {
+      destination[0] = static_cast<char>(unit & 0xFF);
+      destination[1] = static_cast<char>((unit >> 8) & 0xFF);
+    }
+  };
+
+  if (codePoint <= 0xFFFF) {
+    writeUnit(static_cast<char16_t>(codePoint), output);
+    return 2;
+  }
+  const auto adjusted = codePoint - 0x10000;
+  writeUnit(static_cast<char16_t>(0xD800 + (adjusted >> 10)), output);
+  writeUnit(static_cast<char16_t>(0xDC00 + (adjusted & 0x3FF)), output + 2);
+  return 4;
+}
+
+void writeUtf32(char32_t codePoint, char* output, bool bigEndian) {
+  for (size_t i = 0; i < 4; ++i) {
+    const auto shift = bigEndian ? 24 - 8 * i : 8 * i;
+    output[i] = static_cast<char>((codePoint >> shift) & 0xFF);
+  }
+}
+
+Status unmappableCharacter(const StringView& charset) {
+  return Status::UserError(
+      "encode: input contains a character that cannot be encoded using '{}'",
+      std::string(charset.data(), charset.size()));
+}
+
+// ICU recognizes several encodings that the JDK does not expose through
+// Charset.forName, so Spark rejects them. Compare against ICU's canonical name
+// to catch every alias that maps to one of these converters.
+bool isJavaUnsupportedCharset(const char* canonicalName) {
+  static constexpr std::string_view kIcuOnlyCharsets[] = {
+      "UTF-7", "IMAP-mailbox-name", "BOCU-1", "SCSU"};
+  const StringView name{canonicalName};
+  for (const auto& unsupported : kIcuOnlyCharsets) {
+    if (equalsIgnoreCase(name, unsupported)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<UChar> toUtf16(const StringView& input) {
+  std::vector<UChar> utf16;
+  utf16.reserve(input.size());
+  size_t inputPosition{0};
+  while (inputPosition < input.size()) {
+    char32_t codePoint;
+    inputPosition +=
+        decodeCodePoint(input.data(), input.size(), inputPosition, codePoint);
+    if (codePoint <= 0xFFFF) {
+      utf16.push_back(static_cast<UChar>(codePoint));
+    } else {
+      const auto adjusted = codePoint - 0x10000;
+      utf16.push_back(static_cast<UChar>(0xD800 + (adjusted >> 10)));
+      utf16.push_back(static_cast<UChar>(0xDC00 + (adjusted & 0x3FF)));
+    }
+  }
+  return utf16;
+}
+
+Status encodeLegacy(
+    exec::StringWriter& result,
+    const StringView& input,
+    const StringView& charset,
+    bool replaceUnmappable) {
+  if (input.empty()) {
+    result.resize(0);
+    return Status::OK();
+  }
+
+  const std::string charsetName{charset.data(), charset.size()};
+  UErrorCode error{U_ZERO_ERROR};
+  std::unique_ptr<UConverter, decltype(&ucnv_close)> converter{
+      ucnv_open(charsetName.c_str(), &error), &ucnv_close};
+  // resolveCharset() already validated that the charset opens, but a
+  // user-provided name must never trigger a fatal check here, so degrade
+  // gracefully to a catchable user error.
+  if (U_FAILURE(error)) {
+    return Status::UserError("encode: unsupported charset '{}'", charsetName);
+  }
+
+  if (replaceUnmappable) {
+    error = U_ZERO_ERROR;
+    ucnv_setFromUCallBack(
+        converter.get(),
+        UCNV_FROM_U_CALLBACK_SUBSTITUTE,
+        nullptr,
+        nullptr,
+        nullptr,
+        &error);
+    // Spark/Java replace unmappable characters with '?' by default, so use the
+    // same substitution byte. Charsets whose minimum unit is larger than one
+    // byte (e.g. UTF-16/UTF-32 variants reachable only through legacy aliases)
+    // reject a single-byte substitution; because those charsets can represent
+    // every code point, substitution never occurs, so the failure is ignored
+    // rather than treated as fatal.
+    UErrorCode substError{U_ZERO_ERROR};
+    ucnv_setSubstChars(converter.get(), "?", 1, &substError);
+  } else {
+    error = U_ZERO_ERROR;
+    ucnv_setFromUCallBack(
+        converter.get(),
+        UCNV_FROM_U_CALLBACK_STOP,
+        nullptr,
+        nullptr,
+        nullptr,
+        &error);
+  }
+
+  const auto utf16 = toUtf16(input);
+  const auto* utf16Data = utf16.empty() ? nullptr : utf16.data();
+  error = U_ZERO_ERROR;
+  const auto outputSize = ucnv_fromUChars(
+      converter.get(),
+      nullptr,
+      0,
+      utf16Data,
+      static_cast<int32_t>(utf16.size()),
+      &error);
+  if (error != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(error)) {
+    return unmappableCharacter(charset);
+  }
+
+  result.resize(outputSize);
+  if (outputSize == 0) {
+    return Status::OK();
+  }
+  error = U_ZERO_ERROR;
+  ucnv_resetFromUnicode(converter.get());
+  const auto bytesWritten = ucnv_fromUChars(
+      converter.get(),
+      result.data(),
+      outputSize,
+      utf16Data,
+      static_cast<int32_t>(utf16.size()),
+      &error);
+  if (U_FAILURE(error)) {
+    return unmappableCharacter(charset);
+  }
+  VELOX_CHECK_EQ(bytesWritten, outputSize);
+  return Status::OK();
+}
+
+Status encodeUtf8(exec::StringWriter& result, const StringView& input) {
+  size_t outputSize{0};
+  size_t position{0};
+  bool isValid{true};
+  while (position < input.size()) {
+    char32_t codePoint;
+    const auto bytesConsumed =
+        decodeCodePoint(input.data(), input.size(), position, codePoint);
+    if (codePoint == kReplacementCodePoint &&
+        !(bytesConsumed == 3 &&
+          static_cast<unsigned char>(input.data()[position]) == 0xEF &&
+          static_cast<unsigned char>(input.data()[position + 1]) == 0xBF &&
+          static_cast<unsigned char>(input.data()[position + 2]) == 0xBD)) {
+      isValid = false;
+    }
+    outputSize += utf8Length(codePoint);
+    position += bytesConsumed;
+  }
+
+  result.resize(outputSize);
+  if (isValid) {
+    std::memcpy(result.data(), input.data(), input.size());
+    return Status::OK();
+  }
+
+  position = 0;
+  size_t outputPosition{0};
+  while (position < input.size()) {
+    char32_t codePoint;
+    const auto bytesConsumed =
+        decodeCodePoint(input.data(), input.size(), position, codePoint);
+    outputPosition += writeUtf8(codePoint, result.data() + outputPosition);
+    position += bytesConsumed;
+  }
+  return Status::OK();
+}
+
+Status encodeSingleByte(
+    exec::StringWriter& result,
+    const StringView& input,
+    const StringView& charset,
+    char32_t limit,
+    bool replaceUnmappable) {
+  result.resize(input.size());
+  size_t inputPosition{0};
+  size_t outputPosition{0};
+  while (inputPosition < input.size()) {
+    char32_t codePoint;
+    inputPosition +=
+        decodeCodePoint(input.data(), input.size(), inputPosition, codePoint);
+    if (codePoint >= limit) {
+      if (!replaceUnmappable) {
+        return unmappableCharacter(charset);
+      }
+      codePoint = '?';
+    }
+    result.data()[outputPosition++] = static_cast<char>(codePoint);
+  }
+  result.resize(outputPosition);
+  return Status::OK();
+}
+
+Status encodeUtf16(
+    exec::StringWriter& result,
+    const StringView& input,
+    bool bigEndian,
+    bool includeBom) {
+  if (input.empty()) {
+    result.resize(0);
+    return Status::OK();
+  }
+  size_t outputSize{includeBom ? 2u : 0u};
+  size_t position{0};
+  while (position < input.size()) {
+    char32_t codePoint;
+    position +=
+        decodeCodePoint(input.data(), input.size(), position, codePoint);
+    outputSize += codePoint <= 0xFFFF ? 2 : 4;
+  }
+  result.resize(outputSize);
+  size_t outputPosition{0};
+  if (includeBom) {
+    result.data()[outputPosition++] =
+        static_cast<char>(bigEndian ? 0xFE : 0xFF);
+    result.data()[outputPosition++] =
+        static_cast<char>(bigEndian ? 0xFF : 0xFE);
+  }
+  size_t inputPosition{0};
+  while (inputPosition < input.size()) {
+    char32_t codePoint;
+    inputPosition +=
+        decodeCodePoint(input.data(), input.size(), inputPosition, codePoint);
+    outputPosition +=
+        writeUtf16(codePoint, result.data() + outputPosition, bigEndian);
+  }
+  return Status::OK();
+}
+
+Status encodeUtf32(
+    exec::StringWriter& result,
+    const StringView& input,
+    bool bigEndian) {
+  size_t numCodePoints{0};
+  size_t inputPosition{0};
+  while (inputPosition < input.size()) {
+    char32_t codePoint;
+    inputPosition +=
+        decodeCodePoint(input.data(), input.size(), inputPosition, codePoint);
+    ++numCodePoints;
+  }
+  result.resize(numCodePoints * 4);
+  inputPosition = 0;
+  size_t outputPosition{0};
+  while (inputPosition < input.size()) {
+    char32_t codePoint;
+    inputPosition +=
+        decodeCodePoint(input.data(), input.size(), inputPosition, codePoint);
+    writeUtf32(codePoint, result.data() + outputPosition, bigEndian);
+    outputPosition += 4;
+  }
+  return Status::OK();
+}
+
+} // namespace
+
+CharsetType resolveCharset(const StringView& charset, bool legacyJavaCharsets) {
+  if (equalsIgnoreCase(charset, "UTF-8")) {
+    return CharsetType::kUtf8;
+  }
+  if (equalsIgnoreCase(charset, "US-ASCII")) {
+    return CharsetType::kUsAscii;
+  }
+  if (equalsIgnoreCase(charset, "ISO-8859-1")) {
+    return CharsetType::kIso8859_1;
+  }
+  if (equalsIgnoreCase(charset, "UTF-16")) {
+    return CharsetType::kUtf16;
+  }
+  if (equalsIgnoreCase(charset, "UTF-16BE")) {
+    return CharsetType::kUtf16BE;
+  }
+  if (equalsIgnoreCase(charset, "UTF-16LE")) {
+    return CharsetType::kUtf16LE;
+  }
+  if (equalsIgnoreCase(charset, "UTF-32")) {
+    return CharsetType::kUtf32;
+  }
+  if (!legacyJavaCharsets) {
+    return CharsetType::kUnsupported;
+  }
+
+  if (equalsIgnoreCase(charset, "UTF8")) {
+    return CharsetType::kUtf8;
+  }
+  if (equalsIgnoreCase(charset, "ASCII") ||
+      equalsIgnoreCase(charset, "US_ASCII")) {
+    return CharsetType::kUsAscii;
+  }
+  if (equalsIgnoreCase(charset, "LATIN1") ||
+      equalsIgnoreCase(charset, "ISO8859_1") ||
+      equalsIgnoreCase(charset, "ISO_8859_1") ||
+      equalsIgnoreCase(charset, "ISO8859-1")) {
+    return CharsetType::kIso8859_1;
+  }
+  if (equalsIgnoreCase(charset, "UTF16") ||
+      equalsIgnoreCase(charset, "UNICODEBIG")) {
+    return CharsetType::kUtf16;
+  }
+  if (equalsIgnoreCase(charset, "UTF16BE") ||
+      equalsIgnoreCase(charset, "UNICODEBIGUNMARKED")) {
+    return CharsetType::kUtf16BE;
+  }
+  if (equalsIgnoreCase(charset, "UTF16LE") ||
+      equalsIgnoreCase(charset, "UNICODELITTLEUNMARKED")) {
+    return CharsetType::kUtf16LE;
+  }
+  if (equalsIgnoreCase(charset, "UNICODELITTLE")) {
+    return CharsetType::kUtf16LEWithBom;
+  }
+  if (equalsIgnoreCase(charset, "UTF-32BE") ||
+      equalsIgnoreCase(charset, "UTF32BE")) {
+    return CharsetType::kUtf32BE;
+  }
+  if (equalsIgnoreCase(charset, "UTF-32LE") ||
+      equalsIgnoreCase(charset, "UTF32LE")) {
+    return CharsetType::kUtf32LE;
+  }
+
+  UErrorCode error{U_ZERO_ERROR};
+  const std::string charsetName{charset.data(), charset.size()};
+  // Java's Charset.forName rejects names containing a NUL, whereas passing the
+  // name through c_str() below would silently truncate at the first NUL and
+  // resolve a different charset.
+  if (charsetName.find('\0') != std::string::npos) {
+    return CharsetType::kUnsupported;
+  }
+  std::unique_ptr<UConverter, decltype(&ucnv_close)> converter{
+      ucnv_open(charsetName.c_str(), &error), &ucnv_close};
+  if (U_FAILURE(error)) {
+    return CharsetType::kUnsupported;
+  }
+  UErrorCode nameError{U_ZERO_ERROR};
+  const char* canonicalName = ucnv_getName(converter.get(), &nameError);
+  if (U_FAILURE(nameError) || canonicalName == nullptr ||
+      isJavaUnsupportedCharset(canonicalName)) {
+    return CharsetType::kUnsupported;
+  }
+  return CharsetType::kLegacy;
+}
+
+Status encode(
+    exec::StringWriter& result,
+    const StringView& input,
+    const StringView& charset,
+    CharsetType type,
+    bool legacyCodingErrorAction) {
+  switch (type) {
+    case CharsetType::kUtf8:
+      return encodeUtf8(result, input);
+    case CharsetType::kUsAscii:
+      return encodeSingleByte(
+          result, input, charset, 0x80, legacyCodingErrorAction);
+    case CharsetType::kIso8859_1:
+      return encodeSingleByte(
+          result, input, charset, 0x100, legacyCodingErrorAction);
+    case CharsetType::kUtf16:
+      return encodeUtf16(result, input, true, true);
+    case CharsetType::kUtf16BE:
+      return encodeUtf16(result, input, true, false);
+    case CharsetType::kUtf16LE:
+      return encodeUtf16(result, input, false, false);
+    case CharsetType::kUtf16LEWithBom:
+      return encodeUtf16(result, input, false, true);
+    case CharsetType::kUtf32:
+    case CharsetType::kUtf32BE:
+      return encodeUtf32(result, input, true);
+    case CharsetType::kUtf32LE:
+      return encodeUtf32(result, input, false);
+    case CharsetType::kLegacy:
+      return encodeLegacy(result, input, charset, legacyCodingErrorAction);
+    case CharsetType::kUnsupported:
+      VELOX_UNREACHABLE();
+  }
+  VELOX_UNREACHABLE();
+}
+
+} // namespace facebook::velox::functions::sparksql::detail

--- a/velox/functions/sparksql/EncodeFunction.h
+++ b/velox/functions/sparksql/EncodeFunction.h
@@ -1,0 +1,478 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include <folly/Likely.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Status.h"
+#include "velox/functions/Macros.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::functions::sparksql {
+
+namespace detail {
+
+enum class CharsetType : uint8_t {
+  kUtf8,
+  kUsAscii,
+  kIso8859_1,
+  kUtf16, // BOM (0xFE 0xFF) + big-endian data (Java "UTF-16" / "UnicodeBig")
+  kUtf16BE, // Big-endian without BOM (Java "UTF-16BE" / "UnicodeBigUnmarked")
+  kUtf16LE, // Little-endian without BOM (Java "UTF-16LE" /
+            // "UnicodeLittleUnmarked")
+  kUtf16LEWithBom, // BOM (0xFF 0xFE) + little-endian data (Java
+                   // "UnicodeLittle")
+  kUnsupported,
+};
+
+/// Resolves a charset name to a CharsetType enum. Supports canonical IANA names
+/// and common Java aliases (case-insensitive) to match Spark/Java's
+/// Charset.forName() behavior.
+/// Uses a stack buffer to avoid heap allocations on hot paths.
+inline CharsetType resolveCharset(const char* data, size_t length) {
+  // The longest name that can match is "UNICODELITTLEUNMARKED" (21 chars);
+  // kMaxCharsetLen (24) leaves a little headroom and bounds the stack buffer.
+  // Names longer than kMaxCharsetLen cannot match any candidate, so reject
+  // early.
+  static constexpr size_t kMaxCharsetLen = 24;
+  if (length == 0 || length > kMaxCharsetLen) {
+    return CharsetType::kUnsupported;
+  }
+
+  char upperName[kMaxCharsetLen];
+  for (size_t i = 0; i < length; ++i) {
+    // ASCII-only uppercasing: charset names are ASCII, and a locale-sensitive
+    // std::toupper could mis-map bytes (e.g. under a Turkish locale) and break
+    // matching.
+    const char c = data[i];
+    upperName[i] =
+        (c >= 'a' && c <= 'z') ? static_cast<char>(c - ('a' - 'A')) : c;
+  }
+
+  // Use a StringView-like comparison without heap allocation.
+  auto eq = [&](const char* candidate, size_t candidateLen) {
+    return length == candidateLen &&
+        std::memcmp(upperName, candidate, candidateLen) == 0;
+  };
+
+  // Length-based dispatch to reduce comparisons on the hot path.
+  switch (length) {
+    case 4:
+      if (eq("UTF8", 4))
+        return CharsetType::kUtf8;
+      break;
+    case 5:
+      if (eq("UTF-8", 5))
+        return CharsetType::kUtf8;
+      if (eq("ASCII", 5))
+        return CharsetType::kUsAscii;
+      if (eq("UTF16", 5))
+        return CharsetType::kUtf16;
+      break;
+    case 6:
+      if (eq("UTF-16", 6))
+        return CharsetType::kUtf16;
+      if (eq("LATIN1", 6))
+        return CharsetType::kIso8859_1;
+      break;
+    case 7:
+      if (eq("UTF16BE", 7))
+        return CharsetType::kUtf16BE;
+      if (eq("UTF16LE", 7))
+        return CharsetType::kUtf16LE;
+      break;
+    case 8:
+      if (eq("US-ASCII", 8))
+        return CharsetType::kUsAscii;
+      if (eq("US_ASCII", 8))
+        return CharsetType::kUsAscii;
+      if (eq("UTF-16BE", 8))
+        return CharsetType::kUtf16BE;
+      if (eq("UTF-16LE", 8))
+        return CharsetType::kUtf16LE;
+      break;
+    case 9:
+      if (eq("ISO8859_1", 9))
+        return CharsetType::kIso8859_1;
+      if (eq("ISO8859-1", 9))
+        return CharsetType::kIso8859_1;
+      break;
+    case 10:
+      if (eq("ISO-8859-1", 10))
+        return CharsetType::kIso8859_1;
+      if (eq("ISO_8859_1", 10))
+        return CharsetType::kIso8859_1;
+      if (eq("UNICODEBIG", 10))
+        return CharsetType::kUtf16; // BOM + big-endian (matches Java
+                                    // UnicodeBig)
+      break;
+    case 13:
+      if (eq("UNICODELITTLE", 13))
+        return CharsetType::kUtf16LEWithBom; // BOM + little-endian (matches
+                                             // Java UnicodeLittle)
+      break;
+    case 18:
+      if (eq("UNICODEBIGUNMARKED", 18))
+        return CharsetType::kUtf16BE;
+      break;
+    case 21:
+      if (eq("UNICODELITTLEUNMARKED", 21))
+        return CharsetType::kUtf16LE;
+      break;
+    default:
+      break;
+  }
+  return CharsetType::kUnsupported;
+}
+
+/// Decodes the next UTF-8 codepoint from 'data' at position 'pos'.
+/// Advances 'pos' past the consumed bytes. Returns U+FFFD on invalid
+/// sequences. Note: Velox VARCHAR may contain malformed UTF-8; invalid
+/// sequences are replaced with U+FFFD, which then flows into the charset
+/// encoder (a Velox-specific behavior since Java Strings are always valid).
+inline char32_t
+decodeUtf8Codepoint(const char* data, size_t length, size_t& pos) {
+  auto byte = static_cast<unsigned char>(data[pos]);
+  char32_t codePoint;
+  size_t extraBytes;
+
+  if (FOLLY_LIKELY(byte < 0x80)) {
+    ++pos;
+    return static_cast<char32_t>(byte);
+  } else if ((byte & 0xE0) == 0xC0) {
+    codePoint = byte & 0x1F;
+    extraBytes = 1;
+  } else if ((byte & 0xF0) == 0xE0) {
+    codePoint = byte & 0x0F;
+    extraBytes = 2;
+  } else if ((byte & 0xF8) == 0xF0) {
+    codePoint = byte & 0x07;
+    extraBytes = 3;
+  } else {
+    ++pos;
+    return 0xFFFD;
+  }
+
+  if (pos + 1 + extraBytes > length) {
+    pos = length;
+    return 0xFFFD;
+  }
+
+  for (size_t i = 0; i < extraBytes; ++i) {
+    auto continuation = static_cast<unsigned char>(data[pos + 1 + i]);
+    if ((continuation & 0xC0) != 0x80) {
+      pos += 1 + i;
+      return 0xFFFD;
+    }
+    codePoint = (codePoint << 6) | (continuation & 0x3F);
+  }
+  pos += 1 + extraBytes;
+
+  // Reject overlong encodings, surrogate code points, and values > U+10FFFF.
+  if ((extraBytes == 1 && codePoint < 0x80) ||
+      (extraBytes == 2 && codePoint < 0x800) ||
+      (extraBytes == 3 && codePoint < 0x10000) ||
+      (codePoint >= 0xD800 && codePoint <= 0xDFFF) || codePoint > 0x10FFFF) {
+    return 0xFFFD;
+  }
+  return codePoint;
+}
+
+/// Writes a UTF-16BE encoding of 'codePoint' to 'output'. codePoint must be a
+/// valid Unicode scalar value (<= U+10FFFF, not a surrogate). Returns the
+/// number of bytes written (2 for BMP, 4 for supplementary).
+inline size_t writeUtf16BE(char32_t codePoint, char* output) {
+  if (codePoint <= 0xFFFF) {
+    output[0] = static_cast<char>((codePoint >> 8) & 0xFF);
+    output[1] = static_cast<char>(codePoint & 0xFF);
+    return 2;
+  }
+  char32_t adjusted = codePoint - 0x10000;
+  char32_t highSurrogate = 0xD800 + (adjusted >> 10);
+  char32_t lowSurrogate = 0xDC00 + (adjusted & 0x3FF);
+  output[0] = static_cast<char>((highSurrogate >> 8) & 0xFF);
+  output[1] = static_cast<char>(highSurrogate & 0xFF);
+  output[2] = static_cast<char>((lowSurrogate >> 8) & 0xFF);
+  output[3] = static_cast<char>(lowSurrogate & 0xFF);
+  return 4;
+}
+
+/// Writes a UTF-16LE encoding of 'codePoint' to 'output'. codePoint must be a
+/// valid Unicode scalar value (<= U+10FFFF, not a surrogate). Returns the
+/// number of bytes written (2 for BMP, 4 for supplementary).
+inline size_t writeUtf16LE(char32_t codePoint, char* output) {
+  if (codePoint <= 0xFFFF) {
+    output[0] = static_cast<char>(codePoint & 0xFF);
+    output[1] = static_cast<char>((codePoint >> 8) & 0xFF);
+    return 2;
+  }
+  char32_t adjusted = codePoint - 0x10000;
+  char32_t highSurrogate = 0xD800 + (adjusted >> 10);
+  char32_t lowSurrogate = 0xDC00 + (adjusted & 0x3FF);
+  output[0] = static_cast<char>(highSurrogate & 0xFF);
+  output[1] = static_cast<char>((highSurrogate >> 8) & 0xFF);
+  output[2] = static_cast<char>(lowSurrogate & 0xFF);
+  output[3] = static_cast<char>((lowSurrogate >> 8) & 0xFF);
+  return 4;
+}
+
+} // namespace detail
+
+/// Spark-compatible encode function. Converts a VARCHAR (UTF-8) to VARBINARY
+/// using the specified charset.
+/// Supported charsets (case-insensitive): US-ASCII, ISO-8859-1, UTF-8,
+/// UTF-16BE, UTF-16LE, UTF-16. Common Java aliases (e.g. UTF8, ASCII, LATIN1)
+/// are also accepted.
+template <typename T>
+struct EncodeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Varchar>* /*input*/,
+      const arg_type<Varchar>* charset) {
+    if (charset != nullptr) {
+      // Resolve the constant charset once. An unsupported charset is not
+      // rejected here: the error is deferred to call() so that a constant and
+      // a per-row charset behave identically and both are catchable by TRY.
+      charsetType_ = detail::resolveCharset(charset->data(), charset->size());
+      isConstantCharset_ = true;
+    }
+  }
+
+  Status call(
+      out_type<Varbinary>& result,
+      const arg_type<Varchar>& input,
+      const arg_type<Varchar>& charset) {
+    auto type = charsetType_;
+    if (!isConstantCharset_) {
+      // Non-constant charset path: resolve per row.
+      type = detail::resolveCharset(charset.data(), charset.size());
+    }
+    if (type == detail::CharsetType::kUnsupported) {
+      return Status::UserError(
+          "encode: unsupported charset '{}'",
+          std::string(charset.data(), charset.size()));
+    }
+
+    const char* inputData = input.data();
+    const size_t inputSize = input.size();
+
+    // UTF-8: normalize the input by decoding and re-encoding. This replaces
+    // any malformed UTF-8 sequences with U+FFFD (3 bytes each), matching
+    // Spark/Java behavior where the input String is always valid.
+    if (type == detail::CharsetType::kUtf8) {
+      return encodeUtf8(result, inputData, inputSize);
+    }
+
+    // All charsets return empty bytes for empty input, matching Spark's
+    // Encode.encode() which returns input.getBytes (empty) before the encoder
+    // runs.
+    if (inputSize == 0) {
+      result.resize(0);
+      return Status::OK();
+    }
+
+    // UTF-16 with BOM: emit the 2-byte BOM (0xFE 0xFF) followed by
+    // big-endian data, matching Java's String.getBytes("UTF-16").
+    if (type == detail::CharsetType::kUtf16) {
+      return encodeUtf16WithBom(result, inputData, inputSize);
+    }
+
+    // UTF-16LE with BOM: emit the 2-byte BOM (0xFF 0xFE) followed by
+    // little-endian data, matching Java's UnicodeLittle charset.
+    if (type == detail::CharsetType::kUtf16LEWithBom) {
+      return encodeUtf16LEWithBom(result, inputData, inputSize);
+    }
+
+    switch (type) {
+      case detail::CharsetType::kUtf16BE:
+        return encodeUtf16Impl(
+            result, inputData, inputSize, /*bigEndian=*/true);
+      case detail::CharsetType::kUtf16LE:
+        return encodeUtf16Impl(
+            result, inputData, inputSize, /*bigEndian=*/false);
+      case detail::CharsetType::kUsAscii:
+        return encodeSingleByte(result, inputData, inputSize, 0x80);
+      case detail::CharsetType::kIso8859_1:
+        return encodeSingleByte(result, inputData, inputSize, 0x100);
+      default:
+        // kUtf8, kUtf16, kUtf16LEWithBom, and kUnsupported are all handled
+        // before this switch, so no other charset type can reach here.
+        VELOX_UNREACHABLE(
+            "encode: charset type {} should have been handled earlier",
+            static_cast<int>(type));
+    }
+  }
+
+ private:
+  detail::CharsetType charsetType_ = detail::CharsetType::kUnsupported;
+  bool isConstantCharset_ = false;
+
+  /// Encodes to UTF-8 by decoding and re-encoding. Replaces malformed UTF-8
+  /// sequences with U+FFFD (0xEF 0xBF 0xBD). For valid UTF-8 input (the common
+  /// case), the output is identical to the input.
+  static Status encodeUtf8(
+      out_type<Varbinary>& result,
+      const char* inputData,
+      size_t inputSize) {
+    if (inputSize == 0) {
+      result.resize(0);
+      return Status::OK();
+    }
+    // Fast path: if the entire input is ASCII, it's guaranteed valid UTF-8
+    // and the output is identical to the input. Avoids per-character decode.
+    bool allAscii = true;
+    for (size_t i = 0; i < inputSize; ++i) {
+      if (FOLLY_UNLIKELY(static_cast<unsigned char>(inputData[i]) >= 0x80)) {
+        allAscii = false;
+        break;
+      }
+    }
+    if (allAscii) {
+      result.resize(inputSize);
+      std::memcpy(result.data(), inputData, inputSize);
+      return Status::OK();
+    }
+    // Worst case: every byte is invalid → each becomes 3-byte U+FFFD.
+    result.resize(inputSize * 3);
+    char* dest = result.data();
+    size_t writePos = 0;
+    size_t readPos = 0;
+    while (readPos < inputSize) {
+      size_t startPos = readPos;
+      char32_t codePoint =
+          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
+      if (codePoint == 0xFFFD &&
+          (readPos - startPos != 3 ||
+           static_cast<unsigned char>(inputData[startPos]) != 0xEF)) {
+        // Invalid sequence was replaced — emit U+FFFD in UTF-8.
+        dest[writePos++] = static_cast<char>(0xEF);
+        dest[writePos++] = static_cast<char>(0xBF);
+        dest[writePos++] = static_cast<char>(0xBD);
+      } else {
+        // Valid sequence — copy original bytes.
+        std::memcpy(dest + writePos, inputData + startPos, readPos - startPos);
+        writePos += readPos - startPos;
+      }
+    }
+    result.resize(writePos);
+    return Status::OK();
+  }
+
+  /// Encodes to a single-byte charset. Codepoints >= limit are replaced with
+  /// '?' (0x3F), matching Java's CharsetEncoder REPLACE behavior.
+  static Status encodeSingleByte(
+      out_type<Varbinary>& result,
+      const char* inputData,
+      size_t inputSize,
+      char32_t limit) {
+    // Number of codepoints <= inputSize bytes. Over-allocate, then shrink.
+    result.resize(inputSize);
+    char* dest = result.data();
+    size_t writePos = 0;
+    size_t readPos = 0;
+    while (readPos < inputSize) {
+      char32_t codePoint =
+          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
+      dest[writePos++] = codePoint < limit ? static_cast<char>(codePoint) : '?';
+    }
+    result.resize(writePos);
+    return Status::OK();
+  }
+
+  /// Encodes to UTF-16 big-endian with a BOM prefix (0xFE 0xFF).
+  /// Caller guarantees inputSize > 0 (empty input is handled before this).
+  static Status encodeUtf16WithBom(
+      out_type<Varbinary>& result,
+      const char* inputData,
+      size_t inputSize) {
+    // Worst case: 2 (BOM) + 2 bytes per input byte (all ASCII → 2 UTF-16
+    // bytes each). Supplementary codepoints use 4 UTF-8 bytes → 4 UTF-16
+    // bytes, so the ratio never exceeds 2x.
+    const size_t maxOutput = 2 + inputSize * 2;
+    result.resize(maxOutput);
+    char* dest = result.data();
+    dest[0] = static_cast<char>(0xFE);
+    dest[1] = static_cast<char>(0xFF);
+    size_t writePos = 2;
+    size_t readPos = 0;
+    while (readPos < inputSize) {
+      char32_t codePoint =
+          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
+      writePos += detail::writeUtf16BE(codePoint, dest + writePos);
+    }
+    result.resize(writePos);
+    return Status::OK();
+  }
+
+  /// Encodes to UTF-16 little-endian with a BOM prefix (0xFF 0xFE).
+  /// Matches Java's UnicodeLittle charset behavior.
+  /// Caller guarantees inputSize > 0 (empty input is handled before this).
+  static Status encodeUtf16LEWithBom(
+      out_type<Varbinary>& result,
+      const char* inputData,
+      size_t inputSize) {
+    const size_t maxOutput = 2 + inputSize * 2;
+    result.resize(maxOutput);
+    char* dest = result.data();
+    dest[0] = static_cast<char>(0xFF);
+    dest[1] = static_cast<char>(0xFE);
+    size_t writePos = 2;
+    size_t readPos = 0;
+    while (readPos < inputSize) {
+      char32_t codePoint =
+          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
+      writePos += detail::writeUtf16LE(codePoint, dest + writePos);
+    }
+    result.resize(writePos);
+    return Status::OK();
+  }
+
+  /// Encodes to UTF-16 (BE or LE) without BOM.
+  static Status encodeUtf16Impl(
+      out_type<Varbinary>& result,
+      const char* inputData,
+      size_t inputSize,
+      bool bigEndian) {
+    // Worst case: 2 bytes per input byte (see encodeUtf16WithBom comment).
+    const size_t maxOutput = inputSize * 2;
+    result.resize(maxOutput);
+    char* dest = result.data();
+    size_t writePos = 0;
+    size_t readPos = 0;
+    while (readPos < inputSize) {
+      char32_t codePoint =
+          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
+      if (bigEndian) {
+        writePos += detail::writeUtf16BE(codePoint, dest + writePos);
+      } else {
+        writePos += detail::writeUtf16LE(codePoint, dest + writePos);
+      }
+    }
+    result.resize(writePos);
+    return Status::OK();
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/EncodeFunction.h
+++ b/velox/functions/sparksql/EncodeFunction.h
@@ -15,17 +15,14 @@
  */
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <string>
+#include <vector>
 
-#include <folly/Likely.h>
-
-#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Status.h"
+#include "velox/expression/StringWriter.h"
 #include "velox/functions/Macros.h"
-#include "velox/type/Type.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -35,227 +32,45 @@ enum class CharsetType : uint8_t {
   kUtf8,
   kUsAscii,
   kIso8859_1,
-  kUtf16, // BOM (0xFE 0xFF) + big-endian data (Java "UTF-16" / "UnicodeBig")
-  kUtf16BE, // Big-endian without BOM (Java "UTF-16BE" / "UnicodeBigUnmarked")
-  kUtf16LE, // Little-endian without BOM (Java "UTF-16LE" /
-            // "UnicodeLittleUnmarked")
-  kUtf16LEWithBom, // BOM (0xFF 0xFE) + little-endian data (Java
-                   // "UnicodeLittle")
+  kUtf16,
+  kUtf16BE,
+  kUtf16LE,
+  kUtf16LEWithBom,
+  kUtf32,
+  kUtf32BE,
+  kUtf32LE,
+  kLegacy,
   kUnsupported,
 };
 
-/// Resolves a charset name to a CharsetType enum. Supports canonical IANA names
-/// and common Java aliases (case-insensitive) to match Spark/Java's
-/// Charset.forName() behavior.
-/// Uses a stack buffer to avoid heap allocations on hot paths.
-inline CharsetType resolveCharset(const char* data, size_t length) {
-  // The longest name that can match is "UNICODELITTLEUNMARKED" (21 chars);
-  // kMaxCharsetLen (24) leaves a little headroom and bounds the stack buffer.
-  // Names longer than kMaxCharsetLen cannot match any candidate, so reject
-  // early.
-  static constexpr size_t kMaxCharsetLen = 24;
-  if (length == 0 || length > kMaxCharsetLen) {
-    return CharsetType::kUnsupported;
-  }
+/// Resolves a charset name using Spark's configured charset scope.
+CharsetType resolveCharset(const StringView& charset, bool legacyJavaCharsets);
 
-  char upperName[kMaxCharsetLen];
-  for (size_t i = 0; i < length; ++i) {
-    // ASCII-only uppercasing: charset names are ASCII, and a locale-sensitive
-    // std::toupper could mis-map bytes (e.g. under a Turkish locale) and break
-    // matching.
-    const char c = data[i];
-    upperName[i] =
-        (c >= 'a' && c <= 'z') ? static_cast<char>(c - ('a' - 'A')) : c;
-  }
-
-  // Use a StringView-like comparison without heap allocation.
-  auto eq = [&](const char* candidate, size_t candidateLen) {
-    return length == candidateLen &&
-        std::memcmp(upperName, candidate, candidateLen) == 0;
-  };
-
-  // Length-based dispatch to reduce comparisons on the hot path.
-  switch (length) {
-    case 4:
-      if (eq("UTF8", 4))
-        return CharsetType::kUtf8;
-      break;
-    case 5:
-      if (eq("UTF-8", 5))
-        return CharsetType::kUtf8;
-      if (eq("ASCII", 5))
-        return CharsetType::kUsAscii;
-      if (eq("UTF16", 5))
-        return CharsetType::kUtf16;
-      break;
-    case 6:
-      if (eq("UTF-16", 6))
-        return CharsetType::kUtf16;
-      if (eq("LATIN1", 6))
-        return CharsetType::kIso8859_1;
-      break;
-    case 7:
-      if (eq("UTF16BE", 7))
-        return CharsetType::kUtf16BE;
-      if (eq("UTF16LE", 7))
-        return CharsetType::kUtf16LE;
-      break;
-    case 8:
-      if (eq("US-ASCII", 8))
-        return CharsetType::kUsAscii;
-      if (eq("US_ASCII", 8))
-        return CharsetType::kUsAscii;
-      if (eq("UTF-16BE", 8))
-        return CharsetType::kUtf16BE;
-      if (eq("UTF-16LE", 8))
-        return CharsetType::kUtf16LE;
-      break;
-    case 9:
-      if (eq("ISO8859_1", 9))
-        return CharsetType::kIso8859_1;
-      if (eq("ISO8859-1", 9))
-        return CharsetType::kIso8859_1;
-      break;
-    case 10:
-      if (eq("ISO-8859-1", 10))
-        return CharsetType::kIso8859_1;
-      if (eq("ISO_8859_1", 10))
-        return CharsetType::kIso8859_1;
-      if (eq("UNICODEBIG", 10))
-        return CharsetType::kUtf16; // BOM + big-endian (matches Java
-                                    // UnicodeBig)
-      break;
-    case 13:
-      if (eq("UNICODELITTLE", 13))
-        return CharsetType::kUtf16LEWithBom; // BOM + little-endian (matches
-                                             // Java UnicodeLittle)
-      break;
-    case 18:
-      if (eq("UNICODEBIGUNMARKED", 18))
-        return CharsetType::kUtf16BE;
-      break;
-    case 21:
-      if (eq("UNICODELITTLEUNMARKED", 21))
-        return CharsetType::kUtf16LE;
-      break;
-    default:
-      break;
-  }
-  return CharsetType::kUnsupported;
-}
-
-/// Decodes the next UTF-8 codepoint from 'data' at position 'pos'.
-/// Advances 'pos' past the consumed bytes. Returns U+FFFD on invalid
-/// sequences. Note: Velox VARCHAR may contain malformed UTF-8; invalid
-/// sequences are replaced with U+FFFD, which then flows into the charset
-/// encoder (a Velox-specific behavior since Java Strings are always valid).
-inline char32_t
-decodeUtf8Codepoint(const char* data, size_t length, size_t& pos) {
-  auto byte = static_cast<unsigned char>(data[pos]);
-  char32_t codePoint;
-  size_t extraBytes;
-
-  if (FOLLY_LIKELY(byte < 0x80)) {
-    ++pos;
-    return static_cast<char32_t>(byte);
-  } else if ((byte & 0xE0) == 0xC0) {
-    codePoint = byte & 0x1F;
-    extraBytes = 1;
-  } else if ((byte & 0xF0) == 0xE0) {
-    codePoint = byte & 0x0F;
-    extraBytes = 2;
-  } else if ((byte & 0xF8) == 0xF0) {
-    codePoint = byte & 0x07;
-    extraBytes = 3;
-  } else {
-    ++pos;
-    return 0xFFFD;
-  }
-
-  if (pos + 1 + extraBytes > length) {
-    pos = length;
-    return 0xFFFD;
-  }
-
-  for (size_t i = 0; i < extraBytes; ++i) {
-    auto continuation = static_cast<unsigned char>(data[pos + 1 + i]);
-    if ((continuation & 0xC0) != 0x80) {
-      pos += 1 + i;
-      return 0xFFFD;
-    }
-    codePoint = (codePoint << 6) | (continuation & 0x3F);
-  }
-  pos += 1 + extraBytes;
-
-  // Reject overlong encodings, surrogate code points, and values > U+10FFFF.
-  if ((extraBytes == 1 && codePoint < 0x80) ||
-      (extraBytes == 2 && codePoint < 0x800) ||
-      (extraBytes == 3 && codePoint < 0x10000) ||
-      (codePoint >= 0xD800 && codePoint <= 0xDFFF) || codePoint > 0x10FFFF) {
-    return 0xFFFD;
-  }
-  return codePoint;
-}
-
-/// Writes a UTF-16BE encoding of 'codePoint' to 'output'. codePoint must be a
-/// valid Unicode scalar value (<= U+10FFFF, not a surrogate). Returns the
-/// number of bytes written (2 for BMP, 4 for supplementary).
-inline size_t writeUtf16BE(char32_t codePoint, char* output) {
-  if (codePoint <= 0xFFFF) {
-    output[0] = static_cast<char>((codePoint >> 8) & 0xFF);
-    output[1] = static_cast<char>(codePoint & 0xFF);
-    return 2;
-  }
-  char32_t adjusted = codePoint - 0x10000;
-  char32_t highSurrogate = 0xD800 + (adjusted >> 10);
-  char32_t lowSurrogate = 0xDC00 + (adjusted & 0x3FF);
-  output[0] = static_cast<char>((highSurrogate >> 8) & 0xFF);
-  output[1] = static_cast<char>(highSurrogate & 0xFF);
-  output[2] = static_cast<char>((lowSurrogate >> 8) & 0xFF);
-  output[3] = static_cast<char>(lowSurrogate & 0xFF);
-  return 4;
-}
-
-/// Writes a UTF-16LE encoding of 'codePoint' to 'output'. codePoint must be a
-/// valid Unicode scalar value (<= U+10FFFF, not a surrogate). Returns the
-/// number of bytes written (2 for BMP, 4 for supplementary).
-inline size_t writeUtf16LE(char32_t codePoint, char* output) {
-  if (codePoint <= 0xFFFF) {
-    output[0] = static_cast<char>(codePoint & 0xFF);
-    output[1] = static_cast<char>((codePoint >> 8) & 0xFF);
-    return 2;
-  }
-  char32_t adjusted = codePoint - 0x10000;
-  char32_t highSurrogate = 0xD800 + (adjusted >> 10);
-  char32_t lowSurrogate = 0xDC00 + (adjusted & 0x3FF);
-  output[0] = static_cast<char>(highSurrogate & 0xFF);
-  output[1] = static_cast<char>((highSurrogate >> 8) & 0xFF);
-  output[2] = static_cast<char>(lowSurrogate & 0xFF);
-  output[3] = static_cast<char>((lowSurrogate >> 8) & 0xFF);
-  return 4;
-}
+/// Encodes input using the selected charset and Spark coding-error behavior.
+Status encode(
+    exec::StringWriter& result,
+    const StringView& input,
+    const StringView& charset,
+    CharsetType type,
+    bool legacyCodingErrorAction);
 
 } // namespace detail
 
-/// Spark-compatible encode function. Converts a VARCHAR (UTF-8) to VARBINARY
-/// using the specified charset.
-/// Supported charsets (case-insensitive): US-ASCII, ISO-8859-1, UTF-8,
-/// UTF-16BE, UTF-16LE, UTF-16. Common Java aliases (e.g. UTF8, ASCII, LATIN1)
-/// are also accepted.
+/// Encodes a VARCHAR into VARBINARY using Spark-compatible charset semantics.
 template <typename T>
 struct EncodeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
-      const core::QueryConfig& /*config*/,
+      const core::QueryConfig& config,
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* charset) {
+    const SparkQueryConfig sparkConfig{config};
+    legacyJavaCharsets_ = sparkConfig.legacyJavaCharsets();
+    legacyCodingErrorAction_ = sparkConfig.legacyCodingErrorAction();
     if (charset != nullptr) {
-      // Resolve the constant charset once. An unsupported charset is not
-      // rejected here: the error is deferred to call() so that a constant and
-      // a per-row charset behave identically and both are catchable by TRY.
-      charsetType_ = detail::resolveCharset(charset->data(), charset->size());
+      charsetType_ = detail::resolveCharset(*charset, legacyJavaCharsets_);
       isConstantCharset_ = true;
     }
   }
@@ -264,215 +79,30 @@ struct EncodeFunction {
       out_type<Varbinary>& result,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& charset) {
-    auto type = charsetType_;
-    if (!isConstantCharset_) {
-      // Non-constant charset path: resolve per row.
-      type = detail::resolveCharset(charset.data(), charset.size());
-    }
+    const auto type = isConstantCharset_
+        ? charsetType_
+        : detail::resolveCharset(charset, legacyJavaCharsets_);
     if (type == detail::CharsetType::kUnsupported) {
       return Status::UserError(
           "encode: unsupported charset '{}'",
           std::string(charset.data(), charset.size()));
     }
-
-    const char* inputData = input.data();
-    const size_t inputSize = input.size();
-
-    // UTF-8: normalize the input by decoding and re-encoding. This replaces
-    // any malformed UTF-8 sequences with U+FFFD (3 bytes each), matching
-    // Spark/Java behavior where the input String is always valid.
-    if (type == detail::CharsetType::kUtf8) {
-      return encodeUtf8(result, inputData, inputSize);
-    }
-
-    // All charsets return empty bytes for empty input, matching Spark's
-    // Encode.encode() which returns input.getBytes (empty) before the encoder
-    // runs.
-    if (inputSize == 0) {
-      result.resize(0);
-      return Status::OK();
-    }
-
-    // UTF-16 with BOM: emit the 2-byte BOM (0xFE 0xFF) followed by
-    // big-endian data, matching Java's String.getBytes("UTF-16").
-    if (type == detail::CharsetType::kUtf16) {
-      return encodeUtf16WithBom(result, inputData, inputSize);
-    }
-
-    // UTF-16LE with BOM: emit the 2-byte BOM (0xFF 0xFE) followed by
-    // little-endian data, matching Java's UnicodeLittle charset.
-    if (type == detail::CharsetType::kUtf16LEWithBom) {
-      return encodeUtf16LEWithBom(result, inputData, inputSize);
-    }
-
-    switch (type) {
-      case detail::CharsetType::kUtf16BE:
-        return encodeUtf16Impl(
-            result, inputData, inputSize, /*bigEndian=*/true);
-      case detail::CharsetType::kUtf16LE:
-        return encodeUtf16Impl(
-            result, inputData, inputSize, /*bigEndian=*/false);
-      case detail::CharsetType::kUsAscii:
-        return encodeSingleByte(result, inputData, inputSize, 0x80);
-      case detail::CharsetType::kIso8859_1:
-        return encodeSingleByte(result, inputData, inputSize, 0x100);
-      default:
-        // kUtf8, kUtf16, kUtf16LEWithBom, and kUnsupported are all handled
-        // before this switch, so no other charset type can reach here.
-        VELOX_UNREACHABLE(
-            "encode: charset type {} should have been handled earlier",
-            static_cast<int>(type));
-    }
+    return detail::encode(
+        result, input, charset, type, legacyCodingErrorAction_);
   }
 
  private:
-  detail::CharsetType charsetType_ = detail::CharsetType::kUnsupported;
-  bool isConstantCharset_ = false;
+  // Stores the charset resolved from a constant argument.
+  detail::CharsetType charsetType_{detail::CharsetType::kUnsupported};
 
-  /// Encodes to UTF-8 by decoding and re-encoding. Replaces malformed UTF-8
-  /// sequences with U+FFFD (0xEF 0xBF 0xBD). For valid UTF-8 input (the common
-  /// case), the output is identical to the input.
-  static Status encodeUtf8(
-      out_type<Varbinary>& result,
-      const char* inputData,
-      size_t inputSize) {
-    if (inputSize == 0) {
-      result.resize(0);
-      return Status::OK();
-    }
-    // Fast path: if the entire input is ASCII, it's guaranteed valid UTF-8
-    // and the output is identical to the input. Avoids per-character decode.
-    bool allAscii = true;
-    for (size_t i = 0; i < inputSize; ++i) {
-      if (FOLLY_UNLIKELY(static_cast<unsigned char>(inputData[i]) >= 0x80)) {
-        allAscii = false;
-        break;
-      }
-    }
-    if (allAscii) {
-      result.resize(inputSize);
-      std::memcpy(result.data(), inputData, inputSize);
-      return Status::OK();
-    }
-    // Worst case: every byte is invalid → each becomes 3-byte U+FFFD.
-    result.resize(inputSize * 3);
-    char* dest = result.data();
-    size_t writePos = 0;
-    size_t readPos = 0;
-    while (readPos < inputSize) {
-      size_t startPos = readPos;
-      char32_t codePoint =
-          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
-      if (codePoint == 0xFFFD &&
-          (readPos - startPos != 3 ||
-           static_cast<unsigned char>(inputData[startPos]) != 0xEF)) {
-        // Invalid sequence was replaced — emit U+FFFD in UTF-8.
-        dest[writePos++] = static_cast<char>(0xEF);
-        dest[writePos++] = static_cast<char>(0xBF);
-        dest[writePos++] = static_cast<char>(0xBD);
-      } else {
-        // Valid sequence — copy original bytes.
-        std::memcpy(dest + writePos, inputData + startPos, readPos - startPos);
-        writePos += readPos - startPos;
-      }
-    }
-    result.resize(writePos);
-    return Status::OK();
-  }
+  // Indicates whether the charset argument was constant.
+  bool isConstantCharset_{false};
 
-  /// Encodes to a single-byte charset. Codepoints >= limit are replaced with
-  /// '?' (0x3F), matching Java's CharsetEncoder REPLACE behavior.
-  static Status encodeSingleByte(
-      out_type<Varbinary>& result,
-      const char* inputData,
-      size_t inputSize,
-      char32_t limit) {
-    // Number of codepoints <= inputSize bytes. Over-allocate, then shrink.
-    result.resize(inputSize);
-    char* dest = result.data();
-    size_t writePos = 0;
-    size_t readPos = 0;
-    while (readPos < inputSize) {
-      char32_t codePoint =
-          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
-      dest[writePos++] = codePoint < limit ? static_cast<char>(codePoint) : '?';
-    }
-    result.resize(writePos);
-    return Status::OK();
-  }
+  // Enables the configured Java charset alias scope.
+  bool legacyJavaCharsets_{false};
 
-  /// Encodes to UTF-16 big-endian with a BOM prefix (0xFE 0xFF).
-  /// Caller guarantees inputSize > 0 (empty input is handled before this).
-  static Status encodeUtf16WithBom(
-      out_type<Varbinary>& result,
-      const char* inputData,
-      size_t inputSize) {
-    // Worst case: 2 (BOM) + 2 bytes per input byte (all ASCII → 2 UTF-16
-    // bytes each). Supplementary codepoints use 4 UTF-8 bytes → 4 UTF-16
-    // bytes, so the ratio never exceeds 2x.
-    const size_t maxOutput = 2 + inputSize * 2;
-    result.resize(maxOutput);
-    char* dest = result.data();
-    dest[0] = static_cast<char>(0xFE);
-    dest[1] = static_cast<char>(0xFF);
-    size_t writePos = 2;
-    size_t readPos = 0;
-    while (readPos < inputSize) {
-      char32_t codePoint =
-          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
-      writePos += detail::writeUtf16BE(codePoint, dest + writePos);
-    }
-    result.resize(writePos);
-    return Status::OK();
-  }
-
-  /// Encodes to UTF-16 little-endian with a BOM prefix (0xFF 0xFE).
-  /// Matches Java's UnicodeLittle charset behavior.
-  /// Caller guarantees inputSize > 0 (empty input is handled before this).
-  static Status encodeUtf16LEWithBom(
-      out_type<Varbinary>& result,
-      const char* inputData,
-      size_t inputSize) {
-    const size_t maxOutput = 2 + inputSize * 2;
-    result.resize(maxOutput);
-    char* dest = result.data();
-    dest[0] = static_cast<char>(0xFF);
-    dest[1] = static_cast<char>(0xFE);
-    size_t writePos = 2;
-    size_t readPos = 0;
-    while (readPos < inputSize) {
-      char32_t codePoint =
-          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
-      writePos += detail::writeUtf16LE(codePoint, dest + writePos);
-    }
-    result.resize(writePos);
-    return Status::OK();
-  }
-
-  /// Encodes to UTF-16 (BE or LE) without BOM.
-  static Status encodeUtf16Impl(
-      out_type<Varbinary>& result,
-      const char* inputData,
-      size_t inputSize,
-      bool bigEndian) {
-    // Worst case: 2 bytes per input byte (see encodeUtf16WithBom comment).
-    const size_t maxOutput = inputSize * 2;
-    result.resize(maxOutput);
-    char* dest = result.data();
-    size_t writePos = 0;
-    size_t readPos = 0;
-    while (readPos < inputSize) {
-      char32_t codePoint =
-          detail::decodeUtf8Codepoint(inputData, inputSize, readPos);
-      if (bigEndian) {
-        writePos += detail::writeUtf16BE(codePoint, dest + writePos);
-      } else {
-        writePos += detail::writeUtf16LE(codePoint, dest + writePos);
-      }
-    }
-    result.resize(writePos);
-    return Status::OK();
-  }
+  // Replaces unmappable characters instead of returning an error.
+  bool legacyCodingErrorAction_{false};
 };
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/SparkQueryConfig.cpp
+++ b/velox/functions/sparksql/SparkQueryConfig.cpp
@@ -33,6 +33,8 @@ SparkQueryConfig::registeredProperties() {
     VELOX_REGISTER_SPARK_CONFIG(kPartitionId);
     VELOX_REGISTER_SPARK_CONFIG(kLegacyDateFormatter);
     VELOX_REGISTER_SPARK_CONFIG(kLegacyStatisticalAggregate);
+    VELOX_REGISTER_SPARK_CONFIG(kLegacyJavaCharsets);
+    VELOX_REGISTER_SPARK_CONFIG(kLegacyCodingErrorAction);
     VELOX_REGISTER_SPARK_CONFIG(kJsonIgnoreNullFields);
     VELOX_REGISTER_SPARK_CONFIG(kCollectListIgnoreNulls);
 

--- a/velox/functions/sparksql/SparkQueryConfig.h
+++ b/velox/functions/sparksql/SparkQueryConfig.h
@@ -144,6 +144,24 @@ class SparkQueryConfig {
       false,
       "Return NaN instead of NULL for Spark statistical aggregation on divide-by-zero.")
 
+  /// If true, encode and decode accept supported Java charset aliases.
+  VELOX_SPARK_CONFIG(
+      kLegacyJavaCharsets,
+      legacyJavaCharsets,
+      "legacy_java_charsets",
+      bool,
+      false,
+      "Allow supported Java charset aliases in Spark encode and decode functions.")
+
+  /// If true, encode replaces unmappable characters instead of failing.
+  VELOX_SPARK_CONFIG(
+      kLegacyCodingErrorAction,
+      legacyCodingErrorAction,
+      "legacy_coding_error_action",
+      bool,
+      false,
+      "Replace unmappable characters in Spark encode and decode functions.")
+
   /// If true, ignore null fields when generating JSON string.
   VELOX_SPARK_CONFIG(
       kJsonIgnoreNullFields,

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -22,6 +22,7 @@
 #include "velox/functions/sparksql/Base64Function.h"
 #include "velox/functions/sparksql/CharTypeWriteSideCheck.h"
 #include "velox/functions/sparksql/ConcatWs.h"
+#include "velox/functions/sparksql/EncodeFunction.h"
 #include "velox/functions/sparksql/FormatNumber.h"
 #include "velox/functions/sparksql/InitcapFunction.h"
 #include "velox/functions/sparksql/LuhnCheckFunction.h"
@@ -227,6 +228,8 @@ void registerStringFunctions(const std::string& prefix) {
 
   registerFunction<Base64Function, Varchar, Varbinary>({prefix + "base64"});
   registerFunction<UnBase64Function, Varbinary, Varchar>({prefix + "unbase64"});
+  registerFunction<EncodeFunction, Varbinary, Varchar, Varchar>(
+      {prefix + "encode"});
 
   registerFunction<InitCapFunction, Varchar, Varchar>({prefix + "initcap"});
 

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(
   DecimalRoundTest.cpp
   DecimalUtilTest.cpp
   ElementAtTest.cpp
+  EncodeTest.cpp
   FactorialTest.cpp
   FilterTest.cpp
   FormatNumberTest.cpp

--- a/velox/functions/sparksql/tests/EncodeTest.cpp
+++ b/velox/functions/sparksql/tests/EncodeTest.cpp
@@ -17,6 +17,7 @@
 #include <string_view>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 using ::testing::ElementsAre;
@@ -48,13 +49,36 @@ class EncodeTest : public SparkFunctionBaseTest {
   static std::vector<uint8_t> toBytes(std::string_view s) {
     return std::vector<uint8_t>(s.begin(), s.end());
   }
+
+  void enableLegacyJavaCharsets() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {SparkQueryConfig::qualify(SparkQueryConfig::kLegacyJavaCharsets),
+         "true"},
+    });
+  }
+
+  void enableLegacyCodingErrorAction() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {SparkQueryConfig::qualify(SparkQueryConfig::kLegacyCodingErrorAction),
+         "true"},
+    });
+  }
+
+  void enableLegacyCharsetsAndCodingErrorAction() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {SparkQueryConfig::qualify(SparkQueryConfig::kLegacyJavaCharsets),
+         "true"},
+        {SparkQueryConfig::qualify(SparkQueryConfig::kLegacyCodingErrorAction),
+         "true"},
+    });
+  }
 };
 
 TEST_F(EncodeTest, utf8) {
   EXPECT_EQ(encode("hello", "UTF-8"), "hello");
   EXPECT_EQ(encode("Spark SQL", "UTF-8"), "Spark SQL");
   EXPECT_EQ(encode("", "UTF-8"), "");
-  // Canonical name and Java aliases, all case-insensitive.
+  enableLegacyJavaCharsets();
   for (const auto* name : {"utf-8", "UTF8", "utf8"}) {
     SCOPED_TRACE(name);
     EXPECT_EQ(encode("abc", name), "abc");
@@ -64,7 +88,7 @@ TEST_F(EncodeTest, utf8) {
 TEST_F(EncodeTest, usAscii) {
   EXPECT_EQ(encode("hello", "US-ASCII"), "hello");
   EXPECT_EQ(encode("", "US-ASCII"), "");
-  // Canonical name and Java aliases, all case-insensitive.
+  enableLegacyJavaCharsets();
   for (const auto* name : {"us-ascii", "ASCII", "ascii", "US_ASCII"}) {
     SCOPED_TRACE(name);
     EXPECT_EQ(encode("abc", name), "abc");
@@ -72,6 +96,7 @@ TEST_F(EncodeTest, usAscii) {
 }
 
 TEST_F(EncodeTest, usAsciiReplacement) {
+  enableLegacyCodingErrorAction();
   // Non-ASCII codepoints should be replaced with '?' (0x3F).
   // U+00E9 (e-acute) is 0xC3 0xA9 in UTF-8, above 0x7F in US-ASCII.
   EXPECT_EQ(encode("\xC3\xA9", "US-ASCII"), "?");
@@ -88,7 +113,7 @@ TEST_F(EncodeTest, usAsciiReplacement) {
 TEST_F(EncodeTest, iso8859) {
   EXPECT_EQ(encode("hello", "ISO-8859-1"), "hello");
   EXPECT_EQ(encode("", "ISO-8859-1"), "");
-  // Canonical name and Java aliases, all case-insensitive.
+  enableLegacyJavaCharsets();
   for (const auto* name :
        {"iso-8859-1",
         "LATIN1",
@@ -107,6 +132,7 @@ TEST_F(EncodeTest, iso8859Passthrough) {
 }
 
 TEST_F(EncodeTest, iso8859Replacement) {
+  enableLegacyCodingErrorAction();
   // Codepoints > 0xFF should be replaced with '?' (0x3F).
   // U+0100 (Latin A with macron) = 0xC4 0x80 in UTF-8, above 0xFF.
   EXPECT_EQ(encode("\xC4\x80", "ISO-8859-1"), "?");
@@ -115,7 +141,7 @@ TEST_F(EncodeTest, iso8859Replacement) {
 TEST_F(EncodeTest, utf16be) {
   // 'A' in UTF-16BE is 0x00 0x41.
   EXPECT_THAT(encodeBytes("A", "UTF-16BE"), ElementsAre(0x00, 0x41));
-  // Aliases produce the same result.
+  enableLegacyJavaCharsets();
   for (const auto* name : {"UTF16BE", "UnicodeBigUnmarked"}) {
     SCOPED_TRACE(name);
     EXPECT_THAT(encodeBytes("A", name), ElementsAre(0x00, 0x41));
@@ -127,7 +153,7 @@ TEST_F(EncodeTest, utf16be) {
 TEST_F(EncodeTest, utf16le) {
   // 'A' in UTF-16LE is 0x41 0x00.
   EXPECT_THAT(encodeBytes("A", "UTF-16LE"), ElementsAre(0x41, 0x00));
-  // Aliases produce the same result.
+  enableLegacyJavaCharsets();
   for (const auto* name : {"UTF16LE", "UnicodeLittleUnmarked"}) {
     SCOPED_TRACE(name);
     EXPECT_THAT(encodeBytes("A", name), ElementsAre(0x41, 0x00));
@@ -137,6 +163,7 @@ TEST_F(EncodeTest, utf16le) {
 }
 
 TEST_F(EncodeTest, unicodeLittleWithBom) {
+  enableLegacyJavaCharsets();
   // Java's "UnicodeLittle" charset is UTF-16LE with a little-endian BOM,
   // matching "A".getBytes("UnicodeLittle") = FF FE 41 00.
   EXPECT_THAT(
@@ -149,11 +176,22 @@ TEST_F(EncodeTest, utf16) {
   // UTF-16 produces a big-endian BOM (0xFE 0xFF) followed by big-endian data,
   // matching Java/Spark behavior. BOM + 'A' in UTF-16BE = FE FF 00 41.
   EXPECT_THAT(encodeBytes("A", "UTF-16"), ElementsAre(0xFE, 0xFF, 0x00, 0x41));
-  // Alias.
+  enableLegacyJavaCharsets();
   EXPECT_THAT(encodeBytes("A", "UTF16"), ElementsAre(0xFE, 0xFF, 0x00, 0x41));
   // Empty string short-circuits before the encoder runs, returning empty
   // bytes with no BOM (matching Spark's Encode.encode()).
   EXPECT_THAT(encodeBytes("", "UTF-16"), IsEmpty());
+}
+
+TEST_F(EncodeTest, utf32) {
+  EXPECT_THAT(encodeBytes("A", "UTF-32"), ElementsAre(0x00, 0x00, 0x00, 0x41));
+  EXPECT_THAT(encodeBytes("", "UTF-32"), IsEmpty());
+
+  enableLegacyJavaCharsets();
+  EXPECT_THAT(
+      encodeBytes("A", "UTF-32BE"), ElementsAre(0x00, 0x00, 0x00, 0x41));
+  EXPECT_THAT(
+      encodeBytes("A", "UTF-32LE"), ElementsAre(0x41, 0x00, 0x00, 0x00));
 }
 
 TEST_F(EncodeTest, supplementaryCodepoint) {
@@ -187,10 +225,82 @@ TEST_F(EncodeTest, unsupportedCharset) {
   // is catchable by TRY even when the charset is a constant.
   EXPECT_EQ(
       evaluateOnce<std::string>(
-          "try(encode(c0, c1))",
-          std::optional<std::string>("hello"),
-          std::optional<std::string>("INVALID-CHARSET")),
+          "try(encode(c0, 'INVALID-CHARSET'))",
+          std::optional<std::string>("hello")),
       std::nullopt);
+}
+
+TEST_F(EncodeTest, charsetScope) {
+  VELOX_ASSERT_USER_THROW(
+      encode("hello", "UTF8"), "encode: unsupported charset 'UTF8'");
+  VELOX_ASSERT_USER_THROW(
+      encode("\xE2\x82\xAC", "windows-1252"),
+      "encode: unsupported charset 'windows-1252'");
+
+  enableLegacyJavaCharsets();
+  EXPECT_EQ(encode("hello", "UTF8"), "hello");
+  EXPECT_THAT(encodeBytes("\xE2\x82\xAC", "windows-1252"), ElementsAre(0x80));
+  EXPECT_THAT(
+      encodeBytes("\xE3\x81\x82", "Shift_JIS"), ElementsAre(0x82, 0xA0));
+}
+
+TEST_F(EncodeTest, icuOnlyCharsetsRejected) {
+  // ICU recognizes these encodings, but the JDK's Charset.forName does not, so
+  // Spark rejects them even when the legacy Java charset scope is enabled.
+  enableLegacyJavaCharsets();
+  for (const auto* name : {"UTF-7", "BOCU-1", "SCSU", "IMAP-mailbox-name"}) {
+    VELOX_ASSERT_USER_THROW(
+        encode("hello", name),
+        fmt::format("encode: unsupported charset '{}'", name));
+  }
+}
+
+TEST_F(EncodeTest, cesu8Accepted) {
+  // CESU-8 is a valid JDK charset, so the legacy scope must accept it. It
+  // matches UTF-8 for BMP code points but encodes supplementary code points as
+  // a surrogate pair of three-byte sequences.
+  enableLegacyJavaCharsets();
+  EXPECT_THAT(encodeBytes("A", "CESU-8"), ElementsAre(0x41));
+  EXPECT_THAT(
+      encodeBytes("\xF0\x9F\x98\x80", "CESU-8"),
+      ElementsAre(0xED, 0xA0, 0xBD, 0xED, 0xB8, 0x80));
+}
+
+TEST_F(EncodeTest, embeddedNulCharsetRejected) {
+  // A NUL in the charset name must not be truncated and silently resolved to a
+  // different charset; Java rejects such names.
+  enableLegacyJavaCharsets();
+  VELOX_ASSERT_USER_THROW(
+      encode("hello", std::string("UTF-8\x00GBK", 9)),
+      "encode: unsupported charset");
+}
+
+TEST_F(EncodeTest, legacyUnicodeVariantCharset) {
+  // A legacy charset whose minimum unit is larger than one byte (here a
+  // UTF-16LE variant that emits a BOM) rejects a single-byte '?' substitution.
+  // Because it can represent every code point, substitution never occurs, so
+  // encoding must succeed rather than trip a fatal check.
+  enableLegacyCharsetsAndCodingErrorAction();
+  EXPECT_THAT(
+      encodeBytes("A", "x-UTF-16LE-BOM"), ElementsAre(0xFF, 0xFE, 0x41, 0x00));
+}
+
+TEST_F(EncodeTest, codingErrorAction) {
+  VELOX_ASSERT_USER_THROW(
+      encode("\xC3\xA9", "US-ASCII"),
+      "input contains a character that cannot be encoded");
+  enableLegacyCodingErrorAction();
+  EXPECT_EQ(encode("\xC3\xA9", "US-ASCII"), "?");
+}
+
+TEST_F(EncodeTest, legacyCharsetCodingErrorAction) {
+  enableLegacyJavaCharsets();
+  VELOX_ASSERT_USER_THROW(
+      encode("\xE3\x81\x82", "windows-1252"),
+      "input contains a character that cannot be encoded");
+
+  enableLegacyCharsetsAndCodingErrorAction();
+  EXPECT_EQ(encode("\xE3\x81\x82", "windows-1252"), "?");
 }
 
 TEST_F(EncodeTest, malformedUtf8) {
@@ -207,6 +317,31 @@ TEST_F(EncodeTest, malformedUtf8) {
 
   // Invalid start byte 0xFF.
   EXPECT_THAT(encodeBytes("\xFF", "UTF-8"), ElementsAre(0xEF, 0xBF, 0xBD));
+
+  // Java replaces each byte of overlong and out-of-range sequences.
+  EXPECT_THAT(
+      encodeBytes(std::string("\xC0\x80", 2), "UTF-8"),
+      ElementsAre(0xEF, 0xBF, 0xBD, 0xEF, 0xBF, 0xBD));
+  EXPECT_THAT(
+      encodeBytes(std::string("\xF4\x90\x80\x80", 4), "UTF-8"),
+      ElementsAre(
+          0xEF,
+          0xBF,
+          0xBD,
+          0xEF,
+          0xBF,
+          0xBD,
+          0xEF,
+          0xBF,
+          0xBD,
+          0xEF,
+          0xBF,
+          0xBD));
+
+  // A UTF-8 encoded surrogate is one malformed sequence in Java.
+  EXPECT_THAT(
+      encodeBytes(std::string("\xED\xA0\x80", 3), "UTF-8"),
+      ElementsAre(0xEF, 0xBF, 0xBD));
 }
 
 TEST_F(EncodeTest, realReplacementCharInInput) {

--- a/velox/functions/sparksql/tests/EncodeTest.cpp
+++ b/velox/functions/sparksql/tests/EncodeTest.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gmock/gmock.h>
+#include <string_view>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class EncodeTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<std::string> encode(
+      const std::optional<std::string>& input,
+      const std::optional<std::string>& charset) {
+    return evaluateOnce<std::string>("encode(c0, c1)", input, charset);
+  }
+
+  // Encodes and returns the raw output bytes, asserting a value was produced.
+  std::vector<uint8_t> encodeBytes(
+      const std::optional<std::string>& input,
+      const std::optional<std::string>& charset) {
+    auto result = encode(input, charset);
+    EXPECT_TRUE(result.has_value());
+    if (!result.has_value()) {
+      return {};
+    }
+    return toBytes(*result);
+  }
+
+  static std::vector<uint8_t> toBytes(std::string_view s) {
+    return std::vector<uint8_t>(s.begin(), s.end());
+  }
+};
+
+TEST_F(EncodeTest, utf8) {
+  EXPECT_EQ(encode("hello", "UTF-8"), "hello");
+  EXPECT_EQ(encode("Spark SQL", "UTF-8"), "Spark SQL");
+  EXPECT_EQ(encode("", "UTF-8"), "");
+  // Canonical name and Java aliases, all case-insensitive.
+  for (const auto* name : {"utf-8", "UTF8", "utf8"}) {
+    SCOPED_TRACE(name);
+    EXPECT_EQ(encode("abc", name), "abc");
+  }
+}
+
+TEST_F(EncodeTest, usAscii) {
+  EXPECT_EQ(encode("hello", "US-ASCII"), "hello");
+  EXPECT_EQ(encode("", "US-ASCII"), "");
+  // Canonical name and Java aliases, all case-insensitive.
+  for (const auto* name : {"us-ascii", "ASCII", "ascii", "US_ASCII"}) {
+    SCOPED_TRACE(name);
+    EXPECT_EQ(encode("abc", name), "abc");
+  }
+}
+
+TEST_F(EncodeTest, usAsciiReplacement) {
+  // Non-ASCII codepoints should be replaced with '?' (0x3F).
+  // U+00E9 (e-acute) is 0xC3 0xA9 in UTF-8, above 0x7F in US-ASCII.
+  EXPECT_EQ(encode("\xC3\xA9", "US-ASCII"), "?");
+
+  // Mixed ASCII and non-ASCII.
+  EXPECT_EQ(
+      encode(
+          "a\xC3\xA9"
+          "b",
+          "US-ASCII"),
+      "a?b");
+}
+
+TEST_F(EncodeTest, iso8859) {
+  EXPECT_EQ(encode("hello", "ISO-8859-1"), "hello");
+  EXPECT_EQ(encode("", "ISO-8859-1"), "");
+  // Canonical name and Java aliases, all case-insensitive.
+  for (const auto* name :
+       {"iso-8859-1",
+        "LATIN1",
+        "latin1",
+        "ISO8859_1",
+        "ISO_8859_1",
+        "ISO8859-1"}) {
+    SCOPED_TRACE(name);
+    EXPECT_EQ(encode("abc", name), "abc");
+  }
+}
+
+TEST_F(EncodeTest, iso8859Passthrough) {
+  // U+00E9 (e-acute) should pass through as 0xE9 in ISO-8859-1.
+  EXPECT_THAT(encodeBytes("\xC3\xA9", "ISO-8859-1"), ElementsAre(0xE9));
+}
+
+TEST_F(EncodeTest, iso8859Replacement) {
+  // Codepoints > 0xFF should be replaced with '?' (0x3F).
+  // U+0100 (Latin A with macron) = 0xC4 0x80 in UTF-8, above 0xFF.
+  EXPECT_EQ(encode("\xC4\x80", "ISO-8859-1"), "?");
+}
+
+TEST_F(EncodeTest, utf16be) {
+  // 'A' in UTF-16BE is 0x00 0x41.
+  EXPECT_THAT(encodeBytes("A", "UTF-16BE"), ElementsAre(0x00, 0x41));
+  // Aliases produce the same result.
+  for (const auto* name : {"UTF16BE", "UnicodeBigUnmarked"}) {
+    SCOPED_TRACE(name);
+    EXPECT_THAT(encodeBytes("A", name), ElementsAre(0x00, 0x41));
+  }
+  // Empty input yields empty output (no BOM for the unmarked variant).
+  EXPECT_THAT(encodeBytes("", "UTF-16BE"), IsEmpty());
+}
+
+TEST_F(EncodeTest, utf16le) {
+  // 'A' in UTF-16LE is 0x41 0x00.
+  EXPECT_THAT(encodeBytes("A", "UTF-16LE"), ElementsAre(0x41, 0x00));
+  // Aliases produce the same result.
+  for (const auto* name : {"UTF16LE", "UnicodeLittleUnmarked"}) {
+    SCOPED_TRACE(name);
+    EXPECT_THAT(encodeBytes("A", name), ElementsAre(0x41, 0x00));
+  }
+  // Empty input yields empty output (no BOM for the unmarked variant).
+  EXPECT_THAT(encodeBytes("", "UTF-16LE"), IsEmpty());
+}
+
+TEST_F(EncodeTest, unicodeLittleWithBom) {
+  // Java's "UnicodeLittle" charset is UTF-16LE with a little-endian BOM,
+  // matching "A".getBytes("UnicodeLittle") = FF FE 41 00.
+  EXPECT_THAT(
+      encodeBytes("A", "UnicodeLittle"), ElementsAre(0xFF, 0xFE, 0x41, 0x00));
+  // Empty input yields no BOM, matching "".getBytes("UnicodeLittle").
+  EXPECT_THAT(encodeBytes("", "UnicodeLittle"), IsEmpty());
+}
+
+TEST_F(EncodeTest, utf16) {
+  // UTF-16 produces a big-endian BOM (0xFE 0xFF) followed by big-endian data,
+  // matching Java/Spark behavior. BOM + 'A' in UTF-16BE = FE FF 00 41.
+  EXPECT_THAT(encodeBytes("A", "UTF-16"), ElementsAre(0xFE, 0xFF, 0x00, 0x41));
+  // Alias.
+  EXPECT_THAT(encodeBytes("A", "UTF16"), ElementsAre(0xFE, 0xFF, 0x00, 0x41));
+  // Empty string short-circuits before the encoder runs, returning empty
+  // bytes with no BOM (matching Spark's Encode.encode()).
+  EXPECT_THAT(encodeBytes("", "UTF-16"), IsEmpty());
+}
+
+TEST_F(EncodeTest, supplementaryCodepoint) {
+  // U+1F600 (grinning face) is F0 9F 98 80 in UTF-8.
+  // In UTF-16BE it is a surrogate pair D83D DE00.
+  std::string emoji = "\xF0\x9F\x98\x80";
+  EXPECT_THAT(
+      encodeBytes(emoji, "UTF-16BE"), ElementsAre(0xD8, 0x3D, 0xDE, 0x00));
+  // In UTF-16LE: 3D D8 00 DE.
+  EXPECT_THAT(
+      encodeBytes(emoji, "UTF-16LE"), ElementsAre(0x3D, 0xD8, 0x00, 0xDE));
+}
+
+TEST_F(EncodeTest, multibyte) {
+  // Multi-byte UTF-8 character encoded to UTF-16BE.
+  // U+00E9 (e-acute) is 0xC3 0xA9 in UTF-8, 0x00 0xE9 in UTF-16BE.
+  EXPECT_THAT(encodeBytes("\xC3\xA9", "UTF-16BE"), ElementsAre(0x00, 0xE9));
+}
+
+TEST_F(EncodeTest, nullInputs) {
+  EXPECT_EQ(encode(std::nullopt, "UTF-8"), std::nullopt);
+  EXPECT_EQ(encode("hello", std::nullopt), std::nullopt);
+  EXPECT_EQ(encode(std::nullopt, std::nullopt), std::nullopt);
+}
+
+TEST_F(EncodeTest, unsupportedCharset) {
+  VELOX_ASSERT_USER_THROW(
+      encode("hello", "INVALID-CHARSET"),
+      "encode: unsupported charset 'INVALID-CHARSET'");
+  // The unsupported-charset error is raised in call(), not initialize(), so it
+  // is catchable by TRY even when the charset is a constant.
+  EXPECT_EQ(
+      evaluateOnce<std::string>(
+          "try(encode(c0, c1))",
+          std::optional<std::string>("hello"),
+          std::optional<std::string>("INVALID-CHARSET")),
+      std::nullopt);
+}
+
+TEST_F(EncodeTest, malformedUtf8) {
+  // Truncated 2-byte sequence: 0xC3 alone. Should produce U+FFFD.
+  // In UTF-8: U+FFFD = 0xEF 0xBF 0xBD.
+  EXPECT_THAT(encodeBytes("\xC3", "UTF-8"), ElementsAre(0xEF, 0xBF, 0xBD));
+
+  // Invalid continuation byte. Use an explicit length so the embedded NUL is
+  // preserved (a bare "\xC3\x00" literal would truncate at the NUL).
+  // 0xC3 is invalid (bad continuation) → U+FFFD, then 0x00 is valid ASCII.
+  EXPECT_THAT(
+      encodeBytes(std::string("\xC3\x00", 2), "UTF-8"),
+      ElementsAre(0xEF, 0xBF, 0xBD, 0x00));
+
+  // Invalid start byte 0xFF.
+  EXPECT_THAT(encodeBytes("\xFF", "UTF-8"), ElementsAre(0xEF, 0xBF, 0xBD));
+}
+
+TEST_F(EncodeTest, realReplacementCharInInput) {
+  // A genuine U+FFFD (EF BF BD) in the input is valid UTF-8 and must be copied
+  // through unchanged (identity), not confused with a decode-time replacement.
+  EXPECT_THAT(
+      encodeBytes(std::string("\xEF\xBF\xBD", 3), "UTF-8"),
+      ElementsAre(0xEF, 0xBF, 0xBD));
+
+  // Real U+FFFD surrounded by ASCII, still an identity copy.
+  EXPECT_THAT(
+      encodeBytes(
+          std::string(
+              "a\xEF\xBF\xBD"
+              "b",
+              5),
+          "UTF-8"),
+      ElementsAre('a', 0xEF, 0xBF, 0xBD, 'b'));
+}
+
+TEST_F(EncodeTest, perRowCharset) {
+  // Drive the non-constant charset path in call() with a different charset per
+  // row so resolveCharset() runs per row rather than once in initialize().
+  auto inputs = makeFlatVector<StringView>({"AB", "AB", "AB"});
+  auto charsets = makeFlatVector<StringView>({"UTF-8", "US-ASCII", "UTF-16BE"});
+  auto result = evaluate<SimpleVector<StringView>>(
+      "encode(c0, c1)", makeRowVector({inputs, charsets}));
+  auto utf8 = result->valueAt(0);
+  auto ascii = result->valueAt(1);
+  auto utf16be = result->valueAt(2);
+  // UTF-8: "AB" -> 41 42.
+  EXPECT_THAT(toBytes(std::string_view(utf8)), ElementsAre(0x41, 0x42));
+  // US-ASCII: "AB" -> 41 42.
+  EXPECT_THAT(toBytes(std::string_view(ascii)), ElementsAre(0x41, 0x42));
+  // UTF-16BE: "AB" -> 00 41 00 42 (2 bytes per char, no BOM for BE).
+  EXPECT_THAT(
+      toBytes(std::string_view(utf16be)), ElementsAre(0x00, 0x41, 0x00, 0x42));
+}
+
+TEST_F(EncodeTest, charsetNameLengthBoundary) {
+  // A 24-char (== kMaxCharsetLen) unsupported name must be handled without
+  // overrunning the stack buffer, and rejected as unsupported.
+  VELOX_ASSERT_USER_THROW(
+      encode("hello", "ABCDEFGHIJKLMNOPQRSTUVWX"),
+      "encode: unsupported charset 'ABCDEFGHIJKLMNOPQRSTUVWX'");
+  // A 25-char (> kMaxCharsetLen) name is rejected early, also unsupported.
+  VELOX_ASSERT_USER_THROW(
+      encode("hello", "ABCDEFGHIJKLMNOPQRSTUVWXY"),
+      "encode: unsupported charset 'ABCDEFGHIJKLMNOPQRSTUVWXY'");
+}
+
+TEST_F(EncodeTest, batch) {
+  // Test with multiple rows using flat vectors.
+  auto inputs = makeFlatVector<StringView>({"hello", "world", "abc"});
+  auto charsets = makeFlatVector<StringView>({"UTF-8", "UTF-8", "UTF-8"});
+  auto result = evaluate<SimpleVector<StringView>>(
+      "encode(c0, c1)", makeRowVector({inputs, charsets}));
+  EXPECT_EQ(result->valueAt(0).str(), "hello");
+  EXPECT_EQ(result->valueAt(1).str(), "world");
+  EXPECT_EQ(result->valueAt(2).str(), "abc");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
## Summary

Adds the Spark `encode(string, charset) -> varbinary` scalar function, which
converts a VARCHAR value to bytes using the requested character encoding.

By default, the function accepts the Spark-supported charsets `US-ASCII`,
`ISO-8859-1`, `UTF-8`, `UTF-16BE`, `UTF-16LE`, `UTF-16`, and `UTF-32`.
Charset matching is case-insensitive. Enabling
`spark.legacy_java_charsets` additionally permits supported JDK charset names
and aliases.

Spark reference:
https://spark.apache.org/docs/latest/api/sql/index.html#encode

## Semantics

- Unsupported charsets and unmappable characters return catchable user errors
  through the non-throwing function path.
- Enabling `spark.legacy_coding_error_action` replaces unmappable characters
  using the selected JDK charset's replacement bytes.
- `UTF-16` and its marked aliases emit the corresponding byte-order mark.
  `UTF-16BE`, `UTF-16LE`, and `UTF-32` emit no byte-order mark.
- Java UTF-16, Shift_JIS, and Windows-31J aliases preserve their corresponding
  JDK byte-level mappings.
- Empty input produces empty output without a byte-order mark.
- Malformed UTF-8 input is normalized using Java-compatible U+FFFD grouping.
- Null input or charset values produce null.

## Documentation

Adds `encode` to the Spark string function reference.
