### PR TITLE
fix(khyperloglog): Match Presto Java hashing for cross-engine sketch compatibility (#18585)

### DIFF
--- a/velox/common/hyperloglog/Murmur3Hash128.cpp
+++ b/velox/common/hyperloglog/Murmur3Hash128.cpp
@@ -24,12 +24,23 @@ int64_t getLong(const void* data, int32_t offset) {
   return folly::loadUnaligned<int64_t>(static_cast<const char*>(data) + offset);
 }
 
-char getByte(const void* data, int32_t offset) {
-  return *(static_cast<const char*>(data) + offset);
+// Presto Java masks each tail byte with & 0xFF. Reading through 'char', which
+// is signed on x86-64, sign extends bytes >= 0x80 and corrupts the higher lanes
+// of k1/k2. JavaCompat=true reproduces Java; JavaCompat=false preserves the
+// long-standing Velox behaviour that existing sketches were built with.
+template <bool JavaCompat>
+auto getByte(const void* data, int32_t offset) {
+  if constexpr (JavaCompat) {
+    return folly::loadUnaligned<uint8_t>(
+        static_cast<const uint8_t*>(data) + offset);
+  } else {
+    return folly::loadUnaligned<char>(static_cast<const char*>(data) + offset);
+  }
 }
 
-// static
-int64_t Murmur3Hash128::hash64(const void* data, int32_t length, int64_t seed) {
+template <bool JavaCompat>
+int64_t
+Murmur3Hash128::hash64Impl(const void* data, int32_t length, int64_t seed) {
   VELOX_DCHECK_NOT_NULL(data);
   const int32_t fastLimit =
       static_cast<int32_t>(length - (2 * sizeof(int64_t)) + 1);
@@ -71,25 +82,30 @@ int64_t Murmur3Hash128::hash64(const void* data, int32_t length, int64_t seed) {
   VELOX_DCHECK_LE(current + (length & 15), length);
   switch (length & 15) {
     case 15:
-      k2 ^= (static_cast<int64_t>(getByte(data, current + 14))) << 48;
+      k2 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 14)))
+          << 48;
       [[fallthrough]];
     case 14:
-      k2 ^= (static_cast<int64_t>(getByte(data, current + 13))) << 40;
+      k2 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 13)))
+          << 40;
       [[fallthrough]];
     case 13:
-      k2 ^= (static_cast<int64_t>(getByte(data, current + 12))) << 32;
+      k2 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 12)))
+          << 32;
       [[fallthrough]];
     case 12:
-      k2 ^= (static_cast<int64_t>(getByte(data, current + 11))) << 24;
+      k2 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 11)))
+          << 24;
       [[fallthrough]];
     case 11:
-      k2 ^= (static_cast<int64_t>(getByte(data, current + 10))) << 16;
+      k2 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 10)))
+          << 16;
       [[fallthrough]];
     case 10:
-      k2 ^= (static_cast<int64_t>(getByte(data, current + 9))) << 8;
+      k2 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 9))) << 8;
       [[fallthrough]];
     case 9:
-      k2 ^= (static_cast<int64_t>(getByte(data, current + 8))) << 0;
+      k2 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 8))) << 0;
 
       k2 = static_cast<int64_t>(k2 * C2);
       k2 = static_cast<int64_t>(bits::rotateLeft64(k2, 33));
@@ -98,28 +114,34 @@ int64_t Murmur3Hash128::hash64(const void* data, int32_t length, int64_t seed) {
       [[fallthrough]];
 
     case 8:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 7))) << 56;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 7)))
+          << 56;
       [[fallthrough]];
     case 7:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 6))) << 48;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 6)))
+          << 48;
       [[fallthrough]];
     case 6:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 5))) << 40;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 5)))
+          << 40;
       [[fallthrough]];
     case 5:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 4))) << 32;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 4)))
+          << 32;
       [[fallthrough]];
     case 4:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 3))) << 24;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 3)))
+          << 24;
       [[fallthrough]];
     case 3:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 2))) << 16;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 2)))
+          << 16;
       [[fallthrough]];
     case 2:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 1))) << 8;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 1))) << 8;
       [[fallthrough]];
     case 1:
-      k1 ^= (static_cast<int64_t>(getByte(data, current + 0))) << 0;
+      k1 ^= (static_cast<int64_t>(getByte<JavaCompat>(data, current + 0))) << 0;
 
       k1 = static_cast<int64_t>(k1 * C1);
       k1 = static_cast<int64_t>(bits::rotateLeft64(k1, 31));
@@ -140,6 +162,19 @@ int64_t Murmur3Hash128::hash64(const void* data, int32_t length, int64_t seed) {
   h2 = mix64(h2);
 
   return static_cast<int64_t>(h1 + h2);
+}
+
+// static
+int64_t Murmur3Hash128::hash64(const void* data, int32_t length, int64_t seed) {
+  return hash64Impl<false>(data, length, seed);
+}
+
+// static
+int64_t Murmur3Hash128::hash64JavaCompat(
+    const void* data,
+    int32_t length,
+    int64_t seed) {
+  return hash64Impl<true>(data, length, seed);
 }
 
 void Murmur3Hash128::hash(

--- a/velox/common/hyperloglog/Murmur3Hash128.h
+++ b/velox/common/hyperloglog/Murmur3Hash128.h
@@ -28,7 +28,19 @@ class Murmur3Hash128 {
  public:
   /// This method implements
   /// https://github.com/airlift/slice/blob/44896889dcef7a16a2c14800a4a392934909c2cc/src/main/java/io/airlift/slice/Murmur3Hash128.java#L152.
+  ///
+  /// NOTE: this reads tail bytes as signed, so for any input whose length is
+  /// not a multiple of 16 and whose tail contains a byte >= 0x80 it does NOT
+  /// match Presto Java. Existing sketches were built with this behaviour, so it
+  /// is preserved. Use hash64JavaCompat() when cross-engine byte compatibility
+  /// with Presto Java is required.
   static int64_t hash64(const void* data, int32_t length, int64_t seed);
+
+  /// Same as hash64(), but masks each tail byte with 0xFF the way Presto Java
+  /// does, so the result matches airlift's Murmur3Hash128.hash64 for every
+  /// input. Used by the Java-compatible KHyperLogLog aggregate.
+  static int64_t
+  hash64JavaCompat(const void* data, int32_t length, int64_t seed);
 
   /// This method implements
   /// https://github.com/airlift/slice/blob/44896889dcef7a16a2c14800a4a392934909c2cc/src/main/java/io/airlift/slice/Murmur3Hash128.java#L248.
@@ -42,6 +54,13 @@ class Murmur3Hash128 {
   hash(const void* key, const int32_t len, const uint32_t seed, void* out);
 
  private:
+  // Shared body of hash64() and hash64JavaCompat(). When JavaCompat is true the
+  // trailing bytes are read as unsigned, matching Presto Java; otherwise they
+  // are read through a signed char, preserving the original Velox behaviour
+  // that already-persisted sketches depend on.
+  template <bool JavaCompat>
+  static int64_t hash64Impl(const void* data, int32_t length, int64_t seed);
+
   static constexpr uint64_t C1 = 0x87c37b91114253d5L;
   static constexpr uint64_t C2 = 0x4cf5ad432745937fL;
 

--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_common_hyperloglog_test DenseHllTest.cpp SparseHllTest.cpp)
+add_executable(
+  velox_common_hyperloglog_test
+  DenseHllTest.cpp
+  Murmur3Hash128Test.cpp
+  SparseHllTest.cpp
+)
 
 add_test(NAME velox_common_hyperloglog_test COMMAND velox_common_hyperloglog_test)
 

--- a/velox/common/hyperloglog/tests/Murmur3Hash128Test.cpp
+++ b/velox/common/hyperloglog/tests/Murmur3Hash128Test.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/hyperloglog/Murmur3Hash128.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace facebook::velox::common::hll {
+namespace {
+
+uint64_t javaCompatOf(const std::string& s) {
+  return static_cast<uint64_t>(Murmur3Hash128::hash64JavaCompat(
+      s.data(), static_cast<int32_t>(s.size()), 0));
+}
+
+uint64_t legacyOf(const std::string& s) {
+  return static_cast<uint64_t>(
+      Murmur3Hash128::hash64(s.data(), static_cast<int32_t>(s.size()), 0));
+}
+
+std::string bytes(std::initializer_list<int> vals) {
+  std::string s;
+  for (int v : vals) {
+    s.push_back(static_cast<char>(v));
+  }
+  return s;
+}
+
+// hash64ForLong is an independent port of the same airlift method that
+// hash64JavaCompat implements for an 8-byte input, so the two must agree for
+// every int64.
+TEST(Murmur3Hash128Test, javaCompatMatchesHash64ForLong) {
+  std::vector<int64_t> values = {
+      0,
+      1,
+      127, // largest value whose low byte stays below 0x80
+      128, // first value with a tail byte >= 0x80
+      200,
+      255,
+      256,
+      -1,
+      -128,
+      std::numeric_limits<int64_t>::min(),
+      std::numeric_limits<int64_t>::max(),
+      1LL << 40,
+  };
+  for (int64_t i = 0; i < 2000; ++i) {
+    values.push_back(i);
+    values.push_back(-i);
+  }
+
+  for (int64_t value : values) {
+    SCOPED_TRACE(fmt::format("value: {}", value));
+    EXPECT_EQ(
+        Murmur3Hash128::hash64JavaCompat(&value, sizeof(value), 0),
+        Murmur3Hash128::hash64ForLong(value, 0));
+  }
+}
+
+// hash() reads its tail bytes through const uint8_t*, so it is unaffected by
+// char signedness. Its first output word is the hash64 return value by
+// construction, which makes it an in-tree oracle for arbitrary lengths.
+TEST(Murmur3Hash128Test, javaCompatMatchesHash128FirstWord) {
+  std::string data;
+  for (int i = 0; i < 300; ++i) {
+    // Cycles through every byte value, so tails cover 0x00..0xFF.
+    data.push_back(static_cast<char>(i * 7 % 256));
+
+    SCOPED_TRACE(fmt::format("length: {}", data.size()));
+    uint64_t out[2];
+    Murmur3Hash128::hash(
+        data.data(), static_cast<int32_t>(data.size()), 0, out);
+    EXPECT_EQ(javaCompatOf(data), out[0]);
+  }
+}
+
+// Values produced by io.airlift.slice.Murmur3Hash128.hash64.
+TEST(Murmur3Hash128Test, javaCompatibilityVectors) {
+  EXPECT_EQ(javaCompatOf(""), 0x0000000000000000ULL);
+  EXPECT_EQ(javaCompatOf("hello"), 0xcbd8a7b341bd9b02ULL);
+  EXPECT_EQ(javaCompatOf(bytes({0x80})), 0x61619a676395018aULL);
+  // UTF-8 encoding of U+00E9.
+  EXPECT_EQ(javaCompatOf(bytes({0xc3, 0xa9})), 0xc9187aa411d463e8ULL);
+  EXPECT_EQ(
+      javaCompatOf(std::string(15, static_cast<char>(0xff))),
+      0x2c9d1a48cb13ee54ULL);
+}
+
+// hash64() is load-bearing for already-persisted approx_set, make_set_digest
+// and khyperloglog_agg sketches, so its output must not move. These values pin
+// the pre-existing signed-tail behaviour. They intentionally differ from
+// javaCompatibilityVectors wherever a tail byte is >= 0x80.
+TEST(Murmur3Hash128Test, legacyHash64IsUnchanged) {
+  EXPECT_EQ(legacyOf(""), 0x0000000000000000ULL);
+  EXPECT_EQ(legacyOf("hello"), 0xcbd8a7b341bd9b02ULL);
+  EXPECT_EQ(legacyOf(bytes({0x80})), 0xb6aa75aff6f3b434ULL);
+  EXPECT_EQ(legacyOf(bytes({0xc3, 0xa9})), 0x4bcacd1ed0f55280ULL);
+  EXPECT_EQ(
+      legacyOf(std::string(15, static_cast<char>(0xff))),
+      0xe187e84efa24f091ULL);
+}
+
+// The two entry points may only diverge when a tail byte is >= 0x80: inputs
+// that are a whole number of 16-byte blocks, or whose tail is pure ASCII, must
+// hash identically under both.
+TEST(Murmur3Hash128Test, entryPointsAgreeWhenNoHighTailByte) {
+  // No tail at all.
+  const auto block = bytes(
+      {0xf0,
+       0xf1,
+       0xf2,
+       0xf3,
+       0xf4,
+       0xf5,
+       0xf6,
+       0xf7,
+       0xf8,
+       0xf9,
+       0xfa,
+       0xfb,
+       0xfc,
+       0xfd,
+       0xfe,
+       0xff});
+  ASSERT_EQ(block.size(), 16);
+  EXPECT_EQ(javaCompatOf(block), legacyOf(block));
+
+  // Pure-ASCII tails of every length.
+  std::string ascii;
+  for (int i = 0; i < 40; ++i) {
+    ascii.push_back(static_cast<char>('a' + (i % 26)));
+    SCOPED_TRACE(fmt::format("length: {}", ascii.size()));
+    EXPECT_EQ(javaCompatOf(ascii), legacyOf(ascii));
+  }
+
+  // A high tail byte must change the result.
+  EXPECT_NE(javaCompatOf(bytes({0x80})), legacyOf(bytes({0x80})));
+}
+
+} // namespace
+} // namespace facebook::velox::common::hll

--- a/velox/docs/functions/presto/khyperloglog.rst
+++ b/velox/docs/functions/presto/khyperloglog.rst
@@ -14,7 +14,11 @@ A KHyperLogLog is a data sketch which stores approximate cardinality information
 associations. The Velox type for this data structure is called ``KHyperLogLog``.
 For storage and retrieval, KHyperLogLog values may be cast to/from ``VARBINARY``.
 
-Serialization format is compatible with Presto's.
+Serialization format is compatible with Presto's, so a sketch written by either
+engine can be read by the other. The *contents* produced by
+``khyperloglog_agg`` are not byte compatible with Presto Java, because the two
+hash their inputs differently. Use ``khyperloglog_agg_java_compat`` when a
+sketch has to be merged with, or compared against, one built by Presto Java.
 
 Aggregate Functions
 -------------------
@@ -25,6 +29,18 @@ Aggregate Functions
     the key column ``x`` and the unique identifier column ``uii``.
     The ``x`` parameter represents the key values and ``uii`` represents
     the unique identifiers associated with each key.
+
+.. function:: khyperloglog_agg_java_compat(x, uii) -> KHyperLogLog
+
+    Same as :func:`khyperloglog_agg`, but hashes ``x`` and ``uii`` exactly the
+    way Presto Java does, so the resulting sketch is byte identical to one
+    Presto Java would produce for the same input. Sketches produced by this
+    function can safely be merged with Java-built sketches; sketches produced
+    by :func:`khyperloglog_agg` cannot.
+
+    The two functions differ only for a ``varchar``/``varbinary`` ``uii``, and
+    for keys whose hashed bytes include a value ``>= 0x80``. They are otherwise
+    identical.
 
 .. function:: merge(KHyperLogLog) -> KHyperLogLog
    :noindex:

--- a/velox/functions/lib/KHyperLogLog.h
+++ b/velox/functions/lib/KHyperLogLog.h
@@ -36,13 +36,25 @@ class KHyperLogLog {
   static constexpr int32_t kDefaultHllBuckets = 256;
   static constexpr int32_t kDefaultMaxSize = 4096;
 
-  explicit KHyperLogLog(TAllocator* allocator)
-      : KHyperLogLog(kDefaultMaxSize, kDefaultHllBuckets, allocator) {}
+  /// javaCompat selects Presto Java compatible hashing for add(). It affects
+  /// only how new values are hashed in; the serialized format, merging and
+  /// deserialization are identical either way.
+  explicit KHyperLogLog(TAllocator* allocator, bool javaCompat = false)
+      : KHyperLogLog(
+            kDefaultMaxSize,
+            kDefaultHllBuckets,
+            allocator,
+            javaCompat) {}
 
-  KHyperLogLog(int maxSize, int hllBuckets, TAllocator* allocator)
+  KHyperLogLog(
+      int maxSize,
+      int hllBuckets,
+      TAllocator* allocator,
+      bool javaCompat = false)
       : maxSize_(maxSize),
         hllBuckets_(hllBuckets),
         allocator_(allocator),
+        javaCompat_(javaCompat),
         minhash_(
             TStlAllocator<std::pair<
                 const int64_t,
@@ -156,6 +168,7 @@ class KHyperLogLog {
   int32_t hllBuckets_;
   int8_t indexBitLength_;
   TAllocator* allocator_;
+  bool javaCompat_{false};
 
   std::map<
       int64_t,

--- a/velox/functions/lib/KHyperLogLogImpl.h
+++ b/velox/functions/lib/KHyperLogLogImpl.h
@@ -18,7 +18,11 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/IOUtils.h"
+#include "velox/common/base/XxHashInline.h"
 #include "velox/common/hyperloglog/Murmur3Hash128.h"
+// Included so this header is self contained. KHyperLogLog.h includes this file
+// at the bottom; #pragma once makes the cycle a no-op.
+#include "velox/functions/lib/KHyperLogLog.h"
 #include "velox/type/HugeInt.h"
 
 namespace facebook::velox::common::hll {
@@ -29,31 +33,85 @@ constexpr int64_t kHashOutputHalfRange = INT64_MAX;
 constexpr size_t kHeaderSize = sizeof(uint8_t) // version
     + 4 * sizeof(int32_t); // maxSize, hllBuckets, minhashSize, hllsTotalSize;
 
+// Hashes the MinHash join key. When javaCompat is true the hash matches
+// Presto Java exactly; otherwise the long-standing Velox behaviour is kept so
+// that already-persisted khyperloglog_agg sketches stay readable and
+// reproducible.
 template <typename TJoinKey>
-static int64_t hashKey(TJoinKey joinKey) {
+static int64_t hashKey(TJoinKey joinKey, bool javaCompat) {
   int64_t result;
   if constexpr (std::is_same_v<TJoinKey, Timestamp>) {
     result = joinKey.toMillis();
   } else if constexpr (
       std::is_same_v<TJoinKey, int128_t> ||
       std::is_same_v<TJoinKey, uint128_t>) {
-    return Murmur3Hash128::hash64(&joinKey, sizeof(joinKey), 0);
+    return javaCompat
+        ? Murmur3Hash128::hash64JavaCompat(&joinKey, sizeof(joinKey), 0)
+        : Murmur3Hash128::hash64(&joinKey, sizeof(joinKey), 0);
   } else if constexpr (std::is_integral_v<TJoinKey>) {
     result = static_cast<int64_t>(joinKey);
   } else if constexpr (std::is_same_v<TJoinKey, float>) {
-    // Cast to double first, then extract bits, based on implicit coercion
-    double dbl = static_cast<double>(joinKey);
-    std::memcpy(&result, &dbl, sizeof(result));
+    // Presto Java does NOT widen REAL to DOUBLE here. A REAL is carried as its
+    // Float.floatToIntBits() pattern and reaches KHyperLogLog.add(long, ...)
+    // sign extended, so hashing the double bits would pick a different key.
+    // Verified against Presto Java: khyperloglog_agg(CAST(x AS REAL), ...) is
+    // byte identical to khyperloglog_agg(CAST(floatToIntBits(x) AS BIGINT),
+    // ...) for both positive and negative x.
+    int32_t bits;
+    std::memcpy(&bits, &joinKey, sizeof(bits));
+    result = static_cast<int64_t>(bits);
   } else if constexpr (std::is_same_v<TJoinKey, double>) {
     std::memcpy(&result, &joinKey, sizeof(result));
   } else if constexpr (std::is_same_v<TJoinKey, StringView>) {
-    result =
-        common::hll::Murmur3Hash128::hash64(joinKey.data(), joinKey.size(), 0);
+    const auto size = static_cast<int32_t>(joinKey.size());
+    if (javaCompat) {
+      // KHyperLogLog.add(Slice, long) hashes the bytes once; unlike the
+      // numeric overloads there is no second pass through the long hash.
+      return Murmur3Hash128::hash64JavaCompat(joinKey.data(), size, 0);
+    }
+    result = Murmur3Hash128::hash64(joinKey.data(), size, 0);
   } else {
     VELOX_UNREACHABLE("Unsupported input type: {}", typeid(TJoinKey).name());
   }
 
-  return Murmur3Hash128::hash64(&result, sizeof(result), 0);
+  // Presto Java uses the dedicated long overload here. It is equivalent to
+  // hashing the 8 bytes with correctly masked tail bytes.
+  return javaCompat ? Murmur3Hash128::hash64ForLong(result, 0)
+                    : Murmur3Hash128::hash64(&result, sizeof(result), 0);
+}
+
+// Hashes the unique-identifier value that feeds the per-key HLL.
+//
+// Presto Java widens the uii to a long and adds that long to the HLL: a
+// varchar/varbinary uii is pre-hashed with XxHash64 first. Plain approx_set
+// adds the raw bytes instead, which is why this cannot live in
+// HllAccumulator's hashOne(). When javaCompat is false the existing Velox
+// behaviour is preserved.
+template <typename TUii>
+static uint64_t hashUii(const TUii& uii, bool javaCompat) {
+  if (!javaCompat) {
+    return hashOne<TUii, true>(uii);
+  }
+
+  if constexpr (std::is_same_v<TUii, StringView>) {
+    return Murmur3Hash128::hash64ForLong(
+        static_cast<int64_t>(XXH64(uii.data(), uii.size(), 0)), 0);
+  } else if constexpr (std::is_same_v<TUii, Timestamp>) {
+    return Murmur3Hash128::hash64ForLong(uii.toMillis(), 0);
+  } else if constexpr (std::is_same_v<TUii, float>) {
+    // REAL is not widened to DOUBLE; see the matching branch in hashKey().
+    int32_t bits;
+    std::memcpy(&bits, &uii, sizeof(bits));
+    return Murmur3Hash128::hash64ForLong(static_cast<int64_t>(bits), 0);
+  } else if constexpr (std::is_same_v<TUii, double>) {
+    int64_t bits;
+    std::memcpy(&bits, &uii, sizeof(bits));
+    return Murmur3Hash128::hash64ForLong(bits, 0);
+  } else if constexpr (std::is_integral_v<TUii>) {
+    return Murmur3Hash128::hash64ForLong(static_cast<int64_t>(uii), 0);
+  } else {
+    return hashOne<TUii, true>(uii);
+  }
 }
 } // namespace detail
 
@@ -203,7 +261,7 @@ size_t KHyperLogLog<TUii, TAllocator>::estimatedSerializedSize() const {
 template <typename TUii, typename TAllocator>
 template <typename TJoinKey>
 void KHyperLogLog<TUii, TAllocator>::add(TJoinKey joinKey, TUii uii) {
-  update(detail::hashKey(joinKey), uii);
+  update(detail::hashKey(joinKey, javaCompat_), uii);
 }
 
 template <typename TUii, typename TAllocator>
@@ -226,7 +284,7 @@ void KHyperLogLog<TUii, TAllocator>::update(int64_t hash, TUii uii) {
     decreaseTotalHllSize(*hll);
   }
 
-  hll->append(uii);
+  hll->insertHash(detail::hashUii(uii, javaCompat_));
 
   increaseTotalHllSize(*hll);
   removeOverflowEntries();

--- a/velox/functions/lib/tests/KHyperLogLogTest.cpp
+++ b/velox/functions/lib/tests/KHyperLogLogTest.cpp
@@ -708,3 +708,151 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 }
+
+// Presto's KHyperLogLog aggregation pre-hashes a varchar uii with XxHash64 and
+// adds the resulting long to the HLL. That makes these two equivalent on
+// Presto Java, which this test pins:
+//
+//   KHYPERLOGLOG_AGG(k, v)
+//     == KHYPERLOGLOG_AGG(k, FROM_BIG_ENDIAN_64(XXHASH64(CAST(v AS
+//     VARBINARY))))
+//
+// Adding the raw bytes to the HLL instead produces sketches that are binary
+// incompatible with Java.
+TEST_F(KHyperLogLogTest, varcharUiiMatchesXxHash64PreHash) {
+  const std::vector<std::string> uiis = {
+      "abc",
+      "",
+      "a much longer identifier value 1234567890",
+      // Non-ASCII, so the tail bytes exercise the >= 0x80 range as well.
+      "\xc3\xa9\xc3\xa8\xc3\xaa",
+  };
+
+  auto stringKhll =
+      std::make_unique<KHyperLogLog<StringView, HashStringAllocator>>(
+          allocator_, /*javaCompat=*/true);
+  auto longKhll = std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(
+      allocator_, /*javaCompat=*/true);
+
+  for (size_t i = 0; i < uiis.size(); ++i) {
+    const auto key = static_cast<int64_t>(i);
+    stringKhll->add(key, StringView(uiis[i]));
+    longKhll->add(
+        key, static_cast<int64_t>(XXH64(uiis[i].data(), uiis[i].size(), 0)));
+  }
+
+  ASSERT_EQ(
+      stringKhll->estimatedSerializedSize(),
+      longKhll->estimatedSerializedSize());
+  std::string fromString(stringKhll->estimatedSerializedSize(), '\0');
+  std::string fromLong(longKhll->estimatedSerializedSize(), '\0');
+  stringKhll->serialize(fromString.data());
+  longKhll->serialize(fromLong.data());
+  EXPECT_EQ(fromString, fromLong);
+}
+
+// KHyperLogLog.add(Slice, long) hashes the varchar join key ONCE, whereas the
+// numeric overloads route their value through the dedicated long hash. Hashing
+// a varchar key twice silently changes the retained MinHash key set, which is
+// exactly what INTERSECTION_CARDINALITY and JACCARD_INDEX read.
+TEST_F(KHyperLogLogTest, varcharKeyIsHashedOnce) {
+  const std::vector<std::string> keys = {
+      "",
+      "abc",
+      "0123456789",
+      "a much longer join key value 1234567890",
+      "\xc3\xa9\xc3\xa8\xc3\xaa",
+  };
+
+  for (const auto& key : keys) {
+    const auto size = static_cast<int32_t>(key.size());
+    EXPECT_EQ(
+        common::hll::detail::hashKey(StringView(key), /*javaCompat=*/true),
+        Murmur3Hash128::hash64JavaCompat(key.data(), size, 0))
+        << "key: " << key;
+
+    const int64_t legacyInner = Murmur3Hash128::hash64(key.data(), size, 0);
+    EXPECT_EQ(
+        common::hll::detail::hashKey(StringView(key), /*javaCompat=*/false),
+        Murmur3Hash128::hash64(&legacyInner, sizeof(legacyInner), 0))
+        << "key: " << key;
+  }
+}
+
+TEST_F(KHyperLogLogTest, numericKeyUsesLongHash) {
+  for (const int64_t value :
+       {int64_t{0}, int64_t{1}, int64_t{-1}, int64_t{128}, int64_t{1} << 40}) {
+    EXPECT_EQ(
+        common::hll::detail::hashKey(value, /*javaCompat=*/true),
+        Murmur3Hash128::hash64ForLong(value, 0))
+        << "value: " << value;
+  }
+
+  const double dbl = 1.5;
+  int64_t bits;
+  std::memcpy(&bits, &dbl, sizeof(bits));
+  EXPECT_EQ(
+      common::hll::detail::hashKey(dbl, /*javaCompat=*/true),
+      Murmur3Hash128::hash64ForLong(bits, 0));
+}
+
+// Presto Java carries a REAL as its Float.floatToIntBits() pattern and feeds it
+// to the long overload sign extended -- it is NOT widened to DOUBLE. Widening
+// selects different MinHash keys, so a REAL-keyed sketch stops being byte
+// compatible with Java while every other type still matches. A cross-engine
+// type sweep caught this; these cases pin both hash paths.
+TEST_F(KHyperLogLogTest, realUsesFloatBitsNotDoubleBits) {
+  for (const float value : {0.0f, 1.0f, 2.0f, -1.0f, -2.0f, 1.5f, -3.25f}) {
+    int32_t floatBits;
+    std::memcpy(&floatBits, &value, sizeof(floatBits));
+    const int64_t expected = static_cast<int64_t>(floatBits);
+
+    EXPECT_EQ(
+        common::hll::detail::hashKey(value, /*javaCompat=*/true),
+        Murmur3Hash128::hash64ForLong(expected, 0))
+        << "value: " << value;
+
+    // The double-bits form is what the buggy version produced; assert we are
+    // not that, so a regression cannot pass silently on positive values alone.
+    const double widened = static_cast<double>(value);
+    int64_t doubleBits;
+    std::memcpy(&doubleBits, &widened, sizeof(doubleBits));
+    if (doubleBits != expected) {
+      EXPECT_NE(
+          common::hll::detail::hashKey(value, /*javaCompat=*/true),
+          Murmur3Hash128::hash64ForLong(doubleBits, 0))
+          << "value: " << value;
+    }
+  }
+}
+
+// The default (non javaCompat) accumulator must keep its historical hashing so
+// that sketches already persisted by khyperloglog_agg stay reproducible. Under
+// it the varchar-uii identity above does NOT hold.
+TEST_F(KHyperLogLogTest, legacyUiiHashingIsUnchanged) {
+  const std::string uii = "abc";
+
+  auto legacy = std::make_unique<KHyperLogLog<StringView, HashStringAllocator>>(
+      allocator_);
+  auto javaCompat =
+      std::make_unique<KHyperLogLog<StringView, HashStringAllocator>>(
+          allocator_, /*javaCompat=*/true);
+  legacy->add(int64_t{1}, StringView(uii));
+  javaCompat->add(int64_t{1}, StringView(uii));
+
+  std::string legacyBuf(legacy->estimatedSerializedSize(), '\0');
+  std::string javaCompatBuf(javaCompat->estimatedSerializedSize(), '\0');
+  legacy->serialize(legacyBuf.data());
+  javaCompat->serialize(javaCompatBuf.data());
+  EXPECT_NE(legacyBuf, javaCompatBuf);
+
+  // Two default-constructed accumulators fed the same input must still agree,
+  // i.e. the legacy path is deterministic and untouched.
+  auto legacyAgain =
+      std::make_unique<KHyperLogLog<StringView, HashStringAllocator>>(
+          allocator_);
+  legacyAgain->add(int64_t{1}, StringView(uii));
+  std::string legacyAgainBuf(legacyAgain->estimatedSerializedSize(), '\0');
+  legacyAgain->serialize(legacyAgainBuf.data());
+  EXPECT_EQ(legacyBuf, legacyAgainBuf);
+}

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -97,4 +97,7 @@ const char* const kNoisyApproxDistinctSfm = "noisy_approx_distinct_sfm";
 const char* const kNoisyApproxSetSfmFromIndexAndZeros =
     "noisy_approx_set_sfm_from_index_and_zeros";
 const char* const kKHyperLogLogAgg = "khyperloglog_agg";
+/// Presto Java compatible variant. Emits sketches whose bytes match
+/// Presto Java, so they can be merged with Java-built sketches.
+const char* const kKHyperLogLogAggJavaCompat = "khyperloglog_agg_java_compat";
 } // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.cpp
@@ -24,23 +24,31 @@ namespace {
 
 template <TypeKind TValueKind, TypeKind TUiiKind>
 std::unique_ptr<exec::Aggregate> createKHyperLogLogAggregate(
-    const TypePtr& resultType) {
+    const TypePtr& resultType,
+    bool javaCompat) {
   using TValue = typename TypeTraits<TValueKind>::NativeType;
   using TUii = typename TypeTraits<TUiiKind>::NativeType;
-  return std::make_unique<KHyperLogLogAggregate<TValue, TUii>>(resultType);
+  return std::make_unique<KHyperLogLogAggregate<TValue, TUii>>(
+      resultType, javaCompat);
 }
 
 template <TypeKind TJoinKeyKind>
 std::unique_ptr<exec::Aggregate> dispatchOnUiiType(
     TypeKind uiiKind,
-    const TypePtr& resultType) {
+    const TypePtr& resultType,
+    bool javaCompat) {
   return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
-      createKHyperLogLogAggregate, TJoinKeyKind, uiiKind, resultType);
+      createKHyperLogLogAggregate,
+      TJoinKeyKind,
+      uiiKind, // NOLINT(clang-diagnostic-switch-enum)
+      resultType,
+      javaCompat);
 }
 
 /// Registration for khyperloglog_agg aggregate function.
 std::vector<exec::AggregateRegistrationResult> registerKHyperLogLogAgg(
     const std::vector<std::string>& names,
+    bool javaCompat,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -75,7 +83,7 @@ std::vector<exec::AggregateRegistrationResult> registerKHyperLogLogAgg(
   return exec::registerAggregateFunction(
       names,
       signatures,
-      [names](
+      [names, javaCompat](
           core::AggregationNode::Step /*step*/,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
@@ -91,8 +99,9 @@ std::vector<exec::AggregateRegistrationResult> registerKHyperLogLogAgg(
         auto uiiKind = argTypes[1]->kind();
 
         // First dispatch on JoinKey type, then on UII type.
+        // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
         return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-            dispatchOnUiiType, joinKeyKind, uiiKind, resultType);
+            dispatchOnUiiType, joinKeyKind, uiiKind, resultType, javaCompat);
       },
       withCompanionFunctions,
       overwrite);
@@ -101,9 +110,13 @@ std::vector<exec::AggregateRegistrationResult> registerKHyperLogLogAgg(
 
 void registerKHyperLogLogAggregates(
     const std::vector<std::string>& names,
+    const std::vector<std::string>& javaCompatNames,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerKHyperLogLogAgg(names, withCompanionFunctions, overwrite);
+  registerKHyperLogLogAgg(
+      names, /*javaCompat=*/false, withCompanionFunctions, overwrite);
+  registerKHyperLogLogAgg(
+      javaCompatNames, /*javaCompat=*/true, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h
+++ b/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h
@@ -28,8 +28,8 @@ class KHyperLogLogAggregate : public exec::Aggregate {
   using KHllAccumulator = common::hll::KHyperLogLog<TUii, HashStringAllocator>;
 
  public:
-  explicit KHyperLogLogAggregate(const TypePtr& resultType)
-      : exec::Aggregate(resultType) {}
+  KHyperLogLogAggregate(const TypePtr& resultType, bool javaCompat)
+      : exec::Aggregate(resultType), javaCompat_(javaCompat) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(KHllAccumulator);
@@ -197,7 +197,7 @@ class KHyperLogLogAggregate : public exec::Aggregate {
     setAllNulls(groups, indices);
     for (auto i : indices) {
       auto group = groups[i];
-      new (group + offset_) KHllAccumulator(allocator_);
+      new (group + offset_) KHllAccumulator(allocator_, javaCompat_);
     }
   }
 
@@ -206,6 +206,7 @@ class KHyperLogLogAggregate : public exec::Aggregate {
   }
 
  private:
+  const bool javaCompat_;
   DecodedVector decodedValue_;
   DecodedVector decodedUii_;
   DecodedVector decodedIntermediate_;

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -311,6 +311,7 @@ extern void registerApproxWinsorizedMeanAggregate(
     bool overwrite);
 extern void registerKHyperLogLogAggregates(
     const std::vector<std::string>& names,
+    const std::vector<std::string>& javaCompatNames,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerQDigestAggAggregate(
@@ -477,7 +478,10 @@ void registerAllAggregateFunctions(
   registerNumericHistogramAggregate(
       {prefix + kNumericHistogram}, withCompanionFunctions, overwrite);
   registerKHyperLogLogAggregates(
-      {prefix + kKHyperLogLogAgg}, withCompanionFunctions, overwrite);
+      {prefix + kKHyperLogLogAgg},
+      {prefix + kKHyperLogLogAggJavaCompat},
+      withCompanionFunctions,
+      overwrite);
 }
 
 void registerInternalAggregateFunctions(const std::string& prefix) {

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -226,6 +226,8 @@ int main(int argc, char** argv) {
           {"tdigest_agg", std::make_shared<TDigestAggregateResultVerifier>()},
           {"qdigest_agg", std::make_shared<QDigestAggResultVerifier>()},
           {"khyperloglog_agg", std::make_shared<KHyperLogLogResultVerifier>()},
+          {"khyperloglog_agg_java_compat",
+           std::make_shared<KHyperLogLogResultVerifier>()},
           {"arbitrary", std::make_shared<ArbitraryResultVerifier>()},
           {"any_value", nullptr},
           {"array_agg", makeArrayVerifier()},

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -189,6 +189,8 @@ int main(int argc, char** argv) {
           {"tdigest_agg", std::make_shared<TDigestAggregateResultVerifier>()},
           {"qdigest_agg", std::make_shared<QDigestAggResultVerifier>()},
           {"khyperloglog_agg", std::make_shared<KHyperLogLogResultVerifier>()},
+          {"khyperloglog_agg_java_compat",
+           std::make_shared<KHyperLogLogResultVerifier>()},
           {"merge", nullptr},
           // Semantically inconsistent functions
           {"skewness", nullptr},


### PR DESCRIPTION
Summary:

## Description

Velox's `khyperloglog_agg` hashes its inputs differently from Presto Java, so sketches built by the two engines are not interchangeable. Merging across the boundary silently collapses `INTERSECTION_CARDINALITY` / `JACCARD_INDEX` — reported in T279586650 ("Abnormally High New Reach Rates in Reach & Frequency Reports"): jaccard 0–0.06 cross-engine versus 0.14–0.25 same-engine, with no error raised.

This adds `khyperloglog_agg_java_compat`, which reproduces Presto Java's hashing, and leaves `khyperloglog_agg` byte-for-byte unchanged so already-persisted Velox sketches stay readable and reproducible.

## Four hashing defects, all gated to the new function

1. **Murmur3 tail bytes read through signed `char`.** Murmur3-128 folds the ≤15 trailing bytes in one at a time; Java masks each with `& 0xFF` while Velox read them through `char`, which is signed on x86-64. Byte `0x80` sign-extends to `0xFFFFFFFFFFFFFF80` and corrupts every higher lane of `k1`/`k2`. ASCII input is unaffected, which is why it went unnoticed. Adds `hash64JavaCompat` alongside `hash64`; the legacy entry point routes to `hash64Impl<false>` retaining the original read. (This portion was previously D115674030, folded in here — the two were hard-coupled and neither was independently useful or revertable.)

2. **varchar `uii` not pre-hashed.** Presto pre-hashes a varchar `uii` with XxHash64 before it reaches the long overload; Velox did not.

3. **varchar join key hashed twice.** The `StringView` branch computed the hash then fell through into the numeric path's trailing `hash64ForLong`, hashing the hash. `KHyperLogLog.add(Slice, long)` hashes once.

4. **`REAL` widened to `DOUBLE`.** Presto Java carries a `REAL` as its `Float.floatToIntBits()` pattern into the BIGINT overload, sign-extended — it is not widened. Verified: `khyperloglog_agg(CAST(x AS REAL), …)` is byte-identical to `khyperloglog_agg(CAST(floatToIntBits(x) AS BIGINT), …)` for positive and negative x. Found by a cross-engine type sweep after the first three were fixed.

## What this does and does not achieve

It makes the **retained MinHash key set** identical to Java, which is what `cardinality`, `INTERSECTION_CARDINALITY` and `JACCARD_INDEX` read — the metrics that broke.

It does **not** make sketches byte-identical to Java. Inner-HLL sparse→dense encoding still differs (Java flips at 32 on insert and 37 on merge; Velox at 33), so bytes can differ while the answers agree. Measured impact on `uniqueness_distribution` is ≤0.46%, against ~12% intrinsic estimator error at 256 buckets. See the test plan.

## Impact

`khyperloglog_agg` is unchanged — verified byte-identical pre/post, so persisted Velox sketches cannot move. `khyperloglog_agg_java_compat` is a new aggregate and adoption is opt-in per call site.

Differential Revision: D115674438


