### PR TITLE
build(nimble): Track benchmark data headers in CMake

### DIFF
--- a/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -15,7 +15,10 @@ add_executable(
   nimble_fixed_bit_width_benchmark
   FixedBitWidthBenchmark.cpp
   BenchmarkUtils.h
+  DeltaBenchmarkData.h
+  FixedBitWidthBenchmarkData.h
   NimbleEncodingRunner.h
+  SparseBoolBenchmarkData.h
 )
 
 target_link_libraries(


### PR DESCRIPTION
## Summary

The Nimble move (#18468) added three benchmark data headers without
registering them in any CMakeLists.txt target:

- `velox/dwio/nimble/encodings/benchmarks/DeltaBenchmarkData.h`
- `velox/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmarkData.h`
- `velox/dwio/nimble/encodings/benchmarks/SparseBoolBenchmarkData.h`

Because the `check-header-ownership` pre-commit hook runs with
`--all-files`, this currently fails the `Run Checks / pre-commit` job on
every pull request based on `main`.

Register the headers in `nimble_fixed_bit_width_benchmark`, which
already tracks the Buck-only `NimbleEncodingRunner.h` the same way.
Verified locally: `python3 scripts/checks/check-header-ownership.py
velox` reports all 1633 headers tracked, and all pre-commit hooks pass
on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
