### PR TITLE
feat: Support toIntermediate in AggregateCompanionAdapter::PartialFunction

### DIFF
--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -124,6 +124,18 @@ void AggregateCompanionFunctionBase::extractAccumulators(
   fn_->extractAccumulators(groups, numGroups, result);
 }
 
+bool AggregateCompanionAdapter::PartialFunction::supportsToIntermediate()
+    const {
+  return fn_->supportsToIntermediate();
+}
+
+void AggregateCompanionAdapter::PartialFunction::toIntermediate(
+    const SelectivityVector& rows,
+    std::vector<VectorPtr>& args,
+    VectorPtr& result) const {
+  fn_->toIntermediate(rows, args, result);
+}
+
 void AggregateCompanionAdapter::PartialFunction::extractValues(
     char** groups,
     int32_t numGroups,

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -99,6 +99,13 @@ struct AggregateCompanionAdapter {
         const TypePtr& resultType)
         : AggregateCompanionFunctionBase{std::move(fn), resultType} {}
 
+    bool supportsToIntermediate() const override;
+
+    void toIntermediate(
+        const SelectivityVector& rows,
+        std::vector<VectorPtr>& args,
+        VectorPtr& result) const override;
+
     void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
         override;
   };

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1625,6 +1625,8 @@ void GroupingSet::toIntermediate(
     if (function->supportsToIntermediate()) {
       populateTempVectors(i, input);
       VELOX_DCHECK(aggregateVector);
+      TestValue::adjust(
+          "facebook::velox::exec::Aggregate::toIntermediate", function.get());
       function->toIntermediate(rows, tempVectors_, aggregateVector);
       continue;
     }

--- a/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
@@ -305,7 +305,7 @@ TEST_F(MinMaxAggregationTest, failOnUnorderableType) {
   }
 }
 
-TEST_F(MinMaxAggregationTest, partialCompanionAbandonPartialAggregation) {
+DEBUG_ONLY_TEST_F(MinMaxAggregationTest, partialCompanionAbandonPartialAggregation) {
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {

--- a/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
@@ -305,7 +305,9 @@ TEST_F(MinMaxAggregationTest, failOnUnorderableType) {
   }
 }
 
-DEBUG_ONLY_TEST_F(MinMaxAggregationTest, partialCompanionAbandonPartialAggregation) {
+DEBUG_ONLY_TEST_F(
+    MinMaxAggregationTest,
+    partialCompanionAbandonPartialAggregation) {
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {

--- a/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
@@ -324,6 +324,11 @@ TEST_F(MinMaxAggregationTest, partialCompanionAbandonPartialAggregation) {
                   .capturePlanNodeId(partialNodeId)
                   .finalAggregation()
                   .planNode();
+  std::atomic_bool usedToIntermediateFastPath{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Aggregate::toIntermediate",
+      std::function<void(void*)>(
+          [&](void*) { usedToIntermediateFastPath = true; }));
   auto task =
       AssertQueryBuilder(plan, duckDbQueryRunner_)
           .maxDrivers(1)
@@ -337,6 +342,7 @@ TEST_F(MinMaxAggregationTest, partialCompanionAbandonPartialAggregation) {
       stats.at(partialNodeId)
           .customStats.at("abandonedPartialAggregationRows")
           .sum);
+  EXPECT_TRUE(usedToIntermediateFastPath);
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -302,6 +303,40 @@ TEST_F(MinMaxAggregationTest, failOnUnorderableType) {
           builder.singleAggregation({"c1"}, {expr}), kErrorMessage);
     }
   }
+}
+
+TEST_F(MinMaxAggregationTest, partialCompanionAbandonPartialAggregation) {
+  constexpr vector_size_t kBatchSize = 100;
+  std::vector<RowVectorPtr> data;
+  for (auto batch = 0; batch < 3; ++batch) {
+    data.push_back(makeRowVector(
+        {"k", "v"},
+        {makeFlatVector<int64_t>(
+             kBatchSize, [&](auto row) { return batch * kBatchSize + row; }),
+         makeFlatVector<int64_t>(kBatchSize, folly::identity)}));
+  }
+  createDuckDbTable(data);
+
+  core::PlanNodeId partialNodeId;
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .partialAggregation({"k"}, {"spark_min_partial(v)"})
+                  .capturePlanNodeId(partialNodeId)
+                  .finalAggregation()
+                  .planNode();
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .maxDrivers(1)
+          .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
+          .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
+          .assertResults("SELECT k, min(v) FROM tmp GROUP BY k");
+
+  const auto stats = exec::toPlanStats(task->taskStats());
+  EXPECT_LT(
+      0,
+      stats.at(partialNodeId)
+          .customStats.at("abandonedPartialAggregationRows")
+          .sum);
 }
 
 } // namespace


### PR DESCRIPTION
The patch add `toIntermediate` support for the companion adaptor of aggregate functions.

`toIntermediate` is a fast path called from an abandoned partial aggregation.

Related: https://github.com/facebookincubator/velox/issues/18569