### PR TITLE
build(hdfs): Download aarch64 Hadoop native libs on ARM64

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -471,7 +471,11 @@ function install_azure_storage_sdk_cpp {
 
 function install_hdfs_deps {
   # Dependencies for Hadoop testing
-  wget_and_untar https://dlcdn.apache.org/hadoop/common/hadoop-"${HADOOP_VERSION}"/hadoop-"${HADOOP_VERSION}".tar.gz hadoop
+  local arch
+  arch=$(uname -m)
+  local hadoop_tarball="hadoop-${HADOOP_VERSION}.tar.gz"
+  [[ ${arch} == "aarch64" ]] && hadoop_tarball="hadoop-${HADOOP_VERSION}-aarch64.tar.gz"
+  wget_and_untar "https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/${hadoop_tarball}" hadoop
   cp -a "${DEPENDENCY_DIR}"/hadoop "$INSTALL_PREFIX"
   wget "${WGET_OPTS[@]}" -P "$INSTALL_PREFIX"/hadoop/share/hadoop/common/lib/ https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar
   # Needed for HADOOP 3.3.6 minicluster. Can remove after updating to 3.4.2.


### PR DESCRIPTION
`install_hdfs_deps` always downloaded `hadoop-${HADOOP_VERSION}.tar.gz`,
whose native libraries (`libhdfs.so`, `libhadoop.so`) are x86-64 only. On
aarch64 hosts the dynamic linker rejects them, causing
`velox_hdfs_file_test` and `velox_hdfs_insert_test` to fail with
`ConnectLibHdfs failed`. Apache Hadoop ships a parallel `-aarch64.tar.gz`
tarball with correct native binaries; this change detects the host
architecture and selects it on ARM64.

Part of #18086