### PR TITLE
feat(fuzzer): Add an opt-in empty result shape to FilterGenerator

### DIFF
--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -185,3 +185,42 @@ TEST_F(FilterGeneratorSeedTest, differentSeedsProduceDifferentFilters) {
   // seed actually drives the outcome.
   EXPECT_GT(descriptions.size(), 1);
 }
+
+// The old selectivity scheme drew from {1, 10, 20, 30} and {76, 80, ... 100}.
+// Nothing landed between 31% and 75%, and 100% -- a filter that excludes
+// nothing -- came up roughly one draw in thirteen.
+TEST(FilterGeneratorTest, selectivityCoversTheMidBandAndNeverReachesAll) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/4242);
+
+  int32_t low = 0;
+  int32_t mid = 0;
+  int32_t high = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      if (spec.filterKind == common::FilterKind::kIsNull ||
+          spec.filterKind == common::FilterKind::kIsNotNull) {
+        continue;
+      }
+      EXPECT_GT(spec.selectPct, 0);
+      EXPECT_LT(spec.selectPct, 100);
+      // startPct must leave room for the range it introduces.
+      EXPECT_GE(spec.startPct, 0);
+      EXPECT_LT(spec.startPct, 100 - spec.selectPct);
+
+      if (spec.selectPct < 10) {
+        ++low;
+      } else if (spec.selectPct < 75) {
+        ++mid;
+      } else {
+        ++high;
+      }
+    }
+  }
+
+  EXPECT_GT(low, 0);
+  EXPECT_GT(mid, 0);
+  EXPECT_GT(high, 0);
+}

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 
@@ -104,4 +106,82 @@ TEST(FilterGeneratorTest, rowGroupSkipNeverPairedWithNullKinds) {
   // Without this the test would pass with zero assertions run if the draw were
   // ever disabled again -- which is the bug this whole change fixes.
   EXPECT_GT(observed, 0);
+}
+
+namespace {
+
+class FilterGeneratorSeedTest : public testing::Test,
+                                public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::vector<RowVectorPtr> makeBatches(const RowTypePtr& rowType) {
+    std::vector<RowVectorPtr> batches;
+    for (int32_t batch = 0; batch < 2; ++batch) {
+      batches.push_back(makeRowVector(
+          rowType->names(),
+          {makeFlatVector<int64_t>(
+               kBatchRows, [&](auto row) { return row + batch * kBatchRows; }),
+           makeFlatVector<int32_t>(
+               kBatchRows, [&](auto row) { return (row * 7) % 101; })}));
+    }
+    return batches;
+  }
+
+  // Renders the generated filters into a stable string so two runs can be
+  // compared without depending on filter identity.
+  std::string generateFilterDescription(
+      const RowTypePtr& rowType,
+      uint32_t seed) {
+    auto type = rowType;
+    FilterGenerator generator(type, seed);
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    auto specs = generator.makeRandomSpecs(filterable, 0);
+    auto batches = makeBatches(rowType);
+    std::vector<uint64_t> hitRows;
+    auto filters =
+        generator.makeSubfieldFilters(specs, batches, nullptr, hitRows);
+
+    std::vector<std::string> rendered;
+    for (const auto& [subfield, filter] : filters) {
+      rendered.push_back(
+          fmt::format("{}:{}", subfield.toString(), filter->toString()));
+    }
+    std::sort(rendered.begin(), rendered.end());
+    return folly::join(",", rendered);
+  }
+
+  static constexpr vector_size_t kBatchRows = 500;
+};
+
+} // namespace
+
+// Filter kind selection used to be driven by a process-global counter on
+// AbstractColumnStats rather than by the seed, so an unrelated generator run
+// earlier in the same process shifted the choice. A validation service whose
+// whole premise is "replay this failing seed" cannot afford that.
+TEST_F(FilterGeneratorSeedTest, filterKindIsIndependentOfEarlierGenerators) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  const auto before = generateFilterDescription(rowType, /*seed=*/7);
+
+  // Run unrelated generators in between; with a shared global counter these
+  // perturb the next run's filter kinds.
+  for (uint32_t otherSeed = 100; otherSeed < 105; ++otherSeed) {
+    generateFilterDescription(rowType, otherSeed);
+  }
+
+  EXPECT_EQ(before, generateFilterDescription(rowType, /*seed=*/7));
+}
+
+TEST_F(FilterGeneratorSeedTest, differentSeedsProduceDifferentFilters) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  std::set<std::string> descriptions;
+  for (uint32_t seed = 1; seed <= 20; ++seed) {
+    descriptions.insert(generateFilterDescription(rowType, seed));
+  }
+  // Not asserting all 20 differ -- collisions are legitimate -- only that the
+  // seed actually drives the outcome.
+  EXPECT_GT(descriptions.size(), 1);
 }

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/tests/utils/FilterGenerator.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+
+namespace {
+
+// Enough draws that a 1-in-10 branch is overwhelmingly likely to be taken at
+// least once, without making the test slow.
+constexpr int32_t kDraws = 200;
+
+int32_t countRowGroupSkipSpecs(const RowTypePtr& rowType) {
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/12345);
+  int32_t count = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      count += spec.isForRowGroupSkip ? 1 : 0;
+    }
+  }
+  return count;
+}
+
+} // namespace
+
+// The two FilterSpec constructors used to disagree on isForRowGroupSkip -- the
+// explicit one defaulted it true, the in-class initializer false -- and
+// makeRandomSpecs builds specs with the default constructor. Pins them
+// together, since a divergence silently disables or enables the whole
+// row-group-skip path.
+TEST(FilterGeneratorTest, filterSpecDefaultsAgree) {
+  FilterSpec defaultConstructed;
+  FilterSpec explicitlyConstructed("field");
+  EXPECT_EQ(
+      defaultConstructed.isForRowGroupSkip,
+      explicitlyConstructed.isForRowGroupSkip);
+  EXPECT_FALSE(defaultConstructed.isForRowGroupSkip);
+}
+
+TEST(FilterGeneratorTest, rowGroupSkipSpecsForSupportedTypes) {
+  auto rowType = ROW(
+      {{"tiny", TINYINT()},
+       {"small", SMALLINT()},
+       {"int", INTEGER()},
+       {"big", BIGINT()}});
+  EXPECT_GT(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// makeRowGroupSkipRangeFilter has no specialization for these kinds: the
+// generic template funnels the max through getIntegerValue(), which would
+// narrow a double or an int128 into a BigintRange of the wrong type, and
+// ComplexColumnStats fails outright. VARCHAR is excluded for a different
+// reason -- its specialization keys off kMaxString, a sentinel chosen to
+// exceed test data, which selects nothing against real data.
+TEST(FilterGeneratorTest, noRowGroupSkipSpecsForUnsupportedTypes) {
+  auto rowType = ROW(
+      {{"real", REAL()},
+       {"double", DOUBLE()},
+       {"huge", HUGEINT()},
+       {"bool", BOOLEAN()},
+       {"string", VARCHAR()},
+       {"row", ROW({{"nested", BIGINT()}})},
+       {"array", ARRAY(BIGINT())},
+       {"map", MAP(INTEGER(), BIGINT())}});
+  EXPECT_EQ(countRowGroupSkipSpecs(rowType), 0);
+}
+
+// A row-group-skip spec replaces the value filter entirely, so pairing it with
+// a null kind would silently drop the null semantics the category asked for.
+TEST(FilterGeneratorTest, rowGroupSkipNeverPairedWithNullKinds) {
+  auto rowType = ROW({{"int", INTEGER()}, {"big", BIGINT()}});
+  auto type = rowType;
+  FilterGenerator generator(type, /*seed=*/999);
+  int32_t observed = 0;
+  for (int32_t i = 0; i < kDraws; ++i) {
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    for (const auto& spec : generator.makeRandomSpecs(filterable, 0)) {
+      if (spec.isForRowGroupSkip) {
+        ++observed;
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNull);
+        EXPECT_NE(spec.filterKind, common::FilterKind::kIsNotNull);
+      }
+    }
+  }
+  // Without this the test would pass with zero assertions run if the draw were
+  // ever disabled again -- which is the bug this whole change fixes.
+  EXPECT_GT(observed, 0);
+}

--- a/velox/dwio/common/tests/FilterGeneratorTest.cpp
+++ b/velox/dwio/common/tests/FilterGeneratorTest.cpp
@@ -153,8 +153,40 @@ class FilterGeneratorSeedTest : public testing::Test,
     return folly::join(",", rendered);
   }
 
+  // Everything one generation produces: the specs, the filters built from
+  // them, and the reference rows left over once every filter has been applied.
+  struct Generated {
+    std::vector<FilterSpec> specs;
+    SubfieldFilters filters;
+    std::vector<uint64_t> hitRows;
+  };
+
+  Generated generate(
+      const RowTypePtr& rowType,
+      const std::vector<RowVectorPtr>& batches,
+      uint32_t seed,
+      double emptyResultProbability) {
+    auto type = rowType;
+    FilterGenerator generator(type, seed);
+    generator.setEmptyResultProbability(emptyResultProbability);
+    auto filterable = generator.makeFilterables(rowType->size(), 100);
+    Generated result;
+    result.specs = generator.makeRandomSpecs(filterable, 0);
+    result.filters = generator.makeSubfieldFilters(
+        result.specs, batches, nullptr, result.hitRows);
+    return result;
+  }
+
   static constexpr vector_size_t kBatchRows = 500;
 };
+
+int32_t countEmptyResultSpecs(const std::vector<FilterSpec>& specs) {
+  int32_t count = 0;
+  for (const auto& spec : specs) {
+    count += spec.isForEmptyResult ? 1 : 0;
+  }
+  return count;
+}
 
 } // namespace
 
@@ -223,4 +255,108 @@ TEST(FilterGeneratorTest, selectivityCoversTheMidBandAndNeverReachesAll) {
   EXPECT_GT(low, 0);
   EXPECT_GT(mid, 0);
   EXPECT_GT(high, 0);
+}
+
+// An empty result makes every other filter in the set vacuous, so it has to
+// stay off unless a caller asks for it. Also pins that the default draws no
+// random number for it: were it to draw, every existing consumer's filter
+// sequence would shift.
+TEST_F(FilterGeneratorSeedTest, emptyResultIsOptIn) {
+  auto rowType = ROW({{"big", BIGINT()}, {"int", INTEGER()}});
+  auto batches = makeBatches(rowType);
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto defaulted = generate(rowType, batches, seed, 0.0);
+    EXPECT_EQ(countEmptyResultSpecs(defaulted.specs), 0);
+
+    // Explicitly asking for zero has to be indistinguishable from the default,
+    // which it can only be if neither consumed randomness.
+    const auto explicitlyZero = generate(rowType, batches, seed, 0.0);
+    ASSERT_EQ(defaulted.specs.size(), explicitlyZero.specs.size());
+    for (size_t i = 0; i < defaulted.specs.size(); ++i) {
+      EXPECT_EQ(
+          defaulted.specs[i].toString(), explicitlyZero.specs[i].toString());
+    }
+  }
+}
+
+TEST_F(FilterGeneratorSeedTest, emptyResultLeavesNoRows) {
+  // Both columns BIGINT so the test can hand the filter the column's own
+  // min/max regardless of which one the generator picked last.
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  constexpr int64_t kMaxValue = kBatchRows - 1;
+  std::vector<RowVectorPtr> batches{makeRowVector(
+      rowType->names(),
+      {makeFlatVector<int64_t>(kBatchRows, [](auto row) { return row; }),
+       makeFlatVector<int64_t>(
+           kBatchRows, [](auto row) { return kMaxValue - row; })})};
+
+  int32_t emptyResults = 0;
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 1.0);
+    ASSERT_LE(countEmptyResultSpecs(generated.specs), 1);
+    if (countEmptyResultSpecs(generated.specs) == 0) {
+      continue;
+    }
+    ++emptyResults;
+    // Only the last spec may be the empty one; an earlier one would leave the
+    // columns after it filtering an already empty row set.
+    EXPECT_TRUE(generated.specs.back().isForEmptyResult);
+    EXPECT_TRUE(generated.hitRows.empty());
+
+    // Zero surviving rows on its own is not the point -- two ordinary selective
+    // filters intersect to nothing often enough by chance. The filter also has
+    // to sit past the column maximum, so that a reader consulting min/max stats
+    // can skip every row group instead of descending and rejecting row by row.
+    const auto it =
+        generated.filters.find(Subfield(generated.specs.back().field));
+    ASSERT_NE(it, generated.filters.end());
+    EXPECT_FALSE(it->second->testInt64Range(0, kMaxValue, /*hasNull=*/false));
+  }
+  EXPECT_GT(emptyResults, 0);
+}
+
+TEST_F(FilterGeneratorSeedTest, emptyResultLeavesNoRowsForVarchar) {
+  auto rowType = ROW({{"str", VARCHAR()}});
+  std::vector<std::string> data;
+  data.reserve(kBatchRows);
+  for (int32_t i = 0; i < kBatchRows; ++i) {
+    data.push_back(fmt::format("value_{}", i));
+  }
+  std::vector<RowVectorPtr> batches{
+      makeRowVector(rowType->names(), {makeFlatVector(data)})};
+
+  int32_t emptyResults = 0;
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 1.0);
+    if (countEmptyResultSpecs(generated.specs) == 0) {
+      continue;
+    }
+    ++emptyResults;
+    EXPECT_TRUE(generated.hitRows.empty());
+  }
+  EXPECT_GT(emptyResults, 0);
+}
+
+// These kinds have no exact "one past the maximum": getIntegerValue truncates
+// floating point and narrows int128, and there is no bool above true. Picking
+// one anyway would produce a filter that quietly matches real rows, which is
+// worse than not generating the shape at all.
+TEST_F(FilterGeneratorSeedTest, noEmptyResultForUnsupportedTypes) {
+  auto rowType = ROW(
+      {{"real", REAL()},
+       {"double", DOUBLE()},
+       {"huge", HUGEINT()},
+       {"bool", BOOLEAN()}});
+  std::vector<RowVectorPtr> batches{makeRowVector(
+      rowType->names(),
+      {makeFlatVector<float>(kBatchRows, [](auto row) { return row * 0.5f; }),
+       makeFlatVector<double>(kBatchRows, [](auto row) { return row * 1.5; }),
+       makeFlatVector<int128_t>(kBatchRows, [](auto row) { return row; }),
+       makeFlatVector<bool>(
+           kBatchRows, [](auto row) { return row % 2 == 0; })})};
+
+  for (uint32_t seed = 1; seed <= 50; ++seed) {
+    const auto generated = generate(rowType, batches, seed, 1.0);
+    EXPECT_EQ(countEmptyResultSpecs(generated.specs), 0);
+  }
 }

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -287,26 +287,32 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRowGroupSkipRangeFilter(
     const std::vector<RowVectorPtr>& batches,
     const Subfield& subfield) {
   Timestamp max;
-  bool hasMax = false;
-  for (const auto& batch : batches) {
-    auto values = getChildBySubfield(batch.get(), subfield, rootType_)
-                      ->as<SimpleVector<Timestamp>>();
-    DWIO_ENSURE_NOT_NULL(
-        values,
-        "Failed to convert to SimpleVector<Timestamp> for batch of kind ",
-        batch->type()->kindName());
-    for (auto i = 0; i < values->size(); ++i) {
-      if (values->isNullAt(i)) {
-        continue;
-      }
-      if (hasMax && max < values->valueAt(i)) {
-        max = values->valueAt(i);
-      } else if (!hasMax) {
-        max = values->valueAt(i);
-        hasMax = true;
-      }
-    }
+  columnMax(batches, subfield, max);
+  return std::make_unique<velox::common::TimestampRange>(max, max, false);
+}
+
+// The string counterpart of one past the maximum. kMaxString is chosen to
+// exceed the test data, which makes this identical to the row group skip
+// specialization above -- there the filter selecting nothing is the reason
+// VARCHAR is left out of supportsRowGroupSkip, here it is what is wanted.
+template <>
+std::unique_ptr<Filter> ColumnStats<StringView>::makeEmptyResultRangeFilter(
+    const std::vector<RowVectorPtr>& /*batches*/,
+    const Subfield& /*subfield*/) {
+  static std::string max = kMaxString;
+  return std::make_unique<velox::common::BytesRange>(
+      max, false, false, max, false, false, false);
+}
+
+template <>
+std::unique_ptr<Filter> ColumnStats<Timestamp>::makeEmptyResultRangeFilter(
+    const std::vector<RowVectorPtr>& batches,
+    const Subfield& subfield) {
+  Timestamp max;
+  if (!columnMax(batches, subfield, max) || max == Timestamp::max()) {
+    return nullptr;
   }
+  ++max;
   return std::make_unique<velox::common::TimestampRange>(max, max, false);
 }
 
@@ -396,6 +402,20 @@ bool supportsRowGroupSkip(const TypePtr& type) {
   return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
       kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
       kind == TypeKind::TIMESTAMP;
+}
+
+// An empty result filter is built one step past the column maximum, so the
+// kinds are those where "one step past" is exact and expressible: the integral
+// kinds, where getIntegerValue is lossless and the bound is max + 1, plus the
+// two with a specialization of their own. Floating point is excluded because
+// getIntegerValue truncates, and HUGEINT because the bound would not survive
+// the narrowing to int64_t; in both cases the filter could silently overlap a
+// real value. BOOLEAN is excluded because there is no value above true.
+bool supportsEmptyResult(const TypePtr& type) {
+  const auto kind = type->kind();
+  return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
+      kind == TypeKind::VARCHAR || kind == TypeKind::TIMESTAMP;
 }
 
 // Draws a filter selectivity in percent.
@@ -492,6 +512,23 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
         specs.back().filterKind != FilterKind::kIsNotNull &&
         folly::Random::rand32(rng_) % 10 == 0) {
       specs.back().isForRowGroupSkip = true;
+    }
+  }
+
+  // Optionally turn the last spec into one that matches nothing. The last one
+  // and no other: makeSubfieldFilters narrows the reference rows in place as it
+  // walks the specs, so an empty result anywhere earlier would leave every
+  // later column sampling an empty row set and degenerating into an IsNull
+  // filter. Guarded on the probability first so that the default draws nothing
+  // and leaves the sequence above untouched.
+  if (emptyResultProbability_ > 0.0 && !specs.empty() &&
+      folly::Random::randDouble01(rng_) < emptyResultProbability_) {
+    auto& last = specs.back();
+    const auto fieldType = topLevelFieldType(*rowType_, last.field);
+    if (fieldType != nullptr && supportsEmptyResult(fieldType) &&
+        !last.isForRowGroupSkip && last.filterKind != FilterKind::kIsNull &&
+        last.filterKind != FilterKind::kIsNotNull) {
+      last.isForEmptyResult = true;
     }
   }
 
@@ -598,6 +635,8 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
     std::unique_ptr<Filter> filter;
     if (filterSpec.isForRowGroupSkip) {
       filter = stats->rowGroupSkipFilter(batches, subfield, hitRows);
+    } else if (filterSpec.isForEmptyResult) {
+      filter = stats->emptyResultFilter(batches, subfield, hitRows);
     } else {
       filter = stats->filter(batches, filterSpec, hitRows);
     }

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/common/tests/utils/FilterGenerator.h"
 
+#include <cmath>
+
 #include <algorithm>
 #include <memory>
 #include <typeinfo>
@@ -396,6 +398,40 @@ bool supportsRowGroupSkip(const TypePtr& type) {
       kind == TypeKind::TIMESTAMP;
 }
 
+// Draws a filter selectivity in percent.
+//
+// The previous scheme picked from {1, 10, 20, 30} and {76, 80, ... 100}, which
+// left two gaps that matter for reader coverage: nothing between 31% and 75%,
+// which is exactly where a filter partially overlaps a stripe or a row group
+// and boundary handling is interesting, and a degenerate match-everything
+// filter at 100% roughly one draw in thirteen.
+//
+// Splits the range into three equally weighted regimes instead. The low band is
+// log-uniform because selectivity there spans two orders of magnitude and a
+// uniform draw would almost never produce the very selective filters that
+// exercise skipping; the other two are uniform. Capped below 100 so the filter
+// always excludes something and startPct below always has a non-empty range to
+// draw from.
+float randomSelectPct(folly::Random::DefaultGenerator& rng) {
+  switch (folly::Random::rand32(3, rng)) {
+    case 0: {
+      // Highly selective: log-uniform over [0.5, 10).
+      constexpr double kMin = 0.5;
+      constexpr double kMax = 10.0;
+      const double logMin = std::log(kMin);
+      const double span = std::log(kMax) - logMin;
+      return static_cast<float>(
+          std::exp(logMin + folly::Random::randDouble01(rng) * span));
+    }
+    case 1:
+      // The band the old scheme could not reach at all.
+      return static_cast<float>(10.0 + folly::Random::randDouble01(rng) * 65.0);
+    default:
+      // Permissive, but never all-inclusive.
+      return static_cast<float>(75.0 + folly::Random::randDouble01(rng) * 24.0);
+  }
+}
+
 // Resolves a top level field by name. Returns nullptr for the dotted subfield
 // paths a caller may supply directly, which findChild does not accept.
 TypePtr topLevelFieldType(const RowType& rowType, const std::string& name) {
@@ -433,16 +469,12 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
     specs.emplace_back();
     specs.back().field = name;
     auto category = folly::Random::rand32(rng_) % 13;
-    if (category == 0) {
-      specs.back().selectPct = 1;
-    } else if (category < 4) {
-      specs.back().selectPct = category * 10;
-    } else if (category == 11) {
+    if (category == 11) {
       specs.back().filterKind = FilterKind::kIsNull;
     } else if (category == 12) {
       specs.back().filterKind = FilterKind::kIsNotNull;
     } else {
-      specs.back().selectPct = 60 + category * 4;
+      specs.back().selectPct = randomSelectPct(rng_);
     }
 
     specs.back().startPct = specs.back().selectPct < 100

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -382,6 +382,34 @@ std::vector<std::string> FilterGenerator::makeFilterables(
   return filterables;
 }
 
+namespace {
+
+// Row group skip filters are produced by makeRowGroupSkipRangeFilter, which is
+// only implemented for the kinds below. The generic template builds a
+// BigintRange out of getIntegerValue(), so floating point and HUGEINT would
+// narrow into a filter of the wrong type, and the complex type override fails
+// outright. VARCHAR is excluded on purpose: its specialization returns a filter
+// built from kMaxString, a sentinel picked to exceed *test* data, which selects
+// nothing against real data.
+bool supportsRowGroupSkip(const TypePtr& type) {
+  const auto kind = type->kind();
+  return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
+      kind == TypeKind::TIMESTAMP;
+}
+
+// Resolves a top level field by name. Returns nullptr for the dotted subfield
+// paths a caller may supply directly, which findChild does not accept.
+TypePtr topLevelFieldType(const RowType& rowType, const std::string& name) {
+  if (name.find('.') != std::string::npos) {
+    return nullptr;
+  }
+  auto index = rowType.getChildIdxIfExists(name);
+  return index.has_value() ? rowType.childAt(*index) : nullptr;
+}
+
+} // namespace
+
 std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
     const std::vector<std::string>& filterable,
     int32_t countX100) {
@@ -423,6 +451,18 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
         ? folly::Random::rand32(rng_) %
             static_cast<int32_t>(100 - specs.back().selectPct)
         : 0;
+
+    // Ask for a min/max row group skip filter on a fraction of the specs. This
+    // is an independent draw rather than another `category` so the value filter
+    // distribution above is left alone, and it skips the null kinds because
+    // rowGroupSkipFilter ignores filterKind and would silently replace them.
+    const auto fieldType = topLevelFieldType(*rowType_, name);
+    if (fieldType != nullptr && supportsRowGroupSkip(fieldType) &&
+        specs.back().filterKind != FilterKind::kIsNull &&
+        specs.back().filterKind != FilterKind::kIsNotNull &&
+        folly::Random::rand32(rng_) % 10 == 0) {
+      specs.back().isForRowGroupSkip = true;
+    }
   }
 
   return specs;

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -82,8 +82,6 @@ VectorPtr getChildBySubfield(
   return vector;
 }
 
-uint32_t AbstractColumnStats::counter_ = 0;
-
 template <>
 std::unique_ptr<Filter> ColumnStats<bool>::makeRangeFilter(
     const FilterSpec& filterSpec) {
@@ -218,7 +216,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   StringView lower = valueAtPct(filterSpec.startPct, &lowerIndex);
   StringView upper =
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
-  if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 <= 3) {
+  if (upperIndex - lowerIndex < 1000 && folly::Random::rand32(10, rng_) <= 3) {
     std::vector<std::string> inRange;
     inRange.reserve(upperIndex - lowerIndex);
     for (StringView s : values_) {
@@ -227,7 +225,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
         inRange.push_back(s.getString());
       }
     }
-    if (counter_ % 2 == 0 && filterSpec.selectPct != 100.0) {
+    if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct != 100.0) {
       return std::make_unique<velox::common::NegatedBytesValues>(
           inRange, filterSpec.selectPct < 75);
     }
@@ -236,7 +234,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   }
 
   // sometimes create a negated filter instead
-  if (counter_ % 4 == 1 && filterSpec.selectPct < 100.0) {
+  if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
     return std::make_unique<velox::common::NegatedBytesRange>(
         std::string(lower),
         false,
@@ -517,46 +515,46 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
     std::unique_ptr<AbstractColumnStats> stats;
     switch (vector->typeKind()) {
       case TypeKind::BOOLEAN:
-        stats = makeStats<TypeKind::BOOLEAN>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::BOOLEAN>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::TINYINT:
-        stats = makeStats<TypeKind::TINYINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::TINYINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::SMALLINT:
-        stats = makeStats<TypeKind::SMALLINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::SMALLINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::INTEGER:
-        stats = makeStats<TypeKind::INTEGER>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::INTEGER>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::BIGINT:
-        stats = makeStats<TypeKind::BIGINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::BIGINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::HUGEINT:
-        stats = makeStats<TypeKind::HUGEINT>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::HUGEINT>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::VARCHAR:
-        stats = makeStats<TypeKind::VARCHAR>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::VARCHAR>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::VARBINARY:
-        stats = makeStats<TypeKind::VARBINARY>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::VARBINARY>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::REAL:
-        stats = makeStats<TypeKind::REAL>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::REAL>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::DOUBLE:
-        stats = makeStats<TypeKind::DOUBLE>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::DOUBLE>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::TIMESTAMP:
-        stats = makeStats<TypeKind::TIMESTAMP>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::TIMESTAMP>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::ROW:
-        stats = makeStats<TypeKind::ROW>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::ROW>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::ARRAY:
-        stats = makeStats<TypeKind::ARRAY>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::ARRAY>(vector->type(), rowType_, rng_);
         break;
       case TypeKind::MAP:
-        stats = makeStats<TypeKind::MAP>(vector->type(), rowType_);
+        stats = makeStats<TypeKind::MAP>(vector->type(), rowType_, rng_);
         break;
       default:
         VELOX_CHECK(

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -114,7 +114,7 @@ std::unique_ptr<Filter> ColumnStats<float>::makeRangeFilter(
       upper,
       upperUnbounded,
       false,
-      filterSpec.selectPct > 25);
+      drawNullAllowed(filterSpec));
 }
 
 template <>
@@ -153,7 +153,7 @@ std::unique_ptr<Filter> ColumnStats<double>::makeRangeFilter(
       upper,
       upperUnbounded,
       false,
-      filterSpec.selectPct > 25);
+      drawNullAllowed(filterSpec));
 }
 
 template <>
@@ -216,6 +216,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
   StringView lower = valueAtPct(filterSpec.startPct, &lowerIndex);
   StringView upper =
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
+  const bool nullAllowed = drawNullAllowed(filterSpec);
   if (upperIndex - lowerIndex < 1000 && folly::Random::rand32(10, rng_) <= 3) {
     std::vector<std::string> inRange;
     inRange.reserve(upperIndex - lowerIndex);
@@ -227,10 +228,9 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
     }
     if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct != 100.0) {
       return std::make_unique<velox::common::NegatedBytesValues>(
-          inRange, filterSpec.selectPct < 75);
+          inRange, nullAllowed);
     }
-    return std::make_unique<velox::common::BytesValues>(
-        inRange, filterSpec.selectPct > 25);
+    return std::make_unique<velox::common::BytesValues>(inRange, nullAllowed);
   }
 
   // sometimes create a negated filter instead
@@ -242,7 +242,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
         std::string(upper),
         false,
         false,
-        filterSpec.selectPct < 75);
+        nullAllowed);
   }
 
   return std::make_unique<velox::common::BytesRange>(
@@ -252,7 +252,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRandomFilter(
       std::string(upper),
       false,
       false,
-      filterSpec.selectPct > 25);
+      nullAllowed);
 }
 
 template <>
@@ -268,7 +268,7 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRangeFilter(
       valueAtPct(filterSpec.startPct + filterSpec.selectPct, &upperIndex);
 
   return std::make_unique<velox::common::TimestampRange>(
-      lower, upper, filterSpec.selectPct > 25);
+      lower, upper, drawNullAllowed(filterSpec));
 }
 
 template <>

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -41,7 +41,7 @@ struct FilterSpec {
       float startPct = 50,
       float selectPct = 20,
       FilterKind filterKind = FilterKind::kBigintRange,
-      bool isForRowGroupSkip = true,
+      bool isForRowGroupSkip = false,
       bool allowNulls = true)
       : field(field),
         startPct(startPct),

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -115,6 +115,15 @@ class AbstractColumnStats {
   }
 
  protected:
+  // Whether the generated filter should pass nulls. `allowNulls_` on the spec
+  // is a hard constraint from the caller; when it permits nulls the answer is
+  // drawn independently rather than derived from selectPct, which used to tie
+  // the two together and make "selective filter that also passes nulls"
+  // unreachable.
+  bool drawNullAllowed(const FilterSpec& filterSpec) {
+    return filterSpec.allowNulls_ && folly::Random::oneIn(2, rng_);
+  }
+
   const TypePtr type_;
   const RowTypePtr rootType_;
   int32_t numDistinct_ = 0;
@@ -307,6 +316,7 @@ class ColumnStats : public AbstractColumnStats {
       return std::make_unique<velox::common::BigintRange>(
           getIntegerValue(lower), getIntegerValue(upper), false);
     }
+    const bool nullAllowed = drawNullAllowed(filterSpec);
     if (upperIndex - lowerIndex < 1000 &&
         folly::Random::rand32(10, rng_) <= 3) {
       std::vector<int64_t> in;
@@ -315,21 +325,17 @@ class ColumnStats : public AbstractColumnStats {
       }
       // make sure we don't accidentally generate an AlwaysFalse filter
       if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct < 100.0) {
-        return velox::common::createNegatedBigintValues(in, true);
+        return velox::common::createNegatedBigintValues(in, nullAllowed);
       }
-      return velox::common::createBigintValues(in, true);
+      return velox::common::createBigintValues(in, nullAllowed);
     }
     // sometimes make a negated filter instead (1/4 chance)
     if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
       return std::make_unique<velox::common::NegatedBigintRange>(
-          getIntegerValue(lower),
-          getIntegerValue(upper),
-          filterSpec.selectPct < 75);
+          getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
     }
     return std::make_unique<velox::common::BigintRange>(
-        getIntegerValue(lower),
-        getIntegerValue(upper),
-        filterSpec.selectPct > 25);
+        getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
   }
 
   std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -89,8 +89,11 @@ class AbstractColumnStats {
   // ASCII string greater than test data values. Used for row group skipping
   // tests.
   static constexpr const char* kMaxString = "~~~~~";
-  AbstractColumnStats(TypePtr type, RowTypePtr rootType)
-      : type_(type), rootType_(rootType) {}
+  AbstractColumnStats(
+      TypePtr type,
+      RowTypePtr rootType,
+      folly::Random::DefaultGenerator& rng)
+      : type_(type), rootType_(rootType), rng_(rng) {}
 
   virtual ~AbstractColumnStats() = default;
 
@@ -118,14 +121,21 @@ class AbstractColumnStats {
   int32_t numNulls_ = 0;
   int32_t numSamples_ = 0;
   std::unordered_map<size_t, int> uniques_;
-  static uint32_t counter_;
+  // Borrowed from the owning FilterGenerator so that filter kind selection is
+  // driven by the run's seed. This used to be a process-global counter, which
+  // made the choice depend on how many columns happened to be processed
+  // earlier and left it outside the seed's control entirely.
+  folly::Random::DefaultGenerator& rng_;
 };
 
 template <typename T>
 class ColumnStats : public AbstractColumnStats {
  public:
-  explicit ColumnStats(TypePtr type, RowTypePtr rootTypePtr)
-      : AbstractColumnStats(type, rootTypePtr) {}
+  ColumnStats(
+      TypePtr type,
+      RowTypePtr rootTypePtr,
+      folly::Random::DefaultGenerator& rng)
+      : AbstractColumnStats(type, rootTypePtr, rng) {}
 
   void sample(
       const std::vector<RowVectorPtr>& batches,
@@ -297,19 +307,20 @@ class ColumnStats : public AbstractColumnStats {
       return std::make_unique<velox::common::BigintRange>(
           getIntegerValue(lower), getIntegerValue(upper), false);
     }
-    if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 <= 3) {
+    if (upperIndex - lowerIndex < 1000 &&
+        folly::Random::rand32(10, rng_) <= 3) {
       std::vector<int64_t> in;
       for (auto i = lowerIndex; i <= upperIndex; ++i) {
         in.push_back(getIntegerValue(values_[i]));
       }
       // make sure we don't accidentally generate an AlwaysFalse filter
-      if (counter_ % 2 == 1 && filterSpec.selectPct < 100.0) {
+      if (folly::Random::oneIn(2, rng_) && filterSpec.selectPct < 100.0) {
         return velox::common::createNegatedBigintValues(in, true);
       }
       return velox::common::createBigintValues(in, true);
     }
     // sometimes make a negated filter instead (1/4 chance)
-    if (counter_ % 4 == 1 && filterSpec.selectPct < 100.0) {
+    if (folly::Random::oneIn(4, rng_) && filterSpec.selectPct < 100.0) {
       return std::make_unique<velox::common::NegatedBigintRange>(
           getIntegerValue(lower),
           getIntegerValue(upper),
@@ -362,8 +373,11 @@ class ColumnStats : public AbstractColumnStats {
 
 class ComplexColumnStats : public AbstractColumnStats {
  public:
-  explicit ComplexColumnStats(TypePtr type, RowTypePtr rootTypePtr)
-      : AbstractColumnStats(type, rootTypePtr) {}
+  ComplexColumnStats(
+      TypePtr type,
+      RowTypePtr rootTypePtr,
+      folly::Random::DefaultGenerator& rng)
+      : AbstractColumnStats(type, rootTypePtr, rng) {}
 
   void sample(
       const std::vector<RowVectorPtr>& batches,
@@ -488,30 +502,34 @@ std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRowGroupSkipRangeFilter(
 template <TypeKind Kind>
 std::unique_ptr<AbstractColumnStats> makeStats(
     TypePtr type,
-    RowTypePtr rootType) {
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
   using T = typename TypeTraits<Kind>::NativeType;
-  return std::make_unique<ColumnStats<T>>(type, rootType);
+  return std::make_unique<ColumnStats<T>>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ROW>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ARRAY>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 template <>
 inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::MAP>(
     TypePtr type,
-    RowTypePtr rootType) {
-  return std::make_unique<ComplexColumnStats>(type, rootType);
+    RowTypePtr rootType,
+    folly::Random::DefaultGenerator& rng) {
+  return std::make_unique<ComplexColumnStats>(type, rootType, rng);
 }
 
 class FilterGenerator {

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -52,12 +52,13 @@ struct FilterSpec {
 
   std::string toString() const {
     return fmt::format(
-        "FilterSpec(field={}, startPct={}, selectPct={}, filterKind={}, isForRowGroupSkip={}, allowNulls={})",
+        "FilterSpec(field={}, startPct={}, selectPct={}, filterKind={}, isForRowGroupSkip={}, isForEmptyResult={}, allowNulls={})",
         field,
         startPct,
         selectPct,
         filterKind,
         isForRowGroupSkip,
+        isForEmptyResult,
         allowNulls_);
   }
 
@@ -68,6 +69,9 @@ struct FilterSpec {
   // If true, makes a filter that matches max value in the column so as to skip
   // row groups on min/max.
   bool isForRowGroupSkip{false};
+  // If true, makes a filter positioned just past the column maximum, so that no
+  // row survives it. Opt in with FilterGenerator::setEmptyResultProbability.
+  bool isForEmptyResult{false};
   bool allowNulls_{true};
 };
 
@@ -108,6 +112,15 @@ class AbstractColumnStats {
       std::vector<uint64_t>& hits) = 0;
 
   virtual std::unique_ptr<Filter> rowGroupSkipFilter(
+      const std::vector<RowVectorPtr>& /*batches*/,
+      const Subfield& /*subfield*/,
+      std::vector<uint64_t>& /*hits*/) {
+    VELOX_NYI();
+  }
+
+  // Returns a filter that no row passes, or nullptr when the column admits no
+  // such filter (every value null, or the maximum is already the type maximum).
+  virtual std::unique_ptr<Filter> emptyResultFilter(
       const std::vector<RowVectorPtr>& /*batches*/,
       const Subfield& /*subfield*/,
       std::vector<uint64_t>& /*hits*/) {
@@ -194,29 +207,7 @@ class ColumnStats : public AbstractColumnStats {
         break;
     }
 
-    size_t numHits = 0;
-    SimpleVector<T>* values = nullptr;
-    int32_t previousBatch = -1;
-    for (auto hit : hits) {
-      auto batch = batchNumber(hit);
-      if (batch != previousBatch) {
-        previousBatch = batch;
-        auto vector = batches[batch];
-        values = getChildBySubfield(batches[batch].get(), subfield, rootType_)
-                     ->template as<SimpleVector<T>>();
-      }
-      auto row = batchRow(hit);
-      if (values->isNullAt(row)) {
-        if (filter->testNull()) {
-          hits[numHits++] = hit;
-        }
-        continue;
-      }
-      if (velox::common::applyFilter(*filter, values->valueAt(row))) {
-        hits[numHits++] = hit;
-      }
-    }
-    hits.resize(numHits);
+    narrowHits(batches, subfield, *filter, hits);
     return filter;
   }
 
@@ -226,6 +217,31 @@ class ColumnStats : public AbstractColumnStats {
       std::vector<uint64_t>& hits) override {
     std::unique_ptr<Filter> filter;
     filter = makeRowGroupSkipRangeFilter(batches, subfield);
+    narrowHits(batches, subfield, *filter, hits);
+    return filter;
+  }
+
+  std::unique_ptr<Filter> emptyResultFilter(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield,
+      std::vector<uint64_t>& hits) override {
+    auto filter = makeEmptyResultRangeFilter(batches, subfield);
+    if (filter == nullptr) {
+      return nullptr;
+    }
+    narrowHits(batches, subfield, *filter, hits);
+    return filter;
+  }
+
+ private:
+  // Narrows 'hits' to the rows the filter passes. Every filter flavor shares
+  // this: the reference row set has to be derived from the filter that is
+  // actually handed to the reader, not from the spec that produced it.
+  void narrowHits(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield,
+      const Filter& filter,
+      std::vector<uint64_t>& hits) {
     size_t numHits = 0;
     SimpleVector<T>* values = nullptr;
     int32_t previousBatch = -1;
@@ -233,26 +249,23 @@ class ColumnStats : public AbstractColumnStats {
       auto batch = batchNumber(hit);
       if (batch != previousBatch) {
         previousBatch = batch;
-        auto vector = batches[batch];
         values = getChildBySubfield(batches[batch].get(), subfield, rootType_)
                      ->template as<SimpleVector<T>>();
       }
       auto row = batchRow(hit);
       if (values->isNullAt(row)) {
-        if (filter->testNull()) {
+        if (filter.testNull()) {
           hits[numHits++] = hit;
         }
         continue;
       }
-      if (velox::common::applyFilter(*filter, values->valueAt(row))) {
+      if (velox::common::applyFilter(filter, values->valueAt(row))) {
         hits[numHits++] = hit;
       }
     }
     hits.resize(numHits);
-    return filter;
   }
 
- private:
   void addSample(SimpleVector<T>* vector, vector_size_t index) {
     ++numSamples_;
     if (vector->isNullAt(index)) {
@@ -338,10 +351,13 @@ class ColumnStats : public AbstractColumnStats {
         getIntegerValue(lower), getIntegerValue(upper), nullAllowed);
   }
 
-  std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(
+  // Scans every row rather than the sample in 'values_': a filter that has to
+  // sit at or past the column maximum cannot be built from a sample. Returns
+  // false, leaving 'max' untouched, if every value is null.
+  bool columnMax(
       const std::vector<RowVectorPtr>& batches,
-      const Subfield& subfield) {
-    T max;
+      const Subfield& subfield,
+      T& max) {
     bool hasMax = false;
     for (auto batch : batches) {
       auto values = getChildBySubfield(batch.get(), subfield, rootType_)
@@ -356,16 +372,40 @@ class ColumnStats : public AbstractColumnStats {
         if (values->isNullAt(i)) {
           continue;
         }
-        if (hasMax && max < values->valueAt(i)) {
-          max = values->valueAt(i);
-        } else if (!hasMax) {
+        if (!hasMax || max < values->valueAt(i)) {
           max = values->valueAt(i);
           hasMax = true;
         }
       }
     }
+    return hasMax;
+  }
+
+  std::unique_ptr<Filter> makeRowGroupSkipRangeFilter(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield) {
+    T max{};
+    columnMax(batches, subfield, max);
     return std::make_unique<velox::common::BigintRange>(
         getIntegerValue(max), getIntegerValue(max), false);
+  }
+
+  // One past the column maximum. Only reached for the integral kinds, where
+  // getIntegerValue is exact -- see supportsEmptyResult in the .cpp -- so the
+  // resulting range cannot accidentally overlap a value.
+  std::unique_ptr<Filter> makeEmptyResultRangeFilter(
+      const std::vector<RowVectorPtr>& batches,
+      const Subfield& subfield) {
+    T max{};
+    if (!columnMax(batches, subfield, max)) {
+      return nullptr;
+    }
+    const int64_t bound = getIntegerValue(max);
+    if (bound == std::numeric_limits<int64_t>::max()) {
+      return nullptr;
+    }
+    return std::make_unique<velox::common::BigintRange>(
+        bound + 1, bound + 1, false);
   }
 
   std::unique_ptr<Filter> makeRandomFilter(const FilterSpec& filterSpec) {
@@ -451,6 +491,15 @@ class ComplexColumnStats : public AbstractColumnStats {
     VELOX_FAIL("N/A in ComplexType");
   }
 
+  // A complex type only admits is null / is not null, so whether either matches
+  // nothing depends on the data rather than on how the filter is built.
+  std::unique_ptr<Filter> emptyResultFilter(
+      const std::vector<RowVectorPtr>& /*batches*/,
+      const Subfield& /*subfield*/,
+      std::vector<uint64_t>& /*hits*/) override {
+    VELOX_FAIL("N/A in ComplexType");
+  }
+
  private:
   std::unique_ptr<Filter> makeRangeFilter(const FilterSpec&) {
     VELOX_FAIL("N/A in ComplexType");
@@ -502,6 +551,16 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRowGroupSkipRangeFilter(
 
 template <>
 std::unique_ptr<Filter> ColumnStats<Timestamp>::makeRowGroupSkipRangeFilter(
+    const std::vector<RowVectorPtr>& /*batches*/,
+    const Subfield& /*subfield*/);
+
+template <>
+std::unique_ptr<Filter> ColumnStats<StringView>::makeEmptyResultRangeFilter(
+    const std::vector<RowVectorPtr>& /*batches*/,
+    const Subfield& /*subfield*/);
+
+template <>
+std::unique_ptr<Filter> ColumnStats<Timestamp>::makeEmptyResultRangeFilter(
     const std::vector<RowVectorPtr>& /*batches*/,
     const Subfield& /*subfield*/);
 
@@ -572,6 +631,23 @@ class FilterGenerator {
   // Add the filter to an existing ScanSpec.
   static void addToScanSpec(const SubfieldFilters& filters, ScanSpec&);
 
+  // Probability that a generated spec set asks for a filter no row passes.
+  // Zero by default, and at zero not a single random number is drawn for it, so
+  // callers that do not opt in keep their exact filter sequence.
+  //
+  // Ordinary selective filters already intersect to nothing now and then, but
+  // only by accident and only from inside the value range, so the reader still
+  // descends into every row group and rejects row by row. The filter this asks
+  // for sits past the column maximum instead, which is what makes min/max
+  // pruning skip every row group. Opt-in because it is a trade: the columns
+  // filtered alongside it contribute nothing, having no row left to accept or
+  // reject.
+  void setEmptyResultProbability(double probability) {
+    VELOX_CHECK_GE(probability, 0.0);
+    VELOX_CHECK_LE(probability, 1.0);
+    emptyResultProbability_ = probability;
+  }
+
   inline folly::Random::DefaultGenerator& rng() {
     return rng_;
   }
@@ -593,6 +669,7 @@ class FilterGenerator {
   std::shared_ptr<const RowType> rowType_;
   folly::Random::DefaultGenerator::result_type seed_;
   folly::Random::DefaultGenerator rng_;
+  double emptyResultProbability_{0.0};
   std::unordered_map<std::string, std::array<int32_t, 2>> filterCoverage_;
 };
 


### PR DESCRIPTION
Summary:
Lets a caller ask `FilterGenerator` for a filter that no row passes, via
`setEmptyResultProbability`. Off by default.

Ordinary selective filters already intersect to nothing now and then --
two filters at a few percent each over a thousand rows manage it often
enough -- but only by accident, and only from *inside* the value range.
A reader consulting min/max statistics still descends into every row
group and rejects row by row. The filter this adds sits one step past
the column maximum instead, so min/max pruning skips every row group,
which is the part nothing else reaches.

It is opt-in rather than another `category` in the draw because it is a
trade: whichever columns are filtered alongside it contribute nothing,
having no row left to accept or reject. At the default of zero, not a
single random number is drawn for it, so every existing consumer keeps
its exact filter sequence -- confirmed by the E2E numbers below being
identical to the parent's.

Mechanics:

- `FilterSpec::isForEmptyResult`, dispatched in `makeSubfieldFilters`
  exactly like the existing `isForRowGroupSkip`.
- Only the last spec is ever marked. `makeSubfieldFilters` narrows the
  reference rows in place as it walks the specs, so an empty result
  anywhere earlier would leave every later column sampling an empty row
  set and degenerating into an `IsNull` filter.
- `supportsEmptyResult` restricts it to kinds where "one step past" is
  exact: the integral kinds, plus `VARCHAR` and `TIMESTAMP` which get a
  specialization. Floating point truncates through `getIntegerValue` and
  `HUGEINT` would not survive the narrowing to `int64_t`; either could
  produce a filter that silently matches a real value. `BOOLEAN` has no
  value above true.

Deliberately not a `velox::common::AlwaysFalse`, whose declaration says
`This should not be passed down`, and which would also let a reader
short-circuit before touching data.

Two incidental cleanups, both in service of the above:

- The hit-narrowing loop was already duplicated verbatim between
  `filter()` and `rowGroupSkipFilter()`; extracted to `narrowHits` rather
  than add a third copy.
- The max scan was likewise duplicated between the generic
  `makeRowGroupSkipRangeFilter` and its `Timestamp` specialization;
  extracted to `columnMax`. This also gives the all-null case a defined
  value -- the old generic path declared `T max;` and read it
  uninitialized when every value was null.

Reviewed By: raymondlin1

Differential Revision: D116018239


