### PR TITLE
feat(exchange): Add materialized exchange implementation - operator and output buffer (#18579)

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -32,7 +32,11 @@ velox_add_library(
   Exchange.cpp
   InMemoryExchangeClient.cpp
   ExchangeQueue.cpp
+  ExchangeSink.cpp
   ExchangeSource.cpp
+  MaterializedOutputBuffer.cpp
+  MaterializedOutputBufferManager.cpp
+  MaterializedPartitionedOutput.cpp
   SerializedPage.cpp
   Expand.cpp
   FilterProject.cpp
@@ -134,6 +138,7 @@ velox_add_library(
   ExchangeClient.h
   InMemoryExchangeClient.h
   ExchangeQueue.h
+  ExchangeSink.h
   ExchangeSource.h
   Expand.h
   FilterProject.h
@@ -156,6 +161,9 @@ velox_add_library(
   LocalPlanner.h
   MarkDistinct.h
   MarkSorted.h
+  MaterializedOutputBuffer.h
+  MaterializedOutputBufferManager.h
+  MaterializedPartitionedOutput.h
   MemoryReclaimer.h
   Merge.h
   MergeJoin.h

--- a/velox/exec/ExchangeSink.cpp
+++ b/velox/exec/ExchangeSink.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/ExchangeSink.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+void ExchangeSink::append(
+    int32_t partition,
+    std::unique_ptr<folly::IOBuf> data) {
+  VELOX_CHECK_NOT_NULL(data);
+  const auto range = data->coalesce();
+  append(
+      partition,
+      std::string_view(
+          reinterpret_cast<const char*>(range.data()), range.size()));
+}
+
+void ExchangeSink::appendBatch(
+    int32_t partition,
+    std::deque<std::unique_ptr<folly::IOBuf>> data) {
+  VELOX_CHECK(!data.empty());
+  auto chain = std::move(data.front());
+  data.pop_front();
+  for (auto& buffer : data) {
+    chain->appendToChain(std::move(buffer));
+  }
+  append(partition, std::move(chain));
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/ExchangeSink.h
+++ b/velox/exec/ExchangeSink.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <folly/container/F14Map.h>
+#include <folly/io/IOBuf.h>
+#include <string_view>
+
+#include "velox/common/memory/MemoryPool.h"
+
+namespace facebook::velox::exec {
+
+/// Output produced after a durable sink finishes successfully.
+struct CommittedExchangeOutput {
+  folly::F14FastMap<int32_t, std::string> locations;
+};
+
+/// Writes partitioned data to a durable exchange backend.
+class ExchangeSink {
+ public:
+  using Factory = std::function<std::shared_ptr<ExchangeSink>(
+      const std::string& config,
+      const std::string& taskId,
+      velox::memory::MemoryPool* pool)>;
+
+  virtual ~ExchangeSink() = default;
+
+  /// Appends serialized data to a partition. Calls for different partitions
+  /// may run concurrently; calls for one partition are serialized.
+  virtual void append(int32_t partition, std::string_view data) = 0;
+
+  /// Appends a serialized IOBuf chain to a partition. The default
+  /// implementation coalesces the chain and delegates to the string-view
+  /// overload.
+  virtual void append(int32_t partition, std::unique_ptr<folly::IOBuf> data);
+
+  /// Appends an ordered batch of independently serialized buffers. The
+  /// default implementation chains the buffers and delegates to append().
+  virtual void appendBatch(
+      int32_t partition,
+      std::deque<std::unique_ptr<folly::IOBuf>> data);
+
+  /// Commits output and returns its backend-specific locations.
+  virtual CommittedExchangeOutput finish() = 0;
+
+  /// Aborts output and releases uncommitted backend resources.
+  virtual void abort() = 0;
+
+  /// Returns backend-specific runtime counters.
+  virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/MaterializedOutputBuffer.cpp
+++ b/velox/exec/MaterializedOutputBuffer.cpp
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MaterializedOutputBuffer.h"
+
+#include <algorithm>
+#include <numeric>
+#include <thread>
+
+#include <folly/ScopeGuard.h>
+#include <glog/logging.h>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+constexpr double kReclaimDrainThresholdRatio = 0.67;
+constexpr int64_t kDrainChunkMultiplier = 2;
+constexpr int64_t kHighWatermarkNumerator = 9;
+constexpr int64_t kLowWatermarkNumerator = 7;
+constexpr int64_t kWatermarkDenominator = 10;
+
+int64_t computePartitionDrainThreshold(
+    int32_t numPartitions,
+    int64_t maxBufferedBytes,
+    int64_t requestedThreshold) {
+  VELOX_CHECK_GT(numPartitions, 0);
+  VELOX_CHECK_GE(maxBufferedBytes, numPartitions);
+  VELOX_CHECK_GT(requestedThreshold, 0);
+  return std::min(requestedThreshold, maxBufferedBytes / numPartitions);
+}
+
+struct TrackedBufferInfo {
+  memory::MemoryPool* pool;
+  size_t size;
+};
+
+} // namespace
+
+std::string MaterializedOutputBuffer::stateName(State state) {
+  switch (state) {
+    case State::kActive:
+      return "kActive";
+    case State::kDraining:
+      return "kDraining";
+    case State::kClosed:
+      return "kClosed";
+    case State::kAborted:
+      return "kAborted";
+  }
+  return fmt::format("Unknown({})", static_cast<int>(state));
+}
+
+MaterializedOutputBuffer::PartitionBuffer::PartitionBuffer(
+    int32_t partition,
+    int64_t drainThreshold,
+    MaterializedOutputBuffer* buffer)
+    : partition_(partition), drainThreshold_(drainThreshold), buffer_(buffer) {}
+
+bool MaterializedOutputBuffer::PartitionBuffer::tryAcquireFlushing() {
+  bool expected = false;
+  return flushing_.compare_exchange_strong(expected, true);
+}
+
+void MaterializedOutputBuffer::PartitionBuffer::releaseFlushing() {
+  flushing_ = false;
+}
+
+int64_t MaterializedOutputBuffer::PartitionBuffer::drainAndFlush() {
+  int64_t totalDrainedBytes = 0;
+  std::deque<std::unique_ptr<folly::IOBuf>> chunk;
+  int64_t chunkBytes = 0;
+
+  const auto flushChunk = [&]() {
+    buffer_->flushDrained(partition_, chunk);
+    bufferedBytes_.fetch_sub(chunkBytes);
+    totalDrainedBytes += chunkBytes;
+    chunk.clear();
+    chunkBytes = 0;
+  };
+
+  std::unique_ptr<folly::IOBuf> rowGroup;
+  while (rowGroupsQueue_.try_dequeue(rowGroup)) {
+    const auto rowGroupBytes =
+        static_cast<int64_t>(rowGroup->computeChainDataLength());
+    if (chunkBytes > 0 &&
+        chunkBytes + rowGroupBytes > buffer_->drainChunkThresholdBytes_) {
+      flushChunk();
+    }
+    chunk.push_back(std::move(rowGroup));
+    chunkBytes += rowGroupBytes;
+  }
+  if (!chunk.empty()) {
+    flushChunk();
+  }
+  return totalDrainedBytes;
+}
+
+int64_t MaterializedOutputBuffer::PartitionBuffer::tryDrainPartition(
+    int64_t targetBytes) {
+  if (!tryAcquireFlushing()) {
+    ++buffer_->concurrentAppendCount_;
+    return 0;
+  }
+  ++buffer_->flushAcquireCount_;
+
+  int64_t totalDrainedBytes = 0;
+  do {
+    {
+      SCOPE_EXIT {
+        releaseFlushing();
+      };
+      totalDrainedBytes += drainAndFlush();
+    }
+  } while (bufferedBytes_ >= targetBytes && tryAcquireFlushing());
+  return totalDrainedBytes;
+}
+
+int64_t MaterializedOutputBuffer::PartitionBuffer::finish(bool success) {
+  while (!tryAcquireFlushing()) {
+    std::this_thread::yield();
+  }
+  SCOPE_EXIT {
+    releaseFlushing();
+  };
+  if (closed_.exchange(true)) {
+    return 0;
+  }
+  if (success) {
+    return drainAndFlush();
+  }
+
+  int64_t discardedBytes = 0;
+  std::unique_ptr<folly::IOBuf> rowGroup;
+  while (rowGroupsQueue_.try_dequeue(rowGroup)) {
+    discardedBytes += static_cast<int64_t>(rowGroup->computeChainDataLength());
+  }
+  bufferedBytes_.fetch_sub(discardedBytes);
+  return discardedBytes;
+}
+
+int64_t MaterializedOutputBuffer::PartitionBuffer::enqueue(
+    std::unique_ptr<folly::IOBuf> rowGroup) {
+  VELOX_CHECK(!closed_, "enqueue called on closed partition");
+  const auto rowGroupBytes =
+      static_cast<int64_t>(rowGroup->computeChainDataLength());
+  rowGroupsQueue_.enqueue(std::move(rowGroup));
+  const auto newBytes = (bufferedBytes_ += rowGroupBytes);
+  return newBytes >= drainThreshold_ ? tryDrainPartition(drainThreshold_) : 0;
+}
+
+MaterializedOutputBuffer::MaterializedOutputBuffer(
+    int32_t numPartitions,
+    std::shared_ptr<ExchangeSink> sink,
+    int64_t maxBufferedBytes,
+    int64_t requestedPartitionDrainThreshold,
+    std::shared_ptr<memory::MemoryPool> pool)
+    : numPartitions_(numPartitions),
+      maxBufferedBytes_(maxBufferedBytes),
+      partitionDrainThreshold_(computePartitionDrainThreshold(
+          numPartitions,
+          maxBufferedBytes,
+          requestedPartitionDrainThreshold)),
+      reclaimDrainThresholdBytes_(
+          std::max<int64_t>(
+              1,
+              partitionDrainThreshold_ * kReclaimDrainThresholdRatio)),
+      drainChunkThresholdBytes_(
+          partitionDrainThreshold_ * kDrainChunkMultiplier),
+      highWatermarkBytes_(
+          maxBufferedBytes_ * kHighWatermarkNumerator / kWatermarkDenominator),
+      lowWatermarkBytes_(
+          maxBufferedBytes_ * kLowWatermarkNumerator / kWatermarkDenominator),
+      pool_(std::move(pool)),
+      sink_(std::move(sink)) {
+  VELOX_CHECK_NOT_NULL(sink_);
+  initializePartitions();
+}
+
+MaterializedOutputBuffer::~MaterializedOutputBuffer() {
+  if (state_ != State::kClosed && state_ != State::kAborted) {
+    try {
+      abort();
+    } catch (...) {
+      LOG(ERROR) << "MaterializedOutputBuffer abort failed in destructor";
+    }
+  }
+}
+
+void MaterializedOutputBuffer::initializePartitions() {
+  VELOX_CHECK_GT(lowWatermarkBytes_, 0);
+  VELOX_CHECK_LT(lowWatermarkBytes_, highWatermarkBytes_);
+  VELOX_CHECK_LE(highWatermarkBytes_, maxBufferedBytes_);
+  VELOX_CHECK_LT(
+      numPartitions_ * reclaimDrainThresholdBytes_,
+      lowWatermarkBytes_,
+      "reclaim drain threshold is too high for the low watermark");
+
+  partitionBuffers_.reserve(numPartitions_);
+  for (int32_t partition = 0; partition < numPartitions_; ++partition) {
+    partitionBuffers_.push_back(
+        std::make_unique<PartitionBuffer>(
+            partition, partitionDrainThreshold_, this));
+  }
+}
+
+std::unique_ptr<folly::IOBuf> MaterializedOutputBuffer::allocateTrackedIOBuf(
+    size_t size) {
+  if (pool_ == nullptr) {
+    return folly::IOBuf::create(size);
+  }
+  void* buffer = pool_->allocate(size);
+  auto* info = new TrackedBufferInfo{pool_.get(), size};
+  auto iobuf =
+      folly::IOBuf::takeOwnership(buffer, size, freeTrackedIOBuf, info);
+  iobuf->trimEnd(size);
+  return iobuf;
+}
+
+void MaterializedOutputBuffer::freeTrackedIOBuf(void* buffer, void* userData) {
+  auto* info = static_cast<TrackedBufferInfo*>(userData);
+  info->pool->free(buffer, info->size);
+  delete info;
+}
+
+void MaterializedOutputBuffer::enqueue(
+    int32_t partition,
+    std::unique_ptr<folly::IOBuf> rowGroup) {
+  VELOX_CHECK_GE(partition, 0);
+  VELOX_CHECK_LT(partition, numPartitions_);
+  if (state_ == State::kAborted) {
+    return;
+  }
+  VELOX_CHECK_EQ(
+      state_.load(), State::kActive, "enqueue called after noMoreData()");
+
+  const auto rowGroupBytes =
+      static_cast<int64_t>(rowGroup->computeChainDataLength());
+  const auto currentBytes = (bufferedBytes_ += rowGroupBytes);
+  auto peakBytes = peakBufferedBytes_.load(std::memory_order_relaxed);
+  while (currentBytes > peakBytes &&
+         !peakBufferedBytes_.compare_exchange_weak(
+             peakBytes, currentBytes, std::memory_order_relaxed)) {
+  }
+
+  const auto drainedBytes =
+      partitionBuffers_[partition]->enqueue(std::move(rowGroup));
+  if (drainedBytes > 0) {
+    updateDrainStats(drainedBytes);
+    const auto hasBlockedDrivers = blockedPromises_.withRLock(
+        [](const auto& promises) { return !promises.empty(); });
+    if (hasBlockedDrivers && bufferedBytes_ >= lowWatermarkBytes_) {
+      tryDrainForBackpressure();
+    }
+    maybeWakeBlockedDrivers();
+  }
+}
+
+bool MaterializedOutputBuffer::isBufferFull() const {
+  return bufferedBytes_ >= highWatermarkBytes_;
+}
+
+void MaterializedOutputBuffer::addBlockedPromise(ContinueFuture* future) {
+  ContinuePromise promise{"MaterializedOutputBuffer::addBlockedPromise"};
+  *future = promise.getSemiFuture();
+  ++backpressureBlockCount_;
+  blockedPromises_.withWLock(
+      [&](auto& promises) { promises.push_back(std::move(promise)); });
+  maybeWakeBlockedDrivers();
+}
+
+void MaterializedOutputBuffer::tryDrainForBackpressure() {
+  while (bufferedBytes_ >= lowWatermarkBytes_) {
+    const auto drainedBytes = tryDrainPartitionsInternal();
+    backpressureDrainedBytes_ += static_cast<int64_t>(drainedBytes);
+    if (drainedBytes == 0) {
+      break;
+    }
+  }
+}
+
+BlockingReason MaterializedOutputBuffer::isBlocked(ContinueFuture* future) {
+  if (!isBufferFull()) {
+    return BlockingReason::kNotBlocked;
+  }
+
+  tryDrainForBackpressure();
+  if (isBufferFull() && reclaimableBufferedBytes() > 0) {
+    addBlockedPromise(future);
+    return BlockingReason::kWaitForConsumer;
+  }
+  if (isBufferFull()) {
+    LOG_EVERY_N(WARNING, 256)
+        << "MaterializedOutputBuffer is full with no reclaimable data; "
+           "leaving the producer runnable";
+  }
+  return BlockingReason::kNotBlocked;
+}
+
+void MaterializedOutputBuffer::maybeWakeBlockedDrivers() {
+  if (bufferedBytes_ >= lowWatermarkBytes_) {
+    return;
+  }
+  std::vector<ContinuePromise> promisesToFulfill;
+  blockedPromises_.withWLock(
+      [&](auto& promises) { promisesToFulfill.swap(promises); });
+  backpressureWakeCount_ += static_cast<int64_t>(promisesToFulfill.size());
+  for (auto& promise : promisesToFulfill) {
+    promise.setValue();
+  }
+}
+
+void MaterializedOutputBuffer::flushDrained(
+    int32_t partition,
+    std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups) {
+  if (rowGroups.empty()) {
+    return;
+  }
+  sink_->appendBatch(partition, std::move(rowGroups));
+  ++appendCount_;
+}
+
+void MaterializedOutputBuffer::updateDrainStats(int64_t drainedBytes) {
+  ++drainCount_;
+  drainedBytes_ += drainedBytes;
+  bufferedBytes_.fetch_sub(drainedBytes);
+}
+
+int64_t MaterializedOutputBuffer::drainPartitionInternal(
+    int32_t partition,
+    int64_t targetBytes) {
+  VELOX_CHECK_GE(partition, 0);
+  VELOX_CHECK_LT(partition, numPartitions_);
+  const auto drainedBytes =
+      partitionBuffers_[partition]->tryDrainPartition(targetBytes);
+  if (drainedBytes > 0) {
+    updateDrainStats(drainedBytes);
+    maybeWakeBlockedDrivers();
+  }
+  return drainedBytes;
+}
+
+int64_t MaterializedOutputBuffer::drainPartition(int32_t partition) {
+  return drainPartitionInternal(partition, 1);
+}
+
+uint64_t MaterializedOutputBuffer::drainAll() {
+  uint64_t drainedBytes = 0;
+  for (int32_t partition = 0; partition < numPartitions_; ++partition) {
+    drainedBytes += drainPartition(partition);
+  }
+  return drainedBytes;
+}
+
+uint64_t MaterializedOutputBuffer::reclaimableBufferedBytes() const {
+  uint64_t reclaimableBytes = 0;
+  for (const auto& partition : partitionBuffers_) {
+    const auto partitionBytes = partition->bufferedBytes_.load();
+    if (partitionBytes > reclaimDrainThresholdBytes_) {
+      reclaimableBytes += partitionBytes - reclaimDrainThresholdBytes_;
+    }
+  }
+  return reclaimableBytes;
+}
+
+uint64_t MaterializedOutputBuffer::tryDrainPartitionsInternal() {
+  std::vector<int32_t> orderedPartitions(numPartitions_);
+  std::iota(orderedPartitions.begin(), orderedPartitions.end(), 0);
+
+  std::vector<int64_t> partitionSizes(numPartitions_);
+  for (int32_t partition = 0; partition < numPartitions_; ++partition) {
+    partitionSizes[partition] = partitionBuffers_[partition]->bufferedBytes_;
+  }
+  std::sort(
+      orderedPartitions.begin(),
+      orderedPartitions.end(),
+      [&](int32_t lhs, int32_t rhs) {
+        return partitionSizes[lhs] > partitionSizes[rhs];
+      });
+
+  uint64_t drainedBytes = 0;
+  for (const auto partition : orderedPartitions) {
+    if (partitionSizes[partition] < reclaimDrainThresholdBytes_) {
+      break;
+    }
+    drainedBytes +=
+        drainPartitionInternal(partition, reclaimDrainThresholdBytes_);
+  }
+  return drainedBytes;
+}
+
+void MaterializedOutputBuffer::noMoreData() {
+  std::lock_guard<std::mutex> lock(lifecycleMutex_);
+  auto expectedState = State::kActive;
+  if (!state_.compare_exchange_strong(expectedState, State::kDraining)) {
+    return;
+  }
+
+  try {
+    for (auto& partition : partitionBuffers_) {
+      const auto drainedBytes = partition->finish(true);
+      if (drainedBytes > 0) {
+        updateDrainStats(drainedBytes);
+      }
+    }
+    output_ = sink_->finish();
+    state_ = State::kClosed;
+    maybeWakeBlockedDrivers();
+  } catch (...) {
+    state_ = State::kAborted;
+    for (auto& partition : partitionBuffers_) {
+      partition->finish(false);
+    }
+    bufferedBytes_ = 0;
+    try {
+      sink_->abort();
+    } catch (...) {
+    }
+    maybeWakeBlockedDrivers();
+    throw;
+  }
+}
+
+void MaterializedOutputBuffer::abort() {
+  std::lock_guard<std::mutex> lock(lifecycleMutex_);
+  const auto previousState = state_.exchange(State::kAborted);
+  if (previousState == State::kClosed || previousState == State::kAborted) {
+    return;
+  }
+
+  for (auto& partition : partitionBuffers_) {
+    partition->finish(false);
+  }
+  bufferedBytes_ = 0;
+  sink_->abort();
+  output_.reset();
+  maybeWakeBlockedDrivers();
+}
+
+void MaterializedOutputBuffer::setNumDrivers(uint32_t numDrivers) {
+  std::lock_guard<std::mutex> lock(driverMutex_);
+  if (numDrivers_ == 0) {
+    numDrivers_ = numDrivers;
+  }
+}
+
+bool MaterializedOutputBuffer::noMoreDrivers() {
+  bool isLastDriver = false;
+  {
+    std::lock_guard<std::mutex> lock(driverMutex_);
+    ++numFinishedDrivers_;
+    isLastDriver = numDrivers_ > 0 && numFinishedDrivers_ >= numDrivers_;
+  }
+  if (isLastDriver) {
+    noMoreData();
+  }
+  return isLastDriver;
+}
+
+folly::F14FastMap<std::string, int64_t> MaterializedOutputBuffer::stats()
+    const {
+  auto result = sink_->stats();
+  result["materializedOutputBuffer.drainedBytes"] = drainedBytes_;
+  result["materializedOutputBuffer.drainCount"] = drainCount_;
+  result["materializedOutputBuffer.currentDrainThreshold"] =
+      partitionDrainThreshold_;
+  result["materializedOutputBuffer.totalAppendCalls"] = appendCount_;
+  result["materializedOutputBuffer.peakBufferedBytes"] = peakBufferedBytes_;
+  result["materializedOutputBuffer.concurrentAppendCount"] =
+      concurrentAppendCount_;
+  result["materializedOutputBuffer.flushAcquireCount"] = flushAcquireCount_;
+  result["materializedOutputBuffer.backpressureBlockCount"] =
+      backpressureBlockCount_;
+  result["materializedOutputBuffer.backpressureWakeCount"] =
+      backpressureWakeCount_;
+  result["materializedOutputBuffer.backpressureDrainedBytes"] =
+      backpressureDrainedBytes_;
+  return result;
+}
+
+folly::F14FastMap<int32_t, std::string>
+MaterializedOutputBuffer::outputLocations() const {
+  std::lock_guard<std::mutex> lock(lifecycleMutex_);
+  return output_.has_value() ? output_->locations
+                             : folly::F14FastMap<int32_t, std::string>{};
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/MaterializedOutputBuffer.h
+++ b/velox/exec/MaterializedOutputBuffer.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/Synchronized.h>
+#include <folly/concurrency/UnboundedQueue.h>
+#include <folly/io/IOBuf.h>
+#include "velox/common/future/VeloxPromise.h"
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/exec/ExchangeSink.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+/// Shared buffer between materialized output operators and an ExchangeSink.
+/// Appenders enqueue without locking. A CAS-elected flusher serializes sink
+/// appends for each partition, while cooperative high/low-watermark
+/// backpressure bounds the total queued bytes.
+class MaterializedOutputBuffer {
+ public:
+  enum class State : uint8_t {
+    kActive,
+    kDraining,
+    kClosed,
+    kAborted,
+  };
+
+  /// Returns the name of the buffer state.
+  static std::string stateName(State state);
+
+  static constexpr int64_t kDefaultDrainThreshold = 128L * 1024;
+
+  MaterializedOutputBuffer(
+      int32_t numPartitions,
+      std::shared_ptr<ExchangeSink> sink,
+      int64_t maxBufferedBytes,
+      int64_t partitionDrainThreshold = kDefaultDrainThreshold,
+      std::shared_ptr<memory::MemoryPool> pool = nullptr);
+
+  ~MaterializedOutputBuffer();
+
+  /// Enqueues a serialized RowGroup for a partition.
+  void enqueue(int32_t partition, std::unique_ptr<folly::IOBuf> rowGroup);
+
+  /// Drains at the high watermark, then parks until below the low watermark.
+  BlockingReason isBlocked(ContinueFuture* future);
+
+  /// Best-effort drain of one partition without closing it.
+  int64_t drainPartition(int32_t partition);
+
+  /// Best-effort drain of every partition without closing them.
+  uint64_t drainAll();
+
+  /// Drains all remaining data and commits the sink.
+  void noMoreData();
+
+  /// Discards buffered data and aborts the sink.
+  void abort();
+
+  State state() const {
+    return state_.load();
+  }
+
+  int64_t bufferedBytes() const {
+    return bufferedBytes_;
+  }
+
+  int64_t partitionDrainThreshold() const {
+    return partitionDrainThreshold_;
+  }
+
+  int64_t highWatermarkBytes() const {
+    return highWatermarkBytes_;
+  }
+
+  int64_t lowWatermarkBytes() const {
+    return lowWatermarkBytes_;
+  }
+
+  /// Returns true when buffered bytes reach the producer-blocking high
+  /// watermark.
+  bool isBufferFull() const;
+
+  /// Records the number of drivers. Only the first call takes effect.
+  void setNumDrivers(uint32_t numDrivers);
+
+  /// Marks one driver complete and commits when the final driver finishes.
+  bool noMoreDrivers();
+
+  /// Returns sink and buffer runtime counters.
+  folly::F14FastMap<std::string, int64_t> stats() const;
+
+  /// Returns committed output locations after noMoreData().
+  folly::F14FastMap<int32_t, std::string> outputLocations() const;
+
+  /// Allocates a RowGroup IOBuf tracked by the configured memory pool.
+  std::unique_ptr<folly::IOBuf> allocateTrackedIOBuf(size_t size);
+
+  int32_t numPartitions() const {
+    return numPartitions_;
+  }
+
+ private:
+  class PartitionBuffer {
+   public:
+    PartitionBuffer(
+        int32_t partition,
+        int64_t drainThreshold,
+        MaterializedOutputBuffer* buffer);
+
+    /// Lock-free append that opportunistically drains above the threshold.
+    int64_t enqueue(std::unique_ptr<folly::IOBuf> rowGroup);
+
+   private:
+    friend class MaterializedOutputBuffer;
+
+    bool tryAcquireFlushing();
+
+    void releaseFlushing();
+
+    int64_t drainAndFlush();
+
+    int64_t tryDrainPartition(int64_t targetBytes);
+
+    int64_t finish(bool success);
+
+    folly::UMPMCQueue<std::unique_ptr<folly::IOBuf>, false> rowGroupsQueue_;
+    std::atomic_int64_t bufferedBytes_{0};
+    std::atomic<bool> flushing_{false};
+    std::atomic<bool> closed_{false};
+    const int32_t partition_;
+    const int64_t drainThreshold_;
+    MaterializedOutputBuffer* const buffer_;
+  };
+
+  void initializePartitions();
+
+  int64_t drainPartitionInternal(int32_t partition, int64_t targetBytes);
+
+  uint64_t tryDrainPartitionsInternal();
+
+  void tryDrainForBackpressure();
+
+  uint64_t reclaimableBufferedBytes() const;
+
+  void addBlockedPromise(ContinueFuture* future);
+
+  void maybeWakeBlockedDrivers();
+
+  void updateDrainStats(int64_t drainedBytes);
+
+  void flushDrained(
+      int32_t partition,
+      std::deque<std::unique_ptr<folly::IOBuf>>& rowGroups);
+
+  static void freeTrackedIOBuf(void* buffer, void* userData);
+
+  const int32_t numPartitions_;
+  const int64_t maxBufferedBytes_;
+  const int64_t partitionDrainThreshold_;
+  const int64_t reclaimDrainThresholdBytes_;
+  const int64_t drainChunkThresholdBytes_;
+  const int64_t highWatermarkBytes_;
+  const int64_t lowWatermarkBytes_;
+  const std::shared_ptr<memory::MemoryPool> pool_;
+  const std::shared_ptr<ExchangeSink> sink_;
+
+  std::atomic<State> state_{State::kActive};
+  std::atomic_int64_t bufferedBytes_{0};
+  std::vector<std::unique_ptr<PartitionBuffer>> partitionBuffers_;
+
+  std::atomic_int64_t drainedBytes_{0};
+  std::atomic_int64_t drainCount_{0};
+  std::atomic_int64_t peakBufferedBytes_{0};
+  std::atomic_int64_t appendCount_{0};
+  std::atomic_int64_t concurrentAppendCount_{0};
+  std::atomic_int64_t flushAcquireCount_{0};
+  std::atomic_int64_t backpressureBlockCount_{0};
+  std::atomic_int64_t backpressureWakeCount_{0};
+  std::atomic_int64_t backpressureDrainedBytes_{0};
+
+  folly::Synchronized<std::vector<ContinuePromise>> blockedPromises_;
+
+  mutable std::mutex lifecycleMutex_;
+  std::optional<CommittedExchangeOutput> output_;
+
+  std::mutex driverMutex_;
+  uint32_t numDrivers_{0};
+  uint32_t numFinishedDrivers_{0};
+};
+
+} // namespace facebook::velox::exec
+
+template <>
+struct fmt::formatter<facebook::velox::exec::MaterializedOutputBuffer::State>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::exec::MaterializedOutputBuffer::State state,
+      format_context& context) const {
+    return formatter<std::string>::format(
+        facebook::velox::exec::MaterializedOutputBuffer::stateName(state),
+        context);
+  }
+};

--- a/velox/exec/MaterializedOutputBufferManager.cpp
+++ b/velox/exec/MaterializedOutputBufferManager.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MaterializedOutputBufferManager.h"
+
+#include <algorithm>
+
+#include <fmt/format.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/exec/MaterializedPartitionedOutput.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+
+MaterializedOutputBufferManager::MaterializedOutputBufferManager(
+    ExchangeSink::Factory sinkFactory,
+    int64_t maxBufferedBytes,
+    MaterializedOutputBatchConfig outputBatchConfig)
+    : sinkFactory_(std::move(sinkFactory)),
+      maxBufferedBytes_(maxBufferedBytes),
+      outputBatchConfig_(outputBatchConfig) {
+  VELOX_CHECK(sinkFactory_ != nullptr, "Exchange sink factory is null");
+  VELOX_CHECK_GT(maxBufferedBytes_, 0);
+  VELOX_CHECK_GT(outputBatchConfig_.minOutputBatchBytes, 0);
+  VELOX_CHECK_GE(
+      outputBatchConfig_.maxOutputBatchBytes,
+      outputBatchConfig_.minOutputBatchBytes);
+  VELOX_CHECK_GT(outputBatchConfig_.estimatedRowBytes, 0);
+}
+
+int64_t MaterializedOutputBufferManager::outputBatchSizeBytes(
+    int32_t numDestinations) const {
+  VELOX_CHECK_GT(numDestinations, 0);
+  const auto scaledBatchBytes = outputBatchConfig_.estimatedRowBytes >
+          outputBatchConfig_.maxOutputBatchBytes / numDestinations
+      ? outputBatchConfig_.maxOutputBatchBytes
+      : outputBatchConfig_.estimatedRowBytes * numDestinations;
+  return std::clamp(
+      scaledBatchBytes,
+      outputBatchConfig_.minOutputBatchBytes,
+      outputBatchConfig_.maxOutputBatchBytes);
+}
+
+std::shared_ptr<MaterializedOutputBuffer>
+MaterializedOutputBufferManager::buffer(const std::string& taskId) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = buffers_.find(taskId);
+  VELOX_CHECK(
+      it != buffers_.end(),
+      "Materialized output is not configured for task: {}",
+      taskId);
+  return it->second.buffer;
+}
+
+folly::F14FastMap<int32_t, std::string>
+MaterializedOutputBufferManager::outputLocations(
+    const std::string& taskId) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (auto it = buffers_.find(taskId); it != buffers_.end()) {
+    return it->second.buffer->outputLocations();
+  }
+  if (auto it = completedOutputs_.find(taskId); it != completedOutputs_.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+std::shared_ptr<velox::exec::OutputTransportEntry>
+MaterializedOutputBufferManager::transportEntry() {
+  return velox::exec::OutputTransportEntry::make<
+      MaterializedOutputBufferManager>(
+      shared_from_this(),
+      [](int32_t operatorId,
+         velox::exec::DriverCtx* ctx,
+         const std::shared_ptr<const velox::core::PartitionedOutputNode>& node,
+         bool /*eagerFlush*/,
+         const std::shared_ptr<MaterializedOutputBufferManager>& manager) {
+        return std::make_unique<MaterializedPartitionedOutput>(
+            operatorId, ctx, node, manager);
+      });
+}
+
+void MaterializedOutputBufferManager::initializeTask(
+    std::shared_ptr<velox::exec::Task> task,
+    velox::core::PartitionedOutputNode::Kind kind,
+    int numDestinations,
+    int numDrivers,
+    const std::string& transportOptions) {
+  VELOX_CHECK(
+      kind == velox::core::PartitionedOutputNode::Kind::kPartitioned ||
+          kind == velox::core::PartitionedOutputNode::Kind::kBroadcast,
+      "Unsupported materialized output kind: {}",
+      kind);
+  auto sinkPool = task->pool()->addLeafChild("materialized-output");
+  auto sink = sinkFactory_(transportOptions, task->taskId(), sinkPool.get());
+  VELOX_CHECK_NOT_NULL(sink, "Exchange sink factory returned null");
+  auto taskBuffer = std::make_shared<MaterializedOutputBuffer>(
+      numDestinations,
+      std::move(sink),
+      maxBufferedBytes_,
+      MaterializedOutputBuffer::kDefaultDrainThreshold,
+      sinkPool);
+  taskBuffer->setNumDrivers(numDrivers);
+  std::lock_guard<std::mutex> lock(mutex_);
+  VELOX_CHECK(
+      buffers_
+          .emplace(
+              task->taskId(),
+              TaskBuffer{
+                  .buffer = std::move(taskBuffer),
+                  .sinkPool = std::move(sinkPool),
+                  .maxBufferedBytes = maxBufferedBytes_})
+          .second,
+      "Materialized output is already configured for task: {}",
+      task->taskId());
+}
+
+bool MaterializedOutputBufferManager::updateOutputBuffers(
+    const std::string& taskId,
+    int numDestinations,
+    bool noMoreBuffers) {
+  auto taskBuffer = buffer(taskId);
+  VELOX_CHECK_EQ(taskBuffer->numPartitions(), numDestinations);
+  VELOX_CHECK(noMoreBuffers);
+  return true;
+}
+
+bool MaterializedOutputBufferManager::updateNumDrivers(
+    const std::string& taskId,
+    uint32_t newNumDrivers) {
+  buffer(taskId)->setNumDrivers(newNumDrivers);
+  return true;
+}
+
+void MaterializedOutputBufferManager::removeTask(const std::string& taskId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = buffers_.find(taskId);
+  if (it == buffers_.end()) {
+    return;
+  }
+  completedOutputs_[taskId] = it->second.buffer->outputLocations();
+  buffers_.erase(it);
+}
+
+std::optional<velox::exec::OutputBufferStats>
+MaterializedOutputBufferManager::stats(const std::string& taskId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = buffers_.find(taskId);
+  if (it == buffers_.end()) {
+    return std::nullopt;
+  }
+  velox::exec::OutputBufferStats stats;
+  stats.bufferedBytes = it->second.buffer->bufferedBytes();
+  return stats;
+}
+
+std::optional<double> MaterializedOutputBufferManager::getUtilization(
+    const std::string& taskId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = buffers_.find(taskId);
+  if (it == buffers_.end()) {
+    return std::nullopt;
+  }
+  return static_cast<double>(it->second.buffer->bufferedBytes()) /
+      it->second.maxBufferedBytes;
+}
+
+std::optional<bool> MaterializedOutputBufferManager::isOverutilized(
+    const std::string& taskId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = buffers_.find(taskId);
+  if (it == buffers_.end()) {
+    return std::nullopt;
+  }
+  return it->second.buffer->isBufferFull();
+}
+
+std::string MaterializedOutputBufferManager::toString(
+    const std::string& taskId) {
+  auto taskBuffer = buffer(taskId);
+  const auto partitionCount = taskBuffer->numPartitions();
+  return fmt::format(
+      "MaterializedOutputBuffer[task={}, partitionCount={}, bufferedBytes={}, "
+      "maxBufferedBytes={}, partitionDrainThresholdBytes={}, "
+      "highWatermarkBytes={}, lowWatermarkBytes={}, "
+      "outputBatchSizeBytes={}, minOutputBatchBytes={}, "
+      "maxOutputBatchBytes={}, estimatedRowBytes={}]",
+      taskId,
+      partitionCount,
+      taskBuffer->bufferedBytes(),
+      maxBufferedBytes_,
+      taskBuffer->partitionDrainThreshold(),
+      taskBuffer->highWatermarkBytes(),
+      taskBuffer->lowWatermarkBytes(),
+      outputBatchSizeBytes(partitionCount),
+      outputBatchConfig_.minOutputBatchBytes,
+      outputBatchConfig_.maxOutputBatchBytes,
+      outputBatchConfig_.estimatedRowBytes);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/MaterializedOutputBufferManager.h
+++ b/velox/exec/MaterializedOutputBufferManager.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <unordered_map>
+
+#include "velox/exec/MaterializedOutputBuffer.h"
+#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/OutputTransportRegistry.h"
+
+namespace facebook::velox::exec {
+
+/// Controls operator-local serialization batching before RowGroups are
+/// emitted to individual destinations.
+struct MaterializedOutputBatchConfig {
+  int64_t minOutputBatchBytes{1L << 20};
+  int64_t maxOutputBatchBytes{16L << 20};
+  int64_t estimatedRowBytes{1'024};
+};
+
+/// Owns materialized output buffers for all tasks using one exchange transport.
+class MaterializedOutputBufferManager final
+    : public velox::exec::OutputBufferManager,
+      public std::enable_shared_from_this<MaterializedOutputBufferManager> {
+ public:
+  MaterializedOutputBufferManager(
+      ExchangeSink::Factory sinkFactory,
+      int64_t maxBufferedBytes,
+      MaterializedOutputBatchConfig outputBatchConfig = {});
+
+  /// Returns the configured serialization batch size for a destination count.
+  int64_t outputBatchSizeBytes(int32_t numDestinations) const;
+
+  /// Returns the task buffer used by its materialized output operators.
+  std::shared_ptr<MaterializedOutputBuffer> buffer(
+      const std::string& taskId) const;
+
+  /// Returns committed output locations for a completed task.
+  folly::F14FastMap<int32_t, std::string> outputLocations(
+      const std::string& taskId) const;
+
+  /// Creates the Velox transport entry paired with this manager.
+  std::shared_ptr<velox::exec::OutputTransportEntry> transportEntry();
+
+  void initializeTask(
+      std::shared_ptr<velox::exec::Task> task,
+      velox::core::PartitionedOutputNode::Kind kind,
+      int numDestinations,
+      int numDrivers,
+      const std::string& transportOptions = {}) override;
+
+  bool updateOutputBuffers(
+      const std::string& taskId,
+      int numDestinations,
+      bool noMoreBuffers) override;
+
+  bool updateNumDrivers(const std::string& taskId, uint32_t newNumDrivers)
+      override;
+
+  void removeTask(const std::string& taskId) override;
+
+  std::optional<velox::exec::OutputBufferStats> stats(
+      const std::string& taskId) override;
+
+  std::optional<double> getUtilization(const std::string& taskId) override;
+
+  /// Reported only in task statistics; not used by scaled TableWriter
+  /// scheduling.
+  std::optional<bool> isOverutilized(const std::string& taskId) override;
+
+  std::string toString(const std::string& taskId) override;
+
+ private:
+  struct TaskBuffer {
+    std::shared_ptr<MaterializedOutputBuffer> buffer;
+    std::shared_ptr<velox::memory::MemoryPool> sinkPool;
+    int64_t maxBufferedBytes;
+  };
+
+  mutable std::mutex mutex_;
+  const ExchangeSink::Factory sinkFactory_;
+  const int64_t maxBufferedBytes_;
+  const MaterializedOutputBatchConfig outputBatchConfig_;
+  std::unordered_map<std::string, TaskBuffer> buffers_;
+  std::unordered_map<std::string, folly::F14FastMap<int32_t, std::string>>
+      completedOutputs_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/MaterializedPartitionedOutput.cpp
+++ b/velox/exec/MaterializedPartitionedOutput.cpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MaterializedPartitionedOutput.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/Task.h"
+#include "velox/serializers/RowSerializer.h"
+
+namespace facebook::velox::exec {
+
+MaterializedPartitionedOutput::MaterializedPartitionedOutput(
+    int32_t operatorId,
+    DriverCtx* ctx,
+    const std::shared_ptr<const core::PartitionedOutputNode>& planNode,
+    const std::shared_ptr<MaterializedOutputBufferManager>& manager)
+    : Operator(
+          ctx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "MaterializedPartitionedOutput"),
+      numDestinations_(planNode->numPartitions()),
+      broadcast_(planNode->isBroadcast()),
+      outputChannels_(calculateOutputChannels(
+          planNode->inputType(),
+          planNode->outputType(),
+          planNode->outputType())),
+      keyChannels_(toChannels(planNode->inputType(), planNode->keys())),
+      partitionFunction_(
+          broadcast_ || numDestinations_ == 1
+              ? nullptr
+              : planNode->partitionFunctionSpec().create(
+                    numDestinations_,
+                    false)),
+      replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
+      buffer_(manager->buffer(ctx->task->taskId())),
+      targetSizeInBytes_(manager->outputBatchSizeBytes(numDestinations_)),
+      rowGroupMaxBytes_(buffer_->partitionDrainThreshold()),
+      fixedRowSize_(
+          row::CompactRow::fixedRowSize(
+              std::dynamic_pointer_cast<const RowType>(
+                  planNode->outputType()))) {
+  VELOX_CHECK_GT(numDestinations_, 0);
+  VELOX_CHECK_NOT_NULL(buffer_);
+}
+
+void MaterializedPartitionedOutput::initializeInput(RowVectorPtr input) {
+  if (outputType_->size() == 0) {
+    output_ = std::make_shared<RowVector>(
+        input->pool(),
+        outputType_,
+        nullptr,
+        input->size(),
+        std::vector<VectorPtr>{});
+  } else if (outputChannels_.empty()) {
+    output_ = std::move(input);
+  } else {
+    std::vector<VectorPtr> outputColumns;
+    outputColumns.reserve(outputChannels_.size());
+    for (const auto channel : outputChannels_) {
+      outputColumns.push_back(input->childAt(channel));
+    }
+    output_ = std::make_shared<RowVector>(
+        input->pool(),
+        outputType_,
+        nullptr,
+        input->size(),
+        std::move(outputColumns));
+  }
+
+  for (column_index_t channel = 0; channel < output_->childrenSize();
+       ++channel) {
+    output_->childAt(channel)->loadedVector();
+  }
+}
+
+void MaterializedPartitionedOutput::computePartitions(
+    const RowVector& input,
+    int32_t numRows) {
+  partitions_.resize(numRows);
+  if (broadcast_ || numDestinations_ == 1) {
+    std::fill(partitions_.begin(), partitions_.end(), 0);
+    return;
+  }
+  const auto singlePartition =
+      partitionFunction_->partition(input, partitions_);
+  if (singlePartition.has_value()) {
+    std::fill(partitions_.begin(), partitions_.end(), singlePartition.value());
+  }
+}
+
+void MaterializedPartitionedOutput::ensureFlatBufferCapacity(
+    int64_t additionalBytes) {
+  const auto requiredSize = flatBufferSize_ + additionalBytes;
+  const auto currentCapacity = flatBuffer_ ? flatBuffer_->capacity() : 0;
+  if (flatBuffer_ != nullptr &&
+      requiredSize <= static_cast<int64_t>(currentCapacity)) {
+    if (requiredSize > static_cast<int64_t>(flatBuffer_->size())) {
+      flatBuffer_->setSize(requiredSize);
+    }
+    return;
+  }
+  const auto newSize = std::max<int64_t>(
+      {requiredSize, static_cast<int64_t>(currentCapacity) * 2, 1});
+  if (flatBuffer_ == nullptr) {
+    flatBuffer_ = AlignedBuffer::allocate<char>(newSize, pool());
+  } else {
+    AlignedBuffer::reallocate<char>(&flatBuffer_, newSize);
+  }
+}
+
+void MaterializedPartitionedOutput::serializeFixedWidthRows(
+    row::CompactRow& compactRow,
+    int32_t numRows) {
+  const auto startRow = rowCount_;
+  const auto fixedRowSize = fixedRowSize_.value();
+  const auto batchBytes = static_cast<int64_t>(numRows) * fixedRowSize;
+
+  rowSizes_.resize(startRow + numRows);
+  std::fill(rowSizes_.begin() + startRow, rowSizes_.end(), fixedRowSize);
+  ensureFlatBufferCapacity(batchBytes);
+  rowOffsets_.resize(startRow + numRows);
+  rowPartitions_.resize(startRow + numRows);
+
+  std::vector<size_t> bufferOffsets(numRows);
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rowOffsets_[startRow + i] = flatBufferSize_;
+    rowPartitions_[startRow + i] = partitions_[i];
+    bufferOffsets[i] = static_cast<size_t>(flatBufferSize_);
+    flatBufferSize_ += fixedRowSize;
+  }
+  std::memset(
+      flatBuffer_->asMutable<char>() + rowOffsets_[startRow], 0, batchBytes);
+  compactRow.serialize(
+      0, numRows, bufferOffsets.data(), flatBuffer_->asMutable<char>());
+  rowCount_ = startRow + numRows;
+}
+
+void MaterializedPartitionedOutput::serializeVariableWidthRows(
+    row::CompactRow& compactRow,
+    int32_t numRows) {
+  const auto startRow = rowCount_;
+  rowSizes_.resize(startRow + numRows);
+
+  int64_t batchBytes = 0;
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    const auto rowSize = compactRow.rowSize(i);
+    rowSizes_[startRow + i] = rowSize;
+    batchBytes += rowSize;
+  }
+  ensureFlatBufferCapacity(batchBytes);
+  rowOffsets_.resize(startRow + numRows);
+  rowPartitions_.resize(startRow + numRows);
+
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    const auto rowSize = rowSizes_[startRow + i];
+    rowOffsets_[startRow + i] = flatBufferSize_;
+    rowPartitions_[startRow + i] = partitions_[i];
+    std::memset(flatBuffer_->asMutable<char>() + flatBufferSize_, 0, rowSize);
+    compactRow.serialize(i, flatBuffer_->asMutable<char>() + flatBufferSize_);
+    flatBufferSize_ += rowSize;
+  }
+  rowCount_ = startRow + numRows;
+}
+
+void MaterializedPartitionedOutput::serializeRows(
+    row::CompactRow& compactRow,
+    int32_t numRows) {
+  if (fixedRowSize_.has_value()) {
+    serializeFixedWidthRows(compactRow, numRows);
+  } else {
+    serializeVariableWidthRows(compactRow, numRows);
+  }
+}
+
+void MaterializedPartitionedOutput::collectNullRows(
+    const RowVector& input,
+    int32_t numRows) {
+  rows_.resize(numRows);
+  rows_.setAll();
+  nullRows_.resize(numRows);
+  nullRows_.clearAll();
+  decodedVectors_.resize(keyChannels_.size());
+
+  for (size_t keyIndex = 0; keyIndex < keyChannels_.size(); ++keyIndex) {
+    const auto keyChannel = keyChannels_[keyIndex];
+    if (keyChannel == kConstantChannel) {
+      continue;
+    }
+    const auto& keyVector = input.childAt(keyChannel);
+    if (!keyVector->mayHaveNulls()) {
+      continue;
+    }
+    auto& decoded = decodedVectors_[keyIndex];
+    decoded.decode(*keyVector, rows_);
+    if (const auto* rawNulls = decoded.nulls(&rows_)) {
+      bits::orWithNegatedBits(
+          nullRows_.asMutableRange().bits(), rawNulls, 0, numRows);
+    }
+  }
+  nullRows_.updateBounds();
+}
+
+std::vector<int32_t> MaterializedPartitionedOutput::selectRowsToReplicate(
+    int32_t numRows) {
+  std::vector<int32_t> rowsToReplicate;
+  int32_t firstNullRow = 0;
+  if (!replicatedAny_) {
+    rowsToReplicate.push_back(0);
+    replicatedAny_ = true;
+    firstNullRow = 1;
+  }
+  for (int32_t row = firstNullRow; row < numRows; ++row) {
+    if (nullRows_.isValid(row)) {
+      rowsToReplicate.push_back(row);
+    }
+  }
+  return rowsToReplicate;
+}
+
+void MaterializedPartitionedOutput::appendReplicaEntries(
+    int32_t serializeStartRow,
+    const std::vector<int32_t>& rowsToReplicate) {
+  const auto extraEntries =
+      static_cast<size_t>(numDestinations_ - 1) * rowsToReplicate.size();
+  rowOffsets_.reserve(rowOffsets_.size() + extraEntries);
+  rowSizes_.reserve(rowSizes_.size() + extraEntries);
+  rowPartitions_.reserve(rowPartitions_.size() + extraEntries);
+
+  for (const auto inputRow : rowsToReplicate) {
+    const auto serializedRow = serializeStartRow + inputRow;
+    const auto offset = rowOffsets_[serializedRow];
+    const auto size = rowSizes_[serializedRow];
+    rowPartitions_[serializedRow] = 0;
+    for (uint32_t partition = 1;
+         partition < static_cast<uint32_t>(numDestinations_);
+         ++partition) {
+      rowOffsets_.push_back(offset);
+      rowSizes_.push_back(size);
+      rowPartitions_.push_back(partition);
+      ++rowCount_;
+    }
+  }
+}
+
+void MaterializedPartitionedOutput::expandReplicateRows(
+    int32_t serializeStartRow,
+    int32_t numRows) {
+  const auto rowsToReplicate = selectRowsToReplicate(numRows);
+  if (!rowsToReplicate.empty()) {
+    appendReplicaEntries(serializeStartRow, rowsToReplicate);
+  }
+}
+
+void MaterializedPartitionedOutput::addInput(RowVectorPtr input) {
+  auto rawInput = input;
+  initializeInput(std::move(input));
+  VELOX_CHECK_NOT_NULL(output_);
+  const auto numRows = output_->size();
+  if (numRows == 0) {
+    output_.reset();
+    return;
+  }
+
+  computePartitions(*rawInput, numRows);
+  if (shouldReplicate()) {
+    collectNullRows(*rawInput, numRows);
+  }
+
+  const auto serializeStartRow = rowCount_;
+  row::CompactRow compactRow(output_);
+  serializeRows(compactRow, numRows);
+  if (shouldReplicate()) {
+    expandReplicateRows(serializeStartRow, numRows);
+  }
+  output_.reset();
+
+  if (flatBufferSize_ >= targetSizeInBytes_) {
+    flushBatch();
+  }
+
+  blockingReason_ = buffer_->isBlocked(&future_);
+}
+
+void MaterializedPartitionedOutput::flushRowGroup(
+    int32_t partition,
+    std::vector<int32_t>& rowIndices) {
+  using TRowSize = serializer::TRowSize;
+  const auto headerSize = serializer::detail::RowGroupHeader::size();
+
+  int64_t rowDataBytes = 0;
+  for (const auto row : rowIndices) {
+    rowDataBytes += sizeof(TRowSize) + rowSizes_[row];
+  }
+  const auto totalBytes = headerSize + rowDataBytes;
+  auto rowGroup = buffer_->allocateTrackedIOBuf(totalBytes);
+  auto* destination = rowGroup->writableData();
+
+  serializer::detail::RowGroupHeader header;
+  header.uncompressedSize = static_cast<int32_t>(rowDataBytes);
+  header.compressedSize = static_cast<int32_t>(rowDataBytes);
+  header.compressed = false;
+  header.write(reinterpret_cast<char*>(destination));
+  destination += headerSize;
+
+  for (const auto row : rowIndices) {
+    const TRowSize rowSize =
+        folly::Endian::big(static_cast<TRowSize>(rowSizes_[row]));
+    std::memcpy(destination, &rowSize, sizeof(TRowSize));
+    destination += sizeof(TRowSize);
+    std::memcpy(
+        destination,
+        flatBuffer_->asMutable<char>() + rowOffsets_[row],
+        rowSizes_[row]);
+    destination += rowSizes_[row];
+  }
+  rowGroup->append(totalBytes);
+
+  buffer_->enqueue(partition, std::move(rowGroup));
+  rowIndices.clear();
+}
+
+void MaterializedPartitionedOutput::flushBatch() {
+  if (rowCount_ == 0) {
+    return;
+  }
+
+  std::vector<std::vector<int32_t>> partitionRows(numDestinations_);
+  for (int32_t row = 0; row < rowCount_; ++row) {
+    if (broadcast_) {
+      for (auto& rows : partitionRows) {
+        rows.push_back(row);
+      }
+    } else {
+      partitionRows[rowPartitions_[row]].push_back(row);
+    }
+  }
+
+  for (int32_t partition = 0; partition < numDestinations_; ++partition) {
+    const auto& rows = partitionRows[partition];
+    if (rows.empty()) {
+      continue;
+    }
+
+    std::vector<int32_t> rowGroupRows;
+    rowGroupRows.reserve(rows.size());
+    int64_t rowGroupBytes = serializer::detail::RowGroupHeader::size();
+    for (const auto row : rows) {
+      const auto serializedRowBytes =
+          static_cast<int64_t>(sizeof(serializer::TRowSize)) + rowSizes_[row];
+      if (!rowGroupRows.empty() &&
+          rowGroupBytes + serializedRowBytes > rowGroupMaxBytes_) {
+        flushRowGroup(partition, rowGroupRows);
+        rowGroupBytes = serializer::detail::RowGroupHeader::size();
+      }
+      rowGroupRows.push_back(row);
+      rowGroupBytes += serializedRowBytes;
+    }
+    if (!rowGroupRows.empty()) {
+      flushRowGroup(partition, rowGroupRows);
+    }
+  }
+
+  rowOffsets_.clear();
+  rowSizes_.clear();
+  rowPartitions_.clear();
+  rowCount_ = 0;
+  flatBufferSize_ = 0;
+}
+
+RowVectorPtr MaterializedPartitionedOutput::getOutput() {
+  return nullptr;
+}
+
+void MaterializedPartitionedOutput::noMoreInput() {
+  Operator::noMoreInput();
+  finish();
+}
+
+BlockingReason MaterializedPartitionedOutput::isBlocked(
+    ContinueFuture* future) {
+  if (blockingReason_ == BlockingReason::kNotBlocked) {
+    return BlockingReason::kNotBlocked;
+  }
+  *future = std::move(future_);
+  const auto reason = blockingReason_;
+  blockingReason_ = BlockingReason::kNotBlocked;
+  return reason;
+}
+
+bool MaterializedPartitionedOutput::isFinished() {
+  return finished_;
+}
+
+void MaterializedPartitionedOutput::recordBufferStats() {
+  for (const auto& [name, value] : buffer_->stats()) {
+    addRuntimeStat(name, RuntimeCounter(value));
+  }
+}
+
+void MaterializedPartitionedOutput::close() {
+  if (!finished_) {
+    buffer_->abort();
+  }
+  if (isLastDriver_) {
+    recordBufferStats();
+  }
+  Operator::close();
+}
+
+void MaterializedPartitionedOutput::finish() {
+  if (finished_) {
+    return;
+  }
+  flushBatch();
+
+  std::vector<ContinuePromise> peerPromises;
+  std::vector<std::shared_ptr<Driver>> peers;
+  ContinueFuture peerFuture;
+  auto* driverContext = operatorCtx()->driverCtx();
+  const auto isLast = driverContext->task->allPeersFinished(
+      planNodeId(), driverContext->driver, &peerFuture, peerPromises, peers);
+  if (isLast) {
+    // allPeersFinished returns true only for the last driver. That driver owns
+    // the shared buffer's terminal snapshot and publishes it exactly once.
+    isLastDriver_ = true;
+    buffer_->noMoreData();
+    driverContext->task->setAllOutputConsumed();
+    for (auto& promise : peerPromises) {
+      promise.setValue();
+    }
+  }
+  finished_ = true;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/MaterializedPartitionedOutput.h
+++ b/velox/exec/MaterializedPartitionedOutput.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/Expressions.h"
+#include "velox/core/PlanNode.h"
+#include "velox/exec/MaterializedOutputBufferManager.h"
+#include "velox/exec/Operator.h"
+#include "velox/row/CompactRow.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox::exec {
+
+/// Serializes PartitionedOutput rows as CompactRow RowGroups and writes them
+/// through a MaterializedOutputBuffer.
+class MaterializedPartitionedOutput : public Operator {
+ public:
+  MaterializedPartitionedOutput(
+      int32_t operatorId,
+      DriverCtx* ctx,
+      const std::shared_ptr<const core::PartitionedOutputNode>& planNode,
+      const std::shared_ptr<MaterializedOutputBufferManager>& manager);
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  bool needsInput() const override {
+    return !finished_ && blockingReason_ == BlockingReason::kNotBlocked;
+  }
+
+  void noMoreInput() override;
+
+  BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
+
+  void close() override;
+
+ private:
+  // Projects output columns and loads lazy vectors before serialization.
+  void initializeInput(RowVectorPtr input);
+
+  // Computes one destination for each input row before replication.
+  void computePartitions(const RowVector& input, int32_t numRows);
+
+  // Appends the current output rows to the serialized staging buffers.
+  void serializeRows(row::CompactRow& compactRow, int32_t numRows);
+
+  // Serializes fixed-width rows directly into pre-sized staging storage.
+  void serializeFixedWidthRows(row::CompactRow& compactRow, int32_t numRows);
+
+  // Sizes variable-width rows before appending them to staging storage.
+  void serializeVariableWidthRows(row::CompactRow& compactRow, int32_t numRows);
+
+  // Grows staging storage while preserving rows already serialized into it.
+  void ensureFlatBufferCapacity(int64_t additionalBytes);
+
+  // Finds rows with null partition keys for replicate-nulls-and-any.
+  void collectNullRows(const RowVector& input, int32_t numRows);
+
+  // Selects null-key rows and the first row seen by this operator exactly
+  // once.
+  std::vector<int32_t> selectRowsToReplicate(int32_t numRows);
+
+  // Replicates row metadata across destinations without copying row bytes.
+  void appendReplicaEntries(
+      int32_t serializeStartRow,
+      const std::vector<int32_t>& rowsToReplicate);
+
+  // Adds replica metadata for the rows selected from the current input batch.
+  void expandReplicateRows(int32_t serializeStartRow, int32_t numRows);
+
+  // Groups staged rows by destination, emits bounded RowGroups, and resets.
+  void flushBatch();
+
+  // Encodes selected rows as one CompactRow RowGroup and enqueues it.
+  void flushRowGroup(int32_t partition, std::vector<int32_t>& rowIndices);
+
+  // Flushes local rows and lets the last peer commit the shared buffer.
+  void finish();
+
+  // Publishes buffer and sink counters as operator runtime statistics.
+  void recordBufferStats();
+
+  bool shouldReplicate() const {
+    return !broadcast_ && replicateNullsAndAny_ && numDestinations_ > 1;
+  }
+
+  const int32_t numDestinations_;
+  const bool broadcast_;
+  const std::vector<column_index_t> outputChannels_;
+  const std::vector<column_index_t> keyChannels_;
+  std::unique_ptr<core::PartitionFunction> partitionFunction_;
+  const bool replicateNullsAndAny_;
+  const std::shared_ptr<MaterializedOutputBuffer> buffer_;
+  const int64_t targetSizeInBytes_;
+  const int64_t rowGroupMaxBytes_;
+  const std::optional<int32_t> fixedRowSize_;
+
+  BlockingReason blockingReason_{BlockingReason::kNotBlocked};
+  ContinueFuture future_;
+  bool finished_{false};
+  bool isLastDriver_{false};
+
+  RowVectorPtr output_;
+  std::vector<uint32_t> partitions_;
+
+  SelectivityVector rows_;
+  SelectivityVector nullRows_;
+  std::vector<DecodedVector> decodedVectors_;
+  bool replicatedAny_{false};
+
+  int32_t rowCount_{0};
+  int64_t flatBufferSize_{0};
+  BufferPtr flatBuffer_;
+  std::vector<int64_t> rowOffsets_;
+  std::vector<int32_t> rowSizes_;
+  std::vector<uint32_t> rowPartitions_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -477,4 +477,26 @@ target_link_libraries(
   GTest::gmock
 )
 
+add_executable(materialized_output_buffer_test MaterializedOutputBufferTest.cpp)
+add_test(materialized_output_buffer_test materialized_output_buffer_test)
+target_link_libraries(
+  materialized_output_buffer_test
+  velox_exec
+  fmt::fmt
+  Folly::folly
+  GTest::gtest
+  GTest::gtest_main
+)
+
+add_executable(materialized_partitioned_output_test MaterializedPartitionedOutputTest.cpp Main.cpp)
+add_test(materialized_partitioned_output_test materialized_partitioned_output_test)
+target_link_libraries(
+  materialized_partitioned_output_test
+  velox_exec
+  velox_exec_test_lib
+  fmt::fmt
+  Folly::folly
+  GTest::gtest
+)
+
 velox_add_library(velox_aggregate_registry_util INTERFACE HEADERS AggregateRegistryTestUtil.h)

--- a/velox/exec/tests/MaterializedOutputBufferTest.cpp
+++ b/velox/exec/tests/MaterializedOutputBufferTest.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <thread>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/synchronization/Baton.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/MaterializedOutputBuffer.h"
+#include "velox/exec/MaterializedOutputBufferManager.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+class RecordingExchangeSink : public ExchangeSink {
+ public:
+  explicit RecordingExchangeSink(int32_t numPartitions = 0)
+      : numPartitions_(numPartitions) {}
+
+  void append(int32_t /*partition*/, std::string_view data) override {
+    stringAppendBytes_ += data.size();
+  }
+
+  void append(int32_t /*partition*/, std::unique_ptr<folly::IOBuf> data)
+      override {
+    ++chainAppendCount_;
+    chainElementCount_ += data->countChainElements();
+    chainAppendBytes_ += data->computeChainDataLength();
+  }
+
+  CommittedExchangeOutput finish() override {
+    finished_ = true;
+    CommittedExchangeOutput output;
+    for (int32_t partition = 0; partition < numPartitions_; ++partition) {
+      output.locations.emplace(
+          partition, fmt::format("partition:{}", partition));
+    }
+    return output;
+  }
+
+  void abort() override {
+    aborted_ = true;
+  }
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return {{"totalBytesWritten", stringAppendBytes_ + chainAppendBytes_}};
+  }
+
+  const int32_t numPartitions_;
+  std::atomic_int64_t stringAppendBytes_{0};
+  std::atomic_int64_t chainAppendCount_{0};
+  std::atomic_int64_t chainElementCount_{0};
+  std::atomic_int64_t chainAppendBytes_{0};
+  std::atomic_bool finished_{false};
+  std::atomic_bool aborted_{false};
+};
+
+class BlockingExchangeSink : public RecordingExchangeSink {
+ public:
+  void append(int32_t partition, std::unique_ptr<folly::IOBuf> data) override {
+    if (!appendStartedPosted_.exchange(true)) {
+      appendStarted_.post();
+      releaseAppend_.wait();
+    }
+    RecordingExchangeSink::append(partition, std::move(data));
+  }
+
+  std::atomic_bool appendStartedPosted_{false};
+  folly::Baton<> appendStarted_;
+  folly::Baton<> releaseAppend_;
+};
+
+class MaterializedOutputBufferTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<RecordingExchangeSink> createSink(int32_t numPartitions) {
+    return std::make_shared<RecordingExchangeSink>(numPartitions);
+  }
+
+  std::unique_ptr<folly::IOBuf> makeData(std::string_view content) {
+    return folly::IOBuf::copyBuffer(content.data(), content.size());
+  }
+};
+
+TEST_F(MaterializedOutputBufferTest, singleDriverSinglePartition) {
+  auto sink = createSink(1);
+  MaterializedOutputBuffer buffer(1, sink, 1 << 20);
+  buffer.setNumDrivers(1);
+
+  buffer.enqueue(0, makeData("hello"));
+  buffer.enqueue(0, makeData("world"));
+  ContinueFuture future;
+  EXPECT_EQ(buffer.isBlocked(&future), BlockingReason::kNotBlocked);
+
+  EXPECT_TRUE(buffer.noMoreDrivers());
+  EXPECT_TRUE(sink->finished_);
+  EXPECT_EQ(buffer.outputLocations().size(), 1);
+}
+
+TEST_F(MaterializedOutputBufferTest, multiplePartitions) {
+  auto sink = createSink(3);
+  MaterializedOutputBuffer buffer(3, sink, 1 << 20);
+  buffer.setNumDrivers(1);
+
+  buffer.enqueue(0, makeData("partition_0"));
+  buffer.enqueue(1, makeData("partition_1"));
+  buffer.enqueue(2, makeData("partition_2"));
+
+  EXPECT_TRUE(buffer.noMoreDrivers());
+  EXPECT_GT(buffer.stats().at("totalBytesWritten"), 0);
+  EXPECT_EQ(buffer.outputLocations().size(), 3);
+}
+
+TEST_F(MaterializedOutputBufferTest, multipleDrivers) {
+  auto sink = createSink(2);
+  auto buffer = std::make_shared<MaterializedOutputBuffer>(2, sink, 1 << 20);
+  buffer->setNumDrivers(4);
+
+  std::vector<std::thread> threads;
+  for (int32_t driver = 0; driver < 4; ++driver) {
+    threads.emplace_back([buffer, driver]() {
+      for (int32_t row = 0; row < 10; ++row) {
+        const auto data = fmt::format("driver_{}_row_{}", driver, row);
+        buffer->enqueue(
+            row % 2, folly::IOBuf::copyBuffer(data.data(), data.size()));
+      }
+      buffer->noMoreDrivers();
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_TRUE(sink->finished_);
+  EXPECT_EQ(buffer->outputLocations().size(), 2);
+}
+
+TEST_F(MaterializedOutputBufferTest, iobufChainAppend) {
+  auto sink = createSink(1);
+  MaterializedOutputBuffer buffer(1, sink, 100, 10);
+
+  buffer.enqueue(0, makeData("hello"));
+  buffer.enqueue(0, makeData("world!"));
+
+  EXPECT_EQ(sink->chainAppendCount_, 1);
+  EXPECT_EQ(sink->chainElementCount_, 2);
+  EXPECT_EQ(sink->chainAppendBytes_, 11);
+  EXPECT_EQ(sink->stringAppendBytes_, 0);
+}
+
+TEST_F(MaterializedOutputBufferTest, backpressureWhileFlusherIsBusy) {
+  auto sink = std::make_shared<BlockingExchangeSink>();
+  MaterializedOutputBuffer buffer(1, sink, 100, 100);
+
+  buffer.enqueue(0, makeData(std::string(80, 'a')));
+  std::thread flusher(
+      [&]() { buffer.enqueue(0, makeData(std::string(30, 'b'))); });
+  sink->appendStarted_.wait();
+
+  buffer.enqueue(0, makeData(std::string(80, 'c')));
+  ContinueFuture future;
+  EXPECT_EQ(buffer.isBlocked(&future), BlockingReason::kWaitForConsumer);
+  ASSERT_TRUE(future.valid());
+
+  sink->releaseAppend_.post();
+  flusher.join();
+  EXPECT_TRUE(future.isReady());
+  EXPECT_EQ(buffer.bufferedBytes(), 0);
+}
+
+TEST_F(MaterializedOutputBufferTest, fullAtHighWatermark) {
+  auto sink = createSink(1);
+  MaterializedOutputBuffer buffer(1, sink, 100, 100);
+
+  EXPECT_FALSE(buffer.isBufferFull());
+  buffer.enqueue(0, makeData(std::string(89, 'a')));
+  EXPECT_FALSE(buffer.isBufferFull());
+  buffer.enqueue(0, makeData("b"));
+  EXPECT_TRUE(buffer.isBufferFull());
+}
+
+TEST_F(MaterializedOutputBufferTest, drainAll) {
+  auto sink = createSink(3);
+  MaterializedOutputBuffer buffer(3, sink, 1 << 20);
+
+  buffer.enqueue(0, makeData("data_0"));
+  buffer.enqueue(1, makeData("data_1"));
+  buffer.enqueue(2, makeData("data_2"));
+
+  EXPECT_GT(buffer.drainAll(), 0);
+  EXPECT_EQ(buffer.bufferedBytes(), 0);
+  EXPECT_EQ(sink->chainAppendCount_, 3);
+}
+
+TEST_F(MaterializedOutputBufferTest, abort) {
+  auto sink = createSink(1);
+  MaterializedOutputBuffer buffer(1, sink, 1 << 20);
+
+  buffer.enqueue(0, makeData("data"));
+  buffer.abort();
+
+  EXPECT_TRUE(sink->aborted_);
+  EXPECT_EQ(buffer.state(), MaterializedOutputBuffer::State::kAborted);
+  EXPECT_EQ(buffer.bufferedBytes(), 0);
+}
+
+TEST_F(MaterializedOutputBufferTest, noMoreDataIsIdempotent) {
+  auto sink = createSink(1);
+  MaterializedOutputBuffer buffer(1, sink, 1 << 20);
+
+  buffer.enqueue(0, makeData("data"));
+  buffer.noMoreData();
+  buffer.noMoreData();
+
+  EXPECT_TRUE(sink->finished_);
+  EXPECT_EQ(sink->chainAppendCount_, 1);
+}
+
+TEST_F(MaterializedOutputBufferTest, rejectsEnqueueAfterClose) {
+  auto sink = createSink(1);
+  MaterializedOutputBuffer buffer(1, sink, 1 << 20);
+  buffer.noMoreData();
+
+  VELOX_ASSERT_THROW(
+      buffer.enqueue(0, makeData("late")), "enqueue called after noMoreData()");
+}
+
+TEST_F(MaterializedOutputBufferTest, configurableOutputBatchSize) {
+  ExchangeSink::Factory sinkFactory =
+      [](const std::string&,
+         const std::string&,
+         memory::MemoryPool*) -> std::shared_ptr<ExchangeSink> {
+    return std::make_shared<RecordingExchangeSink>();
+  };
+  MaterializedOutputBatchConfig config{
+      .minOutputBatchBytes = 100,
+      .maxOutputBatchBytes = 300,
+      .estimatedRowBytes = 40,
+  };
+  MaterializedOutputBufferManager manager(
+      std::move(sinkFactory), 1'024, config);
+
+  EXPECT_EQ(manager.outputBatchSizeBytes(1), 100);
+  EXPECT_EQ(manager.outputBatchSizeBytes(5), 200);
+  EXPECT_EQ(manager.outputBatchSizeBytes(10), 300);
+}
+
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/MaterializedPartitionedOutputTest.cpp
+++ b/velox/exec/tests/MaterializedPartitionedOutputTest.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <atomic>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/MaterializedOutputBufferManager.h"
+#include "velox/exec/OutputTransportRegistry.h"
+#include "velox/exec/Task.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/vector/VectorStream.h"
+
+using namespace facebook::velox;
+
+namespace facebook::velox::exec::test {
+namespace {
+
+constexpr std::string_view kTransport{"materialized-test"};
+
+struct RecordingSinkState {
+  explicit RecordingSinkState(int32_t numPartitions, bool failFinish = false)
+      : partitionData(numPartitions), failFinish(failFinish) {}
+
+  std::vector<std::string> snapshotData() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return partitionData;
+  }
+
+  std::vector<int64_t> snapshotRowGroupSizes() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return rowGroupSizes;
+  }
+
+  mutable std::mutex mutex;
+  std::vector<std::string> partitionData;
+  std::vector<int64_t> rowGroupSizes;
+  const bool failFinish;
+  std::atomic_bool finished{false};
+  std::atomic_bool aborted{false};
+};
+
+class RecordingExchangeSink : public ExchangeSink {
+ public:
+  explicit RecordingExchangeSink(std::shared_ptr<RecordingSinkState> state)
+      : state_(std::move(state)) {}
+
+  void append(int32_t partition, std::string_view data) override {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    state_->partitionData.at(partition).append(data);
+  }
+
+  void append(int32_t partition, std::unique_ptr<folly::IOBuf> data) override {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    const auto* current = data.get();
+    do {
+      state_->rowGroupSizes.push_back(current->length());
+      current = current->next();
+    } while (current != data.get());
+    data->coalesce();
+    state_->partitionData.at(partition).append(
+        reinterpret_cast<const char*>(data->data()), data->length());
+  }
+
+  CommittedExchangeOutput finish() override {
+    if (state_->failFinish) {
+      VELOX_FAIL("Simulated sink finish failure");
+    }
+    state_->finished = true;
+    CommittedExchangeOutput output;
+    for (int32_t partition = 0;
+         partition < static_cast<int32_t>(state_->partitionData.size());
+         ++partition) {
+      output.locations.emplace(
+          partition, fmt::format("partition:{}", partition));
+    }
+    return output;
+  }
+
+  void abort() override {
+    state_->aborted = true;
+  }
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return {{"sharedSinkCount", 7}};
+  }
+
+ private:
+  const std::shared_ptr<RecordingSinkState> state_;
+};
+
+class MaterializedPartitionedOutputTest : public OperatorTestBase {
+ protected:
+  struct RunResult {
+    std::shared_ptr<Task> task;
+    std::shared_ptr<RecordingSinkState> sink;
+  };
+
+  RunResult runPlan(
+      core::PlanNodePtr plan,
+      int32_t numPartitions,
+      int32_t numDrivers = 1,
+      bool failFinish = false,
+      bool expectFailure = false) {
+    auto sink = std::make_shared<RecordingSinkState>(numPartitions, failFinish);
+    auto manager = std::make_shared<MaterializedOutputBufferManager>(
+        [sink](const std::string&, const std::string&, memory::MemoryPool*)
+            -> std::shared_ptr<ExchangeSink> {
+          return std::make_shared<RecordingExchangeSink>(sink);
+        },
+        64L << 20);
+    auto registry = OutputTransportRegistry::create(nullptr);
+    registry->insert(std::string(kTransport), manager->transportEntry());
+
+    auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
+    queryCtx->setRegistry(OutputTransportRegistry::kRegistryKey, registry);
+    auto task = Task::create(
+        fmt::format("materialized-output-test-{}", nextTaskId_++),
+        core::PlanFragment{std::move(plan)},
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel,
+        Consumer{});
+    task->start(numDrivers);
+    if (expectFailure) {
+      EXPECT_TRUE(waitForTaskFailure(task.get(), 10'000'000));
+    } else {
+      EXPECT_TRUE(waitForTaskCompletion(task.get(), 10'000'000));
+    }
+    return {std::move(task), std::move(sink)};
+  }
+
+  RunResult runExchangeWrite(
+      const std::vector<RowVectorPtr>& data,
+      int32_t numPartitions,
+      int32_t numDrivers = 1,
+      bool replicateNullsAndAny = false) {
+    const std::vector<std::string> keys = numPartitions == 1
+        ? std::vector<std::string>{}
+        : std::vector<std::string>{"c0"};
+    auto plan = PlanBuilder()
+                    .values(data, true)
+                    .partitionedOutput(
+                        keys,
+                        numPartitions,
+                        replicateNullsAndAny,
+                        {},
+                        "CompactRow",
+                        std::string(kTransport))
+                    .planNode();
+    return runPlan(std::move(plan), numPartitions, numDrivers);
+  }
+
+  std::vector<RowVectorPtr> deserialize(
+      const std::shared_ptr<RecordingSinkState>& sink,
+      const RowTypePtr& rowType) {
+    std::vector<RowVectorPtr> results;
+    for (auto& data : sink->snapshotData()) {
+      if (data.empty()) {
+        continue;
+      }
+      ByteRange range{
+          reinterpret_cast<uint8_t*>(data.data()),
+          static_cast<int32_t>(data.size()),
+          0};
+      BufferInputStream stream({range});
+      RowVectorPtr result;
+      getNamedVectorSerde("CompactRow")
+          ->deserialize(&stream, pool(), rowType, &result, nullptr);
+      results.push_back(std::move(result));
+    }
+    return results;
+  }
+
+  static inline std::atomic_int64_t nextTaskId_{0};
+};
+
+TEST_F(MaterializedPartitionedOutputTest, basicEndToEnd) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+      makeFlatVector<std::string>({"a", "bb", "ccc", "dddd", "eeeee", "f"}),
+  });
+
+  auto result = runExchangeWrite({data}, 4, 2);
+  EXPECT_TRUE(result.sink->finished);
+  assertEqualResults(
+      {data, data}, deserialize(result.sink, asRowType(data->type())));
+}
+
+TEST_F(MaterializedPartitionedOutputTest, outputBufferDescription) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4})});
+  auto sinkState = std::make_shared<RecordingSinkState>(4);
+  auto manager = std::make_shared<MaterializedOutputBufferManager>(
+      [sinkState](const std::string&, const std::string&, memory::MemoryPool*)
+          -> std::shared_ptr<ExchangeSink> {
+        return std::make_shared<RecordingExchangeSink>(sinkState);
+      },
+      64L << 20);
+  auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .partitionedOutput(
+              {"c0"}, 4, false, {}, "CompactRow", std::string(kTransport))
+          .planNode();
+  auto task = Task::create(
+      "materialized-output-description-test",
+      core::PlanFragment{std::move(plan)},
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel,
+      Consumer{});
+  manager->initializeTask(
+      task, core::PartitionedOutputNode::Kind::kPartitioned, 4, 2);
+
+  const auto outputBufferDescription = manager->toString(task->taskId());
+
+  EXPECT_NE(
+      outputBufferDescription.find("partitionCount=4"), std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("maxBufferedBytes=67108864"),
+      std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("partitionDrainThresholdBytes=131072"),
+      std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("highWatermarkBytes=60397977"),
+      std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("lowWatermarkBytes=46976204"),
+      std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("outputBatchSizeBytes=1048576"),
+      std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("minOutputBatchBytes=1048576"),
+      std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("maxOutputBatchBytes=16777216"),
+      std::string::npos);
+  EXPECT_NE(
+      outputBufferDescription.find("estimatedRowBytes=1024"),
+      std::string::npos);
+
+  manager->removeTask(task->taskId());
+}
+
+TEST_F(MaterializedPartitionedOutputTest, largeDataEndToEnd) {
+  constexpr int32_t kNumRows = 10'000;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(kNumRows, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(kNumRows, [](auto row) { return row * 100; }),
+      makeFlatVector<std::string>(
+          kNumRows, [](auto row) { return fmt::format("str_{}", row); }),
+      makeFlatVector<double>(kNumRows, [](auto row) { return row * 1.5; }),
+  });
+
+  auto result = runExchangeWrite({data}, 8, 4);
+  assertEqualResults(
+      {data, data, data, data},
+      deserialize(result.sink, asRowType(data->type())));
+}
+
+TEST_F(MaterializedPartitionedOutputTest, preservesManySmallInputBatches) {
+  constexpr int32_t kNumBatches = 4'096;
+  std::vector<RowVectorPtr> data;
+  data.reserve(kNumBatches);
+  for (int32_t batch = 0; batch < kNumBatches; ++batch) {
+    data.push_back(makeRowVector({
+        makeFlatVector<int64_t>({batch}),
+        makeFlatVector<std::string>({fmt::format("Customer#{:09}", batch)}),
+    }));
+  }
+
+  auto result = runExchangeWrite(data, 1);
+  assertEqualResults(
+      data, deserialize(result.sink, asRowType(data.front()->type())));
+}
+
+TEST_F(MaterializedPartitionedOutputTest, recordsSharedSinkStatsOnce) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4}),
+      makeFlatVector<std::string>({"a", "b", "c", "d"}),
+  });
+
+  auto result = runExchangeWrite({data}, 2, 4);
+  int64_t sharedSinkCount = 0;
+  int32_t materializedOutputDrivers = 0;
+  for (const auto& pipeline : result.task->taskStats().pipelineStats) {
+    for (const auto& op : pipeline.operatorStats) {
+      const auto stat = op.runtimeStats.find("sharedSinkCount");
+      if (stat != op.runtimeStats.end()) {
+        sharedSinkCount += stat->second.sum;
+        materializedOutputDrivers += op.numDrivers;
+      }
+    }
+  }
+
+  EXPECT_EQ(materializedOutputDrivers, 4);
+  EXPECT_EQ(sharedSinkCount, 7);
+}
+
+TEST_F(MaterializedPartitionedOutputTest, boundsRowGroupsForLargeInputBatch) {
+  constexpr int32_t kNumRows = 128;
+  constexpr int32_t kValueBytes = 8 * 1024;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(kNumRows, [](auto) { return 0; }),
+      makeFlatVector<std::string>(
+          kNumRows,
+          [](auto row) {
+            return std::string(kValueBytes, static_cast<char>('a' + row % 26));
+          }),
+  });
+
+  auto result = runExchangeWrite({data}, 1);
+  const auto rowGroupSizes = result.sink->snapshotRowGroupSizes();
+  ASSERT_GT(rowGroupSizes.size(), 1);
+  for (const auto size : rowGroupSizes) {
+    EXPECT_LE(size, MaterializedOutputBuffer::kDefaultDrainThreshold);
+  }
+  assertEqualResults({data}, deserialize(result.sink, asRowType(data->type())));
+}
+
+TEST_F(MaterializedPartitionedOutputTest, singlePartition) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({10, 20, 30}),
+      makeFlatVector<std::string>({"x", "y", "z"}),
+  });
+
+  auto result = runExchangeWrite({data}, 1);
+  assertEqualResults({data}, deserialize(result.sink, asRowType(data->type())));
+}
+
+TEST_F(MaterializedPartitionedOutputTest, manyPartitions) {
+  constexpr int32_t kNumRows = 500;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(kNumRows, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(kNumRows, [](auto row) { return row * 7; }),
+  });
+
+  auto result = runExchangeWrite({data}, 16);
+  assertEqualResults({data}, deserialize(result.sink, asRowType(data->type())));
+}
+
+TEST_F(MaterializedPartitionedOutputTest, emptyInput) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(0, [](auto row) { return row; }),
+      makeFlatVector<std::string>(0, [](auto) { return ""; }),
+  });
+
+  auto result = runExchangeWrite({data}, 4);
+  EXPECT_TRUE(result.sink->finished);
+  EXPECT_TRUE(deserialize(result.sink, asRowType(data->type())).empty());
+}
+
+TEST_F(MaterializedPartitionedOutputTest, zeroColumnOutput) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6})});
+  auto sourceType = asRowType(data->type());
+  auto source = PlanBuilder().values({data}).planNode();
+  std::vector<core::TypedExprPtr> keys{
+      std::make_shared<core::FieldAccessTypedExpr>(
+          sourceType->childAt(0), sourceType->nameOf(0))};
+  auto plan = std::make_shared<core::PartitionedOutputNode>(
+      "materialized-output",
+      core::PartitionedOutputNode::Kind::kPartitioned,
+      keys,
+      4,
+      false,
+      std::make_shared<HashPartitionFunctionSpec>(
+          sourceType, std::vector<column_index_t>{0}),
+      ROW({}, {}),
+      "CompactRow",
+      std::string(kTransport),
+      std::move(source));
+
+  auto result = runPlan(std::move(plan), 4);
+  auto rows = deserialize(result.sink, ROW({}, {}));
+  int64_t numRows = 0;
+  for (const auto& vector : rows) {
+    EXPECT_EQ(vector->childrenSize(), 0);
+    numRows += vector->size();
+  }
+  EXPECT_EQ(numRows, data->size());
+}
+
+TEST_F(MaterializedPartitionedOutputTest, replicateNullsAndAny) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, std::nullopt, 4, std::nullopt, 6}),
+      makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}),
+  });
+
+  auto result = runExchangeWrite({data}, 4, 1, true);
+  std::map<std::string, int32_t> counts;
+  for (const auto& vector : deserialize(result.sink, asRowType(data->type()))) {
+    auto* values = vector->childAt(1)->as<SimpleVector<StringView>>();
+    for (vector_size_t row = 0; row < vector->size(); ++row) {
+      ++counts[values->valueAt(row).str()];
+    }
+  }
+
+  EXPECT_EQ(counts["a"], 4);
+  EXPECT_EQ(counts["c"], 4);
+  EXPECT_EQ(counts["e"], 4);
+  EXPECT_EQ(counts["b"], 1);
+  EXPECT_EQ(counts["d"], 1);
+  EXPECT_EQ(counts["f"], 1);
+}
+
+TEST_F(MaterializedPartitionedOutputTest, replicateNullsAndAnyDisabled) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, std::nullopt, 4, std::nullopt, 6}),
+      makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}),
+  });
+
+  auto result = runExchangeWrite({data}, 4, 1, false);
+  std::map<std::string, int32_t> counts;
+  for (const auto& vector : deserialize(result.sink, asRowType(data->type()))) {
+    auto* values = vector->childAt(1)->as<SimpleVector<StringView>>();
+    for (vector_size_t row = 0; row < vector->size(); ++row) {
+      ++counts[values->valueAt(row).str()];
+    }
+  }
+
+  for (const auto* value : {"a", "b", "c", "d", "e", "f"}) {
+    EXPECT_EQ(counts[value], 1);
+  }
+}
+
+TEST_F(MaterializedPartitionedOutputTest, propagatesSinkFinishFailure) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<std::string>({"a", "b", "c"}),
+  });
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .partitionedOutput(
+                      {"c0"}, 4, {}, "CompactRow", std::string(kTransport))
+                  .planNode();
+
+  auto result = runPlan(
+      std::move(plan), 4, 1, /*failFinish=*/true, /*expectFailure=*/true);
+  EXPECT_NE(
+      result.task->errorMessage().find("Simulated sink finish failure"),
+      std::string::npos);
+  EXPECT_TRUE(result.sink->aborted);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:

## Overview

This diff adds the Velox execution-layer implementation for durable materialized partitioned output. Instead of exposing output through the existing in-memory output-buffer protocol, each driver partitions and serializes rows into bounded `CompactRow` RowGroups, places them in a shared per-task buffer, and drains those RowGroups into a pluggable `ExchangeSink` backend.

The operator factory and output-buffer manager are registered together as one `OutputTransportEntry`. A named output transport therefore selects a matched pair of runtime components and cannot accidentally combine the materialized operator with an incompatible buffer manager.

This is the backend-neutral foundation. File- and Cosco-specific sinks, coordinator integration, and fault-tolerant scheduling are added by dependent diffs.

## Design

```text
                           planning / task initialization

  PartitionedOutputNode
  - output transport name
  - partitioning / broadcast
  - destination count
  - replicate-nulls-and-any
  - transport options
             |
             v
  +----------------------------------+
  | OutputTransportRegistry          |
  |                                  |
  | name -> OutputTransportEntry     |
  +----------------+-----------------+
                   |
                   | binds the two components below as one transport
                   v
  +----------------------------------+       +-------------------------------+
  | MaterializedOutputBufferManager  |------>| MaterializedPartitionedOutput |
  |                                  |       | one instance per driver       |
  | - creates one task buffer        |       +---------------+---------------+
  | - creates the backend sink       |                       |
  | - retains committed locations    |                       | RowVector
  | - exposes stats / utilization    |                       v
  +----------------+-----------------+       project and load output columns
                   |                         compute destination partitions
                   | one shared buffer       serialize rows as CompactRow
                   | per task                 stage bounded RowGroups
                   v                                         |
  +----------------------------------+                        |
  | MaterializedOutputBuffer         |<-----------------------+
  |                                  |       enqueue(partition, RowGroup)
  | +------------------------------+ |
  | | PartitionBuffer[0]           | |
  | +------------------------------+ |
  | | PartitionBuffer[1]           | |  lock-free producer queues;
  | +------------------------------+ |  one CAS-elected flusher per partition
  | | ...                          | |
  | +------------------------------+ |
  |                                  |
  | high watermark -> block drivers  |
  | drain largest partitions         |
  | low watermark  -> wake drivers   |
  +----------------+-----------------+
                   |
                   | ordered appendBatch(partition, RowGroups)
                   v
  +----------------------------------+
  | ExchangeSink                     |
  | pluggable durable backend        |
  |                                  |
  | append / appendBatch             |
  | finish -> committed locations    |
  | abort                            |
  | stats                            |
  +----------------+-----------------+
                   |
                   v
  CommittedExchangeOutput
  partition -> backend-specific location
```

### Data path

1. `MaterializedOutputBufferManager::initializeTask()` creates a dedicated sink memory pool, asks the registered `ExchangeSink::Factory` for a backend sink, and creates one `MaterializedOutputBuffer` shared by all output drivers for the task.
2. Each `MaterializedPartitionedOutput` projects the requested output columns, loads lazy vectors, computes the destination partition for every row, and serializes rows with `CompactRow`.
3. Serialized rows are staged locally by the operator. Fixed-width rows use pre-sized contiguous storage; variable-width rows are sized before serialization. Replicate-nulls-and-any duplicates row metadata instead of copying serialized row bytes.
4. Once the operator-local batch reaches its target size, rows are grouped by destination and emitted as RowGroups. A RowGroup never intentionally exceeds the per-partition drain threshold unless one serialized row is itself larger than that threshold.
5. The shared task buffer enqueues each RowGroup into its partition queue. Producers do not take a shared append lock. When a partition reaches its drain threshold, one producer wins a CAS and becomes that partition's flusher; concurrent producers continue enqueueing.
6. The flusher sends ordered RowGroup batches to `ExchangeSink::appendBatch()`. The base sink implementation preserves order by chaining the IOBufs, while a backend may override the IOBuf or batch overloads to avoid coalescing.
7. After all peer drivers finish, the last driver drains all partitions and calls `ExchangeSink::finish()` exactly once. The returned partition locations remain available through the manager after task-buffer removal.

### Backpressure and memory ownership

- The buffer tracks total queued bytes across all partitions and allocates RowGroup IOBufs from the task's dedicated `materialized-output` memory pool.
- Producers first try to drain data themselves. At the high watermark, a driver returns `kWaitForConsumer` only when reclaimable queued data exists.
- Backpressure draining visits the largest partitions first. Blocked drivers are released after queued bytes fall below the low watermark.
- This is cooperative backpressure: no dedicated drain thread is introduced, and sink appends execute on producer/driver work.
- If the buffer is full but all remaining partition queues are below the reclaim threshold, the producer remains runnable to avoid a state in which every driver sleeps while no one can drain.

### Completion and failure semantics

- Successful completion transitions the shared buffer from active to draining to closed, flushes every partition, commits the sink, and records the returned locations.
- `ExchangeSink::finish()` failure changes the buffer to aborted, discards queued data, best-effort aborts the sink, wakes blocked drivers, and propagates the original failure to the task.
- Closing an unfinished operator aborts the shared sink. Buffer destruction also performs a best-effort abort if neither commit nor abort completed.
- Buffer and backend counters are published once, by the last output driver, as operator runtime statistics.

## Classes and responsibilities

- `CommittedExchangeOutput`
  - Transport-neutral result of a successful sink commit.
  - Maps each output partition to a backend-specific location string.

- `ExchangeSink`
  - Backend abstraction for durable partitioned exchange output.
  - Defines ordered partition appends, batched IOBuf appends, commit, abort, and runtime statistics.
  - Its factory receives opaque transport options, the task ID, and the sink memory pool.

- `MaterializedPartitionedOutput`
  - Per-driver Velox output operator.
  - Implements projection, partition selection, broadcast, replicate-nulls-and-any, `CompactRow` serialization, bounded RowGroup construction, and producer blocking.
  - Coordinates peer completion so only the last driver commits the shared task buffer.

- `MaterializedOutputBuffer`
  - Shared per-task bridge between all materialized output operators and one `ExchangeSink`.
  - Owns per-partition queues, memory accounting, opportunistic draining, high/low-watermark backpressure, lifecycle state, committed locations, and combined buffer/sink statistics.

- `MaterializedOutputBuffer::PartitionBuffer`
  - Per-destination lock-free RowGroup queue.
  - Elects one flusher with an atomic CAS, serializes sink appends for that partition, and allows different partitions to flush concurrently.

- `MaterializedOutputBufferManager`
  - Owns active task buffers for one named transport.
  - Creates the sink and buffer during task initialization, supplies the buffer to each operator, exposes standard `OutputBufferManager` statistics/utilization APIs, retains completed locations, and creates the paired `OutputTransportEntry`.

- `MaterializedOutputBatchConfig`
  - Groups the operator-local serialization batch controls.
  - Scales the target batch size with destination count while bounding it between configured minimum and maximum sizes.

## Test coverage

The diff adds direct buffer tests and full operator-to-sink tests covering:

- threshold-based and explicit draining;
- IOBuf-chain batch appends and per-partition ordering;
- high/low-watermark blocking and wake-up, including a busy flusher;
- abort, idempotent completion, late-enqueue rejection, and sink-finish failure propagation;
- multiple drivers, large inputs, and thousands of small input batches;
- bounded RowGroup sizes;
- empty and zero-column output;
- single- and many-destination partitioning plus replicate-nulls-and-any behavior;
- shared sink statistics recorded once; and
- configurable operator-local output batch sizing.

## Configuration surface

This diff does not introduce config-file or session-property keys. It introduces library/API-level controls that an embedding application supplies when registering and initializing a materialized output transport.

- `maxBufferedBytes` — required `MaterializedOutputBufferManager` constructor argument.
  - Bounds total queued bytes for a task buffer.
  - Derives the producer-blocking high watermark at 90% and wake-up low watermark at 70%.
  - Must be positive and large enough to provide capacity for every destination.

- `MaterializedOutputBatchConfig::minOutputBatchBytes` — default 1 MiB.
  - Lower bound for each operator's local serialized-row batch before partition grouping and RowGroup emission.

- `MaterializedOutputBatchConfig::maxOutputBatchBytes` — default 16 MiB.
  - Upper bound for the operator-local batch target.

- `MaterializedOutputBatchConfig::estimatedRowBytes` — default 1 KiB.
  - Scales the target batch with fanout: `clamp(estimatedRowBytes * numDestinations, minOutputBatchBytes, maxOutputBatchBytes)`.

- `partitionDrainThreshold` — `MaterializedOutputBuffer` constructor argument; the manager uses the 128 KiB default.
  - Triggers opportunistic draining for a partition.
  - Also bounds RowGroups produced by `MaterializedPartitionedOutput`.
  - Is capped at `maxBufferedBytes / numPartitions` so every partition can make progress within the global buffer budget.

- `transportOptions` — opaque string supplied during task initialization.
  - Passed unchanged to `ExchangeSink::Factory` for backend-specific configuration.
  - The base materialized transport does not interpret it.

- Plan/task inputs — `numDestinations`, partitioning or broadcast mode, partition keys/function, replicate-nulls-and-any, output columns, and driver count.
  - These determine partition fanout, row routing/replication, operator construction, and buffer driver accounting. Terminal commit ownership is selected separately through task peer coordination.

The following policies are derived implementation constants rather than externally configurable settings: reclaim threshold = 67% of the partition drain threshold, sink drain chunk target = 2x the partition drain threshold, high watermark = 90% of `maxBufferedBytes`, and low watermark = 70% of `maxBufferedBytes`.

Reviewed By: xiaoxmeng

Differential Revision: D115756185
