### PR TITLE
fix(fuzzer): Make row group skip filters reachable in FilterGenerator

### DIFF
--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/tests/utils/FilterGenerator.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+
+namespace {
+
+// Enough draws that a 1-in-10 branch is overwhelmingly likely to be taken at
+// least once, without making the test slow.
+constexpr int32_t kDraws = 200;
+
+int32_t countRowGroupSkipSpecs(const RowTypePtr& rowType) {
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/12345);
+  int32_t count = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      count += spec.isForRowGroupSkip ? 1 : 0;
+    }
+  }
+  return count;
+}
+
+} // namespace
+
+// The two FilterSpec constructors used to disagree on isForRowGroupSkip -- the
+// explicit one defaulted it true, the in-class initializer false -- and
+// makeRandomSpecs builds specs with the default constructor. Pins them
+// together, since a divergence silently disables or enables the whole
+// row-group-skip path.
+TEST(FilterGeneratorTest, filterSpecDefaultsAgree) {
+  FilterSpec defaultConstructed;
+  FilterSpec explicitlyConstructed("field");
+  EXPECT_EQ(
+      defaultConstructed.isForRowGroupSkip,
+      explicitlyConstructed.isForRowGroupSkip);
+  EXPECT_FALSE(defaultConstructed.isForRowGroupSkip);
+}
+
+TEST(FilterGeneratorTest, rowGroupSkipSpecsForSupportedTypes) {
+  auto rowType = ROW(
+      {{"tiny", TINYINT()},
+       {"small", SMALLINT()},
+       {"int", INTEGER()},
+       {"big", BIGINT()}});
+  EXPECT_GT(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// makeRowGroupSkipRangeFilter has no specialization for these kinds: the
+// generic template funnels the max through getIntegerValue(), which would
+// narrow a double or an int128 into a BigintRange of the wrong type, and
+// ComplexColumnStats fails outright. VARCHAR is excluded for a different
+// reason -- its specialization keys off kMaxString, a sentinel chosen to
+// exceed test data, which selects nothing against real data.
+TEST(FilterGeneratorTest, noRowGroupSkipSpecsForUnsupportedTypes) {
+  auto rowType = ROW(
+      {{"real", REAL()},
+       {"double", DOUBLE()},
+       {"huge", HUGEINT()},
+       {"bool", BOOLEAN()},
+       {"string", VARCHAR()},
+       {"row", ROW({{"nested", BIGINT()}})},
+       {"array", ARRAY(BIGINT())},
+       {"map", MAP(INTEGER(), BIGINT())}});
+  EXPECT_EQ(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// A row-group-skip spec replaces the value filter entirely, so pairing it with
+// a null kind would silently drop the null semantics the category asked for.
+TEST(FilterGeneratorTest, rowGroupSkipNeverPairedWithNullKinds) {
+  auto rowType = ROW({{"int", INTEGER()}, {"big", BIGINT()}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/999);
+  int32_t observed = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      if (spec.isForRowGroupSkip) {
+        ++observed;
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNull);
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNotNull);
+      }
+    }
+  }
+  // Without this the test would pass with zero assertions run if the draw were
+  // ever disabled again -- which is the bug this whole change fixes.
+  EXPECT_GT(observed, 0);
+}

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -382,6 +382,34 @@ std::vector<std::string> FilterGenerator::makeFilterables(
   return filterables;
 }
 
+namespace {
+
+// Row group skip filters are produced by makeRowGroupSkipRangeFilter, which is
+// only implemented for the kinds below. The generic template builds a
+// BigintRange out of getIntegerValue(), so floating point and HUGEINT would
+// narrow into a filter of the wrong type, and the complex type override fails
+// outright. VARCHAR is excluded on purpose: its specialization returns a filter
+// built from kMaxString, a sentinel picked to exceed *test* data, which selects
+// nothing against real data.
+bool supportsRowGroupSkip(const TypePtr& type) {
+  const auto kind = type->kind();
+  return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
+      kind == TypeKind::TIMESTAMP;
+}
+
+// Resolves a top level field by name. Returns nullptr for the dotted subfield
+// paths a caller may supply directly, which findChild does not accept.
+TypePtr topLevelFieldType(const RowType& rowType, const std::string& name) {
+  if (name.find('.') != std::string::npos) {
+    return nullptr;
+  }
+  auto index = rowType.getChildIdxIfExists(name);
+  return index.has_value() ? rowType.childAt(*index) : nullptr;
+}
+
+} // namespace
+
 std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
     const std::vector<std::string>& filterable,
     int32_t countX100) {
@@ -423,6 +451,18 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
         ? folly::Random::rand32(rng_) %
             static_cast<int32_t>(100 - specs.back().selectPct)
         : 0;
+
+    // Ask for a min/max row group skip filter on a fraction of the specs. This
+    // is an independent draw rather than another `category` so the value filter
+    // distribution above is left alone, and it skips the null kinds because
+    // rowGroupSkipFilter ignores filterKind and would silently replace them.
+    const auto fieldType = topLevelFieldType(*rowType_, name);
+    if (fieldType != nullptr && supportsRowGroupSkip(fieldType) &&
+        specs.back().filterKind != FilterKind::kIsNull &&
+        specs.back().filterKind != FilterKind::kIsNotNull &&
+        folly::Random::rand32(rng_) % 10 == 0) {
+      specs.back().isForRowGroupSkip = true;
+    }
   }
 
   return specs;

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -41,7 +41,7 @@ struct FilterSpec {
       float startPct = 50,
       float selectPct = 20,
       FilterKind filterKind = FilterKind::kBigintRange,
-      bool isForRowGroupSkip = true,
+      bool isForRowGroupSkip = false,
       bool allowNulls = true)
       : field(field),
         startPct(startPct),


### PR DESCRIPTION
Summary:
`FilterSpec::isForRowGroupSkip` has never been true in a generated spec, so
`makeRowGroupSkipRangeFilter` -- and with it all min/max stripe and row group
pruning coverage -- has been dead code for every consumer of
`makeRandomSpecs`: the Velox E2E reader filter tests, `TableEvolutionFuzzer`,
and the Vader validation service.

Two constructors disagreed on the default:

    explicit FilterSpec(..., bool isForRowGroupSkip = true, ...)   // ctor
    bool isForRowGroupSkip{false};                                 // in-class

`makeRandomSpecs` builds specs with `emplace_back()`, i.e. the default
constructor, so the in-class `false` always won and the branch at
`makeSubfieldFilters` never selected `rowGroupSkipFilter`. Aligns the ctor
default to `false` -- no caller relied on the old `true`, both
`ParquetReaderBenchmark` and `IcebergSplitReaderBenchmark` pass the argument
explicitly -- and has `makeRandomSpecs` set the flag deliberately instead.

The flag cannot simply be turned on for everything, which is likely why it
stayed dead. `makeRowGroupSkipRangeFilter` is only correct for some kinds:

- The generic template funnels the column max through `getIntegerValue()` and
  builds a `BigintRange`, so REAL/DOUBLE narrow into a filter of the wrong
  type and HUGEINT truncates. There are `makeRangeFilter` specializations for
  those kinds but no `makeRowGroupSkipRangeFilter` ones.
- `ComplexColumnStats::rowGroupSkipFilter` fails outright, and the
  `AbstractColumnStats` base is `VELOX_NYI`.
- VARCHAR has a working specialization, but it returns a filter built from
  `kMaxString` ("~~~~~"), documented as a sentinel exceeding *test* data. Real
  warehouse data sorts above it in UTF-8, so it would select nothing and make
  the Vader checksum comparison vacuous.

So the new draw is gated on a `supportsRowGroupSkip` allowlist of TINYINT,
SMALLINT, INTEGER, BIGINT and TIMESTAMP, and skips specs already carrying a
null kind, since `rowGroupSkipFilter` ignores `filterKind` and would silently
replace them. It is an independent 1-in-10 draw rather than another `category`
so the existing value-filter distribution is untouched.

Note TIMESTAMP is on the allowlist but unreachable today:
`collectFilterableSubFields` excludes it from filterable columns. Left in so
the allowlist matches what the implementation supports rather than what the
column selection currently yields.

This shifts the RNG stream, so generated filters differ across every consumer.
That is the point -- a new failure in a downstream suite is a finding, not
necessarily a regression.

Reviewed By: raymondlin1

Differential Revision: D115706170


