### PR TITLE
fix(parquet): Null-fill missing columns correctly in kParquetFieldId mode

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -558,10 +558,16 @@ bool SelectiveStructColumnReaderBase::isChildMissing(
            TypeKind::MAP // If this is the case it means this is a flat map,
                          // so it can't have "missing" fields.
        ) &&
-      // Name-based missing-field check applies only to row types, not flat
-      // maps.
+      // Name-based missing-field check applies to row types when the mapping
+      // mode resolves columns by name or by Parquet field ID.  In field-ID
+      // mode getParquetColumnInfo() renames each file column to match the
+      // requested name, so containsChild() correctly identifies missing ones.
+      // Channel-based detection is only reliable for kPosition mode, where
+      // channel i maps directly to file column i.
       ((fileType_->type()->isRow() &&
-        columnReaderOptions_.columnMappingMode_ == ColumnMappingMode::kName)
+        (columnReaderOptions_.columnMappingMode_ == ColumnMappingMode::kName ||
+         columnReaderOptions_.columnMappingMode_ ==
+             ColumnMappingMode::kParquetFieldId))
            ? !asRowType(fileType_->type())->containsChild(childSpec.fieldName())
            : childSpec.channel() >= fileType_->size());
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -249,6 +249,50 @@ TEST_F(ParquetReaderTest, parquetFieldIdColumnMapping) {
       *leafPool_);
 }
 
+// Regression test for isChildMissing incorrectly using the channel-index
+// guard (channel >= fileType->size) in kParquetFieldId mode.
+//
+// When a new column is inserted before existing ones (e.g. ADD COLUMN z FIRST),
+// the output channel of the trailing columns shifts up.  For a file written
+// with [a(fid=1), b(fid=2)] and read with requested schema
+// [z(fid=3), a(fid=1), b(fid=2)], b lands at output channel 2.  The file has
+// only 2 columns, so channel(b)=2 >= fileSize=2 would incorrectly mark b as
+// missing.  The fix extends the name-based path (containsChild) to cover
+// kParquetFieldId, which correctly identifies z as absent and a/b as present.
+TEST_F(ParquetReaderTest, parquetFieldIdInsertedColumnNotNullFilled) {
+  // Write [a(fid=1), b(fid=2)] — two rows.
+  auto writeType = ROW({"a", "b"}, {INTEGER(), VARCHAR()});
+  auto data = makeRowVector(
+      writeType->names(),
+      {makeFlatVector<int32_t>({1, 2}),
+       makeFlatVector<std::string>({"x", "y"})});
+  ParquetWriterOptions writerOptions;
+  writerOptions.parquetFieldIds = {
+      ParquetFieldId{1, {}}, ParquetFieldId{2, {}}};
+  auto* sink = write(data, writerOptions);
+
+  // Read back with output schema [z(fid=3), a(fid=1), b(fid=2)].
+  // z has no matching field id in the file → null-fill.
+  // a and b are present → must carry their original values.
+  const auto outputType =
+      ROW({"z", "a", "b"}, {INTEGER(), INTEGER(), VARCHAR()});
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setFileSchema(outputType);
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
+  readerOptions.setFieldIds(
+      {ParquetFieldId{3, {}}, ParquetFieldId{1, {}}, ParquetFieldId{2, {}}});
+
+  auto readerBundle =
+      readerBuilder(*sink, outputType).options(readerOptions).build();
+  auto expected = makeRowVector(
+      outputType->names(),
+      {makeNullableFlatVector<int32_t>({std::nullopt, std::nullopt}),
+       makeFlatVector<int32_t>({1, 2}),
+       makeFlatVector<std::string>({"x", "y"})});
+  assertReadWithReaderAndExpected(
+      outputType, *readerBundle.rowReader, expected, *leafPool_);
+}
+
 TEST_F(ParquetReaderTest, nestedNameColumnMapping) {
   auto data = makeRowVector(
       {"nested"},


### PR DESCRIPTION
## Problem

When reading a Parquet file written before an `ALTER TABLE ADD COLUMN ... FIRST|AFTER` DDL,
columns shifted to a higher output-schema ordinal were incorrectly null-filled.

`SelectiveStructColumnReaderBase::isChildMissing()` used a channel-index guard:

```cpp
childSpec.channel() >= fileType_->size()
```

This is only correct for `kPosition` mode, where `channel i` maps directly to file column `i`.
In `kParquetFieldId` mode, `channel` is the ordinal in the **output schema**, not the physical
file. When a new column is inserted at `FIRST` or `AFTER <col>`, all following columns shift up
by one in the output schema. Their channel can then equal or exceed the file's column count even
though they are physically present in the file.

**Example:** a file has `[a(fid=1), b(fid=2)]` (size=2). After `ADD COLUMN z INTEGER FIRST`, the
output schema is `[z(fid=3), a(fid=1), b(fid=2)]` with channels `z=0, a=1, b=2`. The check
`channel(b)=2 >= fileSize=2` is `true`, so `b` is null-filled even though it exists in the file.

Related Presto PR:
https://github.com/prestodb/presto/pull/28328

## Fix

In `kParquetFieldId` mode, `getParquetColumnInfo()` already renames each file column to match the
requested schema name by looking up the Iceberg field ID. This means `containsChild(fieldName())`
on `fileType_` reliably identifies absent columns — exactly as it does in `kName` mode.

Extend the name-based path in `isChildMissing()` to cover `kParquetFieldId` alongside the existing
`kName` branch. The channel-based fallback is preserved for `kPosition` mode where it remains
correct.

```cpp
((fileType_->type()->isRow() &&
  (columnReaderOptions_.columnMappingMode_ == ColumnMappingMode::kName ||
   columnReaderOptions_.columnMappingMode_ == ColumnMappingMode::kParquetFieldId))
     ? !asRowType(fileType_->type())->containsChild(childSpec.fieldName())
     : childSpec.channel() >= fileType_->size());
```

## Test

Added `ParquetReaderTest.parquetFieldIdInsertedColumnNotNullFilled`:

- Writes a file with `[a(fid=1), b(fid=2)]`
- Reads it back with requested schema `[z(fid=3), a(fid=1), b(fid=2)]` in `kParquetFieldId` mode
- Asserts `z` is null-filled (absent from file) and `a`/`b` carry their original values (present
  in file)