### PR TITLE
feat(torchwave): CUDA-event stream ordering and GPU-idle timing

### DIFF
--- a/velox/experimental/torchwave/Builtins.cpp
+++ b/velox/experimental/torchwave/Builtins.cpp
@@ -663,6 +663,37 @@ bool viewHasDynamicShapeArgs(NodeCP node, const ValueTypes& /*types*/) {
   return node->inputs().size() > 1;
 }
 
+// A metadata getter (sym_size / sym_numel) is worth running on the host exactly
+// when it would otherwise be an expression of its own. The host already holds
+// every tensor, so reading a size there is a field access; a kernel op has to
+// pass the tensor's metadata in, compute one scalar, and read it back out. When
+// the getter instead feeds a single fusable consumer it is a subexpression of
+// that consumer's kernel, where the value is wanted on the device anyway, so it
+// stays fused.
+//
+// Consulting the consumer's isStandalone cannot recurse back here: a getter
+// takes a tensor and yields a scalar, so a getter is never the user of a
+// getter.
+// Unused while the isStandaloneFunc call sites below are disabled.
+[[maybe_unused]] bool metadataGetterIsAlone(
+    NodeCP node,
+    const ValueTypes& types) {
+  if (node->outputs().empty() || node->outputs()[0] == nullptr) {
+    return false;
+  }
+  ValueCP out = node->outputs()[0];
+  if (types.graphOutput(out)) {
+    return true;
+  }
+  const auto& users = out->users();
+  if (users.size() != 1) {
+    // Unused, or shared -- either way it is materialized on its own.
+    return true;
+  }
+  const Metadata* userMeta = Registry::metadata(users[0]->target());
+  return userMeta == nullptr || userMeta->isStandalone(users[0], types);
+}
+
 std::vector<std::vector<Dim>> sizeAttrReserveShape(
     NodeCP /*node*/,
     nativert::ExecutionFrame& frame,
@@ -1961,6 +1992,8 @@ void registerBuiltins() {
           {{.isRegister = false, .wholeTensor = true}, {.isRegister = true}})
       .returnMeta({{.isRegister = true}})
       .metadataGetter()
+      .metadataOnly()
+      // TEMP-AB-DISABLED .isStandaloneFunc(metadataGetterIsAlone)
       .isScalarElementwise()
       .registerOp();
 
@@ -1972,6 +2005,8 @@ void registerBuiltins() {
       .argumentMeta({{.isRegister = false, .wholeTensor = true}})
       .returnMeta({{.isRegister = true}})
       .metadataGetter()
+      .metadataOnly()
+      // TEMP-AB-DISABLED .isStandaloneFunc(metadataGetterIsAlone)
       .isScalarElementwise()
       .registerOp();
 

--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -2368,6 +2368,47 @@ void addDuplicateExtraBindings(
   }
 }
 
+// Returns every actual frame value 'op' may read, over all of its grid
+// variants. Used to decide at which step a last-use value can be released, so
+// this has to err on the side of listing too much: a reader missed here is a
+// buffer freed while a later step still reads it. orderingInputs is the right
+// source for a kernel launch -- it is the set the scheduler orders the launch
+// against, and so already includes the host-side view operands that are inputs
+// of no fused node. The subgraph leaves cover an op whose grid is empty.
+std::unordered_set<nativert::ValueId> opReadSet(const OpInvocation& op) {
+  const auto& bindings = op.bindings();
+  auto toActual = [&](nativert::ValueId formalId) {
+    auto it = bindings.find(formalId);
+    return it != bindings.end() ? it->second : formalId;
+  };
+  std::unordered_set<nativert::ValueId> ids;
+  auto* projectOp = op.projectOp();
+  for (const auto* grid :
+       {&projectOp->grid(),
+        &projectOp->singleBlockGrid(),
+        &projectOp->cgGrid()}) {
+    for (const auto& step : *grid) {
+      for (const auto& launch : step) {
+        if (launch.op != nullptr) {
+          for (auto id : launch.op->orderingInputs()) {
+            ids.insert(toActual(id));
+          }
+        } else if (launch.standalone != nullptr) {
+          for (const auto& input : launch.standalone->inputs()) {
+            if (input.value != nullptr) {
+              ids.insert(toActual(input.value->id()));
+            }
+          }
+        }
+      }
+    }
+  }
+  for (const auto* input : projectOp->subgraph().inputs) {
+    ids.insert(toActual(input->id()));
+  }
+  return ids;
+}
+
 bool isAllViews(
     NodeCP node,
     const std::unordered_set<NodeCP>& placed,
@@ -2505,8 +2546,31 @@ std::unique_ptr<CompiledNode> CompileCtx::compileNode(ProjectNode& project) {
   // WaveConfig::freeIntermediates releases their frame tensors after execute().
   std::vector<nativert::ValueId> lastUseIds;
   lastUseIds.reserve(project.lastUse.size());
+  // For each of them, the ops_ indices that read it, which is what lets the
+  // executor release the value after the last step those ops occupy instead of
+  // after the node's last step. Left empty -- meaning "release at the node's
+  // last step" -- for a value produced inside this node: its producer writes
+  // the frame slot at a step this reader-based bound knows nothing about.
+  std::vector<std::vector<int32_t>> lastUseReaderOps;
+  lastUseReaderOps.reserve(project.lastUse.size());
+  std::vector<std::unordered_set<nativert::ValueId>> readSets;
+  readSets.reserve(ops_.size());
+  for (const auto& op : ops_) {
+    readSets.push_back(opReadSet(op));
+  }
+  const std::unordered_set<NodeCP> layerNodes(nodes.begin(), nodes.end());
   for (auto* value : project.lastUse) {
     lastUseIds.push_back(value->id());
+    std::vector<int32_t> readers;
+    const auto* producer = value->producer();
+    if (producer == nullptr || layerNodes.count(producer) == 0) {
+      for (size_t i = 0; i < readSets.size(); ++i) {
+        if (readSets[i].count(value->id()) != 0) {
+          readers.push_back(static_cast<int32_t>(i));
+        }
+      }
+    }
+    lastUseReaderOps.push_back(std::move(readers));
   }
   // Values whose buffer an elementwise op may reuse in place for its output:
   // reusable last-use boundary inputs and expr-local overwritable temps. Only
@@ -2562,6 +2626,7 @@ std::unique_ptr<CompiledNode> CompileCtx::compileNode(ProjectNode& project) {
       std::move(ivalueStorage_),
       waveGraph_.nextCompositeInvocationId(),
       std::move(lastUseIds),
+      std::move(lastUseReaderOps),
       std::move(reusableIds),
       std::vector<Launch>{},
       std::move(elidedCloneInputs));

--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -26,6 +26,7 @@
 #include <c10/core/CachingDeviceAllocator.h>
 #include <c10/util/StringUtil.h>
 #include <folly/ScopeGuard.h>
+#include <folly/chrono/Hardware.h>
 #include <gflags/gflags.h>
 #include <algorithm>
 #include <atomic>
@@ -461,6 +462,24 @@ constexpr int32_t kDefaultNumSMs = 100;
 // Default blocks per SM when occupancy info is unavailable.
 constexpr int32_t kDefaultBlocksPerSM = 4;
 
+// Blocks a step's grid aims to fill: the device's SM count times the blocks of
+// this kernel that stay resident on one SM. makeGrid distributes this many
+// across the step's launches, and layoutParamSlots bounds the BlockInfo
+// reservation by it, so the two must derive it the same way -- a reservation
+// computed from a larger figure than makeGrid uses would be too small.
+int32_t targetBlockCount(int32_t maxBlocksPerSM) {
+  int32_t numSMs = WaveConfig::get().numSms;
+  if (numSMs == 0) {
+    numSMs = kDefaultNumSMs;
+    if (auto* device = facebook::velox::wave::currentDevice()) {
+      numSMs = device->numSM;
+    }
+  }
+  const int32_t blocksPerSM =
+      maxBlocksPerSM > 0 ? maxBlocksPerSM : kDefaultBlocksPerSM;
+  return numSMs * blocksPerSM;
+}
+
 int32_t makeGrid(
     std::vector<LaunchData>& launches,
     StepVectors& sv,
@@ -505,17 +524,7 @@ int32_t makeGrid(
   }
 
   // Target blocks from device SM count and kernel occupancy.
-  int32_t numSMs = WaveConfig::get().numSms;
-  if (numSMs == 0) {
-    numSMs = kDefaultNumSMs;
-    auto* device = facebook::velox::wave::currentDevice();
-    if (device) {
-      numSMs = device->numSM;
-    }
-  }
-  int32_t blocksPerSM =
-      maxBlocksPerSM > 0 ? maxBlocksPerSM : kDefaultBlocksPerSM;
-  int32_t maxBlocks = numSMs * blocksPerSM;
+  int32_t maxBlocks = targetBlockCount(maxBlocksPerSM);
   int32_t targetBlocks = maxBlocks;
 
   // Assign blocks pro rata by cost, at least 1 per launch, capped by
@@ -664,6 +673,166 @@ int32_t makeGrid(
 // --- Launch ---
 
 namespace {
+
+// Marks every launch in 'sv' with LaunchData::d2hProducer: the step whose
+// device-to-host transfer produced a value it reads, i.e. the step whose
+// transfer has to have landed before this launch can be sized, allocated or
+// have its params filled. Runs on every step, not just under kTiming -- the
+// marks are what a deferred D2H wait is driven by; the kTiming counters are
+// tallied from them separately.
+//
+// Shortcuts have to be followed transitively. A metadata-only op (a view, a
+// slice, a ListPack) runs on the host inside this step and its result goes
+// into a fused kernel's param descriptor, so a kernel can reach a returned
+// scalar without naming it: returned size -> shortcut -> param. Shortcuts are
+// walked first, in execution order, and a dependent one taints its own outputs
+// so the chain is followed however long it is.
+void markD2hDependencies(ExecutionState& state, StepVectors& sv) {
+  // LaunchData is pooled across runs, so a mark left by the previous run would
+  // otherwise stand in for this one.
+  for (auto* launches :
+       {&sv.shortcutStandalones, &sv.kernels, &sv.standalones}) {
+    for (auto& data : *launches) {
+      data.d2hProducer = -1;
+    }
+  }
+  if (state.returnedAtStep.empty()) {
+    return;
+  }
+  // Producing step of the nearest returned value an op reads, or -1.
+  auto producerOf = [&](const std::vector<nativert::ValueId>& ids) {
+    int32_t best = -1;
+    for (auto id : ids) {
+      auto it = state.returnedAtStep.find(id);
+      if (it != state.returnedAtStep.end() && it->second > best) {
+        best = it->second;
+      }
+    }
+    return best;
+  };
+
+  // Shortcuts first: they run before the kernel and feed its params.
+  folly::F14FastMap<nativert::ValueId, int32_t> tainted;
+  for (auto& data : sv.shortcutStandalones) {
+    auto producer = producerOf(data.actualInputs);
+    for (auto id : data.actualInputs) {
+      auto it = tainted.find(id);
+      if (it != tainted.end() && it->second > producer) {
+        producer = it->second;
+      }
+    }
+    if (producer < 0) {
+      continue;
+    }
+    data.d2hProducer = producer;
+    for (auto id : data.actualOutputs) {
+      auto& slot = tainted[id];
+      slot = std::max(slot, producer);
+    }
+  }
+
+  auto opProducer = [&](const LaunchData& data) {
+    int32_t producer = producerOf(data.actualInputs);
+    producer = std::max(producer, producerOf(data.tensorsInFrame));
+    producer = std::max(producer, producerOf(data.scalarsInFrame));
+    for (const auto& ids :
+         {data.actualInputs, data.tensorsInFrame, data.scalarsInFrame}) {
+      for (auto id : ids) {
+        auto it = tainted.find(id);
+        if (it != tainted.end() && it->second > producer) {
+          producer = it->second;
+        }
+      }
+    }
+    // An output produced by a host-side view (a viewNode output desc, e.g. a
+    // leaf-input slice) takes its shape and offset operands from that view
+    // node, not from this op's inputs -- a slice end is typically an item() of
+    // a device result. Those ids appear nowhere in actualInputs, which is why
+    // KernelOperation adds them to orderingInputs_ separately. Skip the base
+    // operand, which is the tensor being viewed rather than a bound.
+    for (const auto& desc : data.actualOutputDescs) {
+      if (desc.viewNode == nullptr) {
+        continue;
+      }
+      const auto* viewMeta = Registry::metadata(desc.viewNode->target());
+      int32_t baseOrdinal = (viewMeta && viewMeta->viewOfArg.has_value())
+          ? *viewMeta->viewOfArg
+          : -1;
+      const auto& viewInputs = desc.viewNode->inputs();
+      for (size_t k = 0; k < viewInputs.size(); ++k) {
+        if (static_cast<int32_t>(k) == baseOrdinal ||
+            viewInputs[k].value == nullptr) {
+          continue;
+        }
+        auto id = viewInputs[k].value->id();
+        auto it = state.returnedAtStep.find(id);
+        if (it != state.returnedAtStep.end() && it->second > producer) {
+          producer = it->second;
+        }
+        auto tt = tainted.find(id);
+        if (tt != tainted.end() && tt->second > producer) {
+          producer = tt->second;
+        }
+      }
+    }
+    return producer;
+  };
+  for (auto* launches : {&sv.kernels, &sv.standalones}) {
+    for (auto& data : *launches) {
+      data.d2hProducer = opProducer(data);
+    }
+  }
+}
+
+// Tallies the marks markD2hDependencies left into the per-step report counters:
+// how much of the step is blocked on a transfer, and how far back the nearest
+// producer is. kTiming only.
+void countD2hDependencies(ExecutionState& state, StepVectors& sv) {
+  sv.d2hDepFused = 0;
+  sv.d2hDepStandalone = 0;
+  sv.d2hDepShortcut = 0;
+  sv.d2hDepOnPrevStep = 0;
+  sv.d2hNearestProducer = -1;
+  sv.viewNodeDescs = 0;
+  auto note = [&](int32_t producer) {
+    auto distance = state.executedSteps - producer;
+    if (sv.d2hNearestProducer < 0 || distance < sv.d2hNearestProducer) {
+      sv.d2hNearestProducer = distance;
+    }
+    if (distance == 1) {
+      ++sv.d2hDepOnPrevStep;
+    }
+  };
+  auto tally = [&](const std::vector<LaunchData>& launches, int32_t& counter) {
+    for (const auto& data : launches) {
+      if (data.d2hProducer >= 0) {
+        ++counter;
+        note(data.d2hProducer);
+      }
+    }
+  };
+  tally(sv.shortcutStandalones, sv.d2hDepShortcut);
+  tally(sv.kernels, sv.d2hDepFused);
+  tally(sv.standalones, sv.d2hDepStandalone);
+  for (const auto& data : sv.kernels) {
+    for (const auto& desc : data.actualOutputDescs) {
+      if (desc.viewNode != nullptr) {
+        ++sv.viewNodeDescs;
+      }
+    }
+  }
+}
+
+// Registers the values this step sends back, so later steps can report that
+// they depend on them.
+void recordD2hProducers(ExecutionState& state, const StepVectors& sv) {
+  for (const auto& data : sv.kernels) {
+    for (auto id : data.returnValues) {
+      state.returnedAtStep[id] = state.executedSteps;
+    }
+  }
+}
+
 // Maps a metadata-only standalone op's target to its host-side shortcut.
 StandaloneShortcut standaloneShortcutForTarget(std::string_view target) {
   if (target == "prim.ListPack") {
@@ -701,6 +870,12 @@ StandaloneShortcut standaloneShortcutForTarget(std::string_view target) {
   }
   if (target == "torch.ops.aten.expand.default") {
     return StandaloneShortcut::kExpand;
+  }
+  if (target == "torch.ops.aten.sym_size.int") {
+    return StandaloneShortcut::kSymSize;
+  }
+  if (target == "torch.ops.aten.sym_numel.default") {
+    return StandaloneShortcut::kSymNumel;
   }
   return StandaloneShortcut::kNone;
 }
@@ -783,6 +958,7 @@ CompositeInvocation::CompositeInvocation(
     std::deque<c10::IValue> ivalueStorage,
     int32_t sequenceNumber,
     std::vector<nativert::ValueId> lastUseIds,
+    std::vector<std::vector<int32_t>> lastUseReaderOps,
     std::vector<nativert::ValueId> reusableIds,
     std::vector<Launch> prePassStandalones,
     std::vector<std::pair<nativert::ValueId, int32_t>> elidedCloneInputs)
@@ -791,6 +967,7 @@ CompositeInvocation::CompositeInvocation(
       ivalueStorage_(std::move(ivalueStorage)),
       sequenceNumber_(sequenceNumber),
       lastUseIds_(std::move(lastUseIds)),
+      lastUseReaderOps_(std::move(lastUseReaderOps)),
       reusableIds_(reusableIds.begin(), reusableIds.end()),
       prePassStandalones_(std::move(prePassStandalones)),
       elidedCloneInputs_(std::move(elidedCloneInputs)) {}
@@ -1774,15 +1951,34 @@ void ensureCudaTensor(
     nativert::ExecutionFrame& frame,
     const ValueTypes& types,
     nativert::ValueId actualId,
-    c10::IntArrayRef dims) {
+    c10::IntArrayRef dims,
+    const std::string& sizeKey = std::string("dyn"),
+    ExecutionState* state = nullptr) {
   auto& existing = frame.getIValue(actualId);
+  // Bytes the output needs, for the allocation trace. Computed only when the
+  // trace is on: it is a multiply per dim in the per-op path otherwise.
+  auto requestedBytes = [&](c10::ScalarType dtype) {
+    int64_t numel = 1;
+    for (auto d : dims) {
+      numel *= d;
+    }
+    return numel * static_cast<int64_t>(c10::elementSize(dtype));
+  };
   if (existing.isTensor() && existing.toTensor().is_cuda()) {
     auto& tensor = existing.toTensor();
     if (tensor.sizes() != dims) {
       traceTensor(actualId, dims, "resize");
+      if (allocTraceEnabled()) {
+        logKeyedAllocEvent(
+            "resize", actualId, requestedBytes(tensor.scalar_type()), sizeKey);
+      }
       tensor.resize_(dims);
     } else {
       traceTensor(actualId, dims, "keep");
+      if (allocTraceEnabled()) {
+        logKeyedAllocEvent(
+            "keep", actualId, requestedBytes(tensor.scalar_type()), sizeKey);
+      }
     }
   } else {
     auto* meta = types.types.at(actualId);
@@ -1790,14 +1986,96 @@ void ensureCudaTensor(
       return;
     }
     traceTensor(actualId, dims, "alloc");
+    if (allocTraceEnabled()) {
+      logKeyedAllocEvent(
+          "alloc", actualId, requestedBytes(meta->dtype()), sizeKey);
+    }
+    // A pooled buffer of exactly this size costs a pop instead of an allocator
+    // call, which is the whole cost at any size.
+    const auto bytes = requestedBytes(meta->dtype());
+    if (state != nullptr) {
+      auto donated = takeDonatedTensor(*state, bytes, meta->dtype(), dims);
+      if (donated.defined()) {
+        frame.setIValue(actualId, std::move(donated));
+        return;
+      }
+      // Missed, so this allocation grows the footprint. Shed pooled buffers if
+      // holding them would push past the delayed-free ceiling.
+      const auto limit = WaveConfig::get().maxDelayedFree;
+      if (limit > 0) {
+        evictDonatable(*state, limit);
+      }
+    }
     auto tensor = at::empty(
         dims, at::TensorOptions().dtype(meta->dtype()).device(at::kCUDA));
     frame.setIValue(actualId, std::move(tensor));
   }
 }
 
+// Serializes a SizeExpr into a canonical string. The expression is fixed at
+// compile time and its value depends only on the numel of the values it names,
+// so two outputs whose keys match are provably the same element count on every
+// run. kMax / kSum are commutative, so the value list is sorted to keep the key
+// canonical.
+void appendSizeExprKey(const SizeExpr& expr, std::string& out) {
+  out += std::to_string(static_cast<int>(expr.op));
+  if (expr.broadcast) {
+    out += 'B';
+  }
+  out += '(';
+  auto values = expr.values;
+  std::sort(values.begin(), values.end());
+  for (auto value : values) {
+    out += std::to_string(value);
+    out += ',';
+  }
+  for (const auto& shape : expr.constShapes) {
+    out += '[';
+    for (auto dim : shape) {
+      out += std::to_string(dim);
+      out += ' ';
+    }
+    out += ']';
+  }
+  for (const auto& arg : expr.args) {
+    appendSizeExprKey(arg, out);
+  }
+  out += ')';
+}
+
+// The static size key for an output: the size expression plus the element
+// width, since equal element counts only mean equal bytes at equal width.
+// "dyn" when the shape comes from a reserveShape lambda, which reads the frame
+// and cannot be compared before running.
+std::string staticSizeKey(
+    const OutputDesc& desc,
+    const ValueTypes& types,
+    nativert::ValueId actualId) {
+  if (desc.reserveShape || desc.sizeExpr.op == SizeShortcut::kNone) {
+    return "dyn";
+  }
+  std::string key;
+  appendSizeExprKey(desc.sizeExpr, key);
+  const auto* meta = static_cast<size_t>(actualId) < types.types.size()
+      ? types.types[actualId]
+      : nullptr;
+  key += '#';
+  key += std::to_string(
+      meta ? static_cast<int>(c10::elementSize(meta->dtype())) : 0);
+  return key;
+}
+
+// True for the list kinds whose elements are tensors, i.e. the cases where a
+// pack/unpack only moves handles.
+bool isTensorListKind(nativert::Type::Kind kind) {
+  return kind == nativert::Type::Kind::TensorList ||
+      kind == nativert::Type::Kind::NestedTensorList ||
+      kind == nativert::Type::Kind::OptionalTensorList;
+}
+
 void allocateLaunchOutputs(
     const LaunchData& launch,
+    ExecutionState* state,
     nativert::ExecutionFrame& frame,
     const ValueTypes& types,
     nativert::ValueId largestId,
@@ -1986,7 +2264,8 @@ void allocateLaunchOutputs(
         auto elemActualId =
             elemActualIt != bindings.end() ? elemActualIt->second : elemId;
         std::vector<int64_t> dims(shapes[j].begin(), shapes[j].end());
-        ensureCudaTensor(frame, types, elemActualId, dims);
+        ensureCudaTensor(
+            frame, types, elemActualId, dims, std::string("dyn"), state);
       }
       continue;
     }
@@ -2019,11 +2298,17 @@ void allocateLaunchOutputs(
       }
       continue;
     }
-    ensureCudaTensor(frame, types, actualId, dims);
+    ensureCudaTensor(
+        frame,
+        types,
+        actualId,
+        dims,
+        staticSizeKey(descs[i], types, actualId),
+        state);
   }
 }
 
-int32_t launchParamSize(const LaunchData& launch) {
+[[maybe_unused]] int32_t launchParamSize(const LaunchData& launch) {
   return launch.launch->op->altParamOffset();
 }
 
@@ -2127,32 +2412,473 @@ int64_t numElementsFromReserve(
 
 // --- CompositeInvocation ---
 
-void CompositeInvocation::gatherLaunches(
+namespace {
+// Defined further down, next to the other pending-return helpers.
+int32_t neededPendingStep(
     const ExecutionState& state,
+    const folly::F14FastSet<nativert::ValueId>& readIds);
+} // namespace
+
+void CompositeInvocation::layoutParamSlots(int32_t stepIdx, StepVectors& sv) {
+  if (!sv.opSlotBegin.empty()) {
+    return;
+  }
+  sv.opSlotBegin.reserve(ops_.size() + 1);
+  int64_t cursor = 0;
+  for (auto& op : ops_) {
+    sv.opSlotBegin.push_back(static_cast<int32_t>(sv.slotOffsets.size()));
+    auto* projectOp = op.projectOp();
+    // Per kernel slot, the largest param block any variant would put there. A
+    // variant that has fewer launches at this step simply leaves the tail
+    // slots unused.
+    std::vector<int32_t> slotSizes;
+    for (const auto* grid :
+         {&projectOp->grid(),
+          &projectOp->singleBlockGrid(),
+          &projectOp->cgGrid()}) {
+      if (stepIdx >= static_cast<int32_t>(grid->size())) {
+        continue;
+      }
+      size_t slot = 0;
+      for (const auto& launch : (*grid)[stepIdx]) {
+        if (launch.op == nullptr) {
+          continue;
+        }
+        if (slot >= slotSizes.size()) {
+          slotSizes.resize(slot + 1, 0);
+        }
+        // Grown to slot + 1 just above.
+        // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)
+        auto& slotSize = slotSizes[slot];
+        slotSize = std::max(slotSize, launch.op->altParamOffset());
+        ++slot;
+      }
+    }
+    for (auto size : slotSizes) {
+      sv.slotOffsets.push_back(cursor);
+      cursor += size;
+    }
+  }
+  sv.opSlotBegin.push_back(static_cast<int32_t>(sv.slotOffsets.size()));
+  sv.paramRegionBytes = cursor;
+
+  // Everything this step can read, unioned over the same three variants. Same
+  // sources and same reason as Compile.cpp's opReadSet: orderingInputs is what
+  // the scheduler orders a launch against, so it already covers the operands
+  // that reach the host only through reserveShape / sizeExpr at gather time and
+  // the host-side view operands that are inputs of no fused node. The subgraph
+  // leaves are added for any op present at this step, since a variant can reach
+  // a boundary input without naming it in a launch.
+  sv.opReadIds.resize(ops_.size());
+  sv.opReadSignature.assign(ops_.size(), 0);
+  sv.opKernelCount.assign(ops_.size(), 0);
+  sv.opStandaloneCount.assign(ops_.size(), 0);
+  sv.opShortcutCount.assign(ops_.size(), 0);
+  for (size_t i = 0; i < ops_.size(); ++i) {
+    auto& op = ops_[i];
+    auto& opIds = sv.opReadIds[i];
+    const auto& bindings = op.bindings();
+    auto toActual = [&](nativert::ValueId formalId) {
+      auto it = bindings.find(formalId);
+      return it != bindings.end() ? it->second : formalId;
+    };
+    auto* projectOp = op.projectOp();
+    bool present = false;
+    for (const auto* grid :
+         {&projectOp->grid(),
+          &projectOp->singleBlockGrid(),
+          &projectOp->cgGrid()}) {
+      if (stepIdx >= static_cast<int32_t>(grid->size())) {
+        continue;
+      }
+      present = true;
+      for (const auto& launch : (*grid)[stepIdx]) {
+        if (launch.op != nullptr) {
+          for (auto id : launch.op->orderingInputs()) {
+            opIds.insert(toActual(id));
+          }
+        } else if (launch.standalone != nullptr) {
+          // prim.ListPack / prim.ListUnpack only move tensor handles between
+          // the frame and a list; they never read an element's contents or its
+          // shape. Charging them their inputs' ids would defer them behind a
+          // pending transfer and drag the host into a waveDone wait they do not
+          // need. Consumers of the packed/unpacked values carry their own read
+          // ids, so the real dependency is still enforced where it matters.
+          // Only when the list is a TensorList: then the op merely moves
+          // tensor handles and never reads an element's contents or shape, so
+          // charging it its inputs' ids would defer it behind a pending
+          // transfer and drag the host into a waveDone wait it does not need.
+          // A SymInt / int list is the opposite -- the scalars ARE the data,
+          // and packing one before its transfer lands would store a stale
+          // value. Same distinction Launch::Launch draws for the kListPack
+          // shortcut.
+          const auto target = launch.standalone->target();
+          const bool isPack = target == "prim.ListPack";
+          const bool isUnpack = target == "prim.ListUnpack";
+          if (isPack || isUnpack) {
+            ValueCP listValue = nullptr;
+            if (isPack) {
+              listValue = launch.standalone->outputs().empty()
+                  ? nullptr
+                  : launch.standalone->outputs()[0];
+            } else if (!launch.standalone->inputs().empty()) {
+              listValue = launch.standalone->inputs()[0].value;
+            }
+            if (listValue != nullptr &&
+                isTensorListKind(listValue->type().kind())) {
+              continue;
+            }
+          }
+          for (const auto& input : launch.standalone->inputs()) {
+            if (input.value != nullptr) {
+              opIds.insert(toActual(input.value->id()));
+            }
+          }
+        }
+      }
+    }
+    if (present) {
+      for (const auto* input : projectOp->subgraph().inputs) {
+        opIds.insert(toActual(input->id()));
+      }
+    }
+    uint64_t signature = 0;
+    for (auto id : opIds) {
+      signature |= uint64_t{1} << (static_cast<uint64_t>(id) & 63);
+    }
+    // Assigned ops_.size() entries above; i runs over the same bound.
+    // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+    sv.opReadSignature[i] = signature;
+    sv.readIds.insert(opIds.begin(), opIds.end());
+  }
+
+  // Bound on what makeGrid can assign here. It gives each launch
+  // max(1, round(fraction * targetBlocks)) blocks, then only ever reduces that
+  // (the per-launch cap, the round-down to whole blockSize chunks) and the
+  // rebalancing pass conserves the total. So the sum cannot exceed
+  // targetBlocks plus 1.5 per launch; take 2 per launch.
+  const auto numSlots = static_cast<int32_t>(sv.slotOffsets.size());
+  sv.blockCapacity =
+      2 * numSlots + targetBlockCount(kernel_->kernelInfo().maxOccupancy0);
+}
+
+bool CompositeInvocation::chooseGridVariant(
+    ExecutionState& state,
+    GridChoice& gridChoice,
+    OpInvocation& op,
+    int32_t stepIdx,
+    size_t launchIndex,
+    bool hasByLargestInput,
+    LaunchData& data,
+    nativert::ValueId& largestId) {
+  auto* projectOp = op.projectOp();
+  bool wantSingleBlock;
+  if (WaveConfig::get().useSingleBlock.has_value()) {
+    wantSingleBlock = *WaveConfig::get().useSingleBlock;
+  } else {
+    wantSingleBlock = data.numElements <= projectOp->singleBlockMaxSize();
+  }
+  LaunchGrid* newGrid = nullptr;
+  if (wantSingleBlock != gridChoice.singleBlock) {
+    if (wantSingleBlock) {
+      newGrid = &projectOp->singleBlockGrid();
+    } else {
+      newGrid = &projectOp->grid();
+    }
+  }
+  if (!wantSingleBlock && !projectOp->cgGrid().empty() &&
+      WaveConfig::get().isCg.has_value() && *WaveConfig::get().isCg) {
+    newGrid = &projectOp->cgGrid();
+  }
+  // A scanOutputReturnBarrier op takes a launch break only in the multi-block
+  // grid, so its multi-block grid has more steps than its single-block
+  // variant. The grid-choice kernel can therefore sit at a stepIdx that exists
+  // only in the current (longer) grid; switching to a shorter variant here
+  // would index it out of bounds (the initial access in the caller is guarded,
+  // but these post-swap accesses are not). Only switch when the target grid
+  // actually has this step. Otherwise keep the current grid -- it is a
+  // complete, correct plan for this op -- so the launch still runs, just under
+  // the already-selected variant. The op's earlier steps already ran under that
+  // variant, so this also keeps the whole op on one consistent grid.
+  if (newGrid == nullptr || newGrid == gridChoice.grid ||
+      stepIdx >= static_cast<int32_t>(newGrid->size())) {
+    return false;
+  }
+  gridChoice.singleBlock = wantSingleBlock;
+  gridChoice.grid = newGrid;
+  const auto& newLaunch = (*gridChoice.grid)[stepIdx][launchIndex];
+  data = LaunchData(newLaunch, op, state.waveGraph->idToValue());
+  largestId = -1;
+  if (data.sizeExpr.op == SizeShortcut::kNone) {
+    data.numElements = numElementsFromReserve(data, *state.frame);
+  } else {
+    data.numElements = data.sizeExpr.numElements(
+        state.frame, hasByLargestInput ? &largestId : nullptr);
+  }
+  return true;
+}
+
+void CompositeInvocation::sizeForUnreadyOperands(
+    LaunchData& data,
+    const Launch& launch,
+    nativert::ExecutionFrame& frame) {
+  // If a tensor input this kernel does NOT produce itself is None, skip the
+  // kernel (set numElements=0 so makeGrid assigns 0 blocks). Two kinds of input
+  // can be None without meaning "not ready":
+  //
+  //  - A value the op computes itself. Its producer is one of the op's own
+  //    nodes, so the launch writes it before the code that reads it (ordered by
+  //    the op's internal barriers); it is simply not materialized yet at host
+  //    sizing time.
+  //  - A non-tensor. An absent optional argument -- clamp's `min`, say -- is
+  //    legitimately None and says nothing about readiness.
+  //
+  // Counting either one starved the launch to a single block: it zeroed
+  // numElements and left the cg path to rebuild a size from static shapes
+  // alone.
+  const auto& opInputs = launch.op->orderedInputs();
+  const auto& opNodes = launch.op->allNodes();
+  auto numOpInputs = static_cast<size_t>(launch.op->numInputs());
+  // orderedInputs is the inputs followed by the outputs, and actualInputs is
+  // translated from its first numInputs entries, so these two sizes always
+  // agree. Scanning fewer than all the actual inputs would let a None slip past
+  // and starve the launch to a single block, so this is checked rather than
+  // clamped.
+  TORCH_CHECK(
+      data.actualInputs.size() == numOpInputs && numOpInputs <= opInputs.size(),
+      "Kernel op input count mismatch: ",
+      data.actualInputs.size(),
+      " actual vs ",
+      numOpInputs,
+      " formal of ",
+      opInputs.size(),
+      " ordered");
+  for (size_t k = 0; k < numOpInputs; ++k) {
+    const auto* formal = opInputs[k];
+    auto kind = formal->type().kind();
+    if (kind != nativert::Type::Kind::Tensor &&
+        kind != nativert::Type::Kind::TensorList) {
+      continue;
+    }
+    const auto* producer = formal->producer();
+    if (producer != nullptr && opNodes.count(producer) > 0) {
+      continue;
+    }
+    auto& iv = frame.getIValue(data.actualInputs[k]);
+    if (iv.isNone()) {
+      data.numElements = 0;
+      break;
+    }
+  }
+  if (data.numElements > 0) {
+    for (size_t oi = 0; oi < data.actualOutputs.size(); ++oi) {
+      if (oi < data.actualOutputTypes.size() &&
+          data.actualOutputTypes[oi] == nativert::Type::Kind::Tensor) {
+        const auto& oiv = frame.getIValue(data.actualOutputs[oi]);
+        // A None output comes from a later PN -- its tensor is not
+        // materialized, so the kernel must not launch yet. An empty (0-element)
+        // output is handled in device code (the elementwise size head sets
+        // size=0 -> 0 iterations), so it does not zero the whole launch here --
+        // that would wrongly skip the non-empty lanes of a multi-output kernel.
+        if (oiv.isNone()) {
+          data.numElements = 0;
+          break;
+        }
+      }
+    }
+  }
+  // Under a cooperative grid the whole step launches as ONE kernel, so an op
+  // cannot be skipped -- numElements only sets its block share. A view-rooted
+  // op (e.g. slice->clamp) fused into the step reads an input that is a
+  // step-internal intermediate: None/unallocated at host sizing time, so the
+  // guards above zero its numElements and it is starved to ~1 block even though
+  // it runs correctly once the cooperative kernel materializes that input
+  // mid-launch (op 138: 6 of 480 blocks, ~85ms). Recover a grid size from the
+  // kernel's concrete static input shapes (TensorMeta is available without
+  // materialization). numElements only drives the grid; the kernel loops to the
+  // true size on device, so an over-estimate is safe (surplus blocks
+  // early-out).
+  if (data.numElements == 0 && WaveConfig::get().isCg.value_or(false)) {
+    int64_t staticNumElements = 0;
+    for (const auto* tensorMeta : launch.op->inputTypes()) {
+      if (tensorMeta != nullptr && !tensorMeta->hasSymbolicShape()) {
+        int64_t numElements = 1;
+        for (auto extent : tensorMeta->sizes()) {
+          numElements *= extent;
+        }
+        if (numElements > staticNumElements) {
+          staticNumElements = numElements;
+        }
+      }
+    }
+    if (staticNumElements > 0) {
+      data.numElements = staticNumElements;
+    }
+  }
+}
+
+void CompositeInvocation::fillLaunchParamBlock(
+    LaunchData& data,
+    nativert::ExecutionFrame& frame,
+    uint8_t* pinnedBase,
+    uint8_t* deviceBase,
+    int64_t paramOffset,
+    int32_t& returnBegin,
+    int32_t& returnEnd) {
+  int32_t launchReturnBegin = -1;
+  int32_t launchReturnEnd = -1;
+  fillLaunchParams(
+      data,
+      frame,
+      pinnedBase + paramOffset,
+      launchReturnBegin,
+      launchReturnEnd);
+  patchTensorListPointers(
+      data, pinnedBase + paramOffset, deviceBase + paramOffset);
+  if (launchReturnBegin < 0) {
+    return;
+  }
+  // Min/max rather than first/last: the two passes fill in dependency order,
+  // not in ascending offset order.
+  const auto begin = static_cast<int32_t>(paramOffset + launchReturnBegin);
+  const auto end = static_cast<int32_t>(paramOffset + launchReturnEnd);
+  returnBegin = returnBegin < 0 ? begin : std::min(returnBegin, begin);
+  returnEnd = std::max(returnEnd, end);
+}
+
+void CompositeInvocation::gatherLaunches(
+    ExecutionState& state,
     std::vector<GridChoice>& grids,
     int32_t stepIdx,
-    StepVectors& sv) {
+    StepVectors& sv,
+    uint8_t* pinnedBase,
+    uint8_t* deviceBase,
+    bool deferredOnly,
+    std::vector<std::pair<size_t, DeferReason>>& deferred,
+    int32_t& returnBegin,
+    int32_t& returnEnd) {
   const auto& idToValue = state.waveGraph->idToValue();
-  int32_t kernelIdx = 0;
-  int32_t standaloneIdx = 0;
-  int32_t shortcutIdx = 0;
-  sv.gridChanged = false;
-  sv.isCgGrid = false;
-  sv.hasGpuStandalones = false;
+  LaunchCursor cursor;
+  if (!deferredOnly) {
+    sv.gridChanged = false;
+    sv.isCgGrid = false;
+    sv.hasGpuStandalones = false;
+    layoutParamSlots(stepIdx, sv);
+  }
+  const bool doTiming = WaveConfig::get().printTiming ||
+      (WaveConfig::get().trace & WaveConfig::kTiming);
+  const int64_t maxDelayedFree = WaveConfig::get().maxDelayedFree;
+
+  // Everything the pending transfers bring back, folded into one signature and
+  // one id set -- built once for the whole step, not per op. Actual ids: the
+  // formal-to-actual translation already happened when opReadIds was built.
+  uint64_t pendingSignature = 0;
+  if (!deferredOnly && !state.pendingReturns.empty()) {
+    for (const auto& pending : state.pendingReturns) {
+      const auto& producer =
+          state.stepVectors.at(pending.sequenceNumber).at(pending.stepIdx);
+      for (const auto& data : producer.kernels) {
+        for (auto id : data.returnValues) {
+          pendingSignature |= uint64_t{1} << (static_cast<uint64_t>(id) & 63);
+        }
+      }
+    }
+  }
+  // The memory cap is fixed for the step, so the per-op test is one compare.
+  const bool overMemoryCap =
+      maxDelayedFree > 0 && state.delayedFreeBytes > maxDelayedFree;
+
+  // Ops still waiting on a transfer this step's first pass could not resolve,
+  // or on memory the device has not released yet. The whole op is deferred:
+  // sizing, allocation and fill all read the frame. The common case costs one
+  // AND and one branch; only an op whose signature overlaps pays for the exact
+  // set lookup.
+  auto deferReasonFor = [&](size_t opIndex) -> std::optional<DeferReason> {
+    if (pendingSignature != 0 && opIndex < sv.opReadSignature.size() &&
+        (sv.opReadSignature[opIndex] & pendingSignature) != 0 &&
+        neededPendingStep(state, sv.opReadIds[opIndex]) >= 0) {
+      return DeferReason::kTransfer;
+    }
+    if (overMemoryCap) {
+      return DeferReason::kMemory;
+    }
+    return std::nullopt;
+  };
+
+  // Set of ops the first pass skipped, so the second pass can pick them out
+  // without re-testing (their dependency is resolved by then).
+  folly::F14FastSet<size_t> deferredOps;
+  if (deferredOnly) {
+    for (const auto& [opIndex, reason] : deferred) {
+      deferredOps.insert(opIndex);
+    }
+  }
+
   for (size_t i = 0; i < ops_.size(); ++i) {
     auto* grid = grids.at(i).grid;
     if (stepIdx >= static_cast<int32_t>(grid->size())) {
       continue;
     }
+    // The index and offset bookkeeping below has to run for every op on the
+    // first pass whatever its dependencies, or a deferred op would shift the
+    // parameter offsets and launch indices of the ops after it.
+    bool skipSetup = false;
+    if (deferredOnly) {
+      skipSetup = deferredOps.count(i) == 0;
+    } else if (auto reason = deferReasonFor(i)) {
+      skipSetup = true;
+      deferred.emplace_back(i, *reason);
+    }
+    if (deferredOnly && skipSetup) {
+      // Nothing to set up here, and the first pass already recorded how many
+      // launches this op owns, so step the cursor over it instead of walking
+      // its launches again.
+      cursor.kernel += sv.opKernelCount.at(i);
+      cursor.standalone += sv.opStandaloneCount.at(i);
+      cursor.shortcut += sv.opShortcutCount.at(i);
+      continue;
+    }
+    const LaunchCursor opBegin = cursor;
     auto* step = &(*grid)[stepIdx];
+    // Slot of the next kernel launch of this op, indexing the reservation
+    // layoutParamSlots made for the op's widest variant.
+    int32_t opKernelSlot = 0;
     for (size_t j = 0; j < step->size(); ++j) {
       auto& launch = (*step)[j];
       if (launch.op != nullptr) {
-        bool isNew = kernelIdx >= static_cast<int32_t>(sv.kernels.size());
+        auto slot = sv.opSlotBegin.at(i) + opKernelSlot;
+        TORCH_CHECK(
+            slot < sv.opSlotBegin.at(i + 1),
+            "Kernel launch slot beyond the reservation for op ",
+            i,
+            " at step ",
+            stepIdx);
+        if (cursor.kernel >= static_cast<int32_t>(sv.paramOffsets.size())) {
+          sv.paramOffsets.resize(cursor.kernel + 1);
+        }
+        sv.paramOffsets.at(cursor.kernel) = sv.slotOffsets.at(slot);
+        ++opKernelSlot;
+        bool isNew = cursor.kernel >= static_cast<int32_t>(sv.kernels.size());
         if (isNew) {
           sv.kernels.emplace_back(launch, ops_[i], idToValue);
         }
-        auto& data = sv.kernels.at(kernelIdx);
+        auto& data = sv.kernels.at(cursor.kernel);
+        if (skipSetup) {
+          // Sizing reads the frame, so it waits for the second pass too. The
+          // launch keeps its slot and its index; only its contents are unset.
+          ++cursor.kernel;
+          continue;
+        }
+        // Sizing this launch is a sequence of choices, each able to overturn
+        // the one before, so the order below is the meaning:
+        //   1. an element count, from the reserve or the size expression;
+        //   2. the grid variant that count implies, which if it moves rebuilds
+        //      the launch data and so the count with it;
+        //   3. allocation of the outputs at that size;
+        //   4. zero, if an operand the launch does not produce is still None --
+        //      unless the cooperative grid is on, which recovers a size from
+        //      static shapes because a cooperative step cannot skip an op;
+        //   5. the parameter block, filled from whatever survived.
         bool hasByLargestInput = !data.launch->op->outputDescs().empty() &&
             data.launch->op->outputDescs()[0].byLargestInput;
         nativert::ValueId largestId = -1;
@@ -2163,178 +2889,79 @@ void CompositeInvocation::gatherLaunches(
               state.frame, hasByLargestInput ? &largestId : nullptr);
         }
 
-        if (launch.op->isGridChoice()) {
-          auto* projectOp = ops_[i].projectOp();
-          bool wantSingleBlock;
-          if (WaveConfig::get().useSingleBlock.has_value()) {
-            wantSingleBlock = *WaveConfig::get().useSingleBlock;
-          } else {
-            wantSingleBlock =
-                data.numElements <= projectOp->singleBlockMaxSize();
-          }
-          LaunchGrid* newGrid = nullptr;
-          if (wantSingleBlock != grids[i].singleBlock) {
-            if (wantSingleBlock) {
-              newGrid = &projectOp->singleBlockGrid();
-            } else {
-              newGrid = &projectOp->grid();
-            }
-          }
-          if (!wantSingleBlock && !projectOp->cgGrid().empty() &&
-              WaveConfig::get().isCg.has_value() && *WaveConfig::get().isCg) {
-            newGrid = &projectOp->cgGrid();
-          }
-          // A scanOutputReturnBarrier op takes a launch break only in the
-          // multi-block grid, so its multi-block grid has more steps than its
-          // single-block variant. The grid-choice kernel can therefore sit at a
-          // stepIdx that exists only in the current (longer) grid; switching to
-          // a shorter variant here would index it out of bounds (the initial
-          // access above is guarded, but these post-swap accesses are not).
-          // Only switch when the target grid actually has this step. Otherwise
-          // keep the current grid -- it is a complete, correct plan for this op
-          // -- so the launch still runs, just under the already-selected
-          // variant. The op's earlier steps already ran under that variant, so
-          // this also keeps the whole op on one consistent grid.
-          if (newGrid && newGrid != grids[i].grid &&
-              stepIdx < static_cast<int32_t>(newGrid->size())) {
-            grids[i].singleBlock = wantSingleBlock;
-            grids[i].grid = newGrid;
-            grid = newGrid;
-            step = &(*grid)[stepIdx];
-            if (!isNew) {
-              sv.gridChanged = true;
-            }
-            auto& newLaunch = (*grids[i].grid)[stepIdx][j];
-            data = LaunchData(newLaunch, ops_[i], idToValue);
-            largestId = -1;
-            if (data.sizeExpr.op == SizeShortcut::kNone) {
-              data.numElements = numElementsFromReserve(data, *state.frame);
-            } else {
-              data.numElements = data.sizeExpr.numElements(
-                  state.frame, hasByLargestInput ? &largestId : nullptr);
-            }
+        if (launch.op->isGridChoice() &&
+            chooseGridVariant(
+                state,
+                grids[i],
+                ops_[i],
+                stepIdx,
+                j,
+                hasByLargestInput,
+                data,
+                largestId)) {
+          grid = grids[i].grid;
+          step = &(*grid)[stepIdx];
+          if (!isNew) {
+            sv.gridChanged = true;
           }
         }
 
         // Check if any viewNode output descs have unavailable inputs.
         // If so, skip allocateLaunchOutputs — the viewNode would
         // crash on None inputs from a later PN.
+        //
+        // Timed on its own into allocUs, which is what makes the report say
+        // how much of the interpretation is allocation -- the part no amount of
+        // compiling the host path can remove. The pinned/device buffers are
+        // deliberately not counted: those come from a preallocated arena and
+        // cost nothing.
+        const uint64_t tAlloc = doTiming ? folly::hardware_timestamp() : 0;
         allocateLaunchOutputs(
             data,
+            &state,
             *state.frame,
             *state.valueTypes,
             largestId,
             state.kernelMap,
             idToValue,
             reusableIds_);
-        // If a tensor input this kernel does NOT produce itself is None, skip
-        // the kernel (set numElements=0 so makeGrid assigns 0 blocks). Two
-        // kinds of input can be None without meaning "not ready":
-        //
-        //  - A value the op computes itself. Its producer is one of the op's
-        //    own nodes, so the launch writes it before the code that reads it
-        //    (ordered by the op's internal barriers); it is simply not
-        //    materialized yet at host sizing time.
-        //  - A non-tensor. An absent optional argument -- clamp's `min`, say --
-        //    is legitimately None and says nothing about readiness.
-        //
-        // Counting either one starved the launch to a single block: it zeroed
-        // numElements and left the cg path to rebuild a size from static
-        // shapes alone.
-        const auto& opInputs = launch.op->orderedInputs();
-        const auto& opNodes = launch.op->allNodes();
-        auto numOpInputs = static_cast<size_t>(launch.op->numInputs());
-        // orderedInputs is the inputs followed by the outputs, and
-        // actualInputs is translated from its first numInputs entries, so
-        // these two sizes always agree. Scanning fewer than all the actual
-        // inputs would let a None slip past and starve the launch to a single
-        // block, so this is checked rather than clamped.
-        TORCH_CHECK(
-            data.actualInputs.size() == numOpInputs &&
-                numOpInputs <= opInputs.size(),
-            "Kernel op input count mismatch: ",
-            data.actualInputs.size(),
-            " actual vs ",
-            numOpInputs,
-            " formal of ",
-            opInputs.size(),
-            " ordered");
-        for (size_t k = 0; k < numOpInputs; ++k) {
-          const auto* formal = opInputs[k];
-          auto kind = formal->type().kind();
-          if (kind != nativert::Type::Kind::Tensor &&
-              kind != nativert::Type::Kind::TensorList) {
-            continue;
-          }
-          const auto* producer = formal->producer();
-          if (producer != nullptr && opNodes.count(producer) > 0) {
-            continue;
-          }
-          auto& iv = state.frame->getIValue(data.actualInputs[k]);
-          if (iv.isNone()) {
-            data.numElements = 0;
-            break;
-          }
+        if (doTiming) {
+          sv.allocUs += static_cast<int64_t>(
+              static_cast<double>(folly::hardware_timestamp() - tAlloc) /
+              tscTicksPerMicro());
         }
-        if (data.numElements > 0) {
-          for (size_t oi = 0; oi < data.actualOutputs.size(); ++oi) {
-            if (oi < data.actualOutputTypes.size() &&
-                data.actualOutputTypes[oi] == nativert::Type::Kind::Tensor) {
-              const auto& oiv = state.frame->getIValue(data.actualOutputs[oi]);
-              // A None output comes from a later PN -- its tensor is not
-              // materialized, so the kernel must not launch yet. An empty
-              // (0-element) output is handled in device code (the elementwise
-              // size head sets size=0 -> 0 iterations), so it does not zero the
-              // whole launch here -- that would wrongly skip the non-empty
-              // lanes of a multi-output kernel.
-              if (oiv.isNone()) {
-                data.numElements = 0;
-                break;
-              }
-            }
-          }
-        }
-        // Under a cooperative grid the whole step launches as ONE kernel, so an
-        // op cannot be skipped -- numElements only sets its block share. A
-        // view-rooted op (e.g. slice->clamp) fused into the step reads an input
-        // that is a step-internal intermediate: None/unallocated at host sizing
-        // time, so the guards above zero its numElements and it is starved to
-        // ~1 block even though it runs correctly once the cooperative kernel
-        // materializes that input mid-launch (op 138: 6 of 480 blocks, ~85ms).
-        // Recover a grid size from the kernel's concrete static input shapes
-        // (TensorMeta is available without materialization). numElements only
-        // drives the grid; the kernel loops to the true size on device, so an
-        // over-estimate is safe (surplus blocks early-out).
-        if (data.numElements == 0 && WaveConfig::get().isCg.value_or(false)) {
-          int64_t staticNumElements = 0;
-          for (const auto* tensorMeta : launch.op->inputTypes()) {
-            if (tensorMeta != nullptr && !tensorMeta->hasSymbolicShape()) {
-              int64_t numElements = 1;
-              for (auto extent : tensorMeta->sizes()) {
-                numElements *= extent;
-              }
-              if (numElements > staticNumElements) {
-                staticNumElements = numElements;
-              }
-            }
-          }
-          if (staticNumElements > 0) {
-            data.numElements = staticNumElements;
-          }
-        }
+        sizeForUnreadyOperands(data, launch, *state.frame);
         if (!launch.op->barrierCounters().empty()) {
           sv.isCgGrid = true;
         }
-        ++kernelIdx;
+        // Fill this launch's parameter block now, while its sizes and output
+        // tensors are still in cache, instead of in a second sweep over
+        // sv.kernels. The block's offset comes from the slot reservation, so it
+        // does not move when a later op switches grid variant or is deferred.
+        const uint64_t tFill = doTiming ? folly::hardware_timestamp() : 0;
+        fillLaunchParamBlock(
+            data,
+            *state.frame,
+            pinnedBase,
+            deviceBase,
+            sv.paramOffsets.at(cursor.kernel),
+            returnBegin,
+            returnEnd);
+        if (doTiming) {
+          sv.fillUs += static_cast<int64_t>(
+              static_cast<double>(folly::hardware_timestamp() - tFill) /
+              tscTicksPerMicro());
+        }
+        ++cursor.kernel;
       } else if (launch.standaloneShortcut != StandaloneShortcut::kNone) {
         // Metadata-only shortcut op: separate list, tight switch loop, no sync.
-        if (shortcutIdx >=
+        if (cursor.shortcut >=
             static_cast<int32_t>(sv.shortcutStandalones.size())) {
           sv.shortcutStandalones.emplace_back(launch, ops_[i], idToValue);
         }
-        ++shortcutIdx;
+        ++cursor.shortcut;
       } else {
-        if (standaloneIdx >= static_cast<int32_t>(sv.standalones.size())) {
+        if (cursor.standalone >= static_cast<int32_t>(sv.standalones.size())) {
           sv.standalones.emplace_back(launch, ops_[i], idToValue);
         }
         // A standalone that does real device work needs the wave stream synced
@@ -2343,10 +2970,31 @@ void CompositeInvocation::gatherLaunches(
         if (!launch.metadataOnly) {
           sv.hasGpuStandalones = true;
         }
-        ++standaloneIdx;
+        ++cursor.standalone;
       }
     }
+    if (!deferredOnly) {
+      sv.opKernelCount.at(i) = cursor.kernel - opBegin.kernel;
+      sv.opStandaloneCount.at(i) = cursor.standalone - opBegin.standalone;
+      sv.opShortcutCount.at(i) = cursor.shortcut - opBegin.shortcut;
+    }
   }
+  // Everything downstream -- makeGrid, the param fill, the BlockInfo wiring --
+  // walks all of sv.kernels, so a gather that produced fewer launches than a
+  // previous one for this step would run a stale launch with a stale param
+  // offset. The vectors only ever grow, so say so loudly rather than write
+  // params outside the slot reservation.
+  TORCH_CHECK(
+      cursor.kernel == static_cast<int32_t>(sv.kernels.size()),
+      "Gathered ",
+      cursor.kernel,
+      " kernel launches for node ",
+      sequenceNumber_,
+      " step ",
+      stepIdx,
+      " but the step holds ",
+      sv.kernels.size(),
+      " from an earlier gather");
 }
 
 // Invalidates cached grid, launch, and param state for the given step and all
@@ -2636,7 +3284,7 @@ void readScalarFromDevice(
   }
 }
 
-void CompositeInvocation::processReturnData(
+void processReturnData(
     StepVectors& sv,
     nativert::ExecutionFrame& frame,
     uint8_t* pinnedBase) {
@@ -2682,6 +3330,169 @@ void CompositeInvocation::processReturnData(
   }
 }
 
+namespace {
+
+// Under WaveConfig::syncEachStep, drains both streams before a step allocates,
+// so everything the preceding steps freed is back in the allocator first.
+// Without it the frees trail the host by however far it has run ahead and the
+// peak measures that lag rather than the release schedule.
+//
+// Draining BEFORE the step rather than after it also keeps a node's last step
+// out of kSynced until execute() has stamped the node's leftover last-use
+// values onto it: advanceSyncedStages only ever visits a kAllocated step, so
+// values stamped onto one already swept would never be freed at all.
+void drainBeforeStepIfRequested(ExecutionState& state) {
+  if (!WaveConfig::get().syncEachStep) {
+    return;
+  }
+  syncTorchDefaultStream();
+  syncWaveStream(state);
+}
+
+// Latest executed step among the pending transfers whose returned values this
+// step can read, or -1 when it reads none of them -- in which case the step
+// runs start to finish while every one of them is still in flight. sv.readIds
+// is a union over the step's grid variants, so this does not depend on a
+// variant choice gatherLaunches has not made yet.
+int32_t neededPendingStep(
+    const ExecutionState& state,
+    const folly::F14FastSet<nativert::ValueId>& readIds) {
+  // Newest first: the pending list is in issue order, so the first hit is the
+  // latest transfer this step needs, and resolving through it resolves every
+  // earlier one too.
+  for (auto it = state.pendingReturns.rbegin();
+       it != state.pendingReturns.rend();
+       ++it) {
+    const auto& producer =
+        state.stepVectors.at(it->sequenceNumber).at(it->stepIdx);
+    for (const auto& data : producer.kernels) {
+      for (auto id : data.returnValues) {
+        if (readIds.count(id) != 0) {
+          return it->executedStep;
+        }
+      }
+    }
+  }
+  return -1;
+}
+
+// Fails if any op in 'sv' reads a value a still-pending transfer brings back.
+// sv.readIds -- the union over grid variants that drove the deferral -- is a
+// superset of the read paths markD2hDependencies walks here, so a hit is not a
+// marginal disagreement between the two: it means the read set missed a path
+// and the step has already sized and allocated against a frame value that has
+// not landed. Cheap enough to run unconditionally, and the alternative symptom
+// is a wrong result far downstream.
+void checkNoPendingReads(
+    const ExecutionState& state,
+    const StepVectors& sv,
+    int32_t sequenceNumber,
+    int32_t stepIdx) {
+  if (state.pendingReturns.empty()) {
+    return;
+  }
+  const int32_t oldest = state.pendingReturns.front().executedStep;
+  for (const auto* launches :
+       {&sv.shortcutStandalones, &sv.kernels, &sv.standalones}) {
+    for (const auto& data : *launches) {
+      TORCH_CHECK(
+          data.d2hProducer < oldest,
+          "defer_d2h: node ",
+          sequenceNumber,
+          " step ",
+          stepIdx,
+          " reads a value returned at executed step ",
+          data.d2hProducer,
+          " whose transfer is still pending (oldest pending step ",
+          oldest,
+          ")");
+    }
+  }
+}
+
+// Reports any op in 'sv' that reads a value already stamped for release. Such a
+// read means the reader analysis behind releaseLastUseAtStep missed a reader
+// and the buffer is freed while still live -- a corruption whose only other
+// symptom is a wrong result far downstream. kFrame only; the scan is the same
+// shape as the D2H dependency one and just as unfit for a timed run.
+void checkNoReleasedReads(
+    const ExecutionState& state,
+    const StepVectors& sv,
+    int32_t sequenceNumber,
+    int32_t stepIdx) {
+  auto report = [&](nativert::ValueId id, const char* kind) {
+    auto it = state.releasedAtStep.find(id);
+    if (it != state.releasedAtStep.end()) {
+      LOG(ERROR) << "LASTUSE-RELEASED-TOO-EARLY %" << id << " released at step "
+                 << it->second << " but read by a " << kind << " of node "
+                 << sequenceNumber << " step " << stepIdx;
+    }
+  };
+  for (const auto& data : sv.shortcutStandalones) {
+    for (auto id : data.actualInputs) {
+      report(id, "shortcut");
+    }
+  }
+  for (const auto* launches : {&sv.kernels, &sv.standalones}) {
+    for (const auto& data : *launches) {
+      for (const auto& ids :
+           {data.actualInputs, data.tensorsInFrame, data.scalarsInFrame}) {
+        for (auto id : ids) {
+          report(id, "fused or standalone op");
+        }
+      }
+      for (const auto& desc : data.actualOutputDescs) {
+        if (desc.viewNode == nullptr) {
+          continue;
+        }
+        for (const auto& input : desc.viewNode->inputs()) {
+          if (input.value != nullptr) {
+            report(input.value->id(), "host-side view operand");
+          }
+        }
+      }
+    }
+  }
+}
+
+} // namespace
+
+void CompositeInvocation::releaseLastUseAtStep(
+    ExecutionState& state,
+    const std::vector<GridChoice>& grids,
+    int32_t stepIdx,
+    StepVectors& sv,
+    std::vector<int32_t>& releaseStep) {
+  // An op with a grid of L steps does its last work at step L-1, so once every
+  // reader of a value is past that, no later step of this node can read it.
+  // The grid length is read after gatherLaunches, which is the only place a
+  // variant is switched and only ever at a step the op still has -- so an op
+  // already past its end cannot grow one later.
+  auto readersDone = [&](const std::vector<int32_t>& readers) {
+    for (auto op : readers) {
+      if (static_cast<int32_t>(grids.at(op).grid->size()) > stepIdx + 1) {
+        return false;
+      }
+    }
+    return true;
+  };
+  const bool traceFrame = (WaveConfig::get().trace & WaveConfig::kFrame) != 0;
+  for (size_t i = 0; i < lastUseIds_.size(); ++i) {
+    const auto& readers = lastUseReaderOps_[i];
+    // releaseStep is sized to lastUseIds_.size() by the only caller, which
+    // also gates the call on stepLastUse; i runs over the same bound.
+    // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+    if (releaseStep[i] >= 0 || readers.empty() || !readersDone(readers)) {
+      continue;
+    }
+    releaseStep[i] = stepIdx;
+    addLastUseId(state, sv, lastUseIds_[i]);
+    if (traceFrame) {
+      state.releasedAtStep[lastUseIds_[i]] = state.executedSteps;
+    }
+  }
+}
+
 // Central execution loop: for each step, gathers launches from the
 // subgraph, builds the thread-block grid, fills kernel parameters
 // (tensor pointers, scalars, shapes), transfers params H2D, launches
@@ -2716,6 +3527,9 @@ void CompositeInvocation::execute(ExecutionState& state) {
   using Clock = std::chrono::high_resolution_clock;
   bool doTiming = WaveConfig::get().printTiming ||
       (WaveConfig::get().trace & WaveConfig::kTiming);
+  // Event timing is keyed strictly on kTiming, so printTiming stays the cheap
+  // host-only path and does not allocate timing events.
+  bool doEventTiming = (WaveConfig::get().trace & WaveConfig::kTiming) != 0;
   auto elapsed = [](Clock::time_point start) {
     return std::chrono::duration_cast<std::chrono::microseconds>(
                Clock::now() - start)
@@ -2752,19 +3566,131 @@ void CompositeInvocation::execute(ExecutionState& state) {
     }
   };
 
+  // Release each last-use value at the last step that reads it instead of at
+  // the node's last step. Needs a reader set per value; without one (or with a
+  // pre-pass standalone, which runs outside the grids the reader set is built
+  // from) every value falls back to the node's last step.
+  const bool stepLastUse = WaveConfig::get().freeIntermediates &&
+      WaveConfig::get().stepLastUse && !lastUseIds_.empty() &&
+      lastUseReaderOps_.size() == lastUseIds_.size() &&
+      prePassStandalones_.empty();
+  std::vector<int32_t> lastUseReleaseStep(
+      stepLastUse ? lastUseIds_.size() : 0, -1);
+
   int32_t blockSize;
   int32_t lastExecStep = -1;
   for (int32_t stepIdx = 0;; ++stepIdx) {
     auto& sv = getStepVectors(state.stepVectors, sequenceNumber_, stepIdx);
+    // No step-level wait for pending transfers here. Waiting for everything the
+    // step can read would resolve every dependency before gatherLaunches got to
+    // test any op, so nothing would ever be deferred and the step would stall
+    // whole for one op's transfer. The per-op test inside gatherLaunches drives
+    // it instead: independent ops are set up first, then the wait, then the
+    // rest.
+    drainBeforeStepIfRequested(state);
+    // Running ahead delays every free until the device catches up, so give the
+    // memory back before this step allocates if too much has piled up.
+    enforceDelayedFreeLimit(state);
     // Re-fetch since the resize above may have invalidated the reference.
     auto& currentGridChoices =
         state.stepVectors.at(sequenceNumber_).at(0).gridChoices;
 
+    // The parameter buffer needs only the step's slot reservation and block
+    // capacity, both fixed by layoutParamSlots from the compiled grids, so it
+    // can be acquired before anything is gathered. That is what lets each op be
+    // filled in the same pass that sizes and allocates it, instead of in a
+    // second sweep over sv.kernels.
+    layoutParamSlots(stepIdx, sv);
+    sv.blockInfoOffset = roundUp(sv.paramRegionBytes, int64_t{16});
+    const int64_t totalPinnedBytes = sv.blockInfoOffset +
+        static_cast<int64_t>(sv.blockCapacity) *
+            static_cast<int64_t>(sizeof(BlockInfo));
+    const int64_t totalAllocBytes = totalPinnedBytes +
+        static_cast<int64_t>(sv.blockCapacity) *
+            static_cast<int64_t>(sizeof(DebugInfo));
+    uint8_t* pinnedBase = nullptr;
+    uint8_t* deviceBase = nullptr;
+    // Not timed into allocUs: these come from a preallocated arena and cost
+    // nothing, so counting them would hide the allocation that does cost.
+    auto acquireBuffers = [&]() {
+      pinnedBase = getOrAllocateBuffer(
+                       state.pinnedBuffers,
+                       sequenceNumber_,
+                       stepIdx,
+                       totalAllocBytes,
+                       state.pinnedArena,
+                       WaveConfig::get().debugSingleOps
+                           ? std::function<void(void*, int64_t)>(
+                                 [](void* ptr, int64_t bytes) {
+                                   memset(ptr, 0xaa, bytes);
+                                 })
+                           : nullptr)
+                       ->as<uint8_t>();
+      deviceBase = getOrAllocateBuffer(
+                       state.deviceBuffers,
+                       sequenceNumber_,
+                       stepIdx,
+                       totalAllocBytes,
+                       state.deviceArena)
+                       ->as<uint8_t>();
+      // The arena always hands back a buffer, and every use below indexes off
+      // these; say so once rather than at each use.
+      TORCH_CHECK(pinnedBase != nullptr && deviceBase != nullptr);
+    };
+    acquireBuffers();
+    TORCH_CHECK(pinnedBase != nullptr && deviceBase != nullptr);
+
+    int32_t returnBegin = -1;
+    int32_t returnEnd = -1;
+    std::vector<std::pair<size_t, DeferReason>> deferred;
     {
       auto t0 = Clock::now();
-      gatherLaunches(state, currentGridChoices, stepIdx, sv);
+      sv.allocUs = 0;
+      sv.fillUs = 0;
+      gatherLaunches(
+          state,
+          currentGridChoices,
+          stepIdx,
+          sv,
+          pinnedBase,
+          deviceBase,
+          /*deferredOnly=*/false,
+          deferred,
+          returnBegin,
+          returnEnd);
+      if (sv.gridChanged) {
+        ++state.numGridRedos;
+        // A variant switch changed this step's launch layout, so the caches the
+        // fill just used and the parameter blocks it wrote belong to the old
+        // one. invalidateReusedState also drops the pinned buffer, so the bases
+        // have to be taken again before the redo.
+        // stepVectors has one entry per sequence number, created before the
+        // invocation runs.
+        // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+        auto& seqStepVectors = state.stepVectors[sequenceNumber_];
+        invalidateReusedState(
+            seqStepVectors, state.pinnedBuffers, sequenceNumber_, stepIdx);
+        acquireBuffers();
+        TORCH_CHECK(pinnedBase != nullptr && deviceBase != nullptr);
+        deferred.clear();
+        returnBegin = -1;
+        returnEnd = -1;
+        sv.allocUs = 0;
+        sv.fillUs = 0;
+        gatherLaunches(
+            state,
+            currentGridChoices,
+            stepIdx,
+            sv,
+            pinnedBase,
+            deviceBase,
+            /*deferredOnly=*/false,
+            deferred,
+            returnBegin,
+            returnEnd);
+      }
       if (doTiming) {
-        sv.gatherUs = elapsed(t0);
+        sv.gatherUs = elapsed(t0) - sv.allocUs - sv.fillUs;
       }
     }
     // StepVectors are pooled and reused across executions; reset the
@@ -2773,18 +3699,89 @@ void CompositeInvocation::execute(ExecutionState& state) {
     // measurement point).
     sv.refCheckUs = 0;
     sv.elidedCloneBytes = 0;
-    if (sv.gridChanged) {
-      invalidateReusedState(
-          state.stepVectors[sequenceNumber_],
-          state.pinnedBuffers,
-          sequenceNumber_,
-          stepIdx);
-    }
     if (sv.kernels.empty() && sv.standalones.empty() &&
         sv.shortcutStandalones.empty()) {
       break;
     }
     lastExecStep = stepIdx;
+    // Past the break above, so only steps that actually do work are sampled,
+    // and after every wait this step had to take, so the sample is the device
+    // state its interpretation gets to overlap with. The gather that precedes
+    // it is charged to the previous sample's window, which is the conservative
+    // direction: it can only make the measured depth look larger.
+    sampleRunAhead(state);
+
+    // Second pass: everything that could be set up without waiting is done, so
+    // now wait for exactly what the rest need and finish them. Only makeGrid
+    // and the BlockInfo array are left after this.
+    if (!deferred.empty()) {
+      bool forMemory = false;
+      int32_t throughStep = -1;
+      for (const auto& [opIndex, reason] : deferred) {
+        if (reason == DeferReason::kMemory) {
+          forMemory = true;
+        } else {
+          throughStep = std::max(
+              throughStep, neededPendingStep(state, sv.opReadIds[opIndex]));
+        }
+      }
+      // Deliberately outside the timed region below: this blocks the host on
+      // the device, so it is CPU idle waiting for the GPU, not interpretation.
+      // Counting it as interpretation is what made the second pass look like
+      // it had made the setup loop slower.
+      if (forMemory) {
+        // Memory only comes back as the device catches up, so this waits for
+        // everything rather than for one transfer.
+        enforceDelayedFreeLimit(state);
+        resolveAllPendingReturns(state);
+      } else {
+        resolvePendingReturns(state, throughStep);
+      }
+      auto t0 = Clock::now();
+      const auto allocBefore = sv.allocUs;
+      const auto fillBefore = sv.fillUs;
+      gatherLaunches(
+          state,
+          currentGridChoices,
+          stepIdx,
+          sv,
+          pinnedBase,
+          deviceBase,
+          /*deferredOnly=*/true,
+          deferred,
+          returnBegin,
+          returnEnd);
+      if (doTiming) {
+        sv.gatherUs +=
+            elapsed(t0) - (sv.allocUs - allocBefore) - (sv.fillUs - fillBefore);
+        state.numDeferredOps += static_cast<int32_t>(deferred.size());
+        ++state.numDeferredSteps;
+      }
+    }
+
+    // Which of this step's ops are blocked on an earlier step's D2H, and which
+    // values this step will itself send back. Marked before the step runs, so
+    // the producer map holds only genuinely earlier steps.
+    markD2hDependencies(state, sv);
+    if (!state.pendingReturns.empty()) {
+      checkNoPendingReads(state, sv, sequenceNumber_, stepIdx);
+    }
+    if (doTiming) {
+      countD2hDependencies(state, sv);
+    }
+    recordD2hProducers(state, sv);
+    if (WaveConfig::get().trace & WaveConfig::kFrame) {
+      checkNoReleasedReads(state, sv, sequenceNumber_, stepIdx);
+    }
+    sv.executedStep = state.executedSteps;
+    ++state.executedSteps;
+    // Release what no later step of this node reads. Done here rather than
+    // after the loop because a step that has already been swept to kSynced is
+    // never revisited, so a value stamped onto it later would never be freed.
+    if (stepLastUse) {
+      releaseLastUseAtStep(
+          state, currentGridChoices, stepIdx, sv, lastUseReleaseStep);
+    }
 
     if (sv.kernels.empty()) {
       if (WaveConfig::get().trace &
@@ -2795,15 +3792,25 @@ void CompositeInvocation::execute(ExecutionState& state) {
       // wave-stream sync; run them first in their tight, batch-timed loop.
       runShortcutStandalones(
           sv.shortcutStandalones, state, doTiming, sv.shortcutUs);
-      // Wait for the wave stream before running eager standalone ops only when
-      // a standalone does device-side work. Such ops run on the default stream
-      // and read inputs produced by wave kernels; without this wait the eager
-      // op can read a wave-stream buffer whose producing kernel (or a pending
-      // arena recycle) has not completed, since the two streams are otherwise
-      // unordered. Shortcut ops only touch host-side tensor metadata, so they
-      // need no sync.
+      // Order the eager standalones after the last wave kernel, on the device
+      // rather than by blocking the host. They run on the torch stream and read
+      // inputs produced by wave kernels; without the edge an eager op can read
+      // a wave-stream buffer whose producing kernel has not completed, since
+      // the wave streams are non-blocking and the two are otherwise unordered.
+      // Shortcut ops only touch host-side tensor metadata, so they need none.
+      //
+      // Enqueue the wait BEFORE recording standaloneBegin, so that event's
+      // timestamp is when this step's GPU work actually started with its
+      // dependency already satisfied. Recorded first it would fire as soon as
+      // the stream drained and silently understate idle.
+      auto& stepEvents = newStepEvents(state, sequenceNumber_, stepIdx);
       if (sv.hasGpuStandalones) {
-        syncWaveStream(state);
+        if (state.lastWaveDone != nullptr) {
+          state.lastWaveDone->wait(torchStream());
+        }
+        if (doEventTiming) {
+          stepEvents.standaloneBegin->record(torchStream());
+        }
       }
       auto tStandalone = doTiming ? Clock::now() : Clock::time_point{};
       runStandalones(
@@ -2813,6 +3820,10 @@ void CompositeInvocation::execute(ExecutionState& state) {
           *state.standaloneIndices,
           *state.standaloneStats,
           doTiming);
+      if (sv.hasGpuStandalones) {
+        stepEvents.standaloneDone->record(torchStream());
+        state.lastStandaloneDone = stepEvents.standaloneDone.get();
+      }
       if (doTiming) {
         sv.standaloneUs = elapsed(tStandalone);
         sv.currentBytes = currentAllocatedBytes();
@@ -2830,6 +3841,9 @@ void CompositeInvocation::execute(ExecutionState& state) {
         if (timeRefCheck) {
           syncWaveStream(state);
           syncTorchDefaultStream();
+        }
+        if (WaveConfig::get().referenceFrame != nullptr) {
+          resolveAllPendingReturns(state);
         }
         auto tRefCheck = timeRefCheck ? Clock::now() : Clock::time_point{};
         verifyAgainstReference(sv.shortcutStandalones, frame, state);
@@ -2851,108 +3865,12 @@ void CompositeInvocation::execute(ExecutionState& state) {
       }
     }
 
-    {
-      auto t0 = Clock::now();
-      if (gridSizesMatch(sv.kernels, sv)) {
-        blockSize = sv.cachedBlockSize;
-      } else {
-        blockSize =
-            makeGrid(sv.kernels, sv, kernel_->kernelInfo().maxOccupancy0);
-        TORCH_CHECK(
-            (blockSize & (blockSize - 1)) == 0,
-            "Block size must be a power of two, got ",
-            blockSize);
-        sv.cachedBlockSize = blockSize;
-        updateGridSizeBounds(sv.kernels, sv);
-      }
-      if (doTiming) {
-        sv.gridUs = elapsed(t0);
-      }
-    }
-
-    auto numBlocks = sv.blocks.size();
-    auto blockInfoBytes = static_cast<int64_t>(numBlocks) *
-        static_cast<int64_t>(sizeof(BlockInfo));
-
-    int64_t totalPinnedBytes;
-    int64_t totalAllocBytes;
-    uint8_t* pinnedBase;
-    uint8_t* deviceBase;
-    {
-      auto t0 = Clock::now();
-      sv.paramOffsets.resize(sv.kernels.size());
-      int64_t paramCursor = blockInfoBytes;
-      for (size_t i = 0; i < sv.kernels.size(); ++i) {
-        sv.paramOffsets[i] = paramCursor;
-        paramCursor += launchParamSize(sv.kernels[i]);
-      }
-      totalPinnedBytes = paramCursor;
-
-      auto debugInfoBytes = static_cast<int64_t>(numBlocks) *
-          static_cast<int64_t>(sizeof(DebugInfo));
-      totalAllocBytes = totalPinnedBytes + debugInfoBytes;
-
-      auto& pinnedBuffer = getOrAllocateBuffer(
-          state.pinnedBuffers,
-          sequenceNumber_,
-          stepIdx,
-          totalAllocBytes,
-          state.pinnedArena,
-          WaveConfig::get().debugSingleOps
-              ? std::function<void(void*, int64_t)>(
-                    [](void* ptr, int64_t bytes) { memset(ptr, 0xaa, bytes); })
-              : nullptr);
-      auto& deviceBuffer = getOrAllocateBuffer(
-          state.deviceBuffers,
-          sequenceNumber_,
-          stepIdx,
-          totalAllocBytes,
-          state.deviceArena);
-      pinnedBase = pinnedBuffer->as<uint8_t>();
-      deviceBase = deviceBuffer->as<uint8_t>();
-      if (doTiming) {
-        sv.allocUs = elapsed(t0);
-      }
-    }
-
     auto* deviceDebugBase =
         reinterpret_cast<DebugInfo*>(deviceBase + totalPinnedBytes);
-    int32_t returnBegin = -1;
-    int32_t returnEnd = -1;
     {
-      auto t0 = Clock::now();
-      if (!sv.blocks.empty()) {
-        memcpy(pinnedBase, sv.blocks.data(), blockInfoBytes);
-      }
-
-      for (size_t i = 0; i < sv.kernels.size(); ++i) {
-        int32_t rb = -1;
-        int32_t re = -1;
-        fillLaunchParams(
-            sv.kernels[i], frame, pinnedBase + sv.paramOffsets[i], rb, re);
-        if (rb >= 0) {
-          if (returnBegin == -1) {
-            returnBegin = static_cast<int32_t>(sv.paramOffsets[i] + rb);
-          }
-          returnEnd = static_cast<int32_t>(sv.paramOffsets[i] + re);
-        }
-      }
-
-      auto* pinnedBlocks = reinterpret_cast<BlockInfo*>(pinnedBase);
-      for (size_t b = 0; b < numBlocks; ++b) {
-        auto idx = sv.launchIndices[b];
-        pinnedBlocks[b].params = deviceBase + sv.paramOffsets[idx];
-        pinnedBlocks[b].debugInfo = deviceDebugBase + b;
-      }
-
-      for (size_t i = 0; i < sv.kernels.size(); ++i) {
-        patchTensorListPointers(
-            sv.kernels[i],
-            pinnedBase + sv.paramOffsets[i],
-            deviceBase + sv.paramOffsets[i]);
-      }
+      // Sizing, output allocation and the parameter fill all happened per op in
+      // gatherLaunches above; only the byte accounting is left here.
       if (doTiming) {
-        sv.fillUs = elapsed(t0);
         sv.inputBytes = 0;
         sv.outputBytes = 0;
         for (size_t i = 0; i < sv.kernels.size(); ++i) {
@@ -2975,6 +3893,56 @@ void CompositeInvocation::execute(ExecutionState& state) {
       }
     }
 
+    // Grid last: the params are already in the pinned buffer, so the only work
+    // left after this point is the BlockInfo array, which is what the block
+    // count actually determines.
+    {
+      auto t0 = Clock::now();
+      if (gridSizesMatch(sv.kernels, sv)) {
+        blockSize = sv.cachedBlockSize;
+      } else {
+        blockSize =
+            makeGrid(sv.kernels, sv, kernel_->kernelInfo().maxOccupancy0);
+        TORCH_CHECK(
+            (blockSize & (blockSize - 1)) == 0,
+            "Block size must be a power of two, got ",
+            blockSize);
+        sv.cachedBlockSize = blockSize;
+        updateGridSizeBounds(sv.kernels, sv);
+      }
+      if (doTiming) {
+        sv.gridUs = elapsed(t0);
+      }
+    }
+
+    auto numBlocks = sv.blocks.size();
+    TORCH_CHECK(
+        numBlocks <= static_cast<size_t>(sv.blockCapacity),
+        "makeGrid produced ",
+        numBlocks,
+        " blocks for node ",
+        sequenceNumber_,
+        " step ",
+        stepIdx,
+        " but the buffer was reserved for ",
+        sv.blockCapacity);
+    {
+      auto t0 = Clock::now();
+      auto* pinnedBlocks =
+          reinterpret_cast<BlockInfo*>(pinnedBase + sv.blockInfoOffset);
+      if (!sv.blocks.empty()) {
+        memcpy(pinnedBlocks, sv.blocks.data(), numBlocks * sizeof(BlockInfo));
+      }
+      for (size_t b = 0; b < numBlocks; ++b) {
+        auto idx = sv.launchIndices[b];
+        pinnedBlocks[b].params = deviceBase + sv.paramOffsets[idx];
+        pinnedBlocks[b].debugInfo = deviceDebugBase + b;
+      }
+      if (doTiming) {
+        sv.fillUs += elapsed(t0);
+      }
+    }
+
     if (WaveConfig::get().trace &
         (WaveConfig::kNodes | WaveConfig::kLaunches)) {
       traceStep(stepIdx, sv, currentGridChoices);
@@ -2987,6 +3955,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
          sequenceNumber_,
          stepIdx});
 
+    auto& stepEvents = newStepEvents(state, sequenceNumber_, stepIdx);
     int64_t standaloneElapsed = 0;
     auto runStepStandalones = [&]() {
       // Metadata-only shortcut ops: host-only, tight batch-timed loop, no sync.
@@ -2995,6 +3964,16 @@ void CompositeInvocation::execute(ExecutionState& state) {
             sv.shortcutStandalones, state, doTiming, sv.shortcutUs);
       }
       if (!sv.standalones.empty()) {
+        // This lambda runs inside launch(), i.e. after the kernel has been
+        // enqueued on the wave stream. The standalones wait on lastWaveDone --
+        // step N-1's kernel -- not on this step's, which is exactly what lets
+        // the two overlap.
+        if (state.lastWaveDone != nullptr) {
+          state.lastWaveDone->wait(torchStream());
+        }
+        if (doEventTiming) {
+          stepEvents.standaloneBegin->record(torchStream());
+        }
         auto tStandalone = doTiming ? Clock::now() : Clock::time_point{};
         runStandalones(
             sv.standalones,
@@ -3003,6 +3982,8 @@ void CompositeInvocation::execute(ExecutionState& state) {
             *state.standaloneIndices,
             *state.standaloneStats,
             doTiming);
+        stepEvents.standaloneDone->record(torchStream());
+        state.lastStandaloneDone = stepEvents.standaloneDone.get();
         if (doTiming) {
           standaloneElapsed = elapsed(tStandalone);
         }
@@ -3010,16 +3991,21 @@ void CompositeInvocation::execute(ExecutionState& state) {
       }
     };
 
-    // If this step has device-side standalones, wait for the wave stream before
-    // the fused kernel launch. Such standalones run on the default stream and
-    // may read results of prior wave fused kernels; without this wait those
-    // results may not be complete, since the two streams are otherwise
-    // unordered. Shortcut standalones only touch host-side tensor metadata, so
-    // they need no sync.
-    if (sv.hasGpuStandalones) {
-      syncWaveStream(state);
+    // Order this step's kernel after the previous step's eager standalones,
+    // which may have produced buffers it reads. Device-side, so the host does
+    // not block; the wait is enqueued before waveBegin is recorded so that
+    // event marks the real start of GPU work (see the kernel-less path above).
+    if (state.lastStandaloneDone != nullptr) {
+      state.lastStandaloneDone->wait(*state.stream);
+    }
+    if (doEventTiming) {
+      stepEvents.waveBegin->record(*state.stream);
     }
 
+    // Under debug_single_ops launch() waits after every block anyway, so there
+    // is nothing to defer there.
+    const bool deferReturn = WaveConfig::get().deferD2h && returnBegin >= 0 &&
+        !WaveConfig::get().debugSingleOps;
     {
       auto tLaunch = Clock::now();
       launch(
@@ -3027,16 +4013,36 @@ void CompositeInvocation::execute(ExecutionState& state) {
           blockSize,
           pinnedBase,
           deviceBase,
-          totalPinnedBytes,
+          // Only the params and the BlockInfos actually in use go to the
+          // device; the rest of the reservation is capacity, not content.
+          sv.blockInfoOffset +
+              static_cast<int64_t>(numBlocks) *
+                  static_cast<int64_t>(sizeof(BlockInfo)),
           returnBegin,
           returnEnd,
           deviceDebugBase,
           state.stream.get(),
           sv,
           stepIdx,
-          runStepStandalones);
+          deferReturn,
+          runStepStandalones,
+          &stepEvents);
+      state.lastWaveDone = stepEvents.waveDone.get();
+      // A device-side event wait orders the GPU but tells the host nothing, so
+      // steps cannot be declared synced by it. Sweep with the non-blocking
+      // Event::query() instead to free what has actually completed.
+      advanceCompletedStages(state);
 
-      if (returnBegin >= 0) {
+      if (deferReturn) {
+        // The transfer is in flight and the pinned buffer is not readable yet.
+        // A later step that needs it waits then; one that does not runs right
+        // past it.
+        state.pendingReturns.push_back(
+            {sequenceNumber_,
+             stepIdx,
+             sv.executedStep,
+             stepEvents.waveDone.get()});
+      } else if (returnBegin >= 0) {
         processReturnData(sv, frame, pinnedBase);
       }
       if (doTiming) {
@@ -3054,6 +4060,8 @@ void CompositeInvocation::execute(ExecutionState& state) {
     // Trace outputs of kernel launches after execution.
     if (!state.traceState.empty()) {
       syncWaveStream(state);
+      // The traced values include shapes that only the return data settles.
+      resolveAllPendingReturns(state);
       for (const auto& launch : sv.kernels) {
         traceFrameValues(
             "output", launch.actualOutputs, frame, state.traceState);
@@ -3074,6 +4082,11 @@ void CompositeInvocation::execute(ExecutionState& state) {
         syncWaveStream(state);
         syncTorchDefaultStream();
       }
+      if (WaveConfig::get().referenceFrame != nullptr) {
+        // The check walks this step's outputs, whose shapes the return data
+        // settles, so it has to see a complete frame.
+        resolveAllPendingReturns(state);
+      }
       auto tRefCheck = timeRefCheck ? Clock::now() : Clock::time_point{};
       verifyAgainstReference(sv.shortcutStandalones, frame, state);
       verifyAgainstReference(sv.standalones, frame, state);
@@ -3092,7 +4105,15 @@ void CompositeInvocation::execute(ExecutionState& state) {
   // unordered against wave-stream kernels of later invocations, which can
   // recycle arena buffers an eager op still reads. This sync follows any
   // wave-stream sync already done above (e.g. a device-to-host transfer).
-  if (ranStandalones) {
+  //
+  // Under WaveConfig::runAhead it is skipped. What it guards is now carried
+  // device-side: every later wave kernel waits on lastStandaloneDone before it
+  // launches, and a step's frame values are only freed once its own
+  // standaloneDone has been observed complete, so nothing can recycle a buffer
+  // an in-flight eager op still reads. executeWave still drains both streams
+  // before it returns. Draining here instead costs one host stall per node,
+  // which is what keeps the host from ever getting ahead of the device.
+  if (ranStandalones && !WaveConfig::get().runAhead) {
     // Each step's standaloneUs already covers its eager ops (the per-op
     // default- stream sync in runStandalones drains them at their own step), so
     // this final sync is only for correctness -- it must not be folded back
@@ -3102,13 +4123,42 @@ void CompositeInvocation::execute(ExecutionState& state) {
     syncTorchDefaultStream();
   }
 
-  // Stamp this node's last-use values onto its last executed step so they are
-  // released by the wave-stream sync that advances that step to kSynced, with
-  // no dedicated sync of their own. advanceSyncedStages performs the release.
+  // Stamp the last-use values no step claimed onto this node's last executed
+  // step, so they are released by the wave-stream sync that advances that step
+  // to kSynced, with no dedicated sync of their own. advanceSyncedStages
+  // performs the release -- unless that step has already been swept, which
+  // syncEachStep does at the top of the iteration that ends the loop. A kSynced
+  // step is never revisited, so free those here instead of leaving them for a
+  // sweep that will not come.
   if (WaveConfig::get().freeIntermediates && lastExecStep >= 0 &&
       !lastUseIds_.empty()) {
-    getStepVectors(state.stepVectors, sequenceNumber_, lastExecStep)
-        .lastUseIds = lastUseIds_;
+    auto& lastSv =
+        getStepVectors(state.stepVectors, sequenceNumber_, lastExecStep);
+    std::vector<nativert::ValueId> atNodeEnd;
+    for (size_t i = 0; i < lastUseIds_.size(); ++i) {
+      // Sized to lastUseIds_.size() when stepLastUse, and only read then.
+      // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)
+      const int32_t releasedAt = stepLastUse ? lastUseReleaseStep[i] : -1;
+      if (releasedAt < 0) {
+        atNodeEnd.push_back(lastUseIds_[i]);
+      }
+      if (releasedAt < 0 || releasedAt == lastExecStep) {
+        ++state.numLastUseAtNodeEnd;
+      } else {
+        ++state.numLastUseEarly;
+      }
+    }
+    if (lastSv.executionStage == ExecutionStage::kSynced) {
+      // Same hazard as in the sweeps: a value freed here can be one this step
+      // sent back, and parsing into a cleared frame slot afterwards would read
+      // a None. kSynced implies the transfer has landed, so this only copies.
+      resolvePendingReturns(state, lastSv.executedStep);
+      freeLastUseNow(state, atNodeEnd);
+    } else {
+      for (auto id : atNodeEnd) {
+        addLastUseId(state, lastSv, id);
+      }
+    }
   }
 
   // Per-node elementwise input-reuse summary (alongside the alloc traces
@@ -3127,16 +4177,18 @@ void CompositeInvocation::launch(
     int32_t blockSize,
     uint8_t* pinnedBase,
     uint8_t* deviceBase,
-    int64_t totalPinnedBytes,
+    int64_t h2dBytes,
     int32_t returnBegin,
     int32_t returnEnd,
     DebugInfo* deviceDebugBase,
     facebook::velox::wave::Stream* stream,
     const StepVectors& sv,
     int32_t stepIdx,
-    std::function<void()> betweenLaunchAndSync) {
+    bool deferReturn,
+    const std::function<void()>& betweenLaunchAndSync,
+    StepEvents* events) {
   TorchWaveParams params{};
-  params.info = reinterpret_cast<BlockInfo*>(deviceBase);
+  params.info = reinterpret_cast<BlockInfo*>(deviceBase + sv.blockInfoOffset);
   params.debugInfo = deviceDebugBase;
   void* args[] = {&params};
 
@@ -3164,7 +4216,8 @@ void CompositeInvocation::launch(
     }
   }
 
-  auto* pinnedBlocks = reinterpret_cast<BlockInfo*>(pinnedBase);
+  auto* pinnedBlocks =
+      reinterpret_cast<BlockInfo*>(pinnedBase + sv.blockInfoOffset);
 
   if (WaveConfig::get().debugSingleOps) {
     std::vector<int32_t> originalOps(numBlocks);
@@ -3173,10 +4226,11 @@ void CompositeInvocation::launch(
     }
 
     // Transfer pinned buffer to device once.
-    stream->hostToDeviceAsync(deviceBase, pinnedBase, totalPinnedBytes);
+    stream->hostToDeviceAsync(deviceBase, pinnedBase, h2dBytes);
     stream->wait();
 
-    auto* deviceBlocks = reinterpret_cast<BlockInfo*>(deviceBase);
+    auto* deviceBlocks =
+        reinterpret_cast<BlockInfo*>(deviceBase + sv.blockInfoOffset);
 
     // Run blocks individually or grouped. Ops with barrierCounters need all
     // blocks of the same project op launched together with cooperative launch.
@@ -3278,12 +4332,17 @@ void CompositeInvocation::launch(
           returnEnd - returnBegin);
       stream->wait();
     }
+    // The debug path already syncs after every block; just close the event
+    // chain so the ordering edges stay consistent with the normal path.
+    if (events != nullptr) {
+      events->waveDone->record(*stream);
+    }
 
     if (betweenLaunchAndSync) {
       betweenLaunchAndSync();
     }
   } else {
-    stream->hostToDeviceAsync(deviceBase, pinnedBase, totalPinnedBytes);
+    stream->hostToDeviceAsync(deviceBase, pinnedBase, h2dBytes);
     if (cooperative) {
       kernel_->launchCooperative(numBlocks, blockSize, 0, stream, args);
     } else {
@@ -3294,17 +4353,31 @@ void CompositeInvocation::launch(
           pinnedBase + returnBegin,
           deviceBase + returnBegin,
           returnEnd - returnBegin);
+      // Record before the host wait, so the timestamp is the kernel/D2H
+      // completion rather than the host's observation of it, and so the
+      // ordering edge is established as early as possible.
+      if (events != nullptr) {
+        events->waveDone->record(*stream);
+      }
       if (betweenLaunchAndSync) {
         betweenLaunchAndSync();
       }
-      stream->wait();
-    } else {
-      if (betweenLaunchAndSync) {
-        betweenLaunchAndSync();
-      }
-      if (WaveConfig::get().trace & WaveConfig::kTiming) {
+      if (!deferReturn) {
+        // A real host wait: the caller reads the pinned buffer as soon as this
+        // returns. With deferReturn the caller records waveDone instead and
+        // the wait moves to the first later step that reads the data.
         stream->wait();
       }
+    } else {
+      if (events != nullptr) {
+        events->waveDone->record(*stream);
+      }
+      if (betweenLaunchAndSync) {
+        betweenLaunchAndSync();
+      }
+      // No wait under kTiming any more. Its only purpose was to make the
+      // host-measured kernelUs approximate GPU time; the event pair does that
+      // properly, and the wait destroyed the overlap this is here to measure.
     }
   }
 }

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -34,6 +34,7 @@ namespace torch::wave {
 
 class OpInvocation;
 struct StepVectors;
+struct StepEvents;
 
 /// Represents launch of a single KernelOperation or standalone Node.
 struct Launch {
@@ -312,6 +313,15 @@ struct LaunchData {
 
   std::vector<TensorListParam> tensorLists;
 
+  /// Executed-step index of the latest step whose device-to-host transfer
+  /// produced a value this launch reads -- directly, through a chain of
+  /// metadata-only shortcuts, or through a host-side view operand of an output
+  /// descriptor. -1 when the launch reads nothing that came back over a
+  /// transfer, which is what makes it safe to size, allocate and fill while an
+  /// earlier step's transfer is still in flight. Set by markD2hDependencies
+  /// before the step runs.
+  int32_t d2hProducer{-1};
+
   float costAdjustFactor{1};
   float expectedFraction{0};
 };
@@ -324,6 +334,7 @@ class CompositeInvocation {
       std::deque<c10::IValue> ivalueStorage,
       int32_t sequenceNumber,
       std::vector<nativert::ValueId> lastUseIds,
+      std::vector<std::vector<int32_t>> lastUseReaderOps = {},
       std::vector<nativert::ValueId> reusableIds = {},
       std::vector<Launch> prePassStandalones = {},
       std::vector<std::pair<nativert::ValueId, int32_t>> elidedCloneInputs =
@@ -349,33 +360,123 @@ class CompositeInvocation {
   /// 'betweenLaunchAndSync' is called after the kernel launch (and D2H
   /// scheduling if any) but before the stream sync, to overlap host work
   /// with the GPU. In debug mode it is called after all block-by-block
-  /// launches and transfers.
+  /// launches and transfers. With 'deferReturn', the host wait that makes the
+  /// returned data readable is left to the caller, which records the transfer
+  /// in ExecutionState::pendingReturns instead.
   void launch(
       int32_t numBlocks,
       int32_t blockSize,
       uint8_t* pinnedBase,
       uint8_t* deviceBase,
-      int64_t totalPinnedBytes,
+      int64_t h2dBytes,
       int32_t returnBegin,
       int32_t returnEnd,
       DebugInfo* deviceDebugBase,
       facebook::velox::wave::Stream* stream,
       const StepVectors& sv,
       int32_t stepIdx,
-      std::function<void()> betweenLaunchAndSync = nullptr);
+      bool deferReturn,
+      const std::function<void()>& betweenLaunchAndSync = nullptr,
+      StepEvents* events = nullptr);
 
-  /// Collects LaunchData from all OpInvocations at the given step index.
+  /// Reserves a param slot for every kernel launch any grid variant of any op
+  /// can put at 'stepIdx', each sized for the largest variant, and fills
+  /// sv.slotOffsets / sv.opSlotBegin / sv.paramRegionBytes. Also fills
+  /// sv.readIds. Idempotent: both depend only on the compiled grids, so they
+  /// are built once per step.
+  void layoutParamSlots(int32_t stepIdx, StepVectors& sv);
+
+  /// Why an op's setup was left for the second pass.
+  enum class DeferReason {
+    /// Reads a value whose device-to-host transfer has not landed.
+    kTransfer,
+    /// Allocating it would push past WaveConfig::maxDelayedFree.
+    kMemory,
+  };
+
+  /// Running position over the three parallel per-launch arrays a step fills:
+  /// sv.kernels, sv.standalones and sv.shortcutStandalones. It advances over a
+  /// deferred op as well, whose launches keep their indices so that deferring
+  /// one op cannot move a later op's parameter offsets.
+  struct LaunchCursor {
+    int32_t kernel{0};
+    int32_t standalone{0};
+    int32_t shortcut{0};
+  };
+
+  /// Picks the grid variant 'data' should launch under -- single-block,
+  /// multi-block or cooperative -- from its element count, and rebuilds 'data'
+  /// and 'largestId' from the new variant if the choice moved. Returns true if
+  /// it moved, in which case the caller re-reads the grid and step it cached.
+  /// Only meaningful for a launch whose op isGridChoice().
+  bool chooseGridVariant(
+      ExecutionState& state,
+      GridChoice& gridChoice,
+      OpInvocation& op,
+      int32_t stepIdx,
+      size_t launchIndex,
+      bool hasByLargestInput,
+      LaunchData& data,
+      nativert::ValueId& largestId);
+
+  /// Zeroes 'data.numElements' when a tensor the launch reads or writes but
+  /// does not produce itself is still None, which makes makeGrid give it no
+  /// blocks. Under a cooperative grid, where the whole step launches as one
+  /// kernel and an op therefore cannot be skipped, recovers a grid size from
+  /// the static input shapes instead.
+  void sizeForUnreadyOperands(
+      LaunchData& data,
+      const Launch& launch,
+      nativert::ExecutionFrame& frame);
+
+  /// Fills 'data's parameter block at 'paramOffset', patches its TensorList
+  /// pointers to device addresses, and folds the offsets of the return values
+  /// it writes into 'returnBegin' / 'returnEnd'.
+  void fillLaunchParamBlock(
+      LaunchData& data,
+      nativert::ExecutionFrame& frame,
+      uint8_t* pinnedBase,
+      uint8_t* deviceBase,
+      int64_t paramOffset,
+      int32_t& returnBegin,
+      int32_t& returnEnd);
+
+  /// Sets up the ops at 'stepIdx' that can be set up now: sizes them, allocates
+  /// their outputs and fills their parameter blocks, all in one pass per op so
+  /// each is touched once and tested for dependencies once.
+  ///
+  /// An op that reads a value a pending transfer has not delivered, or that
+  /// would allocate past the delayed-free ceiling, is skipped and appended to
+  /// 'deferred'; run the pass again with 'deferredOnly' after resolving what
+  /// they need. The LaunchData, parameter offsets and launch indices of every
+  /// op are established on the first pass regardless, so the second pass
+  /// cannot move another op's parameters.
+  ///
+  /// 'returnBegin' / 'returnEnd' accumulate as min/max over absolute offsets
+  /// rather than assuming the ops are filled in ascending order, which the
+  /// two-pass split breaks.
   void gatherLaunches(
-      const ExecutionState& state,
+      ExecutionState& state,
       std::vector<GridChoice>& grids,
       int32_t stepIdx,
-      StepVectors& sv);
-
-  /// Copies return values from the pinned buffer back into the execution frame.
-  void processReturnData(
       StepVectors& sv,
-      nativert::ExecutionFrame& frame,
-      uint8_t* pinnedBase);
+      uint8_t* pinnedBase,
+      uint8_t* deviceBase,
+      bool deferredOnly,
+      std::vector<std::pair<size_t, DeferReason>>& deferred,
+      int32_t& returnBegin,
+      int32_t& returnEnd);
+
+  /// Stamps onto step 'stepIdx' every last-use value not yet released whose
+  /// reading ops have all run out of grid steps, recording the step in
+  /// 'releaseStep' (parallel to lastUseIds_, -1 until released). Called once
+  /// per executed step, after gatherLaunches has settled its grid choices.
+  void releaseLastUseAtStep(
+      ExecutionState& state,
+      const std::vector<GridChoice>& grids,
+      int32_t stepIdx,
+      StepVectors& sv,
+      std::vector<int32_t>& releaseStep);
 
   /// Prints per-step trace: step header and per-launch details.
   void traceStep(
@@ -392,6 +493,12 @@ class CompositeInvocation {
   // outputs excluded). When WaveConfig::freeIntermediates is set, their frame
   // tensors are released at the end of execute().
   std::vector<nativert::ValueId> lastUseIds_;
+
+  // Parallel to lastUseIds_: the indices into ops_ of the ops that read that
+  // value. Under WaveConfig::stepLastUse the value is released at the step
+  // where the last of them runs out of grid steps. Empty means the readers are
+  // unknown, which falls back to releasing at the node's last step.
+  std::vector<std::vector<int32_t>> lastUseReaderOps_;
 
   // Frame value ids whose buffer an elementwise output may reuse in place --
   // reusable last-use boundary inputs and expr-local overwritable temps, from

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -18,6 +18,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/core/CachingDeviceAllocator.h>
+#include <folly/CppAttributes.h>
 #include <folly/ScopeGuard.h>
 #include <folly/chrono/Hardware.h>
 #include <gflags/gflags.h>
@@ -27,6 +28,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <unordered_set>
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/experimental/torchwave/NodePrinter.h"
@@ -107,33 +109,20 @@ int64_t peakAllocatedBytes() {
       .peak;
 }
 
-// TSC ticks per microsecond, calibrated once. folly::hardware_timestamp()
-// (rdtsc) costs ~ns, whereas std::chrono here is backed by kvm-clock at ~tens
-// of us/call -- too expensive for per-standalone timing of many cheap ops.
-double tscTicksPerMicro() {
-  static const double ticksPerMicro = [] {
-    auto t0 = std::chrono::steady_clock::now();
-    auto c0 = folly::hardware_timestamp();
-    while (std::chrono::duration_cast<std::chrono::microseconds>(
-               std::chrono::steady_clock::now() - t0)
-               .count() < 2000) {
-    }
-    auto c1 = folly::hardware_timestamp();
-    auto us = std::chrono::duration_cast<std::chrono::microseconds>(
-                  std::chrono::steady_clock::now() - t0)
-                  .count();
-    return static_cast<double>(c1 - c0) /
-        static_cast<double>(std::max<int64_t>(1, us));
-  }();
-  return ticksPerMicro;
-}
-
 struct GlobalResources {
   std::unique_ptr<facebook::velox::wave::GpuArena> deviceArena;
   std::unique_ptr<facebook::velox::wave::GpuArena> pinnedArena;
   std::unique_ptr<facebook::velox::wave::GpuArena> managedArena;
   std::unique_ptr<StreamPool> streamPool;
+  /// Ordering-only events (cudaEventDisableTiming), used on every run.
   std::unique_ptr<EventPool> eventPool;
+  /// Timing-enabled events, used only under the kTiming trace bit. Kept
+  /// separate because elapsedTime() throws on a disable-timing event, so the
+  /// two kinds must never be mixed.
+  std::unique_ptr<EventPool> timingEventPool;
+  /// Non-owning wrapper on the CUDA stream eager standalones run on, so events
+  /// can be recorded on it from this CPU-configured translation unit.
+  std::unique_ptr<facebook::velox::wave::Stream> torchStreamWrapper;
 };
 
 GlobalResources* globals() {
@@ -160,6 +149,27 @@ int64_t storageExtentBytes(const at::Tensor& t) {
 }
 
 } // namespace
+
+// TSC ticks per microsecond, calibrated once. folly::hardware_timestamp()
+// (rdtsc) costs ~ns, whereas std::chrono here is backed by kvm-clock at ~tens
+// of us/call -- too expensive for per-standalone timing of many cheap ops.
+double tscTicksPerMicro() {
+  static const double ticksPerMicro = [] {
+    auto t0 = std::chrono::steady_clock::now();
+    auto c0 = folly::hardware_timestamp();
+    while (std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::steady_clock::now() - t0)
+               .count() < 2000) {
+    }
+    auto c1 = folly::hardware_timestamp();
+    auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+                  std::chrono::steady_clock::now() - t0)
+                  .count();
+    return static_cast<double>(c1 - c0) /
+        static_cast<double>(std::max<int64_t>(1, us));
+  }();
+  return ticksPerMicro;
+}
 
 void initialize() {
   if (initialized().exchange(true)) {
@@ -202,16 +212,101 @@ void initialize() {
       10'000'000, facebook::velox::wave::getHostAllocator(device));
   g->managedArena = std::make_unique<facebook::velox::wave::GpuArena>(
       100'000'000, facebook::velox::wave::getAllocator(device));
-  g->streamPool = std::make_unique<StreamPool>(
-      []() { return std::make_unique<facebook::velox::wave::Stream>(); });
-  g->eventPool = std::make_unique<EventPool>(
-      []() { return std::make_unique<facebook::velox::wave::Event>(); });
+  // Non-blocking: wave kernels and the eager standalones on the torch stream
+  // are ordered explicitly with events (see newStepEvents and its callers), so
+  // the driver's implicit legacy-default-stream serialization is not wanted --
+  // it is exactly what prevents the two from overlapping. The step chain only
+  // covers what happens inside a run; waitForTorchStream covers entering one.
+  g->streamPool = std::make_unique<StreamPool>([]() {
+    return std::make_unique<facebook::velox::wave::Stream>(
+        /*nonBlocking=*/true);
+  });
+  g->eventPool = std::make_unique<EventPool>([]() {
+    return std::make_unique<facebook::velox::wave::Event>(/*withTime=*/false);
+  });
+  g->timingEventPool = std::make_unique<EventPool>([]() {
+    return std::make_unique<facebook::velox::wave::Event>(/*withTime=*/true);
+  });
+  // TODO: eager standalones are dispatched to the legacy default stream, which
+  // is what every sync in this file already assumes (see
+  // syncTorchDefaultStream). If PyTorch is ever built with per-thread default
+  // streams, or standalones move onto a pool stream, this has to become a real
+  // c10::cuda::getCurrentCUDAStream().stream() query, which needs a small
+  // CUDA-configured shim because torch_wave cannot include CUDAStream.h.
+  g->torchStreamWrapper = facebook::velox::wave::Stream::external(nullptr);
+}
+
+facebook::velox::wave::Stream& torchStream() {
+  return *globals()->torchStreamWrapper;
+}
+
+void waitForTorchStream(facebook::velox::wave::Stream& stream) {
+  auto* g = globals();
+  // initialize() bails before creating either when there is no device.
+  if (g->eventPool == nullptr || g->torchStreamWrapper == nullptr) {
+    return;
+  }
+  auto event = g->eventPool->get();
+  event->record(torchStream());
+  event->wait(stream);
+  // Safe to recycle right away: cudaStreamWaitEvent captured the event's state
+  // at the call above, so a later re-record cannot undo the edge just made.
+  event->reset();
+  g->eventPool->put(std::move(event));
+}
+
+StepEvents& newStepEvents(ExecutionState& state, int32_t seq, int32_t stepIdx) {
+  const bool doEventTiming =
+      (WaveConfig::get().trace & WaveConfig::kTiming) != 0;
+  auto* pool = doEventTiming ? globals()->timingEventPool.get()
+                             : globals()->eventPool.get();
+  StepEvents events;
+  events.sequenceNumber = seq;
+  events.stepIdx = stepIdx;
+  events.waveDone = pool->get();
+  events.standaloneDone = pool->get();
+  if (doEventTiming) {
+    events.waveBegin = pool->get();
+    events.standaloneBegin = pool->get();
+  }
+  state.stepEvents.push_back(std::move(events));
+  return state.stepEvents.back();
+}
+
+void releaseStepEvents(ExecutionState& state) {
+  const bool doEventTiming =
+      (WaveConfig::get().trace & WaveConfig::kTiming) != 0;
+  auto* pool = doEventTiming ? globals()->timingEventPool.get()
+                             : globals()->eventPool.get();
+  auto give = [&](EventP& event) {
+    if (event) {
+      event->reset();
+      pool->put(std::move(event));
+    }
+  };
+  for (auto& events : state.stepEvents) {
+    give(events.waveBegin);
+    give(events.waveDone);
+    give(events.standaloneBegin);
+    give(events.standaloneDone);
+  }
+  state.stepEvents.clear();
+  give(state.timelineBase);
+  state.lastWaveDone = nullptr;
+  state.lastStandaloneDone = nullptr;
+  state.syncedCursor = 0;
+  state.returnedAtStep.clear();
+  state.executedSteps = 0;
 }
 
 void tensorsToDevice(
     const std::vector<at::Tensor>& in,
     std::vector<at::Tensor>& out,
     facebook::velox::wave::Stream& stream) {
+  // The device tensors below come from the caching allocator, which can hand
+  // back a block an eager op on the torch stream is still reading; the copies
+  // go out on a non-blocking stream that no longer waits for it implicitly.
+  waitForTorchStream(stream);
   auto deviceId = facebook::velox::wave::currentDevice()->deviceId;
   auto device =
       c10::Device(c10::kCUDA, static_cast<c10::DeviceIndex>(deviceId));
@@ -258,6 +353,8 @@ void tensorsToHost(
     const std::vector<at::Tensor>& in,
     std::vector<at::Tensor>& out,
     facebook::velox::wave::Stream& stream) {
+  // 'in' can hold tensors an eager op on the torch stream is still writing.
+  waitForTorchStream(stream);
   int64_t totalBytes = 0;
   std::vector<int64_t> sizes(in.size());
   for (size_t i = 0; i < in.size(); ++i) {
@@ -482,12 +579,18 @@ void runStandalones(
           actualNode, kernelIt->second, *state.frame, &state.traceState);
     }
     if (timing) {
+      // Per-op GPU attribution needs a sync after each op, which serializes the
+      // standalones against each other and against the wave stream. That is the
+      // largest single perturbation in the measurement, so it is opt-in; the
+      // per-step standaloneBegin/standaloneDone pair measures the same device
+      // time without it. Without the knob the recorded number is host dispatch
+      // time only.
+      //
       // A metadata-only op only manipulates host-side tensor metadata and
-      // enqueues nothing on the device, so it needs no sync. Syncing here
-      // would, via the legacy default stream, drain the wave stream and
-      // massively over-attribute its time. Only real eager ops need a sync to
-      // capture their GPU time.
-      if (!metadataOnly) {
+      // enqueues nothing on the device, so it never needs the sync. Syncing
+      // there would, via the legacy default stream, drain the wave stream and
+      // massively over-attribute its time.
+      if (!metadataOnly && WaveConfig::get().perOpStandaloneTiming) {
         syncTorchDefaultStream();
       }
       auto us = static_cast<int64_t>(
@@ -781,7 +884,29 @@ std::vector<c10::IValue> WaveGraphExecutor::executeWithPrefilledFrame(
 void freeFrameValue(
     nativert::ExecutionFrame& frame,
     nativert::ValueId id,
-    facebook::velox::wave::Stream* stream) {
+    facebook::velox::wave::Stream* stream,
+    ExecutionState* state) {
+  // A released value leaves an empty frame slot, which is indistinguishable
+  // from one that was never produced. Record it so the coverage report can
+  // tell the two apart.
+  if (state != nullptr && WaveConfig::get().trace != 0) {
+    state->freedValueIds.insert(id);
+  }
+  if (allocTraceEnabled()) {
+    const auto& iv = frame.getIValue(id);
+    // Only a solely-owned CUDA storage is donatable: another frame slot or a
+    // view holding the same storage means the buffer does not actually become
+    // free here. Same ownership test the debugSingleOps poison uses below.
+    if (iv.isTensor()) {
+      const at::Tensor& t = iv.toTensor();
+      if (t.defined() && t.has_storage() && t.is_cuda() && t.use_count() == 1 &&
+          t.storage().use_count() == 1) {
+        std::cout << "ALLOCEV free " << id << ' '
+                  << static_cast<int64_t>(t.storage().nbytes()) << ' '
+                  << recordedSizeKey(id) << '\n';
+      }
+    }
+  }
   if (WaveConfig::get().debugSingleOps) {
     const auto& iv = frame.getIValue(id);
     if (iv.isTensor()) {
@@ -812,7 +937,123 @@ void freeFrameValue(
       }
     }
   }
+  // Offer the buffer to the donation pool before clearing the slot: the slot
+  // goes either way, and the pool only accepts storage nothing else references.
+  if (state != nullptr) {
+    const auto& iv = frame.getIValue(id);
+    if (iv.isTensor()) {
+      donateFreedTensor(*state, iv.toTensor());
+    }
+  }
   frame.setIValue(id, c10::IValue());
+}
+
+// Pool key: byte size in the high bits, dtype in the low bits. Buffers only
+// swap between values of the same width, which is what makes the hit path a
+// non-reallocating resize_.
+int64_t donationKey(int64_t bytes, c10::ScalarType dtype) {
+  return (bytes << 8) | static_cast<int64_t>(dtype);
+}
+
+bool donateFreedTensor(ExecutionState& state, const at::Tensor& tensor) {
+  if (!WaveConfig::get().donateBuffers) {
+    return false;
+  }
+  // Sole ownership is the whole safety argument on the donor side: another
+  // frame slot or a view over the same storage means someone still reads it.
+  if (!tensor.defined() || !tensor.has_storage() || !tensor.is_cuda() ||
+      tensor.use_count() != 1 || tensor.storage().use_count() != 1) {
+    return false;
+  }
+  const auto bytes = static_cast<int64_t>(tensor.storage().nbytes());
+  if (bytes <= 0) {
+    return false;
+  }
+  const uint64_t start = folly::hardware_timestamp();
+  state.donatable[donationKey(bytes, tensor.scalar_type())].push_back(tensor);
+  state.donatableBytes += bytes;
+  state.donationUs += static_cast<int64_t>(
+      static_cast<double>(folly::hardware_timestamp() - start) /
+      tscTicksPerMicro());
+  return true;
+}
+
+at::Tensor takeDonatedTensor(
+    ExecutionState& state,
+    int64_t bytes,
+    c10::ScalarType dtype,
+    c10::IntArrayRef dims) {
+  // An empty pool is the common case on the first steps of a run; keep that
+  // path down to one branch.
+  if (!WaveConfig::get().donateBuffers || bytes <= 0 ||
+      state.donatable.empty()) {
+    return {};
+  }
+  const uint64_t start = folly::hardware_timestamp();
+  at::Tensor result;
+  // Keyed by byte size AND dtype so a hit is a single resize_ that cannot
+  // reallocate (same element count, same width), rather than rebuilding a
+  // tensor over the storage -- two dispatcher calls would cost more than the
+  // allocation being avoided.
+  auto it = state.donatable.find(donationKey(bytes, dtype));
+  if (it != state.donatable.end() && !it->second.empty()) {
+    result = std::move(it->second.back());
+    it->second.pop_back();
+    if (it->second.empty()) {
+      state.donatable.erase(it);
+    }
+    state.donatableBytes -= bytes;
+    if (result.sizes() != dims) {
+      result.resize_(dims);
+    }
+    ++state.donationHits;
+  } else {
+    ++state.donationMisses;
+  }
+  state.donationUs += static_cast<int64_t>(
+      static_cast<double>(folly::hardware_timestamp() - start) /
+      tscTicksPerMicro());
+  return result;
+}
+
+void evictDonatable(ExecutionState& state, int64_t limitBytes) {
+  if (state.donatableBytes <= limitBytes || state.donatable.empty()) {
+    return;
+  }
+  const uint64_t start = folly::hardware_timestamp();
+  // Shed the big buffers first: they are what the ceiling is about, and one
+  // pass is enough. Take the largest size present and drop everything at least
+  // half that big, rather than sorting the whole table on every miss.
+  while (state.donatableBytes > limitBytes && !state.donatable.empty()) {
+    int64_t largest = 0;
+    for (const auto& [key, buffers] : state.donatable) {
+      largest = std::max(largest, key >> 8);
+    }
+    const int64_t threshold = largest / 2;
+    for (auto it = state.donatable.begin(); it != state.donatable.end();) {
+      const int64_t sizeBytes = it->first >> 8;
+      if (sizeBytes < threshold) {
+        ++it;
+        continue;
+      }
+      state.donatableBytes -=
+          sizeBytes * static_cast<int64_t>(it->second.size());
+      state.donationEvictions += static_cast<int64_t>(it->second.size());
+      it = state.donatable.erase(it);
+    }
+    // A threshold of 0 would leave the table untouched and spin.
+    if (threshold == 0) {
+      break;
+    }
+  }
+  state.donationUs += static_cast<int64_t>(
+      static_cast<double>(folly::hardware_timestamp() - start) /
+      tscTicksPerMicro());
+}
+
+void clearDonationPool(ExecutionState& state) {
+  state.donatable.clear();
+  state.donatableBytes = 0;
 }
 
 // If a reference frame is loaded, compares the current contents of frame value
@@ -857,6 +1098,203 @@ void checkValueBeforeFree(
                << "\n  actual:   " << tensorDebugString(*actual, limit);
   }
 }
+
+void resolvePendingReturns(ExecutionState& state, int32_t throughStep) {
+  while (!state.pendingReturns.empty() &&
+         state.pendingReturns.front().executedStep <= throughStep) {
+    const auto pending = state.pendingReturns.front();
+    state.pendingReturns.pop_front();
+    if (pending.waveDone != nullptr) {
+      pending.waveDone->wait();
+    }
+    auto& buffer =
+        state.pinnedBuffers.at(pending.sequenceNumber).at(pending.stepIdx);
+    TORCH_CHECK(
+        buffer != nullptr,
+        "The pinned buffer of node ",
+        pending.sequenceNumber,
+        " step ",
+        pending.stepIdx,
+        " was released before its deferred return data was read");
+    processReturnData(
+        state.stepVectors.at(pending.sequenceNumber).at(pending.stepIdx),
+        *state.frame,
+        buffer->as<uint8_t>());
+    ++state.numDeferredReturns;
+    state.deferredStepSpan += state.executedSteps - pending.executedStep;
+  }
+}
+
+void resolveAllPendingReturns(ExecutionState& state) {
+  resolvePendingReturns(state, std::numeric_limits<int32_t>::max());
+}
+
+namespace {
+
+// Bytes a frame value would give back, from the view's own extent rather than
+// its whole storage: a view and its base are separate ids over one buffer, so
+// charging each the full storage over-states the total by more than an order of
+// magnitude. numel/element_size are inline accessors -- no storage access, no
+// hash lookup.
+int64_t frameValueBytes(nativert::ExecutionFrame& frame, nativert::ValueId id) {
+  const auto& ivalue = frame.getIValue(id);
+  if (!ivalue.isTensor()) {
+    return 0;
+  }
+  const auto& tensor = ivalue.toTensor();
+  return tensor.defined() ? tensor.numel() * tensor.element_size() : 0;
+}
+
+// Takes a swept step's stamped bytes back off the running total. A plain
+// subtraction of what the step accumulated -- the per-id sizes are already
+// summed, so nothing is looked up again.
+void releaseDelayedFreeBytes(ExecutionState& state, StepVectors& sv) {
+  state.delayedFreeBytes -= sv.lastUseBytes;
+  sv.lastUseBytes = 0;
+  if (state.delayedFreeBytes < 0) {
+    state.delayedFreeBytes = 0;
+  }
+}
+
+} // namespace
+
+// Charges the enclosing scope to ExecutionState::freeUs. Releasing a frame
+// value can hand memory back to the caching allocator, which is the same kind
+// of cost as allocating it, so the report keeps the two together. On the TSC:
+// this fires once per swept step, and chrono here is kvm-clock at tens of
+// microseconds a call.
+namespace {
+class ScopedFreeTimer {
+ public:
+  explicit ScopedFreeTimer(ExecutionState& state)
+      : state_(state),
+        timing_(
+            WaveConfig::get().printTiming ||
+            (WaveConfig::get().trace & WaveConfig::kTiming)),
+        start_(timing_ ? folly::hardware_timestamp() : 0) {}
+
+  // Scope guard: the reference and const members already make it
+  // non-assignable, so say so rather than leave it to the reader.
+  ScopedFreeTimer(const ScopedFreeTimer&) = delete;
+  ScopedFreeTimer(ScopedFreeTimer&&) = delete;
+  ScopedFreeTimer& operator=(const ScopedFreeTimer&) = delete;
+  ScopedFreeTimer& operator=(ScopedFreeTimer&&) = delete;
+
+  ~ScopedFreeTimer() {
+    if (timing_) {
+      state_.freeUs += static_cast<int64_t>(
+          static_cast<double>(folly::hardware_timestamp() - start_) /
+          tscTicksPerMicro());
+    }
+  }
+
+ private:
+  ExecutionState& state_;
+  const bool timing_;
+  const uint64_t start_;
+};
+
+// Returns the step's vectors, or nullptr if either index is out of range.
+// Launch metadata carries indices that can outlive the vectors they refer to,
+// so every reader has to bounds-check; doing it here also covers a negative
+// index, which the open-coded checks did not.
+StepVectors* FOLLY_NULLABLE
+findStepVectors(ExecutionState& state, int32_t seq, int32_t step) {
+  if (seq < 0 || seq >= static_cast<int32_t>(state.stepVectors.size())) {
+    return nullptr;
+  }
+  auto& steps = state.stepVectors[seq];
+  if (step < 0 || step >= static_cast<int32_t>(steps.size())) {
+    return nullptr;
+  }
+  return &steps[step];
+}
+} // namespace
+
+void addLastUseId(
+    ExecutionState& state,
+    StepVectors& sv,
+    nativert::ValueId id) {
+  sv.lastUseIds.push_back(id);
+  if (WaveConfig::get().maxDelayedFree <= 0) {
+    return;
+  }
+  const auto bytes = frameValueBytes(*state.frame, id);
+  sv.lastUseBytes += bytes;
+  state.delayedFreeBytes += bytes;
+  if (state.delayedFreeBytes > state.maxDelayedFreeSeen) {
+    state.maxDelayedFreeSeen = state.delayedFreeBytes;
+  }
+}
+
+bool enforceDelayedFreeLimit(ExecutionState& state) {
+  const auto limit = WaveConfig::get().maxDelayedFree;
+  if (limit <= 0 || state.delayedFreeBytes <= limit) {
+    return false;
+  }
+  syncTorchDefaultStream();
+  syncWaveStream(state);
+  ++state.numMemoryStalls;
+  return true;
+}
+
+void sampleRunAhead(ExecutionState& state) {
+  if (!(WaveConfig::get().trace & WaveConfig::kTiming)) {
+    return;
+  }
+  // Walk back from the newest step and stop at the first one the device has
+  // finished: steps complete in order, so the run of incomplete ones at the end
+  // is the depth. query() does not block.
+  auto inFlight = [](const EventP& event) {
+    return event && event->recorded() && !event->query();
+  };
+  int32_t depth = 0;
+  for (auto it = state.stepEvents.rbegin(); it != state.stepEvents.rend();
+       ++it) {
+    if (!inFlight(it->waveDone) && !inFlight(it->standaloneDone)) {
+      break;
+    }
+    ++depth;
+  }
+  state.runAheadSum += depth;
+  ++state.runAheadSamples;
+  state.runAheadMax = std::max(state.runAheadMax, depth);
+  if (depth == 0) {
+    ++state.numDrainedStarts;
+  }
+}
+
+namespace {
+
+// True if a still-pending transfer produced at or before 'throughStep' brings
+// back a value in 'ids'. Those are the only ones a sweep about to free 'ids'
+// has to resolve first: parsing into a frame slot that has already been cleared
+// reads a None. Every other transfer can stay in flight past the sweep, which
+// is the point -- the sweep runs after every launch, so resolving
+// unconditionally would end the deferral about two steps after it started
+// however far away the real consumer is.
+bool pendingReturnFreedBy(
+    const ExecutionState& state,
+    int32_t throughStep,
+    const std::vector<nativert::ValueId>& ids) {
+  for (const auto& pending : state.pendingReturns) {
+    if (pending.executedStep > throughStep) {
+      return false;
+    }
+    const auto& producer =
+        state.stepVectors.at(pending.sequenceNumber).at(pending.stepIdx);
+    for (const auto& data : producer.kernels) {
+      for (auto id : data.returnValues) {
+        if (std::find(ids.begin(), ids.end(), id) != ids.end()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+} // namespace
 
 void advanceSyncedStages(ExecutionState& state) {
   // Stage tracking exists only to bundle intermediate freeing with syncs, so
@@ -905,7 +1343,7 @@ void advanceSyncedStages(ExecutionState& state) {
         if (iv.isTensor() && iv.toTensor().defined() &&
             iv.toTensor().has_storage()) {
           const auto& st = iv.toTensor().storage();
-          useCount = st.use_count();
+          useCount = static_cast<int64_t>(st.use_count());
           storagePtr = reinterpret_cast<uintptr_t>(st.data());
           storageBytes = static_cast<int64_t>(st.nbytes());
         }
@@ -926,12 +1364,21 @@ void advanceSyncedStages(ExecutionState& state) {
       // The wave stream was just waited on, so this step's kernels are done and
       // its freeable buffers can be released.
       sv.executionStage = ExecutionStage::kSynced;
+      // A value this step sent back can also be one it last-uses, and parsing
+      // the pinned buffer into a frame slot that has just been cleared would
+      // read a None. The wave stream was waited on above, so the transfer has
+      // landed and this only does the copy.
+      if (pendingReturnFreedBy(state, sv.executedStep, sv.lastUseIds)) {
+        resolvePendingReturns(state, sv.executedStep);
+      }
+      releaseDelayedFreeBytes(state, sv);
       // The node's last-use tensors were stamped onto its last step; they go
       // free in this same sync (no dedicated sync of their own).
+      ScopedFreeTimer freeTimer(state);
       for (auto id : sv.lastUseIds) {
         traceFree(id, "lastUse", seq, step);
         checkValueBeforeFree(frame, id, state.waveGraph);
-        freeFrameValue(frame, id, state.stream.get());
+        freeFrameValue(frame, id, state.stream.get(), &state);
       }
     }
   }
@@ -940,6 +1387,88 @@ void advanceSyncedStages(ExecutionState& state) {
 void syncWaveStream(ExecutionState& state) {
   state.stream->wait();
   advanceSyncedStages(state);
+}
+
+void freeLastUseNow(
+    ExecutionState& state,
+    const std::vector<nativert::ValueId>& ids) {
+  auto& frame = *state.frame;
+  ScopedFreeTimer freeTimer(state);
+  for (auto id : ids) {
+    checkValueBeforeFree(frame, id, state.waveGraph);
+    freeFrameValue(frame, id, state.stream.get(), &state);
+  }
+}
+
+void advanceCompletedStages(ExecutionState& state) {
+  if (!WaveConfig::get().freeIntermediates) {
+    return;
+  }
+  // The debug paths in advanceSyncedStages force full syncs on both streams
+  // before freeing; keep using that stricter version there rather than the
+  // query sweep, so debug modes stay maximally serialized.
+  if (WaveConfig::get().debugSingleOps ||
+      WaveConfig::get().referenceFrame != nullptr) {
+    return;
+  }
+  // A step can be declared synced only once the host knows its work is done.
+  // The event edges give the GPU its ordering but tell the host nothing, so ask
+  // the step's own events; query() does not block.
+  //
+  // Resume at the oldest step not yet synced and stop at the first that is not
+  // done. Steps complete in order: each stream records its events in step
+  // order, and the cross-stream edges make a step's work wait on the previous
+  // step's work on the other stream, so the later of a step's two completion
+  // events is monotone in the step index. Without the early exit this rescans
+  // every step of the run on every launch, which is quadratic in the step
+  // count -- a few thousand cudaEventQuery calls per run on the ROO graph.
+  auto& frame = *state.frame;
+  auto pending = [](const EventP& event) {
+    return event && event->recorded() && !event->query();
+  };
+  while (state.syncedCursor < state.stepEvents.size()) {
+    // The loop condition above bounds syncedCursor.
+    // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+    const auto& events = state.stepEvents[state.syncedCursor];
+    if (pending(events.waveDone) || pending(events.standaloneDone)) {
+      return;
+    }
+    auto* svPtr = findStepVectors(state, events.sequenceNumber, events.stepIdx);
+    if (svPtr == nullptr) {
+      ++state.syncedCursor;
+      continue;
+    }
+    auto& sv = *svPtr;
+    // A blocking sync (syncWaveStream, and so every syncEachStep step) already
+    // ran advanceSyncedStages over this step. Nothing is left to free, so skip
+    // it rather than parking the cursor on it for the rest of the run.
+    if (sv.executionStage == ExecutionStage::kSynced) {
+      ++state.syncedCursor;
+      continue;
+    }
+    // The step being issued right now already has its events but is not marked
+    // kAllocated until its outputs exist. Stop rather than step over it, or its
+    // lastUseIds would never be freed.
+    if (sv.executionStage != ExecutionStage::kAllocated) {
+      return;
+    }
+    ++state.syncedCursor;
+    sv.executionStage = ExecutionStage::kSynced;
+    // Same reason as in advanceSyncedStages: parse before freeing. This step's
+    // events have just been observed complete, so its transfer has landed and
+    // resolving up to it does not block.
+    if (pendingReturnFreedBy(state, sv.executedStep, sv.lastUseIds)) {
+      resolvePendingReturns(state, sv.executedStep);
+    }
+    releaseDelayedFreeBytes(state, sv);
+    {
+      ScopedFreeTimer freeTimer(state);
+      for (auto id : sv.lastUseIds) {
+        checkValueBeforeFree(frame, id, state.waveGraph);
+        freeFrameValue(frame, id, state.stream.get(), &state);
+      }
+    }
+  }
 }
 
 void WaveGraphExecutor::executeWave(
@@ -1034,6 +1563,12 @@ void WaveGraphExecutor::executeWave(
   state.pinnedArena = g->pinnedArena.get();
   state.streamPool = g->streamPool.get();
   state.stream = g->streamPool->get();
+  // The per-step event chain below starts empty, so nothing orders this run
+  // against what the caller left on the torch stream: the eager ops that
+  // produced the inputs, and the buffers they still hold, which the caching
+  // allocator is free to hand this run's first outputs. A blocking wave stream
+  // used to cover both implicitly.
+  waitForTorchStream(*state.stream);
   state.kernelMap = &kernelMap_;
   state.waveGraph = &waveGraph;
   state.standaloneIndices = &waveGraph.standaloneIndices();
@@ -1046,6 +1581,39 @@ void WaveGraphExecutor::executeWave(
   state.traceState = parseTraceValues(WaveConfig::get().traceValues);
   state.traceState.traced.clear();
   state.verifiedIds.clear();
+
+  // Per-step GPU timeline events. releaseStepEvents pools them on the normal
+  // path, after the final stream syncs, so none is recycled while still
+  // pending. This guard is the exception path: those syncs may not have run, so
+  // just destroy the events -- cudaEventDestroy on a pending event is defined
+  // (the resources are freed once the device reaches it), only re-recording one
+  // would be wrong.
+  state.stepEvents.clear();
+  state.timelineBase.reset();
+  state.lastWaveDone = nullptr;
+  state.lastStandaloneDone = nullptr;
+  state.syncedCursor = 0;
+  state.returnedAtStep.clear();
+  state.executedSteps = 0;
+  state.pendingReturns.clear();
+  SCOPE_EXIT {
+    state.stepEvents.clear();
+    state.timelineBase.reset();
+    state.lastWaveDone = nullptr;
+    state.lastStandaloneDone = nullptr;
+    state.syncedCursor = 0;
+    state.returnedAtStep.clear();
+    state.executedSteps = 0;
+    // Exception path only: on the normal path everything has been parsed
+    // below. Dropping an entry here is safe -- the frame is abandoned with the
+    // exception -- whereas parsing one whose transfer may still be in flight
+    // is not.
+    state.pendingReturns.clear();
+  };
+  if (WaveConfig::get().trace & WaveConfig::kTiming) {
+    state.timelineBase = globals()->timingEventPool->get();
+    state.timelineBase->record(*state.stream);
+  }
 
   auto wallStart = std::chrono::high_resolution_clock::now();
 
@@ -1062,17 +1630,56 @@ void WaveGraphExecutor::executeWave(
 
   // Reset per-step lifecycle stages (step vectors are pooled across runs) so
   // freeIntermediates freeing only ever fires for this run's steps.
+  state.numLastUseEarly = 0;
+  state.numLastUseAtNodeEnd = 0;
+  state.numDeferredReturns = 0;
+  state.deferredStepSpan = 0;
+  state.runAheadSum = 0;
+  state.runAheadSamples = 0;
+  state.runAheadMax = 0;
+  state.numDrainedStarts = 0;
+  state.delayedFreeBytes = 0;
+  state.numMemoryStalls = 0;
+  state.maxDelayedFreeSeen = 0;
+  state.numDeferredOps = 0;
+  state.numDeferredSteps = 0;
+  state.numGridRedos = 0;
+  state.freeUs = 0;
+  // donatableBytes is deliberately not reset: the pool outlives the execution,
+  // so the byte accounting has to stay attached to what it actually holds.
+  state.donationHits = 0;
+  state.donationMisses = 0;
+  state.donationEvictions = 0;
+  state.donationUs = 0;
+  state.freedValueIds.clear();
+  state.releasedAtStep.clear();
+  // Runs after the closing stream syncs on the normal path, and on any throw.
+  // The pool is kept across executions -- the next run of this graph allocates
+  // the same shapes, so a warm pool is where the hit rate comes from -- but it
+  // is trimmed to the ceiling here so the memory it holds between runs stays
+  // bounded. Whatever survives is released when the ExecutionState dies.
+  SCOPE_EXIT {
+    const auto cap = WaveConfig::get().donationCarryBytes;
+    if (cap >= 0) {
+      evictDonatable(state, cap);
+    }
+  };
   if (WaveConfig::get().freeIntermediates) {
     for (auto& steps : state.stepVectors) {
       for (auto& sv : steps) {
         sv.executionStage = ExecutionStage::kNotStarted;
         sv.lastUseIds.clear();
+        sv.lastUseBytes = 0;
       }
     }
   }
   for (const auto& node : waveGraph.nodes()) {
     node->execute(state);
   }
+
+  // The last steps' transfers may still be outstanding under
+  // WaveConfig::deferD2h. Everything below reads the frame, so parse them now.
+  resolveAllPendingReturns(state);
 
   // Sanity check (replaces the former deferred-standalone retry pass): every
   // standalone must have executed in place during the composite passes above.
@@ -1102,16 +1709,35 @@ void WaveGraphExecutor::executeWave(
   if (WaveConfig::get().trace != 0) {
     static std::atomic<bool> fusionLogged{false};
     if (!fusionLogged.exchange(true)) {
+      // Coverage is counted from the compiled structure, not from what is
+      // left in the frame. An empty frame slot proves nothing: an op fused
+      // into a kernel produces an internal intermediate that never gets a
+      // frame value at all, and freeIntermediates reclaims most of the ones
+      // that do. Inferring coverage from isNone() reported 3720 of 4697 ROO
+      // nodes as uncovered when nearly all of them had run.
       auto& graph = *waveGraph.graph();
-      int64_t uncovered = 0;
-      for (auto& gnode : graph.nodes()) {
-        if (gnode.target() == "prim.Input" || gnode.target() == "prim.Output") {
-          continue;
-        }
-        for (auto* output : gnode.outputs()) {
-          if (frame.getIValue(output->id()).isNone()) {
-            ++uncovered;
-            break;
+      folly::F14FastSet<NodeCP> fused;
+      for (const auto& composite : waveGraph.nodes()) {
+        for (const auto& op : composite->kernels()->ops()) {
+          const auto& nodeMap = op.nodeMap();
+          // Union over the grid variants: which one runs is a runtime choice,
+          // but every variant covers the same nodes.
+          auto* projectOp = op.projectOp();
+          for (auto* grid :
+               {&projectOp->grid(),
+                &projectOp->singleBlockGrid(),
+                &projectOp->cgGrid()}) {
+            for (const auto& step : *grid) {
+              for (const auto& launch : step) {
+                if (launch.op == nullptr) {
+                  continue;
+                }
+                for (auto* formal : launch.op->allNodes()) {
+                  auto it = nodeMap.find(formal);
+                  fused.insert(it != nodeMap.end() ? it->second : formal);
+                }
+              }
+            }
           }
         }
       }
@@ -1119,26 +1745,41 @@ void WaveGraphExecutor::executeWave(
       auto numComposites = waveGraph.nodes().size();
       int64_t numStandalones = state.numStandalonesRun;
       int64_t numShortcuts = state.numShortcutsRun;
-      int64_t fusedNodes =
-          totalNodes - uncovered - numStandalones - numShortcuts;
+      auto fusedNodes = static_cast<int64_t>(fused.size());
+      // prim.Input / prim.Output are graph plumbing, not work to cover.
+      int64_t plumbing = 0;
+      for (auto& gnode : graph.nodes()) {
+        if (gnode.target() == "prim.Input" || gnode.target() == "prim.Output") {
+          ++plumbing;
+        }
+      }
+      const int64_t coverable = totalNodes - plumbing;
+      int64_t uncovered =
+          coverable - fusedNodes - numStandalones - numShortcuts;
       std::cout << "FUSION: nativert_graph_nodes=" << totalNodes
+                << " coverable=" << coverable
                 << " wave_composite_kernels=" << numComposites
                 << " fused_nodes=" << fusedNodes
                 << " standalone_ops=" << numStandalones
                 << " shortcut_ops=" << numShortcuts
                 << " uncovered_ops=" << uncovered << " (~"
-                << (100.0 * fusedNodes / totalNodes) << "% fused, ~"
-                << (100.0 * uncovered / totalNodes) << "% uncovered)"
-                << std::endl;
+                << (100.0 * static_cast<double>(fusedNodes) /
+                    static_cast<double>(coverable))
+                << "% fused, ~"
+                << (100.0 * static_cast<double>(uncovered) /
+                    static_cast<double>(coverable))
+                << "% uncovered)" << std::endl;
     }
   }
   // Sync the wave stream and the PyTorch default stream: eager standalone ops
   // run on the default stream while fused kernels run on the wave stream, and
   // the two are otherwise unordered. Both must complete before executeWave
   // returns so all results this invocation produced are visible to the
-  // caller.
-  syncWaveStream(state);
+  // caller. Default stream first: syncWaveStream releases frame values off a
+  // wave-stream wait alone, and an eager standalone still in flight can be
+  // reading one of them (same order as enforceDelayedFreeLimit).
   syncTorchDefaultStream();
+  syncWaveStream(state);
   auto wallUs = std::chrono::duration_cast<std::chrono::microseconds>(
                     std::chrono::high_resolution_clock::now() - wallStart)
                     .count();
@@ -1159,16 +1800,135 @@ void WaveGraphExecutor::executeWave(
       TORCH_CHECK(false, "Wave kernel error:\n", threadInfo.errors);
     }
   }
+  // Both streams have been waited on and collectDebugInfo has read the elapsed
+  // times, so the events can go back to their pools for the next run.
+  releaseStepEvents(state);
 }
 
 const WaveThreadInfo& waveThreadInfo() {
   return threadInfo;
 }
 
+bool allocTraceEnabled() {
+  static const bool enabled = std::getenv("TW_ALLOC_TRACE") != nullptr;
+  return enabled;
+}
+
+void logAllocEvent(const char* kind, int32_t valueId, int64_t bytes) {
+  std::cout << "ALLOCEV " << kind << ' ' << valueId << ' ' << bytes << " ?\n";
+}
+
+namespace {
+folly::F14FastMap<int32_t, std::string>& sizeKeys() {
+  static thread_local folly::F14FastMap<int32_t, std::string> keys;
+  return keys;
+}
+} // namespace
+
+void logKeyedAllocEvent(
+    const char* kind,
+    int32_t valueId,
+    int64_t bytes,
+    const std::string& sizeKey) {
+  sizeKeys()[valueId] = sizeKey;
+  std::cout << "ALLOCEV " << kind << ' ' << valueId << ' ' << bytes << ' '
+            << sizeKey << '\n';
+}
+
+const std::string& recordedSizeKey(int32_t valueId) {
+  static const std::string kUnknown = "?";
+  auto it = sizeKeys().find(valueId);
+  return it != sizeKeys().end() ? it->second : kUnknown;
+}
+
+namespace {
+
+// Walks the run's step events in execution order and fills each step's
+// device-measured spans and the idle that preceded it. All timestamps are read
+// as offsets from state.timelineBase, which puts the wave stream and the torch
+// stream on one comparable timeline (cudaEventElapsedTime across streams is
+// valid -- the timestamps are device-global).
+void computeGpuTimeline(ExecutionState& state) {
+  if (!state.timelineBase || !state.timelineBase->recorded()) {
+    return;
+  }
+  auto us = [&](const EventP& event) -> std::optional<double> {
+    if (!event || !event->recorded()) {
+      return std::nullopt;
+    }
+    return event->elapsedTime(*state.timelineBase) * 1000.0;
+  };
+  // End of the previous step's GPU work. A step with no device work at all
+  // (shortcut-only) has neither bound, so it is skipped and this carries
+  // forward rather than resetting.
+  std::optional<double> prevEnd;
+  for (const auto& events : state.stepEvents) {
+    auto waveBegin = us(events.waveBegin);
+    auto waveDone = us(events.waveDone);
+    auto standaloneBegin = us(events.standaloneBegin);
+    auto standaloneDone = us(events.standaloneDone);
+
+    std::optional<double> start;
+    std::optional<double> end;
+    for (const auto& candidate : {waveBegin, standaloneBegin}) {
+      if (candidate && (!start || *candidate < *start)) {
+        start = candidate;
+      }
+    }
+    for (const auto& candidate : {waveDone, standaloneDone}) {
+      if (candidate && (!end || *candidate > *end)) {
+        end = candidate;
+      }
+    }
+    if (!start || !end) {
+      continue;
+    }
+    auto* svPtr = findStepVectors(state, events.sequenceNumber, events.stepIdx);
+    if (svPtr == nullptr) {
+      continue;
+    }
+    auto& sv = *svPtr;
+    if (waveBegin && waveDone) {
+      sv.kernelGpuUs = static_cast<int64_t>(*waveDone - *waveBegin);
+    }
+    if (standaloneBegin && standaloneDone) {
+      sv.standaloneGpuUs =
+          static_cast<int64_t>(*standaloneDone - *standaloneBegin);
+    }
+    sv.gpuIdleUs =
+        prevEnd ? static_cast<int64_t>(std::max(0.0, *start - *prevEnd)) : 0;
+    prevEnd = end;
+  }
+}
+
+} // namespace
+
 void WaveGraphExecutor::collectDebugInfo(ExecutionState& state) {
   auto& infos = state.launchDebugInfos;
   threadInfo.debugInfo.clear();
   threadInfo.launchMeta.clear();
+  threadInfo.gpuIdleUs = 0;
+  threadInfo.numLastUseEarly = state.numLastUseEarly;
+  threadInfo.numLastUseAtNodeEnd = state.numLastUseAtNodeEnd;
+  threadInfo.numDeferredReturns = state.numDeferredReturns;
+  threadInfo.deferredStepSpan = state.deferredStepSpan;
+  threadInfo.runAheadSum = state.runAheadSum;
+  threadInfo.runAheadSamples = state.runAheadSamples;
+  threadInfo.runAheadMax = state.runAheadMax;
+  threadInfo.numDrainedStarts = state.numDrainedStarts;
+  threadInfo.numMemoryStalls = state.numMemoryStalls;
+  threadInfo.maxDelayedFreeSeen = state.maxDelayedFreeSeen;
+  threadInfo.numDeferredOps = state.numDeferredOps;
+  threadInfo.numDeferredSteps = state.numDeferredSteps;
+  threadInfo.numGridRedos = state.numGridRedos;
+  threadInfo.freeUs = state.freeUs;
+  threadInfo.donationHits = state.donationHits;
+  threadInfo.donationMisses = state.donationMisses;
+  threadInfo.donationEvictions = state.donationEvictions;
+  threadInfo.donationUs = state.donationUs;
+  if (WaveConfig::get().trace & WaveConfig::kTiming) {
+    computeGpuTimeline(state);
+  }
   if (infos.empty()) {
     return;
   }
@@ -1196,11 +1956,9 @@ void WaveGraphExecutor::collectDebugInfo(ExecutionState& state) {
     meta.stepIdx = info.stepIdx;
     meta.numBlocks = info.numBlocks;
     if (WaveConfig::get().trace & WaveConfig::kTiming) {
-      auto seq = info.sequenceNumber;
-      auto step = info.stepIdx;
-      if (seq < static_cast<int32_t>(state.stepVectors.size()) &&
-          step < static_cast<int32_t>(state.stepVectors[seq].size())) {
-        auto& sv = state.stepVectors[seq][step];
+      auto* svPtr = findStepVectors(state, info.sequenceNumber, info.stepIdx);
+      if (svPtr != nullptr) {
+        auto& sv = *svPtr;
         meta.gatherUs = sv.gatherUs;
         meta.gridUs = sv.gridUs;
         meta.allocUs = sv.allocUs;
@@ -1215,6 +1973,19 @@ void WaveGraphExecutor::collectDebugInfo(ExecutionState& state) {
         meta.currentBytes = sv.currentBytes;
         meta.refCheckUs = sv.refCheckUs;
         meta.elidedCloneBytes = sv.elidedCloneBytes;
+        meta.kernelGpuUs = sv.kernelGpuUs;
+        meta.standaloneGpuUs = sv.standaloneGpuUs;
+        meta.gpuIdleUs = sv.gpuIdleUs;
+        threadInfo.gpuIdleUs += sv.gpuIdleUs;
+        meta.d2hDepFused = sv.d2hDepFused;
+        meta.d2hDepStandalone = sv.d2hDepStandalone;
+        meta.d2hDepShortcut = sv.d2hDepShortcut;
+        meta.d2hDepOnPrevStep = sv.d2hDepOnPrevStep;
+        meta.d2hNearestProducer = sv.d2hNearestProducer;
+        meta.viewNodeDescs = sv.viewNodeDescs;
+        meta.numFused = static_cast<int32_t>(sv.kernels.size());
+        meta.numStandalone = static_cast<int32_t>(sv.standalones.size());
+        meta.numShortcut = static_cast<int32_t>(sv.shortcutStandalones.size());
       }
     }
     threadInfo.launchMeta.push_back(std::move(meta));
@@ -1414,37 +2185,97 @@ std::string WaveGraphExecutor::makePerfReport(
   }
   ss << fmt::format("E2E wall time: {} us ({:.3f} s)\n", wallUs, wallSec);
   if (wallUs > 0 && totalInputBytes > 0) {
-    double inputGBs = totalInputBytes / (wallSec * 1e9);
+    double inputGBs = static_cast<double>(totalInputBytes) / (wallSec * 1e9);
     ss << fmt::format(
         "Input throughput: {:.2f} GB/s ({:.1f} MB input)\n",
         inputGBs,
-        totalInputBytes / 1e6);
+        static_cast<double>(totalInputBytes) / 1e6);
   }
   if (wallUs > 0 && totalDataBytes > 0) {
-    double dataGBs = totalDataBytes / (wallSec * 1e9);
+    double dataGBs = static_cast<double>(totalDataBytes) / (wallSec * 1e9);
     ss << fmt::format(
         "Internal throughput: {:.2f} GB/s ({:.1f} MB total data)\n",
         dataGBs,
-        totalDataBytes / 1e6);
+        static_cast<double>(totalDataBytes) / 1e6);
   }
   ss << fmt::format(
       "Peak GPU RAM: {}\n", facebook::velox::succinctBytes(info.peakBytes));
+  if (WaveConfig::get().freeIntermediates) {
+    ss << fmt::format(
+        "Last-use release: {} values, {} before their node's last step\n",
+        info.numLastUseEarly + info.numLastUseAtNodeEnd,
+        info.numLastUseEarly);
+  }
+  if (info.runAheadSamples > 0) {
+    // Steps that start with the queue already drained have their whole
+    // interpretation exposed as idle, so this is the direct measure of how much
+    // room deeper run-ahead has.
+    ss << fmt::format(
+        "Host run-ahead: mean {:.2f} steps in flight, max {}, {} of {} steps "
+        "started with the queue drained\n",
+        static_cast<double>(info.runAheadSum) / info.runAheadSamples,
+        info.runAheadMax,
+        info.numDrainedStarts,
+        info.runAheadSamples);
+  }
+  if (info.numGridRedos > 0) {
+    ss << fmt::format(
+        "Grid redos: {} steps changed variant and redid their setup pass\n",
+        info.numGridRedos);
+  }
+  if (info.numDeferredSteps > 0) {
+    ss << fmt::format(
+        "Deferred setup: {} ops over {} steps needed a second pass\n",
+        info.numDeferredOps,
+        info.numDeferredSteps);
+  }
+  if (info.maxDelayedFreeSeen > 0) {
+    // The high-water mark is what the run-ahead adds to the peak; the stall
+    // count is how often the ceiling had to claw it back.
+    ss << fmt::format(
+        "Delayed frees: peak {} held by in-flight steps, {} drains forced by "
+        "the {} ceiling\n",
+        facebook::velox::succinctBytes(info.maxDelayedFreeSeen),
+        info.numMemoryStalls,
+        facebook::velox::succinctBytes(WaveConfig::get().maxDelayedFree));
+  }
+  if (info.numDeferredReturns > 0) {
+    // A span of 1 is a transfer the very next step consumed, which is what
+    // waiting at the producer already gave; the excess over 1 is the run-ahead
+    // WaveConfig::deferD2h actually bought.
+    ss << fmt::format(
+        "Deferred D2H: {} transfers, {:.1f} steps in flight on average\n",
+        info.numDeferredReturns,
+        static_cast<double>(info.deferredStepSpan) / info.numDeferredReturns);
+  }
 
-  // Time split across all steps: kernel (GPU), standalone (eager ATen on the
-  // default stream), and interpretation (gather + grid + alloc + fill = the
-  // host-side scheduling overhead). For a standalone-bound step the measured
-  // kernelUs reflects waiting on the standalone work rather than the GPU
-  // kernel, so estimate the kernel time from that step's max thread-block
-  // clocks (1 clock ~= 0.7 ns).
+  // Time split across all steps. Kernel and standalone are device-measured from
+  // each step's event pair; GPU idle is the summed gap between one step's GPU
+  // work ending and the next step's starting, i.e. time the device had nothing
+  // to do because the host was still interpreting. Interpretation is the host
+  // side of that (gather + grid + alloc + fill).
+  //
+  // A step with no events falls back to the old estimate: for a standalone-
+  // bound step the host-measured kernelUs reflects waiting on the standalone
+  // work rather than on the GPU, so approximate from the step's max
+  // thread-block clocks (1 clock ~= 0.7 ns).
   {
     double kernelUs = 0.0;
     int64_t standaloneUs = 0;
     int64_t interpUs = 0;
+    int64_t gpuIdleUs = 0;
     for (size_t i = 0; i < info.launchMeta.size(); ++i) {
       const auto& m = info.launchMeta[i];
       interpUs += m.gatherUs + m.gridUs + m.allocUs + m.fillUs;
-      standaloneUs += m.standaloneUs + m.shortcutUs;
-      if (m.standaloneBound) {
+      gpuIdleUs += m.gpuIdleUs;
+      if (m.standaloneGpuUs > 0) {
+        standaloneUs += m.standaloneGpuUs;
+      } else {
+        standaloneUs += m.standaloneUs + m.shortcutUs;
+      }
+      if (m.kernelGpuUs > 0) {
+        kernelUs += static_cast<double>(m.kernelGpuUs);
+      } else if (m.standaloneBound) {
         int64_t maxClocks = 0;
         if (i < info.debugInfo.size()) {
           for (const auto& b : info.debugInfo[i]) {
@@ -1457,10 +2288,70 @@ std::string WaveGraphExecutor::makePerfReport(
       }
     }
     ss << fmt::format(
-        "Kernel time: {:.0f} us  Standalone time: {} us  Interpretation time: {} us\n",
+        "Kernel time: {:.0f} us  Standalone time: {} us  GPU idle: {} us  Interpretation time: {} us  Free time: {} us\n",
         kernelUs,
         standaloneUs,
-        interpUs);
+        gpuIdleUs,
+        interpUs,
+        info.freeUs);
+    if (info.donationHits + info.donationMisses > 0) {
+      ss << fmt::format(
+          "Buffer donation: {} hits, {} misses ({:.0f}% of kernel allocations), {} evicted, {} us in the pool\n",
+          info.donationHits,
+          info.donationMisses,
+          100.0 * static_cast<double>(info.donationHits) /
+              static_cast<double>(info.donationHits + info.donationMisses),
+          info.donationEvictions,
+          info.donationUs);
+    }
+    if (WaveConfig::get().perOpStandaloneTiming) {
+      ss << "WARNING per-op standalone timing is on: it syncs after every eager "
+            "op, which serializes the streams and inflates idle.\n";
+    }
+  }
+
+  // How much of each step is genuinely blocked on an earlier step's D2H. The
+  // producing step waits for the transfer today; these counts say how much of
+  // the work that follows would really have had to wait for it.
+  {
+    int32_t stepsWithDep = 0;
+    int32_t stepsDepOnPrev = 0;
+    int32_t depFused = 0, depStandalone = 0, depShortcut = 0;
+    int32_t totFused = 0, totStandalone = 0, totShortcut = 0;
+    for (const auto& m : info.launchMeta) {
+      totFused += m.numFused;
+      totStandalone += m.numStandalone;
+      totShortcut += m.numShortcut;
+      depFused += m.d2hDepFused;
+      depStandalone += m.d2hDepStandalone;
+      depShortcut += m.d2hDepShortcut;
+      if (m.d2hDepFused + m.d2hDepStandalone + m.d2hDepShortcut > 0) {
+        ++stepsWithDep;
+        if (m.d2hDepOnPrevStep > 0) {
+          ++stepsDepOnPrev;
+        }
+      }
+    }
+    ss << fmt::format(
+        "D2H dependencies: {} of {} steps read a value an earlier step "
+        "returned; {} of those from the immediately preceding step\n",
+        stepsWithDep,
+        info.launchMeta.size(),
+        stepsDepOnPrev);
+    ss << fmt::format(
+        "  dependent ops: fused {}/{}  standalone {}/{}  shortcut {}/{}\n",
+        depFused,
+        totFused,
+        depStandalone,
+        totStandalone,
+        depShortcut,
+        totShortcut);
+    int32_t viewDescs = 0;
+    for (const auto& m : info.launchMeta) {
+      viewDescs += m.viewNodeDescs;
+    }
+    ss << fmt::format(
+        "  fused outputs built by a host-side view: {}\n", viewDescs);
   }
   ss << "WaveConfig: " << WaveConfig::get().toString() << "\n";
 
@@ -1483,8 +2374,15 @@ std::string WaveGraphExecutor::makePerfReport(
     for (auto idx : indices) {
       const auto& m = info.launchMeta[idx];
       int64_t interp = m.gatherUs + m.gridUs + m.allocUs + m.fillUs;
-      int64_t hostStandalone = m.standaloneUs + m.shortcutUs;
-      nodeUs += interp + std::max(m.kernelUs, hostStandalone);
+      if (m.kernelGpuUs > 0 || m.standaloneGpuUs > 0) {
+        // Device-measured: the step's wall is the host interpretation plus the
+        // longer of the two device spans plus the idle that preceded it.
+        nodeUs +=
+            interp + std::max(m.kernelGpuUs, m.standaloneGpuUs) + m.gpuIdleUs;
+      } else {
+        int64_t hostStandalone = m.standaloneUs + m.shortcutUs;
+        nodeUs += interp + std::max(m.kernelUs, hostStandalone);
+      }
     }
     nodeWallTimes.emplace_back(seq, nodeUs);
   }
@@ -1543,13 +2441,11 @@ std::string WaveGraphExecutor::makePerfReport(
       if (m.numBlocks == 0) {
         // Standalone-only step.
         int32_t numStandalones = 0;
-        auto seq = m.sequenceNumber;
-        auto step = m.stepIdx;
-        if (seq < static_cast<int32_t>(state.stepVectors.size()) &&
-            step < static_cast<int32_t>(state.stepVectors[seq].size())) {
+        if (const auto* stepVectors =
+                findStepVectors(state, m.sequenceNumber, m.stepIdx)) {
           numStandalones = static_cast<int32_t>(
-              state.stepVectors[seq][step].standalones.size() +
-              state.stepVectors[seq][step].shortcutStandalones.size());
+              stepVectors->standalones.size() +
+              stepVectors->shortcutStandalones.size());
         }
         ss << fmt::format(
             "  step {}: {} standalones  GPU RAM={}  {} us",
@@ -1557,6 +2453,19 @@ std::string WaveGraphExecutor::makePerfReport(
             numStandalones,
             facebook::velox::succinctBytes(m.currentBytes),
             m.standaloneUs);
+        // Standalone-only steps are exactly where the device tends to go idle.
+        if (m.standaloneGpuUs > 0 || m.gpuIdleUs > 0) {
+          ss << fmt::format(" gpu={} idle={}", m.standaloneGpuUs, m.gpuIdleUs);
+        }
+        if (m.d2hDepStandalone + m.d2hDepShortcut > 0) {
+          ss << fmt::format(
+              " d2hDep=[standalone {}/{} shortcut {}/{} back={}]",
+              m.d2hDepStandalone,
+              m.numStandalone,
+              m.d2hDepShortcut,
+              m.numShortcut,
+              m.d2hNearestProducer);
+        }
         if (m.elidedCloneBytes > 0) {
           ss << fmt::format(
               "  elided copies={}",
@@ -1566,8 +2475,10 @@ std::string WaveGraphExecutor::makePerfReport(
         continue;
       }
       auto stepUs = m.gatherUs + m.gridUs + m.allocUs + m.fillUs + m.kernelUs;
-      double bytesTotal = m.inputBytes + m.outputBytes;
-      double gbps = m.kernelUs > 0 ? bytesTotal / (m.kernelUs * 1e3) : 0.0;
+      double bytesTotal = static_cast<double>(m.inputBytes + m.outputBytes);
+      double gbps = m.kernelUs > 0
+          ? bytesTotal / (static_cast<double>(m.kernelUs) * 1e3)
+          : 0.0;
       ss << fmt::format(
           "  step {}: {} us  blocks={}  GPU RAM={}  in={:.1f}KB out={:.1f}KB  {:.1f} GB/s",
           m.stepIdx,
@@ -1582,19 +2493,40 @@ std::string WaveGraphExecutor::makePerfReport(
             "  elided copies={}",
             facebook::velox::succinctBytes(m.elidedCloneBytes));
       }
+      // kernel= is the host cost of issuing the step, gpu= what the device
+      // actually spent on it. They diverge once the two streams overlap, and
+      // that divergence is the interesting signal.
       ss << fmt::format(
-          "  [gather={} grid={} alloc={} fill={} kernel={}]",
+          "  [gather={} grid={} alloc={} fill={} kernel={} gpu={} idle={}]",
           m.gatherUs,
           m.gridUs,
           m.allocUs,
           m.fillUs,
-          m.kernelUs);
+          m.kernelUs,
+          m.kernelGpuUs,
+          m.gpuIdleUs);
       if (m.shortcutUs > 0) {
         ss << fmt::format(" shortcut={}", m.shortcutUs);
       }
       if (m.standaloneUs > 0) {
         ss << fmt::format(
             " standalone={}{}", m.standaloneUs, m.standaloneBound ? "*" : "");
+      }
+      if (m.standaloneGpuUs > 0) {
+        ss << fmt::format(" standaloneGpu={}", m.standaloneGpuUs);
+      }
+      // Ops here that must wait for an earlier step's transfer, and how far
+      // back the nearest producing step is (1 = the step just before).
+      if (m.d2hDepFused + m.d2hDepStandalone + m.d2hDepShortcut > 0) {
+        ss << fmt::format(
+            " d2hDep=[fused {}/{} standalone {}/{} shortcut {}/{} back={}]",
+            m.d2hDepFused,
+            m.numFused,
+            m.d2hDepStandalone,
+            m.numStandalone,
+            m.d2hDepShortcut,
+            m.numShortcut,
+            m.d2hNearestProducer);
       }
       // Op-target breakdown covers both standalone and shortcut lists; print
       // it whenever either ran.
@@ -1655,11 +2587,8 @@ std::string WaveGraphExecutor::makePerfReport(
           opTotalClocks[b.op] += b.clocks;
         }
         // Get per-op element counts from step vectors.
-        auto seq = m.sequenceNumber;
-        auto step = m.stepIdx;
-        if (seq < static_cast<int32_t>(state.stepVectors.size()) &&
-            step < static_cast<int32_t>(state.stepVectors[seq].size())) {
-          for (const auto& kern : state.stepVectors[seq][step].kernels) {
+        if (auto* sv = findStepVectors(state, m.sequenceNumber, m.stepIdx)) {
+          for (const auto& kern : sv->kernels) {
             if (kern.launch && kern.launch->op) {
               auto opCode = kern.launch->op->opCode();
               auto it = opMap.find(opCode);

--- a/velox/experimental/torchwave/Executor.h
+++ b/velox/experimental/torchwave/Executor.h
@@ -18,6 +18,7 @@
 
 #include <torch/nativert/executor/GraphExecutorBase.h>
 #include <torch/nativert/executor/Weights.h>
+#include <deque>
 #include "velox/experimental/torchwave/Compile.h"
 #include "velox/experimental/torchwave/CompiledOp.h"
 #include "velox/experimental/torchwave/Registry.h"
@@ -64,6 +65,20 @@ struct LaunchDebugInfo {
   int32_t stepIdx;
 };
 
+/// Device-timeline events bracketing one step's GPU work. Wave events are
+/// absent for a step with no fused kernel, standalone events for a step with no
+/// device-side eager op. The *Begin events exist only under the kTiming trace
+/// bit; the *Done events are always present because they carry the cross-stream
+/// ordering that replaces the host stream syncs.
+struct StepEvents {
+  int32_t sequenceNumber{0};
+  int32_t stepIdx{0};
+  EventP waveBegin;
+  EventP waveDone;
+  EventP standaloneBegin;
+  EventP standaloneDone;
+};
+
 /// Per-launch metadata stored in thread-local alongside the DebugInfo.
 struct LaunchMeta {
   int32_t sequenceNumber{0};
@@ -88,6 +103,26 @@ struct LaunchMeta {
   int64_t refCheckUs{0};
   // Bytes of copying the clone-elision pass saved, charged to this step.
   int64_t elidedCloneBytes{0};
+  // Device-measured spans from this step's events (kTiming only). kernelUs and
+  // standaloneUs above are host wall times around issuing the work; these are
+  // what the GPU actually spent on it.
+  int64_t kernelGpuUs{0};
+  int64_t standaloneGpuUs{0};
+  // Device idle before this step: the gap between the end of the previous
+  // step's GPU work and the start of this one's.
+  int64_t gpuIdleUs{0};
+  // Ops in this step that read a value an earlier step returned over a D2H.
+  // See StepVectors for the details.
+  int32_t d2hDepFused{0};
+  int32_t d2hDepStandalone{0};
+  int32_t d2hDepShortcut{0};
+  int32_t d2hDepOnPrevStep{0};
+  int32_t d2hNearestProducer{-1};
+  int32_t viewNodeDescs{0};
+  // Total ops in the step, so the dependent counts read as a fraction.
+  int32_t numFused{0};
+  int32_t numStandalone{0};
+  int32_t numShortcut{0};
 };
 
 /// Per-thread debug info from the most recent wave execution. Populated by
@@ -108,6 +143,40 @@ struct WaveThreadInfo {
   /// the start of the run), so it captures transient intra-step peaks. Filled
   /// when trace kTiming is on.
   int64_t peakBytes{0};
+  /// Total device idle across the run, summed from the per-step gpuIdleUs: wall
+  /// time in which neither the wave stream nor the eager standalones had work
+  /// on the device, because the host was still preparing the next launch.
+  int64_t gpuIdleUs{0};
+  /// Last-use values released before their node's last step, and at it.
+  int32_t numLastUseEarly{0};
+  int32_t numLastUseAtNodeEnd{0};
+  /// Deferred device-to-host transfers and the executed steps they spanned.
+  int32_t numDeferredReturns{0};
+  int64_t deferredStepSpan{0};
+  /// Host run-ahead depth over the run: total, samples, max, and how many steps
+  /// began with the device queue already drained.
+  int64_t runAheadSum{0};
+  int32_t runAheadSamples{0};
+  int32_t runAheadMax{0};
+  int32_t numDrainedStarts{0};
+  /// Drains forced by the delayed-free ceiling, and the peak bytes of freeing
+  /// the run-ahead was holding.
+  int32_t numMemoryStalls{0};
+  int64_t maxDelayedFreeSeen{0};
+  /// Ops deferred to a step's second pass, the steps that needed one, and the
+  /// host time spent freeing frame values.
+  int32_t numDeferredOps{0};
+  int32_t numDeferredSteps{0};
+  int32_t numGridRedos{0};
+  int64_t freeUs{0};
+  /// Donation pool: allocations served from a released buffer of the same size,
+  /// those that fell through to the allocator, buffers dropped at the ceiling,
+  /// and the host time the pool itself cost.
+  int64_t donationHits{0};
+  int64_t donationMisses{0};
+  int64_t donationEvictions{0};
+  int64_t donationUs{0};
+
   /// Performance report, filled when trace kTiming is on.
   std::string perfReport;
 };
@@ -131,6 +200,64 @@ enum class ExecutionStage {
 /// (compositeInvocation, stepIdx) pair.  Avoids per-step heap allocation
 /// in CompositeInvocation::execute and makeGrid.
 struct StepVectors {
+  /// Byte offset of the BlockInfo array within the step's pinned and device
+  /// buffers. The kernel params come first, so their offsets depend only on
+  /// which ops are in the step, not on the block count -- which is what lets
+  /// them be filled before makeGrid has settled that count. The BlockInfo
+  /// array sits above them and is written last.
+  int64_t blockInfoOffset{0};
+
+  /// Byte offset of every kernel param slot this step can use, flattened over
+  /// the ops; opSlotBegin[i] is where op i's slots start and opSlotBegin.back()
+  /// is the end. Each slot is reserved for the largest of the op's grid
+  /// variants, and an op gets as many slots as its widest variant needs, so
+  /// switching a variant never moves another op's params. That is what makes it
+  /// safe to fill params before makeGrid has run and before a variant that
+  /// depends on a pending transfer has been chosen. Built once per step by
+  /// layoutParamSlots; paramRegionBytes is the total.
+  std::vector<int64_t> slotOffsets;
+  std::vector<int32_t> opSlotBegin;
+  int64_t paramRegionBytes{0};
+
+  /// Upper bound on the blocks makeGrid can produce for this step. The
+  /// BlockInfo and DebugInfo regions are sized for it rather than for the
+  /// actual count, so the buffer size -- and therefore its base address -- is
+  /// settled before makeGrid runs. Without that, a later size change would
+  /// reallocate and move the base out from under params already filled.
+  int32_t blockCapacity{0};
+
+  /// Every frame value this step can read, over ALL of its grid variants:
+  /// each kernel launch's KernelOperation::orderingInputs(), each standalone
+  /// launch's node inputs, and the ProjectOperation subgraph leaves, translated
+  /// formal -> actual. Built once by layoutParamSlots, from the compiled grids
+  /// alone, so it is available before gatherLaunches has picked a variant --
+  /// which is what lets a step decide whether it must wait for a pending
+  /// device-to-host transfer before it sizes and allocates anything. Being a
+  /// union over variants it is a superset of what the step actually reads,
+  /// which is the safe direction: a read missed here is a step running against
+  /// a frame value that has not landed yet.
+  folly::F14FastSet<nativert::ValueId> readIds;
+
+  /// The same read set split per op, parallel to the invocation's ops. Lets a
+  /// step defer only the ops that actually read a pending transfer instead of
+  /// stalling whole. readIds is the union of these.
+  std::vector<folly::F14FastSet<nativert::ValueId>> opReadIds;
+
+  /// One bit per (id % 64) of opReadIds[i], so testing an op against the
+  /// pending transfers is a single AND against the same signature built from
+  /// the pending ids -- no hash lookup in the per-op path. Zero overlap proves
+  /// independence; a hit falls through to the exact set. Actual ids throughout;
+  /// the formal-to-actual translation happens once, when this is built.
+  std::vector<uint64_t> opReadSignature;
+
+  /// How many kernel / standalone / shortcut launches each op contributed at
+  /// this step, recorded by the first pass. The second pass adds these to its
+  /// running indices for the ops it is skipping, so it lands on a deferred op's
+  /// slots without re-walking the launches of everything before it.
+  std::vector<int32_t> opKernelCount;
+  std::vector<int32_t> opStandaloneCount;
+  std::vector<int32_t> opShortcutCount;
+
   /// Used by CompositeInvocation::execute / gatherLaunches.
   std::vector<LaunchData> kernels;
   std::vector<LaunchData> standalones;
@@ -211,17 +338,70 @@ struct StepVectors {
   // when the kTiming trace bit is on.
   int64_t elidedCloneBytes{0};
 
+  // Device-measured spans from this step's events, and the device idle that
+  // preceded it (kTiming only). See LaunchMeta for what each one means.
+  int64_t kernelGpuUs{0};
+  int64_t standaloneGpuUs{0};
+  int64_t gpuIdleUs{0};
+
+  // How many of this step's ops read a value an earlier step sent back over a
+  // device-to-host transfer, split by op kind. These are the ops that cannot
+  // start before that transfer has landed; every other op in the step could in
+  // principle be prepared while it is still in flight. A shortcut counts as
+  // dependent if any of its inputs is such a value, and it then taints its own
+  // outputs, so a fused op reaching a returned scalar only through a chain of
+  // metadata-only ops is counted too. kTiming only.
+  int32_t d2hDepFused{0};
+  int32_t d2hDepStandalone{0};
+  int32_t d2hDepShortcut{0};
+  // Of the dependent ops, how many depend on the immediately preceding step --
+  // the case where nothing can be overlapped.
+  int32_t d2hDepOnPrevStep{0};
+  // Distance in executed steps back to the nearest producing step, -1 if none.
+  int32_t d2hNearestProducer{-1};
+  // Fused output descriptors built by a host-side view. Their shape/offset
+  // operands come from the view node, not from the op's inputs, so they are a
+  // path by which a fused op can depend on a returned scalar without naming it.
+  int32_t viewNodeDescs{0};
+
   // Lifecycle stage for bundling frees with wave-stream syncs. Reset to
   // kNotStarted at the start of executeWave, set to kAllocated once this step's
   // kernel outputs are allocated, and advanced to kSynced by the first
   // wave-stream wait thereafter (see advanceSyncedStages).
   ExecutionStage executionStage{ExecutionStage::kNotStarted};
 
+  // ExecutionState::executedSteps at the point this step ran, i.e. the index
+  // LaunchData::d2hProducer and PendingReturn::executedStep are expressed in.
+  // -1 before the step has run in this execution.
+  int32_t executedStep{-1};
+
   // Frame value ids to release when this step reaches kSynced (and
   // WaveConfig::freeIntermediates is on). Set on a node's last executed step to
   // that node's ProjectNode::lastUse values, so the node's last-use tensors are
   // freed by the sync that advances this step to kSynced -- no extra sync.
   std::vector<nativert::ValueId> lastUseIds;
+
+  // Bytes behind lastUseIds, summed as each id is stamped and subtracted from
+  // ExecutionState::delayedFreeBytes in one go when this step is swept.
+  int64_t lastUseBytes{0};
+};
+
+/// A step's device-to-host transfer that has been enqueued but whose pinned
+/// buffer has not been parsed into the frame yet (WaveConfig::deferD2h). All
+/// transfers go on the wave stream, so issue order is also completion order and
+/// resolving one entry implies every earlier one has landed.
+struct PendingReturn {
+  int32_t sequenceNumber{0};
+  int32_t stepIdx{0};
+
+  /// ExecutionState::executedSteps at the producing step -- the same index
+  /// LaunchData::d2hProducer carries on a launch that reads one of the values
+  /// this transfer brings back.
+  int32_t executedStep{0};
+
+  /// Completes once the transfer has landed; recorded after the
+  /// deviceToHostAsync. Owned by ExecutionState::stepEvents.
+  facebook::velox::wave::Event* waveDone{nullptr};
 };
 
 /// Holds runtime state for executing a WaveGraph.  Pooled by WaveGraph
@@ -281,7 +461,154 @@ struct ExecutionState {
   /// Generation counter from the last execution. Incremented by returnFrame
   /// to signal that launch caches are stale.
   uint64_t lastFrameGeneration{0};
+
+  /// Per-step GPU timeline events in global execution order, parallel to
+  /// launchDebugInfos. Returned to the event pools at the end of the run. A
+  /// deque because a step holds a reference to its entry while later steps are
+  /// appended, and lastWaveDone / lastStandaloneDone point into it.
+  std::deque<StepEvents> stepEvents;
+
+  /// Reference event for the run's device timeline, recorded on the wave stream
+  /// before the first step. Every other timing event is read as an offset from
+  /// this one, which is what puts the wave stream and the torch stream on a
+  /// single comparable timeline. kTiming only.
+  EventP timelineBase;
+
+  /// Most recently recorded completion events, used to build the cross-stream
+  /// ordering edges. Owned by stepEvents; a step can be missing one side, so
+  /// these are carried forward rather than indexed by step.
+  facebook::velox::wave::Event* lastWaveDone{nullptr};
+  facebook::velox::wave::Event* lastStandaloneDone{nullptr};
+
+  /// Index into stepEvents of the oldest step not yet advanced to kSynced.
+  /// advanceCompletedStages resumes from here, so the sweep costs one query per
+  /// step over the run rather than re-walking every step on every launch.
+  size_t syncedCursor{0};
+
+  /// Value ids an earlier step sent back over a device-to-host transfer, mapped
+  /// to the executed-step index that produced them. Diagnostic only: it is what
+  /// lets a step report which of its ops must wait for a transfer to land.
+  folly::F14FastMap<nativert::ValueId, int32_t> returnedAtStep;
+
+  /// Count of executed steps so far, spanning nodes. Indexes returnedAtStep.
+  int32_t executedSteps{0};
+
+  /// Transfers whose pinned buffers have not been parsed into the frame yet,
+  /// oldest first. Always empty unless WaveConfig::deferD2h is on.
+  std::deque<PendingReturn> pendingReturns;
+
+  /// How many transfers ran deferred, and the total number of executed steps
+  /// they stayed in flight for (resolution step minus producing step). A span
+  /// of one is a transfer resolved by the very next step, i.e. no better than
+  /// waiting at the producer; what the deferral buys is the excess over that.
+  int32_t numDeferredReturns{0};
+  int64_t deferredStepSpan{0};
+
+  /// Sampled once per step, just before the host starts interpreting it: how
+  /// many already-issued steps the device has not finished yet. Zero means the
+  /// queue had drained and this step's whole interpretation is exposed as idle;
+  /// that is the quantity deeper run-ahead has to raise. kTiming only, because
+  /// each sample costs a cudaEventQuery per step still in flight.
+  int64_t runAheadSum{0};
+  int32_t runAheadSamples{0};
+  int32_t runAheadMax{0};
+  int32_t numDrainedStarts{0};
+
+  /// Bytes stamped for release on steps the device has not finished, i.e. the
+  /// memory run-ahead is holding onto. Checked against
+  /// WaveConfig::maxDelayedFree before a step allocates.
+  int64_t delayedFreeBytes{0};
+
+  /// How many times that ceiling forced a drain, and the high-water mark of
+  /// delayedFreeBytes -- which is how much peak the run-ahead is costing.
+  int32_t numMemoryStalls{0};
+  int64_t maxDelayedFreeSeen{0};
+
+  /// Ops whose setup a step's first pass had to leave for the second, and how
+  /// many steps needed a second pass at all.
+  int32_t numDeferredOps{0};
+  int32_t numDeferredSteps{0};
+
+  /// Steps whose grid variant changed mid-run, forcing the setup pass to be
+  /// redone. Under a forced cooperative grid the choice is fixed, so this must
+  /// stay at zero; anything else means a step is paying for two passes.
+  int32_t numGridRedos{0};
+
+  /// Host time spent releasing frame values. Reported next to the allocation
+  /// time as the part of the interpretation that compiling the host path
+  /// cannot remove.
+  int64_t freeUs{0};
+
+  /// Buffers whose last use has passed but which are held here instead of being
+  /// handed back to the caching allocator, keyed by storage bytes. A later wave
+  /// kernel takes one instead of allocating: allocation costs the same per call
+  /// whatever the size, so skipping the call is the whole win. Nothing needs to
+  /// be synced -- the wave stream is in order, so the donor's readers have
+  /// finished before the taker's kernel starts, and the storage never stops
+  /// being owned. Only wave-path kernel outputs take part; a standalone may run
+  /// on the torch stream, where that ordering does not hold.
+  ///
+  /// Cleared after the closing stream syncs (see clearDonationPool), so an
+  /// exception on the way out cannot strand the buffers.
+  folly::F14FastMap<int64_t, std::vector<at::Tensor>> donatable;
+
+  /// Bytes currently parked in 'donatable'.
+  int64_t donatableBytes{0};
+
+  /// Allocations served from the pool, and those that had to fall through to
+  /// the allocator.
+  int64_t donationHits{0};
+  int64_t donationMisses{0};
+
+  /// Buffers dropped to stay under the delayed-free ceiling.
+  int64_t donationEvictions{0};
+
+  /// Host time spent in the pool itself (take + donate + evict), so its
+  /// overhead can be read against the allocation time it removes.
+  int64_t donationUs{0};
+
+  /// Values released during this run. The fusion-coverage report needs them
+  /// because it infers "this node never ran" from an empty frame slot, and a
+  /// released intermediate leaves exactly that -- so without this every value
+  /// freeIntermediates reclaims would be counted as an uncovered op. Only
+  /// populated when tracing, which is the only time the report is produced.
+  folly::F14FastSet<nativert::ValueId> freedValueIds;
+
+  /// Last-use values stamped onto a step before their node's last one, and
+  /// onto the last one. Says how much WaveConfig::stepLastUse actually moved.
+  int32_t numLastUseEarly{0};
+  int32_t numLastUseAtNodeEnd{0};
+
+  /// Under trace kFrame only: every value already stamped for release, mapped
+  /// to the step that stamped it. A later step reading one of them means the
+  /// reader analysis missed a reader and the buffer was freed too early, which
+  /// otherwise only shows up as a wrong result.
+  folly::F14FastMap<nativert::ValueId, int32_t> releasedAtStep;
 };
+
+/// Offers a released buffer to the donation pool. Takes ownership only when the
+/// tensor is a solely-owned CUDA storage -- a view or a second frame slot over
+/// the same memory means it is not actually free. Returns true when the pool
+/// took it, in which case the caller must not also release it.
+bool donateFreedTensor(ExecutionState& state, const at::Tensor& tensor);
+
+/// Returns a tensor of 'dims' and 'dtype' backed by a pooled buffer of exactly
+/// 'bytes', or an undefined tensor when the pool has none. Exact sizes only:
+/// best-fit hands multi-megabyte buffers to small requests and wastes far more
+/// than it saves.
+at::Tensor takeDonatedTensor(
+    ExecutionState& state,
+    int64_t bytes,
+    c10::ScalarType dtype,
+    c10::IntArrayRef dims);
+
+/// Drops pooled buffers, largest first, while the pool holds more than
+/// 'limitBytes'. Called when an allocation misses and the parked bytes would
+/// otherwise push past the delayed-free ceiling.
+void evictDonatable(ExecutionState& state, int64_t limitBytes);
+
+/// Releases every pooled buffer. Call after the closing stream syncs.
+void clearDonationPool(ExecutionState& state);
 
 /// Advances every step vector currently in kAllocated to kSynced (call right
 /// after a wave-stream wait, when those steps' kernels are known complete).
@@ -294,6 +621,116 @@ void advanceSyncedStages(ExecutionState& state);
 /// advanceSyncedStages). Used everywhere the wave stream is drained so freeing
 /// is bundled with the wait.
 void syncWaveStream(ExecutionState& state);
+
+/// Releases 'ids' from the frame right away. For last-use values that have to
+/// be stamped onto a step a blocking sync already swept to kSynced: the sweeps
+/// only ever visit a kAllocated step, so nothing would free them otherwise.
+/// The caller must have waited for that step, which the sweep implies.
+void freeLastUseNow(
+    ExecutionState& state,
+    const std::vector<nativert::ValueId>& ids);
+
+/// Advances to kSynced every kAllocated step whose waveDone event has already
+/// completed, and frees its lastUseIds. The non-blocking counterpart of
+/// advanceSyncedStages: a device-side event wait orders the GPU but tells the
+/// host nothing, so a step must not be declared synced on one. Event::query()
+/// is a cheap non-blocking host check that does establish it. Freeing happens
+/// slightly later than under the old host-sync scheme, which raises the
+/// transient memory peak a little.
+void advanceCompletedStages(ExecutionState& state);
+
+/// Copies the return values a step's kernels sent back from its pinned buffer
+/// into the execution frame: tensor shapes via resize_, scalars via setIValue.
+/// The caller must have waited for that step's transfer.
+void processReturnData(
+    StepVectors& sv,
+    nativert::ExecutionFrame& frame,
+    uint8_t* pinnedBase);
+
+/// Waits for and parses every pending return produced at executed step
+/// 'throughStep' or earlier, oldest first (see ExecutionState::pendingReturns).
+/// A negative 'throughStep' resolves nothing; one past the newest entry
+/// resolves all of them. Cheap when the transfer has already landed, which is
+/// the case at every call site that follows a stream wait.
+void resolvePendingReturns(ExecutionState& state, int32_t throughStep);
+
+/// Resolves everything still pending. For the points where the frame has to be
+/// complete regardless of what is read next: the end of a run, and the debug
+/// paths that walk arbitrary values.
+void resolveAllPendingReturns(ExecutionState& state);
+
+/// Samples how many already-issued steps the device has not finished, and folds
+/// it into the run-ahead counters. Call once per step, immediately before its
+/// interpretation begins, so a sample of zero means that interpretation runs
+/// against an empty queue and is fully exposed as idle. Does nothing unless the
+/// kTiming trace bit is on.
+void sampleRunAhead(ExecutionState& state);
+
+/// TSC ticks per microsecond, calibrated once. Use with
+/// folly::hardware_timestamp() for anything timed per op: std::chrono here is
+/// backed by kvm-clock at tens of microseconds a call, so a per-op chrono pair
+/// costs far more than the work it measures.
+double tscTicksPerMicro();
+
+/// True when TW_ALLOC_TRACE is set in the environment. Enables an event line
+/// per kernel-output allocation and per released frame value, so the fraction
+/// of allocations a same-size freed buffer could have served can be measured
+/// offline. Read once; the check is a load.
+bool allocTraceEnabled();
+
+/// Emits one allocation/free event: "ALLOCEV <kind> <id> <bytes>", where kind
+/// is keep / resize / alloc for a kernel output and free for a released value.
+/// Emission order is host program order, which is what a donation-pool
+/// simulation needs.
+void logAllocEvent(const char* kind, int32_t valueId, int64_t bytes);
+
+/// Emits an allocation event carrying the STATIC size key the compiler already
+/// knows for the output ("dyn" when the shape comes from a reserveShape lambda,
+/// which is opaque before execution), and remembers it for 'valueId' so the
+/// matching free event can report the same key. Two values with equal keys are
+/// provably the same byte size without running anything, which is what a
+/// compile-time donation edge needs.
+void logKeyedAllocEvent(
+    const char* kind,
+    int32_t valueId,
+    int64_t bytes,
+    const std::string& sizeKey);
+
+/// The static size key recorded for 'valueId', or "?" if none was seen.
+const std::string& recordedSizeKey(int32_t valueId);
+
+/// Stamps 'id' onto 'sv' for release when that step is swept, and accounts its
+/// bytes against the delayed-free ceiling.
+void addLastUseId(ExecutionState& state, StepVectors& sv, nativert::ValueId id);
+
+/// Drains both streams when the bytes waiting to be freed on already-issued
+/// steps exceed WaveConfig::maxDelayedFree, giving the memory back before the
+/// next step allocates. Call before a step sizes or allocates anything. Returns
+/// true if it drained. Both streams, not just the wave one: advanceSyncedStages
+/// releases on a wave-stream wait alone, and under run-ahead an eager
+/// standalone on the torch stream can still be reading one of those buffers.
+bool enforceDelayedFreeLimit(ExecutionState& state);
+
+/// Returns the process-wide Stream wrapping the CUDA stream that eager
+/// standalones are dispatched to, for recording events on and waiting for it.
+facebook::velox::wave::Stream& torchStream();
+
+/// Makes 'stream' wait, device-side, for everything already enqueued on the
+/// torch stream. A wave stream is non-blocking, so it no longer implicitly
+/// waits for the legacy default stream: anything a wave stream touches that
+/// eager work produced -- or that the caching allocator could hand it while an
+/// eager op still uses it -- needs this edge first.
+void waitForTorchStream(facebook::velox::wave::Stream& stream);
+
+/// Acquires a step's events, appends them to state.stepEvents and returns the
+/// entry. Under kTiming all four events come from the timing-enabled pool;
+/// otherwise only the ordering (*Done) events are taken, from the untimed pool.
+StepEvents& newStepEvents(ExecutionState& state, int32_t seq, int32_t stepIdx);
+
+/// Returns every event held by 'state' to its pool. Must run only after the
+/// streams that recorded them have been waited on, so no event is recycled
+/// while still pending.
+void releaseStepEvents(ExecutionState& state);
 
 /// Executes a single node via its OpKernel with tracing and error logging.
 /// When 'traceState' is non-null, traces the node's input values before the op

--- a/velox/experimental/torchwave/GraphView.cpp
+++ b/velox/experimental/torchwave/GraphView.cpp
@@ -123,6 +123,9 @@ void printGraphView(
       WaveConfig::get().elideClones) {
     elideReadOnlyClones(graph, waveGraphHolder->types());
   }
+  if (waveGraphHolder && WaveConfig::get().duplicateMetadata) {
+    duplicateMetadataOps(graph, waveGraphHolder->types(), *waveGraphHolder);
+  }
   std::cout << "\nProject Nodes:\n";
   torch::wave::ParallelNodes parallelNodes;
   auto* lastProjectNode = parallelNodes.makeParallelNodes(graph);

--- a/velox/experimental/torchwave/ParallelExpr.cpp
+++ b/velox/experimental/torchwave/ParallelExpr.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <sstream>
 #include <string>
@@ -29,6 +30,7 @@
 #include <vector>
 
 #include <c10/core/MemoryFormat.h>
+#include <c10/core/ScalarType.h>
 #include <fmt/format.h>
 #include <folly/CppAttributes.h>
 #include <folly/ScopeGuard.h>
@@ -1125,6 +1127,289 @@ int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types) {
     LOG(INFO) << "pre-partition clone pass: elided " << elided << " clone(s)";
   }
   return elided;
+}
+
+namespace {
+
+// The ScalarType newScalarValue needs to reproduce a scalar Value's type kind,
+// or nullopt when the kind is not a scalar. Inverse of the mapping in
+// WaveGraph::newScalarValue.
+std::optional<c10::ScalarType> scalarTypeOfKind(nativert::Type::Kind kind) {
+  switch (kind) {
+    case nativert::Type::Kind::SymInt:
+      return c10::ScalarType::Long;
+    case nativert::Type::Kind::SymFloat:
+      return c10::ScalarType::Double;
+    case nativert::Type::Kind::SymBool:
+      return c10::ScalarType::Bool;
+    default:
+      return std::nullopt;
+  }
+}
+
+// An attribute holds a Constant, a variant whose unique_ptr<Graph> alternative
+// makes the whole variant move-only. A getter never carries a subgraph, but
+// check rather than silently duplicating a node without its attributes.
+bool attributesAreCopyable(NodeCP node) {
+  for (const auto& attr : node->attributes()) {
+    if (std::holds_alternative<std::unique_ptr<nativert::Graph>>(attr.value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void copyAttributes(NodeCP from, nativert::Node* to) {
+  for (const auto& attr : from->attributes()) {
+    std::visit(
+        [&](const auto& constant) {
+          using T = std::decay_t<decltype(constant)>;
+          if constexpr (!std::is_same_v<T, std::unique_ptr<nativert::Graph>>) {
+            to->addAttribute({attr.name, constant});
+          }
+        },
+        attr.value);
+  }
+}
+
+// The nodes the partitioner can see. makeParallelNodes seeds from the graph
+// output node and walks back through input producers, so a node reachable only
+// from an _assert_scalar chain is never placed in a ProjectNode and never
+// counts toward a CSE border. Duplicating for such a user would pay a node and
+// remove no boundary. Side-effect edges are deliberately not followed: they
+// only add users, and over-counting is the direction that costs.
+std::unordered_set<NodeCP> reachableFromOutputs(const nativert::Graph& graph) {
+  std::unordered_set<NodeCP> reachable{graph.outputNode()};
+  std::vector<NodeCP> pending{graph.outputNode()};
+  while (!pending.empty()) {
+    NodeCP node = pending.back();
+    pending.pop_back();
+    for (const auto& input : node->inputs()) {
+      if (input.value == nullptr) {
+        continue;
+      }
+      const auto* producer = input.value->producer();
+      if (producer != nullptr && reachable.insert(producer).second) {
+        pending.push_back(producer);
+      }
+    }
+  }
+  return reachable;
+}
+
+// Attaches 'constraint' to a value the pass just created. A rewrite-created
+// value carries nothing by default: types.types is a no-op for a scalar, and a
+// rank left at -1 has produced a rank-0 result before, so copy the original's
+// rank and layout explicitly. graphOutput / externallyOwned are deliberately
+// not carried -- the duplicate is a fresh internal value.
+void setDuplicateConstraint(
+    ValueTypes& types,
+    ValueCP value,
+    const ValueConstraint& constraint) {
+  auto id = value->id();
+  if (id < 0) {
+    return;
+  }
+  if (static_cast<size_t>(id) >= types.constraints.size()) {
+    types.constraints.resize(id + 1);
+  }
+  // Grown to id + 1 just above.
+  // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+  auto& target = types.constraints[id];
+  target.rank = constraint.rank;
+  target.contiguity = constraint.contiguity;
+  target.zeroStrides = constraint.zeroStrides;
+}
+
+} // namespace
+
+int64_t duplicateMetadataOps(
+    nativert::Graph& graph,
+    ValueTypes& types,
+    WaveGraph& waveGraph) {
+  NodeCP outputNode = graph.outputNode();
+  constexpr int32_t kOutputPos = std::numeric_limits<int32_t>::max();
+  const auto reachable = reachableFromOutputs(graph);
+
+  std::unordered_map<NodeCP, int32_t> pos;
+  int32_t idx = 0;
+  for (const auto& node : graph.nodes()) {
+    pos[&node] = &node == outputNode ? kOutputPos : idx++;
+  }
+
+  // Program position of each value's last live read, from the graph as it is
+  // now. Every decision below is taken against this snapshot: inserting a
+  // duplicate adds a read of the getter's operand, and reading a stale lastUse
+  // is what keeps that from being mistaken for a lifetime extension.
+  folly::F14FastMap<ValueCP, int32_t> lastUse;
+  for (const auto& node : graph.nodes()) {
+    if (reachable.count(&node) == 0) {
+      continue;
+    }
+    const int32_t nodePos = pos.at(&node);
+    for (const auto& input : node.inputs()) {
+      if (input.value == nullptr) {
+        continue;
+      }
+      auto [it, inserted] = lastUse.emplace(input.value, nodePos);
+      if (!inserted) {
+        it->second = std::max(it->second, nodePos);
+      }
+    }
+  }
+  auto lastUseOf = [&](ValueCP value) {
+    auto it = lastUse.find(value);
+    return it == lastUse.end() ? -1 : it->second;
+  };
+  auto reachableUsers = [&](ValueCP value) {
+    int32_t count = 0;
+    for (auto* user : value->users()) {
+      count += reachable.count(user) > 0 ? 1 : 0;
+    }
+    return count;
+  };
+
+  // Snapshot the candidates: duplicating rewires users, and a live walk would
+  // revisit the duplicates it just inserted. Two families qualify as free to
+  // recompute: a getter, whose output is a scalar read out of tensor metadata,
+  // and a view, which is set up host-side from its base's sizes and strides and
+  // allocates nothing.
+  std::vector<NodeCP> candidates;
+  for (const auto& node : graph.nodes()) {
+    const Metadata* meta = Registry::metadata(node.target());
+    if (meta == nullptr || (!meta->isMetadataGetter && !meta->metadataOnly)) {
+      continue;
+    }
+    if (node.outputs().size() != 1 || node.inputs().empty() ||
+        node.outputs()[0] == nullptr || !attributesAreCopyable(&node)) {
+      continue;
+    }
+    const auto kind = node.outputs()[0]->type().kind();
+    const bool isGetter =
+        meta->isMetadataGetter && scalarTypeOfKind(kind).has_value();
+    const bool isViewOp = meta->metadataOnly && meta->isView() &&
+        kind == nativert::Type::Kind::Tensor;
+    if (!isGetter && !isViewOp) {
+      continue;
+    }
+    candidates.push_back(&node);
+  }
+
+  int64_t duplicated = 0;
+  int64_t viewsDuplicated = 0;
+  int64_t bordersRemoved = 0;
+  for (NodeCP node : candidates) {
+    ValueCP out = node->outputs()[0];
+    const bool isViewOp = out->type().kind() == nativert::Type::Kind::Tensor;
+    // A returned size keeps the original: replaceAllUses-style rewiring does
+    // not reach the output node, and it costs nothing to leave it there.
+    bool feedsGraphOutput = false;
+    bool writtenInPlace = false;
+    std::vector<NodeCP> users;
+    for (auto* user : out->users()) {
+      if (user == outputNode) {
+        feedsGraphOutput = true;
+      } else if (reachable.count(user) > 0) {
+        // A view written through by one user and read by another is a single
+        // shared buffer, not two interchangeable aliases: splitting it would
+        // send the write to a copy the readers never see.
+        writtenInPlace |= inPlaceSelf(user) == out;
+        users.push_back(user);
+      }
+    }
+    if (writtenInPlace) {
+      continue;
+    }
+    // The original serves the graph output if there is one, else the first
+    // user. Only a value read more than once is a border worth breaking.
+    const size_t firstToRewire = feedsGraphOutput ? 0 : 1;
+    if (users.size() <= firstToRewire) {
+      continue;
+    }
+
+    // Every operand must already be available at the use sites, so that moving
+    // the read there neither creates a new border nor extends a buffer's
+    // lifetime. Three ways to qualify:
+    //   - producer-less (a graph input, weight or constant): live throughout;
+    //   - a scalar with more than one reachable reader: already a CSE border
+    //     the partitioner materializes, and a SymInt owns no buffer, so reading
+    //     it later costs nothing. This is what admits the dynamic slice bounds
+    //     -- slice(input, item(..), item(..)) with both items already
+    //     materialized -- which the lifetime rule alone would reject;
+    //   - otherwise, it must already outlive this node's own last use, which
+    //     also implies a reader besides this node.
+    const int32_t outLastUse = lastUseOf(out);
+    auto isAvailable = [&](ValueCP value) {
+      if (value == nullptr) {
+        return false;
+      }
+      if (types.externallyOwned(value)) {
+        return true;
+      }
+      const auto kind = value->type().kind();
+      if ((kind == nativert::Type::Kind::SymInt ||
+           kind == nativert::Type::Kind::SymFloat ||
+           kind == nativert::Type::Kind::SymBool) &&
+          reachableUsers(value) > 1) {
+        return true;
+      }
+      return lastUseOf(value) >= outLastUse;
+    };
+    bool operandsAvailable = true;
+    for (const auto& input : node->inputs()) {
+      if (!isAvailable(input.value)) {
+        operandsAvailable = false;
+        break;
+      }
+    }
+    if (!operandsAvailable) {
+      continue;
+    }
+
+    // A view's duplicate needs the same dtype as the original, which for a
+    // tensor lives in the TensorMeta rather than the Value's type kind. Without
+    // a TensorMeta there is nothing to reproduce, so leave the node alone.
+    const nativert::TensorMeta* outMeta =
+        isViewOp && static_cast<size_t>(out->id()) < types.types.size()
+        ? types.types[out->id()]
+        : nullptr;
+    if (isViewOp && outMeta == nullptr) {
+      continue;
+    }
+    const auto dtype =
+        isViewOp ? outMeta->dtype() : *scalarTypeOfKind(out->type().kind());
+    const ValueConstraint constraint =
+        static_cast<size_t>(out->id()) < types.constraints.size()
+        // Bound tested on the line above.
+        // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+        ? types.constraints[out->id()]
+        : ValueConstraint{};
+    for (size_t i = firstToRewire; i < users.size(); ++i) {
+      auto* user = const_cast<nativert::Node*>(users[i]);
+      auto* duplicate =
+          graph.createNode(std::string(node->target()), node->inputs());
+      copyAttributes(node, duplicate);
+      // Immediately before the user, so the node list stays in program order
+      // (computeSideEffectEdges checks this) and the operands still precede it.
+      graph.insertBefore(duplicate, user);
+      auto* duplicateOut = isViewOp
+          ? waveGraph.newTensorValue(duplicate, out->name(), dtype)
+          : waveGraph.newScalarValue(duplicate, out->name(), dtype);
+      setDuplicateConstraint(types, duplicateOut, constraint);
+      rewireInput(user, out, duplicateOut);
+      ++duplicated;
+      viewsDuplicated += isViewOp ? 1 : 0;
+    }
+    ++bordersRemoved;
+  }
+
+  if (duplicated > 0) {
+    LOG(INFO) << "pre-partition metadata duplication: " << duplicated
+              << " node(s) duplicated (" << viewsDuplicated << " view, "
+              << duplicated - viewsDuplicated << " getter), " << bordersRemoved
+              << " shared value(s) reduced to a single use";
+  }
+  return duplicated;
 }
 
 void ParallelNodes::computeReuseEligibility(

--- a/velox/experimental/torchwave/ParallelExpr.h
+++ b/velox/experimental/torchwave/ParallelExpr.h
@@ -35,6 +35,17 @@ namespace torch::wave {
 /// layers. Returns the number elided.
 int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types);
 
+/// Rematerializes each multiply-used metadata getter (sym_size / sym_numel) at
+/// its use sites, so it stops being a shared value the partitioner has to
+/// materialize as a top-level output. Only duplicates a getter whose operand is
+/// already live at every use site, so no new border appears in its place.
+/// Call before partitioning and after any pass that merges equal values, which
+/// would undo it. Returns the number of nodes duplicated.
+int64_t duplicateMetadataOps(
+    nativert::Graph& graph,
+    ValueTypes& types,
+    WaveGraph& waveGraph);
+
 class ParallelNodes {
  public:
   /// Divides 'graph' into consecutive layers where each layer's expressions

--- a/velox/experimental/torchwave/Registry.h
+++ b/velox/experimental/torchwave/Registry.h
@@ -91,6 +91,8 @@ enum class StandaloneShortcut {
   kSplitWithSizes,
   kSqueezeDim,
   kExpand,
+  kSymSize,
+  kSymNumel,
 };
 
 /// Specifies which arguments determine the number of elements a kernel

--- a/velox/experimental/torchwave/Standalones.cpp
+++ b/velox/experimental/torchwave/Standalones.cpp
@@ -413,6 +413,19 @@ void runStandaloneShortcut(
       setOutput(c10::IValue(std::move(list)));
       break;
     }
+    case StandaloneShortcut::kSymSize: {
+      // (Tensor self, int dim) -> SymInt. The frame already holds the tensor,
+      // so this is a field read. The D2H path writes a plain Int IValue for a
+      // SymInt-typed kernel return, so produce the same thing here.
+      auto self = tensorAt(0);
+      const auto dim = c10::maybe_wrap_dim(intAt(1), self.dim());
+      setOutput(c10::IValue(self.size(dim)));
+      break;
+    }
+    case StandaloneShortcut::kSymNumel: {
+      setOutput(c10::IValue(tensorAt(0).numel()));
+      break;
+    }
     case StandaloneShortcut::kNone:
       break;
   }

--- a/velox/experimental/torchwave/Utils.h
+++ b/velox/experimental/torchwave/Utils.h
@@ -84,6 +84,7 @@ class Pool {
 
 using StreamPool = Pool<facebook::velox::wave::Stream>;
 using EventPool = Pool<facebook::velox::wave::Event>;
+using EventP = std::unique_ptr<facebook::velox::wave::Event>;
 
 /// Returns an alias of 'base' with the given shape, strides and element
 /// offset, built straight from the TensorImpl. This is the primitive

--- a/velox/experimental/torchwave/WaveConfig.cpp
+++ b/velox/experimental/torchwave/WaveConfig.cpp
@@ -69,6 +69,7 @@ std::string WaveConfig::toString() const {
   addInt("maxElementwiseVars", &WaveConfig::maxElementwiseVars);
   addInt("outOfLineExprSize", &WaveConfig::outOfLineExprSize);
   addBool("printTiming", &WaveConfig::printTiming);
+  addBool("perOpStandaloneTiming", &WaveConfig::perOpStandaloneTiming);
   addStr("traceValues", &WaveConfig::traceValues);
   addInt("tensorPrintElementLimit", &WaveConfig::tensorPrintElementLimit);
   addBool("reverify", &WaveConfig::reverify);
@@ -86,6 +87,14 @@ std::string WaveConfig::toString() const {
   addBool("freeIntermediates", &WaveConfig::freeIntermediates);
   addBool("inputContiguous", &WaveConfig::inputContiguous);
   addBool("mkSelect", &WaveConfig::mkSelect);
+  addBool("stepLastUse", &WaveConfig::stepLastUse);
+  addBool("syncEachStep", &WaveConfig::syncEachStep);
+  addBool("deferD2h", &WaveConfig::deferD2h);
+  addBool("runAhead", &WaveConfig::runAhead);
+  addInt("maxDelayedFree", &WaveConfig::maxDelayedFree);
+  addBool("duplicateMetadata", &WaveConfig::duplicateMetadata);
+  addBool("donateBuffers", &WaveConfig::donateBuffers);
+  addInt("donationCarryBytes", &WaveConfig::donationCarryBytes);
 
   if (parts.empty()) {
     return "defaults";

--- a/velox/experimental/torchwave/WaveConfig.h
+++ b/velox/experimental/torchwave/WaveConfig.h
@@ -87,6 +87,15 @@ struct WaveConfig {
   // Print timing for wave graph execution.
   bool printTiming{false};
 
+  // Attribute GPU time to individual eager standalone ops by syncing the torch
+  // stream after each one. That sync is what makes per-op numbers possible and
+  // is also the largest perturbation in the measurement: it serializes the
+  // standalones against each other and against the wave stream, so the per-step
+  // device times and the GPU-idle figure stop reflecting what an untraced run
+  // does. Off by default under kTiming, where the per-step standalone event
+  // pair gives an unperturbed device measurement instead.
+  bool perOpStandaloneTiming{false};
+
   // Comma-separated list of value ids to trace during execution.
   std::string traceValues;
 
@@ -156,6 +165,72 @@ struct WaveConfig {
   // right after that node's composite invocation executes, instead of keeping
   // them until the whole graph finishes. Off by default.
   bool freeIntermediates{false};
+
+  // If true, release each last-use value after the last STEP that reads it
+  // rather than after the node's last step. A node's ops finish at different
+  // steps, so a value read only by a short op stays live for the whole node
+  // under the coarser scheme. Only consulted when freeIntermediates is set.
+  bool stepLastUse{true};
+
+  // If true, drain both streams at the end of every step, so a step's freeable
+  // buffers are back in the caching allocator before the next step allocates.
+  // Serializes the pipeline and costs wall time; it exists to make the peak
+  // memory reflect the release schedule rather than how far the host ran ahead.
+  bool syncEachStep{false};
+
+  // If true, do not block the host on a step's device-to-host transfer at the
+  // step that issues it. The transfer is recorded as pending and its pinned
+  // buffer is parsed into the frame at the first later step that can read one
+  // of the values it brings back, so a step that reads none of them does its
+  // sizing, allocation, parameter fill and launch while the transfer is still
+  // in flight. Off by default.
+  bool deferD2h{false};
+
+  // If true, drop the host-side stream waits that are not a real data or memory
+  // dependency, so the host can queue as many steps ahead of the device as it
+  // can interpret. Today that is the default-stream drain at the end of every
+  // composite invocation that ran an eager standalone: the cross-stream
+  // ordering it used to provide is now carried device-side by the
+  // lastStandaloneDone / lastWaveDone event edges, and a step's buffers are
+  // only freed once its own completion events have been observed, so the drain
+  // costs a host stall per node and buys nothing. Needs deferD2h to be of any
+  // use -- otherwise every transfer still stops the host at its producing step.
+  // Off by default.
+  bool runAhead{false};
+
+  // Ceiling, in bytes, on how much freeable memory may sit in already-issued
+  // but not yet completed steps. Running ahead delays every free until the
+  // device catches up, so the peak grows by roughly the bytes in flight; when
+  // this is exceeded the host drains both streams before allocating any more,
+  // trading the run-ahead back for the memory. 0 disables the check. Only
+  // meaningful with freeIntermediates, which is what makes the frees delayable.
+  int64_t maxDelayedFree{1LL << 30};
+
+  // If true, hold a released wave-kernel buffer instead of returning it to the
+  // caching allocator, and hand it to a later wave kernel that needs exactly
+  // the same number of bytes. Allocation costs roughly the same per call at any
+  // size, so skipping the call is the win, not the memory. Safe without a sync
+  // because the wave stream is in order and the buffer is never unowned. Off by
+  // default.
+  bool donateBuffers{false};
+
+  // Bytes of donatable buffers carried between executions. The pool is trimmed
+  // to this at the end of each run. Distinct from maxDelayedFree, which bounds
+  // freeing held up by run-ahead within a run: carrying buffers across runs
+  // keeps them out of the caching allocator entirely, so hoarding the big ones
+  // makes every allocation the pool does NOT serve more expensive.
+  int64_t donationCarryBytes{64LL << 20};
+
+  // If true, run the pre-partition metadata-duplication pass: rematerialize a
+  // multiply-used metadata getter (sym_size / sym_numel) once per use site so
+  // it stops being a shared value. A value with more than one user is a CSE
+  // border, which the partitioner turns into a top-level output of its
+  // ProjectNode -- a frame slot, an output and a parameter block per step. A
+  // metadata getter reads only shape fields, so recomputing it is free, but it
+  // only pays when its tensor operand is available at the use site anyway;
+  // otherwise the border just moves from the getter's output to its input. Off
+  // by default.
+  bool duplicateMetadata{false};
 
   // If true, the graph optimizer assumes every producer-less value (model
   // input, weight, or constant) is contiguous, so downstream passes may treat

--- a/velox/experimental/torchwave/WaveGraph.cpp
+++ b/velox/experimental/torchwave/WaveGraph.cpp
@@ -246,6 +246,12 @@ WaveGraph::WaveGraph(ModelContext* modelContext)
     elideReadOnlyClones(*graph_, types_);
   }
 
+  // Last of the pre-partition passes: the clone CSE above merges equal values,
+  // which would undo the duplicates this inserts.
+  if (WaveConfig::get().duplicateMetadata) {
+    duplicateMetadataOps(*graph_, types_, *this);
+  }
+
   // Graph outputs (and, for list-typed outputs, their elements) escape the
   // graph, so LaunchData must never release them as per-op intermediates.
   graphOutputIds_.clear();

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -48,6 +48,10 @@
 // debug_single_ops is now WaveConfig::debugSingleOps
 
 DEFINE_bool(print_timing, false, "Print timing for wave graph execution");
+DEFINE_bool(
+    per_op_standalone_timing,
+    false,
+    "Time each eager standalone separately by syncing the torch stream after every one. That sync is what makes per-op numbers possible and is also the largest perturbation: it serializes the standalones against each other and against the wave stream, so per-step device times and GPU idle stop reflecting an untraced run");
 DEFINE_int32(num_repeats, 1, "Number of timed repetitions for each run type");
 DEFINE_bool(
     standalone_kernels,
@@ -161,6 +165,38 @@ DEFINE_bool(
     free_intermediates,
     false,
     "Release each ProjectNode's last-use value tensors right after its composite invocation executes, instead of at end-of-graph");
+DEFINE_bool(
+    step_last_use,
+    true,
+    "With --free_intermediates, release each last-use value after the last step that reads it instead of after the node's last step");
+DEFINE_bool(
+    sync_each_step,
+    false,
+    "Drain both streams at the end of every step, so freed buffers are back in the allocator before the next step allocates (serializes the pipeline; for measuring peak memory)");
+DEFINE_bool(
+    defer_d2h,
+    false,
+    "Do not wait for a step's device-to-host transfer at the step that issues it; parse its pinned buffer at the first later step that reads one of the returned values");
+DEFINE_bool(
+    run_ahead,
+    false,
+    "Drop the host stream waits that are not a real data or memory dependency (the per-node default-stream drain), so the host can queue steps arbitrarily far ahead of the device");
+DEFINE_int64(
+    max_delayed_free,
+    1LL << 30,
+    "Ceiling in bytes on freeable memory sitting in already-issued but incomplete steps; exceeding it drains both streams before the next allocation. 0 disables");
+DEFINE_bool(
+    donate_buffers,
+    false,
+    "Hold a released wave-kernel buffer and hand it to a later wave kernel needing exactly the same byte size, instead of returning it to the caching allocator");
+DEFINE_int64(
+    donation_carry_bytes,
+    64LL << 20,
+    "Bytes of donatable buffers carried between executions; the pool is trimmed to this at the end of each run");
+DEFINE_bool(
+    duplicate_metadata,
+    false,
+    "Rematerialize each multiply-used sym_size / sym_numel at its use sites before partitioning, so it stops being a top-level output of a ProjectNode");
 DEFINE_bool(
     input_contiguous,
     false,
@@ -548,6 +584,7 @@ void ExecutorTestBase::SetUpTestSuite() {
   }
 
   WaveConfig::get().printTiming = FLAGS_print_timing;
+  WaveConfig::get().perOpStandaloneTiming = FLAGS_per_op_standalone_timing;
   WaveConfig::get().allStandalone = FLAGS_standalone_kernels;
   WaveConfig::get().blockSize = FLAGS_block_dim;
   WaveConfig::get().trace = FLAGS_trace;
@@ -573,6 +610,14 @@ void ExecutorTestBase::SetUpTestSuite() {
   WaveConfig::get().enableReuse = FLAGS_enable_reuse;
   WaveConfig::get().elideClones = FLAGS_elide_clones;
   WaveConfig::get().freeIntermediates = FLAGS_free_intermediates;
+  WaveConfig::get().stepLastUse = FLAGS_step_last_use;
+  WaveConfig::get().syncEachStep = FLAGS_sync_each_step;
+  WaveConfig::get().deferD2h = FLAGS_defer_d2h;
+  WaveConfig::get().runAhead = FLAGS_run_ahead;
+  WaveConfig::get().maxDelayedFree = FLAGS_max_delayed_free;
+  WaveConfig::get().duplicateMetadata = FLAGS_duplicate_metadata;
+  WaveConfig::get().donateBuffers = FLAGS_donate_buffers;
+  WaveConfig::get().donationCarryBytes = FLAGS_donation_carry_bytes;
   WaveConfig::get().inputContiguous = FLAGS_input_contiguous;
   WaveConfig::get().mkSelect = FLAGS_mk_select;
   if (!FLAGS_print_options.empty()) {

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -221,10 +221,25 @@ Stream::Stream() {
   CUDA_CHECK(cudaStreamCreate(&stream_->stream));
 }
 
+Stream::Stream(bool nonBlocking) {
+  stream_ = std::make_unique<StreamImpl>();
+  CUDA_CHECK(cudaStreamCreateWithFlags(
+      &stream_->stream,
+      nonBlocking ? cudaStreamNonBlocking : cudaStreamDefault));
+}
+
 Stream::~Stream() {
-  if (stream_->stream) {
+  if (stream_->stream && owned_) {
     cudaStreamDestroy(stream_->stream);
   }
+}
+
+std::unique_ptr<Stream> Stream::external(void* handle) {
+  auto impl = std::make_unique<StreamImpl>();
+  impl->stream = static_cast<cudaStream_t>(handle);
+  auto stream = std::make_unique<Stream>(std::move(impl));
+  stream->owned_ = false;
+  return stream;
 }
 
 void Stream::wait() {

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -61,6 +61,22 @@ class Stream {
   Stream(std::unique_ptr<StreamImpl> impl);
 
   Stream();
+
+  /// Creates a stream that does not implicitly synchronize with the legacy
+  /// default stream. A default (blocking) stream waits for previously issued
+  /// stream-0 work and stream 0 waits for it, so work on a blocking stream can
+  /// never overlap work another thread issues to stream 0. Pass true only when
+  /// the caller establishes the ordering it needs explicitly, with events.
+  explicit Stream(bool nonBlocking);
+
+  /// Returns a Stream wrapping an externally owned CUDA stream handle
+  /// ('cudaStream_t' passed as void*; nullptr is the legacy default stream).
+  /// Destroying the returned Stream does not destroy the underlying stream.
+  /// Lets callers that cannot include the CUDA headers -- e.g. a
+  /// CPU-configured translation unit -- record events on and wait for a stream
+  /// they did not create, such as PyTorch's.
+  static std::unique_ptr<Stream> external(void* handle);
+
   virtual ~Stream();
 
   /// Waits  until the stream is completed.
@@ -109,6 +125,9 @@ class Stream {
   std::unique_ptr<StreamImpl> stream_;
   void* userData_{nullptr};
   bool isTransfer_{false};
+  // False for a Stream that only wraps a handle someone else created, so the
+  // destructor leaves the underlying stream alone.
+  bool owned_{true};
 
   friend class Event;
 };
@@ -140,6 +159,20 @@ class Event {
   /// Returns time in ms betweene 'this' and an earlier 'start'. Both events
   /// must enable timing.
   float elapsedTime(const Event& start) const;
+
+  /// True once record() has been called. A pooled event that was never
+  /// re-recorded must not be read back: cudaEventQuery reports success on it
+  /// and cudaEventElapsedTime returns nonsense, so the caller has to track this
+  /// rather than ask CUDA.
+  bool recorded() const {
+    return recorded_;
+  }
+
+  /// Clears recorded(), for an event going back to a pool. Re-recording a
+  /// cudaEvent_t simply overwrites it, so there is nothing else to reset.
+  void reset() {
+    recorded_ = false;
+  }
 
  private:
   std::unique_ptr<EventImpl> event_;


### PR DESCRIPTION
Summary:
Orders the wave stream against the PyTorch stream with CUDA events instead of
host-blocking stream syncs, and uses the same events to measure where the
device actually goes idle. Implements the design in the accompanying notes.

- `wave/common`: `Stream::external()` returns a non-owning `Stream` around a
  handle someone else created, so a CPU-configured translation unit can record
  events on PyTorch's stream; `Stream(bool nonBlocking)`; `Event::recorded()` /
  `reset()`, because `cudaEventQuery` reports success on a never-recorded event
  and `cudaEventElapsedTime` returns nonsense on one.
- Two pooled event kinds: ordering-only (`cudaEventDisableTiming`) always, and
  timing-enabled under the kTiming trace bit. Every event is returned to its
  pool at the end of the run, so steady-state allocation is zero after the
  first run.
- `StepEvents` per step. The cross-stream wait is enqueued BEFORE the matching
  `*Begin` event is recorded, so that timestamp is when the step's GPU work
  really started with its dependency satisfied; recorded first it would fire as
  soon as the stream drained and silently understate idle.
- The two `syncWaveStream` calls in the step loop become device-side event
  edges, and the kTiming-only `stream->wait()` in `launch` is deleted -- its
  only purpose was to make the host-measured `kernelUs` approximate GPU time,
  which the event pair now does properly. The D2H path keeps its host wait,
  since `processReturnData` reads the pinned buffer, but records `waveDone`
  before it.
- Wave streams become `cudaStreamNonBlocking`. Without this the driver
  serializes them against the legacy default stream and there is no overlap to
  measure; with it, the event edges above are load-bearing for correctness.
- The condition those edges have to enforce, stated once and applied at every
  entry point: a wave stream must wait on an event recorded on the torch stream
  before it touches any memory PyTorch owns. `waitForTorchStream` is that edge.
  The `StepEvents` chain only covers work issued inside a run, and `executeWave`
  starts it empty, so a run's first kernels were ordered against nothing the
  caller left on the torch stream. Two distinct things need the edge, not one:
  the eager ops that produced the inputs run there, and every wave operand and
  output is a caching-allocator tensor that no `recordStream` call ever
  associates with the wave stream, so the allocator is free to hand a wave
  output a block an eager op is still reading. The second is why per-value
  events are not enough -- the hazard is over memory, not over values. A
  blocking wave stream used to cover both implicitly. Applied at `executeWave`
  entry and in `tensorsToDevice` / `tensorsToHost`, which copy on a pooled
  stream that is now non-blocking too.
- `syncTorchDefaultStream()` now runs BEFORE `syncWaveStream()` at the end of a
  run, matching `enforceDelayedFreeLimit`: the latter releases frame values off
  a wave-stream wait alone, and an eager standalone can still be reading one.
- `advanceCompletedStages`: freeing intermediates must not ride on a
  device-side event wait, which orders the GPU but tells the host nothing.
  Sweeps with the non-blocking `Event::query()` instead, resuming at a cursor
  and stopping at the first step that is not done -- steps complete in order
  because each stream records in step order and the cross-stream edges chain
  them, so this is one query per step rather than a rescan per launch.
- Per-op standalone timing (a `syncTorchDefaultStream()` after every eager op)
  moves behind `WaveConfig::perOpStandaloneTiming`, off by default. It was the
  largest perturbation in the measurement and it defeats the overlap; the
  per-step standalone event pair measures the same device time without it.
- Report gains `GPU idle`, per-step `gpu=` / `idle=` / `standaloneGpu=`, and a
  D2H dependency summary: how many ops in each step read a value an earlier
  step returned, split by fused / standalone / shortcut, with the distance back
  to the nearest producer. Shortcuts taint their outputs so a fused op reaching
  a returned scalar through a chain of metadata-only ops is counted, and output
  descriptors built by a host-side view are followed too, since their shape and
  offset operands come from the view node rather than the op's inputs.

Reviewed By: Yuhta

Differential Revision: D115110721


