### PR TITLE
feat(s3): Resolve per-path credentials from the query TokenProvider

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
@@ -19,6 +19,7 @@ velox_add_library(
   RegisterS3FileSystem.cpp
   HEADERS
   RegisterS3FileSystem.h
+  S3AccessToken.h
   S3Config.h
   S3Counters.h
   S3FileSystem.h

--- a/velox/connectors/hive/storage_adapters/s3fs/S3AccessToken.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3AccessToken.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "velox/common/file/TokenProvider.h"
+
+namespace facebook::velox::filesystems {
+
+/// Key the S3 file system presents to a query's TokenProvider when opening a
+/// file: the scheme-stripped path ("bucket/key") being accessed. A provider
+/// resolves the credential set covering that path from it, which is what
+/// prefix-scoped credentials such as Iceberg REST-catalog vended credentials
+/// need.
+class S3AccessTokenKey : public AccessTokenKey {
+ public:
+  explicit S3AccessTokenKey(std::string path) : path_(std::move(path)) {}
+
+  const std::string& path() const {
+    return path_;
+  }
+
+ private:
+  const std::string path_;
+};
+
+/// A (possibly STS-temporary) S3 credential set resolved by a TokenProvider.
+class S3AccessToken : public AccessToken {
+ public:
+  S3AccessToken(
+      std::string accessKeyId,
+      std::string secretAccessKey,
+      std::string sessionToken = "")
+      : accessKeyId_(std::move(accessKeyId)),
+        secretAccessKey_(std::move(secretAccessKey)),
+        sessionToken_(std::move(sessionToken)) {}
+
+  const std::string& accessKeyId() const {
+    return accessKeyId_;
+  }
+
+  const std::string& secretAccessKey() const {
+    return secretAccessKey_;
+  }
+
+  /// Empty when the credentials are not STS-temporary.
+  const std::string& sessionToken() const {
+    return sessionToken_;
+  }
+
+  /// Stable identity for client caching that does not use the raw secret as a
+  /// map key. Access key ids are unique per issued credential set; the hash
+  /// suffix keeps sets apart if a deployment reuses an access key id with a
+  /// rotated secret.
+  std::string fingerprint() const {
+    return accessKeyId_ + "-" +
+        std::to_string(std::hash<std::string>()(
+            secretAccessKey_ + ":" + sessionToken_));
+  }
+
+ private:
+  const std::string accessKeyId_;
+  const std::string secretAccessKey_;
+  const std::string sessionToken_;
+};
+
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3AccessToken.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Counters.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h"
@@ -227,14 +228,25 @@ void registerCredentialsProvider(
   });
 }
 
+namespace {
+Aws::Client::ClientConfigurationInitValues clientConfigInitValues(
+    const S3Config& s3Config) {
+  Aws::Client::ClientConfigurationInitValues initValues;
+  initValues.shouldDisableIMDS = !s3Config.useIMDS();
+  return initValues;
+}
+} // namespace
+
 class S3FileSystem::Impl {
  public:
   explicit Impl(std::shared_ptr<S3Config> s3Config)
-      : s3Config_(std::move(s3Config)) {
+      : s3Config_(std::move(s3Config)),
+        clientConfig_(clientConfigInitValues(*s3Config_)) {
     VELOX_CHECK(getAwsInstance()->isInitialized(), "S3 is not initialized");
-    Aws::Client::ClientConfigurationInitValues initValues;
-    initValues.shouldDisableIMDS = !s3Config_->useIMDS();
-    Aws::S3::S3ClientConfiguration clientConfig(initValues);
+    // Held as a member so that clients built for TokenProvider-supplied
+    // credentials share the default client's endpoint, proxy, retry and
+    // addressing setup. See clientForToken.
+    Aws::S3::S3ClientConfiguration& clientConfig = clientConfig_;
     clientConfig.checksumConfig.requestChecksumCalculation =
         Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
     clientConfig.checksumConfig.responseChecksumValidation =
@@ -440,6 +452,24 @@ class S3FileSystem::Impl {
     return client_.get();
   }
 
+  // Returns the client that should serve a file open: the default client,
+  // unless the caller's TokenProvider resolves credentials for this path.
+  // 'path' is scheme-stripped, matching getPath().
+  Aws::S3::S3Client* clientForFileOptions(
+      std::string_view path,
+      const FileOptions& options) {
+    if (options.tokenProvider == nullptr) {
+      return s3Client();
+    }
+    const S3AccessTokenKey key{std::string(path)};
+    const auto token = std::dynamic_pointer_cast<S3AccessToken>(
+        options.tokenProvider->getToken(key));
+    if (token == nullptr) {
+      return s3Client();
+    }
+    return clientForToken(*token);
+  }
+
   std::string getLogLevelName() const {
     return getAwsInstance()->getLogLevelName();
   }
@@ -453,8 +483,40 @@ class S3FileSystem::Impl {
   }
 
  private:
+  // One client per credential set, built lazily with the same configuration as
+  // the default client and owned by this file system, so the raw pointers
+  // handed to S3ReadFile/S3WriteFile stay valid for the lifetime of the open
+  // file. The number of entries is bounded by the number of distinct
+  // credential sets the file system is asked to use.
+  Aws::S3::S3Client* clientForToken(const S3AccessToken& token) {
+    const auto fingerprint = token.fingerprint();
+    return tokenClients_.withWLock([&](auto& clients) {
+      auto it = clients.find(fingerprint);
+      if (it == clients.end()) {
+        auto credentialsProvider =
+            std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(
+                awsString(token.accessKeyId()),
+                awsString(token.secretAccessKey()),
+                awsString(token.sessionToken()));
+        it = clients
+                 .emplace(
+                     fingerprint,
+                     std::make_shared<Aws::S3::S3Client>(
+                         credentialsProvider,
+                         nullptr /* endpointProvider */,
+                         clientConfig_))
+                 .first;
+      }
+      return it->second.get();
+    });
+  }
+
   std::shared_ptr<Aws::S3::S3Client> client_;
   std::shared_ptr<S3Config> s3Config_;
+  Aws::S3::S3ClientConfiguration clientConfig_;
+  folly::Synchronized<
+      std::unordered_map<std::string, std::shared_ptr<Aws::S3::S3Client>>>
+      tokenClients_;
 };
 
 S3FileSystem::S3FileSystem(
@@ -477,7 +539,8 @@ std::unique_ptr<ReadFile> S3FileSystem::openFileForRead(
     std::string_view s3Path,
     const FileOptions& options) {
   const auto path = getPath(s3Path);
-  auto s3file = std::make_unique<S3ReadFile>(path, impl_->s3Client());
+  auto s3file = std::make_unique<S3ReadFile>(
+      path, impl_->clientForFileOptions(path, options));
   s3file->initialize(options);
   return s3file;
 }
@@ -487,7 +550,10 @@ std::unique_ptr<WriteFile> S3FileSystem::openFileForWrite(
     const FileOptions& options) {
   const auto path = getPath(s3Path);
   auto s3file = std::make_unique<S3WriteFile>(
-      path, impl_->s3Client(), options.pool, impl_->getS3Config());
+      path,
+      impl_->clientForFileOptions(path, options),
+      options.pool,
+      impl_->getS3Config());
   return s3file;
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -16,9 +16,11 @@
 
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <sys/stat.h>
 
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3AccessToken.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
 
@@ -55,6 +57,45 @@ class MyCredentialsProvider : public Aws::Auth::AWSCredentialsProvider {
   }
 };
 
+/// Hands out one credential set for the paths under 'prefix', nothing for
+/// anything else. Models an engine that resolves prefix-scoped credentials,
+/// e.g. per-table credentials vended by an Iceberg REST catalog.
+class PrefixTokenProvider : public TokenProvider {
+ public:
+  PrefixTokenProvider(
+      std::string prefix,
+      std::string accessKey,
+      std::string secretKey)
+      : prefix_(std::move(prefix)),
+        accessKey_(std::move(accessKey)),
+        secretKey_(std::move(secretKey)) {}
+
+  bool equals(const TokenProvider& other) const override {
+    const auto* typedOther = dynamic_cast<const PrefixTokenProvider*>(&other);
+    return typedOther != nullptr && typedOther->prefix_ == prefix_ &&
+        typedOther->accessKey_ == accessKey_ &&
+        typedOther->secretKey_ == secretKey_;
+  }
+
+  size_t hash() const override {
+    return std::hash<std::string>()(prefix_ + accessKey_);
+  }
+
+  std::shared_ptr<AccessToken> getToken(
+      const AccessTokenKey& key) const override {
+    const auto* s3Key = dynamic_cast<const S3AccessTokenKey*>(&key);
+    if (s3Key == nullptr || s3Key->path().rfind(prefix_, 0) != 0) {
+      return nullptr;
+    }
+    return std::make_shared<S3AccessToken>(accessKey_, secretKey_);
+  }
+
+ private:
+  const std::string prefix_;
+  const std::string accessKey_;
+  const std::string secretKey_;
+};
+
 } // namespace
 
 TEST_F(S3FileSystemTest, writeAndRead) {
@@ -74,6 +115,81 @@ TEST_F(S3FileSystemTest, writeAndRead) {
   filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
   auto readFile = s3fs.openFileForRead(s3File);
   readData(readFile.get());
+}
+
+TEST_F(S3FileSystemTest, tokenProviderCredentials) {
+  const char* bucketName = "tokens";
+  const char* file = "test.txt";
+  const auto filename = localPath(bucketName) + "/" + file;
+  const auto s3File = s3URI(bucketName, file);
+  addBucket(bucketName);
+  {
+    LocalWriteFile writeFile(filename);
+    writeData(&writeFile);
+  }
+
+  // The file system's own credentials are wrong on purpose: only credentials
+  // coming from a TokenProvider can read this bucket.
+  auto hiveConfig = minioServer_->hiveConfig(
+      {{"hive.s3.aws-access-key", "wrong-access-key"},
+       {"hive.s3.aws-secret-key", "wrong-secret-key"}});
+  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+
+  // No token provider: the configured (wrong) credentials are used.
+  VELOX_ASSERT_THROW(
+      s3fs.openFileForRead(s3File), "Failed to get metadata for S3 object");
+
+  // A provider that covers this path: its credentials are used.
+  FileOptions options;
+  options.tokenProvider = std::make_shared<PrefixTokenProvider>(
+      fmt::format("{}/", bucketName), kMinioAccessKey, kMinioSecretKey);
+  auto readFile = s3fs.openFileForRead(s3File, options);
+  readData(readFile.get());
+
+  // A provider that does not cover this path resolves no token, so the
+  // configured (wrong) credentials are used again.
+  FileOptions otherOptions;
+  otherOptions.tokenProvider = std::make_shared<PrefixTokenProvider>(
+      "some-other-bucket/", kMinioAccessKey, kMinioSecretKey);
+  VELOX_ASSERT_THROW(
+      s3fs.openFileForRead(s3File, otherOptions),
+      "Failed to get metadata for S3 object");
+}
+
+TEST_F(S3FileSystemTest, tokenProviderCredentialsPerPath) {
+  const char* bucketName = "multitable";
+  const char* readableFile = "readable/test.txt";
+  const char* deniedFile = "denied/test.txt";
+  addBucket(bucketName);
+  ::mkdir((localPath(bucketName) + "/readable").c_str(), S_IRWXU | S_IRWXG);
+  ::mkdir((localPath(bucketName) + "/denied").c_str(), S_IRWXU | S_IRWXG);
+  {
+    LocalWriteFile writeFile(localPath(bucketName) + "/" + readableFile);
+    writeData(&writeFile);
+  }
+  {
+    LocalWriteFile writeFile(localPath(bucketName) + "/" + deniedFile);
+    writeData(&writeFile);
+  }
+
+  auto hiveConfig = minioServer_->hiveConfig(
+      {{"hive.s3.aws-access-key", "wrong-access-key"},
+       {"hive.s3.aws-secret-key", "wrong-secret-key"}});
+  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+
+  // One provider, two prefixes in the same bucket: only the covered prefix
+  // gets working credentials, which is what per-table credentials require.
+  FileOptions options;
+  options.tokenProvider = std::make_shared<PrefixTokenProvider>(
+      fmt::format("{}/readable/", bucketName),
+      kMinioAccessKey,
+      kMinioSecretKey);
+  auto readFile =
+      s3fs.openFileForRead(s3URI(bucketName, readableFile), options);
+  readData(readFile.get());
+  VELOX_ASSERT_THROW(
+      s3fs.openFileForRead(s3URI(bucketName, deniedFile), options),
+      "Failed to get metadata for S3 object");
 }
 
 TEST_F(S3FileSystemTest, invalidCredentialsConfig) {


### PR DESCRIPTION
## What

Make `S3FileSystem` consume `FileOptions::tokenProvider`, so a query's
`TokenProvider` can supply the credentials used to open a given S3 path.

- New `S3AccessTokenKey` / `S3AccessToken` (`s3fs/S3AccessToken.h`). The file
  system presents the scheme-stripped path (`bucket/key`) being opened; the
  provider returns the credential set (access key, secret, optional session
  token) covering it.
- `openFileForRead` / `openFileForWrite` route through
  `clientForFileOptions()`: the default client unless the caller's provider
  resolves a token for that path, in which case a client for those credentials
  serves the open. Those clients are built lazily with the same configuration
  as the default client, cached by credential fingerprint, and owned by the
  file system, so the raw `S3Client*` held by `S3ReadFile`/`S3WriteFile` stays
  valid for the lifetime of the open file.

Callers that pass no provider, and providers that resolve no token for a path,
behave exactly as before.

## Why

The token provider path is already fully plumbed, but S3 has no consumer:
`FileSplitReader` and the Iceberg delete-file readers put
`ConnectorQueryCtx::fsTokenProvider()` in the `FileHandleKey` (so credential
identity keys the handle cache) and `FileHandleGenerator` forwards it into
`openFileForRead` via `FileOptions::tokenProvider` — yet `S3FileSystem`
ignored it, and every read used the single client built from static
`hive.s3.*` config plus the AWS default credential chain. Today
`PlainUserNameTokenProvider` is the only provider in tree and no file system
resolves a real credential from one.

The motivating case is Iceberg REST catalogs with credential vending (Apache
Polaris, Unity, Glue IRC). `loadTable` returns per-table, prefix-scoped,
short-TTL STS credentials that only the JVM `FileIO` ever sees, so native
scans of such tables fail with S3 403 while the same query reads fine on
vanilla Spark. Because the credentials are scoped **per table**, a bucket- or
session-scoped static config cannot express them: two tables in one bucket can
carry different credentials within a single query. A per-path token provider
can, which is what this change enables.

Reported downstream in apache/gluten:
https://github.com/apache/gluten/issues/12701 — the Gluten-side change that
builds such a provider from the scan's Iceberg `FileIO` properties depends on
this PR. `apache/datafusion-comet` solved the same problem with an equivalent
per-path credential channel (comet#3523, comet#4309).

## Tests

Two new cases in `S3FileSystemTest` (Minio-backed), both configuring the file
system with deliberately wrong static credentials so that only provider
credentials can read:

- `tokenProviderCredentials` — no provider throws; a provider covering the
  path reads the file; a provider that does not cover the path resolves no
  token and falls back to the configured (wrong) credentials.
- `tokenProviderCredentialsPerPath` — one provider, two prefixes in the same
  bucket: only the covered prefix gets working credentials, which is the
  per-table property engines need.
