### PR TITLE
fix(nimble): Update NullColumnReaderTest to enable runtime filter

### DIFF
--- a/velox/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
@@ -177,13 +177,17 @@ TEST_F(NullColumnReaderTest, filterIsNullOnMissing) {
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
   ASSERT_EQ(result->size(), kSize);
+  // Reader returns all rows; the missing column is all nulls.
+  auto* row = result->asUnchecked<RowVector>();
+  for (int i = 0; i < kSize; ++i) {
+    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
+  }
 }
 
 // IsNotNull filter on a missing column.
-// Note: top-level missing field filter rejection is handled by
-// SplitReader::filterOnStats, not by the file reader. The reader materializes
-// all rows with the missing column as null constants regardless of filters.
-TEST_F(NullColumnReaderTest, DISABLED_filterIsNotNullOnMissing) {
+// With runtime filtering enabled for missing constants, all rows are
+// filtered out because the column materializes as all-null.
+TEST_F(NullColumnReaderTest, filterIsNotNullOnMissing) {
   constexpr int kSize = 50;
   auto input = makeRowVector({
       makeFlatVector<int64_t>(kSize, folly::identity),
@@ -195,17 +199,14 @@ TEST_F(NullColumnReaderTest, DISABLED_filterIsNotNullOnMissing) {
   auto readers = makeReaders(input, readType, scanSpec);
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
-  // Reader returns all rows; the missing column is all nulls.
-  auto* row = result->asUnchecked<RowVector>();
-  for (int i = 0; i < kSize; ++i) {
-    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
-  }
+  // Reader returns empty result; the missing column is all nulls.
+  ASSERT_EQ(result->size(), 0);
 }
 
 // BigintRange filter on a missing column.
-// Same as above: top-level missing field filter evaluation is handled by
-// SplitReader, not by the file reader.
-TEST_F(NullColumnReaderTest, DISABLED_filterValueOnMissing) {
+// Missing column materializes as null, which does not pass this filter
+// (nullAllowed=false), so all rows are filtered out.
+TEST_F(NullColumnReaderTest, filterValueOnMissing) {
   constexpr int kSize = 50;
   auto input = makeRowVector({
       makeFlatVector<int64_t>(kSize, folly::identity),
@@ -218,11 +219,8 @@ TEST_F(NullColumnReaderTest, DISABLED_filterValueOnMissing) {
   auto readers = makeReaders(input, readType, scanSpec);
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
-  // Reader returns all rows; the missing column is all nulls.
-  auto* row = result->asUnchecked<RowVector>();
-  for (int i = 0; i < kSize; ++i) {
-    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
-  }
+  // Reader returns empty result; the missing column is all nulls.
+  ASSERT_EQ(result->size(), 0);
 }
 
 // BigintRange(nullAllowed=true) on a missing column — all rows pass.
@@ -240,6 +238,11 @@ TEST_F(NullColumnReaderTest, filterValueAllowNullOnMissing) {
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
   ASSERT_EQ(result->size(), kSize);
+  // Reader returns all rows; the missing column is all nulls.
+  auto* row = result->asUnchecked<RowVector>();
+  for (int i = 0; i < kSize; ++i) {
+    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
+  }
 }
 
 // Read with small batch sizes to exercise skip on NullColumnReader.


### PR DESCRIPTION
With runtime filtering enabled, nulls generated for missing columns can be 
filtered out by runtime filters. This PR updates the affected Nimble tests 
accordingly.

Follow-up for: https://github.com/facebookincubator/velox/pull/17554.