### PR TITLE
feat(hive): Report per-operation latency and retry counts

### DIFF
--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -100,6 +100,10 @@ void addOperationStatsToRuntimeStats(
     add("localThrottleCount", counters.localThrottleCount);
     add("globalThrottleCount", counters.globalThrottleCount);
     add("resourceThrottleCount", counters.resourceThrottleCount);
+    add("retryCount", counters.retryCount);
+    // Cumulative across requests, so consumers must divide by requestCount to
+    // recover a per-request mean.
+    add("latencyInMs", counters.latencyInMs);
   }
 }
 


### PR DESCRIPTION
Summary: Export `latencyInMs` and `retryCount` as `storage.<operation>.<counter>` runtime stats, alongside the request and throttle counts already exported from the same `IoStatistics::operationStats()` loop, so a consumer can recover how long a file system's requests took and how often they were retried.

Differential Revision: D116716182


