### PR TITLE
fix(nimble): Apply encoding layouts to predefined FlatMap keys (#18549)

### DIFF
--- a/velox/dwio/nimble/serializer/Serializer.cpp
+++ b/velox/dwio/nimble/serializer/Serializer.cpp
@@ -273,6 +273,12 @@ void Serializer::initEncodingLayouts(
       // FlatmapFieldAddedEventHandler.
       flatMapBuilder.setContext(
           std::make_unique<FlatmapEncodingLayoutContext>(keyEncodings));
+      for (size_t index = 0; index < flatMapBuilder.childrenCount(); ++index) {
+        const auto it = keyEncodings.find(flatMapBuilder.nameAt(index));
+        if (it != keyEncodings.end()) {
+          initEncodingLayouts(*it->second, flatMapBuilder.childAt(index));
+        }
+      }
       break;
     }
     default:

--- a/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
@@ -5823,6 +5823,92 @@ velox::VectorPtr createMapVector(
 
 } // namespace
 
+TEST_F(SerializationTest, predefinedFlatMapKeysUseEncodingLayout) {
+  constexpr velox::vector_size_t kNumRows = 256;
+  const auto mapType = velox::MAP(velox::INTEGER(), velox::INTEGER());
+  const auto rowType = velox::ROW({{"features", mapType}});
+
+  auto keys =
+      velox::BaseVector::create(velox::INTEGER(), kNumRows, pool_.get());
+  auto values =
+      velox::BaseVector::create(velox::INTEGER(), kNumRows, pool_.get());
+  auto offsets = velox::allocateOffsets(kNumRows, pool_.get());
+  auto sizes = velox::allocateSizes(kNumRows, pool_.get());
+  auto* rawOffsets = offsets->asMutable<velox::vector_size_t>();
+  auto* rawSizes = sizes->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t row = 0; row < kNumRows; ++row) {
+    keys->asFlatVector<int32_t>()->set(row, 1);
+    values->asFlatVector<int32_t>()->set(row, row);
+    rawOffsets[row] = row;
+    rawSizes[row] = 1;
+  }
+  auto map = std::make_shared<velox::MapVector>(
+      pool_.get(),
+      mapType,
+      nullptr,
+      kNumRows,
+      std::move(offsets),
+      std::move(sizes),
+      std::move(keys),
+      std::move(values));
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      rowType,
+      nullptr,
+      kNumRows,
+      std::vector<velox::VectorPtr>{std::move(map)});
+
+  using StreamIdentifiers = EncodingLayoutTree::StreamIdentifiers;
+  const EncodingLayoutTree layout{
+      Kind::Row,
+      {},
+      "",
+      {EncodingLayoutTree{
+          Kind::FlatMap,
+          {},
+          "",
+          {EncodingLayoutTree{
+              Kind::Scalar,
+              {{StreamIdentifiers::Scalar::ScalarStream,
+                EncodingLayout{
+                    EncodingType::Trivial, {}, CompressionType::Uncompressed}}},
+              "1"}}}}};
+  Serializer serializer{
+      SerializerOptions{
+          .version = SerializationVersion::kSerialization,
+          .flatMapColumns = {{"features", {"1"}}},
+          .encodingLayoutTree = layout,
+          .compressionOptions = CompressionOptions{}},
+      rowType,
+      pool_.get()};
+  const std::string serialized{
+      serializer.serialize(input, OrderedRanges::of(0, kNumRows))};
+
+  const auto schema =
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+  const auto valueStreamOffset = schema->asRow()
+                                     .childAt(0)
+                                     ->asFlatMap()
+                                     .childAt(0)
+                                     ->asScalar()
+                                     .scalarDescriptor()
+                                     .offset();
+  const DeserializerOptions deserializerOptions{.hasHeader = true};
+  serde::StreamDataParser parser{pool_.get(), deserializerOptions};
+  parser.initialize(serialized);
+  bool foundValueStream = false;
+  parser.iterateStreams([&](uint32_t offset, std::string_view streamData) {
+    if (offset != valueStreamOffset) {
+      return;
+    }
+    foundValueStream = true;
+    ASSERT_FALSE(streamData.empty());
+    EXPECT_EQ(
+        static_cast<EncodingType>(streamData.front()), EncodingType::Trivial);
+  });
+  EXPECT_TRUE(foundValueStream);
+}
+
 TEST_P(SerializationTest, flatmapColumnsKeysSchemaConsistency) {
   // Two serializers with the same 8 predefined keys, 200 rows each, should
   // produce identical schemas regardless of data arrival order.


### PR DESCRIPTION
Summary:

Apply configured encoding layouts to predefined FlatMap children after the writer tree is constructed. The existing event handler continues to apply layouts to dynamically discovered keys.

Reviewed By: xiaoxmeng, tanjialiang

Differential Revision: D116500459


