### PR TITLE
fix: Close pending MergeJoin filter block when the outer row does not continue across output batches

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -1597,26 +1597,41 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
       }
     }
 
-    // Every time we start a new left key match, `processFilterResult()` will
-    // check if at least one row from the previous match passed the filter. If
-    // none did, it calls onMiss to add a record with null right projections
-    // to the output.
+    // Every time we start a new block of output rows that corresponds to a
+    // new outer-side row, `processFilterResult()` checks if at least one row
+    // from the previous block passed the filter. If none did, it calls
+    // onMiss to add a record with null projections for the other side.
     //
-    // Before we leave the current buffer, since we may not have seen the next
-    // left key match yet, the last key match may still be pending to produce
-    // a row (because `processFilterResult()` was not called yet).
+    // When the output batch ends, the last block may still be pending:
+    // `processFilterResult()` was not called for the next block yet. The
+    // pending state includes 'currentRow_', an output index into THIS batch,
+    // so the decision must be made before the batch is returned unless the
+    // SAME outer-side row continues into the next output batch. Wrongly
+    // deferring the close fires onMiss on a stale index in a later batch: it
+    // appends numRows + 1 dictionary indices (malformed dictionary vector)
+    // and nulls out projections of an unrelated row.
     //
-    // To handle this, we need to call `noMoreFilterResults()` unless the
-    // same current left key match may continue in the next buffer. So there
-    // are two cases to check:
-    //
-    // 1. If leftMatch_ is nullopt, there for sure the next buffer will
-    // contain a different key match.
-    //
-    // 2. leftMatch_ may not be nullopt, but may be related to a different
-    // (subsequent) left key. So we check if the last row in the batch has the
-    // same left row number as the last key match.
-    if (!leftMatch_ || !joinTracker_->isCurrentLeftMatch(numRows - 1)) {
+    // The pending block continues into the next batch only if the row the
+    // in-progress match will emit NEXT is the same outer-side row as the
+    // last row recorded by addMatch. Checking the match's mere presence is
+    // not enough: a match spans all duplicate outer rows of one key, so the
+    // output batch may be cut exactly between two blocks of the same match
+    // (or between two keys while the next match is already in progress), in
+    // which case the last block is complete and must be closed now.
+    bool pendingBlockContinues = false;
+    const auto& outerMatch =
+        (isRightJoin(joinType_) || isRightSemiFilterJoin(joinType_))
+        ? rightMatch_
+        : leftMatch_;
+    if (outerMatch) {
+      const auto& cursor = outerMatch->cursor;
+      const auto& nextBatch = cursor ? outerMatch->inputs[cursor->batchIndex]
+                                     : outerMatch->inputs.front();
+      const auto nextRow =
+          cursor ? cursor->rowIndex : outerMatch->startRowIndex;
+      pendingBlockContinues = joinTracker_->isLastAddedRow(nextBatch, nextRow);
+    }
+    if (!pendingBlockContinues) {
       joinTracker_->noMoreFilterResults(onMiss);
     }
   } else {

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -541,10 +541,13 @@ class MergeJoin : public Operator {
       }
     }
 
-    // Returns whether `row` corresponds to the same left key as the last
-    // left match evaluated.
-    bool isCurrentLeftMatch(vector_size_t row) {
-      return currentLeftRowNumber_ == rawLeftRowNumbers_[row];
+    // Returns true if the given (vector, index) pair identifies the same
+    // input row as the last output row recorded via addMatch. Used to decide
+    // whether the last block of output rows continues into the next output
+    // batch.
+    bool isLastAddedRow(const VectorPtr& vector, vector_size_t index) const {
+      return lastVector_ != nullptr && lastVector_ == vector &&
+          lastIndex_ == index;
     }
 
     // Called when all rows from the current output batch are processed and the

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -1325,6 +1325,90 @@ TEST_F(MergeJoinTest, antiJoinWithFilter) {
           "SELECT t0 FROM t WHERE NOT exists (select 1 from u where t0 = u0 AND t.t0 > 2 ) ");
 }
 
+// The output batch is cut exactly at the boundary between two left rows of
+// the same key run ('leftMatch_' is still set for the run), and every output
+// row of the just-finished left row fails the filter. applyFilter must close
+// that row's block of output rows before the batch is returned: the pending
+// block state holds 'currentRow_', an output index into THIS batch. If the
+// close is wrongly deferred, the next applyFilter call fires onMiss on that
+// stale index: it appends numRows + 1 dictionary indices (malformed
+// dictionary vector) and nulls right-side projections of an unrelated row.
+TEST_F(MergeJoinTest, leftJoinFilterCutAtLeftRowBoundary) {
+  // One key run: 3 left rows x 5 right rows, output batch size 5 => every
+  // output batch ends exactly at a left-row block boundary. t1 = 0 makes all
+  // 5 output rows of the first left row fail the filter; the other left rows
+  // pass on all of theirs.
+  auto left = makeRowVector(
+      {"t0", "t1"},
+      {makeFlatVector<int64_t>({1, 1, 1, 2}),
+       makeFlatVector<int64_t>({0, 1, 2, 10})});
+
+  auto right = makeRowVector(
+      {"u0", "u1"},
+      {makeFlatVector<int64_t>({1, 1, 1, 1, 1, 2}),
+       makeFlatVector<int64_t>({100, 200, 300, 400, 500, 600})});
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {right});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"t0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "t1 > 0",
+              {"t0", "t1", "u0", "u1"},
+              core::JoinType::kLeft)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "5")
+      .config(core::QueryConfig::kMaxOutputBatchRows, "5")
+      .assertResults(
+          "SELECT t0, t1, u0, u1 FROM t LEFT JOIN u ON t0 = u0 AND t1 > 0");
+}
+
+// Anti-join flavor of the wrongly deferred block close: onMiss is the emit
+// path for anti join rows, so the stale index emits the WRONG left row as
+// "unmatched" (silent wrong results, no crash).
+TEST_F(MergeJoinTest, antiJoinFilterCutAtLeftRowBoundary) {
+  auto left = makeRowVector(
+      {"t0", "t1"},
+      {makeFlatVector<int64_t>({1, 1, 1, 2}),
+       makeFlatVector<int64_t>({0, 1, 2, 10})});
+
+  auto right = makeRowVector(
+      {"u0", "u1"},
+      {makeFlatVector<int64_t>({1, 1, 1, 1, 1, 2}),
+       makeFlatVector<int64_t>({100, 200, 300, 400, 500, 600})});
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {right});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"t0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "t1 > 0",
+              {"t0", "t1"},
+              core::JoinType::kAnti)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "5")
+      .config(core::QueryConfig::kMaxOutputBatchRows, "5")
+      .assertResults(
+          "SELECT t0, t1 FROM t WHERE NOT exists "
+          "(select 1 from u where t0 = u0 AND t1 > 0)");
+}
+
 TEST_F(MergeJoinTest, antiJoinFailed) {
   auto size = 1'00;
   auto left = makeRowVector(


### PR DESCRIPTION

`MergeJoin::applyFilter` defers `noMoreFilterResults` when `leftMatch_` is set and
`isCurrentLeftMatch(numRows - 1)`:

https://github.com/facebookincubator/velox/blob/main/velox/exec/MergeJoin.cpp#L1619

That check is vacuous whenever the output batch ends in a match row: the last
filtered row is trivially the tracker's current block, so the decision rests
entirely on `leftMatch_` being set. But a match spans **all duplicate outer rows
of one key**, so `leftMatch_` stays set across outer-row block boundaries inside
the match (and is already set for the next key's match while the previous key's
last rows are being returned). When the output batch is cut exactly at such a
boundary and every row of the just-finished block failed the filter, the block's
close is wrongly deferred.

The pending state includes `currentRow_` — an output index in the **old batch's
coordinates**. The next `applyFilter` call then fires `onMiss` on that stale
index:

- if the new batch is otherwise fully appended, `numPassed` reaches
  `numRows + 1` and `wrap()` aborts:
  `Malformed dictionary, index array is shorter than DictionaryVector`
  (`DictionaryVector-inl.h:86`, observed in production as `(7560 vs. 7564)` on a
  filtered LEFT join under Gluten);
- otherwise the failure is **silent**: an unrelated row of the new batch has its
  right-side projections nulled (`onMiss` calls `setNull(row)` with the stale
  index) and is emitted twice, while the null-extended row for the failed block
  is lost (left outer). For anti joins, `onMiss` is the emit path, so the wrong
  left row is emitted as "unmatched".

## Fix

Defer only when the row the in-progress match will emit NEXT (its cursor
position; `rightMatch_` for right and right-semi joins, mirroring the `addMatch`
dispatch in `tryAddOutputRow`) is the same outer-side row as the last row
recorded by `addMatch`, compared by vector identity + row index. Replaces the
vacuous `JoinTracker::isCurrentLeftMatch` with `JoinTracker::isLastAddedRow`.

Note on `resetLastVector()` in `addInput`: it cannot interleave with a pending
mid-block deferral — output emission for a match only starts once both sides of
the match are complete, which implies `input_` is non-null for the whole
emission, so `needsInput()` is false and no `addInput` (and no
`resetLastVector`) can occur between the deferral and the block's continuation.

## Reproduction

Both new tests cut output batches exactly at left-row block boundaries via
`preferred_output_batch_rows = 5` on a one-key 3×5 duplicate-key run where only
the first left row fails the filter:

- `MergeJoinTest.leftJoinFilterCutAtLeftRowBoundary` — before the fix, batch 1
  (all rows fail) returns `numPassed == 0` and is dropped with the block still
  pending; batch 2 (all rows pass) appends 6 indices into a 5-row buffer and
  aborts with the malformed-dictionary error.
- `MergeJoinTest.antiJoinFilterCutAtLeftRowBoundary` — before the fix, the stale
  `onMiss` emits left row `(1, 1)` as unmatched instead of `(1, 0)` (silent
  wrong results, no crash).

Full `velox_exec_test --gtest_filter='MergeJoinTest.*'` passes with the fix
(verified on linux/aarch64, Release).
