### PR TITLE
build: Use system zstd for OpenZL

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -143,7 +143,7 @@ jobs:
         env:
           VELOX_BUILD_SHARED: "ON"
           VELOX_FBTHRIFT_CMAKE_PATCH: ${{ github.workspace }}/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch
-          VELOX_OPENZL_CMAKE_PATCH: ${{ github.workspace }}/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch
+          VELOX_OPENZL_CMAKE_PATCH: ${{ github.workspace }}/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch ${{ github.workspace }}/CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch
         run: |
           if git diff --name-only HEAD^1 HEAD | grep -q "scripts/setup-"; then
             echo "Removing previous AWS SDK and s2n installations to avoid conflicts..."
@@ -559,7 +559,7 @@ jobs:
         env:
           VELOX_BUILD_SHARED: "ON"
           VELOX_FBTHRIFT_CMAKE_PATCH: ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch
-          VELOX_OPENZL_CMAKE_PATCH: ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch
+          VELOX_OPENZL_CMAKE_PATCH: ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch
         run: |
           if git diff --name-only HEAD^1 HEAD | grep -q "scripts/setup-"; then
             # Overwrite old setup scripts with changed versions
@@ -800,7 +800,7 @@ jobs:
         env:
           VELOX_BUILD_SHARED: "ON"
           VELOX_FBTHRIFT_CMAKE_PATCH: ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch
-          VELOX_OPENZL_CMAKE_PATCH: ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch
+          VELOX_OPENZL_CMAKE_PATCH: ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch ${{ github.workspace }}/velox/CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch
         run: |
           if git diff --name-only HEAD^1 HEAD | grep -q "scripts/setup-"; then
             # Overwrite old setup scripts with changed versions

--- a/CMake/resolve_dependency_modules/openzl.cmake
+++ b/CMake/resolve_dependency_modules/openzl.cmake
@@ -43,6 +43,7 @@ set(OPENZL_BUILD_TESTS OFF)
 set(OPENZL_BUILD_BENCHMARKS OFF)
 set(OPENZL_BUILD_PYTHON_EXT OFF)
 set(OPENZL_INSTALL OFF)
+set(OPENZL_USE_SYSTEM_ZSTD ON)
 
 # OpenZL hard-codes CMAKE_CXX_STANDARD to 17, but Velox builds with C++20. Its
 # C++ bindings select between std:: types and internal polyfills (poly::span,
@@ -58,7 +59,9 @@ FetchContent_Declare(
   openzl
   URL ${VELOX_OPENZL_SOURCE_URL}
   URL_HASH ${VELOX_OPENZL_BUILD_SHA256_CHECKSUM}
-  PATCH_COMMAND git init -q && git apply ${CMAKE_CURRENT_LIST_DIR}/openzl/openzl-cxx-standard.patch
+  PATCH_COMMAND
+    git init -q && git apply ${CMAKE_CURRENT_LIST_DIR}/openzl/openzl-cxx-standard.patch
+    ${CMAKE_CURRENT_LIST_DIR}/openzl/openzl-system-zstd.patch
   OVERRIDE_FIND_PACKAGE
   SYSTEM
   EXCLUDE_FROM_ALL

--- a/CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch
+++ b/CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch
@@ -1,0 +1,96 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c6c7743..0784f1a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,6 +24,7 @@ option(OPENZL_ALLOW_INTROSPECTION "Allow introspection" ON)
+ option(OPENZL_INSTALL "Install OpenZL" ON)
+ option(OPENZL_CPP_INSTALL "Install C++ bindings" ${OPENZL_INSTALL})
+ option(OPENZL_BUILD_PYTHON_DEMO "Build openzl_demo Python extension" ${OPENZL_BUILD_ALL})
++option(OPENZL_USE_SYSTEM_ZSTD "Use system-installed zstd instead of bundled" OFF)
+
+ # Fine-grained control of build directories that can be disabled.
+ # NOTE: Disabling some but not all of these may break the build, use with caution.
+diff --git a/build-scripts/cmake/openzl-config.cmake.in b/build-scripts/cmake/openzl-config.cmake.in
+index 6c8a0df..fce9ef2 100644
+--- a/build-scripts/cmake/openzl-config.cmake.in
++++ b/build-scripts/cmake/openzl-config.cmake.in
+@@ -14,6 +14,25 @@
+
+ include(CMakeFindDependencyMacro)
+
++if(@OPENZL_USE_SYSTEM_ZSTD@)
++  if(NOT TARGET zstd::zstd)
++    find_package(zstd QUIET)
++  endif()
++  if(NOT TARGET zstd::zstd)
++    if(TARGET zstd::libzstd)
++      add_library(zstd::zstd ALIAS zstd::libzstd)
++    elseif(TARGET zstd::libzstd_static)
++      add_library(zstd::zstd ALIAS zstd::libzstd_static)
++    elseif(TARGET zstd::libzstd_shared)
++      add_library(zstd::zstd ALIAS zstd::libzstd_shared)
++    else()
++      find_package(PkgConfig REQUIRED)
++      pkg_check_modules(OPENZL_ZSTD REQUIRED IMPORTED_TARGET GLOBAL libzstd)
++      add_library(zstd::zstd ALIAS PkgConfig::OPENZL_ZSTD)
++    endif()
++  endif()
++endif()
++
+ set_and_check(OPENZL_INCLUDE_DIR "@PACKAGE_OPENZL_INSTALL_INCLUDEDIR@")
+ set_and_check(OPENZL_CMAKE_DIR "@PACKAGE_OPENZL_INSTALL_CMAKEDIR@")
+
+diff --git a/build-scripts/cmake/openzl-deps.cmake b/build-scripts/cmake/openzl-deps.cmake
+index 62c1229..c7e86a2 100644
+--- a/build-scripts/cmake/openzl-deps.cmake
++++ b/build-scripts/cmake/openzl-deps.cmake
+@@ -18,6 +18,25 @@ endif()
+
+ set(ZSTD_LEGACY_SUPPORT OFF)
+
++if(OPENZL_USE_SYSTEM_ZSTD)
++    if(NOT TARGET zstd::zstd)
++        find_package(zstd QUIET)
++    endif()
++    if(NOT TARGET zstd::zstd)
++        if(TARGET zstd::libzstd)
++            add_library(zstd::zstd ALIAS zstd::libzstd)
++        elseif(TARGET zstd::libzstd_static)
++            add_library(zstd::zstd ALIAS zstd::libzstd_static)
++        elseif(TARGET zstd::libzstd_shared)
++            add_library(zstd::zstd ALIAS zstd::libzstd_shared)
++        else()
++            find_package(PkgConfig REQUIRED)
++            pkg_check_modules(OPENZL_ZSTD REQUIRED IMPORTED_TARGET GLOBAL libzstd)
++            add_library(zstd::zstd ALIAS PkgConfig::OPENZL_ZSTD)
++        endif()
++    endif()
++    list(APPEND OPENZL_LINK_LIBRARIES zstd::zstd)
++else()
+ # Two-tier zstd dependency resolution with automated hash verification
+ # 1. Git submodule (matches Makefile behavior)
+ # 2. FetchContent + URL (no git required, cryptographically verified)
+@@ -107,6 +126,7 @@ set(ZSTD_BUILD_TESTS OFF CACHE BOOL "")
+ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/deps/zstd/build/cmake" zstd_build)
+ # Note: find_package not needed when using add_subdirectory - targets are directly available
+ list(APPEND OPENZL_LINK_LIBRARIES libzstd)
++endif()
+
+ # Same two-tier lz4 dependency resolution with automated hash verification
+ set(LZ4_VERSION "1.10.0")
+diff --git a/tools/parquet/CMakeLists.txt b/tools/parquet/CMakeLists.txt
+index 68675ef..5e2ffee 100644
+--- a/tools/parquet/CMakeLists.txt
++++ b/tools/parquet/CMakeLists.txt
+@@ -3,8 +3,9 @@
+ if (OPENZL_BUILD_PARQUET_TOOLS)
+   set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep")
+
+-  # Point arrow to the zstd build directory
+-  list(APPEND CMAKE_PREFIX_PATH "${zstd_BINARY_DIR}")
++  if(NOT OPENZL_USE_SYSTEM_ZSTD)
++    list(APPEND CMAKE_PREFIX_PATH "${zstd_BINARY_DIR}")
++  endif()
+
+   set(ARROW_CMAKE_ARGS
+       -DARROW_PARQUET=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,13 +862,6 @@ if(VELOX_ENABLE_GEO)
   velox_resolve_dependency(s2geometry)
 endif()
 
-# Resolved last, after every other dependency. OpenZL vendors its own copy of
-# zstd, whose CMake defines an `uninstall` target. GEOS defines one too, but
-# without the `if(NOT TARGET uninstall)` guard that zstd has, so GEOS fails
-# outright if anything claimed the name first. Ordering Nimble after GEOS lets
-# GEOS win the race and zstd skip, which is the only arrangement in which a
-# BUNDLED build of both succeeds. Nothing between here and add_subdirectory()
-# needs these targets.
 if(VELOX_ENABLE_NIMBLE)
   # Nimble is the only consumer of both, so they are resolved here rather than
   # unconditionally. FlatBuffers supplies both the runtime library and the flatc

--- a/scripts/docker/centos-multi.dockerfile
+++ b/scripts/docker/centos-multi.dockerfile
@@ -46,6 +46,7 @@ COPY CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /
 COPY CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /
 COPY CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /
 COPY CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /
+COPY CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch /
 
 ARG VELOX_BUILD_SHARED=ON
 # Building libvelox.so requires folly and gflags to be built shared as well for now
@@ -72,7 +73,7 @@ ENV UV_TOOL_BIN_DIR=/usr/local/bin \
 ENV CMAKE_POLICY_VERSION_MINIMUM="3.5" \
     VELOX_ARROW_CMAKE_PATCH="/arrow-testing-boost.patch /cmake-compatibility.patch" \
     VELOX_FBTHRIFT_CMAKE_PATCH="/compactv1-protocol-refiller.patch" \
-    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch"
+    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch /openzl-system-zstd.patch"
 
 # Ensure libraries installed to INSTALL_PREFIX are found at runtime (e.g.
 # thrift1 needs libgflags.so.2.2 when folly links gflags statically but
@@ -138,7 +139,8 @@ FROM base-image AS pyvelox
 
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/velox_deps.conf \
  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/velox_deps.conf \
- && ldconfig
+ && ldconfig \
+ && test ! -e /usr/local/lib64/libzstd.so.1
 
 ########################
 # Stage: Adapters Build#
@@ -223,7 +225,8 @@ COPY --from=adapters-build /deps /usr/local
 # thrift1 requires shared libraries copied from /deps to /usr/local.
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/velox_deps.conf \
  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/velox_deps.conf \
- && ldconfig
+ && ldconfig \
+ && test ! -e /usr/local/lib64/libzstd.so.1
 
 COPY scripts/setup-classpath.sh /
 ENTRYPOINT ["/bin/bash", "-c", "source /setup-classpath.sh && source /opt/rh/gcc-toolset-12/enable && exec \"$@\"", "--"]

--- a/scripts/docker/fedora.dockerfile
+++ b/scripts/docker/fedora.dockerfile
@@ -27,6 +27,7 @@ COPY CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /
 COPY CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /
 COPY CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /
 COPY CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /
+COPY CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch /
 
 ARG VELOX_BUILD_SHARED=ON
 # Building libvelox.so requires folly and gflags to be built shared as well for now
@@ -44,7 +45,7 @@ ENV UV_TOOL_BIN_DIR=/usr/local/bin \
 ENV CMAKE_POLICY_VERSION_MINIMUM="3.5" \
     VELOX_ARROW_CMAKE_PATCH="/cmake-compatibility.patch /arrow-testing-boost.patch" \
     VELOX_FBTHRIFT_CMAKE_PATCH="/compactv1-protocol-refiller.patch" \
-    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch"
+    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch /openzl-system-zstd.patch"
 
 # Some CMake configs contain the hard coded prefix '/deps', we need to replace that with
 # the future location to avoid build errors in the base-image

--- a/scripts/docker/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/docker/ubuntu-22.04-cpp.dockerfile
@@ -48,10 +48,11 @@ COPY CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /
 COPY CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /
 COPY CMake/resolve_dependency_modules/fbthrift/compactv1-protocol-refiller.patch /
 COPY CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /
+COPY CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch /
 
 ENV VELOX_ARROW_CMAKE_PATCH="/cmake-compatibility.patch /arrow-testing-boost.patch" \
     VELOX_FBTHRIFT_CMAKE_PATCH="/compactv1-protocol-refiller.patch" \
-    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch" \
+    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch /openzl-system-zstd.patch" \
     UV_TOOL_BIN_DIR=/usr/local/bin \
     UV_INSTALL_DIR=/usr/local/bin
 

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -91,17 +91,21 @@ function install_openzl {
       # A different path is needed when building the Dockerfile.
       ABSOLUTE_SCRIPTDIR=$(realpath "$SCRIPT_DIR")
       VELOX_OPENZL_CMAKE_PATCH="$ABSOLUTE_SCRIPTDIR/../CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch"
+      VELOX_OPENZL_CMAKE_PATCH+=" $ABSOLUTE_SCRIPTDIR/../CMake/resolve_dependency_modules/openzl/openzl-system-zstd.patch"
     fi
 
     cd "$DEPENDENCY_DIR"/openzl || exit 1
-    if command -v patch >/dev/null 2>&1; then
-      patch -p1 -i "$VELOX_OPENZL_CMAKE_PATCH" || exit 1
-    else
-      git apply "$VELOX_OPENZL_CMAKE_PATCH" || exit 1
-    fi
+    for patch in $VELOX_OPENZL_CMAKE_PATCH; do
+      if command -v patch >/dev/null 2>&1; then
+        patch -p1 -i "$patch" || exit 1
+      else
+        git apply "$patch" || exit 1
+      fi
+    done
   ) || exit 1
   cmake_install_dir openzl \
     -DCMAKE_CXX_STANDARD=20 \
+    -DOPENZL_USE_SYSTEM_ZSTD=ON \
     -DOPENZL_BUILD_CLI=OFF \
     -DOPENZL_BUILD_EXAMPLES=OFF \
     -DOPENZL_BUILD_TOOLS=OFF \


### PR DESCRIPTION
Note: not ready for review yet, I am still iterating and need to address a few more things.

## Summary

- patch OpenZL to use an existing system zstd target, with a `pkg-config` fallback for distributions that do not ship a zstd CMake package
- enable system zstd for bundled and preinstalled OpenZL builds
- verify the CentOS images do not install OpenZL's bundled `libzstd.so.1` into `/usr/local/lib64`

OpenZL's bundled zstd was installed into a globally registered prefix, causing GCC and other system programs to load it instead of the RPM-managed library. This keeps zstd under the operating system package manager while preserving both OpenZL build modes and installed-package dependency resolution.

There are no Velox or OpenZL API changes.

Fixes #18546.
