### PR TITLE
fix(rpc): Correct the low-water report and the BATCH AIMD recovery unit (#18582)

### DIFF
--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -657,11 +657,9 @@ RowVectorPtr RPCOperator::getOutput() {
     }
 
     auto numRows = static_cast<int64_t>(claimedBatch_->responses.size());
-    int64_t batchErrors = 0;
     for (const auto& response : claimedBatch_->responses) {
       if (response.hasError()) {
         numErrors_++;
-        ++batchErrors;
         recordErrorKind(response.errorKind);
       }
     }
@@ -678,10 +676,12 @@ RowVectorPtr RPCOperator::getOutput() {
       // Feed the measured round-trip latency to the gradient window so it
       // learns the in-flight-batch sweet spot without a fixed ceiling.
       state_->onUnitSample(claimedBatch_->rttNs);
-      // Successful rows in this batch drive AIMD recovery of the backend's
-      // shared cap.
-      limiter_->onOutcome(
-          RPCRateLimiter::Outcome::kSuccess, numRows - batchErrors);
+      // One successful batch, credited as one unit, because BATCH reserves one
+      // slot per flushBatch() regardless of row count. onSuccess() steps
+      // capacity by units/capacity, so crediting the row count against a
+      // capacity counted in batches makes recovery accelerate as capacity
+      // shrinks -- the opposite of additive increase.
+      limiter_->onOutcome(RPCRateLimiter::Outcome::kSuccess, /*units=*/1);
     }
 
     auto output = buildOutputFromReadyBatch(*claimedBatch_);
@@ -1121,10 +1121,8 @@ void RPCOperator::recordRuntimeStats() {
       kRpcRateLimiterCap, RuntimeCounter(limiterStats.capacity));
   lockedStats->addRuntimeStat(
       kRpcRateLimiterPeakPending, RuntimeCounter(limiterStats.peakPending));
-  if (limiterStats.lowWaterCapacity > 0) {
-    lockedStats->addRuntimeStat(
-        kRpcRateLimiterMinCap, RuntimeCounter(limiterStats.lowWaterCapacity));
-  }
+  lockedStats->addRuntimeStat(
+      kRpcRateLimiterMinCap, RuntimeCounter(limiterStats.lowWaterCapacity));
 }
 
 RowVectorPtr RPCOperator::buildOutputFromReadyBatch(

--- a/velox/exec/rpc/RPCRateLimiter.cpp
+++ b/velox/exec/rpc/RPCRateLimiter.cpp
@@ -385,7 +385,7 @@ RPCRateLimiter::Stats RPCRateLimiter::stats() const {
       .capacity = capacityLocked(),
       .pending = pending_.load(),
       .peakPending = peakPending_.load(),
-      .lowWaterCapacity = lowWater_,
+      .lowWaterCapacity = lowWater_ > 0 ? lowWater_ : ceilingLocked(),
   };
 }
 

--- a/velox/exec/rpc/RPCRateLimiter.h
+++ b/velox/exec/rpc/RPCRateLimiter.h
@@ -97,7 +97,15 @@ class RPCRateLimiter {
     /// High-water in-flight count over the backend's lifetime.
     int64_t peakPending{0};
 
-    /// Lowest capacity ever reached. Zero means capacity never shrank.
+    /// Lowest capacity ever reached, or the ceiling when capacity never
+    /// shrank. Reporting the ceiling rather than a sentinel zero means the
+    /// value is always meaningful, so readers need no special case.
+    ///
+    /// Scoped to the backend's lifetime in this process, not to one query:
+    /// the mark is never cleared on recovery, so a query that saw no overload
+    /// still reports a dip an earlier query produced. A reader comparing this
+    /// against the ceiling learns that the backend has backed off at some
+    /// point, not that this query did.
     int64_t lowWaterCapacity{0};
   };
 
@@ -295,8 +303,8 @@ class RPCRateLimiter {
   // Adapted capacity. Zero means unshrunk, i.e. defer to the ceiling.
   int64_t capacity_{0};
 
-  // Lowest capacity ever reached. Zero means never shrank, and Stats reports
-  // it unchanged.
+  // Lowest capacity ever reached. Zero means never shrank; Stats resolves that
+  // to the ceiling so a reader never has to special-case a sentinel.
   int64_t lowWater_{0};
 
   // Units currently in flight against this backend. Atomic so acquire() and

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
@@ -170,6 +170,19 @@ int32_t DemoBatchRPCFunction::pendingBatchSize() const {
   return static_cast<int32_t>(pendingRows_.size());
 }
 
+AsyncRPCFunction::CongestionSignal DemoBatchRPCFunction::evaluateCongestion(
+    const std::vector<RPCResponse>& responses) const {
+  if (responses.empty()) {
+    return CongestionSignal::kNone;
+  }
+  for (const auto& response : responses) {
+    if (response.hasError()) {
+      return CongestionSignal::kError;
+    }
+  }
+  return CongestionSignal::kSuccess;
+}
+
 std::vector<std::shared_ptr<exec::FunctionSignature>>
 DemoBatchRPCFunction::signatures() {
   auto sig = exec::FunctionSignatureBuilder()

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.h
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.h
@@ -90,6 +90,14 @@ class DemoBatchRPCFunction : public AsyncRPCFunction {
 
   int32_t pendingBatchSize() const override;
 
+  /// Test hook: a batch carrying any errored response is treated as backend
+  /// overload (kError), an empty batch as kNone, anything else as a clean
+  /// drain (kSuccess). Lets a test drive the operator's AIMD paths in BATCH
+  /// mode; inert unless the backend is configured adaptive, which is off by
+  /// default.
+  CongestionSignal evaluateCongestion(
+      const std::vector<RPCResponse>& responses) const override;
+
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures();
 
   /// Holds each flush open for 'holdMs' on a background thread instead of

--- a/velox/exec/rpc/tests/RPCAimdUnderLoadTest.cpp
+++ b/velox/exec/rpc/tests/RPCAimdUnderLoadTest.cpp
@@ -30,8 +30,9 @@
 /// MockRPCClient::ErrorBurst), and PER_ROW dispatch preserves row order, so the
 /// burst lands on a known, timing-independent slice of rows. The whole
 /// trajectory is captured in a single close()-time stats snapshot: numShrinks>0
-/// proves the window dipped; rpcRateLimiterMinCap (only emitted once the cap
-/// shrank) proves the limiter backed off; the final cap sitting above that
+/// proves the window dipped; rpcRateLimiterMinCap lands on every query, so it
+/// is the value, not its presence, that proves the limiter backed off -- a
+/// low-water mark below the ceiling; the final cap sitting above that
 /// low-water mark proves recovery.
 
 #include <gtest/gtest.h>
@@ -163,6 +164,112 @@ class BurstRPCFunction : public AsyncRPCFunction {
   std::shared_ptr<MockRPCClient> client_;
 };
 
+// The BATCH counterpart of BurstRPCFunction. BATCH reserves one rate-limiter
+// slot per flushBatch() and drains one batch at a time, so the recovery it
+// drives is per batch, not per row -- the reason this needs its own harness
+// rather than reusing the PER_ROW burst above.
+//
+// MockRPCClient::setErrorBurst fails a contiguous run of request ordinals, and
+// callBatch() consumes one ordinal per row, so the burst still lands on a
+// deterministic row range.
+class BurstBatchRPCFunction : public AsyncRPCFunction {
+ public:
+  using Config = BurstRPCFunction::Config;
+
+  explicit BurstBatchRPCFunction(Config config) : config_{std::move(config)} {}
+
+  void initialize(
+      const core::QueryConfig& /*queryConfig*/,
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const std::vector<VectorPtr>& /*constantInputs*/) override {
+    VELOX_CHECK_NULL(client_, "initialize() must be called at most once");
+    client_ =
+        std::make_shared<MockRPCClient>(config_.latency, /*errorRate=*/0.0);
+    client_->setErrorBurst(
+        {config_.burstFirstCall, config_.burstLastCall, config_.burstKind});
+  }
+
+  std::string name() const override {
+    return "burst_batch_rpc";
+  }
+
+  TypePtr resultType() const override {
+    return VARCHAR();
+  }
+
+  std::string tierKey() const override {
+    return config_.tier;
+  }
+
+  // Pure virtual on the base. BATCH never routes here; failing loudly beats
+  // returning nothing, which would strand rows and surface far downstream.
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/) override {
+    VELOX_FAIL("burst_batch_rpc is BATCH-only; dispatchPerRow is unreachable");
+  }
+
+  std::vector<vector_size_t> accumulateBatch(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override {
+    std::vector<vector_size_t> indices;
+    VELOX_CHECK(!args.empty(), "burst_batch_rpc expects one argument");
+    auto* promptVector = args[0]->as<SimpleVector<StringView>>();
+    VELOX_CHECK_NOT_NULL(
+        promptVector, "burst_batch_rpc expects a VARCHAR prompt argument");
+    rows.applyToSelected([&](vector_size_t row) {
+      indices.push_back(row);
+      pending_.push_back(
+          promptVector->isNullAt(row) ? "" : promptVector->valueAt(row).str());
+    });
+    return indices;
+  }
+
+  folly::SemiFuture<std::vector<RPCResponse>> flushBatch(
+      int32_t maxRows) override {
+    const auto count = maxRows > 0
+        ? std::min<int32_t>(maxRows, static_cast<int32_t>(pending_.size()))
+        : static_cast<int32_t>(pending_.size());
+    std::vector<RPCRequest> requests;
+    requests.reserve(count);
+    for (int32_t i = 0; i < count; ++i) {
+      RPCRequest request;
+      // Batch-position rowId: the operator scatters responses back by it.
+      request.rowId = i;
+      request.originalRowIndex = i;
+      request.payload = pending_[i];
+      requests.push_back(std::move(request));
+    }
+    pending_.erase(pending_.begin(), pending_.begin() + count);
+    return client_->callBatch(requests);
+  }
+
+  int32_t pendingBatchSize() const override {
+    return static_cast<int32_t>(pending_.size());
+  }
+
+  // Same classification as the PER_ROW burst: rate-limit / timeout is backend
+  // overload, a clean drain drives recovery.
+  CongestionSignal evaluateCongestion(
+      const std::vector<RPCResponse>& responses) const override {
+    for (const auto& response : responses) {
+      if (response.hasError() &&
+          (response.errorKind == RPCErrorKind::kRateLimited ||
+           response.errorKind == RPCErrorKind::kTimeout)) {
+        return CongestionSignal::kError;
+      }
+    }
+    return responses.empty() ? CongestionSignal::kNone
+                             : CongestionSignal::kSuccess;
+  }
+
+ private:
+  Config config_;
+  std::shared_ptr<MockRPCClient> client_;
+  std::vector<std::string> pending_;
+};
+
 class RPCAimdUnderLoadTest : public OperatorTestBase {
  protected:
   // Phase sizes (rows). PER_ROW issues one call per row in row order, so call
@@ -190,6 +297,14 @@ class RPCAimdUnderLoadTest : public OperatorTestBase {
           BurstRPCFunction::Config{/*burstFirstCall=*/kWarmupRows,
                                    /*burstLastCall=*/kWarmupRows + kBurstRows,
                                    /*burstKind=*/RPCErrorKind::kRateLimited});
+    });
+    AsyncRPCFunctionRegistry::registerFunction("burst_batch_rpc", [] {
+      return std::make_shared<BurstBatchRPCFunction>(
+          BurstRPCFunction::Config{/*burstFirstCall=*/kWarmupRows,
+                                   /*burstLastCall=*/kWarmupRows + kBurstRows,
+                                   /*burstKind=*/RPCErrorKind::kRateLimited,
+                                   /*latency=*/std::chrono::milliseconds(1),
+                                   /*tier=*/"layer2.test.batch.tier"});
     });
   }
 
@@ -227,6 +342,33 @@ class RPCAimdUnderLoadTest : public OperatorTestBase {
     // Default streaming mode is PER_ROW.
     return std::make_shared<core::RPCNode>(
         "rpc-0", source, std::move(call), "__rpc_result", outputType);
+  }
+
+  core::PlanNodePtr makeBatchRPCNode(
+      const core::PlanNodePtr& source,
+      int32_t dispatchBatchSize) {
+    const auto& sourceType = source->outputType();
+    std::vector<core::TypedExprPtr> callInputs;
+    callInputs.push_back(
+        std::make_shared<core::FieldAccessTypedExpr>(
+            sourceType->findChild("prompt"), "prompt"));
+    auto call = std::make_shared<core::CallTypedExpr>(
+        VARCHAR(), std::move(callInputs), "burst_batch_rpc");
+
+    auto outputNames = sourceType->names();
+    auto outputTypes = sourceType->children();
+    outputNames.emplace_back("__rpc_result");
+    outputTypes.push_back(VARCHAR());
+    auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
+
+    return std::make_shared<core::RPCNode>(
+        "rpc-0",
+        source,
+        std::move(call),
+        "__rpc_result",
+        outputType,
+        RPCStreamingMode::kBatch,
+        dispatchBatchSize);
   }
 };
 
@@ -292,14 +434,80 @@ TEST_F(RPCAimdUnderLoadTest, windowAndRateLimiterBackOffThenRecover) {
   //     (this stat is only emitted when numShrinks > 0).
   EXPECT_GT(statSum(RPCOperator::kRpcCongestionShrinks), 0);
 
-  // (3) Overload -> the process-global rate-limiter cap backed off below its
-  //     ceiling. rpcRateLimiterMinCap is only emitted once the cap shrank.
+  // (3) Overload -> this backend's rate-limiter cap backed off below its
+  //     ceiling. rpcRateLimiterMinCap lands on every query, so presence alone
+  //     says nothing about backoff; the value below the ceiling is the claim.
   const int64_t minCap = statSum(RPCOperator::kRpcRateLimiterMinCap);
-  EXPECT_GT(minCap, 0);
+  ASSERT_NE(minCap, -1) << "the low-water stat must be emitted on every query";
   EXPECT_LT(minCap, kMaxLimit) << "cap should have dipped below its ceiling";
 
   // (4) After the burst, the clean success stream drove AIMD additive recovery:
   //     the final cap climbed back above the low-water mark.
+  const int64_t finalCap = statSum(RPCOperator::kRpcRateLimiterCap);
+  EXPECT_GT(finalCap, minCap) << "cap should recover above its low-water mark";
+}
+
+// The BATCH arm of the same closed loop: overload burst -> the backend's cap
+// backs off through the real classifier -> a clean batch stream recovers it.
+//
+// This is the end-to-end complement to
+// RPCOperatorTest.batchAimdRecoversPerBatchNotPerRow, which forces the shrink
+// by calling onOutcome(kOverload) directly and pins the step size. Here the
+// shrink arrives the way production produces one -- rate-limited responses
+// classified by the function -- so classify -> onOverload -> onSuccess is
+// exercised as a loop rather than as three separate calls.
+TEST_F(RPCAimdUnderLoadTest, batchRateLimiterBacksOffThenRecovers) {
+  std::vector<std::string> storage;
+  storage.reserve(kTotalRows);
+  for (int32_t i = 0; i < kTotalRows; ++i) {
+    storage.push_back("row_" + std::to_string(i));
+  }
+  std::vector<StringView> prompts;
+  prompts.reserve(kTotalRows);
+  for (const auto& prompt : storage) {
+    prompts.emplace_back(prompt);
+  }
+  auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
+
+  // Chunks small enough that the burst window spans several flushes, so the
+  // cap shrinks more than once, and small enough that many clean batches
+  // follow it -- recovery is one step per batch, so it needs batches to count.
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(), /*dispatchBatchSize=*/16);
+
+  std::shared_ptr<Task> task;
+  auto result = AssertQueryBuilder(plan)
+                    .maxDrivers(1)
+                    .config("rpc.ratelimiter.adaptive_enabled", "true")
+                    .config("rpc.ratelimiter.max_limit", kMaxLimit)
+                    .config("rpc.ratelimiter.min_limit", kMinLimit)
+                    .config("rpc.ratelimiter.decrease_factor", "0.5")
+                    .config("rpc.congestion.max_window", kMaxWindow)
+                    .config("rpc.congestion.min_window", 1)
+                    .copyResults(pool(), task);
+
+  ASSERT_EQ(result->size(), kTotalRows);
+
+  auto planStats = toPlanStats(task->taskStats());
+  ASSERT_EQ(planStats.count("rpc-0"), 1);
+  const auto& customStats = planStats.at("rpc-0").customStats;
+  auto statSum = [&](const std::string& key) -> int64_t {
+    auto it = customStats.find(key);
+    return it == customStats.end() ? -1 : it->second.sum;
+  };
+
+  // The burst actually landed and was classified by typed cause.
+  EXPECT_GT(statSum(RPCOperator::kRpcErrorKindRateLimited), 0)
+      << "the burst must reach the operator as rate-limit errors";
+
+  // Overload drove the backend's cap below its ceiling.
+  const int64_t minCap = statSum(RPCOperator::kRpcRateLimiterMinCap);
+  ASSERT_NE(minCap, -1) << "the low-water stat must be emitted on every query";
+  EXPECT_LT(minCap, kMaxLimit) << "cap should have dipped below its ceiling";
+
+  // And the clean batches after the burst recovered it. This is the assertion
+  // the unit-level test cannot make: recovery here is credited by the operator
+  // through the real congestion classifier, one unit per drained batch.
   const int64_t finalCap = statSum(RPCOperator::kRpcRateLimiterCap);
   EXPECT_GT(finalCap, minCap) << "cap should recover above its low-water mark";
 }

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -24,6 +24,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/rpc/RPCOperator.h"
 #include "velox/exec/rpc/RPCPlanNodeTranslator.h"
 #include "velox/exec/rpc/RPCRateLimiter.h"
 #include "velox/exec/rpc/tests/DemoBatchRPCFunction.h"
@@ -379,7 +380,7 @@ TEST_F(RPCOperatorTest, batchMakesProgressWhenIntakeIsThrottled) {
     prompts.reserve(kRowsPerVector);
     for (int i = 0; i < kRowsPerVector; ++i) {
       storage.push_back(fmt::format("throttled-{}-{}", v, i));
-      prompts.push_back(StringView(storage.back()));
+      prompts.emplace_back(storage.back());
     }
     inputs.push_back(
         makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)}));
@@ -422,7 +423,7 @@ void RPCOperatorTest::runContendedDrain(bool batchMode) {
   prompts.reserve(kRows);
   for (int i = 0; i < kRows; ++i) {
     storage.push_back(fmt::format("contended-{}", i));
-    prompts.push_back(StringView(storage.back()));
+    prompts.emplace_back(storage.back());
   }
   auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
 
@@ -473,7 +474,7 @@ TEST_F(RPCOperatorTest, batchDispatchRespectsTheTierCap) {
   prompts.reserve(64);
   for (int i = 0; i < 64; ++i) {
     storage.push_back(fmt::format("row-{}", i));
-    prompts.push_back(StringView(storage.back()));
+    prompts.emplace_back(storage.back());
   }
   auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
 
@@ -491,6 +492,102 @@ TEST_F(RPCOperatorTest, batchDispatchRespectsTheTierCap) {
 
   EXPECT_LE(limiter.stats().peakPending, kCeiling)
       << "dispatch admitted more than the tier cap";
+}
+
+// BATCH reserves one slot per flushBatch() regardless of row count, so its
+// AIMD recovery has to be credited in batches too. onSuccess() steps capacity
+// by units/capacity, so crediting the row count against a capacity counted in
+// batches makes the step grow as capacity shrinks -- recovery accelerates
+// exactly when it should be most cautious, undoing the multiplicative
+// decrease.
+//
+// Four batches of 16 rows drain successfully from a capacity of 2. Credited in
+// batches the capacity walks 2 -> 6, one step per batch. Credited in rows it
+// jumps 2 -> 10 on the first batch alone (16/2 = 8) and lands at 13.
+TEST_F(RPCOperatorTest, batchAimdRecoversPerBatchNotPerRow) {
+  constexpr int64_t kCeiling = 64;
+  constexpr int64_t kRows = 64;
+  constexpr int32_t kDispatchBatchSize = 16;
+  constexpr int64_t kNumBatches = kRows / kDispatchBatchSize;
+
+  std::vector<std::string> storage;
+  std::vector<StringView> prompts;
+  storage.reserve(kRows);
+  prompts.reserve(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    storage.push_back(fmt::format("row-{}", i));
+    prompts.emplace_back(storage.back());
+  }
+  auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
+
+  auto& limiter = RPCRateLimiterRegistry::global().get("");
+  limiter.initializeOnce([](RPCRateLimiter::Config& config) {
+    config.ceiling = kCeiling;
+    config.adaptive = true;
+    // Below the built-in floor of 50, so capacity can be driven low enough
+    // for the two crediting schemes to separate.
+    config.floor = 1;
+    config.decreaseFactor = 0.5;
+  });
+
+  // 64 -> 32 -> 16 -> 8 -> 4 -> 2.
+  for (int i = 0; i < 5; ++i) {
+    limiter.onOutcome(RPCRateLimiter::Outcome::kOverload, /*units=*/0);
+  }
+  const int64_t shrunk = limiter.stats().capacity;
+  ASSERT_EQ(shrunk, 2) << "precondition: capacity must start well below the "
+                          "rows per batch for the two schemes to differ";
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc",
+      kDispatchBatchSize);
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+  ASSERT_EQ(result->size(), kRows);
+
+  EXPECT_EQ(limiter.stats().capacity, shrunk + kNumBatches)
+      << "capacity recovered by " << (limiter.stats().capacity - shrunk)
+      << " over " << kNumBatches
+      << " successful batches; additive increase on a batch-denominated "
+         "capacity must be one step per batch";
+}
+
+// The low-water capacity lands on every query, not only the ones where the
+// backend shrank. A query that never backed off reports the ceiling, which is
+// a real capacity; the old sentinel zero was indistinguishable from "the stat
+// was never recorded".
+TEST_F(RPCOperatorTest, lowWaterCapacityIsReportedWhenTheBackendStaysHealthy) {
+  constexpr int64_t kCeiling = 16;
+  std::vector<std::string> storage;
+  std::vector<StringView> prompts;
+  storage.reserve(8);
+  prompts.reserve(8);
+  for (int i = 0; i < 8; ++i) {
+    storage.push_back(fmt::format("healthy-{}", i));
+    prompts.emplace_back(storage.back());
+  }
+  auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
+
+  auto& limiter = RPCRateLimiterRegistry::global().get("");
+  limiter.initializeOnce(
+      [](RPCRateLimiter::Config& config) { config.ceiling = kCeiling; });
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(), {"prompt"}, "demo_batch_rpc");
+  std::shared_ptr<exec::Task> task;
+  auto result =
+      AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool(), task);
+  ASSERT_EQ(result->size(), 8);
+
+  // Nothing drove an overload, so the cap never shrank.
+  ASSERT_EQ(limiter.stats().capacity, kCeiling);
+
+  auto planStats = toPlanStats(task->taskStats());
+  const auto& customStats = planStats.at("rpc-0").customStats;
+  ASSERT_EQ(customStats.count(RPCOperator::kRpcRateLimiterMinCap), 1)
+      << "the low-water stat must land even when the backend never shrank";
+  EXPECT_EQ(customStats.at(RPCOperator::kRpcRateLimiterMinCap).sum, kCeiling);
 }
 
 // Reversed responses: the mock returns results in reverse order.

--- a/velox/exec/rpc/tests/RPCRateLimiterTest.cpp
+++ b/velox/exec/rpc/tests/RPCRateLimiterTest.cpp
@@ -561,6 +561,28 @@ TEST_F(RPCRateLimiterTest, noBackpressureBelowLimit) {
   EXPECT_EQ(limiterFor(tier).stats().pending, 4);
 }
 
+// A backend that never backed off has no low-water mark, and zero would be
+// indistinguishable from "not recorded". Reporting the ceiling means every
+// reading of the stat is a real capacity.
+TEST_F(RPCRateLimiterTest, lowWaterReportsTheCeilingWhenNeverShrunk) {
+  const std::string tier = "test.tier";
+  setCeiling(tier, 64);
+  setAdaptive(tier, /*enabled=*/true, /*floor=*/2, /*decreaseFactor=*/0.5);
+
+  // Nothing has driven an overload, so capacity has never shrunk.
+  EXPECT_EQ(limiterFor(tier).stats().lowWaterCapacity, 64);
+
+  // Once it does shrink, the actual low-water value is reported instead.
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
+  const auto shrunk = limiterFor(tier).stats();
+  EXPECT_LT(shrunk.lowWaterCapacity, 64);
+  EXPECT_EQ(shrunk.lowWaterCapacity, shrunk.capacity);
+
+  // Recovering above the low-water mark leaves the mark where it was.
+  limiterFor(tier).onOutcome(RPCRateLimiter::Outcome::kSuccess, 1'024);
+  EXPECT_EQ(limiterFor(tier).stats().lowWaterCapacity, shrunk.lowWaterCapacity);
+}
+
 // Regression test for the defect that motivated one limiter per backend: the
 // previous API configured the adaptive parameters process-globally, so a
 // second backend's configuration silently reconfigured the first backend's


### PR DESCRIPTION
Summary:

Two capacity numbers were wrong, in different ways.

**The reported low-water mark.** `RPCRateLimiter::Stats::lowWaterCapacity` used
zero to mean "capacity never shrank", which forced `RPCOperator` to gate
emission of `kRpcRateLimiterMinCap` on the sentinel. A reader of the stat could
not distinguish "never adapted" from "not recorded". Report the ceiling when
capacity never shrank, so the value is always meaningful, and drop the gate.
`kRpcRateLimiterMinCap` is now emitted on every query rather than only on
queries where the backend shrank.

**The adapted BATCH capacity.** BATCH reserves one slot per `flushBatch()`
regardless of row count, so its capacity is counted in batches. Recovery was
credited in rows. `onSuccess()` steps capacity by `units / capacity`, so
crediting a row count against a batch-denominated capacity makes the step grow
as capacity shrinks -- recovery accelerates exactly when it should be most
cautious, partly undoing the multiplicative decrease. Credit one unit per
successful batch instead.

PER_ROW needs no change: it reserves one slot per row and credits successful
rows, so its units already agree. The scaling in `onSuccess()` is also kept --
it is correct for a row-denominated capacity, where one drain covers many
tokens; only the BATCH caller's unit was wrong.

Reviewed By: abhinavmuk04

Differential Revision: D116549837


