### PR TITLE
feat(nimble): Keep deprecated encodings read-only for PFOR encoding (#18547)

### DIFF
--- a/velox/dwio/nimble/common/Types.cpp
+++ b/velox/dwio/nimble/common/Types.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/dwio/nimble/common/Types.h"
 
+#include <algorithm>
 #include <array>
 
 #include "velox/dwio/nimble/common/Exceptions.h"
@@ -49,6 +50,9 @@ constexpr auto kEncodingTypes =
         {EncodingType::SharedDictionary, "SharedDictionary"},
     });
 
+constexpr auto kReadOnlyEncodingTypes =
+    std::to_array<EncodingType>({EncodingType::PFOR});
+
 constexpr auto kCompressionTypes =
     std::to_array<std::pair<CompressionType, std::string_view>>({
         {CompressionType::Uncompressed, "Uncompressed"},
@@ -81,6 +85,22 @@ EncodingType toEncodingType(std::string_view name) {
     }
   }
   NIMBLE_USER_FAIL("Unknown encoding type: {}", name);
+}
+
+bool isReadOnlyEncoding(EncodingType encodingType) {
+  return std::find(
+             kReadOnlyEncodingTypes.begin(),
+             kReadOnlyEncodingTypes.end(),
+             encodingType) != kReadOnlyEncodingTypes.end();
+}
+
+bool isReadOnlyEncoding(std::string_view name) {
+  return std::any_of(
+      kReadOnlyEncodingTypes.begin(),
+      kReadOnlyEncodingTypes.end(),
+      [name](const auto encodingType) {
+        return name == toString(encodingType);
+      });
 }
 
 std::ostream& operator<<(std::ostream& out, DataType dataType) {

--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -165,6 +165,10 @@ enum class EncodingType {
 std::string toString(EncodingType encodingType);
 /// Returns the encoding type for 'name'. Throws if 'name' is unknown.
 EncodingType toEncodingType(std::string_view name);
+/// Returns true if the encoding is retained only for reading existing data.
+bool isReadOnlyEncoding(EncodingType encodingType);
+/// Returns true if the name identifies a read-only encoding.
+bool isReadOnlyEncoding(std::string_view name);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);
 
 enum class DataType : uint8_t {

--- a/velox/dwio/nimble/common/tests/TypesTest.cpp
+++ b/velox/dwio/nimble/common/tests/TypesTest.cpp
@@ -68,6 +68,14 @@ TEST(TypesTest, ToEncodingTypeUnknown) {
   EXPECT_ANY_THROW(toEncodingType("unknown"));
 }
 
+TEST(TypesTest, ReadOnlyEncoding) {
+  EXPECT_TRUE(isReadOnlyEncoding(EncodingType::PFOR));
+  EXPECT_TRUE(isReadOnlyEncoding("PFOR"));
+  EXPECT_FALSE(isReadOnlyEncoding(EncodingType::Trivial));
+  EXPECT_FALSE(isReadOnlyEncoding("Trivial"));
+  EXPECT_FALSE(isReadOnlyEncoding("unknown"));
+}
+
 TEST(TypesTest, EncodingTypeStreamOperator) {
   std::ostringstream ss;
   ss << EncodingType::Trivial;

--- a/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -66,6 +66,10 @@ ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
         part);
     bool found = false;
     const auto key = folly::trimWhitespace(kv[0]);
+    NIMBLE_USER_CHECK(
+        !isReadOnlyEncoding(key),
+        "Encoding is read-only and cannot be used for new writes: {}",
+        key);
     for (auto i = 0; i < possibleEncodings.size(); ++i) {
       auto encoding = possibleEncodings[i];
       // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
@@ -159,7 +163,6 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       // enable for production tables without consulting the Nimble team
       // (oncall: dwios).
       EncodingType::ALP,
-      EncodingType::PFOR,
       EncodingType::SimdForBitpack,
       EncodingType::SubIntSplit,
       EncodingType::BlockBitPacking,

--- a/velox/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -19,6 +19,7 @@
 #include <limits>
 #include <optional>
 #include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
@@ -1860,6 +1861,13 @@ TEST(ManualEncodingSelectionPolicyFactoryTest, fsstRequiresExplicitOptIn) {
           "Fsst=1.0"),
       (std::vector<std::pair<nimble::EncodingType, float>>{
           {nimble::EncodingType::Fsst, 1.0}}));
+}
+
+TEST(ManualEncodingSelectionPolicyFactoryTest, rejectsReadOnlyEncodings) {
+  NIMBLE_ASSERT_THROW(
+      nimble::ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
+          "PFOR=1.0"),
+      "Encoding is read-only and cannot be used for new writes: PFOR");
 }
 
 TEST(

--- a/velox/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -29,6 +29,7 @@
 #include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
@@ -131,6 +132,25 @@ TYPED_TEST_SUITE(PFOREncodingTest, PFORTypes);
 TYPED_TEST(PFOREncodingTest, singleElement) {
   using T = TypeParam;
   this->roundTripAndExpect({T{42}});
+}
+
+TYPED_TEST(PFOREncodingTest, readerFactoriesDecodeExistingData) {
+  using T = TypeParam;
+  const std::vector<T> values{T{1}, T{2}, T{3}, T{100}, T{5}};
+  Buffer buffer{*this->pool_};
+  const auto encoded =
+      EncodingFactory::encode<T>(this->createSelectionPolicy(), values, buffer);
+
+  for (const auto useLegacyReader : {false, true}) {
+    SCOPED_TRACE(fmt::format("legacy={}", useLegacyReader));
+    std::unique_ptr<Encoding> encoding = useLegacyReader
+        ? legacy::EncodingFactory{}.create(*this->pool_, encoded, nullptr)
+        : EncodingFactory{}.create(*this->pool_, encoded, nullptr);
+    std::vector<T> decoded(values.size());
+    encoding->materialize(
+        static_cast<uint32_t>(decoded.size()), decoded.data());
+    EXPECT_EQ(decoded, values);
+  }
 }
 
 TYPED_TEST(PFOREncodingTest, allSameValues) {

--- a/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
@@ -290,7 +290,6 @@ TEST_F(
   NimbleWriterFuzzer fuzzer(options, *rootPool_);
   for (const auto encodingType :
        {EncodingType::DeltaBlock,
-        EncodingType::PFOR,
         EncodingType::SimdForBitpack,
         EncodingType::Huffman}) {
     SCOPED_TRACE(toString(encodingType));

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -65,6 +65,11 @@ using ::facebook::velox::TypePtr;
 using ::facebook::velox::VectorPtr;
 using ::facebook::velox::fuzzer::FuzzerGenerator;
 
+// Writable encodings that this fuzzer target intentionally does not force.
+// This is not a global unsupported-encoding list.
+constexpr auto kExcludedFuzzerCandidateEncodings =
+    std::to_array({EncodingType::SubIntSplit});
+
 // Scalar types the Nimble writer round-trips with type identity.
 // FieldWriter::create dispatches on the physical TypeKind, so DATE, TIME,
 // INTERVAL and short DECIMAL write fine but read back as INTEGER/BIGINT, which
@@ -141,7 +146,6 @@ bool isNumericCompatible(EncodingType encodingType) {
       return true;
     // Gated on isIntegralType<physicalType>(), which holds for float and
     // double as well since their physical types are uint32_t and uint64_t.
-    case EncodingType::PFOR:
     case EncodingType::SimdForBitpack:
     case EncodingType::Huffman:
       return true;
@@ -730,23 +734,16 @@ std::string_view toString(ReaderPath readerPath) {
 }
 
 std::vector<EncodingType> allCandidateEncodings() {
-  return {
-      EncodingType::Constant,
-      EncodingType::Trivial,
-      EncodingType::FixedBitWidth,
-      EncodingType::MainlyConstant,
-      EncodingType::SparseBool,
-      EncodingType::Dictionary,
-      EncodingType::RLE,
-      EncodingType::Varint,
-      EncodingType::ALP,
-      EncodingType::BlockBitPacking,
-      EncodingType::Fsst,
-      EncodingType::DeltaBlock,
-      EncodingType::PFOR,
-      EncodingType::SimdForBitpack,
-      EncodingType::Huffman,
-  };
+  // The fuzzer's repair phase forces each candidate through
+  // `nimble.encoding_selection_config` using the `encodings:` key. Keep this
+  // list derived from the same writable-encoding source as that parser, so
+  // deprecating an encoding for new writes does not leave the fuzzer forcing a
+  // config string production code now rejects.
+  auto encodings = ManualEncodingSelectionPolicyFactory::possibleEncodings();
+  for (const auto encodingType : kExcludedFuzzerCandidateEncodings) {
+    std::erase(encodings, encodingType);
+  }
+  return encodings;
 }
 
 bool isTypeCompatible(EncodingType encodingType, DataType dataType) {
@@ -760,8 +757,8 @@ bool isTypeCompatible(EncodingType encodingType, DataType dataType) {
     return isStringCompatible(encodingType);
   }
 
-  // Gated on isFloatingPointType<T>() / isIntegralType<T>(), which unlike the
-  // PFOR family test the logical type, so these two split cleanly.
+  // Gated on isFloatingPointType<T>() / isIntegralType<T>(), which test the
+  // logical type, so these two split cleanly.
   if (encodingType == EncodingType::ALP) {
     return isFloatingPointDataType(dataType);
   }
@@ -779,7 +776,6 @@ bool isTypeCompatible(EncodingType encodingType, DataType dataType) {
 
 bool isIntegralOnlyEncoding(EncodingType encodingType) {
   return encodingType == EncodingType::DeltaBlock ||
-      encodingType == EncodingType::PFOR ||
       encodingType == EncodingType::SimdForBitpack ||
       encodingType == EncodingType::Huffman;
 }
@@ -830,9 +826,9 @@ std::string NimbleWriterFuzzer::writeFile(
       selectionConfig);
   EncodingSelectionPolicyCreator policyCreator = std::move(*parsedCreator);
 
-  // The write-side gate admits floating point directly for PFOR, SimdForBitpack
-  // and Huffman. A Nullable float's nested policy can also admit DeltaBlock
-  // after the logical type becomes its Uint32/Uint64 physical type.
+  // The write-side gate admits floating point directly for SimdForBitpack and
+  // Huffman. A Nullable float's nested policy can also admit DeltaBlock after
+  // the logical type becomes its Uint32/Uint64 physical type.
   writerOptions.encodingSelectionPolicyCreator = encodingType.has_value()
       ? gateFloatingPointStreams(
             std::move(policyCreator),
@@ -1414,7 +1410,7 @@ void NimbleWriterFuzzer::logPairCoverage() const {
     std::vector<std::string> unapplied;
     std::vector<std::string> incompatible;
     for (const auto encodingType : allCandidateEncodings()) {
-      // The integral-only four are withheld from floating point on purpose
+      // Integral-only encodings are withheld from floating point on purpose
       // (T283330065), so for those streams they are unusable rather than
       // merely unapplied.
       if (!isTypeCompatible(encodingType, dataType) ||

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
@@ -127,25 +127,26 @@ enum class WriteOutcome {
   kNotApplied,
 };
 
-/// Every encoding the fuzzer requests. All of them are accepted by the
-/// 'encodings:' key of nimble.encoding_selection_config, which validates
-/// against ManualEncodingSelectionPolicyFactory::possibleEncodings().
+/// Writable encodings the fuzzer requests. The list is derived from
+/// ManualEncodingSelectionPolicyFactory::possibleEncodings(), which is also the
+/// source of truth for the 'encodings:' key of
+/// nimble.encoding_selection_config.
 std::vector<EncodingType> allCandidateEncodings();
 
 /// Number of unfiltered random-policy files written before coverage repair.
 inline constexpr uint32_t kNumUnfilteredRounds = 10;
 
 /// Whether an encoding may only be requested for a stream that is not REAL or
-/// DOUBLE. PFOR, SimdForBitpack and Huffman can be selected for a
-/// floating-point stream because their write-side gate tests physicalType
-/// (uint32_t/uint64_t, hence integral). DeltaBlock's direct gate tests the
-/// logical type, but a Nullable float's nested policy sees the physical type
-/// and can select it there. Every read-side gate rejects all four for float and
-/// double, producing a file no selective reader can decode. See T283330065.
+/// DOUBLE. SimdForBitpack and Huffman can be selected for a floating-point
+/// stream because their write-side gate tests physicalType (uint32_t/uint64_t,
+/// hence integral). DeltaBlock's direct gate tests the logical type, but a
+/// Nullable float's nested policy sees the physical type and can select it
+/// there. Every read-side gate rejects all three for float and double,
+/// producing a file no selective reader can decode. See T283330065.
 ///
 /// The restriction is per stream, not per schema: a schema holding one REAL
-/// column alongside integer columns still exercises these four on the integer
-/// columns.
+/// column alongside integer columns still exercises these encodings on the
+/// integer columns.
 bool isIntegralOnlyEncoding(EncodingType encodingType);
 
 /// Whether EncodingSizeEstimation's *type* gate admits 'encodingType' for a
@@ -159,12 +160,12 @@ bool isIntegralOnlyEncoding(EncodingType encodingType);
 /// recovers it by mirroring the `if constexpr` gates and the
 /// numeric/bool/string dispatch in EncodingSizeEstimation.
 ///
-/// It mirrors the *write* side only: PFOR, SimdForBitpack and Huffman are
-/// reported compatible with Float and Double because that is what the
-/// write-side gate does -- it tests physicalType, which is integral for floats
-/// -- even though no reader can decode the result (T283330065). Callers that
-/// also care about readability must exclude those separately. Nothing pins
-/// this mirror to EncodingSizeEstimation; it has drifted once (T283801877).
+/// It mirrors the *write* side only: SimdForBitpack and Huffman are reported
+/// compatible with Float and Double because that is what the write-side gate
+/// does -- it tests physicalType, which is integral for floats -- even though
+/// no reader can decode the result (T283330065). Callers that also care about
+/// readability must exclude those separately. Nothing pins this mirror to
+/// EncodingSizeEstimation; it has drifted once (T283801877).
 bool isTypeCompatible(EncodingType encodingType, DataType dataType);
 
 /// Knobs for a fuzzer run. Everything else is derived from the seed so a

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -2080,6 +2080,34 @@ TEST_F(WriterTest, openZLCompressionNumericRoundTrip) {
   ASSERT_FALSE(reader.next(1, result));
 }
 
+TEST_F(WriterTest, rejectsReadOnlyEncodingLayout) {
+  nimble::WriterOptions options;
+  options.encodingLayoutTree.emplace(
+      nimble::Kind::Row,
+      std::unordered_map<
+          nimble::EncodingLayoutTree::StreamIdentifier,
+          nimble::EncodingLayout>{},
+      "",
+      std::vector<nimble::EncodingLayoutTree>{nimble::EncodingLayoutTree{
+          nimble::Kind::Scalar,
+          {{nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+            nimble::EncodingLayout{
+                nimble::EncodingType::PFOR,
+                {},
+                nimble::CompressionType::Uncompressed,
+                {std::nullopt, std::nullopt}}}},
+          "c0"}});
+
+  std::string file;
+  NIMBLE_ASSERT_THROW(
+      nimble::Writer(
+          velox::ROW({{"c0", velox::BIGINT()}}),
+          std::make_unique<velox::InMemoryWriteFile>(&file),
+          *rootPool_,
+          std::move(options)),
+      "Encoding is read-only and cannot be used for new writes: PFOR");
+}
+
 TEST_F(WriterTest, encodingLayoutSchemaMismatch) {
   nimble::EncodingLayoutTree expected{
       nimble::Kind::Row,

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -391,11 +391,36 @@ EncodingLayoutTree remapEncodingLayoutTree(
       std::move(children)};
 }
 
+void validateEncodingLayout(const EncodingLayout& layout) {
+  NIMBLE_USER_CHECK(
+      !isReadOnlyEncoding(layout.encodingType()),
+      "Encoding is read-only and cannot be used for new writes: {}",
+      layout.encodingType());
+  for (uint32_t index = 0; index < layout.childrenCount(); ++index) {
+    const auto& child = layout.child(index);
+    if (child.has_value()) {
+      validateEncodingLayout(child.value());
+    }
+  }
+}
+
+void validateEncodingLayoutTree(const EncodingLayoutTree& tree) {
+  for (const auto identifier : tree.encodingLayoutIdentifiers()) {
+    validateEncodingLayout(*tree.encodingLayout(identifier));
+  }
+  for (uint32_t index = 0; index < tree.childrenCount(); ++index) {
+    validateEncodingLayoutTree(tree.child(index));
+  }
+}
+
 WriterOptions storedWriterOptions(
     const velox::TypePtr& inputType,
     const velox::TypePtr& storedType,
     const std::vector<velox::column_index_t>& storedInputColumnIndices,
     WriterOptions options) {
+  if (options.encodingLayoutTree.has_value()) {
+    validateEncodingLayoutTree(options.encodingLayoutTree.value());
+  }
   if (!omitClusterIndexKeyColumnStorage(options)) {
     return options;
   }


### PR DESCRIPTION
Summary:

Mark PFOR as read-only, reject it from new writer read-factor and explicit-layout configuration, and retain both reader implementations for existing files.

Reviewed By: shanhao-203, tanjialiang, xiaoxmeng

Differential Revision: D115374439


