### PR TITLE
fix(dwio): Correct row-index size when a scan has a filter and no child readers

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -346,6 +346,17 @@ void SelectiveStructColumnReaderBase::next(
       break;
     }
   }
+  // 'outputRows_' is populated only when there is a deletion, but outputRows()
+  // consults useOutputRows(), which is also true when the scan spec has a
+  // filter. With a filter and no deletion it therefore returns the empty
+  // 'outputRows_', which would size the synthesized fields below to zero while
+  // the result vector is sized to 'numValues', producing a RowVector whose
+  // child is shorter than its parent. Size them from 'numValues' instead so the
+  // two always agree.
+  const RowSet fieldRows = hasDeletion_
+      ? RowSet(outputRows_)
+      : RowSet(rows.data(), static_cast<size_t>(numValues));
+
   prepareResult(result);
   auto* resultRowVector = result->asChecked<RowVector>();
   resultRowVector->unsafeResize(numValues);
@@ -366,7 +377,7 @@ void SelectiveStructColumnReaderBase::next(
         velox::common::ScanSpec::ColumnType::kRowIndex) {
       VELOX_CHECK(!childSpec->hasFilter());
       setRowNumberField(
-          currentRowNumber_, outputRows(), resultRowVector->pool(), childField);
+          currentRowNumber_, fieldRows, resultRowVector->pool(), childField);
     } else if (
         childSpec->columnType() ==
         velox::common::ScanSpec::ColumnType::kComposite) {
@@ -374,7 +385,7 @@ void SelectiveStructColumnReaderBase::next(
       setCompositeField(
           *childSpec,
           currentRowNumber_,
-          outputRows(),
+          fieldRows,
           resultRowVector->pool(),
           childField);
     } else {

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <numeric>
-
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
+
+#include <numeric>
 
 #include "velox/dwio/common/ColumnLoader.h"
 

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <numeric>
+
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 
 #include "velox/dwio/common/ColumnLoader.h"
@@ -338,25 +340,30 @@ void SelectiveStructColumnReaderBase::next(
   if (hasDeletion_) {
     fillOutputRowsFromMutation(numValues);
     numValues = outputRows_.size();
+  } else if (useOutputRows()) {
+    // Nothing on this path populates 'outputRows_', but useOutputRows() is also
+    // true when the scan spec has a filter, so outputRows() would return an
+    // empty set while the result carries 'numValues' rows. Callers rely on the
+    // two agreeing -- the synthesized fields below, and
+    // RowReader::readWithRowNumber -- so keep the invariant here rather than at
+    // each use. No row is eliminated on this path: with no child readers the
+    // only filters are on constant columns, and those are all-or-nothing and
+    // handled below.
+    outputRows_.resize(numValues);
+    std::iota(outputRows_.begin(), outputRows_.end(), 0);
   }
   for (const auto& childSpec : scanSpec_->children()) {
     if (isChildConstant(*childSpec) && !testFilterOnConstant(*childSpec)) {
       outputRows_.clear();
+      // A constant column's filter is not counted by ScanSpec::hasFilter(), so
+      // useOutputRows() can be false here; clear 'inputRows_' too, otherwise
+      // outputRows() would fall back to it and report rows that were filtered
+      // out.
+      inputRows_ = {};
       numValues = 0;
       break;
     }
   }
-  // 'outputRows_' is populated only when there is a deletion, but outputRows()
-  // consults useOutputRows(), which is also true when the scan spec has a
-  // filter. With a filter and no deletion it therefore returns the empty
-  // 'outputRows_', which would size the synthesized fields below to zero while
-  // the result vector is sized to 'numValues', producing a RowVector whose
-  // child is shorter than its parent. Size them from 'numValues' instead so the
-  // two always agree.
-  const RowSet fieldRows = hasDeletion_
-      ? RowSet(outputRows_)
-      : RowSet(rows.data(), static_cast<size_t>(numValues));
-
   prepareResult(result);
   auto* resultRowVector = result->asChecked<RowVector>();
   resultRowVector->unsafeResize(numValues);
@@ -377,7 +384,7 @@ void SelectiveStructColumnReaderBase::next(
         velox::common::ScanSpec::ColumnType::kRowIndex) {
       VELOX_CHECK(!childSpec->hasFilter());
       setRowNumberField(
-          currentRowNumber_, fieldRows, resultRowVector->pool(), childField);
+          currentRowNumber_, outputRows(), resultRowVector->pool(), childField);
     } else if (
         childSpec->columnType() ==
         velox::common::ScanSpec::ColumnType::kComposite) {
@@ -385,7 +392,7 @@ void SelectiveStructColumnReaderBase::next(
       setCompositeField(
           *childSpec,
           currentRowNumber_,
-          fieldRows,
+          outputRows(),
           resultRowVector->pool(),
           childField);
     } else {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -6184,6 +6184,69 @@ TEST_F(TableScanTest, rowNumberInRemainingFilter) {
       .assertResults(expected);
 }
 
+// A scan that projects only columns which are not read from the file has no
+// child readers. If such a scan also has a filter, outputRows() returns the
+// empty outputRows_, and the synthesized row-index column used to come out
+// shorter than the vector containing it.
+TEST_F(TableScanTest, rowIndexWithFilterOnPartitionKeyOnly) {
+  constexpr vector_size_t kNumRows = 10;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; })});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+  const auto fileSchema = asRowType(data->type());
+
+  // Neither output column is read from the file: 'row_index' is synthesized and
+  // 'p' is a partition key, so the struct reader ends up with no child readers.
+  auto outputType = ROW({"row_index", "p"}, {BIGINT(), INTEGER()});
+
+  connector::ColumnHandleMap assignments;
+  assignments["row_index"] = std::make_shared<HiveColumnHandle>(
+      "row_index", FileColumnHandle::ColumnType::kRowIndex, BIGINT(), BIGINT());
+  assignments["p"] = makeColumnHandle(
+      "p",
+      INTEGER(),
+      INTEGER(),
+      {},
+      FileColumnHandle::ColumnType::kPartitionKey);
+
+  // The filter is satisfied by this split, so it eliminates no row. Its only
+  // effect is to make ScanSpec::hasFilter() true.
+  common::SubfieldFilters filters;
+  filters.emplace(
+      common::Subfield("p"),
+      std::make_unique<common::BigintRange>(1, 1, /*nullAllowed=*/false));
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(outputType)
+                  .dataColumns(fileSchema)
+                  .subfieldFiltersMap(filters)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys{
+      {"p", "1"}};
+  auto splits = makeHiveConnectorSplits(
+      filePath->getPath(), 1, dwio::common::FileFormat::DWRF, partitionKeys);
+
+  auto result =
+      AssertQueryBuilder(plan)
+          .split(splits[0])
+          .config(core::QueryConfig::kValidateOutputFromOperators, "true")
+          .copyResults(pool());
+
+  ASSERT_EQ(result->size(), kNumRows);
+  ASSERT_EQ(result->childAt(0)->size(), result->size());
+  auto* rowIndex = result->childAt(0)->asFlatVector<int64_t>();
+  for (vector_size_t row = 0; row < kNumRows; ++row) {
+    EXPECT_FALSE(result->childAt(0)->isNullAt(row));
+    EXPECT_EQ(rowIndex->valueAt(row), row);
+  }
+}
+
 TEST_F(TableScanTest, hugeStripe) {
   CursorParameters params;
   params.planNode =

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -6247,6 +6247,72 @@ TEST_F(TableScanTest, rowIndexWithFilterOnPartitionKeyOnly) {
   }
 }
 
+// The same defect reached through a dynamic filter rather than a static one.
+// This is the shape a real engine hits: there is no constant partition
+// predicate anywhere in the query, so nothing could have been resolved during
+// split generation. The filter appears on the scan spec only at runtime, pushed
+// down from the join whose key is the partition column.
+TEST_F(TableScanTest, rowIndexWithDynamicFilterOnPartitionKey) {
+  constexpr vector_size_t kNumRows = 10;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; })});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+  const auto fileSchema = asRowType(data->type());
+
+  auto outputType = ROW({"row_index", "p"}, {BIGINT(), INTEGER()});
+
+  connector::ColumnHandleMap assignments;
+  assignments["row_index"] = std::make_shared<HiveColumnHandle>(
+      "row_index", FileColumnHandle::ColumnType::kRowIndex, BIGINT(), BIGINT());
+  assignments["p"] = makeColumnHandle(
+      "p",
+      INTEGER(),
+      INTEGER(),
+      {},
+      FileColumnHandle::ColumnType::kPartitionKey);
+
+  // No subfield filter here. The build side supplies the only filter, and it
+  // matches the partition value, so it eliminates no row.
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto build =
+      PlanBuilder(planNodeIdGenerator)
+          .values({makeRowVector(
+              {"bk"}, {makeFlatVector<int32_t>(std::vector<int32_t>{1})})})
+          .planNode();
+
+  core::PlanNodeId scanId;
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .startTableScan()
+                  .outputType(outputType)
+                  .dataColumns(fileSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .capturePlanNodeId(scanId)
+                  .hashJoin({"p"}, {"bk"}, build, "", {"row_index", "p"})
+                  .planNode();
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys{
+      {"p", "1"}};
+  auto splits = makeHiveConnectorSplits(
+      filePath->getPath(), 1, dwio::common::FileFormat::DWRF, partitionKeys);
+
+  auto result =
+      AssertQueryBuilder(plan)
+          .split(scanId, splits[0])
+          .config(core::QueryConfig::kValidateOutputFromOperators, "true")
+          .copyResults(pool());
+
+  ASSERT_EQ(result->size(), kNumRows);
+  ASSERT_EQ(result->childAt(0)->size(), result->size());
+  auto* dynamicRowIndex = result->childAt(0)->asFlatVector<int64_t>();
+  for (vector_size_t row = 0; row < kNumRows; ++row) {
+    EXPECT_FALSE(result->childAt(0)->isNullAt(row));
+    EXPECT_EQ(dynamicRowIndex->valueAt(row), row);
+  }
+}
+
 TEST_F(TableScanTest, hugeStripe) {
   CursorParameters params;
   params.planNode =


### PR DESCRIPTION
## Summary

`SelectiveStructColumnReaderBase::next()` has a branch for structs with **no child readers** — a scan that projects only columns which are not read from the file (partition keys, synthesized columns, row-index columns). There it clears `outputRows_` and repopulates it only when there is a deletion, then sizes the result vector to `numValues` while sizing the synthesized fields from `outputRows()`:

```cpp
  inputRows_ = rows;
  outputRows_.clear();
  if (hasDeletion_) {
    fillOutputRowsFromMutation(numValues);
    numValues = outputRows_.size();
  }
  ...
  resultRowVector->unsafeResize(numValues);                                     // parent <- numValues
  ...
      setRowNumberField(currentRowNumber_, outputRows(), ..., childField);      // child  <- outputRows().size()
```

`outputRows()` returns `outputRows_` whenever `useOutputRows()` holds, and that is true for a filter as well as for a deletion:

```cpp
  const RowSet outputRows() const {
    return useOutputRows() ? outputRows_ : inputRows_;
  }

  bool useOutputRows() const {
    return scanSpec_->hasFilter() || hasDeletion();
  }
```

So a scan with a filter and no deletion reads back the empty `outputRows_`, and the row-index column comes out with zero rows while the `RowVector` containing it reports `numValues` rows.

## Reachability

The filter that trips this does not have to be in the query. A **dynamic filter**, pushed to the scan at runtime from a join whose key is the partition column, is enough — and such a filter cannot be resolved during split generation, since its values do not exist until the build side completes. A static subfield filter on a partition key reaches the same branch; it is the simpler form and is kept as the minimal reproduction.

## Fix

Populate `outputRows_` in `next()` itself when `useOutputRows()` holds and there is no deletion, so `outputRows()` and `numValues` agree for every caller rather than at each use. No row is eliminated on that path: with no child readers the only filters are on constant columns, and those are all-or-nothing.

Doing it centrally also covers `RowReader::readWithRowNumber()` (`Reader.cpp`), which reads the same `outputRows()` and today is guarded only by a `VELOX_DCHECK_EQ` — so in a release build it silently wrote nothing.

The constant-column path needs one more thing: when a constant child fails its filter the code clears `outputRows_`, but `ScanSpec::hasFilter()` does not count constant children, so `useOutputRows()` can be false there and `outputRows()` would fall back to `inputRows_` and report rows that were filtered out. `inputRows_` is now cleared alongside it.

| case | `outputRows()` | `numValues` |
|---|---|---|
| deletion | from mutation | `outputRows_.size()` |
| filter, no deletion | `0..numValues` — **was empty, the bug** | unchanged |
| constant child fails its filter | empty | 0 |
| plain (no filter, no deletion) | `inputRows_` | unchanged |

## Tests

Two tests in `TableScanTest`, both projecting only a `kRowIndex` column and a `kPartitionKey`, with a filter that is satisfied by the split (so it removes no row) and no deletion:

* `rowIndexWithFilterOnPartitionKeyOnly` — the filter is a static subfield filter. Minimal, and independent of dynamic-filter behaviour.
* `rowIndexWithDynamicFilterOnPartitionKey` — no filter in the plan at all; a hash join on the partition column supplies the only filter, at runtime.

Both fail before this change and pass after it. Before, with `debug.validate_output_from_operators` (transcript captured on the revision Gluten pins; the same check is `ComplexVector.cpp:659` on current `main`):

```
Reason: Child vector has size 0 less than parent and parent has no nulls 10.
Expression: nulls_ != nullptr
Function: validate
File: velox/vector/ComplexVector.cpp   Line: 647
```

Without that flag they still fail, but further downstream and less legibly (`Expression: source->size() > 0` at `velox/vector/EncodedVectorCopy.cpp:1224`).

## Impact beyond the assertion

`BaseVector::wrapInDictionary()` does not validate indexes against the base vector's size, so a downstream operator can wrap the empty child in a dictionary of size N. Reading it then indexes past the end of a zero-length buffer and returns whatever heap memory follows.

We hit this in Apache Gluten. A Delta Lake `MERGE` produces deletion vectors, and to do that it scans the target table for `_metadata.row_index` plus the partition key; the join on the partition column pushes a dynamic filter into that scan. The row indexes came back as arbitrary heap words — observed values included `9223372036854775807`, `-1`, and pointer-shaped values such as `0xe43315c000007f00`. Most were silently accepted; occasionally one fell outside the valid range and aborted the query, which is how we found it (apache/gluten#12377).

## Verification

* Both new tests fail before the change and pass after it.
* Applied to the Velox revision Gluten pins, the deterministic Gluten reproduction goes from 9 scan-validation failures and a failed test to 0 failures and a pass.
* The full Delta deletion-vector suite (~360 tests) run with `debug.validate_output_from_operators` enabled reports 0 validation failures and results identical to the pre-existing baseline.

Fixes #18535
