### PR TITLE
feat(serializer): Add API to decode multiple row ranges from a single batch (#18557)

### DIFF
--- a/velox/dwio/nimble/serializer/Deserializer.cpp
+++ b/velox/dwio/nimble/serializer/Deserializer.cpp
@@ -636,7 +636,7 @@ void Deserializer::appendStreamSegments(
 
 uint32_t Deserializer::appendBatch(
     std::string_view batch,
-    std::optional<nimble::RowRange> rowRange,
+    folly::Range<const nimble::RowRange*> rowRanges,
     DecodeRun& run,
     velox::VectorPtr& output) const {
   const auto rowCount = parser_->initialize(batch);
@@ -647,34 +647,51 @@ uint32_t Deserializer::appendBatch(
 
   // Rows this batch exposes: the parser's rowRange (kTablet header) or the
   // whole batch if the header didn't encode one.
-  nimble::RowRange range =
+  const nimble::RowRange exposed =
       parser_->rowRange().value_or(nimble::RowRange{0, rowCount});
+
   // A caller range narrows within what the batch exposes rather than
-  // replacing it, so it is relative to `range.startRow`. For a kTablet
+  // replacing it, so it is relative to `exposed.startRow`. For a kTablet
   // batch windowed to [500, 600), caller [0, 50) selects [500, 550). For
-  // every other version `range` starts at 0, so the two coincide.
-  if (rowRange.has_value()) {
+  // every other version `exposed` starts at 0, so the two coincide.
+  uint32_t previousEnd = 0;
+  uint32_t outputRows = 0;
+  for (const auto& rowRange : rowRanges) {
     NIMBLE_USER_CHECK_LE(
-        rowRange->startRow,
-        rowRange->endRow,
+        rowRange.startRow,
+        rowRange.endRow,
         "rowRange startRow must be <= endRow");
     NIMBLE_USER_CHECK_LE(
-        rowRange->endRow,
-        range.numRows(),
+        rowRange.endRow,
+        exposed.numRows(),
         "rowRange endRow exceeds the rows this batch exposes");
-    range = nimble::RowRange{
-        range.startRow + rowRange->startRow, range.startRow + rowRange->endRow};
+    NIMBLE_USER_CHECK_LE(
+        previousEnd,
+        rowRange.startRow,
+        "rowRanges must be sorted ascending and non-overlapping");
+    previousEnd = rowRange.endRow;
+    outputRows += rowRange.numRows();
   }
 
   appendStreamSegments(rowCount, /*startRow=*/run.rows, requiresBarrier);
-  runRanges_.push_back({run.rows + range.startRow, run.rows + range.endRow});
+  if (rowRanges.empty()) {
+    runRanges_.push_back(
+        {run.rows + exposed.startRow, run.rows + exposed.endRow});
+    outputRows = exposed.numRows();
+  } else {
+    for (const auto& rowRange : rowRanges) {
+      runRanges_.push_back(
+          {run.rows + exposed.startRow + rowRange.startRow,
+           run.rows + exposed.startRow + rowRange.endRow});
+    }
+  }
   run.rows += rowCount;
   ++run.batches;
   if (FOLLY_UNLIKELY(requiresBarrier)) {
     decodeRun(run, output);
     parser_->reset();
   }
-  return range.numRows();
+  return outputRows;
 }
 
 void Deserializer::deserialize(
@@ -692,6 +709,28 @@ void Deserializer::deserialize(
       folly::Range<const nimble::RowRange*>(rowRanges.data(), rowRanges.size()),
       output,
       /*outputRowCounts=*/nullptr);
+}
+
+void Deserializer::deserialize(
+    std::string_view data,
+    const std::vector<nimble::RowRange>& rowRanges,
+    velox::VectorPtr& output) const {
+  NIMBLE_CHECK(
+      runRanges_.empty(), "runRanges_ must be empty on deserialize entry");
+  SCOPE_EXIT {
+    runRanges_.clear();
+  };
+
+  output = nullptr;
+  DecodeRun run;
+  runRanges_.reserve(rowRanges.size());
+  appendBatch(
+      data,
+      folly::Range<const nimble::RowRange*>(rowRanges.data(), rowRanges.size()),
+      run,
+      output);
+  decodeRun(run, output);
+  parser_->reset();
 }
 
 void Deserializer::deserializeImpl(
@@ -722,11 +761,9 @@ void Deserializer::deserializeImpl(
   DecodeRun run;
   runRanges_.reserve(data.size());
   for (size_t i = 0; i < data.size(); ++i) {
-    std::optional<nimble::RowRange> rowRange;
-    if (!rowRanges.empty()) {
-      rowRange = rowRanges[i];
-    }
-    const auto outputRows = appendBatch(data[i], rowRange, run, output);
+    const auto outputRows = rowRanges.empty()
+        ? appendBatch(data[i], {}, run, output)
+        : appendBatch(data[i], rowRanges.subpiece(i, 1), run, output);
     if (outputRowCounts != nullptr) {
       outputRowCounts->emplace_back(outputRows);
     }

--- a/velox/dwio/nimble/serializer/Deserializer.h
+++ b/velox/dwio/nimble/serializer/Deserializer.h
@@ -130,6 +130,27 @@ class Deserializer {
       const std::vector<nimble::RowRange>& rowRanges,
       velox::VectorPtr& output) const;
 
+  /// Decodes a single serialized batch, appending only the rows in
+  /// `rowRanges`.
+  ///
+  /// Each range is relative to the rows the batch exposes, matching the
+  /// multi-batch overload above: a kTablet batch windowed to `[500, 600)`
+  /// combined with caller range `[0, 50)` selects physical rows
+  /// `[500, 550)`.
+  ///
+  /// Equivalent output to concatenating, over `rowRanges` in order,
+  ///   deserialize(data).slice(r.startRow, r.numRows())
+  /// but rows outside the ranges are never materialized.
+  ///
+  /// Preconditions:
+  ///   * `rowRanges` is sorted ascending and non-overlapping.
+  ///   * For each `r`: `r.startRow <= r.endRow` and `r.endRow <= ` the
+  ///     number of rows `data` exposes.
+  void deserialize(
+      std::string_view data,
+      const std::vector<nimble::RowRange>& rowRanges,
+      velox::VectorPtr& output) const;
+
  private:
   // Invoked by constructors to build parser, reader factory, reader, and stream
   // decoders from the requested schema and field selection.
@@ -225,22 +246,26 @@ class Deserializer {
       OutputProjection& outputProjection);
 
   // Queues `batch`'s streams onto the pending decode run and records the
-  // batch's effective rowRange in `runRanges_` (run-local coordinates).
+  // batch's effective rowRanges in `runRanges_` (run-local coordinates).
+  // The batch is parsed and its stream segments registered once regardless
+  // of how many ranges are supplied.
   //
-  // `rowRange` narrows within the range the batch already exposes (the
-  // kTablet header rowRange, or the full batch for other versions) and is
-  // relative to that range's start, so it cannot widen the window or
-  // address rows outside it. When set, requires
-  // `rowRange->startRow <= rowRange->endRow <= exposed numRows()`.
+  // Each range in `rowRanges` narrows within the range the batch already
+  // exposes (the kTablet header rowRange, or the full batch for other
+  // versions) and is relative to that range's start, so it cannot widen the
+  // window or address rows outside it. Requires each
+  // `startRow <= endRow <= exposed numRows()`, and the ranges to be sorted
+  // ascending and non-overlapping. An empty `rowRanges` selects the whole
+  // exposed range.
   //
   // If the batch requires a null barrier, `decodeRun` fires before and
-  // after queuing so the barrier batch decodes standalone. A rowRange
-  // applies there too: a barrier batch is a one-batch run, which is exactly
-  // the unit the range narrows. Returns the number of rows this batch adds to
+  // after queuing so the barrier batch decodes standalone. Ranges apply
+  // there too: a barrier batch is a one-batch run, which is exactly
+  // the unit they narrow. Returns the number of rows this batch adds to
   // the output.
   uint32_t appendBatch(
       std::string_view batch,
-      std::optional<nimble::RowRange> rowRange,
+      folly::Range<const nimble::RowRange*> rowRanges,
       DecodeRun& run,
       velox::VectorPtr& output) const;
 

--- a/velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
@@ -1098,6 +1098,84 @@ TEST_F(DeserializerSkipTest, rejectRowRangeEndRowPastBatchRowCount) {
       ds.deserialize(views, {nimble::RowRange{0, 11}}, out), NimbleUserError);
 }
 
+// Many ranges out of one batch must match feeding the same batch once per
+// range through the multi-batch overload, which is the pattern this
+// overload replaces.
+TEST_F(DeserializerSkipTest, singleBatchMultipleRanges) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  constexpr velox::vector_size_t kRows = 1000;
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(kRows, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  const std::vector<nimble::RowRange> ranges{
+      nimble::RowRange{10, 20},
+      nimble::RowRange{100, 101},
+      nimble::RowRange{500, 550},
+      nimble::RowRange{999, 1000}};
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  Deserializer singleBatch{schema, pool_.get(), dsOpts};
+  velox::VectorPtr out;
+  singleBatch.deserialize(serialized[0], ranges, out);
+
+  std::vector<std::string_view> repeated(ranges.size(), serialized[0]);
+  Deserializer multiBatch{schema, pool_.get(), dsOpts};
+  velox::VectorPtr expected;
+  multiBatch.deserialize(repeated, ranges, expected);
+
+  ASSERT_EQ(out->size(), 62);
+  ASSERT_EQ(expected->size(), out->size());
+  auto* column =
+      out->as<velox::RowVector>()->childAt(0)->as<velox::FlatVector<int32_t>>();
+  velox::vector_size_t position = 0;
+  for (const auto& range : ranges) {
+    for (uint32_t row = range.startRow; row < range.endRow; ++row) {
+      EXPECT_EQ(column->valueAt(position), static_cast<int32_t>(row));
+      EXPECT_TRUE(out->equalValueAt(expected.get(), position, position));
+      ++position;
+    }
+  }
+}
+
+// buildDecodeOps only emits a skip when a range starts past the cursor, so
+// out-of-order or overlapping ranges would silently fold into the preceding
+// read instead of failing.
+TEST_F(DeserializerSkipTest, rejectUnsortedOrOverlappingSingleBatchRanges) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(100, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  velox::VectorPtr out;
+
+  Deserializer unsorted{schema, pool_.get(), dsOpts};
+  EXPECT_THROW(
+      unsorted.deserialize(
+          serialized[0],
+          {nimble::RowRange{50, 60}, nimble::RowRange{10, 20}},
+          out),
+      NimbleUserError);
+
+  Deserializer overlapping{schema, pool_.get(), dsOpts};
+  EXPECT_THROW(
+      overlapping.deserialize(
+          serialized[0],
+          {nimble::RowRange{10, 30}, nimble::RowRange{20, 40}},
+          out),
+      NimbleUserError);
+
+  Deserializer pastEnd{schema, pool_.get(), dsOpts};
+  EXPECT_THROW(
+      pastEnd.deserialize(serialized[0], {nimble::RowRange{90, 200}}, out),
+      NimbleUserError);
+}
+
 // Bad input: data.size() != rowRanges.size().
 TEST_F(DeserializerSkipTest, rejectMismatchedRowRangesSize) {
   auto type = velox::ROW({{"a", velox::INTEGER()}});

--- a/velox/dwio/nimble/tools/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/CMakeLists.txt
@@ -90,6 +90,8 @@ target_link_libraries(
 # instrumentation include Meta-internal headers that are not part of the OSS
 # export, so they have no OSS build.
 
+add_subdirectory(encoding)
+
 if(NIMBLE_BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/velox/dwio/nimble/tools/encoding/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/encoding/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(nimble_encoding_evaluation EncodingEvaluation.cpp EncodingEvaluation.h)
+
+target_link_libraries(
+  nimble_encoding_evaluation
+  nimble_common
+  nimble_encodings
+  nimble_writer
+  nimble_serializer
+  nimble_deserializer
+  nimble_serializer_options
+  nimble_velox_schema_serialization
+  velox_memory
+  velox_time
+  velox_vector
+  Folly::folly
+  fmt::fmt
+)
+
+if(NIMBLE_BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/velox/dwio/nimble/tools/encoding/EncodingEvaluation.cpp
+++ b/velox/dwio/nimble/tools/encoding/EncodingEvaluation.cpp
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/tools/encoding/EncodingEvaluation.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include <fmt/core.h>
+#include <folly/futures/Future.h>
+
+#include "velox/common/time/CpuWallTimer.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/NimbleException.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/serializer/Deserializer.h"
+#include "velox/dwio/nimble/serializer/Serializer.h"
+#include "velox/dwio/nimble/velox/OrderedRanges.h"
+#include "velox/dwio/nimble/velox/SchemaSerialization.h"
+
+namespace facebook::nimble::selection {
+namespace {
+
+struct ChunkMeasurement {
+  uint64_t encodedBytes{};
+  uint64_t encodeNanos{};
+  uint64_t decodeNanos{};
+};
+
+uint8_t nestedChildrenCount(nimble::EncodingType encodingType) {
+  switch (encodingType) {
+    case nimble::EncodingType::Delta:
+    case nimble::EncodingType::BlockBitPacking:
+    case nimble::EncodingType::FOR:
+      return 3;
+    case nimble::EncodingType::RLE:
+    case nimble::EncodingType::Dictionary:
+    case nimble::EncodingType::MainlyConstant:
+    case nimble::EncodingType::PFOR:
+      return 2;
+    case nimble::EncodingType::SparseBool:
+    case nimble::EncodingType::Trivial:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+nimble::EncodingLayoutTree buildScalarOverrideTree(nimble::EncodingType type) {
+  using StreamIds = nimble::EncodingLayoutTree::StreamIdentifiers;
+  std::vector<std::optional<const nimble::EncodingLayout>> nestedChildren(
+      nestedChildrenCount(type), std::nullopt);
+  return nimble::EncodingLayoutTree(
+      nimble::Kind::Scalar,
+      {{StreamIds::Scalar::ScalarStream,
+        nimble::EncodingLayout(
+            type,
+            {},
+            nimble::CompressionType::Uncompressed,
+            std::move(nestedChildren))}},
+      "");
+}
+
+nimble::SerializerOptions buildSerializerOptions(
+    const CandidateEncoding& candidate,
+    const EvaluationOptions& opts) {
+  nimble::SerializerOptions options;
+  options.version = nimble::SerializationVersion::kSerialization;
+  options.encodingOptions.blockBitPackingBlockSize =
+      opts.blockBitPackingBlockSize;
+  options.encodingOptions.fixedBitWidthUseExactBits =
+      opts.fixedBitWidthUseExactBits;
+  options.compressionOptions = opts.compressionOptions;
+  options.flatMapColumns = opts.flatMapColumns;
+
+  auto readFactors = opts.readFactors;
+  if (readFactors.empty()) {
+    readFactors = nimble::ManualEncodingSelectionPolicyFactory::
+        defaultEncodingReadFactors();
+  }
+  nimble::ManualEncodingSelectionPolicyFactory factory{
+      std::move(readFactors), opts.compressionOptions, opts.nestedReadFactors};
+  options.encodingSelectionPolicyCreator =
+      [factory = std::move(factory)](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return factory.createPolicy(dataType);
+  };
+
+  options.encodingLayoutTree.emplace(candidate.tree);
+  return options;
+}
+
+ChunkMeasurement evaluateCandidateEncodingOnce(
+    const CandidateEncoding& candidate,
+    const std::vector<velox::VectorPtr>& vectors,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool) {
+  auto serializerOptions = buildSerializerOptions(candidate, opts);
+  nimble::Serializer serializer{
+      serializerOptions, vectors.front()->type(), pool};
+
+  velox::CpuWallTiming encodeTiming;
+  std::vector<std::string> serializedBuffers;
+  serializedBuffers.reserve(vectors.size());
+  uint64_t chunkBytes{0};
+
+  for (const auto& vector : vectors) {
+    nimble::OrderedRanges ranges;
+    ranges.add(0, vector->size());
+    std::string_view serialized;
+    {
+      velox::CpuWallTimer timer(encodeTiming);
+      serialized = serializer.serialize(vector, ranges);
+    }
+    serializedBuffers.emplace_back(serialized);
+    chunkBytes += serialized.size();
+  }
+
+  nimble::SchemaSerializer schemaSerializer;
+  const auto serializedSchema =
+      schemaSerializer.serialize(serializer.schemaBuilder());
+  auto schema = nimble::SchemaDeserializer::deserialize(serializedSchema);
+  nimble::DeserializerOptions deserializerOptions{.hasHeader = true};
+  nimble::Deserializer deserializer(schema, pool, deserializerOptions);
+
+  velox::CpuWallTiming decodeTiming;
+  for (const auto& buffer : serializedBuffers) {
+    velox::CpuWallTimer timer(decodeTiming);
+    velox::VectorPtr deserialized;
+    deserializer.deserialize(buffer, deserialized);
+  }
+
+  return {chunkBytes, encodeTiming.wallNanos, decodeTiming.wallNanos};
+}
+
+ChunkMeasurement evaluateCandidateEncodingParallel(
+    const CandidateEncoding& candidate,
+    const std::vector<velox::VectorPtr>& vectors,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  const auto parallelism =
+      std::min<size_t>(vectors.size(), std::max<size_t>(opts.parallelism, 1));
+  const auto chunkSize = (vectors.size() + parallelism - 1) / parallelism;
+  std::vector<folly::Future<ChunkMeasurement>> futures;
+  for (size_t t = 0; t < parallelism; ++t) {
+    const auto start = t * chunkSize;
+    const auto end = std::min(start + chunkSize, vectors.size());
+    if (start >= end) {
+      break;
+    }
+    std::vector<velox::VectorPtr> chunkVectors(
+        vectors.begin() + start, vectors.begin() + end);
+    auto chunkPool = pool->addLeafChild(fmt::format("chunk_{}", t));
+    futures.emplace_back(
+        folly::via(
+            executor,
+            [&candidate,
+             &opts,
+             chunkVectors = std::move(chunkVectors),
+             chunkPool = std::move(chunkPool)]() {
+              return evaluateCandidateEncodingOnce(
+                  candidate, chunkVectors, opts, chunkPool.get());
+            }));
+  }
+  auto perChunk = folly::collectAll(std::move(futures)).get();
+  ChunkMeasurement total;
+  for (auto& chunkResult : perChunk) {
+    const auto& measurement = chunkResult.value();
+    total.encodedBytes += measurement.encodedBytes;
+    total.encodeNanos += measurement.encodeNanos;
+    total.decodeNanos += measurement.decodeNanos;
+  }
+  return total;
+}
+
+std::optional<EvaluationResult> evaluateCandidateEncoding(
+    const CandidateEncoding& candidate,
+    const std::vector<velox::VectorPtr>& vectors,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  uint64_t encodeNanos{std::numeric_limits<uint64_t>::max()};
+  uint64_t decodeNanos{std::numeric_limits<uint64_t>::max()};
+  uint64_t encodedBytes{0};
+
+  for (int32_t iter = 0; iter < opts.iterations; ++iter) {
+    try {
+      const auto chunk =
+          (executor != nullptr && opts.parallelism > 1 && vectors.size() > 1)
+          ? evaluateCandidateEncodingParallel(
+                candidate, vectors, opts, pool, executor)
+          : evaluateCandidateEncodingOnce(candidate, vectors, opts, pool);
+      encodeNanos = std::min(encodeNanos, chunk.encodeNanos);
+      decodeNanos = std::min(decodeNanos, chunk.decodeNanos);
+      encodedBytes = chunk.encodedBytes;
+    } catch (const nimble::NimbleUserError& error) {
+      if (error.errorCode() != nimble::error_code::IncompatibleEncoding) {
+        throw;
+      }
+      return std::nullopt;
+    }
+  }
+
+  return EvaluationResult{
+      .type = candidate.type,
+      .encodedBytes = encodedBytes,
+      .encodeNanos = encodeNanos,
+      .decodeNanos = decodeNanos,
+  };
+}
+
+const EvaluationResult& findTrivialEncodingResult(
+    const std::vector<std::optional<EvaluationResult>>& results) {
+  for (const auto& result : results) {
+    if (result.has_value() && result->type == nimble::EncodingType::Trivial) {
+      return *result;
+    }
+  }
+  NIMBLE_USER_CHECK(
+      false, "Trivial encoding required for result normalization.");
+}
+
+} // namespace
+
+std::vector<std::optional<EvaluationResult>> evaluateCandidates(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  NIMBLE_USER_CHECK(
+      !vectors.empty(), "No data provided for encoding evaluation.");
+  NIMBLE_USER_CHECK(
+      opts.iterations > 0, "EvaluationOptions.iterations must be positive.");
+  NIMBLE_USER_CHECK(
+      std::any_of(
+          candidates.begin(),
+          candidates.end(),
+          [](const auto& c) {
+            return c.type == nimble::EncodingType::Trivial;
+          }),
+      "Trivial encoding required for result normalization.");
+
+  std::vector<std::optional<EvaluationResult>> results;
+  results.reserve(candidates.size());
+  for (const auto& candidate : candidates) {
+    results.emplace_back(
+        evaluateCandidateEncoding(candidate, vectors, opts, pool, executor));
+  }
+  return results;
+}
+
+std::vector<EvaluationResult> rankResults(
+    const std::vector<std::optional<EvaluationResult>>& results,
+    const ScoreWeights& weights) {
+  const auto& baseline = findTrivialEncodingResult(results);
+  NIMBLE_CHECK(
+      baseline.encodedBytes > 0,
+      "Trivial baseline encodedBytes must be positive.");
+  NIMBLE_CHECK(
+      baseline.encodeNanos > 0,
+      "Trivial baseline encodeNanos must be positive.");
+  NIMBLE_CHECK(
+      baseline.decodeNanos > 0,
+      "Trivial baseline decodeNanos must be positive.");
+
+  std::vector<EvaluationResult> ranked;
+  ranked.reserve(results.size());
+  for (const auto& result : results) {
+    if (!result.has_value()) {
+      continue;
+    }
+    EvaluationResult copy = *result;
+    copy.sizeRatio =
+        static_cast<double>(copy.encodedBytes) / baseline.encodedBytes;
+    copy.encodeRatio =
+        static_cast<double>(copy.encodeNanos) / baseline.encodeNanos;
+    copy.decodeRatio =
+        static_cast<double>(copy.decodeNanos) / baseline.decodeNanos;
+    copy.score = weights.encodeSize * copy.sizeRatio +
+        weights.encodeTime * copy.encodeRatio +
+        weights.decodeTime * copy.decodeRatio;
+    ranked.emplace_back(std::move(copy));
+  }
+
+  std::sort(ranked.begin(), ranked.end(), [](const auto& lhs, const auto& rhs) {
+    return lhs.score < rhs.score;
+  });
+  return ranked;
+}
+
+nimble::EncodingLayoutTree getOptimalEncoding(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  auto rawResults =
+      evaluateCandidates(vectors, candidates, opts, pool, executor);
+  auto ranked = rankResults(rawResults, opts.weights);
+  NIMBLE_USER_CHECK(!ranked.empty());
+  const auto best = ranked.front().type;
+  for (const auto& candidate : candidates) {
+    if (candidate.type == best) {
+      return candidate.tree;
+    }
+  }
+  NIMBLE_UNREACHABLE();
+}
+
+std::vector<CandidateEncoding> buildEncodingCandidates(
+    const std::vector<nimble::EncodingType>& encodings) {
+  std::vector<CandidateEncoding> candidates;
+  candidates.reserve(encodings.size());
+  for (const auto encoding : encodings) {
+    candidates.push_back({encoding, buildScalarOverrideTree(encoding)});
+  }
+  return candidates;
+}
+
+} // namespace facebook::nimble::selection

--- a/velox/dwio/nimble/tools/encoding/EncodingEvaluation.h
+++ b/velox/dwio/nimble/tools/encoding/EncodingEvaluation.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <folly/Executor.h>
+#include <folly/container/F14Map.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Constants.h"
+#include "velox/dwio/nimble/compression/CompressionPolicy.h"
+#include "velox/dwio/nimble/encodings/common/EncodingType.h"
+#include "velox/dwio/nimble/serializer/Options.h"
+#include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::nimble::selection {
+
+/// Weights applied to normalized encoding metrics during candidate ranking.
+struct ScoreWeights {
+  double encodeSize{1.0};
+  double encodeTime{0.0};
+  double decodeTime{0.0};
+};
+
+/// Configuration for an encoding evaluation.
+struct EvaluationOptions {
+  int32_t iterations{3};
+  ScoreWeights weights;
+  std::optional<nimble::CompressionOptions> compressionOptions;
+  uint16_t blockBitPackingBlockSize{nimble::kBlockBitPackingBlockSize};
+  bool fixedBitWidthUseExactBits{true};
+  std::vector<std::pair<nimble::EncodingType, float>> readFactors;
+  std::optional<std::vector<std::pair<nimble::EncodingType, float>>>
+      nestedReadFactors;
+  folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns;
+  size_t parallelism{1};
+};
+
+/// One candidate encoding to evaluate.
+struct CandidateEncoding {
+  nimble::EncodingType type{};
+  nimble::EncodingLayoutTree tree;
+};
+
+/// Measurement plus normalized ranking metrics for one candidate.
+struct EvaluationResult {
+  nimble::EncodingType type{};
+  uint64_t encodedBytes{};
+  uint64_t encodeNanos{};
+  uint64_t decodeNanos{};
+  double sizeRatio{};
+  double encodeRatio{};
+  double decodeRatio{};
+  double score{};
+};
+
+/// Measures each candidate against the given vectors. Nullopt slot means the
+/// encoding was incompatible with the data. When executor is set and vectors
+/// has more than one element, per-candidate measurement fans out across
+/// vector chunks on the executor.
+std::vector<std::optional<EvaluationResult>> evaluateCandidates(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor = nullptr);
+
+/// Normalizes results against the Trivial baseline, applies weights, and
+/// returns them sorted best-first.
+std::vector<EvaluationResult> rankResults(
+    const std::vector<std::optional<EvaluationResult>>& results,
+    const ScoreWeights& weights);
+
+/// Evaluates the candidates and returns the winning EncodingLayoutTree.
+nimble::EncodingLayoutTree getOptimalEncoding(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor = nullptr);
+
+/// Builds one CandidateEncoding per encoding type.
+std::vector<CandidateEncoding> buildEncodingCandidates(
+    const std::vector<nimble::EncodingType>& encodings);
+
+} // namespace facebook::nimble::selection

--- a/velox/dwio/nimble/tools/encoding/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/encoding/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(nimble_encoding_evaluation_tests EncodingEvaluationTest.cpp)
+add_test(nimble_encoding_evaluation_tests nimble_encoding_evaluation_tests)
+target_link_libraries(
+  nimble_encoding_evaluation_tests
+  nimble_encoding_evaluation
+  nimble_common
+  nimble_writer
+  velox_memory
+  velox_vector_test_lib
+  gtest
+  gtest_main
+)

--- a/velox/dwio/nimble/tools/encoding/tests/EncodingEvaluationTest.cpp
+++ b/velox/dwio/nimble/tools/encoding/tests/EncodingEvaluationTest.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/tools/encoding/EncodingEvaluation.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/NimbleException.h"
+#include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::nimble::selection {
+namespace {
+
+class EncodingEvaluationTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool("encoding_eval_test");
+    vectorMaker_ = std::make_unique<velox::test::VectorMaker>(pool_.get());
+  }
+
+  velox::VectorPtr makeConstantColumn(int64_t value, int32_t size) {
+    return vectorMaker_->flatVector<int64_t>(
+        size, [value](velox::vector_size_t) { return value; });
+  }
+
+  velox::VectorPtr makeVariedColumn(int32_t size) {
+    return vectorMaker_->flatVector<int64_t>(
+        size, [](velox::vector_size_t i) { return i * 17 + 3; });
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<velox::test::VectorMaker> vectorMaker_;
+};
+
+TEST_F(EncodingEvaluationTest, evaluateCandidatesReturnsResultsForCompatible) {
+  const std::vector<velox::VectorPtr> vectors{makeConstantColumn(42, 1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::FixedBitWidth,
+  });
+
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto results =
+      evaluateCandidates(vectors, candidates, opts, pool_.get());
+
+  ASSERT_EQ(results.size(), 2u);
+  ASSERT_TRUE(results[0].has_value());
+  ASSERT_TRUE(results[1].has_value());
+  EXPECT_EQ(results[0]->type, nimble::EncodingType::Trivial);
+  EXPECT_EQ(results[1]->type, nimble::EncodingType::FixedBitWidth);
+  EXPECT_GT(results[0]->encodedBytes, 0u);
+  EXPECT_GT(results[1]->encodedBytes, 0u);
+}
+
+TEST_F(EncodingEvaluationTest, evaluateCandidatesReturnsNulloptOnIncompatible) {
+  const std::vector<velox::VectorPtr> vectors{makeVariedColumn(1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::Constant,
+  });
+
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto results =
+      evaluateCandidates(vectors, candidates, opts, pool_.get());
+
+  ASSERT_EQ(results.size(), 2u);
+  EXPECT_TRUE(results[0].has_value());
+  EXPECT_FALSE(results[1].has_value());
+}
+
+TEST_F(EncodingEvaluationTest, evaluateCandidatesThrowsOnEmptyVectors) {
+  const std::vector<velox::VectorPtr> vectors;
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+  });
+  EvaluationOptions opts;
+
+  EXPECT_THROW(
+      evaluateCandidates(vectors, candidates, opts, pool_.get()),
+      nimble::NimbleUserError);
+}
+
+TEST_F(EncodingEvaluationTest, rankResultsThrowsWithoutTrivialBaseline) {
+  std::vector<std::optional<EvaluationResult>> results;
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::FixedBitWidth,
+          .encodedBytes = 100,
+          .encodeNanos = 100,
+          .decodeNanos = 100,
+      });
+
+  ScoreWeights weights;
+  EXPECT_THROW(rankResults(results, weights), nimble::NimbleUserError);
+}
+
+TEST_F(EncodingEvaluationTest, rankResultsSortsAscendingByScore) {
+  std::vector<std::optional<EvaluationResult>> results;
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::Trivial,
+          .encodedBytes = 1'000,
+          .encodeNanos = 1'000,
+          .decodeNanos = 1'000,
+      });
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::FixedBitWidth,
+          .encodedBytes = 500,
+          .encodeNanos = 2'000,
+          .decodeNanos = 2'000,
+      });
+  results.emplace_back(std::nullopt);
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::Constant,
+          .encodedBytes = 10,
+          .encodeNanos = 10'000,
+          .decodeNanos = 10'000,
+      });
+
+  ScoreWeights sizeOnly;
+  const auto rankedBySize = rankResults(results, sizeOnly);
+  ASSERT_EQ(rankedBySize.size(), 3u);
+  EXPECT_EQ(rankedBySize[0].type, nimble::EncodingType::Constant);
+  EXPECT_EQ(rankedBySize[1].type, nimble::EncodingType::FixedBitWidth);
+  EXPECT_EQ(rankedBySize[2].type, nimble::EncodingType::Trivial);
+
+  ScoreWeights decodeOnly{.encodeSize = 0.0, .decodeTime = 1.0};
+  const auto rankedByDecode = rankResults(results, decodeOnly);
+  ASSERT_EQ(rankedByDecode.size(), 3u);
+  EXPECT_EQ(rankedByDecode[0].type, nimble::EncodingType::Trivial);
+}
+
+TEST_F(EncodingEvaluationTest, getOptimalEncodingPicksConstantForConstantData) {
+  const std::vector<velox::VectorPtr> vectors{makeConstantColumn(7, 1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::FixedBitWidth,
+      nimble::EncodingType::Constant,
+  });
+
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto winningTree =
+      getOptimalEncoding(vectors, candidates, opts, pool_.get());
+
+  ASSERT_EQ(winningTree.schemaKind(), nimble::Kind::Scalar);
+  const auto* layout = winningTree.encodingLayout(
+      nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream);
+  ASSERT_NE(layout, nullptr);
+  EXPECT_EQ(layout->encodingType(), nimble::EncodingType::Constant);
+}
+
+TEST_F(EncodingEvaluationTest, getOptimalEncodingSkipsIncompatibleCandidates) {
+  const std::vector<velox::VectorPtr> vectors{makeVariedColumn(1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::Constant,
+  });
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto winningTree =
+      getOptimalEncoding(vectors, candidates, opts, pool_.get());
+  ASSERT_EQ(winningTree.schemaKind(), nimble::Kind::Scalar);
+  const auto* layout = winningTree.encodingLayout(
+      nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream);
+  ASSERT_NE(layout, nullptr);
+  EXPECT_EQ(layout->encodingType(), nimble::EncodingType::Trivial);
+}
+
+} // namespace
+} // namespace facebook::nimble::selection


### PR DESCRIPTION
Summary:

`Deserializer`'s range overload takes one range per batch. Extracting
several ranges from a single serialized batch therefore requires passing
that batch once per range, and each repetition re-parses the header and
trailer and rebuilds every stream's `Encoding` — which for compressed
streams means decompressing the whole stream again, and for
`DictionaryEncoding` re-materializing the full alphabet. Cost scales with
the number of ranges rather than the rows returned.

Add an overload taking a single `std::string_view` plus a list of ranges.
The batch is parsed and its stream segments registered once; the ranges
are translated into run-local coordinates and appended to `runRanges_`,
which `buildDecodeOps` already folds into a minimal skip/read sequence.

`appendBatch` now takes `folly::Range<const RowRange*>` instead of
`std::optional<RowRange>`; it is private with a single caller, and the
multi-batch path passes a one-element view per batch, preserving its
`data.size() == rowRanges.size()` precondition and behavior.

Ranges within a batch must be sorted ascending and non-overlapping.
`buildDecodeOps` only emits a skip when a range starts past its cursor,
so an out-of-order or overlapping range would otherwise fold into the
preceding read and silently return wrong rows.

Reviewed By: duxiao1212

Differential Revision: D115963599


