### PR TITLE
Eliminate O(size) bitmap scan in GroupingSet::updateRow spill-merge path (#18573)

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1514,7 +1514,8 @@ void GroupingSet::updateRow(SpillMergeStream& input, char* row) {
     mergeSelection_.clearAll();
   }
   mergeSelection_.setValid(input.currentIndex(), true);
-  mergeSelection_.updateBounds();
+  mergeSelection_.setActiveBounds(
+      input.currentIndex(), input.currentIndex() + 1);
   for (auto i = 0; i < aggregates_.size(); ++i) {
     if (!aggregates_[i].sortingKeys.empty()) {
       continue;

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -302,6 +302,15 @@ class SelectivityVector {
     allSelected_.reset();
   }
 
+  /// Sets the active bounds [begin, end) directly instead of computing them
+  /// from the bitmap like updateBounds() does. The caller must guarantee that
+  /// all selected bits lie within [begin, end).
+  void setActiveBounds(vector_size_t begin, vector_size_t end) {
+    begin_ = begin;
+    end_ = end;
+    allSelected_.reset();
+  }
+
   bool isAllSelected() const {
     if (allSelected_.has_value()) {
       return allSelected_.value();


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookincubator/velox/pull/18573

Differential Revision: D116539363


