### PR TITLE
feat(nimble): Add PFOR encoding benchmark

### DIFF
--- a/velox/dwio/nimble/encodings/benchmarks/BlockBitPackingBenchmarkData.h
+++ b/velox/dwio/nimble/encodings/benchmarks/BlockBitPackingBenchmarkData.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "velox/dwio/nimble/common/Constants.h"
+
+namespace facebook::nimble::benchmarks {
+
+/// Default seed shared by the native benchmark and executable runner.
+inline constexpr uint64_t kBlockBitPackingBenchmarkDefaultSeed = 0xC0FFEE;
+
+/// First per-block baseline in the representative unsigned corpus.
+inline constexpr uint32_t kBlockBitPackingBenchmarkBaseline = 50'000;
+
+/// Distance between adjacent block baselines in the representative corpus.
+inline constexpr uint32_t kBlockBitPackingBenchmarkBaselineStride = 8'192;
+
+/// Largest residual in each representative 12-bit block.
+inline constexpr uint32_t kBlockBitPackingBenchmarkResidualMax = 0xFFF;
+
+/// Returns one deterministic value from the representative block-local corpus.
+inline constexpr uint32_t blockBitPackingBenchmarkValue(
+    uint64_t index,
+    uint64_t seed = kBlockBitPackingBenchmarkDefaultSeed) {
+  const uint64_t block = index / kBlockBitPackingBlockSize;
+  const uint64_t blockOffset = index % kBlockBitPackingBlockSize;
+  const auto baseline = static_cast<uint32_t>(
+      kBlockBitPackingBenchmarkBaseline +
+      block * kBlockBitPackingBenchmarkBaselineStride + (seed & 0xFF));
+  if (blockOffset == 0) {
+    return baseline;
+  }
+  if (blockOffset == 1) {
+    return baseline + kBlockBitPackingBenchmarkResidualMax;
+  }
+  const uint64_t mixed = (index * 1'000'003ULL) ^ seed ^ (seed >> 32);
+  return baseline +
+      static_cast<uint32_t>(mixed & kBlockBitPackingBenchmarkResidualMax);
+}
+
+static_assert(
+    blockBitPackingBenchmarkValue(1) - blockBitPackingBenchmarkValue(0) ==
+    kBlockBitPackingBenchmarkResidualMax);
+
+} // namespace facebook::nimble::benchmarks

--- a/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   FixedBitWidthBenchmarkData.h
   NimbleEncodingRunner.h
   SparseBoolBenchmarkData.h
+  VarintBenchmarkData.h
 )
 
 target_link_libraries(
@@ -30,7 +31,11 @@ target_link_libraries(
   velox_memory
 )
 
-add_executable(nimble_block_bit_packing_encoding_benchmark BlockBitPackingEncodingBenchmark.cpp)
+add_executable(
+  nimble_block_bit_packing_encoding_benchmark
+  BlockBitPackingEncodingBenchmark.cpp
+  BlockBitPackingBenchmarkData.h
+)
 
 target_link_libraries(
   nimble_block_bit_packing_encoding_benchmark
@@ -64,7 +69,7 @@ target_link_libraries(
   fsst
 )
 
-add_executable(nimble_huffman_benchmark HuffmanBenchmark.cpp)
+add_executable(nimble_huffman_benchmark HuffmanBenchmark.cpp HuffmanBenchmarkData.h)
 
 target_link_libraries(
   nimble_huffman_benchmark
@@ -89,7 +94,11 @@ target_link_libraries(
   fmt::fmt
 )
 
-add_executable(nimble_simd_for_bitpack_benchmark SimdForBitpackBenchmark.cpp)
+add_executable(
+  nimble_simd_for_bitpack_benchmark
+  SimdForBitpackBenchmark.cpp
+  SimdForBitpackBenchmarkData.h
+)
 
 target_link_libraries(
   nimble_simd_for_bitpack_benchmark
@@ -106,6 +115,40 @@ add_executable(nimble_pfor_encoding_benchmark PFOREncodingBenchmark.cpp PFOREnco
 
 target_link_libraries(
   nimble_pfor_encoding_benchmark
+  nimble_encodings
+  nimble_common
+  Folly::follybenchmark
+  Folly::folly
+  velox_memory
+)
+
+add_executable(
+  nimble_fsst_encoding_benchmark
+  FsstEncodingBenchmark.cpp
+  FsstBenchmarkData.h
+  StringBenchmarkCorpus.h
+)
+
+target_link_libraries(
+  nimble_fsst_encoding_benchmark
+  nimble_encodings
+  nimble_common
+  Folly::follybenchmark
+  Folly::folly
+  velox_memory
+  fsst
+  fmt::fmt
+)
+
+add_executable(
+  nimble_prefix_encoding_benchmark
+  PrefixEncodingBenchmark.cpp
+  PrefixBenchmarkData.h
+  StringBenchmarkCorpus.h
+)
+
+target_link_libraries(
+  nimble_prefix_encoding_benchmark
   nimble_encodings
   nimble_common
   Folly::follybenchmark

--- a/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -101,3 +101,14 @@ target_link_libraries(
   velox_common_base
   velox_memory
 )
+
+add_executable(nimble_pfor_encoding_benchmark PFOREncodingBenchmark.cpp PFOREncodingBenchmarkData.h)
+
+target_link_libraries(
+  nimble_pfor_encoding_benchmark
+  nimble_encodings
+  nimble_common
+  Folly::follybenchmark
+  Folly::folly
+  velox_memory
+)

--- a/velox/dwio/nimble/encodings/benchmarks/FsstBenchmarkData.h
+++ b/velox/dwio/nimble/encodings/benchmarks/FsstBenchmarkData.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "velox/dwio/nimble/encodings/benchmarks/StringBenchmarkCorpus.h"
+
+namespace facebook::nimble::benchmarks {
+
+/// Default seed shared by the native benchmark and executable runner.
+inline constexpr uint64_t kFsstBenchmarkDefaultSeed = 0xC0FFEE;
+
+/// Default row count for the representative structured string corpus.
+inline constexpr uint32_t kFsstBenchmarkDefaultRowCount = 4096;
+
+namespace detail {
+
+inline std::string fsstBenchmarkEdgeValue(uint32_t row, uint64_t seed) {
+  switch (row) {
+    case 0:
+    case 1:
+      return {};
+    case 2:
+    case 3:
+      return "a";
+    case 4: {
+      std::string value{"edge/embedded"};
+      value.append("\0nul", 4);
+      return value;
+    }
+    case 5: {
+      std::string value{"edge/rare-byte/"};
+      value.push_back(static_cast<char>(0xff));
+      return value;
+    }
+    case 6: {
+      std::string value{"edge/rare-tail/"};
+      value.push_back(static_cast<char>(0xff));
+      return value;
+    }
+    case 7: {
+      std::string value{"edge/long/"};
+      value.append(8 * 1024, 'x');
+      return value;
+    }
+    case 8: {
+      std::string value{"edge/chunked/"};
+      value.append(1025, 'q');
+      value.append("\0tail", 5);
+      return value;
+    }
+    default:
+      return fmt::format("edge/{:02}/seed={:016x}", row, seed);
+  }
+}
+
+inline std::string fsstBenchmarkUrlValue(uint32_t row, uint64_t seed) {
+  return fmt::format(
+      "https://api.example.test/v3/tenant/{:06}/users/{:08}/events/"
+      "{:08}?locale=en-US&source=mobile&session={:016x}&page={}",
+      (row + seed) % 100'000,
+      row * 17,
+      row * 31,
+      seed ^ (static_cast<uint64_t>(row) * 0x9E3779B97F4A7C15ULL),
+      row % 97);
+}
+
+inline std::string fsstBenchmarkLogValue(uint32_t row, uint64_t seed) {
+  static constexpr std::array<std::string_view, 5> kLevels{
+      "DEBUG", "INFO", "NOTICE", "WARN", "ERROR"};
+  static constexpr std::array<std::string_view, 4> kComponents{
+      "cache", "planner", "storage", "transport"};
+  return fmt::format(
+      R"({{"timestamp":"2026-08-09T21:{:02}:{:02}Z","level":"{}","component":"{}","tenant":{},"request":{},"message":"completed structured benchmark request","seed":"{:016x}"}})",
+      row % 60,
+      (row * 13) % 60,
+      kLevels[row % kLevels.size()],
+      kComponents[(row / 3) % kComponents.size()],
+      (row + seed) % 10'000,
+      row,
+      seed);
+}
+
+inline std::string fsstBenchmarkUuidValue(uint32_t row, uint64_t seed) {
+  const uint64_t mixed =
+      seed ^ (static_cast<uint64_t>(row) * 0xD6E8FEB86659FD93ULL);
+  return fmt::format(
+      "event/{:08x}-{:04x}-4{:03x}-{:04x}-{:012x}/trace/{:016x}",
+      static_cast<uint32_t>(mixed),
+      static_cast<uint32_t>(mixed >> 32) & 0xffff,
+      row & 0xfff,
+      0x8000 | (row & 0x3fff),
+      mixed & 0xffffffffffffULL,
+      mixed ^ 0xA5A5A5A5A5A5A5A5ULL);
+}
+
+inline std::string fsstBenchmarkLongValue(uint32_t row, uint64_t seed) {
+  std::string value = fmt::format(
+      "payload/tenant={:06}/partition={:08}/codec=fsst/data=",
+      (row + seed) % 100'000,
+      row / 8);
+  value.append(
+      1024 + (row % 4) * 128, static_cast<char>('a' + ((row ^ seed) % 26)));
+  value.append("\0binary-tail/", 13);
+  value.push_back(static_cast<char>(0xff));
+  return value;
+}
+
+inline std::string fsstBenchmarkStructuredValue(uint32_t row, uint64_t seed) {
+  switch (row % 8) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+      return fsstBenchmarkUrlValue(row, seed);
+    case 4:
+    case 5:
+      return fsstBenchmarkLogValue(row, seed);
+    case 6:
+      return fsstBenchmarkUuidValue(row, seed);
+    case 7:
+      return fsstBenchmarkLongValue(row, seed);
+  }
+  return {};
+}
+
+} // namespace detail
+
+/// Builds the deterministic SortedStructuredTextMixedLengths FSST corpus.
+inline StringBenchmarkCorpus makeFsstBenchmarkCorpus(
+    uint32_t rowCount = kFsstBenchmarkDefaultRowCount,
+    uint64_t seed = kFsstBenchmarkDefaultSeed) {
+  std::vector<std::string> storage;
+  storage.reserve(rowCount);
+  for (uint32_t row = 0; row < rowCount; ++row) {
+    storage.push_back(
+        row < 16 ? detail::fsstBenchmarkEdgeValue(row, seed)
+                 : detail::fsstBenchmarkStructuredValue(row, seed));
+  }
+  return finalizeStringBenchmarkCorpus(std::move(storage));
+}
+
+} // namespace facebook::nimble::benchmarks

--- a/velox/dwio/nimble/encodings/benchmarks/FsstEncodingBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/FsstEncodingBenchmark.cpp
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/buffer/Buffer.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/FsstEncoding.h"
+#include "velox/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "velox/dwio/nimble/encodings/benchmarks/FsstBenchmarkData.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+constexpr size_t kStringPageSize = 256 * 1024;
+constexpr uint32_t kMaxStringPageBytes = 16 * 1024 * 1024;
+constexpr uint64_t kMaxTotalStringPageBytes = 256 * 1024 * 1024;
+constexpr size_t kMaxStringPageCount = 2048;
+
+EncodingSelectionPolicyCreator fallbackPolicyCreator() {
+  return [](DataType dataType) {
+    return ManualEncodingSelectionPolicyFactory{
+        {{EncodingType::Trivial, 1.0}},
+        /*compressionOptions=*/std::nullopt}
+        .createPolicy(dataType);
+  };
+}
+
+std::unique_ptr<EncodingSelectionPolicy<std::string_view>> fsstPolicy() {
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.emplace_back(
+      EncodingLayout{
+          EncodingType::FixedBitWidth, {}, CompressionType::Uncompressed});
+  EncodingLayout layout{
+      EncodingType::Fsst,
+      {},
+      CompressionType::Uncompressed,
+      std::move(children)};
+  return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+      std::move(layout),
+      /*compressionOptions=*/std::nullopt,
+      fallbackPolicyCreator());
+}
+
+Encoding::Options fsstOptions() {
+  Encoding::Options options;
+  options.fsstCompressionTargetRatio = std::numeric_limits<double>::max();
+  return options;
+}
+
+std::string_view encodeFsstToBuffer(
+    std::span<const std::string_view> values,
+    Buffer& buffer) {
+  return EncodingFactory::encode<std::string_view>(
+      fsstPolicy(), values, buffer, fsstOptions());
+}
+
+std::string encodeFsstFixture(std::span<const std::string_view> values) {
+  Buffer buffer{*benchmarkPool()};
+  return std::string{encodeFsstToBuffer(values, buffer)};
+}
+
+class StringPageArena {
+ public:
+  void* allocate(uint32_t bytes) {
+    if (bytes == 0) {
+      throw std::runtime_error{"FSST requested an empty string page"};
+    }
+    if (bytes > kMaxStringPageBytes ||
+        allocatedBytes_ > kMaxTotalStringPageBytes - bytes ||
+        pages_.size() >= kMaxStringPageCount) {
+      throw std::runtime_error{"FSST benchmark string page limit exceeded"};
+    }
+    allocatedBytes_ += bytes;
+    auto& page = pages_.emplace_back(
+        facebook::velox::AlignedBuffer::allocate<char>(
+            bytes, benchmarkPool().get()));
+    return page->asMutable<void>();
+  }
+
+  size_t pageCount() const {
+    return pages_.size();
+  }
+
+  uint64_t allocatedBytes() const {
+    return allocatedBytes_;
+  }
+
+ private:
+  std::vector<facebook::velox::BufferPtr> pages_;
+  uint64_t allocatedBytes_{0};
+};
+
+std::unique_ptr<Encoding> createFsstDecoder(
+    std::string_view encoded,
+    StringPageArena& stringPages) {
+  auto stringBufferFactory = [&stringPages](uint32_t bytes) -> void* {
+    return stringPages.allocate(bytes);
+  };
+  return EncodingFactory{}.create(
+      *benchmarkPool(), encoded, std::move(stringBufferFactory));
+}
+
+uint32_t runFsstSkipSeek(
+    Encoding& encoding,
+    uint32_t rowCount,
+    std::string_view* output) {
+  encoding.reset();
+  uint32_t cursor{0};
+  uint32_t outputRows{0};
+  while (cursor < rowCount) {
+    const uint32_t skip = std::min<uint32_t>(31, rowCount - cursor);
+    encoding.skip(skip);
+    cursor += skip;
+    if (cursor == rowCount) {
+      break;
+    }
+    const uint32_t read = std::min<uint32_t>(3, rowCount - cursor);
+    encoding.materialize(read, output + outputRows);
+    outputRows += read;
+    cursor += read;
+  }
+  return outputRows;
+}
+
+class FsstBenchmarkFixture {
+ public:
+  FsstBenchmarkFixture()
+      : corpus_{makeFsstBenchmarkCorpus()},
+        encoded_{encodeFsstFixture(corpus_.values)},
+        decoder_{createFsstDecoder(encoded_, stringPages_)},
+        output_{benchmarkPool().get(), corpus_.values.size()} {
+    validateMetadata();
+    decodeDense();
+    validateDenseResult();
+    const uint32_t outputRows = skipSeek();
+    validateSkipResult(outputRows);
+    if (stringPages_.pageCount() < 3) {
+      throw std::runtime_error{
+          "FSST benchmark decode must span at least three string pages"};
+    }
+    decoder_->reset();
+    stablePageCount_ = stringPages_.pageCount();
+    stablePageBytes_ = stringPages_.allocatedBytes();
+  }
+
+  const StringBenchmarkCorpus& corpus() const {
+    return corpus_;
+  }
+
+  std::string_view encoded() const {
+    return encoded_;
+  }
+
+  void decodeDense() {
+    decoder_->reset();
+    decoder_->materialize(rowCount(), output_.data());
+  }
+
+  uint32_t skipSeek() {
+    return runFsstSkipSeek(*decoder_, rowCount(), output_.data());
+  }
+
+  std::string_view lastOutput() const {
+    return output_.back();
+  }
+
+  std::string_view skipOutput(uint32_t outputRows) const {
+    return output_[outputRows - 1];
+  }
+
+  void validateDenseResult() const {
+    if (!std::equal(output_.begin(), output_.end(), corpus_.values.begin())) {
+      throw std::runtime_error{"FSST benchmark dense decode mismatch"};
+    }
+  }
+
+  void validateSkipResult(uint32_t outputRows) const {
+    uint32_t cursor{0};
+    uint32_t outputRow{0};
+    while (cursor < rowCount()) {
+      cursor += std::min<uint32_t>(31, rowCount() - cursor);
+      if (cursor == rowCount()) {
+        break;
+      }
+      const uint32_t read = std::min<uint32_t>(3, rowCount() - cursor);
+      if (!std::equal(
+              output_.begin() + outputRow,
+              output_.begin() + outputRow + read,
+              corpus_.values.begin() + cursor)) {
+        throw std::runtime_error{"FSST benchmark skip trace mismatch"};
+      }
+      outputRow += read;
+      cursor += read;
+    }
+    if (outputRow != outputRows) {
+      throw std::runtime_error{"FSST benchmark skip trace row mismatch"};
+    }
+  }
+
+  void validateStablePages() const {
+    if (stringPages_.pageCount() != stablePageCount_ ||
+        stringPages_.allocatedBytes() != stablePageBytes_) {
+      throw std::runtime_error{
+          "FSST benchmark decode allocated string pages during timing"};
+    }
+  }
+
+ private:
+  uint32_t rowCount() const {
+    return static_cast<uint32_t>(corpus_.values.size());
+  }
+
+  void validateMetadata() const {
+    if (corpus_.rawBytes <= 2 * kStringPageSize) {
+      throw std::runtime_error{
+          "FSST benchmark corpus must span multiple string pages"};
+    }
+    if (encoded_.empty() || encoded_.size() >= corpus_.rawBytes) {
+      throw std::runtime_error{
+          "FSST benchmark full artifact did not compress the corpus"};
+    }
+    if (decoder_->encodingType() != EncodingType::Fsst ||
+        decoder_->dataType() != DataType::String ||
+        decoder_->rowCount() != corpus_.values.size()) {
+      throw std::runtime_error{"FSST benchmark fixture metadata mismatch"};
+    }
+  }
+
+  StringBenchmarkCorpus corpus_;
+  std::string encoded_;
+  StringPageArena stringPages_;
+  std::unique_ptr<Encoding> decoder_;
+  Vector<std::string_view> output_;
+  size_t stablePageCount_{0};
+  uint64_t stablePageBytes_{0};
+};
+
+BENCHMARK(FSST_Encode_String_SortedStructuredTextMixedLengths, iterations) {
+  std::unique_ptr<FsstBenchmarkFixture> fixture;
+  std::unique_ptr<Buffer> buffer;
+  std::string_view timedArtifact;
+  BENCHMARK_SUSPEND {
+    fixture = std::make_unique<FsstBenchmarkFixture>();
+    buffer = std::make_unique<Buffer>(*benchmarkPool());
+    timedArtifact = fixture->encoded();
+  }
+  while (iterations--) {
+    buffer->reset();
+    timedArtifact = encodeFsstToBuffer(fixture->corpus().values, *buffer);
+    folly::doNotOptimizeAway(timedArtifact);
+  }
+  BENCHMARK_SUSPEND {
+    if (timedArtifact != fixture->encoded()) {
+      throw std::runtime_error{"FSST benchmark timed encode mismatch"};
+    }
+  }
+}
+
+BENCHMARK(
+    FSST_DecodeDense_String_SortedStructuredTextMixedLengths,
+    iterations) {
+  std::unique_ptr<FsstBenchmarkFixture> fixture;
+  BENCHMARK_SUSPEND {
+    fixture = std::make_unique<FsstBenchmarkFixture>();
+  }
+  while (iterations--) {
+    fixture->decodeDense();
+    folly::doNotOptimizeAway(fixture->lastOutput());
+  }
+  BENCHMARK_SUSPEND {
+    fixture->validateDenseResult();
+    fixture->validateStablePages();
+  }
+}
+
+BENCHMARK(FSST_SkipSeek_String_SortedStructuredTextMixedLengths, iterations) {
+  std::unique_ptr<FsstBenchmarkFixture> fixture;
+  uint32_t outputRows{0};
+  BENCHMARK_SUSPEND {
+    fixture = std::make_unique<FsstBenchmarkFixture>();
+  }
+  while (iterations--) {
+    outputRows = fixture->skipSeek();
+    folly::doNotOptimizeAway(fixture->skipOutput(outputRows));
+  }
+  BENCHMARK_SUSPEND {
+    fixture->validateSkipResult(outputRows);
+    fixture->validateStablePages();
+  }
+}
+
+void printArtifactRatio() {
+  const FsstBenchmarkFixture fixture;
+  fmt::print(
+      "FSST full artifact: raw={} encoded={} encoded_to_raw={:.6f} "
+      "raw_to_encoded={:.6f}\n",
+      fixture.corpus().rawBytes,
+      fixture.encoded().size(),
+      static_cast<double>(fixture.encoded().size()) / fixture.corpus().rawBytes,
+      static_cast<double>(fixture.corpus().rawBytes) /
+          fixture.encoded().size());
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const folly::Init init{&argc, &argv};
+  facebook::velox::memory::MemoryManager::initialize({});
+  printArtifactRatio();
+  folly::runBenchmarks();
+}

--- a/velox/dwio/nimble/encodings/benchmarks/HuffmanBenchmarkData.h
+++ b/velox/dwio/nimble/encodings/benchmarks/HuffmanBenchmarkData.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::nimble::benchmarks {
+
+/// Default seed shared by the native benchmark and executable runner.
+inline constexpr uint64_t kHuffmanBenchmarkDefaultSeed = 0xC0FFEE;
+
+/// Returns one value from the deterministic 90% / 6% / 4% native profile.
+inline constexpr uint32_t huffmanSkewedLowCardinalityValue(
+    uint64_t row,
+    uint64_t seed = kHuffmanBenchmarkDefaultSeed) {
+  const uint64_t rotation = seed ^ kHuffmanBenchmarkDefaultSeed;
+  const uint32_t phase = static_cast<uint32_t>((row + rotation % 100) % 100);
+  if (phase < 90) {
+    return 0;
+  }
+  if (phase < 96) {
+    return 1;
+  }
+  const uint32_t tailRotation = static_cast<uint32_t>((rotation / 100) % 14);
+  return 2 + static_cast<uint32_t>((row + tailRotation) % 14);
+}
+
+static_assert(huffmanSkewedLowCardinalityValue(0) == 0);
+static_assert(huffmanSkewedLowCardinalityValue(89) == 0);
+static_assert(huffmanSkewedLowCardinalityValue(90) == 1);
+static_assert(huffmanSkewedLowCardinalityValue(95) == 1);
+static_assert(huffmanSkewedLowCardinalityValue(96) == 14);
+
+} // namespace facebook::nimble::benchmarks

--- a/velox/dwio/nimble/encodings/benchmarks/PFOREncodingBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/PFOREncodingBenchmark.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <folly/Benchmark.h>
+
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "velox/dwio/nimble/encodings/benchmarks/PFOREncodingBenchmarkData.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+Vector<uint32_t> makePforData(
+    uint32_t rowCount = kNumElements,
+    uint64_t seed = kPforBenchmarkDefaultSeed) {
+  Vector<uint32_t> values{benchmarkPool().get()};
+  values.reserve(rowCount);
+  for (uint32_t row = 0; row < rowCount; ++row) {
+    values.push_back(pforBenchmarkValue(row, seed));
+  }
+  return values;
+}
+
+EncodingSelectionPolicyCreator fallbackPolicyCreator() {
+  return [](DataType dataType) {
+    return ManualEncodingSelectionPolicyFactory{
+        {{EncodingType::Trivial, 1.0}},
+        /*compressionOptions=*/std::nullopt}
+        .createPolicy(dataType);
+  };
+}
+
+std::unique_ptr<EncodingSelectionPolicy<uint32_t>> pforPolicy() {
+  EncodingLayout fixedBitWidth{
+      EncodingType::FixedBitWidth, {}, CompressionType::Uncompressed};
+  EncodingLayout pfor{
+      EncodingType::PFOR,
+      {},
+      CompressionType::Uncompressed,
+      {fixedBitWidth, fixedBitWidth}};
+  return std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
+      std::move(pfor),
+      /*compressionOptions=*/std::nullopt,
+      fallbackPolicyCreator());
+}
+
+std::string_view encodePforToBuffer(
+    const Vector<uint32_t>& values,
+    Buffer& buffer) {
+  return EncodingFactory::encode<uint32_t>(
+      pforPolicy(),
+      std::span<const uint32_t>{values.data(), values.size()},
+      buffer);
+}
+
+std::string encodePforFixture(const Vector<uint32_t>& values) {
+  Buffer buffer{*benchmarkPool()};
+  return std::string{encodePforToBuffer(values, buffer)};
+}
+
+BENCHMARK(PFOR_Encode_Outliers10Pct, iterations) {
+  Vector<uint32_t> values{benchmarkPool().get()};
+  std::unique_ptr<Buffer> buffer;
+  BENCHMARK_SUSPEND {
+    values = makePforData();
+    buffer = std::make_unique<Buffer>(*benchmarkPool());
+  }
+  while (iterations--) {
+    buffer->reset();
+    const auto encoded = encodePforToBuffer(values, *buffer);
+    folly::doNotOptimizeAway(encoded);
+  }
+}
+
+BENCHMARK(PFOR_DecodeDense_Outliers10Pct, iterations) {
+  std::string encoded;
+  std::unique_ptr<Encoding> encoding;
+  Vector<uint32_t> output{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    encoded = encodePforFixture(makePforData());
+    encoding = EncodingFactory{}.create(
+        *benchmarkPool(), encoded, [](uint32_t) -> void* { return nullptr; });
+    output.resize(kNumElements);
+  }
+  while (iterations--) {
+    encoding->reset();
+    encoding->materialize(kNumElements, output.data());
+    folly::doNotOptimizeAway(output.back());
+  }
+}
+
+BENCHMARK(PFOR_SkipSeek_Outliers10Pct, iterations) {
+  std::string encoded;
+  std::unique_ptr<Encoding> encoding;
+  Vector<uint32_t> output{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    encoded = encodePforFixture(makePforData());
+    encoding = EncodingFactory{}.create(
+        *benchmarkPool(), encoded, [](uint32_t) -> void* { return nullptr; });
+    output.resize(kNumElements);
+  }
+  while (iterations--) {
+    encoding->reset();
+    uint32_t cursor{0};
+    uint32_t outputRows{0};
+    while (cursor < kNumElements) {
+      const uint32_t skip = std::min<uint32_t>(31, kNumElements - cursor);
+      encoding->skip(skip);
+      cursor += skip;
+      if (cursor == kNumElements) {
+        break;
+      }
+      const uint32_t read = std::min<uint32_t>(3, kNumElements - cursor);
+      encoding->materialize(read, output.data() + outputRows);
+      outputRows += read;
+      cursor += read;
+    }
+    folly::doNotOptimizeAway(output[outputRows - 1]);
+  }
+}
+
+} // namespace
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/velox/dwio/nimble/encodings/benchmarks/PFOREncodingBenchmarkData.h
+++ b/velox/dwio/nimble/encodings/benchmarks/PFOREncodingBenchmarkData.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::nimble::benchmarks {
+
+/// Default seed shared by the native benchmark and executable runner.
+inline constexpr uint64_t kPforBenchmarkDefaultSeed = 0xC0FFEE;
+
+/// Minimum value in the representative PFOR corpus.
+inline constexpr uint32_t kPforBenchmarkBaseline = 50;
+
+/// Largest residual in the representative corpus's narrow population.
+inline constexpr uint32_t kPforBenchmarkNarrowMax = 127;
+
+/// Minimum residual in the representative corpus's outlier population.
+inline constexpr uint32_t kPforBenchmarkOutlierBase = 100'000;
+
+/// Returns whether `index` belongs to the approximately-ten-percent outliers.
+inline constexpr bool pforBenchmarkIsOutlier(uint64_t index, uint64_t seed) {
+  return index > 1 && (index + seed % 10) % 10 == 7;
+}
+
+/// Returns one deterministic value from the representative PFOR corpus.
+inline constexpr uint32_t pforBenchmarkValue(
+    uint64_t index,
+    uint64_t seed = kPforBenchmarkDefaultSeed) {
+  if (index == 0) {
+    return kPforBenchmarkBaseline;
+  }
+  if (index == 1) {
+    return kPforBenchmarkBaseline + kPforBenchmarkNarrowMax;
+  }
+  const uint64_t mixed = (index * 1'000'003ULL) ^ seed ^ (seed >> 32);
+  if (pforBenchmarkIsOutlier(index, seed)) {
+    return kPforBenchmarkBaseline + kPforBenchmarkOutlierBase +
+        static_cast<uint32_t>(mixed & 0xFFFF);
+  }
+  return kPforBenchmarkBaseline +
+      static_cast<uint32_t>(mixed & kPforBenchmarkNarrowMax);
+}
+
+static_assert(
+    pforBenchmarkValue(0) == kPforBenchmarkBaseline &&
+    pforBenchmarkValue(1) == kPforBenchmarkBaseline + kPforBenchmarkNarrowMax);
+static_assert(pforBenchmarkIsOutlier(7, kPforBenchmarkDefaultSeed));
+static_assert(
+    pforBenchmarkValue(7) >=
+    kPforBenchmarkBaseline + kPforBenchmarkOutlierBase);
+
+} // namespace facebook::nimble::benchmarks

--- a/velox/dwio/nimble/encodings/benchmarks/PrefixBenchmarkData.h
+++ b/velox/dwio/nimble/encodings/benchmarks/PrefixBenchmarkData.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "velox/dwio/nimble/encodings/benchmarks/StringBenchmarkCorpus.h"
+
+namespace facebook::nimble::benchmarks {
+
+/// Default seed shared by the native benchmark and executable runner.
+inline constexpr uint64_t kPrefixBenchmarkDefaultSeed = 0xC0FFEE;
+
+/// Default row count for the representative sorted string corpus.
+inline constexpr uint32_t kPrefixBenchmarkDefaultRowCount = 4096;
+
+namespace detail {
+
+inline std::string prefixBenchmarkEdgeValue(uint32_t row, uint64_t seed) {
+  switch (row) {
+    case 0:
+    case 1:
+      return {};
+    case 2:
+      return std::string{"\0embedded-prefix", 16};
+    case 3:
+    case 4:
+      return "a";
+    case 5:
+      return "b/short";
+    case 6:
+      return "c/" + std::string(8 * 1024, 'c');
+    default:
+      return fmt::format("edge/{:02}/seed={:016x}", row, seed);
+  }
+}
+
+inline std::string prefixBenchmarkPathValue(uint32_t row, uint64_t seed) {
+  constexpr uint32_t kRestartInterval = 16;
+  const uint32_t relativeRow = row - kRestartInterval;
+  const uint32_t group = relativeRow / kRestartInterval;
+  const uint32_t groupRow = relativeRow % kRestartInterval;
+  std::string value = fmt::format(
+      "warehouse/tenant={:06}/table=customer_events/schema=v7/"
+      "date=2026-08-{:02}/hour={:02}/partition={:08}/",
+      (group + seed) % 100'000,
+      1 + group % 28,
+      group % 24,
+      group);
+
+  static constexpr std::array<std::string_view, 15> kSuffixes{
+      "",
+      "column=account_id",
+      "column=account_id",
+      "column=account_name",
+      "column=country_code",
+      "column=event_name",
+      "column=event_timestamp",
+      "column=ingestion_timestamp",
+      "column=metadata_json",
+      "column=partition_date",
+      "column=session_id",
+      "column=source_service",
+      "column=tenant_id",
+      "column=user_agent",
+      "column=user_id",
+  };
+  if (groupRow < kSuffixes.size()) {
+    value.append(kSuffixes[groupRow]);
+    if (groupRow == 3) {
+      value.append("\0binary", 7);
+    }
+    return value;
+  }
+
+  value.append("payload=z/");
+  value.append(1024, static_cast<char>('a' + ((group ^ seed) % 26)));
+  return value;
+}
+
+} // namespace detail
+
+/// Builds the deterministic SortedPathPrefixMixedLengths string corpus.
+inline StringBenchmarkCorpus makePrefixBenchmarkCorpus(
+    uint32_t rowCount = kPrefixBenchmarkDefaultRowCount,
+    uint64_t seed = kPrefixBenchmarkDefaultSeed) {
+  std::vector<std::string> storage;
+  storage.reserve(rowCount);
+  for (uint32_t row = 0; row < rowCount; ++row) {
+    storage.push_back(
+        row < 16 ? detail::prefixBenchmarkEdgeValue(row, seed)
+                 : detail::prefixBenchmarkPathValue(row, seed));
+  }
+  return finalizeStringBenchmarkCorpus(std::move(storage));
+}
+
+} // namespace facebook::nimble::benchmarks

--- a/velox/dwio/nimble/encodings/benchmarks/PrefixEncodingBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/PrefixEncodingBenchmark.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/buffer/Buffer.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/PrefixEncoding.h"
+#include "velox/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "velox/dwio/nimble/encodings/benchmarks/PrefixBenchmarkData.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+constexpr size_t kStringPageSize = 256 * 1024;
+
+EncodingSelectionPolicyCreator fallbackPolicyCreator() {
+  return [](DataType dataType) {
+    return ManualEncodingSelectionPolicyFactory{
+        {{EncodingType::Trivial, 1.0}},
+        /*compressionOptions=*/std::nullopt}
+        .createPolicy(dataType);
+  };
+}
+
+std::unique_ptr<EncodingSelectionPolicy<std::string_view>> prefixPolicy() {
+  EncodingLayout layout{
+      EncodingType::Prefix, {}, CompressionType::Uncompressed};
+  return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+      std::move(layout),
+      /*compressionOptions=*/std::nullopt,
+      fallbackPolicyCreator());
+}
+
+std::string_view encodePrefixToBuffer(
+    std::span<const std::string_view> values,
+    Buffer& buffer) {
+  return EncodingFactory::encode<std::string_view>(
+      prefixPolicy(), values, buffer);
+}
+
+std::string encodePrefixFixture(std::span<const std::string_view> values) {
+  Buffer buffer{*benchmarkPool()};
+  return std::string{encodePrefixToBuffer(values, buffer)};
+}
+
+std::unique_ptr<Encoding> createPrefixDecoder(
+    std::string_view encoded,
+    std::vector<facebook::velox::BufferPtr>& stringPages) {
+  auto stringBufferFactory = [&stringPages](uint32_t bytes) -> void* {
+    auto& page = stringPages.emplace_back(
+        facebook::velox::AlignedBuffer::allocate<char>(
+            bytes, benchmarkPool().get()));
+    return page->asMutable<void>();
+  };
+  return EncodingFactory{}.create(
+      *benchmarkPool(), encoded, std::move(stringBufferFactory));
+}
+
+void validatePrefixFixture(
+    const StringBenchmarkCorpus& corpus,
+    std::string_view encoded,
+    Encoding& encoding,
+    Vector<std::string_view>& output) {
+  if (corpus.rawBytes <= 2 * kStringPageSize) {
+    throw std::runtime_error{
+        "Prefix benchmark corpus must span multiple string pages"};
+  }
+  if (encoded.empty() || encoded.size() >= corpus.rawBytes) {
+    throw std::runtime_error{
+        "Prefix benchmark fixture did not compress its logical strings"};
+  }
+  if (encoding.encodingType() != EncodingType::Prefix ||
+      encoding.rowCount() != corpus.values.size()) {
+    throw std::runtime_error{"Prefix benchmark fixture metadata mismatch"};
+  }
+
+  encoding.reset();
+  encoding.materialize(corpus.values.size(), output.data());
+  if (!std::equal(output.begin(), output.end(), corpus.values.begin())) {
+    throw std::runtime_error{"Prefix benchmark fixture failed round trip"};
+  }
+  encoding.reset();
+}
+
+uint32_t runPrefixSkipSeek(
+    Encoding& encoding,
+    uint32_t rowCount,
+    std::string_view* output) {
+  encoding.reset();
+  uint32_t cursor{0};
+  uint32_t outputRows{0};
+  while (cursor < rowCount) {
+    const uint32_t skip = std::min<uint32_t>(31, rowCount - cursor);
+    encoding.skip(skip);
+    cursor += skip;
+    if (cursor == rowCount) {
+      break;
+    }
+    const uint32_t read = std::min<uint32_t>(3, rowCount - cursor);
+    encoding.materialize(read, output + outputRows);
+    outputRows += read;
+    cursor += read;
+  }
+  return outputRows;
+}
+
+void validatePrefixSkipSeek(
+    Encoding& encoding,
+    const StringBenchmarkCorpus& corpus,
+    Vector<std::string_view>& output) {
+  const uint32_t outputRows =
+      runPrefixSkipSeek(encoding, corpus.values.size(), output.data());
+  uint32_t cursor{0};
+  uint32_t outputRow{0};
+  while (cursor < corpus.values.size()) {
+    cursor += std::min<uint32_t>(31, corpus.values.size() - cursor);
+    if (cursor == corpus.values.size()) {
+      break;
+    }
+    const uint32_t read = std::min<uint32_t>(3, corpus.values.size() - cursor);
+    if (!std::equal(
+            output.begin() + outputRow,
+            output.begin() + outputRow + read,
+            corpus.values.begin() + cursor)) {
+      throw std::runtime_error{"Prefix benchmark skip trace mismatch"};
+    }
+    outputRow += read;
+    cursor += read;
+  }
+  if (outputRow != outputRows) {
+    throw std::runtime_error{"Prefix benchmark skip trace row mismatch"};
+  }
+  encoding.reset();
+}
+
+BENCHMARK(Prefix_Encode_String_SortedPathPrefixMixedLengths, iterations) {
+  StringBenchmarkCorpus corpus;
+  std::unique_ptr<Buffer> buffer;
+  BENCHMARK_SUSPEND {
+    corpus = makePrefixBenchmarkCorpus();
+    buffer = std::make_unique<Buffer>(*benchmarkPool());
+    const auto encoded = encodePrefixToBuffer(corpus.values, *buffer);
+    std::vector<facebook::velox::BufferPtr> stringPages;
+    auto encoding = createPrefixDecoder(encoded, stringPages);
+    Vector<std::string_view> output{
+        benchmarkPool().get(), corpus.values.size()};
+    validatePrefixFixture(corpus, encoded, *encoding, output);
+  }
+  while (iterations--) {
+    buffer->reset();
+    const auto encoded = encodePrefixToBuffer(corpus.values, *buffer);
+    folly::doNotOptimizeAway(encoded);
+  }
+}
+
+BENCHMARK(Prefix_DecodeDense_String_SortedPathPrefixMixedLengths, iterations) {
+  StringBenchmarkCorpus corpus;
+  std::string encoded;
+  std::vector<facebook::velox::BufferPtr> stringPages;
+  std::unique_ptr<Encoding> encoding;
+  Vector<std::string_view> output{benchmarkPool().get()};
+  size_t stablePageCount{0};
+  BENCHMARK_SUSPEND {
+    corpus = makePrefixBenchmarkCorpus();
+    encoded = encodePrefixFixture(corpus.values);
+    encoding = createPrefixDecoder(encoded, stringPages);
+    output.resize(corpus.values.size());
+    validatePrefixFixture(corpus, encoded, *encoding, output);
+    stablePageCount = stringPages.size();
+  }
+  while (iterations--) {
+    encoding->reset();
+    encoding->materialize(corpus.values.size(), output.data());
+    folly::doNotOptimizeAway(output.back());
+  }
+  BENCHMARK_SUSPEND {
+    if (stringPages.size() != stablePageCount) {
+      throw std::runtime_error{"Prefix dense decode allocated during timing"};
+    }
+  }
+}
+
+BENCHMARK(Prefix_SkipSeek_String_SortedPathPrefixMixedLengths, iterations) {
+  StringBenchmarkCorpus corpus;
+  std::string encoded;
+  std::vector<facebook::velox::BufferPtr> stringPages;
+  std::unique_ptr<Encoding> encoding;
+  Vector<std::string_view> output{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    corpus = makePrefixBenchmarkCorpus();
+    encoded = encodePrefixFixture(corpus.values);
+    encoding = createPrefixDecoder(encoded, stringPages);
+    output.resize(corpus.values.size());
+    validatePrefixFixture(corpus, encoded, *encoding, output);
+    validatePrefixSkipSeek(*encoding, corpus, output);
+  }
+  while (iterations--) {
+    const uint32_t outputRows =
+        runPrefixSkipSeek(*encoding, corpus.values.size(), output.data());
+    folly::doNotOptimizeAway(output[outputRows - 1]);
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const folly::Init init{&argc, &argv};
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/velox/dwio/nimble/encodings/benchmarks/SimdForBitpackBenchmarkData.h
+++ b/velox/dwio/nimble/encodings/benchmarks/SimdForBitpackBenchmarkData.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::nimble::benchmarks {
+
+/// Default seed shared by the native benchmark and executable runner.
+inline constexpr uint64_t kSimdForBitpackBenchmarkDefaultSeed = 0xC0FFEE;
+
+/// Baseline used by the representative unsigned corpus.
+inline constexpr uint32_t kSimdForBitpackBenchmarkBaseline = 50'000;
+
+/// Largest residual in the representative 16-bit corpus.
+inline constexpr uint32_t kSimdForBitpackBenchmarkResidualMax = 0xFFFF;
+
+/// Returns one deterministic value from the representative 16-bit corpus.
+inline constexpr uint32_t simdForBitpackBenchmarkValue(
+    uint64_t index,
+    uint64_t seed = kSimdForBitpackBenchmarkDefaultSeed) {
+  if (index == 0) {
+    return kSimdForBitpackBenchmarkBaseline;
+  }
+  if (index == 1) {
+    return kSimdForBitpackBenchmarkBaseline +
+        kSimdForBitpackBenchmarkResidualMax;
+  }
+  const uint64_t mixed = (index * 1'000'003ULL) ^ seed ^ (seed >> 32);
+  return kSimdForBitpackBenchmarkBaseline +
+      static_cast<uint32_t>(mixed & kSimdForBitpackBenchmarkResidualMax);
+}
+
+static_assert(
+    simdForBitpackBenchmarkValue(0) == kSimdForBitpackBenchmarkBaseline &&
+    simdForBitpackBenchmarkValue(1) ==
+        kSimdForBitpackBenchmarkBaseline + kSimdForBitpackBenchmarkResidualMax);
+
+} // namespace facebook::nimble::benchmarks

--- a/velox/dwio/nimble/encodings/benchmarks/StringBenchmarkCorpus.h
+++ b/velox/dwio/nimble/encodings/benchmarks/StringBenchmarkCorpus.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace facebook::nimble::benchmarks {
+
+/// Owns immutable string storage and stable views used by native benchmarks.
+struct StringBenchmarkCorpus {
+  StringBenchmarkCorpus() = default;
+  StringBenchmarkCorpus(const StringBenchmarkCorpus&) = delete;
+  StringBenchmarkCorpus& operator=(const StringBenchmarkCorpus&) = delete;
+  StringBenchmarkCorpus(StringBenchmarkCorpus&&) noexcept = default;
+  StringBenchmarkCorpus& operator=(StringBenchmarkCorpus&&) noexcept = default;
+
+  /// Owns the bytes referenced by values. Do not mutate after finalization.
+  std::vector<std::string> storage;
+  /// Provides sorted views into storage.
+  std::vector<std::string_view> values;
+  /// Sums logical string bytes without encoding metadata.
+  uint64_t rawBytes{0};
+  /// Records the largest logical string in bytes.
+  size_t maxValueBytes{0};
+};
+
+/// Sorts owned values and builds stable views after storage is finalized.
+inline StringBenchmarkCorpus finalizeStringBenchmarkCorpus(
+    std::vector<std::string> storage) {
+  std::sort(storage.begin(), storage.end());
+
+  StringBenchmarkCorpus corpus;
+  corpus.storage = std::move(storage);
+  corpus.values.reserve(corpus.storage.size());
+  for (const auto& value : corpus.storage) {
+    corpus.values.push_back(value);
+    corpus.rawBytes += value.size();
+    corpus.maxValueBytes = std::max(corpus.maxValueBytes, value.size());
+  }
+  return corpus;
+}
+
+} // namespace facebook::nimble::benchmarks

--- a/velox/dwio/nimble/encodings/benchmarks/VarintBenchmarkData.h
+++ b/velox/dwio/nimble/encodings/benchmarks/VarintBenchmarkData.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+
+namespace facebook::nimble::benchmarks {
+
+inline constexpr std::string_view kVarintBenchmarkProfileName =
+    "Uint32NonZeroBaselineMixedWidths";
+inline constexpr uint64_t kVarintBenchmarkDefaultSeed = 0xC0FFEE;
+inline constexpr uint32_t kVarintBenchmarkBaseValue = 50'000;
+inline constexpr size_t kVarintBulkDecodePaddingBytes = 7;
+
+inline constexpr uint32_t varintBenchmarkBaseline(
+    uint64_t seed = kVarintBenchmarkDefaultSeed) {
+  return kVarintBenchmarkBaseValue + static_cast<uint8_t>(seed);
+}
+
+inline constexpr uint64_t varintBenchmarkMix(uint64_t value) {
+  value += 0x9E3779B97F4A7C15ULL;
+  value = (value ^ (value >> 30)) * 0xBF58476D1CE4E5B9ULL;
+  value = (value ^ (value >> 27)) * 0x94D049BB133111EBULL;
+  return value ^ (value >> 31);
+}
+
+inline constexpr uint32_t varintBenchmarkResidual(
+    uint32_t row,
+    uint64_t seed = kVarintBenchmarkDefaultSeed) {
+  const uint32_t maxResidual =
+      std::numeric_limits<uint32_t>::max() - varintBenchmarkBaseline(seed);
+  switch (row & 0xFF) {
+    case 0:
+      return 0;
+    case 1:
+      return 0x7F;
+    case 2:
+      return 0x80;
+    case 3:
+      return 0x3FFF;
+    case 4:
+      return 0x4000;
+    case 5:
+      return 0x1FFFFF;
+    case 6:
+      return 0x200000;
+    case 7:
+      return 0x0FFFFFFF;
+    case 8:
+      return 0x10000000;
+    case 9:
+      return maxResidual;
+  }
+
+  const uint64_t mixed = varintBenchmarkMix(seed + static_cast<uint64_t>(row));
+  uint64_t lower;
+  uint64_t upper;
+  switch (row % 5) {
+    case 0:
+      lower = 0;
+      upper = 0x7F;
+      break;
+    case 1:
+      lower = 0x80;
+      upper = 0x3FFF;
+      break;
+    case 2:
+      lower = 0x4000;
+      upper = 0x1FFFFF;
+      break;
+    case 3:
+      lower = 0x200000;
+      upper = 0x0FFFFFFF;
+      break;
+    default:
+      lower = 0x10000000;
+      upper = maxResidual;
+      break;
+  }
+  return static_cast<uint32_t>(lower + mixed % (upper - lower + 1));
+}
+
+inline constexpr uint32_t varintBenchmarkValue(
+    uint32_t row,
+    uint64_t seed = kVarintBenchmarkDefaultSeed) {
+  return varintBenchmarkBaseline(seed) + varintBenchmarkResidual(row, seed);
+}
+
+static_assert(varintBenchmarkResidual(0) == 0);
+static_assert(varintBenchmarkResidual(1) == 0x7F);
+static_assert(varintBenchmarkResidual(2) == 0x80);
+static_assert(varintBenchmarkResidual(3) == 0x3FFF);
+static_assert(varintBenchmarkResidual(4) == 0x4000);
+static_assert(varintBenchmarkResidual(5) == 0x1FFFFF);
+static_assert(varintBenchmarkResidual(6) == 0x200000);
+static_assert(varintBenchmarkResidual(7) == 0x0FFFFFFF);
+static_assert(varintBenchmarkResidual(8) == 0x10000000);
+static_assert(varintBenchmarkValue(9) == std::numeric_limits<uint32_t>::max());
+
+} // namespace facebook::nimble::benchmarks


### PR DESCRIPTION
`PFOREncodingBenchmark.cpp` and `PFOREncodingBenchmarkData.h` already exist in
fbcode, but they were written after the content of #18468 was captured, so the
Nimble move did not carry them across.

Bringing them over matters beyond the benchmark itself. Velox syncs GitHub into
fbcode, so once Nimble sync is re-enabled internally the first verification job
would see two files present internally and absent here, and generate a fixup
that deletes them from fbcode. Landing them here first avoids that.

The two sources are copied without modification so the trees match exactly. The
only other change is the `nimble_pfor_encoding_benchmark` target, which follows
the existing pattern in `velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt`.


---

## Update: the nine remaining Nimble benchmark files

Nine more benchmark files exist in fbcode and have never been on main, so the
same argument applies to them and they are added here rather than in a separate
pull request.

**Two complete benchmarks, five files**, which get CMake targets:

```
FsstEncodingBenchmark.cpp   -> FsstBenchmarkData.h   -> StringBenchmarkCorpus.h
PrefixEncodingBenchmark.cpp -> PrefixBenchmarkData.h -> StringBenchmarkCorpus.h
```

`StringBenchmarkCorpus.h` is shared by both data headers, so the five arrive
together. `nimble_fsst_encoding_benchmark` links `fsst`, because
`FsstEncoding.h` includes `<fsst.h>`, and `fmt::fmt` for its formatting;
`nimble_prefix_encoding_benchmark` needs neither.

**Four data headers with no consumer:** `BlockBitPackingBenchmarkData.h`,
`HuffmanBenchmarkData.h`, `SimdForBitpackBenchmarkData.h` and
`VarintBenchmarkData.h`. Nothing includes them in either tree; their benchmarks
are already here and reference no data header. They are listed against the
benchmark target they belong to so `check-header-ownership` sees them, which is
what #18538 did for the data headers already in the tree, where
`nimble_fixed_bit_width_benchmark` lists five headers that
`FixedBitWidthBenchmark.cpp` does not include. `VarintBenchmarkData.h` goes on
that same target because no varint benchmark target exists.

All nine files are byte-identical to their fbcode copies. Editing them would
reintroduce the drift this change exists to remove.
