### PR TITLE
feat: Support toIntermediate in SumAggregate

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1625,6 +1625,8 @@ void GroupingSet::toIntermediate(
     if (function->supportsToIntermediate()) {
       populateTempVectors(i, input);
       VELOX_DCHECK(aggregateVector);
+      TestValue::adjust(
+          "facebook::velox::exec::Aggregate::toIntermediate", function.get());
       function->toIntermediate(rows, tempVectors_, aggregateVector);
       ++numToIntermediateFastPathCalls_;
       continue;

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1625,8 +1625,6 @@ void GroupingSet::toIntermediate(
     if (function->supportsToIntermediate()) {
       populateTempVectors(i, input);
       VELOX_DCHECK(aggregateVector);
-      TestValue::adjust(
-          "facebook::velox::exec::Aggregate::toIntermediate", function.get());
       function->toIntermediate(rows, tempVectors_, aggregateVector);
       ++numToIntermediateFastPathCalls_;
       continue;

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -45,6 +45,35 @@ class SumAggregateBase
     return 1;
   }
 
+  bool supportsToIntermediate() const override {
+    return true;
+  }
+
+  void toIntermediate(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+    if constexpr (std::is_same_v<TInput, TAccumulator>) {
+      this->singleInputAsIntermediate(rows, args, result);
+      return;
+    }
+
+    auto* vector = result->asFlatVector<TAccumulator>();
+    auto* rawNulls = vector->mutableRawNulls();
+    bits::fillBits(rawNulls, 0, rows.size(), bits::kNull);
+    auto* rawValues = vector->mutableRawValues();
+
+    DecodedVector decoded(*args[0], rows);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decoded.isNullAt(row)) {
+        bits::clearNull(rawNulls, row);
+        rawValues[row] =
+            static_cast<TAccumulator>(decoded.valueAt<TInput>(row));
+      }
+    });
+  }
+
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::template doExtractValues<ResultType>(

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "exec/PlanNodeStats.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/AggregateUtil.h"
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -723,9 +723,11 @@ TEST_F(SumAggregationTest, dummySum) {
 }
 
 TEST_F(SumAggregationTest, abandonPartialAggregation) {
+  constexpr int32_t kNumBatches = 3;
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
-  for (auto batch = 0; batch < 3; ++batch) {
+  data.reserve(kNumBatches);
+  for (auto batch = 0; batch < kNumBatches; ++batch) {
     data.push_back(makeRowVector(
         {"k", "i", "b", "r", "m"},
         {makeFlatVector<int64_t>(

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -722,7 +722,7 @@ TEST_F(SumAggregationTest, dummySum) {
   assertQuery(plan, "SELECT sum(distinct c0), avg(c1) from tmp");
 }
 
-TEST_F(SumAggregationTest, abandonPartialAggregation) {
+DEBUG_ONLY_TEST_F(SumAggregationTest, abandonPartialAggregation) {
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -757,6 +757,11 @@ TEST_F(SumAggregationTest, abandonPartialAggregation) {
                   .capturePlanNodeId(partialNodeId)
                   .finalAggregation()
                   .planNode();
+  std::atomic_bool usedToIntermediateFastPath{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Aggregate::toIntermediate",
+      std::function<void(void*)>(
+          [&](void*) { usedToIntermediateFastPath = true; }));
   auto task =
       AssertQueryBuilder(plan, duckDbQueryRunner_)
           .maxDrivers(1)
@@ -773,6 +778,7 @@ TEST_F(SumAggregationTest, abandonPartialAggregation) {
       stats.at(partialNodeId)
           .customStats.at("abandonedPartialAggregationRows")
           .sum);
+  EXPECT_TRUE(usedToIntermediateFastPath);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -722,7 +722,7 @@ TEST_F(SumAggregationTest, dummySum) {
   assertQuery(plan, "SELECT sum(distinct c0), avg(c1) from tmp");
 }
 
-DEBUG_ONLY_TEST_F(SumAggregationTest, abandonPartialAggregation) {
+TEST_F(SumAggregationTest, abandonPartialAggregation) {
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {
@@ -757,11 +757,6 @@ DEBUG_ONLY_TEST_F(SumAggregationTest, abandonPartialAggregation) {
                   .capturePlanNodeId(partialNodeId)
                   .finalAggregation()
                   .planNode();
-  std::atomic_bool usedToIntermediateFastPath{false};
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Aggregate::toIntermediate",
-      std::function<void(void*)>(
-          [&](void*) { usedToIntermediateFastPath = true; }));
   auto task =
       AssertQueryBuilder(plan, duckDbQueryRunner_)
           .maxDrivers(1)
@@ -778,7 +773,9 @@ DEBUG_ONLY_TEST_F(SumAggregationTest, abandonPartialAggregation) {
       stats.at(partialNodeId)
           .customStats.at("abandonedPartialAggregationRows")
           .sum);
-  EXPECT_TRUE(usedToIntermediateFastPath);
+  EXPECT_GT(
+      stats.at(partialNodeId).customStats.at("toIntermediateFastPathCalls").sum,
+      0);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "exec/PlanNodeStats.h"
 #include "velox/exec/AggregateUtil.h"
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -719,6 +720,59 @@ TEST_F(SumAggregationTest, dummySum) {
       std::move(child));
 
   assertQuery(plan, "SELECT sum(distinct c0), avg(c1) from tmp");
+}
+
+TEST_F(SumAggregationTest, abandonPartialAggregation) {
+  constexpr vector_size_t kBatchSize = 100;
+  std::vector<RowVectorPtr> data;
+  for (auto batch = 0; batch < 3; ++batch) {
+    data.push_back(makeRowVector(
+        {"k", "i", "b", "r", "m"},
+        {makeFlatVector<int64_t>(
+             kBatchSize, [&](auto row) { return batch * kBatchSize + row; }),
+         makeFlatVector<int32_t>(
+             kBatchSize,
+             folly::identity,
+             [](auto row) { return row % 5 == 0; }),
+         makeFlatVector<int64_t>(
+             kBatchSize,
+             folly::identity,
+             [](auto row) { return row % 11 == 0; }),
+         makeFlatVector<float>(
+             kBatchSize,
+             folly::identity,
+             [](auto row) { return row % 7 == 0; }),
+         makeFlatVector<bool>(
+             kBatchSize, [](auto row) { return row % 3 != 0; })}));
+  }
+  createDuckDbTable(data);
+
+  core::PlanNodeId partialNodeId;
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .partialAggregation(
+                      {"k"},
+                      {"spark_sum(i)", "spark_sum(b)", "spark_sum(r)"},
+                      {"m", "m", "m"})
+                  .capturePlanNodeId(partialNodeId)
+                  .finalAggregation()
+                  .planNode();
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .maxDrivers(1)
+          .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
+          .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
+          .assertResults(
+              "SELECT k, sum(i) FILTER (WHERE m), "
+              "sum(b) FILTER (WHERE m), "
+              "sum(r) FILTER (WHERE m) FROM tmp GROUP BY k");
+
+  const auto stats = exec::toPlanStats(task->taskStats());
+  EXPECT_LT(
+      0,
+      stats.at(partialNodeId)
+          .customStats.at("abandonedPartialAggregationRows")
+          .sum);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/AggregateUtil.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"


### PR DESCRIPTION
The patch add `toIntermediate` support for sum aggregate.

`toIntermediate` is a fast path called from an abandoned partial aggregation.

Related: https://github.com/facebookincubator/velox/issues/18569