### PR TITLE
fix(ci): Run clang-tidy for Breeze separately

### DIFF
--- a/.github/actions/setup-clang-tidy/action.yml
+++ b/.github/actions/setup-clang-tidy/action.yml
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Set up clang-tidy
+description: Install the clang-tidy used by Velox CI.
+
+runs:
+  using: composite
+  steps:
+    - name: Install clang-tidy
+      shell: bash
+      run: uv tool install clang-tidy==18.1.8

--- a/.github/workflows/breeze.yml
+++ b/.github/workflows/breeze.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: velox
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv
@@ -67,6 +68,7 @@ jobs:
           source scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Make Debug Build
+        id: build
         env:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
         # OpenMP build with asan+ubsan enabled
@@ -74,9 +76,37 @@ jobs:
           cmake -S velox/experimental/breeze -B _build-breeze/debug \
                 -DCMAKE_BUILD_TYPE=Asan \
                 -DCMAKE_CXX_FLAGS="-fsanitize=undefined" \
+                -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                 -DBUILD_GENERATE_TEST_FIXTURES=OFF \
                 -DBUILD_OPENMP=ON
+          compiler_file=$(find _build-breeze/debug/CMakeFiles -name CMakeCXXCompiler.cmake -print -quit)
+          compiler_id=$(sed -n 's/^set(CMAKE_CXX_COMPILER_ID "\(.*\)")$/\1/p' "$compiler_file")
+          echo "compiler_file=${compiler_file}" >> "$GITHUB_OUTPUT"
+          echo "compiler_id=${compiler_id}" >> "$GITHUB_OUTPUT"
           cmake --build _build-breeze/debug -j 8
+
+      - name: Install and run clang-tidy
+        if: ${{ steps.build.outcome == 'success' && github.event_name == 'pull_request' && steps.build.outputs.compiler_id == 'GNU' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          COMPILER_FILE: ${{ steps.build.outputs.compiler_file }}
+        run: |
+          uv tool install clang-tidy==18.1.8
+          RANGE="${BASE_SHA}..HEAD"
+          FILES=$(git diff --name-only "$RANGE" -- velox/experimental/breeze/ | grep -E '\.(cpp|h|hpp)$' || true)
+          # The usage of GCC14 adds compiler warnings not understood by Clang/Clang-tidy.
+          # We replace them for now but eventually move Clang-tidy to the Clang based build.
+          BUILD_PATH=$(realpath _build-breeze/debug)
+          CXX_COMPILER=$(sed -n 's/^set(CMAKE_CXX_COMPILER "\(.*\)")$/\1/p' "$COMPILER_FILE")
+          GCC_INCLUDE=$("$CXX_COMPILER" -print-file-name=include)
+          sed -i 's/-Wno-maybe-uninitialized//g' "$BUILD_PATH/compile_commands.json"
+          sed -i "s# -fopenmp -DPLATFORM_OPENMP# -isystem ${GCC_INCLUDE} -fopenmp -DPLATFORM_OPENMP#g" "$BUILD_PATH/compile_commands.json"
+
+          if [[ -n "$FILES" ]]; then
+            python ./scripts/checks/run-clang-tidy.py -p "$BUILD_PATH" --commit "$RANGE" $FILES
+          else
+            echo "No changed Breeze C++ files to run clang-tidy."
+          fi
 
       - name: Run Tests
         run: |

--- a/.github/workflows/breeze.yml
+++ b/.github/workflows/breeze.yml
@@ -100,6 +100,7 @@ jobs:
           CXX_COMPILER=$(sed -n 's/^set(CMAKE_CXX_COMPILER "\(.*\)")$/\1/p' "$COMPILER_FILE")
           GCC_INCLUDE=$("$CXX_COMPILER" -print-file-name=include)
           sed -i 's/-Wno-maybe-uninitialized//g' "$BUILD_PATH/compile_commands.json"
+          sed -i 's/-Werror/-Werror -Wno-error=deprecated-declarations/g' "$BUILD_PATH/compile_commands.json"
           sed -i "s# -fopenmp -DPLATFORM_OPENMP# -isystem ${GCC_INCLUDE} -fopenmp -DPLATFORM_OPENMP#g" "$BUILD_PATH/compile_commands.json"
 
           if [[ -n "$FILES" ]]; then

--- a/.github/workflows/breeze.yml
+++ b/.github/workflows/breeze.yml
@@ -57,7 +57,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: velox
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv
@@ -85,26 +84,35 @@ jobs:
           echo "compiler_id=${compiler_id}" >> "$GITHUB_OUTPUT"
           cmake --build _build-breeze/debug -j 8
 
-      - name: Install and run clang-tidy
+      - name: Install clang-tidy
         if: ${{ steps.build.outcome == 'success' && github.event_name == 'pull_request' && steps.build.outputs.compiler_id == 'GNU' }}
+        uses: ./velox/.github/actions/setup-clang-tidy
+
+      - name: Run clang-tidy
+        if: ${{ steps.build.outcome == 'success' && github.event_name == 'pull_request' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           COMPILER_FILE: ${{ steps.build.outputs.compiler_file }}
+          COMPILER_ID: ${{ steps.build.outputs.compiler_id }}
         run: |
-          uv tool install clang-tidy==18.1.8
+          git fetch origin "$BASE_SHA"
           RANGE="${BASE_SHA}..HEAD"
           FILES=$(git diff --name-only "$RANGE" -- velox/experimental/breeze/ | grep -E '\.(cpp|h|hpp)$' || true)
-          # The usage of GCC14 adds compiler warnings not understood by Clang/Clang-tidy.
-          # We replace them for now but eventually move Clang-tidy to the Clang based build.
-          BUILD_PATH=$(realpath _build-breeze/debug)
-          CXX_COMPILER=$(sed -n 's/^set(CMAKE_CXX_COMPILER "\(.*\)")$/\1/p' "$COMPILER_FILE")
-          GCC_INCLUDE=$("$CXX_COMPILER" -print-file-name=include)
-          sed -i 's/-Wno-maybe-uninitialized//g' "$BUILD_PATH/compile_commands.json"
-          sed -i 's/-Werror/-Werror -Wno-error=deprecated-declarations/g' "$BUILD_PATH/compile_commands.json"
-          sed -i "s# -fopenmp -DPLATFORM_OPENMP# -isystem ${GCC_INCLUDE} -fopenmp -DPLATFORM_OPENMP#g" "$BUILD_PATH/compile_commands.json"
+          if [[ -n "$FILES" && "$COMPILER_ID" == "GNU" ]]; then
+            # The usage of GCC14 adds compiler warnings not understood by Clang/Clang-tidy.
+            # We replace them for now but eventually move Clang-tidy to the Clang based build.
+            BUILD_PATH=$(realpath _build-breeze/debug)
+            CXX_COMPILER=$(sed -n 's/^set(CMAKE_CXX_COMPILER "\(.*\)")$/\1/p' "$COMPILER_FILE")
+            sed -i 's/-Wno-maybe-uninitialized//g' "$BUILD_PATH/compile_commands.json"
+            sed -i 's/-Werror/-Werror -Wno-error=deprecated-declarations/g' "$BUILD_PATH/compile_commands.json"
+            # clang-tidy uses Clang, add GCC's private include directory as a system include so Clang can find
+            # the GCC headers referenced by the compile commands.
+            GCC_INCLUDE=$("$CXX_COMPILER" -print-file-name=include)
+            sed -i "s# -fopenmp -DPLATFORM_OPENMP# -isystem ${GCC_INCLUDE} -fopenmp -DPLATFORM_OPENMP#g" "$BUILD_PATH/compile_commands.json"
 
-          if [[ -n "$FILES" ]]; then
             python ./scripts/checks/run-clang-tidy.py -p "$BUILD_PATH" --commit "$RANGE" $FILES
+          elif [[ "$COMPILER_ID" != "GNU" ]]; then
+            echo "Skip clang-tidy: the compiler is $COMPILER_ID, but clang-tidy check currently supports GCC only."
           else
             echo "No changed Breeze C++ files to run clang-tidy."
           fi

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -297,7 +297,11 @@ jobs:
       # When clang is used a number of dependencies are excluded from the build so we don't
       # need to run clang-tidy for that.
       # Let's also run this as last step so that if skipped it doesn't affect subsequent steps.
-      - name: Install and run clang-tidy
+      - name: Install clang-tidy
+        if: ${{ steps.build.outcome == 'success' && ! inputs.use-clang && needs.get-changes.outputs.run-clang-tidy == 'true' }}
+        uses: ./.github/actions/setup-clang-tidy
+
+      - name: Run clang-tidy
         if: ${{ steps.build.outcome == 'success' && ! inputs.use-clang && needs.get-changes.outputs.run-clang-tidy == 'true' }}
         env:
           FILES: ${{ needs.get-changes.outputs.changed-files }}
@@ -305,7 +309,6 @@ jobs:
           MERGE_BASE_COMMIT: ${{ needs.get-changes.outputs.merge-base-commit }}
         run: |
           git config --global --add safe.directory /__w/velox/velox
-          uv tool install clang-tidy==18.1.8
           git fetch origin $MERGE_BASE_COMMIT
           # The usage of GCC14 adds compiler warnings not understood by Clang/Clang-tidy.
           # We replace them for now but eventually move Clang-tidy to the Clang based build.

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -314,7 +314,9 @@ jobs:
           sed -i 's/-Wno-class-memaccess//g' $BUILD_PATH/compile_commands.json
           sed -i 's/-Wno-maybe-uninitialized//g' $BUILD_PATH/compile_commands.json
           sed -i 's/-fcoroutines//g' $BUILD_PATH/compile_commands.json
-          python ./scripts/checks/run-clang-tidy.py -p $BUILD_PATH --commit $RANGE $FILES
+          # Breeze is a separate CMake project. Its files need the Breeze
+          # compile database, not the adapters build compile database.
+          python ./scripts/checks/run-clang-tidy.py -p $BUILD_PATH --commit $RANGE --exclude-dir breeze/ $FILES
 
       - name: Check cuDF Changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -83,7 +83,11 @@ def check_output(output):
 
 def tidy(args):
     files = util.input_files(args.files)
-    files = [file for file in files if not any(exclude_dir in file for exclude_dir in args.exclude_dirs)]
+    files = [
+        file
+        for file in files
+        if not any(exclude_dir in file for exclude_dir in args.exclude_dirs)
+    ]
     files = [file for file in files if re.match(r".*(\.cpp|\.h|\.hpp)$", file)]
 
     # Exclude files in cudf, wave, and torchwave directories

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -54,7 +54,9 @@ def git_changed_lines(commit, exclude_dirs=None):
                 "cudf/" not in matched_file
                 and "wave/" not in matched_file
                 and "ucx-exchange/" not in matched_file
-                and not any(exclude_dir in matched_file for exclude_dir in (exclude_dirs or []))
+                and not any(
+                    exclude_dir in matched_file for exclude_dir in (exclude_dirs or [])
+                )
                 and not matched_file.endswith("-inl.h")
             ):
                 file = matched_file

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -30,7 +30,7 @@ class Multimap(dict):
             self[key].append(value)
 
 
-def git_changed_lines(commit):
+def git_changed_lines(commit, exclude_dirs=None):
     file = ""
     changed_lines = Multimap()
 
@@ -54,6 +54,7 @@ def git_changed_lines(commit):
                 "cudf/" not in matched_file
                 and "wave/" not in matched_file
                 and "ucx-exchange/" not in matched_file
+                and not any(exclude_dir in matched_file for exclude_dir in (exclude_dirs or []))
                 and not matched_file.endswith("-inl.h")
             ):
                 file = matched_file
@@ -80,6 +81,7 @@ def check_output(output):
 
 def tidy(args):
     files = util.input_files(args.files)
+    files = [file for file in files if not any(exclude_dir in file for exclude_dir in args.exclude_dirs)]
     files = [file for file in files if re.match(r".*(\.cpp|\.h|\.hpp)$", file)]
 
     # Exclude files in cudf, wave, and torchwave directories
@@ -96,7 +98,7 @@ def tidy(args):
     files = [file for file in files if not file.endswith("-inl.h")]
 
     in_gha = os.environ.get("GITHUB_ACTIONS") is not None
-    changed_lines = git_changed_lines(args.commit)
+    changed_lines = git_changed_lines(args.commit, args.exclude_dirs)
 
     line_filter = json.dumps(
         [{"name": key, "lines": value} for key, value in changed_lines.items()]
@@ -162,6 +164,13 @@ def parse_args():
     parser.add_argument("--fix")
     parser.add_argument("-p", help="Path containing 'compile_commands.json'")
 
+    parser.add_argument(
+        "--exclude-dir",
+        action="append",
+        default=[],
+        dest="exclude_dirs",
+        help="Additional path substring to exclude from clang-tidy.",
+    )
     parser.add_argument("files", metavar="FILES", nargs="+", help="files to process")
 
     return parser.parse_args()


### PR DESCRIPTION
Fix clang-tidy for Breeze sources by running it with Breeze's own compilation database.

The Linux adapters job currently runs clang-tidy on changed Breeze files using the adapters build database. That database lacks Breeze's platform definitions (for example, `PLATFORM_OPENMP`), causing false-positive parse errors such as `#error unsupported platform`.

This change:

- Excludes Breeze files from clang-tidy in the Linux adapters job.
- Runs clang-tidy for changed Breeze C++ files in the Breeze workflow, using the Breeze debug build's `compile_commands.json`.

Spilt of https://github.com/facebookincubator/velox/pull/17602

Change is verified in https://github.com/facebookincubator/velox/pull/18540