### PR TITLE
refactor: Drop the prefix from TrackedExecutor::reportTo

### DIFF
--- a/velox/common/base/TrackedExecutor.cpp
+++ b/velox/common/base/TrackedExecutor.cpp
@@ -51,17 +51,11 @@ TrackedExecutor::Func TrackedExecutor::wrapFunc(Func func) {
   };
 }
 
-void TrackedExecutor::reportTo(
-    BaseRuntimeStatWriter& writer,
-    std::string_view prefix) const {
+void TrackedExecutor::reportTo(BaseRuntimeStatWriter& writer) const {
+  writer.setRuntimeStat(kExecutorWaitNanos, metrics_->waitTime);
   writer.setRuntimeStat(
-      fmt::format("{}-{}", prefix, kExecutorWaitNanos), metrics_->waitTime);
-  writer.setRuntimeStat(
-      fmt::format("{}-{}", prefix, kExecutorExecutionWallNanos),
-      metrics_->executionWallTime);
-  writer.setRuntimeStat(
-      fmt::format("{}-{}", prefix, kExecutorExecutionCpuNanos),
-      metrics_->executionCpuTime);
+      kExecutorExecutionWallNanos, metrics_->executionWallTime);
+  writer.setRuntimeStat(kExecutorExecutionCpuNanos, metrics_->executionCpuTime);
 }
 
 } // namespace facebook::velox

--- a/velox/common/base/TrackedExecutor.h
+++ b/velox/common/base/TrackedExecutor.h
@@ -67,8 +67,8 @@ class TrackedExecutor final : public folly::Executor {
     return executor_->getNumPriorities();
   }
 
-  /// Reports accumulated metrics to 'writer', naming each 'prefix-<metric>'.
-  void reportTo(BaseRuntimeStatWriter& writer, std::string_view prefix) const;
+  /// Reports accumulated metrics to 'writer' under the kExecutor* names.
+  void reportTo(BaseRuntimeStatWriter& writer) const;
 
  private:
   // Instruments 'func' to record its enqueue-wait, wall, and cpu time into

--- a/velox/common/base/tests/TrackedExecutorTest.cpp
+++ b/velox/common/base/tests/TrackedExecutorTest.cpp
@@ -33,7 +33,7 @@ namespace {
 
 class TrackedExecutorTest : public testing::Test {};
 
-TEST_F(TrackedExecutorTest, reportsPerCallbackMetricsUnderPrefix) {
+TEST_F(TrackedExecutorTest, reportsOneSamplePerCallback) {
   // Run callbacks inline so the per-metric counts are deterministic.
   TrackedExecutor tracked{
       folly::getKeepAliveToken(folly::InlineExecutor::instance())};
@@ -51,19 +51,19 @@ TEST_F(TrackedExecutorTest, reportsPerCallbackMetricsUnderPrefix) {
   }
 
   ConcurrentRuntimeStatWriter writer;
-  tracked.reportTo(writer, "myOp");
+  tracked.reportTo(writer);
   const auto metrics = writer.runtimeStats();
 
   ASSERT_THAT(
       metrics,
       testing::UnorderedElementsAre(
-          testing::Key("myOp-executorWaitNanos"),
-          testing::Key("myOp-executorExecutionWallNanos"),
-          testing::Key("myOp-executorExecutionCpuNanos")));
+          testing::Key("executorWaitNanos"),
+          testing::Key("executorExecutionWallNanos"),
+          testing::Key("executorExecutionCpuNanos")));
 
-  const auto& wait = metrics.at("myOp-executorWaitNanos");
-  const auto& wall = metrics.at("myOp-executorExecutionWallNanos");
-  const auto& cpu = metrics.at("myOp-executorExecutionCpuNanos");
+  const auto& wait = metrics.at("executorWaitNanos");
+  const auto& wall = metrics.at("executorExecutionWallNanos");
+  const auto& cpu = metrics.at("executorExecutionCpuNanos");
 
   // Every scheduled callback contributes one sample to each metric.
   EXPECT_EQ(wait.count, kNumTasks);
@@ -94,12 +94,12 @@ TEST_F(TrackedExecutorTest, keepsMetricCountsAlignedWhenCallbackThrows) {
       std::runtime_error);
 
   ConcurrentRuntimeStatWriter writer;
-  tracked.reportTo(writer, "op");
+  tracked.reportTo(writer);
   const auto metrics = writer.runtimeStats();
 
-  EXPECT_EQ(metrics.at("op-executorWaitNanos").count, 1);
-  EXPECT_EQ(metrics.at("op-executorExecutionWallNanos").count, 1);
-  EXPECT_EQ(metrics.at("op-executorExecutionCpuNanos").count, 1);
+  EXPECT_EQ(metrics.at("executorWaitNanos").count, 1);
+  EXPECT_EQ(metrics.at("executorExecutionWallNanos").count, 1);
+  EXPECT_EQ(metrics.at("executorExecutionCpuNanos").count, 1);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
`reportTo` took a prefix and wrote each metric as `<prefix>-<name>`, so the executor decided how its metrics were spelled. It now writes the bare names and leaves the naming to the caller:

    void reportTo(BaseRuntimeStatWriter& writer) const;

A caller reporting several executors into one store wraps the writer it passes in, so keeping their samples apart stays where the naming is decided.

Published names are unchanged.

Differential Revision: D116372892


