### PR TITLE
feat(fuzzer): Cover the whole selectivity range in FilterGenerator

### DIFF
--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -185,3 +185,42 @@ TEST_F(FilterGeneratorSeedTest, differentSeedsProduceDifferentFilters) {
   // seed actually drives the outcome.
   EXPECT_GT(descriptions.size(), 1);
 }
+
+// The old selectivity scheme drew from {1, 10, 20, 30} and {76, 80, ... 100}.
+// Nothing landed between 31% and 75%, and 100% -- a filter that excludes
+// nothing -- came up roughly one draw in thirteen.
+TEST(FilterGeneratorTest, selectivityCoversTheMidBandAndNeverReachesAll) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/4242);
+
+  int32_t low = 0;
+  int32_t mid = 0;
+  int32_t high = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      if (spec.filterKind == common::FilterKind::kIsNull ||
+          spec.filterKind == common::FilterKind::kIsNotNull) {
+        continue;
+      }
+      EXPECT_GT(spec.selectPct, 0);
+      EXPECT_LT(spec.selectPct, 100);
+      // startPct must leave room for the range it introduces.
+      EXPECT_GE(spec.startPct, 0);
+      EXPECT_LT(spec.startPct, 100 - spec.selectPct);
+
+      if (spec.selectPct < 10) {
+        ++low;
+      } else if (spec.selectPct < 75) {
+        ++mid;
+      } else {
+        ++high;
+      }
+    }
+  }
+
+  EXPECT_GT(low, 0);
+  EXPECT_GT(mid, 0);
+  EXPECT_GT(high, 0);
+}

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 
@@ -104,4 +106,82 @@ TEST(FilterGeneratorTest, rowGroupSkipNeverPairedWithNullKinds) {
   // Without this the test would pass with zero assertions run if the draw were
   // ever disabled again -- which is the bug this whole change fixes.
   EXPECT_GT(observed, 0);
+}
+
+namespace {
+
+class FilterGeneratorSeedTest : public testing::Test,
+                                public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::vector<RowVectorPtr> makeBatches(const RowTypePtr& rowType) {
+    std::vector<RowVectorPtr> batches;
+    for (int32_t batch = 0; batch < 2; ++batch) {
+      batches.push_back(makeRowVector(
+          rowType->names(),
+          {makeFlatVector<int64_t>(
+               kBatchRows, [&](auto row) { return row + batch * kBatchRows; }),
+           makeFlatVector<int32_t>(
+               kBatchRows, [&](auto row) { return (row * 7) % 101; })}));
+    }
+    return batches;
+  }
+
+  // Renders the generated filters into a stable string so two runs can be
+  // compared without depending on filter identity.
+  std::string generateFilterDescription(
+      const RowTypePtr& rowType,
+      uint32_t seed) {
+    auto type = rowType;
+    FilterGenerator generator(type, seed);
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    auto specs = generator.makeRandomSpecs(filterable, 0);
+    auto batches = makeBatches(rowType);
+    std::vector<uint64_t> hitRows;
+    auto filters =
+        generator.makeSubfieldFilters(specs, batches, nullptr, hitRows);
+
+    std::vector<std::string> rendered;
+    for (const auto& [subfield, filter] : filters) {
+      rendered.push_back(
+          fmt::format("{}:{}", subfield.toString(), filter->toString()));
+    }
+    std::sort(rendered.begin(), rendered.end());
+    return folly::join(",", rendered);
+  }
+
+  static constexpr vector_size_t kBatchRows = 500;
+};
+
+} // namespace
+
+// Filter kind selection used to be driven by a process-global counter on
+// AbstractColumnStats rather than by the seed, so an unrelated generator run
+// earlier in the same process shifted the choice. A validation service whose
+// whole premise is "replay this failing seed" cannot afford that.
+TEST_F(FilterGeneratorSeedTest, filterKindIsIndependentOfEarlierGenerators) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  const auto before = generateFilterDescription(rowType, /*seed=*/7);
+
+  // Run unrelated generators in between; with a shared global counter these
+  // perturb the next run's filter kinds.
+  for (uint32_t otherSeed = 100; otherSeed < 105; ++otherSeed) {
+    generateFilterDescription(rowType, otherSeed);
+  }
+
+  EXPECT_EQ(before, generateFilterDescription(rowType, /*seed=*/7));
+}
+
+TEST_F(FilterGeneratorSeedTest, differentSeedsProduceDifferentFilters) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  std::set<std::string> descriptions;
+  for (uint32_t seed = 1; seed <= 20; ++seed) {
+    descriptions.insert(generateFilterDescription(rowType, seed));
+  }
+  // Not asserting all 20 differ -- collisions are legitimate -- only that the
+  // seed actually drives the outcome.
+  EXPECT_GT(descriptions.size(), 1);
 }

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/tests/utils/FilterGenerator.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+
+namespace {
+
+// Enough draws that a 1-in-10 branch is overwhelmingly likely to be taken at
+// least once, without making the test slow.
+constexpr int32_t kDraws = 200;
+
+int32_t countRowGroupSkipSpecs(const RowTypePtr& rowType) {
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/12345);
+  int32_t count = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      count += spec.isForRowGroupSkip ? 1 : 0;
+    }
+  }
+  return count;
+}
+
+} // namespace
+
+// The two FilterSpec constructors used to disagree on isForRowGroupSkip -- the
+// explicit one defaulted it true, the in-class initializer false -- and
+// makeRandomSpecs builds specs with the default constructor. Pins them
+// together, since a divergence silently disables or enables the whole
+// row-group-skip path.
+TEST(FilterGeneratorTest, filterSpecDefaultsAgree) {
+  FilterSpec defaultConstructed;
+  FilterSpec explicitlyConstructed("field");
+  EXPECT_EQ(
+      defaultConstructed.isForRowGroupSkip,
+      explicitlyConstructed.isForRowGroupSkip);
+  EXPECT_FALSE(defaultConstructed.isForRowGroupSkip);
+}
+
+TEST(FilterGeneratorTest, rowGroupSkipSpecsForSupportedTypes) {
+  auto rowType = ROW(
+      {{"tiny", TINYINT()},
+       {"small", SMALLINT()},
+       {"int", INTEGER()},
+       {"big", BIGINT()}});
+  EXPECT_GT(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// makeRowGroupSkipRangeFilter has no specialization for these kinds: the
+// generic template funnels the max through getIntegerValue(), which would
+// narrow a double or an int128 into a BigintRange of the wrong type, and
+// ComplexColumnStats fails outright. VARCHAR is excluded for a different
+// reason -- its specialization keys off kMaxString, a sentinel chosen to
+// exceed test data, which selects nothing against real data.
+TEST(FilterGeneratorTest, noRowGroupSkipSpecsForUnsupportedTypes) {
+  auto rowType = ROW(
+      {{"real", REAL()},
+       {"double", DOUBLE()},
+       {"huge", HUGEINT()},
+       {"bool", BOOLEAN()},
+       {"string", VARCHAR()},
+       {"row", ROW({{"nested", BIGINT()}})},
+       {"array", ARRAY(BIGINT())},
+       {"map", MAP(INTEGER(), BIGINT())}});
+  EXPECT_EQ(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// A row-group-skip spec replaces the value filter entirely, so pairing it with
+// a null kind would silently drop the null semantics the category asked for.
+TEST(FilterGeneratorTest, rowGroupSkipNeverPairedWithNullKinds) {
+  auto rowType = ROW({{"int", INTEGER()}, {"big", BIGINT()}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/999);
+  int32_t observed = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      if (spec.isForRowGroupSkip) {
+        ++observed;
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNull);
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNotNull);
+      }
+    }
+  }
+  // Without this the test would pass with zero assertions run if the draw were
+  // ever disabled again -- which is the bug this whole change fixes.
+  EXPECT_GT(observed, 0);
+}

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/common/tests/utils/FilterGenerator.h"
 
+#include <cmath>
+
 #include <algorithm>
 #include <memory>
 #include <typeinfo>
@@ -396,6 +398,40 @@ bool supportsRowGroupSkip(const TypePtr& type) {
       kind == TypeKind::TIMESTAMP;
 }
 
+// Draws a filter selectivity in percent.
+//
+// The previous scheme picked from {1, 10, 20, 30} and {76, 80, ... 100}, which
+// left two gaps that matter for reader coverage: nothing between 31% and 75%,
+// which is exactly where a filter partially overlaps a stripe or a row group
+// and boundary handling is interesting, and a degenerate match-everything
+// filter at 100% roughly one draw in thirteen.
+//
+// Splits the range into three equally weighted regimes instead. The low band is
+// log-uniform because selectivity there spans two orders of magnitude and a
+// uniform draw would almost never produce the very selective filters that
+// exercise skipping; the other two are uniform. Capped below 100 so the filter
+// always excludes something and startPct below always has a non-empty range to
+// draw from.
+float randomSelectPct(folly::Random::DefaultGenerator& rng) {
+  switch (folly::Random::rand32(3, rng)) {
+    case 0: {
+      // Highly selective: log-uniform over [0.5, 10).
+      constexpr double kMin = 0.5;
+      constexpr double kMax = 10.0;
+      const double logMin = std::log(kMin);
+      const double span = std::log(kMax) - logMin;
+      return static_cast<float>(
+          std::exp(logMin + folly::Random::randDouble01(rng) * span));
+    }
+    case 1:
+      // The band the old scheme could not reach at all.
+      return static_cast<float>(10.0 + folly::Random::randDouble01(rng) * 65.0);
+    default:
+      // Permissive, but never all-inclusive.
+      return static_cast<float>(75.0 + folly::Random::randDouble01(rng) * 24.0);
+  }
+}
+
 // Resolves a top level field by name. Returns nullptr for the dotted subfield
 // paths a caller may supply directly, which findChild does not accept.
 TypePtr topLevelFieldType(const RowType& rowType, const std::string& name) {
@@ -433,16 +469,12 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
     specs.emplace_back();
     specs.back().field = name;
     auto category = folly::Random::rand32(rng_) % 13;
-    if (category == 0) {
-      specs.back().selectPct = 1;
-    } else if (category < 4) {
-      specs.back().selectPct = category * 10;
-    } else if (category == 11) {
+    if (category == 11) {
       specs.back().filterKind = FilterKind::kIsNull;
     } else if (category == 12) {
       specs.back().filterKind = FilterKind::kIsNotNull;
     } else {
-      specs.back().selectPct = 60 + category * 4;
+      specs.back().selectPct = randomSelectPct(rng_);
     }
 
     specs.back().startPct = specs.back().selectPct < 100

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -382,6 +382,34 @@ std::vector<std::string> FilterGenerator::makeFilterables(
   return filterables;
 }
 
+namespace {
+
+// Row group skip filters are produced by makeRowGroupSkipRangeFilter, which is
+// only implemented for the kinds below. The generic template builds a
+// BigintRange out of getIntegerValue(), so floating point and HUGEINT would
+// narrow into a filter of the wrong type, and the complex type override fails
+// outright. VARCHAR is excluded on purpose: its specialization returns a filter
+// built from kMaxString, a sentinel picked to exceed *test* data, which selects
+// nothing against real data.
+bool supportsRowGroupSkip(const TypePtr& type) {
+  const auto kind = type->kind();
+  return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
+      kind == TypeKind::TIMESTAMP;
+}
+
+// Resolves a top level field by name. Returns nullptr for the dotted subfield
+// paths a caller may supply directly, which findChild does not accept.
+TypePtr topLevelFieldType(const RowType& rowType, const std::string& name) {
+  if (name.find('.') != std::string::npos) {
+    return nullptr;
+  }
+  auto index = rowType.getChildIdxIfExists(name);
+  return index.has_value() ? rowType.childAt(*index) : nullptr;
+}
+
+} // namespace
+
 std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
     const std::vector<std::string>& filterable,
     int32_t countX100) {
@@ -423,6 +451,18 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
         ? folly::Random::rand32(rng_) %
             static_cast<int32_t>(100 - specs.back().selectPct)
         : 0;
+
+    // Ask for a min/max row group skip filter on a fraction of the specs. This
+    // is an independent draw rather than another `category` so the value filter
+    // distribution above is left alone, and it skips the null kinds because
+    // rowGroupSkipFilter ignores filterKind and would silently replace them.
+    const auto fieldType = topLevelFieldType(*rowType_, name);
+    if (fieldType != nullptr && supportsRowGroupSkip(fieldType) &&
+        specs.back().filterKind != FilterKind::kIsNull &&
+        specs.back().filterKind != FilterKind::kIsNotNull &&
+        folly::Random::rand32(rng_) % 10 == 0) {
+      specs.back().isForRowGroupSkip = true;
+    }
   }
 
   return specs;

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -82,8 +82,6 @@ VectorPtr getChildBySubfield(
   return vector;
 }
 
-uint32_t AbstractColumnStats::counter_ = 0;
-
 template <>
 std::unique_ptr<Filter> ColumnStats<bool>::makeRangeFilter(
     const FilterSpec& filterSpec) {
@@ -218,7 +216,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   StringView lower = valueAtPct(filterSpec.startPct, &lowerIndex);
   StringView upper =
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
-  if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 <= 3) {
+  if (upperIndex - lowerIndex < 1000 && folly::Random::rand32(10, rng_) <= 3) {
     std::vector<std::string> inRange;
     inRange.reserve(upperIndex - lowerIndex);
     for (StringView s : values_) {
@@ -227,7 +225,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
         inRange.push_back(s.getString());
       }
     }
-    if (counter_ % 2 == 0 && filterSpec.selectPct != 100.0) {
+    if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct != 100.0) {
       return std::make_unique<velox::common::NegatedBytesValues>(
           inRange, filterSpec.selectPct < 75);
     }
@@ -236,7 +234,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   }
 
   // sometimes create a negated filter instead
-  if (counter_ % 4 == 1 && filterSpec.selectPct < 100.0) {
+  if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
     return std::make_unique<velox::common::NegatedBytesRange>(
         std::string(lower),
         false,
@@ -517,46 +515,46 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
     std::unique_ptr<AbstractColumnStats> stats;
     switch (vector->typeKind()) {
       case TypeKind::BOOLEAN:
-        stats = makeStats<TypeKind::BOOLEAN>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::BOOLEAN>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::TINYINT:
-        stats = makeStats<TypeKind::TINYINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::TINYINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::SMALLINT:
-        stats = makeStats<TypeKind::SMALLINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::SMALLINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::INTEGER:
-        stats = makeStats<TypeKind::INTEGER>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::INTEGER>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::BIGINT:
-        stats = makeStats<TypeKind::BIGINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::BIGINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::HUGEINT:
-        stats = makeStats<TypeKind::HUGEINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::HUGEINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::VARCHAR:
-        stats = makeStats<TypeKind::VARCHAR>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::VARCHAR>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::VARBINARY:
-        stats = makeStats<TypeKind::VARBINARY>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::VARBINARY>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::REAL:
-        stats = makeStats<TypeKind::REAL>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::REAL>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::DOUBLE:
-        stats = makeStats<TypeKind::DOUBLE>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::DOUBLE>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::TIMESTAMP:
-        stats = makeStats<TypeKind::TIMESTAMP>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::TIMESTAMP>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::ROW:
-        stats = makeStats<TypeKind::ROW>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::ROW>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::ARRAY:
-        stats = makeStats<TypeKind::ARRAY>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::ARRAY>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::MAP:
-        stats = makeStats<TypeKind::MAP>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::MAP>(vector->type(), rowType_, rng_);
         break;
       default:
         VELOX_CHECK(

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -114,7 +114,7 @@ std::unique_ptr<Filter> ColumnStats<float>::makeRangeFilter(
       upper,
       upperUnbounded,
       false,
-      filterSpec.selectPct > 25);
+      drawNullAllowed(filterSpec));
 }
 
 template <>
@@ -153,7 +153,7 @@ std::unique_ptr<Filter> ColumnStats<double>::makeRangeFilter(
       upper,
       upperUnbounded,
       false,
-      filterSpec.selectPct > 25);
+      drawNullAllowed(filterSpec));
 }
 
 template <>
@@ -216,6 +216,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   StringView lower = valueAtPct(filterSpec.startPct, &lowerIndex);
   StringView upper =
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
+  const bool nullAllowed = drawNullAllowed(filterSpec);
   if (upperIndex - lowerIndex < 1000 && folly::Random::rand32(10, rng_) <= 3) {
     std::vector<std::string> inRange;
     inRange.reserve(upperIndex - lowerIndex);
@@ -227,10 +228,9 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
     }
     if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct != 100.0) {
       return std::make_unique<velox::common::NegatedBytesValues>(
-          inRange, filterSpec.selectPct < 75);
+          inRange, nullAllowed);
     }
-    return std::make_unique<velox::common::BytesValues>(
-        inRange, filterSpec.selectPct > 25);
+    return std::make_unique<velox::common::BytesValues>(inRange, nullAllowed);
   }
 
   // sometimes create a negated filter instead
@@ -242,7 +242,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
         std::string(upper),
         false,
         false,
-        filterSpec.selectPct < 75);
+        nullAllowed);
   }
 
   return std::make_unique<velox::common::BytesRange>(
@@ -252,7 +252,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
       std::string(upper),
       false,
       false,
-      filterSpec.selectPct > 25);
+      nullAllowed);
 }
 
 template <>
@@ -268,7 +268,7 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRangeFilter(
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
 
   return std::make_unique<velox::common::TimestampRange>(
-      lower, upper, filterSpec.selectPct > 25);
+      lower, upper, drawNullAllowed(filterSpec));
 }
 
 template <>

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -41,7 +41,7 @@ struct FilterSpec {
       float startPct = 50,
       float selectPct = 20,
       FilterKind filterKind = FilterKind::kBigintRange,
-      bool isForRowGroupSkip = true,
+      bool isForRowGroupSkip = false,
       bool allowNulls = true)
       : field(field),
         startPct(startPct),

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -115,6 +115,15 @@ class AbstractColumnStats {
   }
 
  protected:
+  // Whether the generated filter should pass nulls. `allowNulls_` on the spec
+  // is a hard constraint from the caller; when it permits nulls the answer is
+  // drawn independently rather than derived from selectPct, which used to tie
+  // the two together and make "selective filter that also passes nulls"
+  // unreachable.
+  bool drawNullAllowed(const FilterSpec& filterSpec) {
+    return filterSpec.allowNulls_ && folly::Random::oneIn(2, rng_);
+  }
+
   const TypePtr type_;
   const RowTypePtr rootType_;
   int32_t numDistinct_ = 0;
@@ -307,6 +316,7 @@ class ColumnStats : public AbstractColumnStats {
       return std::make_unique<velox::common::BigintRange>(
           getIntegerValue(lower), getIntegerValue(upper), false);
     }
+    const bool nullAllowed = drawNullAllowed(filterSpec);
     if (upperIndex - lowerIndex < 1000 &&
         folly::Random::rand32(10, rng_) <= 3) {
       std::vector<int64_t> in;
@@ -315,21 +325,17 @@ class ColumnStats : public AbstractColumnStats {
       }
       // make sure we don't accidentally generate an AlwaysFalse filter
       if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct < 100.0) {
-        return velox::common::createNegatedBigintValues(in, true);
+        return velox::common::createNegatedBigintValues(in, nullAllowed);
       }
-      return velox::common::createBigintValues(in, true);
+      return velox::common::createBigintValues(in, nullAllowed);
     }
     // sometimes make a negated filter instead (1/4 chance)
     if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
       return std::make_unique<velox::common::NegatedBigintRange>(
-          getIntegerValue(lower),
-          getIntegerValue(upper),
-          filterSpec.selectPct < 75);
+          getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
     }
     return std::make_unique<velox::common::BigintRange>(
-        getIntegerValue(lower),
-        getIntegerValue(upper),
-        filterSpec.selectPct > 25);
+        getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
   }
 
   std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -89,8 +89,11 @@ class AbstractColumnStats {
   // ASCII string greater than test data values. Used for row group skipping
   // tests.
   static constexpr const char* kMaxString = "~~~~~";
-  AbstractColumnStats(TypePtr type, RowTypePtr rootType)
-      : type_(type), rootType_(rootType) {}
+  AbstractColumnStats(
+      TypePtr type,
+      RowTypePtr rootType,
+      folly::Random::DefaultGenerator& rng)
+      : type_(type), rootType_(rootType), rng_(rng) {}
 
   virtual ~AbstractColumnStats() = default;
 
@@ -118,14 +121,21 @@ class AbstractColumnStats {
   int32_t numNulls_ = 0;
   int32_t numSamples_ = 0;
   std::unordered_map<size_t, int> uniques_;
-  static uint32_t counter_;
+  // Borrowed from the owning FilterGenerator so that filter kind selection is
+  // driven by the run's seed. This used to be a process-global counter, which
+  // made the choice depend on how many columns happened to be processed
+  // earlier and left it outside the seed's control entirely.
+  folly::Random::DefaultGenerator& rng_;
 };
 
 template <typename T>
 class ColumnStats : public AbstractColumnStats {
  public:
-  explicit ColumnStats(TypePtr type, RowTypePtr rootTypePtr)
-      : AbstractColumnStats(type, rootTypePtr) {}
+  ColumnStats(
+      TypePtr type,
+      RowTypePtr rootTypePtr,
+      folly::Random::DefaultGenerator& rng)
+      : AbstractColumnStats(type, rootTypePtr, rng) {}
 
   void sample(
       const std::vector<RowVectorPtr>& batches,
@@ -297,19 +307,20 @@ class ColumnStats : public AbstractColumnStats {
       return std::make_unique<velox::common::BigintRange>(
           getIntegerValue(lower), getIntegerValue(upper), false);
     }
-    if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 <= 3) {
+    if (upperIndex - lowerIndex < 1000 &&
+        folly::Random::rand32(10, rng_) <= 3) {
       std::vector<int64_t> in;
       for (auto i = lowerIndex; i <= upperIndex; ++i) {
         in.push_back(getIntegerValue(values_[i]));
       }
       // make sure we don't accidentally generate an AlwaysFalse filter
-      if (counter_ % 2 == 1 && filterSpec.selectPct < 100.0) {
+      if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct < 100.0) {
         return velox::common::createNegatedBigintValues(in, true);
       }
       return velox::common::createBigintValues(in, true);
     }
     // sometimes make a negated filter instead (1/4 chance)
-    if (counter_ % 4 == 1 && filterSpec.selectPct < 100.0) {
+    if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
       return std::make_unique<velox::common::NegatedBigintRange>(
           getIntegerValue(lower),
           getIntegerValue(upper),
@@ -362,8 +373,11 @@ class ColumnStats : public AbstractColumnStats {
 
 class ComplexColumnStats : public AbstractColumnStats {
  public:
-  explicit ComplexColumnStats(TypePtr type, RowTypePtr rootTypePtr)
-      : AbstractColumnStats(type, rootTypePtr) {}
+  ComplexColumnStats(
+      TypePtr type,
+      RowTypePtr rootTypePtr,
+      folly::Random::DefaultGenerator& rng)
+      : AbstractColumnStats(type, rootTypePtr, rng) {}
 
   void sample(
       const std::vector<RowVectorPtr>& batches,
@@ -488,30 +502,34 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRowGroupSkipRangeFilter(
 template <TypeKind Kind>
 std::unique_ptr<AbstractColumnStats> makeStats(
     TypePtr type,
-    RowTypePtr rootType) {
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
   using T = typename TypeTraits<Kind>::NativeType;
-  return std::make_unique<ColumnStats<T>>(type, rootType);
+  return std::make_unique<ColumnStats<T>>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ROW>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ARRAY>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::MAP>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 class FilterGenerator {


### PR DESCRIPTION
Summary:
`makeRandomSpecs` drew selectivity from thirteen fixed categories: 1%, then
10/20/30%, then 60 + category * 4 for the rest, giving {76, 80, 84, 88, 92, 96,
100}. Two gaps followed from that.

Nothing ever landed between 31% and 75%. That band is where a filter partially
overlaps a stripe or a row group, so it is where boundary handling in the
readers is most interesting, and it was unreachable -- 45 points of the range,
never sampled.

And category 10 produced `selectPct = 100`, a filter that excludes nothing,
roughly one draw in thirteen. It also forced `startPct` to 0, since the
expression below it divides by `100 - selectPct`.

Replaces the buckets with `randomSelectPct`, three equally weighted regimes
spanning the range:

- highly selective, log-uniform over [0.5, 10) -- log rather than uniform
  because that band spans two orders of magnitude and a uniform draw would
  almost never produce the very selective filters that exercise skipping;
- [10, 75), the band the old scheme could not reach;
- [75, 99), permissive but never all-inclusive.

The two null categories keep their weight, 2 in 13, so the null/value split is
unchanged.

Capping below 100 means every generated filter excludes something, and
`startPct` always has a non-empty range to draw from.

This is a prerequisite for spreading filters across more columns. Selectivity
multiplies as `makeSubfieldFilters` narrows `hitRows` column by column, so a
wider filter set needs per-column selectivity well above the old buckets to
avoid converging on zero surviving rows and a vacuous comparison.

Reviewed By: raymondlin1

Differential Revision: D116018235


