### PR TITLE
build: Bump the OpenZL pin to the revision fbcode builds against

### DIFF
--- a/CMake/resolve_dependency_modules/openzl.cmake
+++ b/CMake/resolve_dependency_modules/openzl.cmake
@@ -13,14 +13,18 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-# Pinned to the commit the standalone Nimble repository carries as its openzl
-# submodule, rather than to the v0.2.0 tag: Nimble is validated against this
-# revision, and v0.2.0 predates the cross-platform zstd/xxhash dependency
-# handling that OpenZL needs to configure cleanly here.
-set(VELOX_OPENZL_VERSION 6b48fa4868160ed1e5c78ac422639615dd0dcf28)
+# Pinned to a raw commit rather than to the v0.2.0 tag, which predates both the
+# cross-platform zstd/xxhash dependency handling OpenZL needs to configure
+# cleanly here and the current descriptor API. The revision tracks what fbcode
+# builds Nimble against, so that velox/dwio/nimble compiles identically in both
+# trees; a pin older than fbcode's OpenZL breaks the internal build. OpenZL
+# ships from fbcode to GitHub, so there is no tag to follow. Keep in sync with
+# OPENZL_VERSION in scripts/setup-versions.sh, which installs the same revision
+# for builds that resolve OpenZL as a system package.
+set(VELOX_OPENZL_VERSION 7340a712cce1b8331bec3467600dba99a562e052)
 set(
   VELOX_OPENZL_BUILD_SHA256_CHECKSUM
-  59bd4d05cc8a34a8d92863e42846af4bf99772da4452f5d59cde1229cb7d89d4
+  ace6a975c3bb28da0f211c86b3f172b427acec4a2044ab637e66649cb022a953
 )
 string(
   CONCAT

--- a/scripts/setup-versions.sh
+++ b/scripts/setup-versions.sh
@@ -50,13 +50,16 @@ FAST_FLOAT_VERSION="v8.0.2"
 CCACHE_VERSION="4.11.3"
 # Only needed for VELOX_ENABLE_NIMBLE=ON. FSST is vendored under
 # velox/external/fsst, so it has no pin here. OpenZL is pinned to the revision
-# Nimble's own submodule carries rather than to v0.2.0, which predates the
-# cross-platform zstd handling it needs to configure here. FlatBuffers is held
-# at the version cuDF expects, since a system install of anything newer is
-# picked up by cuDF's own find_package() and breaks its build; see
+# fbcode builds Nimble against rather than to v0.2.0, which predates the
+# cross-platform zstd handling it needs to configure here; keep it in sync with
+# VELOX_OPENZL_VERSION in CMake/resolve_dependency_modules/openzl.cmake, or a
+# system install and a bundled build resolve different descriptor APIs.
+# FlatBuffers is held at the version cuDF expects, since a system install of
+# anything newer is picked up by cuDF's own find_package() and breaks its
+# build; see
 # CMake/resolve_dependency_modules/flatbuffers.cmake. Keep the two in sync.
 FLATBUFFERS_VERSION="24.3.25"
-OPENZL_VERSION="6b48fa4868160ed1e5c78ac422639615dd0dcf28"
+OPENZL_VERSION="7340a712cce1b8331bec3467600dba99a562e052"
 
 # Adapter related versions.
 ABSEIL_VERSION="20240116.2"

--- a/velox/dwio/nimble/compression/OpenZLCompressor.cpp
+++ b/velox/dwio/nimble/compression/OpenZLCompressor.cpp
@@ -253,8 +253,9 @@ openzl::GraphID wrapWithDefaultSegmenter(
       .customGraphs = nullptr,
       .numCustomGraphs = 0,
       .localParams = {},
-      .materializer = {},
       .opaque = {},
+      .mparamMat = {},
+      .mparam = {},
   };
   ZL_GraphID const segmenterBase =
       ZL_Compressor_registerSegmenter(cgraph, &desc);
@@ -276,6 +277,7 @@ openzl::GraphID wrapWithDefaultSegmenter(
       .customNodes = nullptr,
       .nbCustomNodes = 0,
       .localParams = &segParams,
+      .mparam = {},
   };
   return ZL_Compressor_registerParameterizedGraph(cgraph, &segGraphDesc);
 }

--- a/velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
@@ -104,7 +104,6 @@ class DeserializerSkipTest : public ::testing::Test {
         .requiresNullBarrier = parser.requiresNullBarrier(),
         .streamEncodingUsesVarintRowCount =
             parser.streamEncodingUsesVarintRowCount(),
-        .streamHasChunkHeader = false,
         .rowRange = rowRange,
     });
     std::string output(


### PR DESCRIPTION
## Summary

`velox/dwio/nimble/compression/OpenZLCompressor.cpp` compiles in the open source
build and fails inside fbcode:

```
OpenZLCompressor.cpp:256:8: error: field designator 'materializer'
  does not refer to any field in type 'ZL_SegmenterDesc'
```

The two trees compile against different OpenZL versions. Velox pins
`6b48fa4868`, from 2026-06-24. fbcode builds v0.2.3, landed internally
2026-07-28. `7340a712cc` ("Remove old ZL_MaterializerDesc API...", public
2026-07-22) removed the old API in between, so the descriptors disagree:

| | fields |
|---|---|
| Velox's old pin | `... localParams, `**`materializer`**`, opaque` |
| fbcode v0.2.3 and this pin | `... localParams, opaque, `**`mparamMat`**`, `**`mparam`** |

Nothing is wrong with either the open source code or the internal tree. The pin
is a month stale. OpenZL ships from fbcode to GitHub, and the newest public tag
is still v0.2.0, which is why Velox pins a raw commit rather than a tag.

## Changes

- **`CMake/resolve_dependency_modules/openzl.cmake`** bumps
  `VELOX_OPENZL_VERSION` to `7340a712cce1b8331bec3467600dba99a562e052` with the
  matching checksum. The comment above the pin justified the revision by
  reference to the standalone Nimble repository's submodule; that repository is
  being archived now that Nimble lives in Velox, so it now says the pin tracks
  what fbcode builds against.

- **`scripts/setup-versions.sh`** bumps `OPENZL_VERSION` to the same revision.
  This is the copy installed into the CI docker images, so a build resolving
  OpenZL as a system package would otherwise still see the old descriptor API.
  The two pins now cross-reference each other.

- **`velox/dwio/nimble/compression/OpenZLCompressor.cpp`** reorders the
  designated initializers at both descriptor sites. C++20 requires them in
  declaration order.

  - `ZL_SegmenterDesc`: `materializer` is replaced by `mparamMat` and `mparam`,
    both declared after `opaque`.
  - `ZL_ParameterizedGraphDesc`: gained `mparam` after `localParams`.

  These are zero initializers that exist only to satisfy
  `-Wmissing-designated-field-initializers`, so there is no behaviour change.

## Verification

Built in `ghcr.io/facebookincubator/velox-dev:adapters` with GCC 14, release,
`-Werror`, OpenZL resolved `BUNDLED` at the new pin:

- `nimble_compression` compiles and links.
- `openzl-cxx-standard.patch` applies cleanly at the new revision, so the patch
  is still needed and still correct.
- The tree contains no other reference to `materializer`, `ZL_MaterializerDesc`
  or `ZL_MaterializerDesc2`.

The failure itself is only visible internally. After this merges and imports,
the check is that these two now pass:

```
buck build --flagfile fbcode//mode/dev fbcode//velox/dwio/nimble/compression:compression
buck build --flagfile fbcode//mode/dev fbcode//velox/dwio/nimble/serializer:stream_data_parser
```

Nimble's runtime coverage of the new OpenZL comes from `ubuntu-bundled-deps` on
this pull request, which is the job that builds Nimble with `BUNDLED`
dependencies and runs its tests.

## Context

Surfaced on D115111041, the Diff Train fixup bringing fbsource back in sync
with velox main after Nimble moved into Velox. The fixup pulled the open source
`OpenZLCompressor.cpp` into fbcode, where its initializers no longer matched.

The internal stopgap is deleting the `.materializer = {},` line inside fbcode.
That compiles and is semantically a no-op, but leaves permanent drift that the
next verification tries to re-add. Fixing the pin removes the problem and stops
the next OpenZL API change from repeating it.

---

## Second commit: unbreaking the Nimble build on main

`Ubuntu debug with bundled dependencies` is the only job that enables
`VELOX_ENABLE_NIMBLE=ON`, and it currently fails on main, so this pull request
could not get a clean run without also fixing it:

```
velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp:102:49: error:
  invalid initialization of reference of type
  'const facebook::nimble::serde::TabletChunkHeader&' from expression of type
  '<brace-enclosed initializer list>'
```

`DeserializerSkipTest::makeTabletBatch` sets `.streamHasChunkHeader = false`,
and `TabletChunkHeader` at `SerializationHeader.h:294` declares no such member,
so the aggregate initialization fails.

The test arrived with #18548 (`8a6663d58`), which brought the internal version
of `DeserializerSkipTest.cpp` across but not the corresponding
`SerializationHeader.h` change. The member exists in fbcode. Here the
identifier appears exactly once in the whole tree:

```
$ grep -rn streamHasChunkHeader velox/
velox/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp:107: .streamHasChunkHeader = false,
```

Dropping the line is the smaller correction. It is set to `false`, which is the
field's default internally, so the test asserts exactly what it asserted
before, and the remaining designated initializers are already in declaration
order. The line comes back when `SerializationHeader.h` itself is synced.
Adding the member here instead would mean guessing at wire format handling that
has no other consumer in this tree.

Verified in `ghcr.io/facebookincubator/velox-dev:adapters` with
`VELOX_ENABLE_NIMBLE=ON` and `NIMBLE_BUILD_TESTING=ON`: 1027/1027 targets,
`nimble_serializer_tests` compiles and links.
