### PR TITLE
feat(spark): Support toIntermediate in AverageAggregate

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1625,6 +1625,8 @@ void GroupingSet::toIntermediate(
     if (function->supportsToIntermediate()) {
       populateTempVectors(i, input);
       VELOX_DCHECK(aggregateVector);
+      TestValue::adjust(
+          "facebook::velox::exec::Aggregate::toIntermediate", function.get());
       function->toIntermediate(rows, tempVectors_, aggregateVector);
       ++numToIntermediateFastPathCalls_;
       continue;

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1625,8 +1625,6 @@ void GroupingSet::toIntermediate(
     if (function->supportsToIntermediate()) {
       populateTempVectors(i, input);
       VELOX_DCHECK(aggregateVector);
-      TestValue::adjust(
-          "facebook::velox::exec::Aggregate::toIntermediate", function.get());
       function->toIntermediate(rows, tempVectors_, aggregateVector);
       ++numToIntermediateFastPathCalls_;
       continue;

--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -40,12 +40,29 @@ class AverageAggregate
       VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 1);
     auto* rowVector = result->as<RowVector>();
+    rowVector->clearAllNulls();
+
+    if (rows.isAllSelected() && !args[0]->mayHaveNulls()) {
+      rowVector->childAt(1) = BaseVector::createConstant(
+          BIGINT(), int64_t{1}, rows.size(), this->allocator_->pool());
+      if constexpr (std::is_same_v<TInput, TAccumulator>) {
+        rowVector->childAt(0) = args[0];
+      } else {
+        auto* sumVector = rowVector->childAt(0)->asFlatVector<TAccumulator>();
+        sumVector->clearAllNulls();
+        auto* rawSums = sumVector->mutableRawValues();
+        DecodedVector decoded(*args[0], rows);
+        for (vector_size_t row = 0; row < rows.size(); ++row) {
+          rawSums[row] = TAccumulator(decoded.valueAt<TInput>(row));
+        }
+      }
+      return;
+    }
+
     auto* sumVector = rowVector->childAt(0)->asFlatVector<TAccumulator>();
     auto* countVector = rowVector->childAt(1)->asFlatVector<int64_t>();
-    rowVector->clearAllNulls();
     sumVector->clearAllNulls();
     countVector->clearAllNulls();
-
     auto* rawSums = sumVector->mutableRawValues();
     auto* rawCounts = countVector->mutableRawValues();
     std::fill_n(rawSums, rows.size(), TAccumulator{0});

--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -30,6 +30,36 @@ class AverageAggregate
   explicit AverageAggregate(TypePtr resultType)
       : AverageAggregateBase<TInput, TAccumulator, TResult>(resultType) {}
 
+  bool supportsToIntermediate() const override {
+    return true;
+  }
+
+  void toIntermediate(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+    auto* rowVector = result->as<RowVector>();
+    auto* sumVector = rowVector->childAt(0)->asFlatVector<TAccumulator>();
+    auto* countVector = rowVector->childAt(1)->asFlatVector<int64_t>();
+    rowVector->clearAllNulls();
+    sumVector->clearAllNulls();
+    countVector->clearAllNulls();
+
+    auto* rawSums = sumVector->mutableRawValues();
+    auto* rawCounts = countVector->mutableRawValues();
+    std::fill_n(rawSums, rows.size(), TAccumulator{0});
+    std::fill_n(rawCounts, rows.size(), 0);
+
+    DecodedVector decoded(*args[0], rows);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decoded.isNullAt(row)) {
+        rawSums[row] = TAccumulator(decoded.valueAt<TInput>(row));
+        rawCounts[row] = 1;
+      }
+    });
+  }
+
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     auto rowVector = (*result)->as<RowVector>();

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -388,6 +388,11 @@ TEST_F(AverageAggregationTest, abandonPartialAggregation) {
                   .capturePlanNodeId(partialNodeId)
                   .finalAggregation()
                   .planNode();
+  std::atomic_bool usedToIntermediateFastPath{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Aggregate::toIntermediate",
+      std::function<void(void*)>(
+          [&](void*) { usedToIntermediateFastPath = true; }));
   auto task =
       AssertQueryBuilder(plan, duckDbQueryRunner_)
           .maxDrivers(1)
@@ -403,6 +408,7 @@ TEST_F(AverageAggregationTest, abandonPartialAggregation) {
       stats.at(partialNodeId)
           .customStats.at("abandonedPartialAggregationRows")
           .sum);
+  EXPECT_TRUE(usedToIntermediateFastPath);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -15,7 +15,7 @@
  */
 #include <folly/init/Init.h>
 
-#include "common/base/tests/GTestUtils.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -360,7 +360,7 @@ TEST_F(AverageAggregationTest, avgDecimalCompanionMergeExtract) {
   AssertQueryBuilder(plan).assertResults(expected);
 }
 
-DEBUG_ONLY_TEST_F(AverageAggregationTest, abandonPartialAggregation) {
+TEST_F(AverageAggregationTest, abandonPartialAggregation) {
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {
@@ -389,11 +389,6 @@ DEBUG_ONLY_TEST_F(AverageAggregationTest, abandonPartialAggregation) {
                   .capturePlanNodeId(partialNodeId)
                   .finalAggregation()
                   .planNode();
-  std::atomic_bool usedToIntermediateFastPath{false};
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Aggregate::toIntermediate",
-      std::function<void(void*)>(
-          [&](void*) { usedToIntermediateFastPath = true; }));
   auto task =
       AssertQueryBuilder(plan, duckDbQueryRunner_)
           .maxDrivers(1)
@@ -409,7 +404,9 @@ DEBUG_ONLY_TEST_F(AverageAggregationTest, abandonPartialAggregation) {
       stats.at(partialNodeId)
           .customStats.at("abandonedPartialAggregationRows")
           .sum);
-  EXPECT_TRUE(usedToIntermediateFastPath);
+  EXPECT_GT(
+      stats.at(partialNodeId).customStats.at("toIntermediateFastPathCalls").sum,
+      0);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -15,6 +15,7 @@
  */
 #include <folly/init/Init.h>
 
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
@@ -356,6 +357,52 @@ TEST_F(AverageAggregationTest, avgDecimalCompanionMergeExtract) {
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>(std::vector<int64_t>{2000000}, DECIMAL(16, 5))});
   AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(AverageAggregationTest, abandonPartialAggregation) {
+  constexpr vector_size_t kBatchSize = 100;
+  std::vector<RowVectorPtr> data;
+  for (auto batch = 0; batch < 3; ++batch) {
+    data.push_back(makeRowVector(
+        {"k", "i", "d", "m"},
+        {makeFlatVector<int64_t>(
+             kBatchSize, [&](auto row) { return batch * kBatchSize + row; }),
+         makeFlatVector<int32_t>(
+             kBatchSize,
+             folly::identity,
+             [](auto row) { return row % 5 == 0; }),
+         makeFlatVector<double>(
+             kBatchSize,
+             folly::identity,
+             [](auto row) { return row % 7 == 0; }),
+         makeFlatVector<bool>(
+             kBatchSize, [](auto row) { return row % 3 != 0; })}));
+  }
+  createDuckDbTable(data);
+
+  core::PlanNodeId partialNodeId;
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .partialAggregation(
+                      {"k"}, {"spark_avg(i)", "spark_avg(d)"}, {"m", "m"})
+                  .capturePlanNodeId(partialNodeId)
+                  .finalAggregation()
+                  .planNode();
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .maxDrivers(1)
+          .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
+          .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
+          .assertResults(
+              "SELECT k, avg(i) FILTER (WHERE m), "
+              "avg(d) FILTER (WHERE m) FROM tmp GROUP BY k");
+
+  const auto stats = exec::toPlanStats(task->taskStats());
+  EXPECT_LT(
+      0,
+      stats.at(partialNodeId)
+          .customStats.at("abandonedPartialAggregationRows")
+          .sum);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -365,7 +365,7 @@ TEST_F(AverageAggregationTest, abandonPartialAggregation) {
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {
     data.push_back(makeRowVector(
-        {"k", "i", "d", "m"},
+        {"k", "i", "d", "b", "v", "m"},
         {makeFlatVector<int64_t>(
              kBatchSize, [&](auto row) { return batch * kBatchSize + row; }),
          makeFlatVector<int32_t>(
@@ -376,6 +376,8 @@ TEST_F(AverageAggregationTest, abandonPartialAggregation) {
              kBatchSize,
              folly::identity,
              [](auto row) { return row % 7 == 0; }),
+         makeFlatVector<int64_t>(kBatchSize, folly::identity),
+         makeFlatVector<double>(kBatchSize, folly::identity),
          makeFlatVector<bool>(
              kBatchSize, [](auto row) { return row % 3 != 0; })}));
   }
@@ -407,6 +409,28 @@ TEST_F(AverageAggregationTest, abandonPartialAggregation) {
   EXPECT_GT(
       stats.at(partialNodeId).customStats.at("toIntermediateFastPathCalls").sum,
       0);
+
+  // Exercise the all-selected, non-null fast paths for different and matching
+  // input and accumulator types, respectively.
+  core::PlanNodeId fastPartialNodeId;
+  plan = PlanBuilder()
+             .values(data)
+             .partialAggregation({"k"}, {"spark_avg(b)", "spark_avg(v)"})
+             .capturePlanNodeId(fastPartialNodeId)
+             .finalAggregation()
+             .planNode();
+  task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+             .maxDrivers(1)
+             .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
+             .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
+             .assertResults("SELECT k, avg(b), avg(v) FROM tmp GROUP BY k");
+
+  const auto fastStats = exec::toPlanStats(task->taskStats());
+  EXPECT_GE(
+      fastStats.at(fastPartialNodeId)
+          .customStats.at("toIntermediateFastPathCalls")
+          .sum,
+      2);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -15,6 +15,7 @@
  */
 #include <folly/init/Init.h>
 
+#include "common/base/tests/GTestUtils.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
@@ -359,7 +360,7 @@ TEST_F(AverageAggregationTest, avgDecimalCompanionMergeExtract) {
   AssertQueryBuilder(plan).assertResults(expected);
 }
 
-TEST_F(AverageAggregationTest, abandonPartialAggregation) {
+DEBUG_ONLY_TEST_F(AverageAggregationTest, abandonPartialAggregation) {
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {


### PR DESCRIPTION
The patch add `toIntermediate` support for Spark avg aggregate.

`toIntermediate` is a fast path called from an abandoned partial aggregation.

The change is only for Spark AVG because Spark and Presto don't share the same intermediate data layout for null inputs.

Related: https://github.com/facebookincubator/velox/issues/18569