### PR TITLE
feat(fuzzer): Make nested struct fields filterable in FilterGenerator

### DIFF
--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -185,3 +185,42 @@ TEST_F(FilterGeneratorSeedTest, differentSeedsProduceDifferentFilters) {
   // seed actually drives the outcome.
   EXPECT_GT(descriptions.size(), 1);
 }
+
+// The old selectivity scheme drew from {1, 10, 20, 30} and {76, 80, ... 100}.
+// Nothing landed between 31% and 75%, and 100% -- a filter that excludes
+// nothing -- came up roughly one draw in thirteen.
+TEST(FilterGeneratorTest, selectivityCoversTheMidBandAndNeverReachesAll) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/4242);
+
+  int32_t low = 0;
+  int32_t mid = 0;
+  int32_t high = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      if (spec.filterKind == common::FilterKind::kIsNull ||
+          spec.filterKind == common::FilterKind::kIsNotNull) {
+        continue;
+      }
+      EXPECT_GT(spec.selectPct, 0);
+      EXPECT_LT(spec.selectPct, 100);
+      // startPct must leave room for the range it introduces.
+      EXPECT_GE(spec.startPct, 0);
+      EXPECT_LT(spec.startPct, 100 - spec.selectPct);
+
+      if (spec.selectPct < 10) {
+        ++low;
+      } else if (spec.selectPct < 75) {
+        ++mid;
+      } else {
+        ++high;
+      }
+    }
+  }
+
+  EXPECT_GT(low, 0);
+  EXPECT_GT(mid, 0);
+  EXPECT_GT(high, 0);
+}

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 
@@ -104,4 +106,82 @@ TEST(FilterGeneratorTest, rowGroupSkipNeverPairedWithNullKinds) {
   // Without this the test would pass with zero assertions run if the draw were
   // ever disabled again -- which is the bug this whole change fixes.
   EXPECT_GT(observed, 0);
+}
+
+namespace {
+
+class FilterGeneratorSeedTest : public testing::Test,
+                                public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::vector<RowVectorPtr> makeBatches(const RowTypePtr& rowType) {
+    std::vector<RowVectorPtr> batches;
+    for (int32_t batch = 0; batch < 2; ++batch) {
+      batches.push_back(makeRowVector(
+          rowType->names(),
+          {makeFlatVector<int64_t>(
+               kBatchRows, [&](auto row) { return row + batch * kBatchRows; }),
+           makeFlatVector<int32_t>(
+               kBatchRows, [&](auto row) { return (row * 7) % 101; })}));
+    }
+    return batches;
+  }
+
+  // Renders the generated filters into a stable string so two runs can be
+  // compared without depending on filter identity.
+  std::string generateFilterDescription(
+      const RowTypePtr& rowType,
+      uint32_t seed) {
+    auto type = rowType;
+    FilterGenerator generator(type, seed);
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    auto specs = generator.makeRandomSpecs(filterable, 0);
+    auto batches = makeBatches(rowType);
+    std::vector<uint64_t> hitRows;
+    auto filters =
+        generator.makeSubfieldFilters(specs, batches, nullptr, hitRows);
+
+    std::vector<std::string> rendered;
+    for (const auto& [subfield, filter] : filters) {
+      rendered.push_back(
+          fmt::format("{}:{}", subfield.toString(), filter->toString()));
+    }
+    std::sort(rendered.begin(), rendered.end());
+    return folly::join(",", rendered);
+  }
+
+  static constexpr vector_size_t kBatchRows = 500;
+};
+
+} // namespace
+
+// Filter kind selection used to be driven by a process-global counter on
+// AbstractColumnStats rather than by the seed, so an unrelated generator run
+// earlier in the same process shifted the choice. A validation service whose
+// whole premise is "replay this failing seed" cannot afford that.
+TEST_F(FilterGeneratorSeedTest, filterKindIsIndependentOfEarlierGenerators) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  const auto before = generateFilterDescription(rowType, /*seed=*/7);
+
+  // Run unrelated generators in between; with a shared global counter these
+  // perturb the next run's filter kinds.
+  for (uint32_t otherSeed = 100; otherSeed < 105; ++otherSeed) {
+    generateFilterDescription(rowType, otherSeed);
+  }
+
+  EXPECT_EQ(before, generateFilterDescription(rowType, /*seed=*/7));
+}
+
+TEST_F(FilterGeneratorSeedTest, differentSeedsProduceDifferentFilters) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  std::set<std::string> descriptions;
+  for (uint32_t seed = 1; seed <= 20; ++seed) {
+    descriptions.insert(generateFilterDescription(rowType, seed));
+  }
+  // Not asserting all 20 differ -- collisions are legitimate -- only that the
+  // seed actually drives the outcome.
+  EXPECT_GT(descriptions.size(), 1);
 }

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/tests/utils/FilterGenerator.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+
+namespace {
+
+// Enough draws that a 1-in-10 branch is overwhelmingly likely to be taken at
+// least once, without making the test slow.
+constexpr int32_t kDraws = 200;
+
+int32_t countRowGroupSkipSpecs(const RowTypePtr& rowType) {
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/12345);
+  int32_t count = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      count += spec.isForRowGroupSkip ? 1 : 0;
+    }
+  }
+  return count;
+}
+
+} // namespace
+
+// The two FilterSpec constructors used to disagree on isForRowGroupSkip -- the
+// explicit one defaulted it true, the in-class initializer false -- and
+// makeRandomSpecs builds specs with the default constructor. Pins them
+// together, since a divergence silently disables or enables the whole
+// row-group-skip path.
+TEST(FilterGeneratorTest, filterSpecDefaultsAgree) {
+  FilterSpec defaultConstructed;
+  FilterSpec explicitlyConstructed("field");
+  EXPECT_EQ(
+      defaultConstructed.isForRowGroupSkip,
+      explicitlyConstructed.isForRowGroupSkip);
+  EXPECT_FALSE(defaultConstructed.isForRowGroupSkip);
+}
+
+TEST(FilterGeneratorTest, rowGroupSkipSpecsForSupportedTypes) {
+  auto rowType = ROW(
+      {{"tiny", TINYINT()},
+       {"small", SMALLINT()},
+       {"int", INTEGER()},
+       {"big", BIGINT()}});
+  EXPECT_GT(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// makeRowGroupSkipRangeFilter has no specialization for these kinds: the
+// generic template funnels the max through getIntegerValue(), which would
+// narrow a double or an int128 into a BigintRange of the wrong type, and
+// ComplexColumnStats fails outright. VARCHAR is excluded for a different
+// reason -- its specialization keys off kMaxString, a sentinel chosen to
+// exceed test data, which selects nothing against real data.
+TEST(FilterGeneratorTest, noRowGroupSkipSpecsForUnsupportedTypes) {
+  auto rowType = ROW(
+      {{"real", REAL()},
+       {"double", DOUBLE()},
+       {"huge", HUGEINT()},
+       {"bool", BOOLEAN()},
+       {"string", VARCHAR()},
+       {"row", ROW({{"nested", BIGINT()}})},
+       {"array", ARRAY(BIGINT())},
+       {"map", MAP(INTEGER(), BIGINT())}});
+  EXPECT_EQ(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// A row-group-skip spec replaces the value filter entirely, so pairing it with
+// a null kind would silently drop the null semantics the category asked for.
+TEST(FilterGeneratorTest, rowGroupSkipNeverPairedWithNullKinds) {
+  auto rowType = ROW({{"int", INTEGER()}, {"big", BIGINT()}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/999);
+  int32_t observed = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      if (spec.isForRowGroupSkip) {
+        ++observed;
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNull);
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNotNull);
+      }
+    }
+  }
+  // Without this the test would pass with zero assertions run if the draw were
+  // ever disabled again -- which is the bug this whole change fixes.
+  EXPECT_GT(observed, 0);
+}

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -440,3 +440,83 @@ TEST_F(FilterGeneratorSeedTest, multiRangeHitRowsAgreeWithTheFilter) {
   }
   EXPECT_GT(checked, 0);
 }
+
+// Nested struct fields used to be invisible to filtering: a ROW column was
+// offered whole, so the only filter it could carry was is null / is not null.
+TEST(FilterGeneratorTest, nestedSubfieldsAreFilterable) {
+  auto rowType = ROW(
+      {{"flat", BIGINT()},
+       {"s", ROW({{"a", BIGINT()}, {"t", ROW({{"b", INTEGER()}})}})}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/1234);
+  auto filterable = generator.makeFilterables(100, 100);
+
+  std::set<std::string> names(filterable.begin(), filterable.end());
+  EXPECT_TRUE(names.contains("flat"));
+  // The struct stays filterable in its own right -- is null on a struct is a
+  // real shape -- and its scalar leaves become reachable alongside it.
+  EXPECT_TRUE(names.contains("s"));
+  EXPECT_TRUE(names.contains("s.a"));
+  EXPECT_TRUE(names.contains("s.t"));
+  EXPECT_TRUE(names.contains("s.t.b"));
+}
+
+// Positions inside an array's elements vector are element indices, not row
+// indices, so a path through one would make the reference row computation read
+// values belonging to other rows.
+TEST(FilterGeneratorTest, recursionStopsAtArraysAndMaps) {
+  auto rowType = ROW(
+      {{"arr", ARRAY(ROW({{"a", BIGINT()}}))},
+       {"m", MAP(INTEGER(), ROW({{"b", BIGINT()}}))}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/1234);
+  for (const auto& name : generator.makeFilterables(100, 100)) {
+    EXPECT_EQ(name.find('.'), std::string::npos) << name;
+  }
+}
+
+// A null struct does not mark its children null -- the leaf keeps whatever
+// value it happened to be built with -- but a reader projects the whole
+// subfield as null. If the reference row set were computed from the leaf's own
+// null flags it would disagree with every reader on exactly those rows.
+TEST_F(FilterGeneratorSeedTest, nestedSubfieldTreatsNullParentAsNull) {
+  auto innerType = ROW({{"a", BIGINT()}});
+  auto rowType = ROW({{"s", innerType}});
+
+  // Every third row has a null struct, while the child underneath holds a
+  // perfectly ordinary value there.
+  auto inner = makeRowVector(
+      {"a"},
+      {makeFlatVector<int64_t>(kBatchRows, [](auto row) { return row; })});
+  for (vector_size_t row = 0; row < kBatchRows; row += 3) {
+    inner->setNull(row, true);
+  }
+  std::vector<RowVectorPtr> batches{makeRowVector({"s"}, {inner})};
+
+  std::vector<FilterSpec> specs(1);
+  specs[0].field = "s.a";
+  specs[0].startPct = 0;
+  specs[0].selectPct = 100;
+  specs[0].filterKind = common::FilterKind::kBigintRange;
+  // Pins the filter to one that rejects nulls, so the assertion below cannot
+  // pass merely because the filter happened to accept them. The range then
+  // spans every sampled value, so a row under a null struct can only survive
+  // by having been evaluated against the leaf's own value.
+  specs[0].allowNulls_ = false;
+
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/7);
+  std::vector<uint64_t> hitRows;
+  auto filters =
+      generator.makeSubfieldFilters(specs, batches, nullptr, hitRows);
+
+  auto it = filters.find(Subfield("s.a"));
+  ASSERT_NE(it, filters.end());
+  ASSERT_FALSE(it->second->testNull());
+  for (auto hit : hitRows) {
+    EXPECT_NE(batchRow(hit) % 3, 0)
+        << "row under a null struct survived a null-rejecting filter";
+  }
+  // Non-vacuous: the rows that are not under a null struct do survive.
+  EXPECT_GT(hitRows.size(), 0);
+}

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -153,8 +153,40 @@ class FilterGeneratorSeedTest : public testing::Test,
     return folly::join(",", rendered);
   }
 
+  // Everything one generation produces: the specs, the filters built from
+  // them, and the reference rows left over once every filter has been applied.
+  struct Generated {
+    std::vector<FilterSpec> specs;
+    SubfieldFilters filters;
+    std::vector<uint64_t> hitRows;
+  };
+
+  Generated generate(
+      const RowTypePtr& rowType,
+      const std::vector<RowVectorPtr>& batches,
+      uint32_t seed,
+      double emptyResultProbability) {
+    auto type = rowType;
+    FilterGenerator generator(type, seed);
+    generator.setEmptyResultProbability(emptyResultProbability);
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    Generated result;
+    result.specs = generator.makeRandomSpecs(filterable, 0);
+    result.filters = generator.makeSubfieldFilters(
+        result.specs, batches, nullptr, result.hitRows);
+    return result;
+  }
+
   static constexpr vector_size_t kBatchRows = 500;
 };
+
+int32_t countEmptyResultSpecs(const std::vector<FilterSpec>& specs) {
+  int32_t count = 0;
+  for (const auto& spec : specs) {
+    count += spec.isForEmptyResult ? 1 : 0;
+  }
+  return count;
+}
 
 } // namespace
 
@@ -223,4 +255,108 @@ TEST(FilterGeneratorTest, selectivityCoversTheMidBandAndNeverReachesAll) {
   EXPECT_GT(low, 0);
   EXPECT_GT(mid, 0);
   EXPECT_GT(high, 0);
+}
+
+// An empty result makes every other filter in the set vacuous, so it has to
+// stay off unless a caller asks for it. Also pins that the default draws no
+// random number for it: were it to draw, every existing consumer's filter
+// sequence would shift.
+TEST_F(FilterGeneratorSeedTest, emptyResultIsOptIn) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  auto batches = makeBatches(rowType);
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto defaulted = generate(rowType, batches, seed, 0.0);
+    EXPECT_EQ(countEmptyResultSpecs(defaulted.specs), 0);
+
+    // Explicitly asking for zero has to be indistinguishable from the default,
+    // which it can only be if neither consumed randomness.
+    const auto explicitlyZero = generate(rowType, batches, seed, 0.0);
+    ASSERT_EQ(defaulted.specs.size(), explicitlyZero.specs.size());
+    for (size_t i = 0; i < defaulted.specs.size(); ++i) {
+      EXPECT_EQ(
+          defaulted.specs[i].toString(), explicitlyZero.specs[i].toString());
+    }
+  }
+}
+
+TEST_F(FilterGeneratorSeedTest, emptyResultLeavesNoRows) {
+  // Both columns BIGINT so the test can hand the filter the column's own
+  // min/max regardless of which one the generator picked last.
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  constexpr int64_t kMaxValue = kBatchRows - 1;
+  std::vector<RowVectorPtr> batches{makeRowVector(
+      rowType->names(),
+      {makeFlatVector<int64_t>(kBatchRows, [](auto row) { return row; }),
+       makeFlatVector<int64_t>(
+           kBatchRows, [](auto row) { return kMaxValue - row; })})};
+
+  int32_t emptyResults = 0;
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 1.0);
+    ASSERT_LE(countEmptyResultSpecs(generated.specs), 1);
+    if (countEmptyResultSpecs(generated.specs) == 0) {
+      continue;
+    }
+    ++emptyResults;
+    // Only the last spec may be the empty one; an earlier one would leave the
+    // columns after it filtering an already empty row set.
+    EXPECT_TRUE(generated.specs.back().isForEmptyResult);
+    EXPECT_TRUE(generated.hitRows.empty());
+
+    // Zero surviving rows on its own is not the point -- two ordinary selective
+    // filters intersect to nothing often enough by chance. The filter also has
+    // to sit past the column maximum, so that a reader consulting min/max stats
+    // can skip every row group instead of descending and rejecting row by row.
+    const auto it =
+        generated.filters.find(Subfield(generated.specs.back().field));
+    ASSERT_NE(it, generated.filters.end());
+    EXPECT_FALSE(it->second->testInt64Range(0, kMaxValue, /*hasNull=*/false));
+  }
+  EXPECT_GT(emptyResults, 0);
+}
+
+TEST_F(FilterGeneratorSeedTest, emptyResultLeavesNoRowsForVarchar) {
+  auto rowType = ROW({{"str", VARCHAR()}});
+  std::vector<std::string> data;
+  data.reserve(kBatchRows);
+  for (int32_t i = 0; i < kBatchRows; ++i) {
+    data.push_back(fmt::format("value_{}", i));
+  }
+  std::vector<RowVectorPtr> batches{
+      makeRowVector(rowType->names(), {makeFlatVector(data)})};
+
+  int32_t emptyResults = 0;
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 1.0);
+    if (countEmptyResultSpecs(generated.specs) == 0) {
+      continue;
+    }
+    ++emptyResults;
+    EXPECT_TRUE(generated.hitRows.empty());
+  }
+  EXPECT_GT(emptyResults, 0);
+}
+
+// These kinds have no exact "one past the maximum": getIntegerValue truncates
+// floating point and narrows int128, and there is no bool above true. Picking
+// one anyway would produce a filter that quietly matches real rows, which is
+// worse than not generating the shape at all.
+TEST_F(FilterGeneratorSeedTest, noEmptyResultForUnsupportedTypes) {
+  auto rowType = ROW(
+      {{"real", REAL()},
+       {"double", DOUBLE()},
+       {"huge", HUGEINT()},
+       {"bool", BOOLEAN()}});
+  std::vector<RowVectorPtr> batches{makeRowVector(
+      rowType->names(),
+      {makeFlatVector<float>(kBatchRows, [](auto row) { return row * 0.5f; }),
+       makeFlatVector<double>(kBatchRows, [](auto row) { return row * 1.5; }),
+       makeFlatVector<int128_t>(kBatchRows, [](auto row) { return row; }),
+       makeFlatVector<bool>(
+           kBatchRows, [](auto row) { return row % 2 == 0; })})};
+
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 1.0);
+    EXPECT_EQ(countEmptyResultSpecs(generated.specs), 0);
+  }
 }

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -360,3 +360,83 @@ TEST_F(FilterGeneratorSeedTest, noEmptyResultForUnsupportedTypes) {
     EXPECT_EQ(countEmptyResultSpecs(generated.specs), 0);
   }
 }
+
+// An OR of disjoint ranges reaches reader code that a single contiguous range
+// does not: BigintMultiRange has its own testInt64 and testInt64Range, so a
+// min/max check stops being one comparison against a pair of bounds.
+TEST_F(FilterGeneratorSeedTest, multiRangeFiltersAreGenerated) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  std::vector<RowVectorPtr> batches{makeRowVector(
+      rowType->names(),
+      {makeFlatVector<int64_t>(kBatchRows, [](auto row) { return row; }),
+       makeFlatVector<int64_t>(kBatchRows, [](auto row) { return row * 3; })})};
+
+  int32_t multiRanges = 0;
+  for (uint32_t seed = 1; seed <= 200; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 0.0);
+    for (const auto& [subfield, filter] : generated.filters) {
+      if (filter->kind() != common::FilterKind::kBigintMultiRange) {
+        continue;
+      }
+      ++multiRanges;
+      const auto* multiRange =
+          static_cast<const common::BigintMultiRange*>(filter.get());
+      const auto& ranges = multiRange->ranges();
+      // The constructor enforces this, so a violation would have thrown rather
+      // than reached here -- the assertions pin that the fallback, not luck, is
+      // what keeps a coarse sample from producing an invalid filter.
+      ASSERT_GE(ranges.size(), 2);
+      for (size_t i = 1; i < ranges.size(); ++i) {
+        EXPECT_GT(ranges[i]->lower(), ranges[i - 1]->upper());
+      }
+    }
+  }
+  EXPECT_GT(multiRanges, 0);
+}
+
+TEST_F(FilterGeneratorSeedTest, multiRangeFiltersAreGeneratedForVarchar) {
+  auto rowType = ROW({{"str", VARCHAR()}});
+  std::vector<std::string> data;
+  data.reserve(kBatchRows);
+  for (int32_t i = 0; i < kBatchRows; ++i) {
+    data.push_back(fmt::format("value_{:04d}", i));
+  }
+  std::vector<RowVectorPtr> batches{
+      makeRowVector(rowType->names(), {makeFlatVector(data)})};
+
+  int32_t multiRanges = 0;
+  for (uint32_t seed = 1; seed <= 200; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 0.0);
+    for (const auto& [subfield, filter] : generated.filters) {
+      multiRanges += filter->kind() == common::FilterKind::kMultiRange ? 1 : 0;
+    }
+  }
+  EXPECT_GT(multiRanges, 0);
+}
+
+// The reference row set has to agree with whatever filter was handed back. A
+// multi-range is built from percentile boundaries rather than from the two
+// bounds the surrounding code computed, so a mistake there would desynchronise
+// the two and every consumer would compare against the wrong expected rows.
+TEST_F(FilterGeneratorSeedTest, multiRangeHitRowsAgreeWithTheFilter) {
+  auto rowType = ROW({{"a", BIGINT()}});
+  std::vector<RowVectorPtr> batches{makeRowVector(
+      rowType->names(),
+      {makeFlatVector<int64_t>(kBatchRows, [](auto row) { return row; })})};
+
+  int32_t checked = 0;
+  for (uint32_t seed = 1; seed <= 200; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 0.0);
+    const auto it = generated.filters.find(Subfield("a"));
+    if (it == generated.filters.end() ||
+        it->second->kind() != common::FilterKind::kBigintMultiRange) {
+      continue;
+    }
+    ++checked;
+    auto* values = batches[0]->childAt(0)->asFlatVector<int64_t>();
+    for (auto hit : generated.hitRows) {
+      EXPECT_TRUE(it->second->testInt64(values->valueAt(batchRow(hit))));
+    }
+  }
+  EXPECT_GT(checked, 0);
+}

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -287,26 +287,32 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRowGroupSkipRangeFilter(
     const std::vector<RowVectorPtr>& batches,
     const Subfield& subfield) {
   Timestamp max;
-  bool hasMax = false;
-  for (const auto& batch : batches) {
-    auto values = getChildBySubfield(batch.get(), subfield, rootType_)
-                      ->as<SimpleVector<Timestamp>>();
-    DWIO_ENSURE_NOT_NULL(
-        values,
-        "Failed to convert to SimpleVector<Timestamp> for batch of kind ",
-        batch->type()->kindName());
-    for (auto i = 0; i < values->size(); ++i) {
-      if (values->isNullAt(i)) {
-        continue;
-      }
-      if (hasMax && max < values->valueAt(i)) {
-        max = values->valueAt(i);
-      } else if (!hasMax) {
-        max = values->valueAt(i);
-        hasMax = true;
-      }
-    }
+  columnMax(batches, subfield, max);
+  return std::make_unique<velox::common::TimestampRange>(max, max, false);
+}
+
+// The string counterpart of one past the maximum. kMaxString is chosen to
+// exceed the test data, which makes this identical to the row group skip
+// specialization above -- there the filter selecting nothing is the reason
+// VARCHAR is left out of supportsRowGroupSkip, here it is what is wanted.
+template <>
+std::unique_ptr<Filter> ColumnStats<StringView>::makeEmptyResultRangeFilter(
+    const std::vector<RowVectorPtr>& /*batches*/,
+    const Subfield& /*subfield*/) {
+  static std::string max = kMaxString;
+  return std::make_unique<velox::common::BytesRange>(
+      max, false, false, max, false, false, false);
+}
+
+template <>
+std::unique_ptr<Filter> ColumnStats<Timestamp>::makeEmptyResultRangeFilter(
+    const std::vector<RowVectorPtr>& batches,
+    const Subfield& subfield) {
+  Timestamp max;
+  if (!columnMax(batches, subfield, max) || max == Timestamp::max()) {
+    return nullptr;
   }
+  ++max;
   return std::make_unique<velox::common::TimestampRange>(max, max, false);
 }
 
@@ -396,6 +402,20 @@ bool supportsRowGroupSkip(const TypePtr& type) {
   return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
       kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
       kind == TypeKind::TIMESTAMP;
+}
+
+// An empty result filter is built one step past the column maximum, so the
+// kinds are those where "one step past" is exact and expressible: the integral
+// kinds, where getIntegerValue is lossless and the bound is max + 1, plus the
+// two with a specialization of their own. Floating point is excluded because
+// getIntegerValue truncates, and HUGEINT because the bound would not survive
+// the narrowing to int64_t; in both cases the filter could silently overlap a
+// real value. BOOLEAN is excluded because there is no value above true.
+bool supportsEmptyResult(const TypePtr& type) {
+  const auto kind = type->kind();
+  return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
+      kind == TypeKind::VARCHAR || kind == TypeKind::TIMESTAMP;
 }
 
 // Draws a filter selectivity in percent.
@@ -492,6 +512,23 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
         specs.back().filterKind != FilterKind::kIsNotNull &&
         folly::Random::rand32(rng_) % 10 == 0) {
       specs.back().isForRowGroupSkip = true;
+    }
+  }
+
+  // Optionally turn the last spec into one that matches nothing. The last one
+  // and no other: makeSubfieldFilters narrows the reference rows in place as it
+  // walks the specs, so an empty result anywhere earlier would leave every
+  // later column sampling an empty row set and degenerating into an IsNull
+  // filter. Guarded on the probability first so that the default draws nothing
+  // and leaves the sequence above untouched.
+  if (emptyResultProbability_ > 0.0 && !specs.empty() &&
+      folly::Random::randDouble01(rng_) < emptyResultProbability_) {
+    auto& last = specs.back();
+    const auto fieldType = topLevelFieldType(*rowType_, last.field);
+    if (fieldType != nullptr && supportsEmptyResult(fieldType) &&
+        !last.isForRowGroupSkip && last.filterKind != FilterKind::kIsNull &&
+        last.filterKind != FilterKind::kIsNotNull) {
+      last.isForEmptyResult = true;
     }
   }
 
@@ -598,6 +635,8 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
     std::unique_ptr<Filter> filter;
     if (filterSpec.isForRowGroupSkip) {
       filter = stats->rowGroupSkipFilter(batches, subfield, hitRows);
+    } else if (filterSpec.isForEmptyResult) {
+      filter = stats->emptyResultFilter(batches, subfield, hitRows);
     } else {
       filter = stats->filter(batches, filterSpec, hitRows);
     }

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -247,6 +247,40 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
         nullAllowed);
   }
 
+  // The string counterpart of the OR of disjoint ranges the integer path
+  // builds. MultiRange has no ordering contract of its own -- overlapping
+  // members would still be a correct OR -- but ascending disjoint members are
+  // what makes it more than a single wide range, so fall back when the sample
+  // is too coarse to give them.
+  if (folly::Random::oneIn(4, rng_)) {
+    std::vector<std::unique_ptr<Filter>> ranges;
+    std::string previousUpper;
+    bool usable = true;
+    for (const auto& [from, to] : multiRangeBands(filterSpec)) {
+      std::string rangeLower = std::string(valueAtPct(from));
+      std::string rangeUpper = std::string(valueAtPct(to));
+      if (rangeLower > rangeUpper ||
+          (!ranges.empty() && rangeLower <= previousUpper)) {
+        usable = false;
+        break;
+      }
+      previousUpper = rangeUpper;
+      ranges.push_back(
+          std::make_unique<velox::common::BytesRange>(
+              std::move(rangeLower),
+              false,
+              false,
+              std::move(rangeUpper),
+              false,
+              false,
+              nullAllowed));
+    }
+    if (usable) {
+      return std::make_unique<velox::common::MultiRange>(
+          std::move(ranges), nullAllowed);
+    }
+  }
+
   return std::make_unique<velox::common::BytesRange>(
       std::string(lower),
       false,

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/common/tests/utils/FilterGenerator.h"
 
+#include <cmath>
+
 #include <algorithm>
 #include <memory>
 #include <typeinfo>
@@ -396,6 +398,40 @@ bool supportsRowGroupSkip(const TypePtr& type) {
       kind == TypeKind::TIMESTAMP;
 }
 
+// Draws a filter selectivity in percent.
+//
+// The previous scheme picked from {1, 10, 20, 30} and {76, 80, ... 100}, which
+// left two gaps that matter for reader coverage: nothing between 31% and 75%,
+// which is exactly where a filter partially overlaps a stripe or a row group
+// and boundary handling is interesting, and a degenerate match-everything
+// filter at 100% roughly one draw in thirteen.
+//
+// Splits the range into three equally weighted regimes instead. The low band is
+// log-uniform because selectivity there spans two orders of magnitude and a
+// uniform draw would almost never produce the very selective filters that
+// exercise skipping; the other two are uniform. Capped below 100 so the filter
+// always excludes something and startPct below always has a non-empty range to
+// draw from.
+float randomSelectPct(folly::Random::DefaultGenerator& rng) {
+  switch (folly::Random::rand32(3, rng)) {
+    case 0: {
+      // Highly selective: log-uniform over [0.5, 10).
+      constexpr double kMin = 0.5;
+      constexpr double kMax = 10.0;
+      const double logMin = std::log(kMin);
+      const double span = std::log(kMax) - logMin;
+      return static_cast<float>(
+          std::exp(logMin + folly::Random::randDouble01(rng) * span));
+    }
+    case 1:
+      // The band the old scheme could not reach at all.
+      return static_cast<float>(10.0 + folly::Random::randDouble01(rng) * 65.0);
+    default:
+      // Permissive, but never all-inclusive.
+      return static_cast<float>(75.0 + folly::Random::randDouble01(rng) * 24.0);
+  }
+}
+
 // Resolves a top level field by name. Returns nullptr for the dotted subfield
 // paths a caller may supply directly, which findChild does not accept.
 TypePtr topLevelFieldType(const RowType& rowType, const std::string& name) {
@@ -433,16 +469,12 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
     specs.emplace_back();
     specs.back().field = name;
     auto category = folly::Random::rand32(rng_) % 13;
-    if (category == 0) {
-      specs.back().selectPct = 1;
-    } else if (category < 4) {
-      specs.back().selectPct = category * 10;
-    } else if (category == 11) {
+    if (category == 11) {
       specs.back().filterKind = FilterKind::kIsNull;
     } else if (category == 12) {
       specs.back().filterKind = FilterKind::kIsNotNull;
     } else {
-      specs.back().selectPct = 60 + category * 4;
+      specs.back().selectPct = randomSelectPct(rng_);
     }
 
     specs.back().startPct = specs.back().selectPct < 100

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -42,10 +42,11 @@ vector_size_t batchRow(uint64_t position) {
   return position & 0xffffffff;
 }
 
-VectorPtr getChildBySubfield(
+VectorPtr getChildBySubfieldWithAncestorNulls(
     const RowVector* rowVector,
     const Subfield& subfield,
-    const RowTypePtr& rootType) {
+    const RowTypePtr& rootType,
+    std::vector<uint8_t>* ancestorNulls) {
   const Type* type = rootType ? rootType.get() : rowVector->type().get();
   auto& path = subfield.path();
   VELOX_CHECK(!path.empty());
@@ -57,31 +58,61 @@ VectorPtr getChildBySubfield(
   auto vector = rowVector->childAt(fieldIndex);
   for (int i = 1; i < path.size(); ++i) {
     switch (type->kind()) {
-      case TypeKind::ROW:
+      case TypeKind::ROW: {
         rowType = &type->asRow();
         field = dynamic_cast<const Subfield::NestedField*>(path[i].get());
         VELOX_CHECK(field);
         fieldIndex = rowType->getChildIdx(field->name());
         type = rowType->childAt(fieldIndex).get();
-        vector = vector->asUnchecked<RowVector>()->childAt(fieldIndex);
+        auto* parent = vector->asUnchecked<RowVector>();
+        // A null struct leaves its children's values undefined rather than
+        // marking them null, so the leaf's own null flags are not enough to
+        // decide what a reader will see for this subfield.
+        if (ancestorNulls != nullptr && parent->mayHaveNulls()) {
+          ancestorNulls->resize(parent->size(), 0);
+          for (vector_size_t row = 0; row < parent->size(); ++row) {
+            if (parent->isNullAt(row)) {
+              (*ancestorNulls)[row] = 1;
+            }
+          }
+        }
+        vector = parent->childAt(fieldIndex);
         break;
+      }
       case TypeKind::ARRAY:
         VELOX_CHECK(
             dynamic_cast<const Subfield::AllSubscripts*>(path[i].get()));
         type = type->childAt(0).get();
         vector = vector->asUnchecked<ArrayVector>()->elements();
+        // Positions in an elements vector are element indices, not row
+        // indices, so anything collected above no longer lines up with the
+        // rows the caller is iterating.
+        if (ancestorNulls != nullptr) {
+          ancestorNulls->clear();
+        }
         break;
       case TypeKind::MAP:
         VELOX_CHECK(
             dynamic_cast<const Subfield::AllSubscripts*>(path[i].get()));
         type = type->childAt(1).get();
         vector = vector->asUnchecked<MapVector>()->mapValues();
+        if (ancestorNulls != nullptr) {
+          ancestorNulls->clear();
+        }
         break;
       default:
         VELOX_FAIL();
     }
   }
   return vector;
+}
+
+VectorPtr getChildBySubfield(
+    const RowVector* rowVector,
+    const Subfield& subfield,
+    const RowTypePtr& rootType) {
+  return getChildBySubfieldWithAncestorNulls(
+      rowVector, subfield, rootType, nullptr);
 }
 
 template <>
@@ -374,25 +405,58 @@ SubfieldFilters FilterGenerator::cloneSubfieldFilters(
   return copy;
 }
 
+namespace {
+
+// ignore these types for filtering
+bool isFilterableKind(TypeKind kind) {
+  return kind != TypeKind::UNKNOWN && kind != TypeKind::FUNCTION &&
+      kind != TypeKind::OPAQUE && kind != TypeKind::VARBINARY &&
+      kind != TypeKind::TIMESTAMP && kind != TypeKind::INVALID;
+}
+
+// Nesting beyond this is left alone: the paths get long, the leaves get
+// sparse, and each extra level multiplies the candidate list that
+// makeFilterables then has to sample from.
+constexpr int32_t kMaxSubfieldDepth = 3;
+
+void collectFilterableSubFieldsAt(
+    const RowType& rowType,
+    const std::string& prefix,
+    int32_t depth,
+    std::vector<std::string>& subFields) {
+  for (int i = 0; i < rowType.size(); ++i) {
+    const auto& child = rowType.childAt(i);
+    if (!isFilterableKind(child->kind())) {
+      continue;
+    }
+    const auto& name = rowType.nameOf(i);
+    // A dot in a field name would make the path built below ambiguous when
+    // Subfield parses it back apart, so such a field is offered only at the
+    // level it sits at and never descended into.
+    if (name.find('.') != std::string::npos) {
+      if (prefix.empty()) {
+        subFields.push_back(name);
+      }
+      continue;
+    }
+    auto path = prefix.empty() ? name : fmt::format("{}.{}", prefix, name);
+    subFields.push_back(path);
+    // Only ROW is descended into. A path through an ARRAY or a MAP lands on
+    // the elements vector, whose positions are element indices rather than row
+    // indices, so the row-wise reference computation would read values that
+    // belong to other rows.
+    if (child->kind() == TypeKind::ROW && depth + 1 < kMaxSubfieldDepth) {
+      collectFilterableSubFieldsAt(child->asRow(), path, depth + 1, subFields);
+    }
+  }
+}
+
+} // namespace
+
 void FilterGenerator::collectFilterableSubFields(
     const RowType* rowType,
     std::vector<std::string>& subFields) {
-  for (int i = 0; i < rowType->size(); ++i) {
-    auto kind = rowType->childAt(i)->kind();
-    switch (kind) {
-      // ignore these types for filtering
-      case TypeKind::UNKNOWN:
-      case TypeKind::FUNCTION:
-      case TypeKind::OPAQUE:
-      case TypeKind::VARBINARY:
-      case TypeKind::TIMESTAMP:
-      case TypeKind::INVALID:
-        continue;
-
-      default:
-        subFields.push_back(rowType->nameOf(i));
-    }
-  }
+  collectFilterableSubFieldsAt(*rowType, "", 0, subFields);
 }
 
 std::vector<std::string> FilterGenerator::makeFilterables(

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -382,6 +382,34 @@ std::vector<std::string> FilterGenerator::makeFilterables(
   return filterables;
 }
 
+namespace {
+
+// Row group skip filters are produced by makeRowGroupSkipRangeFilter, which is
+// only implemented for the kinds below. The generic template builds a
+// BigintRange out of getIntegerValue(), so floating point and HUGEINT would
+// narrow into a filter of the wrong type, and the complex type override fails
+// outright. VARCHAR is excluded on purpose: its specialization returns a filter
+// built from kMaxString, a sentinel picked to exceed *test* data, which selects
+// nothing against real data.
+bool supportsRowGroupSkip(const TypePtr& type) {
+  const auto kind = type->kind();
+  return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
+      kind == TypeKind::TIMESTAMP;
+}
+
+// Resolves a top level field by name. Returns nullptr for the dotted subfield
+// paths a caller may supply directly, which findChild does not accept.
+TypePtr topLevelFieldType(const RowType& rowType, const std::string& name) {
+  if (name.find('.') != std::string::npos) {
+    return nullptr;
+  }
+  auto index = rowType.getChildIdxIfExists(name);
+  return index.has_value() ? rowType.childAt(*index) : nullptr;
+}
+
+} // namespace
+
 std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
     const std::vector<std::string>& filterable,
     int32_t countX100) {
@@ -423,6 +451,18 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
         ? folly::Random::rand32(rng_) %
             static_cast<int32_t>(100 - specs.back().selectPct)
         : 0;
+
+    // Ask for a min/max row group skip filter on a fraction of the specs. This
+    // is an independent draw rather than another `category` so the value filter
+    // distribution above is left alone, and it skips the null kinds because
+    // rowGroupSkipFilter ignores filterKind and would silently replace them.
+    const auto fieldType = topLevelFieldType(*rowType_, name);
+    if (fieldType != nullptr && supportsRowGroupSkip(fieldType) &&
+        specs.back().filterKind != FilterKind::kIsNull &&
+        specs.back().filterKind != FilterKind::kIsNotNull &&
+        folly::Random::rand32(rng_) % 10 == 0) {
+      specs.back().isForRowGroupSkip = true;
+    }
   }
 
   return specs;

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -82,8 +82,6 @@ VectorPtr getChildBySubfield(
   return vector;
 }
 
-uint32_t AbstractColumnStats::counter_ = 0;
-
 template <>
 std::unique_ptr<Filter> ColumnStats<bool>::makeRangeFilter(
     const FilterSpec& filterSpec) {
@@ -218,7 +216,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   StringView lower = valueAtPct(filterSpec.startPct, &lowerIndex);
   StringView upper =
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
-  if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 <= 3) {
+  if (upperIndex - lowerIndex < 1000 && folly::Random::rand32(10, rng_) <= 3) {
     std::vector<std::string> inRange;
     inRange.reserve(upperIndex - lowerIndex);
     for (StringView s : values_) {
@@ -227,7 +225,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
         inRange.push_back(s.getString());
       }
     }
-    if (counter_ % 2 == 0 && filterSpec.selectPct != 100.0) {
+    if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct != 100.0) {
       return std::make_unique<velox::common::NegatedBytesValues>(
           inRange, filterSpec.selectPct < 75);
     }
@@ -236,7 +234,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   }
 
   // sometimes create a negated filter instead
-  if (counter_ % 4 == 1 && filterSpec.selectPct < 100.0) {
+  if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
     return std::make_unique<velox::common::NegatedBytesRange>(
         std::string(lower),
         false,
@@ -517,46 +515,46 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
     std::unique_ptr<AbstractColumnStats> stats;
     switch (vector->typeKind()) {
       case TypeKind::BOOLEAN:
-        stats = makeStats<TypeKind::BOOLEAN>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::BOOLEAN>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::TINYINT:
-        stats = makeStats<TypeKind::TINYINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::TINYINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::SMALLINT:
-        stats = makeStats<TypeKind::SMALLINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::SMALLINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::INTEGER:
-        stats = makeStats<TypeKind::INTEGER>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::INTEGER>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::BIGINT:
-        stats = makeStats<TypeKind::BIGINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::BIGINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::HUGEINT:
-        stats = makeStats<TypeKind::HUGEINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::HUGEINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::VARCHAR:
-        stats = makeStats<TypeKind::VARCHAR>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::VARCHAR>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::VARBINARY:
-        stats = makeStats<TypeKind::VARBINARY>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::VARBINARY>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::REAL:
-        stats = makeStats<TypeKind::REAL>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::REAL>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::DOUBLE:
-        stats = makeStats<TypeKind::DOUBLE>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::DOUBLE>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::TIMESTAMP:
-        stats = makeStats<TypeKind::TIMESTAMP>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::TIMESTAMP>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::ROW:
-        stats = makeStats<TypeKind::ROW>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::ROW>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::ARRAY:
-        stats = makeStats<TypeKind::ARRAY>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::ARRAY>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::MAP:
-        stats = makeStats<TypeKind::MAP>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::MAP>(vector->type(), rowType_, rng_);
         break;
       default:
         VELOX_CHECK(

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -114,7 +114,7 @@ std::unique_ptr<Filter> ColumnStats<float>::makeRangeFilter(
       upper,
       upperUnbounded,
       false,
-      filterSpec.selectPct > 25);
+      drawNullAllowed(filterSpec));
 }
 
 template <>
@@ -153,7 +153,7 @@ std::unique_ptr<Filter> ColumnStats<double>::makeRangeFilter(
       upper,
       upperUnbounded,
       false,
-      filterSpec.selectPct > 25);
+      drawNullAllowed(filterSpec));
 }
 
 template <>
@@ -216,6 +216,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   StringView lower = valueAtPct(filterSpec.startPct, &lowerIndex);
   StringView upper =
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
+  const bool nullAllowed = drawNullAllowed(filterSpec);
   if (upperIndex - lowerIndex < 1000 && folly::Random::rand32(10, rng_) <= 3) {
     std::vector<std::string> inRange;
     inRange.reserve(upperIndex - lowerIndex);
@@ -227,10 +228,9 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
     }
     if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct != 100.0) {
       return std::make_unique<velox::common::NegatedBytesValues>(
-          inRange, filterSpec.selectPct < 75);
+          inRange, nullAllowed);
     }
-    return std::make_unique<velox::common::BytesValues>(
-        inRange, filterSpec.selectPct > 25);
+    return std::make_unique<velox::common::BytesValues>(inRange, nullAllowed);
   }
 
   // sometimes create a negated filter instead
@@ -242,7 +242,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
         std::string(upper),
         false,
         false,
-        filterSpec.selectPct < 75);
+        nullAllowed);
   }
 
   return std::make_unique<velox::common::BytesRange>(
@@ -252,7 +252,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
       std::string(upper),
       false,
       false,
-      filterSpec.selectPct > 25);
+      nullAllowed);
 }
 
 template <>
@@ -268,7 +268,7 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRangeFilter(
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
 
   return std::make_unique<velox::common::TimestampRange>(
-      lower, upper, filterSpec.selectPct > 25);
+      lower, upper, drawNullAllowed(filterSpec));
 }
 
 template <>

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -41,7 +41,7 @@ struct FilterSpec {
       float startPct = 50,
       float selectPct = 20,
       FilterKind filterKind = FilterKind::kBigintRange,
-      bool isForRowGroupSkip = true,
+      bool isForRowGroupSkip = false,
       bool allowNulls = true)
       : field(field),
         startPct(startPct),

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -137,6 +137,25 @@ class AbstractColumnStats {
     return filterSpec.allowNulls_ && folly::Random::oneIn(2, rng_);
   }
 
+  // Carves the selected percentile band into two or three sub-bands for an
+  // OR of disjoint ranges. Each sub-band covers only the first half of its
+  // slice; the second half is the gap that makes the result an OR rather than
+  // one wide range. Returned as percentiles so both the integer and the string
+  // side can resolve them against their own sorted samples.
+  std::vector<std::pair<float, float>> multiRangeBands(
+      const FilterSpec& filterSpec) {
+    const int32_t count =
+        2 + static_cast<int32_t>(folly::Random::rand32(2, rng_));
+    const float width = filterSpec.selectPct / static_cast<float>(count);
+    std::vector<std::pair<float, float>> bands;
+    bands.reserve(count);
+    for (int32_t i = 0; i < count; ++i) {
+      const float from = filterSpec.startPct + static_cast<float>(i) * width;
+      bands.emplace_back(from, from + width / 2);
+    }
+    return bands;
+  }
+
   const TypePtr type_;
   const RowTypePtr rootType_;
   int32_t numDistinct_ = 0;
@@ -347,8 +366,40 @@ class ColumnStats : public AbstractColumnStats {
       return std::make_unique<velox::common::NegatedBigintRange>(
           getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
     }
+    // An OR of disjoint ranges. Its own testInt64 and testInt64Range mean a
+    // reader takes a different path than for one contiguous range, and a
+    // min/max check can no longer be a single comparison against the bounds.
+    if (folly::Random::oneIn(4, rng_)) {
+      auto multiRange = makeMultiRangeFilter(filterSpec, nullAllowed);
+      if (multiRange != nullptr) {
+        return multiRange;
+      }
+    }
     return std::make_unique<velox::common::BigintRange>(
         getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
+  }
+
+  // Returns nullptr when the sample is too coarse for the sub-ranges to come
+  // out ascending and disjoint, which BigintMultiRange requires and a column
+  // with few distinct values cannot always satisfy -- valueAtPct then hands
+  // back the same value for neighbouring percentiles.
+  std::unique_ptr<Filter> makeMultiRangeFilter(
+      const FilterSpec& filterSpec,
+      bool nullAllowed) {
+    std::vector<std::unique_ptr<velox::common::BigintRange>> ranges;
+    int64_t previousUpper = 0;
+    for (const auto& [from, to] : multiRangeBands(filterSpec)) {
+      const int64_t lower = getIntegerValue(valueAtPct(from));
+      const int64_t upper = getIntegerValue(valueAtPct(to));
+      if (lower > upper || (!ranges.empty() && lower <= previousUpper)) {
+        return nullptr;
+      }
+      previousUpper = upper;
+      ranges.push_back(
+          std::make_unique<velox::common::BigintRange>(lower, upper, false));
+    }
+    return std::make_unique<velox::common::BigintMultiRange>(
+        std::move(ranges), nullAllowed);
   }
 
   // Scans every row rather than the sample in 'values_': a filter that has to

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -115,6 +115,15 @@ class AbstractColumnStats {
   }
 
  protected:
+  // Whether the generated filter should pass nulls. `allowNulls_` on the spec
+  // is a hard constraint from the caller; when it permits nulls the answer is
+  // drawn independently rather than derived from selectPct, which used to tie
+  // the two together and make "selective filter that also passes nulls"
+  // unreachable.
+  bool drawNullAllowed(const FilterSpec& filterSpec) {
+    return filterSpec.allowNulls_ && folly::Random::oneIn(2, rng_);
+  }
+
   const TypePtr type_;
   const RowTypePtr rootType_;
   int32_t numDistinct_ = 0;
@@ -307,6 +316,7 @@ class ColumnStats : public AbstractColumnStats {
       return std::make_unique<velox::common::BigintRange>(
           getIntegerValue(lower), getIntegerValue(upper), false);
     }
+    const bool nullAllowed = drawNullAllowed(filterSpec);
     if (upperIndex - lowerIndex < 1000 &&
         folly::Random::rand32(10, rng_) <= 3) {
       std::vector<int64_t> in;
@@ -315,21 +325,17 @@ class ColumnStats : public AbstractColumnStats {
       }
       // make sure we don't accidentally generate an AlwaysFalse filter
       if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct < 100.0) {
-        return velox::common::createNegatedBigintValues(in, true);
+        return velox::common::createNegatedBigintValues(in, nullAllowed);
       }
-      return velox::common::createBigintValues(in, true);
+      return velox::common::createBigintValues(in, nullAllowed);
     }
     // sometimes make a negated filter instead (1/4 chance)
     if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
       return std::make_unique<velox::common::NegatedBigintRange>(
-          getIntegerValue(lower),
-          getIntegerValue(upper),
-          filterSpec.selectPct < 75);
+          getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
     }
     return std::make_unique<velox::common::BigintRange>(
-        getIntegerValue(lower),
-        getIntegerValue(upper),
-        filterSpec.selectPct > 25);
+        getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
   }
 
   std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -88,6 +88,18 @@ VectorPtr getChildBySubfield(
     const Subfield& subfield,
     const RowTypePtr& rowType = nullptr);
 
+// As above, and additionally marks in 'ancestorNulls' the rows where a struct
+// enclosing the subfield is null. Needed because a null struct leaves its
+// children's values undefined instead of marking them null, so the leaf's own
+// null flags do not say what a reader will produce for the subfield. Left
+// empty when the path crosses an ARRAY or a MAP, where positions stop being
+// row indices and nothing collected can be lined up with the caller's rows.
+VectorPtr getChildBySubfieldWithAncestorNulls(
+    const RowVector* rowVector,
+    const Subfield& subfield,
+    const RowTypePtr& rootType,
+    std::vector<uint8_t>* ancestorNulls);
+
 class AbstractColumnStats {
  public:
   // ASCII string greater than test data values. Used for row group skipping
@@ -128,6 +140,14 @@ class AbstractColumnStats {
   }
 
  protected:
+  // Empty whenever the subfield has no struct above it, or the path crossed an
+  // ARRAY or a MAP and the positions stopped meaning rows.
+  static bool isAncestorNull(
+      const std::vector<uint8_t>& ancestorNulls,
+      vector_size_t row) {
+    return !ancestorNulls.empty() && ancestorNulls[row] != 0;
+  }
+
   // Whether the generated filter should pass nulls. `allowNulls_` on the spec
   // is a hard constraint from the caller; when it permits nulls the answer is
   // drawn independently rather than derived from selectPct, which used to tie
@@ -184,16 +204,27 @@ class ColumnStats : public AbstractColumnStats {
       std::vector<uint64_t>& rows) override {
     int32_t previousBatch = -1;
     SimpleVector<T>* values = nullptr;
+    std::vector<uint8_t> ancestorNulls;
     for (auto row : rows) {
       auto batch = batchNumber(row);
       if (batch != previousBatch) {
         previousBatch = batch;
         auto vector = batches[batch];
 
-        values = getChildBySubfield(vector.get(), subfield, rootType_)
+        ancestorNulls.clear();
+        values = getChildBySubfieldWithAncestorNulls(
+                     vector.get(), subfield, rootType_, &ancestorNulls)
                      ->template asUnchecked<SimpleVector<T>>();
       }
 
+      // A row under a null struct contributes nothing to the value
+      // distribution: the leaf holds a value there, but no reader will ever
+      // return it.
+      if (isAncestorNull(ancestorNulls, batchRow(row))) {
+        ++numSamples_;
+        ++numNulls_;
+        continue;
+      }
       addSample(values, batchRow(row));
     }
     if constexpr (!std::is_same_v<T, ComplexType>) {
@@ -264,15 +295,18 @@ class ColumnStats : public AbstractColumnStats {
     size_t numHits = 0;
     SimpleVector<T>* values = nullptr;
     int32_t previousBatch = -1;
+    std::vector<uint8_t> ancestorNulls;
     for (auto hit : hits) {
       auto batch = batchNumber(hit);
       if (batch != previousBatch) {
         previousBatch = batch;
-        values = getChildBySubfield(batches[batch].get(), subfield, rootType_)
+        ancestorNulls.clear();
+        values = getChildBySubfieldWithAncestorNulls(
+                     batches[batch].get(), subfield, rootType_, &ancestorNulls)
                      ->template as<SimpleVector<T>>();
       }
       auto row = batchRow(hit);
-      if (values->isNullAt(row)) {
+      if (values->isNullAt(row) || isAncestorNull(ancestorNulls, row)) {
         if (filter.testNull()) {
           hits[numHits++] = hit;
         }
@@ -410,8 +444,11 @@ class ColumnStats : public AbstractColumnStats {
       const Subfield& subfield,
       T& max) {
     bool hasMax = false;
+    std::vector<uint8_t> ancestorNulls;
     for (auto batch : batches) {
-      auto values = getChildBySubfield(batch.get(), subfield, rootType_)
+      ancestorNulls.clear();
+      auto values = getChildBySubfieldWithAncestorNulls(
+                        batch.get(), subfield, rootType_, &ancestorNulls)
                         ->template as<SimpleVector<T>>();
       DWIO_ENSURE_NOT_NULL(
           values,
@@ -420,7 +457,7 @@ class ColumnStats : public AbstractColumnStats {
           "> for batch of kind ",
           batch->type()->kindName());
       for (auto i = 0; i < values->size(); ++i) {
-        if (values->isNullAt(i)) {
+        if (values->isNullAt(i) || isAncestorNull(ancestorNulls, i)) {
           continue;
         }
         if (!hasMax || max < values->valueAt(i)) {
@@ -482,16 +519,20 @@ class ComplexColumnStats : public AbstractColumnStats {
       std::vector<uint64_t>& rows) override {
     int32_t previousBatch = -1;
     VectorPtr values = nullptr;
+    std::vector<uint8_t> ancestorNulls;
     for (auto row : rows) {
       auto batch = batchNumber(row);
       if (batch != previousBatch) {
         previousBatch = batch;
         auto vector = batches[batch];
 
-        values = getChildBySubfield(vector.get(), subfield, rootType_);
+        ancestorNulls.clear();
+        values = getChildBySubfieldWithAncestorNulls(
+            vector.get(), subfield, rootType_, &ancestorNulls);
       }
       ++numSamples_;
-      if (values->isNullAt(batchRow(row))) {
+      if (values->isNullAt(batchRow(row)) ||
+          isAncestorNull(ancestorNulls, batchRow(row))) {
         ++numNulls_;
       }
     }
@@ -514,16 +555,21 @@ class ComplexColumnStats : public AbstractColumnStats {
     BaseVector* values = nullptr;
     bool isNull = filter->kind() == velox::common::FilterKind::kIsNull;
     int32_t previousBatch = -1;
+    std::vector<uint8_t> ancestorNulls;
+    VectorPtr held;
     for (auto hit : hits) {
       auto batch = batchNumber(hit);
       if (batch != previousBatch) {
         previousBatch = batch;
-        auto vector = batches[batch];
-        values =
-            getChildBySubfield(batches[batch].get(), subfield, rootType_).get();
+        ancestorNulls.clear();
+        held = getChildBySubfieldWithAncestorNulls(
+            batches[batch].get(), subfield, rootType_, &ancestorNulls);
+        values = held.get();
       }
       auto row = batchRow(hit);
-      if (values->isNullAt(row) == isNull) {
+      const bool rowIsNull =
+          values->isNullAt(row) || isAncestorNull(ancestorNulls, row);
+      if (rowIsNull == isNull) {
         hits[numHits++] = hit;
       }
     }

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -89,8 +89,11 @@ class AbstractColumnStats {
   // ASCII string greater than test data values. Used for row group skipping
   // tests.
   static constexpr const char* kMaxString = "~~~~~";
-  AbstractColumnStats(TypePtr type, RowTypePtr rootType)
-      : type_(type), rootType_(rootType) {}
+  AbstractColumnStats(
+      TypePtr type,
+      RowTypePtr rootType,
+      folly::Random::DefaultGenerator& rng)
+      : type_(type), rootType_(rootType), rng_(rng) {}
 
   virtual ~AbstractColumnStats() = default;
 
@@ -118,14 +121,21 @@ class AbstractColumnStats {
   int32_t numNulls_ = 0;
   int32_t numSamples_ = 0;
   std::unordered_map<size_t, int> uniques_;
-  static uint32_t counter_;
+  // Borrowed from the owning FilterGenerator so that filter kind selection is
+  // driven by the run's seed. This used to be a process-global counter, which
+  // made the choice depend on how many columns happened to be processed
+  // earlier and left it outside the seed's control entirely.
+  folly::Random::DefaultGenerator& rng_;
 };
 
 template <typename T>
 class ColumnStats : public AbstractColumnStats {
  public:
-  explicit ColumnStats(TypePtr type, RowTypePtr rootTypePtr)
-      : AbstractColumnStats(type, rootTypePtr) {}
+  ColumnStats(
+      TypePtr type,
+      RowTypePtr rootTypePtr,
+      folly::Random::DefaultGenerator& rng)
+      : AbstractColumnStats(type, rootTypePtr, rng) {}
 
   void sample(
       const std::vector<RowVectorPtr>& batches,
@@ -297,19 +307,20 @@ class ColumnStats : public AbstractColumnStats {
       return std::make_unique<velox::common::BigintRange>(
           getIntegerValue(lower), getIntegerValue(upper), false);
     }
-    if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 <= 3) {
+    if (upperIndex - lowerIndex < 1000 &&
+        folly::Random::rand32(10, rng_) <= 3) {
       std::vector<int64_t> in;
       for (auto i = lowerIndex; i <= upperIndex; ++i) {
         in.push_back(getIntegerValue(values_[i]));
       }
       // make sure we don't accidentally generate an AlwaysFalse filter
-      if (counter_ % 2 == 1 && filterSpec.selectPct < 100.0) {
+      if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct < 100.0) {
         return velox::common::createNegatedBigintValues(in, true);
       }
       return velox::common::createBigintValues(in, true);
     }
     // sometimes make a negated filter instead (1/4 chance)
-    if (counter_ % 4 == 1 && filterSpec.selectPct < 100.0) {
+    if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
       return std::make_unique<velox::common::NegatedBigintRange>(
           getIntegerValue(lower),
           getIntegerValue(upper),
@@ -362,8 +373,11 @@ class ColumnStats : public AbstractColumnStats {
 
 class ComplexColumnStats : public AbstractColumnStats {
  public:
-  explicit ComplexColumnStats(TypePtr type, RowTypePtr rootTypePtr)
-      : AbstractColumnStats(type, rootTypePtr) {}
+  ComplexColumnStats(
+      TypePtr type,
+      RowTypePtr rootTypePtr,
+      folly::Random::DefaultGenerator& rng)
+      : AbstractColumnStats(type, rootTypePtr, rng) {}
 
   void sample(
       const std::vector<RowVectorPtr>& batches,
@@ -488,30 +502,34 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRowGroupSkipRangeFilter(
 template <TypeKind Kind>
 std::unique_ptr<AbstractColumnStats> makeStats(
     TypePtr type,
-    RowTypePtr rootType) {
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
   using T = typename TypeTraits<Kind>::NativeType;
-  return std::make_unique<ColumnStats<T>>(type, rootType);
+  return std::make_unique<ColumnStats<T>>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ROW>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ARRAY>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::MAP>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 class FilterGenerator {

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -52,12 +52,13 @@ struct FilterSpec {
 
   std::string toString() const {
     return fmt::format(
-        "FilterSpec(field={}, startPct={}, selectPct={}, filterKind={}, isForRowGroupSkip={}, allowNulls={})",
+        "FilterSpec(field={}, startPct={}, selectPct={}, filterKind={}, isForRowGroupSkip={}, isForEmptyResult={}, allowNulls={})",
         field,
         startPct,
         selectPct,
         filterKind,
         isForRowGroupSkip,
+        isForEmptyResult,
         allowNulls_);
   }
 
@@ -68,6 +69,9 @@ struct FilterSpec {
   // If true, makes a filter that matches max value in the column so as to skip
   // row groups on min/max.
   bool isForRowGroupSkip{false};
+  // If true, makes a filter positioned just past the column maximum, so that no
+  // row survives it. Opt in with FilterGenerator::setEmptyResultProbability.
+  bool isForEmptyResult{false};
   bool allowNulls_{true};
 };
 
@@ -108,6 +112,15 @@ class AbstractColumnStats {
       std::vector<uint64_t>& hits) = 0;
 
   virtual std::unique_ptr<Filter> rowGroupSkipFilter(
+      const std::vector<RowVectorPtr>& /*batches*/,
+      const Subfield& /*subfield*/,
+      std::vector<uint64_t>& /*hits*/) {
+    VELOX_NYI();
+  }
+
+  // Returns a filter that no row passes, or nullptr when the column admits no
+  // such filter (every value null, or the maximum is already the type maximum).
+  virtual std::unique_ptr<Filter> emptyResultFilter(
       const std::vector<RowVectorPtr>& /*batches*/,
       const Subfield& /*subfield*/,
       std::vector<uint64_t>& /*hits*/) {
@@ -194,29 +207,7 @@ class ColumnStats : public AbstractColumnStats {
         break;
     }
 
-    size_t numHits = 0;
-    SimpleVector<T>* values = nullptr;
-    int32_t previousBatch = -1;
-    for (auto hit : hits) {
-      auto batch = batchNumber(hit);
-      if (batch != previousBatch) {
-        previousBatch = batch;
-        auto vector = batches[batch];
-        values = getChildBySubfield(batches[batch].get(), subfield, rootType_)
-                     ->template as<SimpleVector<T>>();
-      }
-      auto row = batchRow(hit);
-      if (values->isNullAt(row)) {
-        if (filter->testNull()) {
-          hits[numHits++] = hit;
-        }
-        continue;
-      }
-      if (velox::common::applyFilter(*filter, values->valueAt(row))) {
-        hits[numHits++] = hit;
-      }
-    }
-    hits.resize(numHits);
+    narrowHits(batches, subfield, *filter, hits);
     return filter;
   }
 
@@ -226,6 +217,31 @@ class ColumnStats : public AbstractColumnStats {
       std::vector<uint64_t>& hits) override {
     std::unique_ptr<Filter> filter;
     filter = makeRowGroupSkipRangeFilter(batches, subfield);
+    narrowHits(batches, subfield, *filter, hits);
+    return filter;
+  }
+
+  std::unique_ptr<Filter> emptyResultFilter(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield,
+      std::vector<uint64_t>& hits) override {
+    auto filter = makeEmptyResultRangeFilter(batches, subfield);
+    if (filter == nullptr) {
+      return nullptr;
+    }
+    narrowHits(batches, subfield, *filter, hits);
+    return filter;
+  }
+
+ private:
+  // Narrows 'hits' to the rows the filter passes. Every filter flavor shares
+  // this: the reference row set has to be derived from the filter that is
+  // actually handed to the reader, not from the spec that produced it.
+  void narrowHits(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield,
+      const Filter& filter,
+      std::vector<uint64_t>& hits) {
     size_t numHits = 0;
     SimpleVector<T>* values = nullptr;
     int32_t previousBatch = -1;
@@ -233,26 +249,23 @@ class ColumnStats : public AbstractColumnStats {
       auto batch = batchNumber(hit);
       if (batch != previousBatch) {
         previousBatch = batch;
-        auto vector = batches[batch];
         values = getChildBySubfield(batches[batch].get(), subfield, rootType_)
                      ->template as<SimpleVector<T>>();
       }
       auto row = batchRow(hit);
       if (values->isNullAt(row)) {
-        if (filter->testNull()) {
+        if (filter.testNull()) {
           hits[numHits++] = hit;
         }
         continue;
       }
-      if (velox::common::applyFilter(*filter, values->valueAt(row))) {
+      if (velox::common::applyFilter(filter, values->valueAt(row))) {
         hits[numHits++] = hit;
       }
     }
     hits.resize(numHits);
-    return filter;
   }
 
- private:
   void addSample(SimpleVector<T>* vector, vector_size_t index) {
     ++numSamples_;
     if (vector->isNullAt(index)) {
@@ -338,10 +351,13 @@ class ColumnStats : public AbstractColumnStats {
         getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
   }
 
-  std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(
+  // Scans every row rather than the sample in 'values_': a filter that has to
+  // sit at or past the column maximum cannot be built from a sample. Returns
+  // false, leaving 'max' untouched, if every value is null.
+  bool columnMax(
       const std::vector<RowVectorPtr>& batches,
-      const Subfield& subfield) {
-    T max;
+      const Subfield& subfield,
+      T& max) {
     bool hasMax = false;
     for (auto batch : batches) {
       auto values = getChildBySubfield(batch.get(), subfield, rootType_)
@@ -356,16 +372,40 @@ class ColumnStats : public AbstractColumnStats {
         if (values->isNullAt(i)) {
           continue;
         }
-        if (hasMax && max < values->valueAt(i)) {
-          max = values->valueAt(i);
-        } else if (!hasMax) {
+        if (!hasMax || max < values->valueAt(i)) {
           max = values->valueAt(i);
           hasMax = true;
         }
       }
     }
+    return hasMax;
+  }
+
+  std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield) {
+    T max{};
+    columnMax(batches, subfield, max);
     return std::make_unique<velox::common::BigintRange>(
         getIntegerValue(max), getIntegerValue(max), false);
+  }
+
+  // One past the column maximum. Only reached for the integral kinds, where
+  // getIntegerValue is exact -- see supportsEmptyResult in the .cpp -- so the
+  // resulting range cannot accidentally overlap a value.
+  std::unique_ptr<Filter> makeEmptyResultRangeFilter(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield) {
+    T max{};
+    if (!columnMax(batches, subfield, max)) {
+      return nullptr;
+    }
+    const int64_t bound = getIntegerValue(max);
+    if (bound == std::numeric_limits<int64_t>::max()) {
+      return nullptr;
+    }
+    return std::make_unique<velox::common::BigintRange>(
+        bound + 1, bound + 1, false);
   }
 
   std::unique_ptr<Filter> makeRandomFilter(const FilterSpec& filterSpec) {
@@ -451,6 +491,15 @@ class ComplexColumnStats : public AbstractColumnStats {
     VELOX_FAIL("N/A in ComplexType");
   }
 
+  // A complex type only admits is null / is not null, so whether either matches
+  // nothing depends on the data rather than on how the filter is built.
+  std::unique_ptr<Filter> emptyResultFilter(
+      const std::vector<RowVectorPtr>& /*batches*/,
+      const Subfield& /*subfield*/,
+      std::vector<uint64_t>& /*hits*/) override {
+    VELOX_FAIL("N/A in ComplexType");
+  }
+
  private:
   std::unique_ptr<Filter> makeRangeFilter(const FilterSpec&) {
     VELOX_FAIL("N/A in ComplexType");
@@ -502,6 +551,16 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRowGroupSkipRangeFilter(
 
 template <>
 std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRowGroupSkipRangeFilter(
+    const std::vector<RowVectorPtr>& /*batches*/,
+    const Subfield& /*subfield*/);
+
+template <>
+std::unique_ptr<Filter> ColumnStats<StringView>::makeEmptyResultRangeFilter(
+    const std::vector<RowVectorPtr>& /*batches*/,
+    const Subfield& /*subfield*/);
+
+template <>
+std::unique_ptr<Filter> ColumnStats<Timestamp>::makeEmptyResultRangeFilter(
     const std::vector<RowVectorPtr>& /*batches*/,
     const Subfield& /*subfield*/);
 
@@ -572,6 +631,23 @@ class FilterGenerator {
   // Add the filter to an existing ScanSpec.
   static void addToScanSpec(const SubfieldFilters& filters, ScanSpec&);
 
+  // Probability that a generated spec set asks for a filter no row passes.
+  // Zero by default, and at zero not a single random number is drawn for it, so
+  // callers that do not opt in keep their exact filter sequence.
+  //
+  // Ordinary selective filters already intersect to nothing now and then, but
+  // only by accident and only from inside the value range, so the reader still
+  // descends into every row group and rejects row by row. The filter this asks
+  // for sits past the column maximum instead, which is what makes min/max
+  // pruning skip every row group. Opt-in because it is a trade: the columns
+  // filtered alongside it contribute nothing, having no row left to accept or
+  // reject.
+  void setEmptyResultProbability(double probability) {
+    VELOX_CHECK_GE(probability, 0.0);
+    VELOX_CHECK_LE(probability, 1.0);
+    emptyResultProbability_ = probability;
+  }
+
   inline folly::Random::DefaultGenerator& rng() {
     return rng_;
   }
@@ -593,6 +669,7 @@ class FilterGenerator {
   std::shared_ptr<const RowType> rowType_;
   folly::Random::DefaultGenerator::result_type seed_;
   folly::Random::DefaultGenerator rng_;
+  double emptyResultProbability_{0.0};
   std::unordered_map<std::string, std::array<int32_t, 2>> filterCoverage_;
 };
 


### PR DESCRIPTION
Summary:
`collectFilterableSubFields` only ever offered top level column names, so a
`ROW` column was offered whole and the only filter it could carry was
`IsNull` / `IsNotNull` from `ComplexColumnStats`. Every scalar inside a
struct was unreachable -- no range, no in-list, nothing. Real schemas put
plenty of ordinary integer and string columns one level down.

It now descends into `ROW` children and offers dotted paths, keeping the
struct itself filterable alongside them.

Two things had to be handled to make the reference row set correct rather
than merely plausible.

**A null struct does not mark its children null.** The child keeps whatever
value it was built with, while a reader projects the whole subfield as null.
Computing the reference from the leaf's own null flags would therefore
disagree with every reader on exactly those rows -- silently, and only for
data that has null structs.
`getChildBySubfieldWithAncestorNulls` now reports the rows where an
enclosing struct is null, and sampling, hit narrowing, the complex path and
`columnMax` all treat those rows as null. `getChildBySubfield` keeps its
signature and forwards.

**Recursion stops at `ARRAY` and `MAP`.** A path through either lands on the
elements vector, whose positions are element indices rather than row
indices, so `valueAt(batchRow(hit))` would read values belonging to other
rows. Descending only through `ROW` keeps every generated path row
addressable. Hand written specs may still use array and map paths; for those
the ancestor null list is left empty, which is exactly the behaviour they
have today.

Also bounded at three levels, and a field whose name already contains a dot
is offered at its own level but never descended into, since the path would
be ambiguous once `Subfield` parses it back apart.

Note that a nested field cannot currently be chosen for the row group skip
or empty result shapes: `topLevelFieldType` returns nullptr for a dotted
name, so those draws skip it. Worth extending later; it degrades to not
generating those two shapes for nested fields rather than to anything wrong.

Reviewed By: raymondlin1

Differential Revision: D116018238


