### PR TITLE
feat(nimble): Verify writer metadata in fuzzers (#18545)

### DIFF
--- a/velox/dwio/nimble/fuzzer/encoding_selection/CMakeLists.txt
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/CMakeLists.txt
@@ -53,8 +53,10 @@ target_link_libraries(
   nimble_common
   nimble_common_file_writer
   nimble_encodings
+  nimble_index_test_utils
   nimble_random_encoding_selection_policy
   nimble_tablet_reader
+  nimble_velox_schema_serialization
   nimble_velox_reader
   nimble_velox_selective
   nimble_writer

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -29,6 +29,7 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <folly/Random.h>
+#include <folly/container/F14Set.h>
 #include <folly/hash/Hash.h>
 #include <glog/logging.h>
 
@@ -40,16 +41,20 @@
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/ChunkHeader.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/FixedBitArray.h"
 #include "velox/dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
+#include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/writer/EncodingSelectionPolicyFactory.h"
 #include "velox/dwio/nimble/writer/FlushPolicy.h"
@@ -270,7 +275,8 @@ void randomizeWriterOptions(WriterOptions& options, FuzzerGenerator& rng) {
       : (uint64_t{1} << folly::Random::rand32(14, rng));
   options.maxStreamChunkRawSize = uint64_t{1}
       << (10 + folly::Random::rand32(12, rng));
-  options.enableChunkIndex = folly::Random::oneIn(2, rng);
+  options.enableChunkIndex =
+      options.enableChunking && folly::Random::oneIn(2, rng);
   options.enableStreamDeduplication = folly::Random::oneIn(2, rng);
   options.fixedBitWidthUseExactBits = folly::Random::oneIn(2, rng);
   options.allowNestedAlpSelection = folly::Random::oneIn(2, rng);
@@ -328,6 +334,143 @@ uint64_t totalRows(const std::vector<VectorPtr>& batches) {
     rows += batch->size();
   }
   return rows;
+}
+
+// Identifies stream IDs whose values have special meaning when validating
+// chunk null counts and recording scalar-versus-structural coverage.
+struct PhysicalStreamRoles {
+  // Streams that store parent validity as Boolean values.
+  folly::F14FastSet<uint32_t> nullStreams;
+  // Streams that directly store scalar column values.
+  folly::F14FastSet<uint32_t> scalarStreams;
+};
+
+// Collects the physical stream roles represented by a serialized schema.
+void collectPhysicalStreamRoles(const Type& type, PhysicalStreamRoles& roles) {
+  switch (type.kind()) {
+    case Kind::Scalar:
+      roles.scalarStreams.insert(type.asScalar().scalarDescriptor().offset());
+      return;
+    case Kind::TimestampMicroNano: {
+      const auto& timestamp = type.asTimestampMicroNano();
+      roles.scalarStreams.insert(timestamp.microsDescriptor().offset());
+      roles.scalarStreams.insert(timestamp.nanosDescriptor().offset());
+      return;
+    }
+    case Kind::Row: {
+      const auto& row = type.asRow();
+      roles.nullStreams.insert(row.nullsDescriptor().offset());
+      for (size_t i = 0; i < row.childrenCount(); ++i) {
+        collectPhysicalStreamRoles(*row.childAt(i), roles);
+      }
+      return;
+    }
+    case Kind::Array:
+      collectPhysicalStreamRoles(*type.asArray().elements(), roles);
+      return;
+    case Kind::ArrayWithOffsets:
+      collectPhysicalStreamRoles(*type.asArrayWithOffsets().elements(), roles);
+      return;
+    case Kind::Map: {
+      const auto& map = type.asMap();
+      collectPhysicalStreamRoles(*map.keys(), roles);
+      collectPhysicalStreamRoles(*map.values(), roles);
+      return;
+    }
+    case Kind::SlidingWindowMap: {
+      const auto& map = type.asSlidingWindowMap();
+      collectPhysicalStreamRoles(*map.keys(), roles);
+      collectPhysicalStreamRoles(*map.values(), roles);
+      return;
+    }
+    case Kind::FlatMap: {
+      const auto& flatMap = type.asFlatMap();
+      roles.nullStreams.insert(flatMap.nullsDescriptor().offset());
+      for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+        collectPhysicalStreamRoles(*flatMap.childAt(i), roles);
+      }
+      return;
+    }
+  }
+  NIMBLE_UNREACHABLE("Unsupported schema kind: {}.", type.kind());
+}
+
+/// Materializes a nullable encoding and counts null entries in the bitmap.
+template <typename T>
+uint32_t materializedNullCount(
+    Encoding& encoding,
+    velox::memory::MemoryPool* pool) {
+  const auto rowCount = encoding.rowCount();
+  Vector<T> values{pool, rowCount};
+  Vector<char> nonNulls{
+      pool, static_cast<uint32_t>(FixedBitArray::bufferSize(rowCount, 1))};
+  nonNulls.zero_out();
+  const auto returnedNonNullCount = encoding.materializeNullable(
+      rowCount, values.data(), [&]() { return nonNulls.data(); });
+
+  uint32_t bitmapNonNullCount{0};
+  for (uint32_t row = 0; row < rowCount; ++row) {
+    bitmapNonNullCount += velox::bits::isBitSet(
+        reinterpret_cast<const uint8_t*>(nonNulls.data()), row);
+  }
+  NIMBLE_CHECK_EQ(
+      returnedNonNullCount,
+      bitmapNonNullCount,
+      "Nullable encoding returned a non-null count inconsistent with its bitmap.");
+  return rowCount - bitmapNonNullCount;
+}
+
+/// Returns the null count for a chunk by decoding its content independently.
+/// Null-only streams count false Boolean values; nullable typed streams
+/// materialize the bitmap; non-nullable streams return 0.
+uint32_t decodedNullCount(
+    Encoding& encoding,
+    bool isNullStream,
+    velox::memory::MemoryPool* pool) {
+  if (isNullStream) {
+    NIMBLE_CHECK_EQ(
+        encoding.dataType(),
+        DataType::Bool,
+        "Null-only stream must contain Boolean validity values.");
+    Vector<bool> nonNulls{pool, encoding.rowCount()};
+    encoding.materialize(encoding.rowCount(), nonNulls.data());
+    return static_cast<uint32_t>(
+        std::count(nonNulls.begin(), nonNulls.end(), false));
+  }
+
+  if (!encoding.isNullable()) {
+    return 0;
+  }
+
+  switch (encoding.dataType()) {
+    case DataType::Bool:
+      return materializedNullCount<bool>(encoding, pool);
+    case DataType::Int8:
+      return materializedNullCount<int8_t>(encoding, pool);
+    case DataType::Uint8:
+      return materializedNullCount<uint8_t>(encoding, pool);
+    case DataType::Int16:
+      return materializedNullCount<int16_t>(encoding, pool);
+    case DataType::Uint16:
+      return materializedNullCount<uint16_t>(encoding, pool);
+    case DataType::Int32:
+      return materializedNullCount<int32_t>(encoding, pool);
+    case DataType::Uint32:
+      return materializedNullCount<uint32_t>(encoding, pool);
+    case DataType::Int64:
+      return materializedNullCount<int64_t>(encoding, pool);
+    case DataType::Uint64:
+      return materializedNullCount<uint64_t>(encoding, pool);
+    case DataType::Float:
+      return materializedNullCount<float>(encoding, pool);
+    case DataType::Double:
+      return materializedNullCount<double>(encoding, pool);
+    case DataType::String:
+      return materializedNullCount<std::string_view>(encoding, pool);
+    case DataType::Undefined:
+      NIMBLE_UNREACHABLE("Nullable encoding has undefined data type.");
+  }
+  NIMBLE_UNREACHABLE("Unknown data type: {}.", encoding.dataType());
 }
 
 const std::vector<EncodingType>& unfilteredCandidateEncodings() {
@@ -839,8 +982,240 @@ std::string NimbleWriterFuzzer::writeFile(
   // flushAfterWrite=false leaves stripe boundaries to the flush policy; the
   // helper's default would cut a stripe after every batch and make every flush
   // regime identical.
-  return test::createNimbleFile(
+  const bool chunkStatsEnabled = writerOptions.enableChunkIndex;
+  auto file = test::createNimbleFile(
       rootPool_, batches, std::move(writerOptions), /*flushAfterWrite=*/false);
+  verifyChunkStatsMetadata(file, chunkStatsEnabled);
+  return file;
+}
+
+void NimbleWriterFuzzer::verifyChunkStatsMetadata(
+    const std::string& file,
+    bool chunkStatsEnabled) {
+  struct PhysicalChunk {
+    uint32_t offset;
+    uint32_t size;
+    CompressionType compressionType;
+  };
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = TabletReader::create(
+      readFile, leafPool_.get(), test::makeTestTabletOptions(leafPool_.get()));
+
+  auto schemaSection = tablet->loadOptionalSection(std::string(kSchemaSection));
+  NIMBLE_CHECK(schemaSection.has_value(), "Schema not found.");
+  const auto nimbleSchema =
+      SchemaDeserializer::deserialize(schemaSection->content());
+  PhysicalStreamRoles roles;
+  collectPhysicalStreamRoles(*nimbleSchema, roles);
+
+  if (chunkStatsEnabled) {
+    ++chunkStatsCoverage_.numIndexedFiles;
+  } else {
+    ++chunkStatsCoverage_.numUnindexedFiles;
+  }
+
+  folly::F14FastSet<uint32_t> stripeGroups;
+  for (uint32_t stripe = 0; stripe < tablet->stripeCount(); ++stripe) {
+    const auto stripeIdentifier = tablet->stripeIdentifier(stripe);
+    const auto& chunkStats = stripeIdentifier.chunkStats();
+    if (!chunkStatsEnabled) {
+      NIMBLE_CHECK_NULL(
+          chunkStats,
+          "Chunk stats present in stripe {} but chunk index is disabled (seed {}).",
+          stripe,
+          options_.seed);
+    }
+    if (!chunkStats) {
+      continue;
+    }
+    ++chunkStatsCoverage_.numStripes;
+
+    index::test::ChunkStatsTestHelper chunkHelper(chunkStats.get());
+    stripeGroups.insert(chunkHelper.firstStripe());
+    const uint32_t stripeOffset = stripe - chunkHelper.firstStripe();
+    NIMBLE_CHECK_LT(stripeOffset, chunkHelper.stripeCount());
+
+    const uint32_t streamCount = tablet->streamCount(stripeIdentifier);
+    NIMBLE_CHECK_EQ(streamCount, chunkHelper.streamCount());
+    std::vector<uint32_t> streamIdentifiers(streamCount);
+    std::iota(streamIdentifiers.begin(), streamIdentifiers.end(), 0);
+    auto streams = tablet->load(stripeIdentifier, streamIdentifiers);
+
+    for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+      auto streamStats = chunkHelper.streamStats(streamId);
+      NIMBLE_CHECK_EQ(
+          streamStats.chunkCounts.size(), chunkHelper.stripeCount());
+      NIMBLE_CHECK_EQ(
+          streamStats.chunkRows.size(), streamStats.chunkOffsets.size());
+      NIMBLE_CHECK_EQ(
+          streamStats.chunkRows.size(), streamStats.chunkNullCounts.size());
+      const uint32_t beginChunk =
+          stripeOffset == 0 ? 0 : streamStats.chunkCounts[stripeOffset - 1];
+      const uint32_t endChunk = streamStats.chunkCounts[stripeOffset];
+      NIMBLE_CHECK_LE(beginChunk, endChunk);
+      NIMBLE_CHECK_LE(endChunk, streamStats.chunkRows.size());
+      const uint32_t chunkCount = endChunk - beginChunk;
+
+      auto& stream = streams[streamId];
+      std::string_view rawStream;
+      if (stream != nullptr) {
+        rawStream = stream->getStream();
+      }
+      NIMBLE_CHECK_EQ(
+          rawStream.size(), tablet->streamSize(stripeIdentifier, streamId));
+      NIMBLE_CHECK_LE(rawStream.size(), std::numeric_limits<uint32_t>::max());
+
+      std::vector<PhysicalChunk> physicalChunks;
+      uint32_t offset{0};
+      while (offset < rawStream.size()) {
+        NIMBLE_CHECK_LE(
+            kChunkHeaderSize,
+            rawStream.size() - offset,
+            "Truncated chunk header in stripe {}, stream {}.",
+            stripe,
+            streamId);
+        const char* cursor = rawStream.data() + offset;
+        const auto header = readChunkHeader(cursor);
+        const uint64_t size = uint64_t{kChunkHeaderSize} + header.length;
+        NIMBLE_CHECK_LE(
+            size,
+            rawStream.size() - offset,
+            "Chunk exceeds stripe {}, stream {} boundary.",
+            stripe,
+            streamId);
+        physicalChunks.push_back(
+            {offset, static_cast<uint32_t>(size), header.compressionType});
+        offset += size;
+      }
+      NIMBLE_CHECK_EQ(offset, rawStream.size());
+      NIMBLE_CHECK_EQ(
+          chunkCount,
+          physicalChunks.size(),
+          "Chunk count mismatch in stripe {}, stream {} (seed {}).",
+          stripe,
+          streamId,
+          options_.seed);
+
+      if (chunkCount == 0) {
+        NIMBLE_CHECK_NULL(stream);
+        continue;
+      }
+      NIMBLE_CHECK_NOT_NULL(stream);
+
+      if (roles.scalarStreams.contains(streamId)) {
+        ++chunkStatsCoverage_.numScalarStreams;
+      } else {
+        ++chunkStatsCoverage_.numStructuralStreams;
+      }
+      if (chunkCount > 1) {
+        ++chunkStatsCoverage_.numMultiChunkStreams;
+      }
+
+      auto streamIndex = chunkStats->createStreamIndex(
+          stripe, streamId, static_cast<uint32_t>(rawStream.size()));
+      NIMBLE_CHECK_EQ(streamIndex != nullptr, chunkCount > 1);
+
+      InMemoryChunkedStream chunkedStream{*leafPool_, std::move(stream)};
+      Buffer stringBuffer{*leafPool_};
+      auto stringBufferFactory = [&stringBuffer](uint32_t size) -> void* {
+        return stringBuffer.reserve(size);
+      };
+      uint32_t previousRowBoundary{0};
+      for (uint32_t chunk = 0; chunk < chunkCount; ++chunk) {
+        const uint32_t metadataChunk = beginChunk + chunk;
+        const auto& physicalChunk = physicalChunks.at(chunk);
+        NIMBLE_CHECK_EQ(
+            streamStats.chunkOffsets[metadataChunk], physicalChunk.offset);
+
+        const uint32_t nextOffset = chunk + 1 < chunkCount
+            ? streamStats.chunkOffsets[metadataChunk + 1]
+            : static_cast<uint32_t>(rawStream.size());
+        NIMBLE_CHECK_EQ(nextOffset - physicalChunk.offset, physicalChunk.size);
+
+        const uint32_t rowBoundary = streamStats.chunkRows[metadataChunk];
+        NIMBLE_CHECK_GT(rowBoundary, previousRowBoundary);
+        const uint32_t chunkRows = rowBoundary - previousRowBoundary;
+        NIMBLE_CHECK(chunkedStream.hasNext());
+        auto encoding = EncodingFactory().create(
+            *leafPool_, chunkedStream.nextChunk(), stringBufferFactory);
+        NIMBLE_CHECK_NOT_NULL(encoding);
+        NIMBLE_CHECK_EQ(
+            encoding->rowCount(),
+            chunkRows,
+            "Chunk row count mismatch in stripe {}, stream {}, chunk {}.",
+            stripe,
+            streamId,
+            chunk);
+
+        const auto expectedNullCount = decodedNullCount(
+            *encoding, roles.nullStreams.contains(streamId), leafPool_.get());
+        const auto indexedNullCount =
+            streamStats.chunkNullCounts[metadataChunk];
+        NIMBLE_CHECK_EQ(
+            indexedNullCount,
+            expectedNullCount,
+            "Chunk null count mismatch in stripe {}, stream {}, chunk {} (seed {}).",
+            stripe,
+            streamId,
+            chunk,
+            options_.seed);
+        NIMBLE_CHECK_EQ(indexedNullCount > 0, expectedNullCount > 0);
+
+        if (indexedNullCount == 0) {
+          ++chunkStatsCoverage_.numZeroNullChunks;
+        } else if (indexedNullCount == chunkRows) {
+          ++chunkStatsCoverage_.numFullyNullChunks;
+        } else {
+          ++chunkStatsCoverage_.numPartiallyNullChunks;
+        }
+        if (physicalChunk.compressionType == CompressionType::Uncompressed) {
+          ++chunkStatsCoverage_.numUncompressedChunks;
+        } else {
+          ++chunkStatsCoverage_.numCompressedChunks;
+        }
+        if (chunk == 0) {
+          ++chunkStatsCoverage_.numFirstChunks;
+        }
+        if (chunk + 1 == chunkCount) {
+          ++chunkStatsCoverage_.numFinalChunks;
+        }
+        if (chunk > 0 && chunk + 1 < chunkCount) {
+          ++chunkStatsCoverage_.numMiddleChunks;
+        }
+
+        if (streamIndex) {
+          const auto first = streamIndex->lookupChunk(previousRowBoundary);
+          const auto last = streamIndex->lookupChunk(rowBoundary - 1);
+          NIMBLE_CHECK_EQ(first.chunkOffset, physicalChunk.offset);
+          NIMBLE_CHECK_EQ(first.chunkSize, physicalChunk.size);
+          NIMBLE_CHECK_EQ(first.rowOffset, previousRowBoundary);
+          NIMBLE_CHECK_EQ(last.chunkIndex, first.chunkIndex);
+          NIMBLE_CHECK_EQ(last.chunkOffset, first.chunkOffset);
+          const auto lookupNullCount =
+              streamIndex->chunkNullCount(first.chunkIndex);
+          NIMBLE_CHECK(
+              lookupNullCount.has_value(),
+              "Chunk {} of stripe {}, stream {} has no indexed null count.",
+              chunk,
+              stripe,
+              streamId);
+          NIMBLE_CHECK_EQ(*lookupNullCount, indexedNullCount);
+          if (chunk + 1 < chunkCount) {
+            const auto next = streamIndex->lookupChunk(rowBoundary);
+            NIMBLE_CHECK_NE(next.chunkIndex, first.chunkIndex);
+            NIMBLE_CHECK_EQ(next.chunkOffset, physicalChunks[chunk + 1].offset);
+          }
+        }
+        previousRowBoundary = rowBoundary;
+      }
+      NIMBLE_CHECK(!chunkedStream.hasNext());
+      if (streamIndex) {
+        NIMBLE_CHECK_EQ(streamIndex->rowCount(), previousRowBoundary);
+      }
+    }
+  }
+  chunkStatsCoverage_.numStripeGroups += stripeGroups.size();
 }
 
 void NimbleWriterFuzzer::readAndVerify(
@@ -1478,6 +1853,58 @@ void NimbleWriterFuzzer::logCoverage() const {
         stats.numForcedChunksFellBack,
         stats.numChunksApplied == 0 ? "   <-- NEVER APPLIED" : "");
   }
+}
+
+void NimbleWriterFuzzer::logChunkStatsCoverage() const {
+  LOG(WARNING) << fmt::format(
+      "Chunk-index coverage: files(indexed={},unindexed={}) groups={} stripes={} streams(scalar={},structural={},multiChunk={}) chunks(first={},middle={},final={},zeroNull={},partialNull={},fullNull={},compressed={},uncompressed={})",
+      chunkStatsCoverage_.numIndexedFiles,
+      chunkStatsCoverage_.numUnindexedFiles,
+      chunkStatsCoverage_.numStripeGroups,
+      chunkStatsCoverage_.numStripes,
+      chunkStatsCoverage_.numScalarStreams,
+      chunkStatsCoverage_.numStructuralStreams,
+      chunkStatsCoverage_.numMultiChunkStreams,
+      chunkStatsCoverage_.numFirstChunks,
+      chunkStatsCoverage_.numMiddleChunks,
+      chunkStatsCoverage_.numFinalChunks,
+      chunkStatsCoverage_.numZeroNullChunks,
+      chunkStatsCoverage_.numPartiallyNullChunks,
+      chunkStatsCoverage_.numFullyNullChunks,
+      chunkStatsCoverage_.numCompressedChunks,
+      chunkStatsCoverage_.numUncompressedChunks);
+}
+
+std::vector<std::string_view> NimbleWriterFuzzer::uncoveredChunkStatsShapes()
+    const {
+  std::vector<std::string_view> uncovered;
+  auto require = [&](bool covered, std::string_view name) {
+    if (!covered) {
+      uncovered.push_back(name);
+    }
+  };
+  require(chunkStatsCoverage_.numIndexedFiles > 0, "indexed file");
+  require(chunkStatsCoverage_.numUnindexedFiles > 0, "unindexed file");
+  // TabletWithIndexTest.multipleGroups deterministically covers multiple
+  // stripe groups. WriterOptions does not expose the tablet metadata flush
+  // threshold, so requiring that layout here would be unreachable.
+  require(
+      chunkStatsCoverage_.numStripes > chunkStatsCoverage_.numStripeGroups,
+      "multiple stripes per group");
+  require(chunkStatsCoverage_.numScalarStreams > 0, "scalar stream");
+  require(chunkStatsCoverage_.numStructuralStreams > 0, "structural stream");
+  require(chunkStatsCoverage_.numMultiChunkStreams > 0, "multi-chunk stream");
+  require(chunkStatsCoverage_.numFirstChunks > 0, "first chunk");
+  require(chunkStatsCoverage_.numMiddleChunks > 0, "middle chunk");
+  require(chunkStatsCoverage_.numFinalChunks > 0, "final chunk");
+  require(chunkStatsCoverage_.numZeroNullChunks > 0, "zero-null chunk");
+  require(
+      chunkStatsCoverage_.numPartiallyNullChunks > 0, "partially-null chunk");
+  // Fully-null chunks are generated deterministically by
+  // WriterTest.chunkNullCountsForStructNullStream. Requiring a random schema
+  // and chunk boundary to align around one here would make CI probabilistic.
+  require(chunkStatsCoverage_.numUncompressedChunks > 0, "uncompressed chunk");
+  return uncovered;
 }
 
 } // namespace facebook::nimble::fuzzer

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
@@ -271,6 +271,9 @@ class NimbleWriterFuzzer {
   /// as covered.
   void logPairCoverage() const;
 
+  /// Logs the physical chunk and metadata shapes validated by the run.
+  void logChunkStatsCoverage() const;
+
   /// Candidate encodings that were never applied to a single chunk, either
   /// because no iteration drew a schema they accept or because every stream
   /// fell back to Trivial. A non-empty result means the run verified fewer
@@ -294,7 +297,36 @@ class NimbleWriterFuzzer {
   /// either way.
   std::vector<EncodingPair> unappliedPairs() const;
 
+  /// Names of required chunk-stats metadata shapes not observed by the run.
+  std::vector<std::string_view> uncoveredChunkStatsShapes() const;
+
  private:
+  // Counts physical stream and metadata shapes validated during the run.
+  struct ChunkStatsVerificationCoverage {
+    // Counts files whose chunk stats were enabled or disabled.
+    uint64_t numIndexedFiles{0};
+    uint64_t numUnindexedFiles{0};
+    // Counts indexed groups and stripes.
+    uint64_t numStripeGroups{0};
+    uint64_t numStripes{0};
+    // Counts present scalar-value streams, structural streams emitted for
+    // complex types, and streams split into multiple chunks.
+    uint64_t numScalarStreams{0};
+    uint64_t numStructuralStreams{0};
+    uint64_t numMultiChunkStreams{0};
+    // Counts chunk positions within their streams.
+    uint64_t numFirstChunks{0};
+    uint64_t numMiddleChunks{0};
+    uint64_t numFinalChunks{0};
+    // Counts decoded null distributions.
+    uint64_t numZeroNullChunks{0};
+    uint64_t numPartiallyNullChunks{0};
+    uint64_t numFullyNullChunks{0};
+    // Counts physical chunk-wrapper compression states.
+    uint64_t numCompressedChunks{0};
+    uint64_t numUncompressedChunks{0};
+  };
+
   // Writes 'batches', returning the file bytes. When 'encodingType' is set,
   // that is the only candidate offered to the random policy; otherwise the
   // policy chooses from its full default set. The write type is taken from
@@ -303,6 +335,12 @@ class NimbleWriterFuzzer {
       const std::vector<velox::VectorPtr>& batches,
       std::optional<EncodingType> encodingType,
       uint64_t iterationSeed);
+
+  // Validates the chunk-stats section against independently parsed and decoded
+  // physical chunks, and records which metadata shapes were exercised.
+  void verifyChunkStatsMetadata(
+      const std::string& file,
+      bool chunkStatsEnabled);
 
   // Reads 'file' through 'readerPath' and compares every row against
   // 'batches'. Throws on the first difference.
@@ -336,6 +374,7 @@ class NimbleWriterFuzzer {
   std::map<EncodingType, EncodingCoverage> coverage_;
   std::map<EncodingPair, PairCoverage> pairCoverage_;
   uint64_t numUnfilteredFilesWritten_{0};
+  ChunkStatsVerificationCoverage chunkStatsCoverage_;
   // DataTypes some stream actually carried. Bounds what unappliedPairs() may
   // demand, and is deliberately observed rather than derived from the schema:
   // the writer emits Uint32 length streams, Bool null streams and the Uint16

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzerRunner.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzerRunner.cpp
@@ -53,12 +53,10 @@ DEFINE_int32(nimble_writer_fuzzer_num_batches, 3, "Batches written per file.");
 DEFINE_bool(
     nimble_writer_fuzzer_require_coverage,
     false,
-    "Fail the run if any candidate encoding was never applied to a chunk. "
-    "Round-trip assertions cannot catch this: an encoding the writer always "
-    "falls back on verifies Trivial over and over and still passes. Off by "
-    "default so a short local run does not fail on an encoding whose schema "
-    "shape it did not happen to draw; enabled in CI, where the run is long "
-    "enough for every candidate to appear.");
+    "Fail the run if any candidate encoding or required chunk-stats metadata "
+    "shape was not exercised. Off by default so short local runs do not fail "
+    "on a shape they did not happen to draw; enabled in CI, where the run is "
+    "long enough to cover every required case.");
 
 namespace facebook::nimble::fuzzer {
 
@@ -107,6 +105,7 @@ void runNimbleWriterFuzzer() {
     LOG(WARNING) << "Completed " << iteration << " iterations.";
     fuzzer.logCoverage();
     fuzzer.logPairCoverage();
+    fuzzer.logChunkStatsCoverage();
   };
 
   // Catch and rethrow rather than a scope guard: an exception that escapes
@@ -178,6 +177,13 @@ void runNimbleWriterFuzzer() {
           iteration,
           fmt::join(details, ", "));
     }
+
+    const auto uncoveredChunkStatsShapes = fuzzer.uncoveredChunkStatsShapes();
+    NIMBLE_CHECK(
+        uncoveredChunkStatsShapes.empty(),
+        "Chunk-stats metadata coverage is incomplete after {} iterations: {}.",
+        iteration,
+        fmt::join(uncoveredChunkStatsShapes, ", "));
   }
 }
 

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzerRunner.h
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzerRunner.h
@@ -26,7 +26,8 @@ void setUpFuzzerEnvironments();
 /// elapses, re-seeding each iteration. At least one iteration always runs. The
 /// per-encoding coverage tally is logged on the way out whether or not an
 /// iteration threw, and with --nimble_writer_fuzzer_require_coverage the run
-/// also fails if any candidate encoding was never applied.
+/// also fails if any candidate encoding or required chunk-stats metadata shape
+/// was not exercised.
 ///
 /// Parameters come from the nimble_writer_fuzzer_ gflags (seed, duration_sec,
 /// max_schema_depth, batch_size, num_batches, require_coverage); when the seed

--- a/velox/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/velox/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -172,6 +172,18 @@ StreamStats ChunkStatsTestHelper::streamStats(uint32_t streamId) const {
   const auto* chunkNullCounts = root->stream_chunk_null_counts();
 
   const uint32_t stripeCount = chunkStats_->stripeCount_;
+  NIMBLE_CHECK_EQ(
+      streamChunkCounts->size(),
+      static_cast<size_t>(stripeCount) * streamCount);
+  NIMBLE_CHECK_EQ(chunkRows->size(), chunkOffsets->size());
+  if (chunkNullCounts != nullptr) {
+    NIMBLE_CHECK_EQ(chunkRows->size(), chunkNullCounts->size());
+  }
+  if (streamChunkCounts->size() > 0) {
+    NIMBLE_CHECK_EQ(
+        streamChunkCounts->Get(streamChunkCounts->size() - 1),
+        chunkRows->size());
+  }
 
   uint32_t accumulatedChunkCountForStream = 0;
   for (uint32_t stripeOffset = 0; stripeOffset < stripeCount; ++stripeOffset) {
@@ -179,6 +191,7 @@ StreamStats ChunkStatsTestHelper::streamStats(uint32_t streamId) const {
     const uint32_t globalAccumulatedCount = streamChunkCounts->Get(idx);
     const uint32_t prevGlobalAccumulatedCount =
         idx == 0 ? 0 : streamChunkCounts->Get(idx - 1);
+    NIMBLE_CHECK_LE(prevGlobalAccumulatedCount, globalAccumulatedCount);
     const uint32_t chunksInThisStripe =
         globalAccumulatedCount - prevGlobalAccumulatedCount;
     accumulatedChunkCountForStream += chunksInThisStripe;


### PR DESCRIPTION
Summary:

CONTEXT: The Nimble writer fuzzer exercises diverse encoding and layout
configurations but did not verify the chunk-stats metadata it produces.
Chunk-stats metadata records per-chunk offsets, row boundaries, and null counts
so readers can seek directly to a chunk without scanning the raw stream.

WHAT:
- Add `verifyChunkStatsMetadata()` to `NimbleWriterFuzzer`. After every file
  write, it reopens the file with `TabletReader`, independently scans the raw
  stream bytes via 5-byte chunk headers, decodes each chunk through
  `EncodingFactory`, and asserts the serialized chunk-stats metadata matches
  the decoded values (offsets, sizes, row counts, null counts, lookups).
- Enable chunk-stats metadata in chunked table-evolution runs. The chunk index
  is enabled only when chunking is on (`ENABLE_CHUNKING = true`), because
  chunk-level metadata is meaningless for single-chunk (non-chunked) streams.
  In the table-evolution fuzzer, this means ~2/3 of configs (test_per_batch and
  test_random flush modes) enable the chunk index, while the remaining ~1/3
  (default size-based flush, which does not enable chunking) leave it off.
- In `NimbleWriterFuzzer`, `enableChunkIndex` now requires `enableChunking` to
  be true, preventing an invalid configuration that produced wrong null counts
  for struct null-only streams in the non-chunked write path (T285998584).
- Track coverage of metadata shapes (indexed/unindexed files, scalar/structural
  streams, multi-chunk streams, null distributions, chunk positions) and fail
  CI if required shapes are not exercised.

Reviewed By: xiaoxmeng

Differential Revision: D116438539


