### PR TITLE
feat(nimble): Optimize result adapter batch decoding (#18548)

### DIFF
--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -49,11 +49,13 @@ def git_changed_lines(commit):
             # as clang-tidy doesn't support CUDA compiler flags and CUDA
             # headers. Exclude *-inl.h files: they are designed to be
             # included from their corresponding header and cannot be
-            # compiled as standalone translation units.
+            # compiled as standalone translation units. Nimble is not enabled
+            # in the adapters build that produces the compilation database.
             if (
                 "cudf/" not in matched_file
                 and "wave/" not in matched_file
                 and "ucx-exchange/" not in matched_file
+                and "velox/dwio/nimble/" not in matched_file
                 and not matched_file.endswith("-inl.h")
             ):
                 file = matched_file

--- a/velox/dwio/nimble/serializer/Deserializer.cpp
+++ b/velox/dwio/nimble/serializer/Deserializer.cpp
@@ -485,6 +485,17 @@ void Deserializer::deserialize(
       folly::Range<const std::string_view*>(data.data(), data.size()), output);
 }
 
+void Deserializer::deserialize(
+    const std::vector<std::string_view>& data,
+    velox::VectorPtr& output,
+    std::vector<uint32_t>& outputRowCounts) const {
+  deserializeImpl(
+      folly::Range<const std::string_view*>(data.data(), data.size()),
+      {},
+      output,
+      &outputRowCounts);
+}
+
 void Deserializer::appendToOutput(
     velox::VectorPtr&& decoded,
     velox::VectorPtr& output) const {
@@ -617,7 +628,7 @@ void Deserializer::appendStreamSegments(
   }
 }
 
-void Deserializer::appendBatch(
+uint32_t Deserializer::appendBatch(
     std::string_view batch,
     std::optional<nimble::RowRange> rowRange,
     DecodeRun& run,
@@ -657,12 +668,13 @@ void Deserializer::appendBatch(
     decodeRun(run, output);
     parser_->reset();
   }
+  return range.numRows();
 }
 
 void Deserializer::deserialize(
     folly::Range<const std::string_view*> data,
     velox::VectorPtr& output) const {
-  deserializeImpl(data, {}, output);
+  deserializeImpl(data, /*rowRanges=*/{}, output, /*outputRowCounts=*/nullptr);
 }
 
 void Deserializer::deserialize(
@@ -672,13 +684,15 @@ void Deserializer::deserialize(
   deserializeImpl(
       folly::Range<const std::string_view*>(data.data(), data.size()),
       folly::Range<const nimble::RowRange*>(rowRanges.data(), rowRanges.size()),
-      output);
+      output,
+      /*outputRowCounts=*/nullptr);
 }
 
 void Deserializer::deserializeImpl(
     folly::Range<const std::string_view*> data,
     folly::Range<const nimble::RowRange*> rowRanges,
-    velox::VectorPtr& output) const {
+    velox::VectorPtr& output,
+    std::vector<uint32_t>* outputRowCounts) const {
   NIMBLE_USER_CHECK(!data.empty(), "Expected at least one serialized batch");
   if (!rowRanges.empty()) {
     NIMBLE_USER_CHECK_EQ(
@@ -695,6 +709,10 @@ void Deserializer::deserializeImpl(
   };
 
   output = nullptr;
+  if (outputRowCounts != nullptr) {
+    outputRowCounts->clear();
+    outputRowCounts->reserve(data.size());
+  }
   DecodeRun run;
   runRanges_.reserve(data.size());
   for (size_t i = 0; i < data.size(); ++i) {
@@ -702,7 +720,10 @@ void Deserializer::deserializeImpl(
     if (!rowRanges.empty()) {
       rowRange = rowRanges[i];
     }
-    appendBatch(data[i], rowRange, run, output);
+    const auto outputRows = appendBatch(data[i], rowRange, run, output);
+    if (outputRowCounts != nullptr) {
+      outputRowCounts->emplace_back(outputRows);
+    }
   }
   decodeRun(run, output);
   parser_->reset();

--- a/velox/dwio/nimble/serializer/Deserializer.h
+++ b/velox/dwio/nimble/serializer/Deserializer.h
@@ -90,6 +90,14 @@ class Deserializer {
       const std::vector<std::string_view>& data,
       velox::VectorPtr& output) const;
 
+  /// Decodes a sequence of serialized batches and records the number of rows
+  /// each input batch contributes to `output` in `outputRowCounts`.
+  /// Per-batch rowRange handling matches the overload above.
+  void deserialize(
+      const std::vector<std::string_view>& data,
+      velox::VectorPtr& output,
+      std::vector<uint32_t>& outputRowCounts) const;
+
   /// Decodes each batch in `data`, appending only the rows in
   /// `rowRanges[i]` for `data[i]`. The output is the concatenation of the
   /// selected rows across batches, in order.
@@ -160,10 +168,13 @@ class Deserializer {
   // `rowRanges` to decode whatever range each batch exposes (its header
   // rowRange, or the whole batch); pass a `data.size()`-sized `rowRanges`
   // to narrow within that range per batch (`rowRanges[i]` for `data[i]`).
+  // When set, `outputRowCounts` receives the number of rows contributed by
+  // each input batch.
   void deserializeImpl(
       folly::Range<const std::string_view*> data,
       folly::Range<const nimble::RowRange*> rowRanges,
-      velox::VectorPtr& output) const;
+      velox::VectorPtr& output,
+      std::vector<uint32_t>* outputRowCounts) const;
 
   // Open run of non-barrier batches that can be decoded together.
   struct DecodeRun {
@@ -225,8 +236,9 @@ class Deserializer {
   // If the batch requires a null barrier, `decodeRun` fires before and
   // after queuing so the barrier batch decodes standalone. A rowRange
   // applies there too: a barrier batch is a one-batch run, which is exactly
-  // the unit the range narrows.
-  void appendBatch(
+  // the unit the range narrows. Returns the number of rows this batch adds to
+  // the output.
+  uint32_t appendBatch(
       std::string_view batch,
       std::optional<nimble::RowRange> rowRange,
       DecodeRun& run,

--- a/velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
@@ -95,6 +95,43 @@ class DeserializerSkipTest : public ::testing::Test {
     return {std::move(serialized), std::move(schema)};
   }
 
+  std::string makeTabletBatch(std::string_view serialized, RowRange rowRange) {
+    const DeserializerOptions parserOptions{.hasHeader = true};
+    serde::StreamDataParser parser{pool_.get(), parserOptions};
+    const auto rowCount = parser.initialize(serialized);
+    auto header = serde::createTabletChunkHeader({
+        .rowCount = rowCount,
+        .requiresNullBarrier = parser.requiresNullBarrier(),
+        .streamEncodingUsesVarintRowCount =
+            parser.streamEncodingUsesVarintRowCount(),
+        .streamHasChunkHeader = false,
+        .rowRange = rowRange,
+    });
+    std::string output(
+        reinterpret_cast<const char*>(header.data()), header.length());
+    std::vector<uint32_t> streamIds;
+    std::vector<uint32_t> streamSizeIndices;
+    std::vector<uint32_t> streamSizes;
+    parser.iterateStreams([&](uint32_t streamId, std::string_view streamData) {
+      if (streamData.empty()) {
+        return;
+      }
+      streamIds.emplace_back(streamId);
+      streamSizeIndices.emplace_back(static_cast<uint32_t>(streamSizes.size()));
+      streamSizes.emplace_back(static_cast<uint32_t>(streamData.size()));
+      output.append(streamData);
+    });
+    serde::detail::writeTrailer(
+        streamIds,
+        streamSizeIndices,
+        streamSizes,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        output);
+    return output;
+  }
+
   // ROW(a INTEGER, s ROW(b INTEGER)). Rows listed in `nestedNullRows` get a
   // null `s`, so s's Row null stream is written with real nulls and the
   // batch's null-barrier flag is set. A nullable *scalar* column would not
@@ -293,6 +330,71 @@ class DeserializerSkipTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<velox::test::VectorMaker> vm_;
 };
+
+TEST_F(DeserializerSkipTest, reportsOutputRowsPerInputBatch) {
+  const std::vector<velox::VectorPtr> inputs{
+      makeBarrierBatch(/*base=*/100, /*rows=*/3, /*nestedNullRows=*/{}),
+      makeBarrierBatch(/*base=*/200, /*rows=*/4, /*nestedNullRows=*/{1}),
+  };
+  auto [serialized, schema] = serialize(barrierType(), inputs);
+  struct TestCase {
+    std::string name;
+    std::array<RowRange, 2> rowRanges;
+    std::vector<uint32_t> expectedOutputRows;
+  };
+  const std::vector<TestCase> testCases{
+      {
+          .name = "allFull",
+          .rowRanges = {RowRange{0, 3}, RowRange{0, 4}},
+          .expectedOutputRows = {3, 4},
+      },
+      {
+          .name = "allPartial",
+          .rowRanges = {RowRange{1, 2}, RowRange{1, 3}},
+          .expectedOutputRows = {1, 2},
+      },
+      {
+          .name = "fullThenPartial",
+          .rowRanges = {RowRange{0, 3}, RowRange{1, 3}},
+          .expectedOutputRows = {3, 2},
+      },
+      {
+          .name = "partialThenFull",
+          .rowRanges = {RowRange{1, 2}, RowRange{0, 4}},
+          .expectedOutputRows = {1, 4},
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    std::vector<std::string> tabletBatches;
+    tabletBatches.reserve(serialized.size());
+    for (size_t i = 0; i < serialized.size(); ++i) {
+      tabletBatches.emplace_back(
+          makeTabletBatch(serialized[i], testCase.rowRanges[i]));
+    }
+    std::vector<std::string_view> views;
+    views.reserve(tabletBatches.size());
+    for (const auto& batch : tabletBatches) {
+      views.emplace_back(batch);
+    }
+
+    Deserializer deserializer{
+        schema, pool_.get(), DeserializerOptions{.hasHeader = true}};
+    velox::VectorPtr output;
+    std::vector<uint32_t> outputRows;
+    deserializer.deserialize(views, output, outputRows);
+
+    EXPECT_EQ(outputRows, testCase.expectedOutputRows);
+    ASSERT_NE(output, nullptr);
+    EXPECT_EQ(
+        output->size(),
+        std::accumulate(
+            testCase.expectedOutputRows.begin(),
+            testCase.expectedOutputRows.end(),
+            uint32_t{0}));
+  }
+}
 
 // --- Dense scalar column, no nulls -----------------------------------------
 


### PR DESCRIPTION
Summary:

Extend the Nimble deserializer to report the output row count for each serialized input batch. The Nimble result adapter uses these counts to order scan chunks by input row and decode all chunks in one call. It builds array offsets and sizes directly from the reported counts. This removes per-scan decode calls and decoded-vector regrouping copies while preserving the rows produced for each scan result.

Reviewed By: xingbowang, jiahaol-work

Differential Revision: D116481267


