### PR TITLE
fix(rpc): Let each backend adapt its concurrency independently (#18559)

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -1460,46 +1460,46 @@ class QueryConfig {
       "admission-controlled dispatch this ceiling now actually bounds in-flight "
       "rows, so it must be sized for the backend's healthy concurrency.")
 
-  /// Enables the adaptive per-tier RPC rate limiter (RPCRateLimiter).
+  /// Enables AIMD adaptation of each backend's rate-limit capacity.
   VELOX_QUERY_CONFIG(
       kRpcRateLimiterAdaptiveEnabled,
       rpcRateLimiterAdaptiveEnabled,
       "rpc.ratelimiter.adaptive_enabled",
       bool,
       true,
-      "When true (default), the process-global per-tier RPC rate limiter adapts "
-      "its max-pending cap via AIMD driven by the backend overload signal "
+      "When true (default), each backend's rate limiter adapts its capacity "
+      "via AIMD driven by the backend overload signal "
       "(rate-limit/timeout): multiplicative-decrease on an overload-classified "
       "drain, additive-increase on a clean drain. On by default because it is "
       "the protective behavior for shared, rate-limited inference backends; set "
       "false to keep a static cap. Unlike the per-driver congestion window, this "
       "coordinates all drivers on the worker and reacts to the rate-limit signal "
-      "directly, not to RTT.")
+      "directly, not to RTT. The first query to reach a backend fixes its policy for the life of the worker process; later queries contribute their outcomes to the adaptation but cannot change the setting. ")
 
-  /// Floor for the adaptive per-tier RPC rate limiter's max-pending cap.
+  /// Floor the adaptive rate-limit capacity may shrink to.
   VELOX_QUERY_CONFIG(
       kRpcRateLimiterMinLimit,
       rpcRateLimiterMinLimit,
       "rpc.ratelimiter.min_limit",
       int64_t,
       50,
-      "Floor the adaptive RPC rate limiter's per-tier max-pending cap may "
+      "Floor that a backend's adaptive rate-limit capacity may "
       "shrink to under sustained overload. Default 50 (a floor of 1 can stall a "
       "workload under sustained throttling). Only used when "
-      "rpc.ratelimiter.adaptive_enabled is true.")
+      "rpc.ratelimiter.adaptive_enabled is true. The first query to reach a backend fixes its policy for the life of the worker process; later queries contribute their outcomes to the adaptation but cannot change the setting. ")
 
-  /// Multiplicative-decrease factor for the adaptive RPC rate limiter.
+  /// Multiplicative-decrease factor for the adaptive rate-limit capacity.
   VELOX_QUERY_CONFIG(
       kRpcRateLimiterDecreaseFactor,
       rpcRateLimiterDecreaseFactor,
       "rpc.ratelimiter.decrease_factor",
       double,
       0.5,
-      "Factor applied to the adaptive RPC rate limiter's per-tier max-pending "
-      "cap on each overload-classified drain. Default 0.5 (halve). Clamped to "
-      "(0, 1). Only used when rpc.ratelimiter.adaptive_enabled is true.")
+      "Factor applied to a backend's adaptive rate-limit capacity "
+      "on each overload-classified drain. Default 0.5 (halve). Clamped to "
+      "(0, 1). Only used when rpc.ratelimiter.adaptive_enabled is true. The first query to reach a backend fixes its policy for the life of the worker process; later queries contribute their outcomes to the adaptation but cannot change the setting. ")
 
-  /// Ceiling for the per-tier RPC rate-limiter max-pending cap.
+  /// Ceiling for a backend's rate-limit capacity.
   VELOX_QUERY_CONFIG(
       kRpcRateLimiterMaxLimit,
       rpcRateLimiterMaxLimit,
@@ -1507,11 +1507,16 @@ class QueryConfig {
       int64_t,
       200,
       "Ceiling (and, with adaptive enabled, the starting value) for the "
-      "process-global per-tier RPC rate-limiter max-pending cap. Default 200 "
+      "per-backend rate-limit capacity, shared across drivers. Default 200 "
       "(validated for LLM-inference backends); 0 falls back to the built-in 20. "
-      "With admission-controlled dispatch this cap actually bounds process-wide "
-      "in-flight rows per tier; the adaptive limiter shrinks from here toward "
-      "rpc.ratelimiter.min_limit under overload.")
+      "With admission-controlled dispatch this cap bounds in-flight work "
+      "against that backend across every driver on the worker; the adaptive "
+      "limiter shrinks from here toward rpc.ratelimiter.min_limit under "
+      "overload. Any positive value here overrides a ceiling the function "
+      "asked for through its own options; set 0 to defer to that. The first "
+      "query to reach a backend fixes its policy for the life of the worker "
+      "process; later queries contribute their outcomes to the adaptation but "
+      "cannot change the setting.")
 
   // --- Hand-written accessors for properties that need custom logic ---
 

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -116,18 +116,29 @@ void RPCOperator::initialize() {
   // Size output vectors from config; see getOutput().
   outputBatchRows_ = queryConfig.preferredOutputBatchRows();
 
-  // Configure the process-global adaptive rate limiter from QueryConfig. This
-  // is idempotent and cluster-default-driven; off by default (static cap).
-  RPCRateLimiter::setAdaptiveConfig(
-      queryConfig.rpcRateLimiterAdaptiveEnabled(),
-      queryConfig.rpcRateLimiterMinLimit(),
-      queryConfig.rpcRateLimiterDecreaseFactor());
-  // Raise the per-tier ceiling so a high-latency backend can run at high
-  // concurrency; admission-controlled dispatch makes this cap bind, and the
-  // adaptive limiter shrinks from here under overload. 0 keeps the built-in 20.
-  if (const auto rlMax = queryConfig.rpcRateLimiterMaxLimit(); rlMax > 0) {
-    RPCRateLimiter::setMaxPending(tierKey_, rlMax);
-  }
+  limiter_ = &RPCRateLimiterRegistry::global().get(tierKey_);
+  // A backend's configuration is fixed by the first query to reach it and is
+  // shared by every query after. The limiter is a controller: its policy has
+  // to hold still while it adapts, and the adaptation itself is learned from
+  // all of them jointly. A later query asking for something different is
+  // logged and ignored rather than allowed to move the target mid-flight.
+  //
+  // One call, so one query's whole view lands or none of it does. Applying the
+  // function's option and the session properties as two writes left a window
+  // where a second query could interleave and fix a mixture of the two.
+  limiter_->initializeOnce([this,
+                            &queryConfig](RPCRateLimiter::Config& config) {
+    if (const auto fnCeiling = function_->configuredCeiling(); fnCeiling > 0) {
+      config.ceiling = fnCeiling;
+    }
+    config.adaptive = queryConfig.rpcRateLimiterAdaptiveEnabled();
+    config.floor = queryConfig.rpcRateLimiterMinLimit();
+    config.decreaseFactor = queryConfig.rpcRateLimiterDecreaseFactor();
+    // 0 keeps whatever the function asked for; any positive value wins.
+    if (const auto rlMax = queryConfig.rpcRateLimiterMaxLimit(); rlMax > 0) {
+      config.ceiling = rlMax;
+    }
+  });
 
   RPC_OP_VLOG(1) << "Created operator for function '"
                  << rpcNode_->functionName() << "', planNodeId=" << planNodeId()
@@ -159,9 +170,10 @@ bool RPCOperator::needsInput() const {
     return false;
   }
 
-  // Don't take a new input vector until the current one's buffered rows
-  // are fully dispatched (drained under admission control).
-  if (hasPendingRows()) {
+  // Don't take more input while this driver already holds as much as it
+  // should buffer. This bounds memory; whether the tier can take a flush
+  // right now is isBlocked()'s question, not this one.
+  if (inputBufferIsFull()) {
     return false;
   }
 
@@ -222,16 +234,16 @@ void RPCOperator::addInput(RowVectorPtr input) {
 
   if (streamingMode == RPCStreamingMode::kPerRow) {
     // PER_ROW: buffer the input and drip its rows out under admission
-    // control (dispatchPendingRows) instead of dispatching the whole vector at
-    // once, which would overrun both the per-driver window and the per-tier
-    // rate limiter. needsInput() returns false until this buffer is drained, so
-    // exactly one input vector is buffered at a time.
+    // control (dispatchRowsUnderAdmission) instead of dispatching the whole
+    // vector at once, which would overrun both the per-driver window and the
+    // shared admission control. needsInput() returns false until this buffer is
+    // drained, so exactly one input vector is buffered at a time.
     pendingArgs_ = std::move(args);
     pendingNumRows_ = static_cast<vector_size_t>(input->size());
     pendingCursor_ = 0;
     pendingBatchIndex_ = state_->storeInputBatch(
         std::move(flattenedColumns), static_cast<int64_t>(pendingNumRows_));
-    dispatchPendingRows();
+    dispatchRowsUnderAdmission();
   } else {
     // BATCH: function accumulates typed data internally.
     auto rowIndices = function_->accumulateBatch(rows, args);
@@ -247,33 +259,37 @@ void RPCOperator::addInput(RowVectorPtr input) {
       batchRowIds_.push_back(rowId);
     }
 
-    if (dispatchBatchSize_ > 0 &&
-        function_->pendingBatchSize() >= dispatchBatchSize_) {
-      // Flush in chunks of dispatchBatchSize_ to avoid sending one
-      // giant batch_predict call that overwhelms the server.
-      while (function_->pendingBatchSize() >= dispatchBatchSize_ &&
-             !state_->isUnderBackpressure()) {
-        flushBatchRequests(dispatchBatchSize_);
-      }
-    }
+    // Flush in chunks of dispatchBatchSize_ rather than one giant
+    // batch_predict call that would overwhelm the server.
+    dispatchBatchUnderAdmission(DispatchScope::kFullChunksOnly);
   }
 }
 
-void RPCOperator::dispatchPendingRows() {
+void RPCOperator::dispatchRowsUnderAdmission() {
   while (hasPendingRows()) {
-    // Admission headroom = min(per-driver congestion window, process-global
-    // per-tier rate limiter). Both must have room; the tighter one binds. This
-    // is what makes rpcPeakInFlight track the cap instead of the vector size.
-    const int64_t headroom = std::min(
-        state_->dispatchHeadroom(),
-        RPCRateLimiter::availableHeadroom(tierKey_));
-    if (headroom <= 0) {
+    // The per-driver congestion window bounds this driver; the tier's capacity
+    // bounds every driver sharing the backend. Both must have room.
+    const int64_t windowHeadroom = state_->dispatchHeadroom();
+    if (windowHeadroom <= 0) {
       break;
     }
     const auto remaining =
         static_cast<int64_t>(pendingNumRows_ - pendingCursor_);
-    const auto numRowsInChunk =
-        static_cast<vector_size_t>(std::min(headroom, remaining));
+    const int64_t want = std::min(windowHeadroom, remaining);
+
+    // Reserve the tier's slots BEFORE dispatching, one token per row, and send
+    // exactly what was granted. Sizing the chunk against available() and
+    // acquiring after the RPC is out lets N drivers each measure the same free
+    // capacity and all dispatch against it, overshooting the cap by roughly
+    // the driver count.
+    // One grant for the whole chunk: reserving row by row would take the
+    // backend's exclusive lock once per row, and that lock also carries
+    // available(), waitForCapacity() and the adaptation callbacks.
+    auto reserved = limiter_->tryAcquireUpTo(want);
+    if (reserved.empty()) {
+      break;
+    }
+    const auto numRowsInChunk = static_cast<vector_size_t>(reserved.size());
 
     // Select this chunk's rows [pendingCursor_, pendingCursor_ +
     // numRowsInChunk).
@@ -293,10 +309,13 @@ void RPCOperator::dispatchPendingRows() {
         futures.size(),
         numRowsInChunk);
     numRequestsDispatched_ += static_cast<int64_t>(futures.size());
+    size_t reservedIndex = 0;
     for (auto& [originalRowIndex, future] : futures) {
       auto rowId = globalRowIdCounter_++;
+      // One pre-reserved slot per row, handed to the continuation so it is
+      // released when the row completes.
       auto token = std::make_shared<RPCRateLimiter::Token>(
-          RPCRateLimiter::acquire(tierKey_));
+          std::move(reserved[reservedIndex++]));
       auto wrapped =
           std::move(future)
               .within(kBatchRpcTimeout)
@@ -325,7 +344,7 @@ void RPCOperator::dispatchPendingRows() {
   }
 }
 
-void RPCOperator::flushBatchRequests(int32_t maxRows) {
+bool RPCOperator::flushBatchRequests(int32_t maxRows) {
   if (function_->pendingBatchSize() == 0) {
     VELOX_CHECK(
         batchRowLocations_.empty(),
@@ -333,7 +352,16 @@ void RPCOperator::flushBatchRequests(int32_t maxRows) {
         "pendingBatchSize=0. Function must override pendingBatchSize() "
         "when using BATCH mode.",
         batchRowLocations_.size());
-    return;
+    return false;
+  }
+
+  // Reserve the tier slot before touching any state: the accumulator is only
+  // split and handed to flushBatch() once this flush is admitted. Checking
+  // available() and acquiring after the call is out lets concurrent drivers
+  // overshoot the cap.
+  auto reserved = limiter_->tryAcquireUpTo(1);
+  if (reserved.empty()) {
+    return false;
   }
 
   // Determine how many rows to flush.
@@ -355,9 +383,9 @@ void RPCOperator::flushBatchRequests(int32_t maxRows) {
 
   auto future = function_->flushBatch(maxRows);
 
-  // Count each flushBatch() as 1 pending unit in the rate limiter.
-  auto token = std::make_shared<RPCRateLimiter::Token>(
-      RPCRateLimiter::acquire(tierKey_));
+  // Each flushBatch() is 1 pending unit against tier capacity, reserved above.
+  auto token =
+      std::make_shared<RPCRateLimiter::Token>(std::move(reserved.front()));
 
   // Share rowIds across both continuations. Order matters: deferError runs
   // BEFORE deferValue, so a whole-batch backend failure is first converted into
@@ -433,6 +461,7 @@ void RPCOperator::flushBatchRequests(int32_t maxRows) {
           });
 
   state_->addPendingBatch(state_, std::move(wrapped), std::move(rowLocations));
+  return true;
 }
 
 void RPCOperator::noMoreInput() {
@@ -441,14 +470,96 @@ void RPCOperator::noMoreInput() {
   RPC_OP_VLOG(1) << "noMoreInput: totalRequestsDispatched="
                  << numRequestsDispatched_;
 
-  if (state_->streamingMode() == RPCStreamingMode::kBatch) {
-    // Flush any remaining accumulated rows in chunks.
-    while (function_->pendingBatchSize() > 0) {
-      flushBatchRequests(dispatchBatchSize_ > 0 ? dispatchBatchSize_ : 0);
-    }
-  }
+  // BATCH flushes its accumulator here; PER_ROW has nothing buffered at this
+  // point (see hasUndispatchedWork()).
+  drainPending();
 
-  state_->setNoMoreInput();
+  // Only declare the input closed once nothing is left undispatched. Anything
+  // admission held back goes out from isBlocked() as slots free, and
+  // signalling here would let the finish condition fire while rows are still
+  // waiting to be sent.
+  if (!hasUndispatchedWork()) {
+    state_->setNoMoreInput();
+  }
+}
+
+bool RPCOperator::inputBufferIsFull() const {
+  if (state_->streamingMode() == RPCStreamingMode::kPerRow) {
+    return hasPendingRows();
+  }
+  // Depth only. Deliberately not gated on the tier's free capacity, which
+  // churns as tokens release: throttling intake on an instantaneous zero both
+  // stalls the pipeline and ignores this driver's own in-flight work that is
+  // about to free a slot. dispatchBatchSize_ of 0 means buffer-everything, so
+  // there is no depth to bound.
+  return dispatchBatchSize_ > 0 &&
+      function_->pendingBatchSize() >= kBufferedChunks * dispatchBatchSize_;
+}
+
+bool RPCOperator::hasUndispatchedWork() const {
+  return state_->streamingMode() == RPCStreamingMode::kPerRow
+      ? hasPendingRows()
+      : function_->pendingBatchSize() > 0;
+}
+
+void RPCOperator::drainPending() {
+  if (state_->streamingMode() == RPCStreamingMode::kPerRow) {
+    dispatchRowsUnderAdmission();
+  } else {
+    dispatchBatchUnderAdmission(DispatchScope::kEverything);
+  }
+}
+
+std::optional<exec::BlockingReason> RPCOperator::drainOrParkOnAdmission(
+    ContinueFuture* future) {
+  if (!hasUndispatchedWork()) {
+    return std::nullopt;
+  }
+  drainPending();
+  if (!hasUndispatchedWork()) {
+    // Everything went out, so the input can finally be declared closed --
+    // noMoreInput() and startDrain() defer that until exactly this point.
+    state_->setNoMoreInput();
+    return std::nullopt;
+  }
+  if (state_->numInFlight() == 0) {
+    // Nothing of ours is in flight, so only another driver's release can help.
+    // admitOrWait() decides and enrols under one lock, so a slot freeing here
+    // cannot leave us waiting on nothing, and this never falls through to a
+    // wait that nothing could fulfil.
+    auto admission = limiter_->admitOrWait();
+    if (admission.admitted) {
+      // Room appeared; come back round and dispatch into it.
+      return exec::BlockingReason::kNotBlocked;
+    }
+    *future = std::move(admission.wait);
+    blockWaitStartNs_ = getCurrentTimeNano();
+    blockWaitIsBackpressure_ = true;
+    return exec::BlockingReason::kWaitForRPC;
+  }
+  // Our own completions will free slots and wake the wait below.
+  return std::nullopt;
+}
+
+void RPCOperator::dispatchBatchUnderAdmission(DispatchScope scope) {
+  int32_t minRows = 1;
+  if (scope == DispatchScope::kFullChunksOnly) {
+    if (dispatchBatchSize_ <= 0) {
+      // Dispatch-once mode: nothing is a full chunk until the input closes.
+      return;
+    }
+    minRows = dispatchBatchSize_;
+  }
+  const auto chunk = dispatchBatchSize_ > 0 ? dispatchBatchSize_ : 0;
+  // Both gates, the same pair dispatchRowsUnderAdmission() applies: the
+  // per-driver window, and the tier's shared capacity. Checking only the window
+  // lets a driver whose window is open keep flushing while other drivers have
+  // already exhausted the tier, which is the over-admission this exists to
+  // stop. The tier slot is reserved inside flushBatchRequests(), which returns
+  // false when the backend is full, so this stops instead of overshooting.
+  while (function_->pendingBatchSize() >= minRows &&
+         !state_->isUnderBackpressure() && flushBatchRequests(chunk)) {
+  }
 }
 
 RowVectorPtr RPCOperator::getOutput() {
@@ -456,8 +567,8 @@ RowVectorPtr RPCOperator::getOutput() {
 
   if (streamingMode == RPCStreamingMode::kPerRow) {
     // Drip more buffered rows now that in-flight completions may have
-    // freed window / rate-limiter headroom.
-    dispatchPendingRows();
+    // freed window / tier capacity.
+    dispatchRowsUnderAdmission();
 
     if (claimedRows_.empty()) {
       // If draining and nothing left to output, check finish.
@@ -503,7 +614,8 @@ RowVectorPtr RPCOperator::getOutput() {
     // CongestionController.h / the function's CongestionPolicy):
     //  - Window (per-driver): halve on overload; otherwise feed the successful
     //    rows' RTTs to the latency gradient.
-    //  - Rate limiter (process-global per tier): halve the cap on overload,
+    //  - Rate limiter (one per provisioned capacity): halve the cap on
+    //    overload,
     //    additive-recover on success.
     // The policy classifies overload as rate-limit / timeout / majority error
     // (ignoring null_input). Both scopes must back off on it: a rate-limit
@@ -513,13 +625,14 @@ RowVectorPtr RPCOperator::getOutput() {
     const auto signal = function_->evaluateCongestion(responses);
     if (signal == AsyncRPCFunction::CongestionSignal::kError) {
       state_->onUnitError();
-      RPCRateLimiter::onRateLimited(tierKey_);
+      limiter_->onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
     } else if (signal == AsyncRPCFunction::CongestionSignal::kSuccess) {
       // Feed the whole drained batch of successful RTTs to the gradient in one
       // lock acquisition; its size is the success count driving AIMD recovery.
       state_->onUnitSamples(roundTripTimesNs);
-      RPCRateLimiter::onSuccess(
-          tierKey_, static_cast<int64_t>(roundTripTimesNs.size()));
+      limiter_->onOutcome(
+          RPCRateLimiter::Outcome::kSuccess,
+          static_cast<int64_t>(roundTripTimesNs.size()));
     }
 
     auto output = buildOutputVector(responses, locations);
@@ -555,18 +668,20 @@ RowVectorPtr RPCOperator::getOutput() {
 
     // Both AIMD controllers back off on the function's overload verdict (see
     // PER_ROW above): the window (per-driver) halves on overload, else feeds
-    // the batch RTT to the latency gradient; the rate limiter (global) halves
+    // the batch RTT to the latency gradient; tier capacity (shared) halves
     // the cap on overload and recovers on success.
     const auto signal = function_->evaluateCongestion(claimedBatch_->responses);
     if (signal == AsyncRPCFunction::CongestionSignal::kError) {
       state_->onUnitError();
-      RPCRateLimiter::onRateLimited(tierKey_);
+      limiter_->onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
     } else if (signal == AsyncRPCFunction::CongestionSignal::kSuccess) {
       // Feed the measured round-trip latency to the gradient window so it
       // learns the in-flight-batch sweet spot without a fixed ceiling.
       state_->onUnitSample(claimedBatch_->rttNs);
-      // Successful rows in this batch drive AIMD recovery of the per-tier cap.
-      RPCRateLimiter::onSuccess(tierKey_, numRows - batchErrors);
+      // Successful rows in this batch drive AIMD recovery of the backend's
+      // shared cap.
+      limiter_->onOutcome(
+          RPCRateLimiter::Outcome::kSuccess, numRows - batchErrors);
     }
 
     auto output = buildOutputFromReadyBatch(*claimedBatch_);
@@ -590,8 +705,8 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
 
   // Emit ready output / report finished BEFORE any backpressure gate: a driver
   // holding completed rows (or with its own in-flight completions to harvest)
-  // must never park behind the shared per-tier cap held by OTHER drivers. The
-  // per-tier backpressure wait is applied as a last resort below, only when
+  // must never park behind the backend's shared cap held by OTHER drivers.
+  // That wait is applied as a last resort below, only when
   // this operator has buffered rows and nothing in-flight (i.e. it is genuinely
   // blocked on the global cap, with no local completion to wake it).
   if (!claimedRows_.empty() || claimedBatch_.has_value()) {
@@ -608,7 +723,7 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
   if (streamingMode == RPCStreamingMode::kPerRow) {
     if (!noMoreInput_ && !isDraining()) {
       // A completion may have freed headroom — try to drip more.
-      dispatchPendingRows();
+      dispatchRowsUnderAdmission();
       auto claimedRow = state_->tryClaimReady();
       if (claimedRow) {
         claimedRows_.push_back(std::move(*claimedRow));
@@ -617,11 +732,11 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
       // No ready output. Wait on the per-state completion future ONLY when this
       // operator has in-flight rows — those are guaranteed to fire that future.
       // If rows are buffered but nothing is in-flight, they are blocked solely
-      // on the process-global per-tier rate limiter (its cap held by other
+      // on the backend's shared admission capacity (held by other
       // drivers); the per-state future would never resolve, so returning
       // kWaitForRPC here would hang the driver. Instead fall through to
       // kNotBlocked and let the next isBlocked() re-check
-      // RPCRateLimiter::checkBackpressure(), which a slot-freeing decrement on
+      // RPCRateLimiter::admitOrWait(), which a slot-freeing release on
       // any driver wakes. needsInput() stays false while the buffer is
       // non-empty, so no new input arrives meanwhile.
       if (state_->numInFlight() > 0) {
@@ -642,18 +757,29 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
         }
       }
       // Buffered rows but nothing in-flight: this operator is blocked solely on
-      // the process-global per-tier cap (its slots held by other drivers). Park
-      // on the limiter's waiter — woken by any driver's slot-freeing decrement
+      // the backend's shared cap (its slots held by other drivers). Park
+      // on the tier's waiter queue — woken by any driver's slot-freeing release
       // — rather than busy-spinning via repeated kNotBlocked.
       if (hasPendingRows()) {
-        if (auto bp = RPCRateLimiter::checkBackpressure(tierKey_)) {
-          *future = std::move(*bp);
-          blockWaitStartNs_ = getCurrentTimeNano();
-          blockWaitIsBackpressure_ = true;
-          return exec::BlockingReason::kWaitForRPC;
+        auto admission = limiter_->admitOrWait();
+        if (admission.admitted) {
+          // Room appeared; come back round and dispatch into it.
+          return exec::BlockingReason::kNotBlocked;
         }
+        *future = std::move(admission.wait);
+        blockWaitStartNs_ = getCurrentTimeNano();
+        blockWaitIsBackpressure_ = true;
+        return exec::BlockingReason::kWaitForRPC;
       }
       return exec::BlockingReason::kNotBlocked;
+    }
+
+    // Resume the drain: rows admission held back still have to go out, and
+    // noMoreInput()/startDrain() deferred the end-of-input signal until they
+    // do. Mirrors the BATCH path below. Completions free slots, and this runs
+    // on the same wake-ups that deliver them.
+    if (auto reason = drainOrParkOnAdmission(future)) {
+      return reason.value();
     }
 
     std::optional<RPCState::ReadyRow> claimedRow;
@@ -678,6 +804,11 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
   } else {
     // BATCH mode
     if (!noMoreInput_ && !isDraining()) {
+      // A completion may have freed a slot. BATCH otherwise only flushes on
+      // new input, so once needsInput() stops taking input a full accumulator
+      // would sit here indefinitely with capacity going unused.
+      dispatchBatchUnderAdmission(DispatchScope::kFullChunksOnly);
+
       auto readyBatch = state_->tryPollReady();
       if (readyBatch) {
         if (readyBatch->error.has_value()) {
@@ -719,7 +850,58 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
             break;
         }
       }
+
+      // Admission refused a flush this driver is otherwise ready to make.
+      // Yield the thread rather than report not-blocked: needsInput() also
+      // refuses while the accumulator holds an unflushable chunk, so the
+      // driver would come straight back here with nothing to do.
+      if (dispatchBatchSize_ > 0 &&
+          function_->pendingBatchSize() >= dispatchBatchSize_ &&
+          limiter_->available() == 0) {
+        // Same order as the PER_ROW path: prefer this driver's own in-flight
+        // batches, whose completion both frees a slot and is guaranteed to
+        // fire. Only with nothing of ours in flight is the cap held entirely
+        // by other drivers, and the tier's waiter queue the one thing that can
+        // wake us.
+        if (state_->numInFlight() > 0) {
+          ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+          std::optional<RPCState::ReadyBatch> polledBatch;
+          switch (state_->tryPollBatchOrWait(&waitFuture, &polledBatch)) {
+            case RPCState::BatchPollResult::kGotBatch:
+              if (polledBatch->error.has_value()) {
+                RPC_OP_LOG(WARNING) << "Received batch with error: "
+                                    << polledBatch->error.value();
+              }
+              claimedBatch_ = std::move(*polledBatch);
+              return exec::BlockingReason::kNotBlocked;
+            case RPCState::BatchPollResult::kMustWait:
+              *future = std::move(waitFuture);
+              blockWaitStartNs_ = getCurrentTimeNano();
+              blockWaitIsBackpressure_ = true;
+              return exec::BlockingReason::kWaitForRPC;
+            case RPCState::BatchPollResult::kFinished:
+              break;
+          }
+        } else {
+          auto admission = limiter_->admitOrWait();
+          if (admission.admitted) {
+            // Room appeared; come back round and dispatch into it.
+            return exec::BlockingReason::kNotBlocked;
+          }
+          *future = std::move(admission.wait);
+          blockWaitStartNs_ = getCurrentTimeNano();
+          blockWaitIsBackpressure_ = true;
+          return exec::BlockingReason::kWaitForRPC;
+        }
+      }
       return exec::BlockingReason::kNotBlocked;
+    }
+
+    // Resume the drain: noMoreInput() dispatched only what admission allowed,
+    // so anything still accumulated is waiting on a slot. Completions free
+    // slots, and this runs on the same wake-ups that deliver them.
+    if (auto reason = drainOrParkOnAdmission(future)) {
+      return reason.value();
     }
 
     std::optional<RPCState::ReadyBatch> readyBatch;
@@ -758,14 +940,19 @@ bool RPCOperator::startDrain() {
   VELOX_CHECK(isDraining());
   VELOX_CHECK(!noMoreInput_);
 
-  // Flush any undispatched accumulated rows.
-  if (function_->pendingBatchSize() > 0) {
-    flushBatchRequests();
-  }
+  // Send what admission allows; whatever does not fit goes out from
+  // isBlocked() as slots free.
+  drainPending();
 
-  // Signal RPCState that no more rows will be dispatched so it can
-  // detect the finish condition once in-flight RPCs complete.
-  state_->setNoMoreInput();
+  // Same rule as noMoreInput(): declare the input closed only once nothing is
+  // left undispatched, or the finish condition could fire while rows are
+  // still waiting to be sent.
+  if (!hasUndispatchedWork()) {
+    state_->setNoMoreInput();
+  } else {
+    // Those rows still have to go out, so there is buffered data to drain.
+    return true;
+  }
 
   // If we have claimed output or pending in-flight RPCs, there is
   // buffered data to drain.
@@ -924,20 +1111,19 @@ void RPCOperator::recordRuntimeStats() {
         kRpcErrorKindBackendError, RuntimeCounter(numErrorsBackend_));
   }
 
-  // Process-global per-tier rate-limiter cap trajectory (the shared cap this
+  // Per-tier admission capacity trajectory (the shared capacity this
   // operator drips against). Distinct from the per-driver rpcCongestion*
   // window. Emitted unconditionally — including for the empty/default tier,
   // which is the bucket the meta.ai per-row-key path uses; gating on a
   // non-empty tierKey_ would hide the cap on exactly that main path.
+  const auto limiterStats = limiter_->stats();
   lockedStats->addRuntimeStat(
-      kRpcRateLimiterCap,
-      RuntimeCounter(RPCRateLimiter::currentLimit(tierKey_)));
+      kRpcRateLimiterCap, RuntimeCounter(limiterStats.capacity));
   lockedStats->addRuntimeStat(
-      kRpcRateLimiterPeakPending,
-      RuntimeCounter(RPCRateLimiter::peakPending(tierKey_)));
-  const auto minCap = RPCRateLimiter::minLimitReached(tierKey_);
-  if (minCap > 0) {
-    lockedStats->addRuntimeStat(kRpcRateLimiterMinCap, RuntimeCounter(minCap));
+      kRpcRateLimiterPeakPending, RuntimeCounter(limiterStats.peakPending));
+  if (limiterStats.lowWaterCapacity > 0) {
+    lockedStats->addRuntimeStat(
+        kRpcRateLimiterMinCap, RuntimeCounter(limiterStats.lowWaterCapacity));
   }
 }
 

--- a/velox/exec/rpc/RPCOperator.h
+++ b/velox/exec/rpc/RPCOperator.h
@@ -68,8 +68,7 @@ namespace facebook::velox::exec::rpc {
 ///   All cross-thread coordination goes through RPCState, which is fully
 ///   mutex-protected (see RPCState.h for per-method annotations).
 /// - RPCRateLimiter tokens use RAII: destruction (including from cancelled
-///   futures) automatically decrements the pending count and notifies
-///   waiters.
+///   futures) automatically releases the slot and wakes a parked driver.
 ///
 class RPCOperator : public exec::Operator {
  public:
@@ -118,19 +117,72 @@ class RPCOperator : public exec::Operator {
   static inline const std::string kRpcErrorKindTimeout{"rpcErrorKindTimeout"};
   static inline const std::string kRpcErrorKindBackendError{
       "rpcErrorKindBackendError"};
-  // Process-global per-tier RPCRateLimiter observability (adaptive cap
-  // trajectory), snapshotted at close(). The rpcCongestion* stats above are the
-  // per-DRIVER window; these are the shared rate-limiter cap.
+  // Per-tier RPCRateLimiter observability (capacity trajectory), snapshotted
+  // at close(). The rpcCongestion* stats above are the per-DRIVER window; these
+  // are the capacity shared by every driver on the tier.
   static inline const std::string kRpcRateLimiterCap{"rpcRateLimiterCap"};
   static inline const std::string kRpcRateLimiterPeakPending{
       "rpcRateLimiterPeakPending"};
   static inline const std::string kRpcRateLimiterMinCap{"rpcRateLimiterMinCap"};
 
  private:
+  // How much of the accumulator a dispatch is willing to send.
+  enum class DispatchScope {
+    // Whole dispatch chunks only: a partial batch waits for more input. In
+    // dispatch-once mode (dispatchBatchSize_ == 0) nothing qualifies, since
+    // the accumulator buffers everything until the input closes.
+    kFullChunksOnly,
+    // Everything accumulated, including a final partial chunk. Used once the
+    // input is closed, where the remainder has to go out however small.
+    kEverything,
+  };
+
+  // Send accumulated rows while the per-driver window and the backend both
+  // allow it. The BATCH arm of drainPending(). Whatever admission refuses
+  // stays accumulated and goes out from isBlocked() as slots free, so a drain
+  // never exceeds either cap and never strands rows.
+  void dispatchBatchUnderAdmission(DispatchScope scope);
+
+  // Work this driver has taken in but not yet dispatched: buffered rows in
+  // PER_ROW, accumulated rows in BATCH. The two are mode-exclusive -- only the
+  // PER_ROW branch of addInput() sets the row buffer, only the BATCH branch
+  // accumulates -- so this asks the one question that matters per mode.
+  //
+  // The signal sites gate on it so end-of-input is never declared while
+  // admission still holds rows. In PER_ROW that guard cannot currently fire:
+  // the Driver only calls noMoreInput() when needsInput() is true, and a
+  // non-empty buffer already makes that false. It is kept so the invariant is
+  // local to this operator rather than resting on that Driver contract.
+  bool hasUndispatchedWork() const;
+
+  // Send whatever admission currently allows of that work.
+  void drainPending();
+
+  // The end-of-input drain, shared by both modes. Sends what admission allows;
+  // once nothing is left, declares the input closed. If work remains and this
+  // driver has nothing in flight, only another driver's release can help, so
+  // it parks on the backend. Returns a reason only in that parking case --
+  // otherwise the caller carries on to its own finish handling.
+  std::optional<exec::BlockingReason> drainOrParkOnAdmission(
+      ContinueFuture* future);
+
+  // How many dispatch chunks the accumulator may hold before needsInput()
+  // stops taking more. One chunk would leave nothing staged when a slot
+  // frees, costing a round trip upstream at exactly the wrong moment.
+  static constexpr int64_t kBufferedChunks = 2;
+
+  // needsInput(): true when this driver already holds as much as it should
+  // buffer. Depth only -- intake must not swing on an instantaneous capacity
+  // reading, and bounding it is what keeps the accumulator from growing to
+  // the whole input against a busy backend.
+  bool inputBufferIsFull() const;
+
   /// Flush accumulated batch rows via function_->flushBatch().
   /// Called when threshold is reached or at noMoreInput/drain time.
   /// @param maxRows Maximum rows to flush. 0 means flush all.
-  void flushBatchRequests(int32_t maxRows = 0);
+  // Returns false when the flush did not happen: nothing accumulated, or the
+  // tier had no free slot. Callers loop on this so they stop rather than spin.
+  bool flushBatchRequests(int32_t maxRows = 0);
 
   /// Build output RowVector from a ready batch (BATCH mode).
   RowVectorPtr buildOutputFromReadyBatch(RPCState::ReadyBatch& readyBatch);
@@ -148,11 +200,11 @@ class RPCOperator : public exec::Operator {
   // Increment the per-error-kind counter for a single response.
   void recordErrorKind(velox::rpc::RPCErrorKind kind);
 
-  // PER_ROW admission control: dispatch buffered rows up to the
-  // available headroom = min(per-driver window headroom, process-global
+  // The PER_ROW arm of drainPending(): dispatch buffered rows up to the
+  // available headroom = min(per-driver window headroom, this backend's
   // rate-limiter headroom). Called from addInput()/getOutput()/isBlocked() so a
   // whole input vector is dripped at the sustainable rate instead of blasted.
-  void dispatchPendingRows();
+  void dispatchRowsUnderAdmission();
 
   // Whether the PER_ROW dispatch buffer still has undispatched rows.
   bool hasPendingRows() const {
@@ -166,8 +218,15 @@ class RPCOperator : public exec::Operator {
   std::shared_ptr<RPCState> state_;
   std::shared_ptr<AsyncRPCFunction> function_;
 
-  // Tier key for per-tier rate limiting (from function_->tierKey()).
+  // Identifies the provisioned capacity this operator admits against: a
+  // backend tier plus the credential used to reach it (from
+  // function_->tierKey()). Everything sharing this key shares one quota.
   std::string tierKey_;
+
+  // Admission control for tierKey_, resolved once in initialize(). Points into
+  // the process-scoped RPCRateLimiterRegistry, which outlives every operator
+  // and every token captured into a continuation.
+  RPCRateLimiter* limiter_{nullptr};
 
   // Precomputed per-argument sources, in call()->inputs() order. Built once in
   // initialize() by walking the RPC call's argument expressions. A
@@ -205,9 +264,9 @@ class RPCOperator : public exec::Operator {
 
   // PER_ROW admission-controlled dispatch buffer. addInput() stores the
   // input vector's args here (flattened, shared across its rows) and records
-  // the stored batch index; dispatchPendingRows() drips rows [pendingCursor_,
-  // pendingNumRows_) in headroom-sized chunks. Empty (pendingCursor_ ==
-  // pendingNumRows_ == 0) when nothing is pending.
+  // the stored batch index; dispatchRowsUnderAdmission() drips rows
+  // [pendingCursor_, pendingNumRows_) in headroom-sized chunks. Empty
+  // (pendingCursor_ == pendingNumRows_ == 0) when nothing is pending.
   std::vector<VectorPtr> pendingArgs_;
   int32_t pendingBatchIndex_{-1};
   vector_size_t pendingCursor_{0};

--- a/velox/exec/rpc/RPCRateLimiter.cpp
+++ b/velox/exec/rpc/RPCRateLimiter.cpp
@@ -17,333 +17,417 @@
 #include "velox/exec/rpc/RPCRateLimiter.h"
 
 #include <algorithm>
-#include <mutex>
-#include <shared_mutex>
+#include <utility>
+#include <vector>
 
 #define RPC_RATE_LIMITER_LOG(severity) LOG(severity) << "[RPC_RATE_LIMITER] "
 #define RPC_RATE_LIMITER_VLOG(level) VLOG(level) << "[RPC_RATE_LIMITER] "
 
 namespace facebook::velox::exec::rpc {
 
-// --- Token implementation ---
+namespace {
+// Fallback ceiling for a backend configured with Config::ceiling == 0: 20
+// concurrent RPCs per process per backend.
+std::atomic<int64_t>& defaultCapacityRef() {
+  static std::atomic<int64_t> capacity{20};
+  return capacity;
+}
+} // namespace
 
-RPCRateLimiter::Token::Token(const std::string& tierKey)
-    : tierKey_(tierKey), valid_(true) {}
+// --- Token ---
 
 RPCRateLimiter::Token& RPCRateLimiter::Token::operator=(
     Token&& other) noexcept {
   if (this != &other) {
-    if (valid_) {
-      decrementPending(tierKey_);
+    if (owner_ != nullptr) {
+      owner_->release();
     }
-    tierKey_ = std::move(other.tierKey_);
-    valid_ = other.valid_;
-    other.valid_ = false;
+    owner_ = other.owner_;
+    other.owner_ = nullptr;
   }
   return *this;
 }
 
 RPCRateLimiter::Token::~Token() {
-  if (valid_) {
-    decrementPending(tierKey_);
+  if (owner_ != nullptr) {
+    owner_->release();
   }
 }
 
-// --- Function-local statics ---
+// --- RPCRateLimiter ---
 
-std::shared_mutex& RPCRateLimiter::mapMutex() {
-  static std::shared_mutex mutex;
-  return mutex;
+RPCRateLimiter::RPCRateLimiter(std::string tierKey)
+    : tierKey_{std::move(tierKey)} {}
+
+void RPCRateLimiter::setDefaultCapacity(int64_t capacity) {
+  defaultCapacityRef().store(capacity);
+  RPC_RATE_LIMITER_VLOG(1) << "default capacity set to " << capacity;
 }
 
-std::atomic<int64_t>& RPCRateLimiter::defaultMaxPendingRef() {
-  // Default: 20 concurrent RPCs per process per tier.
-  static std::atomic<int64_t> maxPending{20};
-  return maxPending;
+int64_t RPCRateLimiter::defaultCapacity() {
+  return defaultCapacityRef().load();
 }
 
-std::unordered_map<std::string, std::unique_ptr<RPCRateLimiter::TierState>>&
-RPCRateLimiter::tiers() {
-  static std::unordered_map<std::string, std::unique_ptr<TierState>> tierMap;
-  return tierMap;
+int64_t RPCRateLimiter::ceilingLocked() const {
+  return config_.ceiling > 0 ? config_.ceiling : defaultCapacityRef().load();
 }
 
-std::atomic<bool>& RPCRateLimiter::adaptiveEnabledRef() {
-  static std::atomic<bool> enabled{false};
-  return enabled;
+int64_t RPCRateLimiter::floorLocked(int64_t ceiling) const {
+  return std::min<int64_t>(std::max<int64_t>(1, config_.floor), ceiling);
 }
 
-std::atomic<int64_t>& RPCRateLimiter::adaptiveMinRef() {
-  static std::atomic<int64_t> minLimit{1};
-  return minLimit;
-}
-
-std::atomic<double>& RPCRateLimiter::adaptiveFactorRef() {
-  static std::atomic<double> factor{0.5};
-  return factor;
-}
-
-// Caller holds state.mutex.
-int64_t RPCRateLimiter::effectiveLimitLocked(const TierState& state) {
-  const int64_t ceiling =
-      state.maxPending > 0 ? state.maxPending : defaultMaxPendingRef().load();
-  if (!adaptiveEnabledRef().load() || state.adaptiveLimit <= 0) {
+int64_t RPCRateLimiter::capacityLocked() const {
+  const int64_t ceiling = ceilingLocked();
+  if (!config_.adaptive || capacity_ <= 0) {
     return ceiling;
   }
-  // Floor is clamped to <= ceiling so a misconfigured min_limit > ceiling can't
-  // make std::clamp's lo exceed hi (undefined behavior).
-  const int64_t floor =
-      std::min<int64_t>(std::max<int64_t>(1, adaptiveMinRef().load()), ceiling);
-  return std::clamp<int64_t>(state.adaptiveLimit, floor, ceiling);
+  return std::clamp<int64_t>(capacity_, floorLocked(ceiling), ceiling);
 }
 
-// --- TierState lookup ---
+void RPCRateLimiter::configure(const Config& config) {
+  // Replacing the whole config is one kind of amendment, so it shares
+  // amend()'s clamping and adaptive-flip logging rather than repeating them.
+  amend([&config](Config& target) { target = config; });
+}
 
-RPCRateLimiter::TierState& RPCRateLimiter::getOrCreateTierState(
-    const std::string& tierKey) {
-  auto& tierMap = tiers();
-  // Fast path: shared lock for the common case (tier already exists), so
-  // concurrent lookups from all drivers do not serialize. TierState is held by
-  // unique_ptr, so the returned reference stays valid after we drop the lock
-  // even if other threads later insert new tiers (only the map nodes move, not
-  // the pointed-to TierState).
+void RPCRateLimiter::initializeOnce(
+    const std::function<void(Config&)>& mutate) {
+  std::vector<ContinuePromise> toNotify;
   {
-    std::shared_lock<std::shared_mutex> rl(mapMutex());
-    auto it = tierMap.find(tierKey);
-    if (it != tierMap.end()) {
-      return *it->second;
+    std::lock_guard<std::mutex> l(mutex_);
+    if (initialized_) {
+      // Compare what the caller would actually get, not what they passed: an
+      // out-of-range floor or factor clamps to the same effective value and is
+      // not a divergent request.
+      Config wanted = config_;
+      mutate(wanted);
+      clampLocked(wanted);
+      if (wanted.adaptive != config_.adaptive ||
+          wanted.floor != config_.floor ||
+          wanted.decreaseFactor != config_.decreaseFactor ||
+          wanted.ceiling != config_.ceiling) {
+        // Per backend, not LOG_FIRST_N: that is process-wide, so the first
+        // backend to take this path would silence the warning for every other
+        // one even though the message names a specific tier.
+        if (!loggedDivergentSettings_) {
+          loggedDivergentSettings_ = true;
+          RPC_RATE_LIMITER_LOG(WARNING)
+              << "backend " << tierKey_
+              << " is already initialized; ignoring different settings from a "
+                 "later query. One configuration is shared by every query on a "
+                 "backend, and it is fixed by the first of them.";
+        }
+      }
+    } else {
+      applyMutationLocked(mutate);
+      collectWakeableLocked(toNotify);
+      // Sealed here rather than by a second call: two calls left a window in
+      // which another query saw initialized_ still false and overwrote.
+      initialized_ = true;
     }
   }
-  // Slow path: first sighting of this tier — take the exclusive lock to insert,
-  // re-checking in case another thread created it between the two locks.
-  std::unique_lock<std::shared_mutex> wl(mapMutex());
-  auto it = tierMap.find(tierKey);
-  if (it != tierMap.end()) {
-    return *it->second;
-  }
-  auto [newIt, _] = tierMap.emplace(tierKey, std::make_unique<TierState>());
-  return *newIt->second;
-}
-
-// --- Public API ---
-
-RPCRateLimiter::Token RPCRateLimiter::acquire(const std::string& tierKey) {
-  incrementPending(tierKey);
-  return Token(tierKey);
-}
-
-std::optional<ContinueFuture> RPCRateLimiter::checkBackpressure(
-    const std::string& tierKey) {
-  auto& state = getOrCreateTierState(tierKey);
-
-  std::lock_guard<std::mutex> l(state.mutex);
-
-  int64_t pending = state.pendingCount.load();
-  int64_t maxPending = effectiveLimitLocked(state);
-
-  if (pending < maxPending) {
-    RPC_RATE_LIMITER_VLOG(2)
-        << "checkBackpressure[" << tierKey << "]: OK (pending=" << pending
-        << ", max=" << maxPending << ")";
-    return std::nullopt;
-  }
-
-  RPC_RATE_LIMITER_VLOG(1) << "checkBackpressure[" << tierKey
-                           << "]: BLOCKED (pending=" << pending
-                           << ", max=" << maxPending
-                           << "), creating wait promise #"
-                           << state.waiters.size();
-  state.waiters.emplace_back("RPCRateLimiter::checkBackpressure");
-  return state.waiters.back().getSemiFuture();
-}
-
-int64_t RPCRateLimiter::pendingCount(const std::string& tierKey) {
-  auto& state = getOrCreateTierState(tierKey);
-  return state.pendingCount.load();
-}
-
-int64_t RPCRateLimiter::availableHeadroom(const std::string& tierKey) {
-  auto& state = getOrCreateTierState(tierKey);
-  std::lock_guard<std::mutex> l(state.mutex);
-  const int64_t cap = effectiveLimitLocked(state);
-  const int64_t pending = state.pendingCount.load();
-  return std::max<int64_t>(0, cap - pending);
-}
-
-int64_t RPCRateLimiter::currentLimit(const std::string& tierKey) {
-  auto& state = getOrCreateTierState(tierKey);
-  std::lock_guard<std::mutex> l(state.mutex);
-  return effectiveLimitLocked(state);
-}
-
-int64_t RPCRateLimiter::peakPending(const std::string& tierKey) {
-  return getOrCreateTierState(tierKey).peakPending.load();
-}
-
-int64_t RPCRateLimiter::minLimitReached(const std::string& tierKey) {
-  auto& state = getOrCreateTierState(tierKey);
-  std::lock_guard<std::mutex> l(state.mutex);
-  return state.minAdaptiveLimit;
-}
-
-void RPCRateLimiter::setMaxPending(const std::string& tierKey, int64_t limit) {
-  auto& state = getOrCreateTierState(tierKey);
-  std::lock_guard<std::mutex> l(state.mutex);
-  state.maxPending = limit;
-  RPC_RATE_LIMITER_VLOG(1) << "setMaxPending[" << tierKey << "]: set to "
-                           << limit;
-}
-
-void RPCRateLimiter::setDefaultMaxPending(int64_t limit) {
-  defaultMaxPendingRef().store(limit);
-  RPC_RATE_LIMITER_VLOG(1) << "setDefaultMaxPending: set to " << limit;
-}
-
-int64_t RPCRateLimiter::defaultMaxPending() {
-  return defaultMaxPendingRef().load();
-}
-
-void RPCRateLimiter::setAdaptiveConfig(
-    bool enabled,
-    int64_t minLimit,
-    double decreaseFactor) {
-  adaptiveMinRef().store(std::max<int64_t>(1, minLimit));
-  adaptiveFactorRef().store(std::clamp(decreaseFactor, 0.01, 0.99));
-  const bool was = adaptiveEnabledRef().exchange(enabled);
-  if (was != enabled) {
-    RPC_RATE_LIMITER_LOG(WARNING)
-        << "adaptive limiter " << (enabled ? "ENABLED" : "DISABLED")
-        << " (min=" << adaptiveMinRef().load()
-        << ", decrease=" << adaptiveFactorRef().load() << ")";
-  }
-}
-
-bool RPCRateLimiter::adaptiveEnabled() {
-  return adaptiveEnabledRef().load();
-}
-
-void RPCRateLimiter::onRateLimited(const std::string& tierKey) {
-  if (!adaptiveEnabledRef().load()) {
-    return;
-  }
-  auto& state = getOrCreateTierState(tierKey);
-  std::lock_guard<std::mutex> l(state.mutex);
-  const int64_t ceiling =
-      state.maxPending > 0 ? state.maxPending : defaultMaxPendingRef().load();
-  const int64_t cur = state.adaptiveLimit > 0 ? state.adaptiveLimit : ceiling;
-  // Floor clamped to <= ceiling so a misconfigured min_limit can't make
-  // std::clamp's lo exceed hi (undefined behavior).
-  const int64_t floor =
-      std::min<int64_t>(std::max<int64_t>(1, adaptiveMinRef().load()), ceiling);
-  int64_t next = static_cast<int64_t>(
-      static_cast<double>(cur) * adaptiveFactorRef().load());
-  next = std::clamp<int64_t>(next, floor, ceiling);
-  if (next < cur) {
-    state.adaptiveLimit = next;
-    if (state.minAdaptiveLimit == 0 || next < state.minAdaptiveLimit) {
-      state.minAdaptiveLimit = next;
-    }
-    RPC_RATE_LIMITER_VLOG(1)
-        << "RPC congestion: adaptive cap[" << tierKey << "] " << cur << " -> "
-        << next << " (rate-limit)";
-  }
-}
-
-void RPCRateLimiter::onSuccess(const std::string& tierKey, int64_t successes) {
-  if (!adaptiveEnabledRef().load() || successes <= 0) {
-    return;
-  }
-  auto& state = getOrCreateTierState(tierKey);
-  std::vector<ContinuePromise> waitersToNotify;
-  {
-    std::lock_guard<std::mutex> l(state.mutex);
-    // Only recover if we previously shrank (adaptiveLimit > 0).
-    if (state.adaptiveLimit <= 0) {
-      return;
-    }
-    const int64_t ceiling =
-        state.maxPending > 0 ? state.maxPending : defaultMaxPendingRef().load();
-    // AIMD additive-increase, TCP-Reno style: one +1 step per cap-worth of
-    // successes, floored at +1 per call so a steady success stream always makes
-    // progress. Scaling the step to the drain size makes recovery track the ÷2
-    // decrease's aggressiveness, instead of crawling +1 per (up-to-1k-row)
-    // drain — which in practice never recovered within a query. Reaching the
-    // ceiling clears the adaptive state so the static cap governs again.
-    const int64_t step = std::max<int64_t>(
-        1, successes / std::max<int64_t>(1, state.adaptiveLimit));
-    const int64_t next = state.adaptiveLimit + step;
-    state.adaptiveLimit = next >= ceiling ? 0 : next;
-    // A large recovery step can reopen several slots at once, so wake up to the
-    // recovered headroom's worth of blocked waiters (FIFO) — not just one, or
-    // drivers stay parked in checkBackpressure() despite available capacity.
-    int64_t headroom = effectiveLimitLocked(state) - state.pendingCount.load();
-    while (headroom > 0 && !state.waiters.empty()) {
-      waitersToNotify.push_back(std::move(state.waiters.front()));
-      state.waiters.pop_front();
-      --headroom;
-    }
-  }
-  for (auto& waiter : waitersToNotify) {
+  for (auto& waiter : toNotify) {
     waiter.setValue();
   }
 }
 
-void RPCRateLimiter::testingResetAllState() {
-  std::unique_lock<std::shared_mutex> l(mapMutex());
-  defaultMaxPendingRef().store(20);
-  adaptiveEnabledRef().store(false);
-  adaptiveMinRef().store(1);
-  adaptiveFactorRef().store(0.5);
-  tiers().clear();
+void RPCRateLimiter::testingReset() {
+  std::lock_guard<std::mutex> l(mutex_);
+  config_ = Config{};
+  initialized_ = false;
+  loggedDivergentSettings_ = false;
+  capacity_ = 0;
+  lowWater_ = 0;
+  pending_.store(0);
+  peakPending_.store(0);
+  waiters_.clear();
 }
 
-// --- Internal helpers ---
+void RPCRateLimiter::clampLocked(Config& config) {
+  config.floor = std::max<int64_t>(1, config.floor);
+  config.decreaseFactor = std::clamp(config.decreaseFactor, 0.01, 0.99);
+}
 
-void RPCRateLimiter::incrementPending(const std::string& tierKey) {
-  auto& state = getOrCreateTierState(tierKey);
-  int64_t newCount = ++state.pendingCount;
-  // Lock-free high-water update for observability. Relaxed ordering: this is a
-  // best-effort max for stats only, not a synchronization point.
-  int64_t prevPeak = state.peakPending.load(std::memory_order_relaxed);
-  while (newCount > prevPeak &&
-         !state.peakPending.compare_exchange_weak(
-             prevPeak, newCount, std::memory_order_relaxed)) {
+void RPCRateLimiter::collectWakeableLocked(
+    std::vector<ContinuePromise>& toNotify) {
+  int64_t headroom = capacityLocked() - pending_.load();
+  while (headroom > 0 && !waiters_.empty()) {
+    toNotify.push_back(std::move(waiters_.front()));
+    waiters_.pop_front();
+    --headroom;
   }
-  RPC_RATE_LIMITER_VLOG(2) << "incrementPending[" << tierKey
-                           << "]: pending=" << newCount;
 }
 
-void RPCRateLimiter::decrementPending(const std::string& tierKey) {
-  auto& state = getOrCreateTierState(tierKey);
-  int64_t newCount = --state.pendingCount;
-  RPC_RATE_LIMITER_VLOG(2) << "decrementPending[" << tierKey
-                           << "]: pending=" << newCount;
+void RPCRateLimiter::applyMutationLocked(
+    const std::function<void(Config&)>& mutate) {
+  const bool was = config_.adaptive;
+  mutate(config_);
+  clampLocked(config_);
+  if (was != config_.adaptive) {
+    RPC_RATE_LIMITER_LOG(WARNING)
+        << "adaptive capacity " << (config_.adaptive ? "ENABLED" : "DISABLED")
+        << " for backend " << tierKey_ << " (floor=" << config_.floor
+        << ", decrease=" << config_.decreaseFactor << ")";
+  }
+}
 
-  // CRITICAL: Hold the per-tier mutex when checking whether to notify waiters.
-  // This prevents a TOCTOU race where:
-  // 1. We read newCount < maxPending (should notify)
-  // 2. A new waiter is added in checkBackpressure() between read and notify
-  //
-  // By holding the lock during check-and-notify, any waiter added in
-  // checkBackpressure() will either:
-  // - Be in state.waiters before we check (and we'll notify it)
-  // - See the updated count and not need to wait at all
-  //
-  // We notify only one waiter per decrement (FIFO) to avoid thundering herd.
-  std::optional<ContinuePromise> waiterToNotify;
+void RPCRateLimiter::amend(const std::function<void(Config&)>& mutate) {
+  std::vector<ContinuePromise> toNotify;
   {
-    std::lock_guard<std::mutex> l(state.mutex);
-    int64_t maxPending = effectiveLimitLocked(state);
-    if (newCount < maxPending && !state.waiters.empty()) {
-      RPC_RATE_LIMITER_VLOG(1)
-          << "decrementPending[" << tierKey << "]: notifying 1 of "
-          << state.waiters.size() << " waiters";
-      waiterToNotify = std::move(state.waiters.front());
-      state.waiters.pop_front();
+    std::lock_guard<std::mutex> l(mutex_);
+    applyMutationLocked(mutate);
+    // A mutation that raises the ceiling grows capacity, and no release or
+    // adaptation is guaranteed to follow, so drivers parked under the old
+    // capacity would stay parked. Wake whatever now fits.
+    collectWakeableLocked(toNotify);
+  }
+  for (auto& waiter : toNotify) {
+    waiter.setValue();
+  }
+}
+
+RPCRateLimiter::Config RPCRateLimiter::config() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  return config_;
+}
+
+void RPCRateLimiter::notePeakPending(int64_t pending) {
+  // Relaxed ordering: a best-effort max for stats, not a synchronization
+  // point.
+  int64_t peak = peakPending_.load(std::memory_order_relaxed);
+  while (pending > peak &&
+         !peakPending_.compare_exchange_weak(
+             peak, pending, std::memory_order_relaxed)) {
+  }
+}
+
+RPCRateLimiter::Token RPCRateLimiter::acquire() {
+  const int64_t pending = ++pending_;
+  notePeakPending(pending);
+  RPC_RATE_LIMITER_VLOG(2) << "acquire[" << tierKey_
+                           << "]: pending=" << pending;
+  return Token{this};
+}
+
+std::vector<RPCRateLimiter::Token> RPCRateLimiter::tryAcquireUpTo(
+    int64_t want) {
+  std::vector<Token> granted;
+  if (want <= 0) {
+    return granted;
+  }
+
+  int64_t capacity;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    capacity = capacityLocked();
+  }
+
+  // One compare-exchange for the whole grant rather than a read followed by an
+  // increment, so concurrent callers cannot both take the last slot however
+  // many race here. The capacity snapshot may be stale, but it moves only on
+  // adaptation, which is far slower than dispatch.
+  int64_t pending = pending_.load();
+  int64_t take = 0;
+  do {
+    take = std::min<int64_t>(want, std::max<int64_t>(0, capacity - pending));
+    if (take == 0) {
+      return granted;
+    }
+    // compare_exchange_weak refreshes 'pending' on failure, so a caller that
+    // loses the exchange recomputes its grant against the winner's value
+    // rather than its own stale read.
+  } while (!pending_.compare_exchange_weak(pending, pending + take));
+
+  // The post-exchange total, not the caller's pre-read: reporting the stale
+  // value would hide exactly the overshoot this loop exists to prevent, and
+  // the contention tests assert on this counter.
+  notePeakPending(pending + take);
+  granted.reserve(static_cast<size_t>(take));
+  for (int64_t i = 0; i < take; ++i) {
+    // One token per slot: each releases exactly one on destruction, so the
+    // bulk grant unwinds row by row as the requests complete.
+    granted.emplace_back(this);
+  }
+  return granted;
+}
+
+int64_t RPCRateLimiter::available() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  return std::max<int64_t>(0, capacityLocked() - pending_.load());
+}
+
+RPCRateLimiter::Admission RPCRateLimiter::admitOrWait() {
+  Admission result;
+  std::lock_guard<std::mutex> l(mutex_);
+  const int64_t pending = pending_.load();
+  const int64_t capacity = capacityLocked();
+  if (pending < capacity) {
+    RPC_RATE_LIMITER_VLOG(2)
+        << "admitOrWait[" << tierKey_ << "]: admitted (pending=" << pending
+        << ", capacity=" << capacity << ")";
+    result.admitted = true;
+    return result;
+  }
+  RPC_RATE_LIMITER_VLOG(1) << "admitOrWait[" << tierKey_
+                           << "]: waiting (pending=" << pending
+                           << ", capacity=" << capacity << "), waiter #"
+                           << waiters_.size();
+  // Enrolled under the same lock that decided, so any release from here on
+  // must see this waiter.
+  waiters_.emplace_back("RPCRateLimiter::admitOrWait");
+  result.wait = waiters_.back().getSemiFuture();
+  return result;
+}
+
+void RPCRateLimiter::onOutcome(Outcome outcome, int64_t units) {
+  switch (outcome) {
+    case Outcome::kOverload:
+      onOverload();
+      return;
+    case Outcome::kSuccess:
+      onSuccess(units);
+      return;
+    case Outcome::kNone:
+      return;
+  }
+}
+
+void RPCRateLimiter::onOverload() {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (!config_.adaptive) {
+    return;
+  }
+  const int64_t ceiling = ceilingLocked();
+  const int64_t current = capacity_ > 0 ? capacity_ : ceiling;
+  const int64_t next = std::clamp<int64_t>(
+      static_cast<int64_t>(
+          static_cast<double>(current) * config_.decreaseFactor),
+      floorLocked(ceiling),
+      ceiling);
+  if (next >= current) {
+    return;
+  }
+  capacity_ = next;
+  if (lowWater_ == 0 || next < lowWater_) {
+    lowWater_ = next;
+  }
+  RPC_RATE_LIMITER_VLOG(1) << "RPC congestion: capacity[" << tierKey_ << "] "
+                           << current << " -> " << next << " (overload)";
+}
+
+void RPCRateLimiter::onSuccess(int64_t units) {
+  if (units <= 0) {
+    return;
+  }
+  std::vector<ContinuePromise> toNotify;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    // Only recover from a capacity we previously shrank.
+    if (!config_.adaptive || capacity_ <= 0) {
+      return;
+    }
+    const int64_t ceiling = ceilingLocked();
+    // AIMD additive-increase, TCP-Reno style: one +1 step per capacity-worth
+    // of successes, floored at +1 so a steady success stream always makes
+    // progress. Scaling the step to the drain size makes recovery track the
+    // decrease's aggressiveness instead of crawling +1 per arbitrarily-sized
+    // drain, which in practice never recovered within a query. Reaching the
+    // ceiling clears the adapted value so the ceiling governs again.
+    const int64_t step =
+        std::max<int64_t>(1, units / std::max<int64_t>(1, capacity_));
+    const int64_t next = capacity_ + step;
+    capacity_ = next >= ceiling ? 0 : next;
+    // A large step can reopen several slots at once, so wake up to the
+    // recovered headroom's worth of parked drivers. Waking only one would
+    // leave drivers parked despite available capacity.
+    collectWakeableLocked(toNotify);
+  }
+  for (auto& waiter : toNotify) {
+    waiter.setValue();
+  }
+}
+
+void RPCRateLimiter::release() {
+  // Saturate at zero. A token can outlive testingReset(), which zeroes the
+  // count; without the floor its release would drive pending_ negative and
+  // make available() report more capacity than exists.
+  int64_t pending = pending_.load();
+  while (pending > 0 && !pending_.compare_exchange_weak(pending, pending - 1)) {
+  }
+  pending = std::max<int64_t>(0, pending - 1);
+  RPC_RATE_LIMITER_VLOG(2) << "release[" << tierKey_
+                           << "]: pending=" << pending;
+
+  // Hold the lock across check-and-dequeue. Otherwise a waiter parked by
+  // admitOrWait() between the capacity read and the dequeue would be missed:
+  // with the lock held it is either already queued and gets this slot, or it
+  // observes the decremented count and never parks.
+  //
+  // One waiter per release (FIFO), to avoid a thundering herd.
+  std::optional<ContinuePromise> toNotify;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (pending < capacityLocked() && !waiters_.empty()) {
+      RPC_RATE_LIMITER_VLOG(1) << "release[" << tierKey_ << "]: waking 1 of "
+                               << waiters_.size() << " waiters";
+      toNotify = std::move(waiters_.front());
+      waiters_.pop_front();
     }
   }
-  if (waiterToNotify) {
-    waiterToNotify->setValue();
+  if (toNotify.has_value()) {
+    toNotify->setValue();
+  }
+}
+
+RPCRateLimiter::Stats RPCRateLimiter::stats() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  return Stats{
+      .capacity = capacityLocked(),
+      .pending = pending_.load(),
+      .peakPending = peakPending_.load(),
+      .lowWaterCapacity = lowWater_,
+  };
+}
+
+// --- RPCRateLimiterRegistry ---
+
+RPCRateLimiterRegistry& RPCRateLimiterRegistry::global() {
+  static RPCRateLimiterRegistry registry;
+  return registry;
+}
+
+RPCRateLimiter& RPCRateLimiterRegistry::get(const std::string& tierKey) {
+  // Fast path: the backend already exists, so concurrent lookups from every
+  // driver share the lock rather than serializing. Values are held by
+  // unique_ptr, so the reference outlives later insertions.
+  {
+    std::shared_lock<std::shared_mutex> rl(mutex_);
+    auto it = backends_.find(tierKey);
+    if (it != backends_.end()) {
+      return *it->second;
+    }
+  }
+  // Slow path: first sight of this backend. Re-check under the exclusive lock
+  // in case another thread created it between the two locks.
+  std::unique_lock<std::shared_mutex> wl(mutex_);
+  auto it = backends_.find(tierKey);
+  if (it != backends_.end()) {
+    return *it->second;
+  }
+  auto [inserted, _] =
+      backends_.emplace(tierKey, std::make_unique<RPCRateLimiter>(tierKey));
+  return *inserted->second;
+}
+
+void RPCRateLimiterRegistry::testingReset() {
+  std::unique_lock<std::shared_mutex> wl(mutex_);
+  defaultCapacityRef().store(20);
+  // Reset each backend in place rather than dropping it. Tokens outlive the
+  // operator that acquired them and release through a back-pointer, so
+  // destroying a RPCRateLimiter that still has outstanding tokens would leave
+  // them writing through a dangling pointer.
+  for (auto& [tierKey, admission] : backends_) {
+    admission->testingReset();
   }
 }
 

--- a/velox/exec/rpc/RPCRateLimiter.h
+++ b/velox/exec/rpc/RPCRateLimiter.h
@@ -18,173 +18,330 @@
 
 #include <atomic>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include "velox/common/future/VeloxPromise.h"
 
 namespace facebook::velox::exec::rpc {
 
-/// Per-tier (per-process) rate limiter for RPC dispatch.
+/// Admission control for one unit of provisioned capacity: a backend tier
+/// plus the credential used to reach it. Everything sharing that pair --
+/// every driver, every query, both streaming modes -- draws on one quota,
+/// because that is what the remote service actually provisions.
 ///
-/// Each backend service tier (e.g., "service.backend.prod") gets its own
-/// independent concurrency limit and waiter queue. This allows different
-/// backends to have different concurrency budgets.
+/// A backend (e.g. "translation-service") is shared by every driver in the
+/// process that dispatches to it, so admission is a process-scoped concern:
+/// each Presto worker holds its own ServiceRouter connections, and
+/// cross-worker coordination is the backend's own job. Instances are obtained
+/// from RPCRateLimiterRegistry rather than constructed directly, except in
+/// tests.
 ///
-/// The rate limiter is per-process. Each Presto worker is a separate process
-/// with its own ServiceRouter connections. Cross-worker coordination is
-/// handled by the backend's own admission control.
+/// The name says "rate limiter" but the mechanism bounds concurrency, not a
+/// rate: capacity is a semaphore over in-flight units. The name is kept
+/// because it is the one the user-facing session properties
+/// (rpc.ratelimiter.*) and the runtime stats (rpcRateLimiterCap) already use,
+/// and those cannot be renamed without breaking queries and dashboards.
 ///
-/// The tier key comes from IRPCClient::tierKey(). Empty string means
-/// "no tier configured" and falls back to the global default limit.
+/// Capacity is a semaphore whose ceiling is configured and whose current value
+/// adapts (AIMD) to overload reported by the caller. Occupancy is held as a
+/// pending count plus a FIFO queue of parked drivers.
 class RPCRateLimiter {
  public:
-  /// RAII token representing one in-flight request slot.
-  /// Decrements the pending count on destruction, guaranteeing cleanup
-  /// even if the RPC future is abandoned (e.g., query cancellation).
+  /// Tuning for one backend. One field per user-facing session property, kept
+  /// deliberately literal so the mapping is checkable by eye.
+  struct Config {
+    /// Whether capacity adapts to overload. When false, capacity is pinned at
+    /// the ceiling. Maps to rpc.ratelimiter.adaptive_enabled.
+    bool adaptive{false};
+
+    /// Unshrunk capacity. Zero defers to defaultCapacity(), resolved on read
+    /// so a later change to the process default still takes effect. Maps to
+    /// rpc.ratelimiter.max_limit.
+    int64_t ceiling{0};
+
+    /// Lower bound on adapted capacity. Maps to rpc.ratelimiter.min_limit.
+    int64_t floor{1};
+
+    /// Multiplicative-decrease factor applied on overload, in (0, 1). Maps to
+    /// rpc.ratelimiter.decrease_factor.
+    double decreaseFactor{0.5};
+  };
+
+  /// What one drained batch of work told us about the backend. The admission
+  /// layer's own vocabulary: callers translate their function-level congestion
+  /// signal into it, which keeps this target free of any dependency on the
+  /// expression layer.
+  enum class Outcome {
+    /// The backend served the work. Drives additive increase.
+    kSuccess,
+    /// The backend shed load. Drives multiplicative decrease.
+    kOverload,
+    /// Nothing to learn from; capacity is left alone.
+    kNone,
+  };
+
+  /// A snapshot for per-query runtime stats, read once at operator close().
+  struct Stats {
+    /// Current capacity, after any adaptation.
+    int64_t capacity{0};
+
+    /// In-flight requests right now.
+    int64_t pending{0};
+
+    /// High-water in-flight count over the backend's lifetime.
+    int64_t peakPending{0};
+
+    /// Lowest capacity ever reached. Zero means capacity never shrank.
+    int64_t lowWaterCapacity{0};
+  };
+
+  /// One in-flight request slot, released on destruction so a slot is returned
+  /// even when the RPC future is abandoned (e.g. query cancellation).
+  ///
+  /// Holds a back-pointer to its issuing RPCRateLimiter, which is safe only
+  /// because tokens are captured into continuations that outlive the operator
+  /// and the registry outlives every future. A locally constructed
+  /// RPCRateLimiter must therefore outlive any token taken from it.
   class Token {
    public:
     Token() = default;
 
-    Token(Token&& other) noexcept
-        : tierKey_(std::move(other.tierKey_)), valid_(other.valid_) {
-      other.valid_ = false;
+    /// Takes ownership of one slot already claimed on 'owner'. Prefer
+    /// RPCRateLimiter::acquire(); this is public only to avoid a friend
+    /// declaration.
+    explicit Token(RPCRateLimiter* owner) : owner_{owner} {}
+
+    Token(Token&& other) noexcept : owner_{other.owner_} {
+      other.owner_ = nullptr;
     }
 
     Token& operator=(Token&& other) noexcept;
 
     ~Token();
 
-    // Non-copyable.
     Token(const Token&) = delete;
     Token& operator=(const Token&) = delete;
 
    private:
-    friend class RPCRateLimiter;
-    explicit Token(const std::string& tierKey);
-
-    std::string tierKey_;
-    bool valid_{false};
+    // Null means moved-from or default-constructed: no slot is held.
+    RPCRateLimiter* owner_{nullptr};
   };
 
-  /// Acquire a slot for the given tier. Increments pending count and
-  /// returns a Token that will decrement on destruction.
-  static Token acquire(const std::string& tierKey);
+  explicit RPCRateLimiter(std::string tierKey);
 
-  /// Check backpressure for a specific tier.
-  /// Returns a future to wait on if that tier's limit is reached.
-  /// @return Future to wait on if blocked, nullopt if can proceed.
-  static std::optional<ContinueFuture> checkBackpressure(
-      const std::string& tierKey);
+  /// Applies tuning. Last writer wins, matching the two independent writers
+  /// that configure a backend today: the function's SQL option first, then the
+  /// session properties. rpc.ratelimiter.max_limit defaults to 200, so the
+  /// session ceiling wins on every query unless it is explicitly set to 0 --
+  /// the function's max_concurrent_requests is honoured only in that case.
+  /// Never touches work already in flight — a ceiling that lands below the
+  /// current pending count stops admission but cancels nothing and wakes no
+  /// waiter, because nothing was freed.
+  void configure(const Config& config);
 
-  /// Get current pending count for a specific tier.
-  static int64_t pendingCount(const std::string& tierKey);
+  /// Applies 'mutate' to this backend's tuning under the lock, so a
+  /// read-modify-write cannot lose a concurrent writer's fields. Prefer this
+  /// over config() + configure() whenever only some fields are being changed:
+  /// two initializers race on the same backend when the operator amends the
+  /// session-property fields while the function sets its SQL-option ceiling.
+  void amend(const std::function<void(Config&)>& mutate);
 
-  /// Available dispatch headroom for a tier: max(0, effectiveCap - pending).
-  /// Admission-controlled dispatch uses this to size each drip chunk so the
-  /// per-tier cap actually bounds offered concurrency (rather than being
-  /// overrun by a whole-vector blast).
-  static int64_t availableHeadroom(const std::string& tierKey);
+  /// Applies `mutate` on the first call for this backend and seals the
+  /// configuration; later calls are refused.
+  /// A backend's configuration is shared by every query running against it and
+  /// has to hold still while the limiter adapts, so a later query's settings
+  /// are ignored rather than allowed to move the target mid-flight. A
+  /// divergent request is logged once so the no-op is visible.
+  void initializeOnce(const std::function<void(Config&)>& mutate);
 
-  /// Configure the max pending limit for a specific tier.
-  /// If not configured, falls back to the global default.
-  static void setMaxPending(const std::string& tierKey, int64_t limit);
+  /// The tuning currently in effect. Lets a later writer amend individual
+  /// fields without discarding what an earlier one set — the operator writes
+  /// the ceiling from rpc.ratelimiter.max_limit whenever it is positive, and
+  /// must otherwise preserve the ceiling the function configured from its SQL
+  /// option.
+  Config config() const;
 
-  /// Set the global default max pending (used when no per-tier config).
-  static void setDefaultMaxPending(int64_t limit);
+  /// Claims a slot unconditionally and returns the token that releases it.
+  /// Does not block or check capacity; callers gate on available() or
+  /// admitOrWait() first.
+  Token acquire();
 
-  /// Get the global default max pending.
-  static int64_t defaultMaxPending();
-
-  /// Configure the process-global adaptive AIMD limiter. When enabled, each
-  /// tier's effective cap adapts: multiplicative-decrease (by decreaseFactor,
-  /// floored at minLimit) on onRateLimited(), additive-increase back toward the
-  /// static per-tier cap on onSuccess(). When disabled (default), the static
-  /// per-tier cap is used and behavior is unchanged. Idempotent; safe to call
-  /// per operator setup with the cluster-default config.
-  static void
-  setAdaptiveConfig(bool enabled, int64_t minLimit, double decreaseFactor);
-
-  /// Whether the adaptive limiter is currently enabled.
-  static bool adaptiveEnabled();
-
-  /// Overload signal for a tier: multiplicative-decrease its adaptive cap.
-  /// No-op when the adaptive limiter is disabled. Call once per
-  /// overload-classified drain (not per errored row).
-  static void onRateLimited(const std::string& tierKey);
-
-  /// Recovery signal for a tier: additive-increase its adaptive cap back toward
-  /// the static ceiling, waking a waiter if headroom opened. No-op when the
-  /// adaptive limiter is disabled or the tier is already at its ceiling.
+  /// Claims up to 'want' slots in one pass and returns the tokens granted,
+  /// which may be fewer than asked for and may be none.
   ///
-  /// @param successes Number of successful units this signal represents (e.g.
-  /// the row count of a drained PER_ROW batch). Recovery is AIMD-linear — one
-  /// step of additive-increase per cap-worth of successes — so it tracks the
-  /// multiplicative-decrease's aggressiveness instead of crawling +1 per
-  /// arbitrarily-sized drain (which never recovered within a query).
-  static void onSuccess(const std::string& tierKey, int64_t successes);
+  /// Takes the backend's lock once for the whole grant rather than once per
+  /// slot. A caller reserving a chunk of rows would otherwise acquire an
+  /// exclusive, process-scoped lock once per row -- the same lock that carries
+  /// available(), admitOrWait() and the adaptation callbacks. The capacity
+  /// read is a snapshot, which is safe because capacity moves only on
+  /// adaptation, far slower than dispatch; the grant itself is a single
+  /// compare-exchange, so concurrent callers cannot both take the last slot.
+  std::vector<Token> tryAcquireUpTo(int64_t want);
 
-  /// Observability: the tier's current effective cap (adaptive value if shrunk,
-  /// else the static ceiling). Snapshotted into per-query runtime stats.
-  static int64_t currentLimit(const std::string& tierKey);
+  /// Slots free right now: capacity minus pending, floored at zero.
+  /// Admission-controlled dispatch sizes each chunk by this so the cap
+  /// actually bounds offered concurrency instead of being overrun by a
+  /// whole-vector blast.
+  int64_t available() const;
 
-  /// Observability: high-water in-flight (pending) count for the tier.
-  static int64_t peakPending(const std::string& tierKey);
+  /// The answer to "can you take work now, and if not, what do I wait on?" --
+  /// the same question a Velox operator asks its consumer.
+  struct Admission {
+    /// The backend has room; go and reserve.
+    bool admitted{false};
 
-  /// Observability: lowest adaptive cap the tier ever reached (0 = never shrank
-  /// / adaptive disabled).
-  static int64_t minLimitReached(const std::string& tierKey);
+    /// Valid exactly when 'admitted' is false: resolves when a slot frees.
+    ContinueFuture wait;
+  };
 
-  /// Reset all state. Intended ONLY for unit tests
-  /// to avoid test contamination across test cases.
-  /// WARNING: Do NOT call this in production code.
-  static void testingResetAllState();
+  /// Decides and enrols under one lock, so a slot freeing cannot slip between
+  /// the two. Asking separately -- check capacity, then enrol -- leaves a
+  /// window where the check says "free", nothing is enrolled, and the caller
+  /// is holding nothing to wait on; falling through to some other wait is how
+  /// a driver ends up parked on a future nothing can fulfil.
+  Admission admitOrWait();
+
+  /// Feeds one drained batch's verdict back into capacity. 'units' is the
+  /// number of successful items the batch represents and is read only for
+  /// Outcome::kSuccess, where recovery is AIMD-linear in it; the other
+  /// outcomes ignore it, so an error path need not count anything.
+  void onOutcome(Outcome outcome, int64_t units);
+
+  Stats stats() const;
+
+  /// Fallback ceiling for backends configured with ceiling == 0.
+  static void setDefaultCapacity(int64_t capacity);
+  static int64_t defaultCapacity();
+
+  /// Restores this backend to its as-constructed state. Intended only for
+  /// tests. Resets in place rather than being destroyed and recreated, because
+  /// outstanding tokens hold a back-pointer here and release through it.
+  void testingReset();
 
  private:
-  /// Per-tier state. Allocated via unique_ptr for pointer stability across
-  /// map inserts (std::unordered_map does not invalidate existing entries).
-  struct TierState {
-    std::mutex mutex;
-    std::atomic<int64_t> pendingCount{0};
-    int64_t maxPending{0}; // 0 = use global default
-    // Adaptive AIMD cap. 0 = unshrunk (fall back to maxPending/default as the
-    // effective cap). Only consulted when the adaptive limiter is enabled.
-    int64_t adaptiveLimit{0};
-    std::deque<ContinuePromise> waiters;
-    // Observability: high-water pending count and the lowest adaptive cap ever
-    // reached for this tier (0 = never shrank). Read at operator close() so the
-    // adaptive cap's trajectory is visible in per-query runtime stats.
-    std::atomic<int64_t> peakPending{0};
-    int64_t minAdaptiveLimit{0};
-  };
+  // Capacity under the current adaptive state. Caller holds mutex_.
+  int64_t capacityLocked() const;
 
-  static void incrementPending(const std::string& tierKey);
-  static void decrementPending(const std::string& tierKey);
+  // Ceiling with Config::ceiling == 0 resolved against the process default.
+  // Caller holds mutex_.
+  int64_t ceilingLocked() const;
 
-  static TierState& getOrCreateTierState(const std::string& tierKey);
+  // Config::floor clamped to at most the ceiling, so a min_limit configured
+  // above the ceiling cannot make std::clamp's lo exceed its hi (undefined
+  // behavior). Caller holds mutex_.
+  int64_t floorLocked(int64_t ceiling) const;
 
-  // Read-write mutex over the tier map. Lookups (the hot path: every dispatch
-  // and completion resolves its TierState here) take a shared lock and so do
-  // not serialize against each other; only first-time tier creation takes the
-  // exclusive lock. The map is read-mostly (tiers are created once, then only
-  // looked up), so this removes a worker-wide serialization point.
-  static std::shared_mutex& mapMutex();
-  static std::atomic<int64_t>& defaultMaxPendingRef();
-  static std::unordered_map<std::string, std::unique_ptr<TierState>>& tiers();
+  // Clamps a Config into its valid ranges: floor at least 1, decreaseFactor
+  // within (0, 1). Caller holds mutex_.
+  static void clampLocked(Config& config);
 
-  // Adaptive limiter config (process-global).
-  static std::atomic<bool>& adaptiveEnabledRef();
-  static std::atomic<int64_t>& adaptiveMinRef();
-  static std::atomic<double>& adaptiveFactorRef();
+  // Applies `mutate` to config_, clamps the result, and logs when adaptation
+  // flips on or off. Shared by amend() and initializeOnce() so the clamping
+  // and the logging live in one place. Caller holds mutex_.
+  void applyMutationLocked(const std::function<void(Config&)>& mutate);
 
-  // Effective per-tier cap under the current adaptive state. Caller must hold
-  // state.mutex.
-  static int64_t effectiveLimitLocked(const TierState& state);
+  // Moves out up to the currently available headroom's worth of parked
+  // waiters, FIFO. The caller fulfils them after dropping the lock, so a
+  // waiter's continuation never runs under mutex_.
+  void collectWakeableLocked(std::vector<ContinuePromise>& toNotify);
+
+  // Lock-free high-water update for stats.
+  void notePeakPending(int64_t pending);
+
+  // Multiplicative decrease: halves capacity by Config::decreaseFactor, down
+  // to the floor. A no-op when adaptation is off, and never raises capacity.
+  void onOverload();
+
+  // Additive increase: one step per capacity-worth of successful units,
+  // floored at +1 so a steady stream always makes progress. Reaching the
+  // ceiling clears the adapted value so the ceiling governs again.
+  void onSuccess(int64_t units);
+
+  // Called by Token on destruction; releases the slot and hands it to the
+  // longest-waiting parked driver, if any.
+  void release();
+
+  // Identifies the backend this limiter admits for. Composed by the transport
+  // from whatever distinguishes one deployment from another, so two
+  // deployments never share a limiter.
+  const std::string tierKey_;
+
+  // Guards config_, capacity_, lowWater_ and waiters_. pending_ and
+  // peakPending_ are atomic so the hot increment path stays lock-free, but
+  // they are read under the lock wherever a capacity comparison depends on
+  // them.
+  mutable std::mutex mutex_;
+
+  // Mutable rather than a constructor argument: the function's SQL option and
+  // the session properties configure a backend in a fixed order, so both need
+  // a seam to write through before initialization is sealed.
+  Config config_;
+
+  // Set once the first query to reach this backend has finished configuring
+  // it. Guards config_ against later queries; the adapted capacity below keeps
+  // moving, because that is learned from every query's outcomes.
+  bool initialized_{false};
+
+  // Warn once per backend about settings a later query asked for and did not
+  // get, rather than once per process.
+  bool loggedDivergentSettings_{false};
+
+  // Adapted capacity. Zero means unshrunk, i.e. defer to the ceiling.
+  int64_t capacity_{0};
+
+  // Lowest capacity ever reached. Zero means never shrank, and Stats reports
+  // it unchanged.
+  int64_t lowWater_{0};
+
+  // Units currently in flight against this backend. Atomic so acquire() and
+  // release() stay off the lock; read under mutex_ wherever it is compared
+  // against capacity.
+  std::atomic<int64_t> pending_{0};
+
+  // High-water pending count over the backend's lifetime, for runtime stats.
+  // Updated with a relaxed compare-exchange: best effort, not a
+  // synchronization point.
+  std::atomic<int64_t> peakPending_{0};
+
+  // Drivers parked waiting for a slot, oldest first. Woken FIFO, one per
+  // release, so a burst of returning slots does not stampede.
+  std::deque<ContinuePromise> waiters_;
+};
+
+/// Process-scoped owner of one RPCRateLimiter per backend key.
+///
+/// A backend is shared across queries by definition, so the registry is a
+/// process singleton rather than something threaded through the operator.
+class RPCRateLimiterRegistry {
+ public:
+  static RPCRateLimiterRegistry& global();
+
+  /// Returns the backend's admission control, creating it on first sight. The
+  /// reference stays valid for the process lifetime: values are held by
+  /// unique_ptr, so later insertions move only the map nodes.
+  RPCRateLimiter& get(const std::string& tierKey);
+
+  /// Resets every backend in place and restores process-global defaults.
+  /// Resets rather than drops: a Token releases through a back-pointer to its
+  /// issuing limiter, so erasing the map would leave outstanding tokens
+  /// pointing at freed memory. Intended only
+  /// for tests and benchmarks that drive a real operator, which resolves its
+  /// backend through this registry and so needs process state reset between
+  /// iterations. Never call this from production code.
+  void testingReset();
+
+ private:
+  // Read-mostly: backends are created once then only looked up, so lookups take
+  // a shared lock and do not serialize against each other. Only first sight
+  // of a backend takes the exclusive lock.
+  mutable std::shared_mutex mutex_;
+  std::unordered_map<std::string, std::unique_ptr<RPCRateLimiter>> backends_;
 };
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCState.h
+++ b/velox/exec/rpc/RPCState.h
@@ -298,7 +298,7 @@ class RPCState {
 
   /// Available dispatch headroom under the per-driver congestion window:
   /// max(0, window.limit() - inFlight). Admission-controlled dispatch takes the
-  /// min of this and the process-global rate-limiter headroom to size each
+  /// min of this and the backend's rate-limiter headroom to size each
   /// drip chunk, so a whole-vector blast can no longer overrun the window.
   /// Thread-safe.
   int64_t dispatchHeadroom();
@@ -324,8 +324,8 @@ class RPCState {
   OperatorSnapshot operatorSnapshot() const;
 
  private:
-  /// Move a completed row into readyRows_ and notify waiters.
-  /// Called from the RPC completion callback (runs on executor thread).
+  // Moves a completed row into readyRows_ and notifies waiters. Called from
+  // the RPC completion callback, which runs on an executor thread.
   void completeRow(
       int64_t rowId,
       RowLocation location,
@@ -341,10 +341,10 @@ class RPCState {
   // driver thread (a potential deadlock TSAN flags).
   [[nodiscard]] std::vector<ContinuePromise> takeWaitersLocked();
 
-  /// Extract the ready batch referenced by `it`: compute its round-trip
-  /// latency, move out the responses (capturing any error), erase the entry,
-  /// and decrement inFlight_. Must be called under mutex_ with `it->future`
-  /// ready.
+  // Extracts the ready batch referenced by 'it': computes its round-trip
+  // latency, moves out the responses (capturing any error), erases the entry,
+  // and decrements inFlight_. Must be called under mutex_ with 'it->future'
+  // ready.
   ReadyBatch extractReadyBatchLocked(
       const std::deque<PendingBatch>::iterator& it);
 

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
@@ -16,6 +16,10 @@
 
 #include "velox/exec/rpc/tests/DemoBatchRPCFunction.h"
 
+#include <thread>
+
+#include <folly/futures/Future.h>
+
 #include <algorithm>
 
 namespace facebook::velox::exec::rpc {
@@ -138,7 +142,28 @@ folly::SemiFuture<std::vector<RPCResponse>> DemoBatchRPCFunction::flushBatch(
     responses.pop_back();
   }
 
-  return folly::makeSemiFuture(std::move(responses));
+  if (!holdFlushes_) {
+    return folly::makeSemiFuture(std::move(responses));
+  }
+
+  // Hold the flush open so it is genuinely outstanding while the operator
+  // decides whether to dispatch the next one. Completing inline releases the
+  // token first, so nothing ever overlaps and admission gating is invisible.
+  auto [promise, future] =
+      folly::makePromiseContract<std::vector<RPCResponse>>();
+  holdExecutor_->add([hold = holdMs_,
+                      p = std::move(promise),
+                      r = std::move(responses)]() mutable {
+    std::this_thread::sleep_for(std::chrono::milliseconds(hold));
+    p.setValue(std::move(r));
+  });
+  return std::move(future);
+}
+
+void DemoBatchRPCFunction::testingHoldFlushes(int32_t holdMs, int32_t threads) {
+  holdExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(threads);
+  holdMs_ = holdMs;
+  holdFlushes_ = true;
 }
 
 int32_t DemoBatchRPCFunction::pendingBatchSize() const {

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.h
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.h
@@ -16,7 +16,12 @@
 
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <memory>
 #include <unordered_set>
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
 
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/rpc/AsyncRPCFunction.h"
@@ -87,11 +92,26 @@ class DemoBatchRPCFunction : public AsyncRPCFunction {
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures();
 
+  /// Holds each flush open for 'holdMs' on a background thread instead of
+  /// completing it inline, so several flushes are genuinely in flight at once
+  /// and the operator's admission gating becomes observable.
+  ///
+  /// Must be called before the query starts: the members it sets are read
+  /// without synchronization by every subsequent flush, so changing them once
+  /// flushes are running is a data race.
+  void testingHoldFlushes(int32_t holdMs = 50, int32_t threads = 16);
+
  private:
   struct PendingRow {
     std::string prompt;
     bool isNull;
   };
+
+  // Set only by testingHoldFlushes() before the query starts, then read-only
+  // for the rest of the run; see the comment there.
+  bool holdFlushes_{false};
+  int32_t holdMs_{0};
+  std::shared_ptr<folly::CPUThreadPoolExecutor> holdExecutor_;
 
   std::vector<PendingRow> pendingRows_;
   ResponseOrder responseOrder_;

--- a/velox/exec/rpc/tests/RPCAimdUnderLoadTest.cpp
+++ b/velox/exec/rpc/tests/RPCAimdUnderLoadTest.cpp
@@ -203,7 +203,7 @@ class RPCAimdUnderLoadTest : public OperatorTestBase {
   void TearDown() override {
     // The rate limiter is process-global; reset it so its adaptive state does
     // not leak into other tests.
-    RPCRateLimiter::testingResetAllState();
+    RPCRateLimiterRegistry::global().testingReset();
     OperatorTestBase::TearDown();
   }
 

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -51,6 +51,11 @@ class RPCOperatorTest : public OperatorTestBase {
     registerRPCPlanNodeTranslator();
     AsyncRPCFunctionRegistry::registerFunction(
         "demo_rpc", []() { return std::make_shared<DemoAsyncRPCFunction>(); });
+    AsyncRPCFunctionRegistry::registerFunction("demo_batch_rpc_held", []() {
+      auto fn = std::make_shared<DemoBatchRPCFunction>();
+      fn->testingHoldFlushes();
+      return fn;
+    });
     AsyncRPCFunctionRegistry::registerFunction("demo_batch_rpc", []() {
       return std::make_shared<DemoBatchRPCFunction>();
     });
@@ -103,9 +108,13 @@ class RPCOperatorTest : public OperatorTestBase {
   }
 
   void TearDown() override {
-    RPCRateLimiter::testingResetAllState();
+    RPCRateLimiterRegistry::global().testingReset();
     OperatorTestBase::TearDown();
   }
+
+  // Drives a query whose tier is fully held by the test body until a
+  // background thread releases it. Defined below the fixture.
+  void runContendedDrain(bool batchMode);
 
   /// Build a BATCH-mode RPCNode on top of a source plan node.
   core::PlanNodePtr makeBatchRPCNode(
@@ -312,6 +321,176 @@ TEST_F(RPCOperatorTest, batchBasic) {
   EXPECT_EQ(rows["hello"], "Batch response for: hello");
   EXPECT_EQ(rows["world"], "Batch response for: world");
   EXPECT_EQ(rows["batch"], "Batch response for: batch");
+}
+
+// A backend is configured by the first query to reach it, and every query
+// after shares that configuration. The limiter is a controller: its policy has
+// to hold still while it adapts, so a later query cannot move the target
+// mid-flight. Before this, initialize() rewrote the policy on every query --
+// a pipeline that lowered the floor to match a small entitlement had it reset
+// to 50 by the next default query, with nothing logged.
+TEST_F(RPCOperatorTest, backendIsConfiguredByTheFirstQueryOnly) {
+  auto input =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"a", "b"})});
+  auto& limiter = RPCRateLimiterRegistry::global().get("");
+
+  // First query: a deliberate policy, as a small-entitlement pipeline sets.
+  limiter.initializeOnce([](RPCRateLimiter::Config& config) {
+    config.adaptive = true;
+    config.floor = 4;
+    config.decreaseFactor = 0.25;
+  });
+
+  // A later query on the same backend, carrying the defaults.
+  auto plan =
+      makeBatchRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+  ASSERT_EQ(result->size(), 2);
+
+  const auto config = limiter.config();
+  EXPECT_TRUE(config.adaptive);
+  EXPECT_EQ(config.floor, 4) << "a later query reconfigured the backend";
+  EXPECT_DOUBLE_EQ(config.decreaseFactor, 0.25);
+}
+
+// Dispatch must respect the tier's admission cap, not only the per-driver
+// window. Other drivers can exhaust the tier while this driver's window is
+// still open, and an ungated flush loop then pushes pending past the cap.
+// The mock holds each flush open so several are genuinely in flight; the tier
+// ceiling is set below the BATCH window's starting value so the tier is the
+// binding constraint and the two gates are distinguishable.
+// Intake is bounded by accumulator depth, and BATCH flushes from isBlocked()
+// as well as addInput(). Both halves are needed: bounding intake without the
+// flush from isBlocked() lets a full accumulator sit forever once needsInput()
+// stops taking input, because BATCH has no other place to drain from -- the
+// query then hangs rather than fails. Feeds many input vectors so needsInput()
+// is actually consulted mid-stream, against a tier admitting one flush.
+TEST_F(RPCOperatorTest, batchMakesProgressWhenIntakeIsThrottled) {
+  constexpr int64_t kCeiling = 1;
+  constexpr int32_t kVectors = 8;
+  constexpr int32_t kRowsPerVector = 16;
+
+  std::vector<std::string> storage;
+  storage.reserve(kVectors * kRowsPerVector);
+  std::vector<RowVectorPtr> inputs;
+  inputs.reserve(kVectors);
+  for (int v = 0; v < kVectors; ++v) {
+    std::vector<StringView> prompts;
+    prompts.reserve(kRowsPerVector);
+    for (int i = 0; i < kRowsPerVector; ++i) {
+      storage.push_back(fmt::format("throttled-{}-{}", v, i));
+      prompts.push_back(StringView(storage.back()));
+    }
+    inputs.push_back(
+        makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)}));
+  }
+
+  auto& limiter = RPCRateLimiterRegistry::global().get("");
+  limiter.initializeOnce(
+      [](RPCRateLimiter::Config& config) { config.ceiling = kCeiling; });
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values(inputs).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_held",
+      /*dispatchBatchSize=*/4);
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+
+  // Every row comes out: throttling intake never stranded the accumulator.
+  ASSERT_EQ(result->size(), kVectors * kRowsPerVector);
+  EXPECT_LE(limiter.stats().peakPending, kCeiling);
+}
+
+// Contended admission: the tier's slots are held by someone else, so a refused
+// dispatch meets numInFlight() == 0 -- the state the other operator tests never
+// reach, since they run one driver against a tier nothing else holds. The test
+// body holds the ceiling itself and releases from a background thread, which is
+// the only way to produce a refusal this operator cannot resolve alone.
+//
+// Coverage, not a regression guard for one defect: it exercises a state nothing
+// else does, and asserts the query neither hangs nor comes up short. Reverting
+// the end-of-input guards does not fail it, because the Driver only calls
+// noMoreInput() when needsInput() is true and a non-empty buffer already makes
+// that false.
+void RPCOperatorTest::runContendedDrain(bool batchMode) {
+  constexpr int64_t kCeiling = 2;
+  constexpr int32_t kRows = 64;
+
+  std::vector<std::string> storage;
+  std::vector<StringView> prompts;
+  storage.reserve(kRows);
+  prompts.reserve(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    storage.push_back(fmt::format("contended-{}", i));
+    prompts.push_back(StringView(storage.back()));
+  }
+  auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
+
+  auto& limiter = RPCRateLimiterRegistry::global().get("");
+  limiter.initializeOnce(
+      [](RPCRateLimiter::Config& config) { config.ceiling = kCeiling; });
+
+  // Occupy every slot before the query starts, so the operator's first
+  // dispatch is refused with nothing of its own in flight.
+  std::vector<RPCRateLimiter::Token> held;
+  held.reserve(kCeiling);
+  for (int64_t i = 0; i < kCeiling; ++i) {
+    held.push_back(limiter.acquire());
+  }
+
+  std::thread releaser([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    held.clear();
+  });
+
+  auto plan = batchMode
+      ? makeBatchRPCNode(
+            PlanBuilder().values({input}).planNode(),
+            {"prompt"},
+            "demo_batch_rpc",
+            /*dispatchBatchSize=*/8)
+      : makeRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+  releaser.join();
+
+  // Nothing dropped while admission held the rows, and nothing hung.
+  ASSERT_EQ(result->size(), kRows);
+}
+
+TEST_F(RPCOperatorTest, perRowDrainCompletesWhileTheTierIsHeld) {
+  runContendedDrain(/*batchMode=*/false);
+}
+
+TEST_F(RPCOperatorTest, batchDrainCompletesWhileTheTierIsHeld) {
+  runContendedDrain(/*batchMode=*/true);
+}
+
+TEST_F(RPCOperatorTest, batchDispatchRespectsTheTierCap) {
+  constexpr int64_t kCeiling = 1;
+  std::vector<std::string> storage;
+  std::vector<StringView> prompts;
+  storage.reserve(64);
+  prompts.reserve(64);
+  for (int i = 0; i < 64; ++i) {
+    storage.push_back(fmt::format("row-{}", i));
+    prompts.push_back(StringView(storage.back()));
+  }
+  auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
+
+  auto& limiter = RPCRateLimiterRegistry::global().get("");
+  limiter.initializeOnce(
+      [](RPCRateLimiter::Config& config) { config.ceiling = kCeiling; });
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_held",
+      /*dispatchBatchSize=*/4);
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+  ASSERT_EQ(result->size(), 64);
+
+  EXPECT_LE(limiter.stats().peakPending, kCeiling)
+      << "dispatch admitted more than the tier cap";
 }
 
 // Reversed responses: the mock returns results in reverse order.

--- a/velox/exec/rpc/tests/RPCRateLimiterTest.cpp
+++ b/velox/exec/rpc/tests/RPCRateLimiterTest.cpp
@@ -14,166 +14,273 @@
  * limitations under the License.
  */
 
-/// RPCRateLimiterTest - Tests for the per-tier RPC rate limiter.
+/// RPCRateLimiterTest - Tests for per-tier RPC limiter control.
 ///
 /// RPCRateLimiter provides per-tier concurrency limits with FIFO waiter
 /// notification and RAII token-based slot management.
 ///
 /// Tests cover:
 /// - acquireAndRelease: Token acquire increments, destruction decrements.
-/// - backpressureWhenAtLimit: checkBackpressure returns future at limit.
+/// - backpressureWhenAtLimit: admitOrWait waits once at capacity.
 /// - backpressureReliefOnRelease: Waiter notified when token released.
 /// - fifoWaiterNotification: Multiple waiters notified in FIFO order.
 /// - perTierIsolation: Different tiers have independent limits.
-/// - perTierMaxPending: setMaxPending overrides global default.
-/// - defaultMaxPending: setDefaultMaxPending affects tiers without override.
+/// - perTierMaxPending: a per-tier ceiling overrides the process default.
+/// - defaultMaxPending: the process default applies to unconfigured tiers.
 /// - tokenMoveSemantics: Move constructor/assignment transfer ownership.
-/// - testingResetAllState: Reset clears all tiers and restores defaults.
+/// - testingResetClearsStateInPlace: Reset restores defaults and zeroes
+///   pending without destroying a backend an outstanding token points at.
+/// - adaptiveIsPerTier: Two tiers adapt independently.
+/// - adaptiveFactorsAreIndependent: Each tier uses its own decrease factor.
 
 #include "velox/exec/rpc/RPCRateLimiter.h"
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
 #include <vector>
 
 namespace facebook::velox::exec::rpc {
 namespace {
 
+// RPCRateLimiter takes a whole Config per tier. These helpers amend one field
+// group at a time so each test states only the setting it cares about.
+RPCRateLimiter& limiterFor(const std::string& tierKey) {
+  return RPCRateLimiterRegistry::global().get(tierKey);
+}
+
+void setCeiling(const std::string& tierKey, int64_t ceiling) {
+  auto& limiter = limiterFor(tierKey);
+  auto config = limiter.config();
+  config.ceiling = ceiling;
+  limiter.configure(config);
+}
+
+void setAdaptive(
+    const std::string& tierKey,
+    bool enabled,
+    int64_t floor,
+    double decreaseFactor) {
+  auto& limiter = limiterFor(tierKey);
+  auto config = limiter.config();
+  config.adaptive = enabled;
+  config.floor = floor;
+  config.decreaseFactor = decreaseFactor;
+  limiter.configure(config);
+}
+
 class RPCRateLimiterTest : public testing::Test {
  protected:
   void SetUp() override {
-    RPCRateLimiter::testingResetAllState();
+    RPCRateLimiterRegistry::global().testingReset();
   }
 
   void TearDown() override {
-    RPCRateLimiter::testingResetAllState();
+    RPCRateLimiterRegistry::global().testingReset();
   }
 };
 
 TEST_F(RPCRateLimiterTest, acquireAndRelease) {
   const std::string tier = "test.tier";
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+  EXPECT_EQ(limiterFor(tier).stats().pending, 0);
 
   {
-    auto token = RPCRateLimiter::acquire(tier);
-    EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 1);
+    auto token = limiterFor(tier).acquire();
+    EXPECT_EQ(limiterFor(tier).stats().pending, 1);
   }
   // Token destroyed — count should be back to 0.
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+  EXPECT_EQ(limiterFor(tier).stats().pending, 0);
 }
 
 TEST_F(RPCRateLimiterTest, multipleAcquires) {
   const std::string tier = "test.tier";
 
-  auto token1 = RPCRateLimiter::acquire(tier);
-  auto token2 = RPCRateLimiter::acquire(tier);
-  auto token3 = RPCRateLimiter::acquire(tier);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 3);
+  auto token1 = limiterFor(tier).acquire();
+  auto token2 = limiterFor(tier).acquire();
+  auto token3 = limiterFor(tier).acquire();
+  EXPECT_EQ(limiterFor(tier).stats().pending, 3);
+}
+
+// admitOrWait() answers "can you take work now, and if not, what do I wait on?"
+// in one call. Deciding and enrolling under the same lock is what makes the
+// answer usable: asked separately, a slot freeing between the two steps leaves
+// the caller neither admitted nor enrolled, and falling through to some other
+// wait is how a driver ends up parked on a future nothing can fulfil.
+// A backend's configuration is fixed whole, by one query. This pins the
+// invariant rather than the defect: the defect was two separate writes per
+// query -- the function's ceiling, then the operator's session properties --
+// with a window between them where a second query saw the backend still
+// unconfigured and overwrote, fixing one query's ceiling with another's floor.
+// There is one call site now, so that shape cannot be written to fail this.
+TEST_F(RPCRateLimiterTest, concurrentInitializersDoNotMixConfigurations) {
+  constexpr int kThreads = 16;
+  auto& limiter = limiterFor("test.tier");
+
+  // Each thread offers an internally consistent policy; the pairs are chosen
+  // so a mixture is detectable.
+  struct Policy {
+    int64_t ceiling;
+    int64_t floor;
+  };
+  auto policyFor = [](int i) -> Policy {
+    return {static_cast<int64_t>(100 * (i + 1)), static_cast<int64_t>(i + 1)};
+  };
+
+  std::atomic<bool> go{false};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&, i]() {
+      const auto policy = policyFor(i);
+      while (!go.load(std::memory_order_relaxed)) {
+      }
+      limiter.initializeOnce([policy](RPCRateLimiter::Config& config) {
+        config.ceiling = policy.ceiling;
+        config.floor = policy.floor;
+      });
+    });
+  }
+  go.store(true);
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Whatever landed must be exactly one thread's pair, not a blend.
+  const auto config = limiter.config();
+  bool matchesSomeThread = false;
+  for (int i = 0; i < kThreads; ++i) {
+    const auto policy = policyFor(i);
+    if (config.ceiling == policy.ceiling && config.floor == policy.floor) {
+      matchesSomeThread = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(matchesSomeThread)
+      << "configuration is a mixture: ceiling " << config.ceiling
+      << " with floor " << config.floor;
+}
+
+TEST_F(RPCRateLimiterTest, admitOrWaitEitherAdmitsOrEnrols) {
+  const std::string tier = "test.tier";
+  setCeiling(tier, 1);
+
+  // Room: admitted, and nothing enrolled to be woken later.
+  auto free = limiterFor(tier).admitOrWait();
+  EXPECT_TRUE(free.admitted);
+
+  auto token = limiterFor(tier).acquire();
+
+  // Full: not admitted, and the wait is fulfilled by the release.
+  auto parked = limiterFor(tier).admitOrWait();
+  ASSERT_FALSE(parked.admitted);
+  EXPECT_FALSE(parked.wait.isReady());
+  token = RPCRateLimiter::Token();
+  EXPECT_TRUE(parked.wait.isReady());
 }
 
 TEST_F(RPCRateLimiterTest, backpressureWhenAtLimit) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 2);
+  setCeiling(tier, 2);
 
-  auto token1 = RPCRateLimiter::acquire(tier);
-  // 1 pending, limit 2 — no backpressure.
-  EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier).has_value());
+  auto token1 = limiterFor(tier).acquire();
+  // 1 pending, limit 2 -- capacity is free, so the future comes back ready.
+  EXPECT_TRUE(limiterFor(tier).admitOrWait().admitted);
 
-  auto token2 = RPCRateLimiter::acquire(tier);
-  // 2 pending, limit 2 — at limit, should get backpressure.
-  auto future = RPCRateLimiter::checkBackpressure(tier);
-  EXPECT_TRUE(future.has_value());
+  auto token2 = limiterFor(tier).acquire();
+  // 2 pending, limit 2 -- at the limit, so the caller genuinely waits.
+  auto admission = limiterFor(tier).admitOrWait();
+  EXPECT_FALSE(admission.wait.isReady());
 }
 
 TEST_F(RPCRateLimiterTest, backpressureReliefOnRelease) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 1);
+  setCeiling(tier, 1);
 
-  auto token1 = RPCRateLimiter::acquire(tier);
+  auto token1 = limiterFor(tier).acquire();
 
   // At limit — should block.
-  auto future = RPCRateLimiter::checkBackpressure(tier);
-  ASSERT_TRUE(future.has_value());
-  EXPECT_FALSE(future->isReady());
+  auto admission = limiterFor(tier).admitOrWait();
+  EXPECT_FALSE(admission.wait.isReady());
 
   // Release the token — waiter should be notified.
   token1 = RPCRateLimiter::Token();
-  EXPECT_TRUE(future->isReady());
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+  EXPECT_TRUE(admission.wait.isReady());
+  EXPECT_EQ(limiterFor(tier).stats().pending, 0);
 }
 
 TEST_F(RPCRateLimiterTest, fifoWaiterNotification) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 1);
+  setCeiling(tier, 1);
 
-  auto token = RPCRateLimiter::acquire(tier);
+  auto token = limiterFor(tier).acquire();
 
   // Two waiters enqueue while at limit.
-  auto future1 = RPCRateLimiter::checkBackpressure(tier);
-  auto future2 = RPCRateLimiter::checkBackpressure(tier);
-  ASSERT_TRUE(future1.has_value());
-  ASSERT_TRUE(future2.has_value());
+  auto admission1 = limiterFor(tier).admitOrWait();
+  auto admission2 = limiterFor(tier).admitOrWait();
+  ASSERT_FALSE(admission1.wait.isReady());
+  ASSERT_FALSE(admission2.wait.isReady());
 
   // Release token — only first waiter should be notified (FIFO).
   token = RPCRateLimiter::Token();
-  EXPECT_TRUE(future1->isReady());
-  EXPECT_FALSE(future2->isReady());
+  EXPECT_TRUE(admission1.wait.isReady());
+  EXPECT_FALSE(admission2.wait.isReady());
 
   // Acquire and release again — second waiter should be notified.
   {
-    auto token2 = RPCRateLimiter::acquire(tier);
+    auto token2 = limiterFor(tier).acquire();
   }
-  EXPECT_TRUE(future2->isReady());
+  EXPECT_TRUE(admission2.wait.isReady());
 }
 
 TEST_F(RPCRateLimiterTest, perTierIsolation) {
   const std::string tier1 = "tier.one";
   const std::string tier2 = "tier.two";
-  RPCRateLimiter::setMaxPending(tier1, 1);
-  RPCRateLimiter::setMaxPending(tier2, 1);
+  setCeiling(tier1, 1);
+  setCeiling(tier2, 1);
 
-  auto tokenA = RPCRateLimiter::acquire(tier1);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier1), 1);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier2), 0);
+  auto tokenA = limiterFor(tier1).acquire();
+  EXPECT_EQ(limiterFor(tier1).stats().pending, 1);
+  EXPECT_EQ(limiterFor(tier2).stats().pending, 0);
 
   // tier1 at limit, tier2 not.
-  EXPECT_TRUE(RPCRateLimiter::checkBackpressure(tier1).has_value());
-  EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier2).has_value());
+  EXPECT_FALSE(limiterFor(tier1).admitOrWait().admitted);
+  EXPECT_TRUE(limiterFor(tier2).admitOrWait().admitted);
 }
 
 TEST_F(RPCRateLimiterTest, perTierMaxPending) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setDefaultMaxPending(10);
-  RPCRateLimiter::setMaxPending(tier, 2);
+  RPCRateLimiter::setDefaultCapacity(10);
+  setCeiling(tier, 2);
 
-  auto token1 = RPCRateLimiter::acquire(tier);
-  auto token2 = RPCRateLimiter::acquire(tier);
+  auto token1 = limiterFor(tier).acquire();
+  auto token2 = limiterFor(tier).acquire();
 
-  // Per-tier limit of 2 applies, not global default of 10.
-  EXPECT_TRUE(RPCRateLimiter::checkBackpressure(tier).has_value());
+  // This backend's own limit of 2 applies, not the global default of 10.
+  EXPECT_FALSE(limiterFor(tier).admitOrWait().admitted);
 }
 
 TEST_F(RPCRateLimiterTest, defaultMaxPending) {
-  RPCRateLimiter::setDefaultMaxPending(2);
+  RPCRateLimiter::setDefaultCapacity(2);
   const std::string tier = "test.default.tier";
 
-  auto token1 = RPCRateLimiter::acquire(tier);
-  EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier).has_value());
+  auto token1 = limiterFor(tier).acquire();
+  EXPECT_TRUE(limiterFor(tier).admitOrWait().admitted);
 
-  auto token2 = RPCRateLimiter::acquire(tier);
+  auto token2 = limiterFor(tier).acquire();
   // Global default of 2 reached.
-  EXPECT_TRUE(RPCRateLimiter::checkBackpressure(tier).has_value());
+  EXPECT_FALSE(limiterFor(tier).admitOrWait().admitted);
 }
 
 TEST_F(RPCRateLimiterTest, tokenMoveConstructor) {
   const std::string tier = "test.tier";
 
-  auto token1 = RPCRateLimiter::acquire(tier);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 1);
+  auto token1 = limiterFor(tier).acquire();
+  EXPECT_EQ(limiterFor(tier).stats().pending, 1);
 
   // Move construct — ownership transfers, count stays 1.
   auto token2 = std::move(token1);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 1);
+  EXPECT_EQ(limiterFor(tier).stats().pending, 1);
 
   // Destroy moved-from token — no effect.
   // (token1 is already moved-from, but let it go out of scope naturally)
@@ -183,112 +290,313 @@ TEST_F(RPCRateLimiterTest, tokenMoveAssignment) {
   const std::string tier1 = "tier.one";
   const std::string tier2 = "tier.two";
 
-  auto token1 = RPCRateLimiter::acquire(tier1);
-  auto token2 = RPCRateLimiter::acquire(tier2);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier1), 1);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier2), 1);
+  auto token1 = limiterFor(tier1).acquire();
+  auto token2 = limiterFor(tier2).acquire();
+  EXPECT_EQ(limiterFor(tier1).stats().pending, 1);
+  EXPECT_EQ(limiterFor(tier2).stats().pending, 1);
 
   // Move-assign token2 into token1 — old token1 (tier1) released.
   token1 = std::move(token2);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier1), 0);
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier2), 1);
+  EXPECT_EQ(limiterFor(tier1).stats().pending, 0);
+  EXPECT_EQ(limiterFor(tier2).stats().pending, 1);
 }
 
-TEST_F(RPCRateLimiterTest, testingResetAllState) {
+// A Token releases through a back-pointer to its issuing limiter, so the
+// registry resets each backend in place rather than destroying it. Holding a
+// live token across the reset is the case that would dangle if it did not.
+// Two writers configure a backend in a fixed order: the function sets a
+// ceiling from its SQL option during initialize(), then the operator applies
+// the session properties. amend() exists so the second writer keeps the first
+// one's ceiling. A read-modify-write through config()/configure() would drop
+// it silently -- ceiling falls to 0, which resolves to the built-in default,
+// and a backend provisioned for 200 quietly runs at 20.
+// A backend's identity is its tier key, and each transport composes that key
+// from whatever distinguishes one deployment from another -- IPNext uses
+// smcTier plus tenant plus group. Two deployments must therefore resolve to
+// two limiters, so one saturating or backing off cannot admit or throttle the
+// other. Collapsing the key would silently reunite them.
+TEST_F(RPCRateLimiterTest, deploymentsResolveToSeparateLimiters) {
+  const std::string groupA = "ipnext_prod/deployment#tm908223594#ggti_a";
+  const std::string groupB = "ipnext_prod/deployment#tm908223594#ggti_b";
+  const std::string otherTenant = "ipnext_prod/deployment#tm111111111#ggti_a";
+
+  // Same key is the same backend; different keys are different backends.
+  EXPECT_EQ(&limiterFor(groupA), &limiterFor(groupA));
+  EXPECT_NE(&limiterFor(groupA), &limiterFor(groupB));
+  EXPECT_NE(&limiterFor(groupA), &limiterFor(otherTenant));
+
+  // Configuration does not leak across them.
+  setCeiling(groupA, 8);
+  setCeiling(groupB, 64);
+  EXPECT_EQ(limiterFor(groupA).stats().capacity, 8);
+  EXPECT_EQ(limiterFor(groupB).stats().capacity, 64);
+
+  // Nor does occupancy: saturating one leaves the other's admission untouched.
+  std::vector<RPCRateLimiter::Token> held;
+  held.reserve(8);
+  for (int i = 0; i < 8; ++i) {
+    held.push_back(limiterFor(groupA).acquire());
+  }
+  EXPECT_EQ(limiterFor(groupA).available(), 0);
+  EXPECT_EQ(limiterFor(groupB).available(), 64);
+}
+
+// Raising the ceiling grows capacity, but no release or adaptation need
+// follow, so a driver parked under the old capacity would stay parked until
+// some unrelated event woke it.
+// available() followed by acquire() is two steps, so concurrent callers can
+// each observe the same free slot and all take it -- the cap then bounds each
+// caller's decision rather than the backend. tryAcquireUpTo() decides and
+// claims in one atomic step, so pending can never exceed capacity however many
+// race.
+//
+// One-sided by construction: the atomic form cannot overshoot, so this cannot
+// flake; a check-then-claim form overshoots within a few thousand attempts.
+// The bulk grant takes one lock for the whole chunk, so the capacity read and
+// the claim are separated by a compare-exchange rather than a mutex. Concurrent
+// callers must never be granted more than capacity between them.
+//
+// One-sided by construction: the atomic form cannot overshoot, so this cannot
+// flake; a read-then-add form overshoots within a few thousand attempts.
+TEST_F(RPCRateLimiterTest, bulkGrantNeverExceedsCapacity) {
+  constexpr int64_t kCeiling = 6;
+  constexpr int kThreads = 12;
+  constexpr int kAttemptsPerThread = 20'000;
+  auto& limiter = limiterFor("test.tier");
+  limiter.amend(
+      [](RPCRateLimiter::Config& config) { config.ceiling = kCeiling; });
+
+  // Asking for more than the ceiling yields exactly the ceiling, not none.
+  {
+    auto all = limiter.tryAcquireUpTo(kCeiling * 4);
+    EXPECT_EQ(static_cast<int64_t>(all.size()), kCeiling);
+    EXPECT_EQ(limiter.stats().pending, kCeiling);
+  }
+  EXPECT_EQ(limiter.stats().pending, 0) << "tokens release on destruction";
+
+  std::atomic<bool> go{false};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&]() {
+      while (!go.load(std::memory_order_relaxed)) {
+      }
+      for (int n = 0; n < kAttemptsPerThread; ++n) {
+        // Each asks for the whole ceiling, so two concurrent callers reading
+        // the same pending count would together claim twice it.
+        auto grant = limiter.tryAcquireUpTo(kCeiling);
+      }
+    });
+  }
+  go.store(true);
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(limiter.stats().pending, 0) << "every slot should be released";
+  EXPECT_LE(limiter.stats().peakPending, kCeiling)
+      << kThreads << " racing callers drove pending to "
+      << limiter.stats().peakPending << " against a capacity of " << kCeiling;
+}
+
+TEST_F(RPCRateLimiterTest, tryAcquireNeverExceedsCapacityUnderContention) {
+  constexpr int64_t kCeiling = 4;
+  constexpr int kThreads = 16;
+  constexpr int kAttemptsPerThread = 20'000;
+  auto& limiter = limiterFor("test.tier");
+  limiter.amend(
+      [](RPCRateLimiter::Config& config) { config.ceiling = kCeiling; });
+
+  std::atomic<bool> go{false};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&]() {
+      while (!go.load(std::memory_order_relaxed)) {
+      }
+      for (int n = 0; n < kAttemptsPerThread; ++n) {
+        // Take and immediately release, so slots churn and callers keep
+        // racing for the same few.
+        auto slot = limiter.tryAcquireUpTo(1);
+      }
+    });
+  }
+  go.store(true);
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(limiter.stats().pending, 0) << "every slot should be released";
+  EXPECT_LE(limiter.stats().peakPending, kCeiling)
+      << kThreads << " racing callers drove pending to "
+      << limiter.stats().peakPending << " against a capacity of " << kCeiling;
+}
+
+TEST_F(RPCRateLimiterTest, amendWakesWaitersWhenCapacityGrows) {
+  auto& limiter = limiterFor("test.tier");
+  limiter.amend([](RPCRateLimiter::Config& config) { config.ceiling = 1; });
+
+  // Take the only slot, then park a second caller behind it.
+  auto token = limiter.acquire();
+  auto parked = limiter.admitOrWait();
+  EXPECT_FALSE(parked.wait.isReady());
+
+  // Growing the ceiling alone must release the waiter; nothing else happens.
+  limiter.amend([](RPCRateLimiter::Config& config) { config.ceiling = 4; });
+  EXPECT_TRUE(parked.wait.isReady())
+      << "a waiter stayed parked after capacity grew";
+}
+
+TEST_F(RPCRateLimiterTest, amendPreservesAnEarlierWritersCeiling) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setDefaultMaxPending(5);
-  RPCRateLimiter::setMaxPending(tier, 3);
-  auto token = RPCRateLimiter::acquire(tier);
+  auto& limiter = limiterFor(tier);
 
-  // Move the token out so it doesn't decrement during reset.
-  // (In practice, testingResetAllState clears the tiers map,
-  // so the token's destructor will create a new empty tier state.)
+  // Writer one: the function's SQL option.
+  limiter.amend([](RPCRateLimiter::Config& config) { config.ceiling = 200; });
 
-  RPCRateLimiter::testingResetAllState();
+  // Writer two: session properties, with max_limit unset (0), so it must not
+  // touch the ceiling.
+  limiter.amend([](RPCRateLimiter::Config& config) {
+    config.adaptive = true;
+    config.floor = 4;
+    config.decreaseFactor = 0.25;
+  });
 
-  // Default restored to 20.
-  EXPECT_EQ(RPCRateLimiter::defaultMaxPending(), 20);
-  // Tier state cleared — pending count is 0 for a fresh tier.
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+  const auto config = limiter.config();
+  EXPECT_EQ(config.ceiling, 200);
+  EXPECT_TRUE(config.adaptive);
+  EXPECT_EQ(config.floor, 4);
+  EXPECT_DOUBLE_EQ(config.decreaseFactor, 0.25);
+  EXPECT_EQ(limiter.stats().capacity, 200);
+}
+
+TEST_F(RPCRateLimiterTest, testingResetClearsStateInPlace) {
+  const std::string tier = "test.tier";
+  RPCRateLimiter::setDefaultCapacity(5);
+  setCeiling(tier, 3);
+  auto token = limiterFor(tier).acquire();
+
+  RPCRateLimiterRegistry::global().testingReset();
+
+  EXPECT_EQ(RPCRateLimiter::defaultCapacity(), 20);
+  EXPECT_EQ(limiterFor(tier).stats().pending, 0);
 }
 
 TEST_F(RPCRateLimiterTest, adaptiveDisabledIsNoop) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 10);
+  setCeiling(tier, 10);
   // Adaptive off (default): the overload signal must not shrink the cap.
-  RPCRateLimiter::onRateLimited(tier);
-  EXPECT_EQ(RPCRateLimiter::currentLimit(tier), 10);
-  RPCRateLimiter::onSuccess(tier, 1000);
-  EXPECT_EQ(RPCRateLimiter::currentLimit(tier), 10);
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
+  EXPECT_EQ(limiterFor(tier).stats().capacity, 10);
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kSuccess, 1'000);
+  EXPECT_EQ(limiterFor(tier).stats().capacity, 10);
 }
 
 TEST_F(RPCRateLimiterTest, adaptiveMultiplicativeDecrease) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 16);
-  RPCRateLimiter::setAdaptiveConfig(
-      /*enabled*/ true, /*minLimit*/ 1, /*decreaseFactor*/ 0.5);
+  setCeiling(tier, 16);
+  setAdaptive(tier, /*enabled*/ true, /*floor*/ 1, /*decreaseFactor*/ 0.5);
 
-  RPCRateLimiter::onRateLimited(tier);
-  EXPECT_EQ(RPCRateLimiter::currentLimit(tier), 8);
-  RPCRateLimiter::onRateLimited(tier);
-  EXPECT_EQ(RPCRateLimiter::currentLimit(tier), 4);
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
+  EXPECT_EQ(limiterFor(tier).stats().capacity, 8);
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
+  EXPECT_EQ(limiterFor(tier).stats().capacity, 4);
 }
 
 TEST_F(RPCRateLimiterTest, adaptiveFlooredAtMinLimit) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 16);
-  RPCRateLimiter::setAdaptiveConfig(true, /*minLimit*/ 4, 0.5);
+  setCeiling(tier, 16);
+  setAdaptive(tier, true, /*floor*/ 4, 0.5);
 
   for (int i = 0; i < 10; ++i) {
-    RPCRateLimiter::onRateLimited(tier);
+    limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
   }
   // 16 -> 8 -> 4, then pinned at the floor.
-  EXPECT_EQ(RPCRateLimiter::currentLimit(tier), 4);
+  EXPECT_EQ(limiterFor(tier).stats().capacity, 4);
 }
 
 TEST_F(RPCRateLimiterTest, adaptiveRecoveryScalesWithSuccesses) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 16);
-  RPCRateLimiter::setAdaptiveConfig(true, 1, 0.5);
+  setCeiling(tier, 16);
+  setAdaptive(tier, true, 1, 0.5);
 
-  RPCRateLimiter::onRateLimited(tier); // 16 -> 8
-  ASSERT_EQ(RPCRateLimiter::currentLimit(tier), 8);
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kOverload, 0); // 16 -> 8
+  ASSERT_EQ(limiterFor(tier).stats().capacity, 8);
 
   // A tiny drain recovers by the +1 floor (step = max(1, 1/8)).
-  RPCRateLimiter::onSuccess(tier, 1);
-  EXPECT_EQ(RPCRateLimiter::currentLimit(tier), 9);
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kSuccess, 1);
+  EXPECT_EQ(limiterFor(tier).stats().capacity, 9);
 
   // A large drain recovers proportionally (step = successes/cap) and, on
   // reaching the ceiling, clears the adaptive state so the static cap governs.
-  RPCRateLimiter::onSuccess(tier, 1000);
-  EXPECT_EQ(RPCRateLimiter::currentLimit(tier), 16);
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kSuccess, 1'000);
+  EXPECT_EQ(limiterFor(tier).stats().capacity, 16);
 }
 
 TEST_F(RPCRateLimiterTest, adaptiveShrinkReducesAdmission) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 4);
-  RPCRateLimiter::setAdaptiveConfig(true, 1, 0.5);
+  setCeiling(tier, 4);
+  setAdaptive(tier, true, 1, 0.5);
 
-  RPCRateLimiter::onRateLimited(tier); // cap 4 -> 2
-  ASSERT_EQ(RPCRateLimiter::currentLimit(tier), 2);
+  limiterFor(tier).onOutcome(
+      RPCRateLimiter::Outcome::kOverload, 0); // cap 4 -> 2
+  ASSERT_EQ(limiterFor(tier).stats().capacity, 2);
 
-  auto token1 = RPCRateLimiter::acquire(tier);
-  EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier).has_value());
-  auto token2 = RPCRateLimiter::acquire(tier);
+  auto token1 = limiterFor(tier).acquire();
+  EXPECT_TRUE(limiterFor(tier).admitOrWait().admitted);
+  auto token2 = limiterFor(tier).acquire();
   // At the shrunk cap of 2 (not the static 4), backpressure kicks in.
-  EXPECT_TRUE(RPCRateLimiter::checkBackpressure(tier).has_value());
+  EXPECT_FALSE(limiterFor(tier).admitOrWait().admitted);
 }
 
 TEST_F(RPCRateLimiterTest, noBackpressureBelowLimit) {
   const std::string tier = "test.tier";
-  RPCRateLimiter::setMaxPending(tier, 5);
+  setCeiling(tier, 5);
 
   std::vector<RPCRateLimiter::Token> tokens;
   for (int i = 0; i < 4; ++i) {
-    tokens.push_back(RPCRateLimiter::acquire(tier));
-    EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier).has_value());
+    tokens.push_back(limiterFor(tier).acquire());
+    EXPECT_TRUE(limiterFor(tier).admitOrWait().admitted);
   }
-  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 4);
+  EXPECT_EQ(limiterFor(tier).stats().pending, 4);
+}
+
+// Regression test for the defect that motivated one limiter per backend: the
+// previous API configured the adaptive parameters process-globally, so a
+// second backend's configuration silently reconfigured the first backend's
+// limiter and both shrank together.
+TEST_F(RPCRateLimiterTest, adaptiveIsPerTier) {
+  const std::string adaptiveTier = "backend.adaptive";
+  const std::string fixedTier = "backend.fixed";
+  setCeiling(adaptiveTier, 16);
+  setCeiling(fixedTier, 16);
+  setAdaptive(adaptiveTier, true, /*floor*/ 1, /*decreaseFactor*/ 0.5);
+  setAdaptive(fixedTier, false, /*floor*/ 1, /*decreaseFactor*/ 0.5);
+
+  limiterFor(adaptiveTier)
+      .onOutcome(RPCRateLimiter::Outcome::kOverload, /*units*/ 0);
+  limiterFor(fixedTier).onOutcome(
+      RPCRateLimiter::Outcome::kOverload, /*units*/ 0);
+
+  EXPECT_EQ(limiterFor(adaptiveTier).stats().capacity, 8);
+  EXPECT_EQ(limiterFor(fixedTier).stats().capacity, 16);
+}
+
+// Two adapting tiers shrink by their own decrease factors rather than sharing
+// one process-global value.
+TEST_F(RPCRateLimiterTest, adaptiveFactorsAreIndependent) {
+  const std::string halving = "backend.halving";
+  const std::string quartering = "backend.quartering";
+  setCeiling(halving, 16);
+  setCeiling(quartering, 16);
+  setAdaptive(halving, true, /*floor*/ 1, /*decreaseFactor*/ 0.5);
+  setAdaptive(quartering, true, /*floor*/ 1, /*decreaseFactor*/ 0.25);
+
+  limiterFor(halving).onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
+  limiterFor(quartering).onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
+
+  EXPECT_EQ(limiterFor(halving).stats().capacity, 8);
+  EXPECT_EQ(limiterFor(quartering).stats().capacity, 4);
 }
 
 } // namespace

--- a/velox/expression/rpc/AsyncRPCFunction.h
+++ b/velox/expression/rpc/AsyncRPCFunction.h
@@ -91,6 +91,14 @@ class AsyncRPCFunction {
   /// Return the Velox type of the result column.
   virtual TypePtr resultType() const = 0;
 
+  /// The concurrency ceiling this function's own options ask for, or 0 when
+  /// unset. The operator applies it alongside the session properties in a
+  /// single configuration step, so a backend's whole policy lands at once
+  /// rather than in two writes a concurrent query could interleave with.
+  virtual int64_t configuredCeiling() const {
+    return 0;
+  }
+
   /// Return the service tier key for rate limiting.
   /// Empty string means "no tier configured — uses global default limit."
   virtual std::string tierKey() const {


### PR DESCRIPTION
Summary:

`RPCRateLimiter` becomes one instance per backend, owned by a process-scoped
`RPCRateLimiterRegistry`. A backend here is one unit of provisioned capacity: a
tier plus the credential used to reach it.

The per-tier numbers were already keyed. What carried no key was the policy --
`adaptiveEnabledRef`, `adaptiveMinRef` and `adaptiveFactorRef` were process-wide
statics that every tier read, rewritten on each operator init. Only the ceiling
was per-tier. Moving them into per-instance `Config` is therefore strictly
narrower than what it replaces, not a new sharing of scope: backends now shrink
and recover on their own schedules.

A backend's configuration is fixed by the first query to reach it and shared by
every query after, so the setpoint holds still while the limiter adapts to all
of them jointly. It is applied in one step -- the function's own ceiling and the
session properties together -- so two queries starting at once cannot fix a
mixture of both.

Dispatch gates on that capacity as well as the per-driver congestion window, and
reserves before issuing the request. Two calls carry that:

- `tryAcquireUpTo()` claims a whole chunk in a single compare-exchange, so
  concurrent callers cannot both take the last slot however many race. It takes
  the backend's lock once, to read capacity, rather than once per row.
- `admitOrWait()` answers "can you take work, and if not what do I wait on?" in
  one call -- deciding and enrolling together, so a slot freeing in between
  cannot leave a driver waiting on nothing.

Applied per mode:

- PER_ROW reserves one slot per row up front and sends exactly what was granted.
- BATCH reserves at the top of `flushBatchRequests()`, before the accumulator is
  split, and reports whether the flush happened so the calling loops stop.
- Intake is bounded by accumulator depth, and refused dispatch parks rather than
  spinning.

Reviewed By: Yuhta, abhinavmuk04

Differential Revision: D116526970


