### PR TITLE
test(fuzzer): Stop skipping xxhash128 in the Presto SOT expression fuzzer (#18581)

### DIFF
--- a/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
+++ b/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
@@ -345,9 +345,6 @@ const std::unordered_set<std::string>& prestoSkippedFunctionsSOT() {
       // Skipping until the new signature is merged and released in Presto:
       // https://github.com/prestodb/presto/pull/25521
       "xxhash64(varbinary,bigint) -> varbinary",
-      // Skipping until xxhash128 is merged and released in Presto.
-      "xxhash128(varbinary) -> varbinary",
-      "xxhash128(varbinary,bigint) -> varbinary",
       "map_keys_by_top_n_values", // https://github.com/facebookincubator/velox/issues/14374
       "$internal$split_to_map",
       "$internal$canonicalize",


### PR DESCRIPTION
Summary:

`xxhash128` is live in Presto now, so the fuzzer no longer needs to skip it
when comparing Velox against a real Presto instance.

Both sides of the parity pair are in place. Presto: D115976155 (upstream
prestodb/presto PR #28289) added `xxhash128(varbinary)` and
`xxhash128(varbinary, bigint)` to `VarbinaryFunctions.java`, and D116322772
added the function to the UPM Crux builtin allowlist. D115976155 is the
diff-train mirror of an already-merged upstream commit, so Presto has the
function today regardless of when that diff lands internally. Velox:
D115043392, exported as facebookincubator/velox PR #18436.

Verified end to end against a live cluster: evaluating
`LOWER(TO_HEX(REVERSE(CAST(XXHASH128(TO_UTF8(x)) AS VARBINARY))))` in Presto
reproduces the same digest as the Velox/C++ implementation.

`prestoSkippedFunctionsSOT()` is a static set -- nothing re-checks it against
the live engine, so an entry survives until a human deletes the line. Stale
neighbours like `xxhash64(varbinary,bigint)`, `t_cdf` and `ip_version` are what
that looks like. Leaving `xxhash128` in means Velox-vs-Presto parity for it is
silently never exercised.

Differential Revision: D116035569


