### PR TITLE
feat(cudf): Account cuDF GPU memory in custom pools

### DIFF
--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -89,7 +89,14 @@ QueryCtx::QueryCtx(
 }
 
 QueryCtx::~QueryCtx() {
-  for (auto& cb : releaseCallbacks_) {
+  // Move the callbacks out before running them: a callback may re-enter
+  // QueryCtx, which would deadlock on mutex_ if it were held here.
+  std::deque<ReleaseCallback> callbacks;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    callbacks.swap(releaseCallbacks_);
+  }
+  for (auto& cb : callbacks) {
     try {
       cb();
     } catch (const std::exception& e) {

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -288,7 +288,10 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   /// Note: Callbacks are invoked in registration order. Exceptions thrown by
   /// callbacks are caught and logged; they do not prevent subsequent callbacks
   /// from running.
+  ///
+  /// Safe to call concurrently from multiple tasks of the same query.
   void addReleaseCallback(ReleaseCallback callback) {
+    std::lock_guard<std::mutex> l(mutex_);
     releaseCallbacks_.push_back(std::move(callback));
   }
 
@@ -515,6 +518,7 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   std::vector<ContinuePromise> arbitrationPromises_;
   std::shared_ptr<filesystems::TokenProvider> fsTokenProvider_;
   // Callbacks invoked before destruction to clean up external resources.
+  // Guarded by mutex_; tasks of one query register concurrently.
   std::deque<ReleaseCallback> releaseCallbacks_;
 
   // A function that constructs a custom trace ctx object.

--- a/velox/core/tests/QueryCtxTest.cpp
+++ b/velox/core/tests/QueryCtxTest.cpp
@@ -15,6 +15,9 @@
  */
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/QueryCtx.h"
 
@@ -82,6 +85,39 @@ TEST_F(QueryCtxTest, releaseCallbacks) {
   // After QueryCtx destruction, all callbacks should have been invoked.
   ASSERT_EQ(callbackCount, 2);
   ASSERT_EQ(capturedQueryId, "test_query_id");
+}
+
+TEST_F(QueryCtxTest, concurrentReleaseCallbackRegistration) {
+  constexpr int32_t kNumThreads = 8;
+  constexpr int32_t kCallbacksPerThread = 500;
+  std::atomic<int32_t> callbackCount{0};
+
+  {
+    auto queryCtx = QueryCtx::create(
+        nullptr,
+        QueryConfig{{}},
+        std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+        nullptr,
+        nullptr,
+        nullptr,
+        "test_query_id");
+
+    // Tasks of one query register release callbacks from their own threads.
+    std::vector<std::thread> threads;
+    threads.reserve(kNumThreads);
+    for (int32_t i = 0; i < kNumThreads; ++i) {
+      threads.emplace_back([&]() {
+        for (int32_t j = 0; j < kCallbacksPerThread; ++j) {
+          queryCtx->addReleaseCallback([&callbackCount]() { ++callbackCount; });
+        }
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  }
+
+  ASSERT_EQ(callbackCount, kNumThreads * kCallbacksPerThread);
 }
 
 TEST_F(QueryCtxTest, releaseCallbackException) {

--- a/velox/experimental/cudf/CudfNoDefaults.h
+++ b/velox/experimental/cudf/CudfNoDefaults.h
@@ -58,13 +58,8 @@ get_current_device_resource_ref();
 
 namespace facebook::velox::cudf_velox {
 
-/// Returns the current device memory resource as an async resource reference.
-/// Equivalent to cudf::get_current_device_resource_ref(), but bypasses the
-/// __attribute__((error)) redeclaration above by calling the underlying RMM
-/// function directly. Use this at call sites where you intentionally want
-/// the current default device memory resource.
-inline rmm::device_async_resource_ref get_temp_mr() {
-  return rmm::mr::get_current_device_resource_ref();
-}
+/// Returns the temporary resource selected for the current cuDF call, falling
+/// back to RMM's current device resource outside an operator call.
+rmm::device_async_resource_ref get_temp_mr();
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/benchmarks/CMakeLists.txt
+++ b/velox/experimental/cudf/benchmarks/CMakeLists.txt
@@ -36,6 +36,13 @@ target_link_libraries(
 
 # --- other benchmarks ---
 
+add_executable(
+  velox_cudf_temporary_memory_resource_benchmark
+  CudfTemporaryMemoryResourceBenchmark.cpp
+)
+
+target_link_libraries(velox_cudf_temporary_memory_resource_benchmark velox_cudf_exec Folly::folly)
+
 add_executable(velox_cudf_interop_benchmark CudfInteropBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/experimental/cudf/benchmarks/CudfTemporaryMemoryResourceBenchmark.cpp
+++ b/velox/experimental/cudf/benchmarks/CudfTemporaryMemoryResourceBenchmark.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Measures the cost the thread-local temporary memory resource dispatcher adds
+// to cuDF's implicit allocation path. The dispatcher keeps a pointer-keyed map
+// so a temporary freed on another thread still routes back to the resource
+// that allocated it, and that map is what this benchmark prices.
+//
+// Run against the memory resource modes that matter: "async" (the default) has
+// no host-side lock of its own, so the dispatcher is the only serialization
+// point, whereas "pool" already serializes every allocation on RMM's own
+// mutex.
+
+#include "velox/experimental/cudf/exec/GpuResources.h"
+
+#include <cuda/stream_ref>
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+DEFINE_string(memory_resource, "async", "RMM resource mode to benchmark.");
+DEFINE_int32(memory_percent, 50, "Percent of device memory for pooled modes.");
+DEFINE_int32(allocations_per_thread, 20000, "Allocate/free pairs per thread.");
+DEFINE_int32(allocation_bytes, 4096, "Size of each temporary allocation.");
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+// Nanoseconds per allocate/free pair, averaged over all threads.
+double runTrial(
+    rmm::device_async_resource_ref resource,
+    int32_t numThreads,
+    int32_t allocationsPerThread,
+    std::size_t bytes) {
+  constexpr std::size_t kAlignment = 256;
+  const cuda::stream_ref stream{cudaStream_t{0}};
+
+  std::atomic<int32_t> ready{0};
+  std::atomic<bool> start{false};
+
+  std::vector<std::thread> threads;
+  threads.reserve(numThreads);
+  for (int32_t i = 0; i < numThreads; ++i) {
+    threads.emplace_back([&]() {
+      ready.fetch_add(1);
+      while (!start.load(std::memory_order_acquire)) {
+      }
+      for (int32_t j = 0; j < allocationsPerThread; ++j) {
+        auto* pointer = resource.allocate(stream, bytes, kAlignment);
+        resource.deallocate(stream, pointer, bytes, kAlignment);
+      }
+    });
+  }
+
+  while (ready.load() < numThreads) {
+  }
+  const auto began = std::chrono::steady_clock::now();
+  start.store(true, std::memory_order_release);
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  const auto elapsed = std::chrono::steady_clock::now() - began;
+
+  const auto nanos =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count();
+  return static_cast<double>(nanos) /
+      (static_cast<double>(numThreads) * allocationsPerThread);
+}
+
+void runBenchmark() {
+  auto upstream =
+      createMemoryResource(FLAGS_memory_resource, FLAGS_memory_percent);
+  auto dispatcher = createThreadLocalTemporaryMemoryResource(upstream);
+
+  const std::size_t bytes = FLAGS_allocation_bytes;
+  std::printf(
+      "mode=%s bytes=%zu allocations/thread=%d\n\n",
+      FLAGS_memory_resource.c_str(),
+      bytes,
+      FLAGS_allocations_per_thread);
+  std::printf(
+      "%8s %14s %14s %10s\n", "threads", "direct(ns)", "dispatch(ns)", "ratio");
+
+  for (const int32_t numThreads : {1, 2, 4, 8, 16, 32}) {
+    // Warm the pool so the first trial does not pay for growth.
+    runTrial(upstream, numThreads, 1000, bytes);
+
+    const auto direct =
+        runTrial(upstream, numThreads, FLAGS_allocations_per_thread, bytes);
+    const auto dispatched =
+        runTrial(dispatcher, numThreads, FLAGS_allocations_per_thread, bytes);
+    std::printf(
+        "%8d %14.1f %14.1f %10.2fx\n",
+        numThreads,
+        direct,
+        dispatched,
+        dispatched / direct);
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::cudf_velox
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  facebook::velox::cudf_velox::runBenchmark();
+  return 0;
+}

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -30,7 +30,9 @@ add_library(
   CudfLocalMerge.cpp
   CudfLocalPartition.cpp
   CudfMarkDistinct.cpp
+  CudfMemoryResource.cpp
   CudfNestedLoopJoin.cpp
+  CudfOperator.cpp
   CudfOrderBy.cpp
   CudfReduce.cpp
   CudfTopN.cpp
@@ -62,6 +64,7 @@ target_link_libraries(
     velox_cudf_vector
     velox_exception
     velox_exec
+    velox_memory
     velox_test_util
 )
 

--- a/velox/experimental/cudf/exec/CudfAssignUniqueId.h
+++ b/velox/experimental/cudf/exec/CudfAssignUniqueId.h
@@ -44,10 +44,6 @@ class CudfAssignUniqueId : public CudfOperatorBase {
     return input_ == nullptr;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool startDrain() override {
     // No need to drain for assignUniqueId operator.
     return false;

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -38,10 +38,6 @@ class CudfBatchConcat : public CudfOperatorBase {
         currentNumRows_ < targetRows_;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override;
 
  protected:

--- a/velox/experimental/cudf/exec/CudfConversion.h
+++ b/velox/experimental/cudf/exec/CudfConversion.h
@@ -44,10 +44,6 @@ class CudfFromVelox : public CudfOperatorBase {
     return !finished_;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override {
     return finished_;
   }
@@ -77,10 +73,6 @@ class CudfToVelox : public CudfOperatorBase {
 
   bool needsInput() const override {
     return !finished_;
-  }
-
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
   }
 
   bool isFinished() override {

--- a/velox/experimental/cudf/exec/CudfDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfDistinct.cpp
@@ -50,9 +50,7 @@ CudfDistinct::CudfDistinct(
       maxPartialAggregationMemoryUsage_(
           driverCtx->queryConfig().maxPartialAggregationMemoryUsage()) {}
 
-void CudfDistinct::initialize() {
-  Operator::initialize();
-
+void CudfDistinct::doInitialize() {
   inputType_ = aggregationNode_->sources()[0]->outputType();
   setupGroupingKeyChannelProjections(
       *aggregationNode_, groupingKeyInputChannels_, groupingKeyOutputChannels_);

--- a/velox/experimental/cudf/exec/CudfDistinct.h
+++ b/velox/experimental/cudf/exec/CudfDistinct.h
@@ -27,14 +27,10 @@ class CudfDistinct : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::AggregationNode> const& aggregationNode);
 
-  void initialize() override;
+  void doInitialize() override;
 
   bool needsInput() const override {
     return !noMoreInput_;
-  }
-
-  exec::BlockingReason isBlocked(ContinueFuture* /* unused */) override {
-    return exec::BlockingReason::kNotBlocked;
   }
 
   bool isFinished() override;

--- a/velox/experimental/cudf/exec/CudfEnforceSingleRow.h
+++ b/velox/experimental/cudf/exec/CudfEnforceSingleRow.h
@@ -53,10 +53,6 @@ class CudfEnforceSingleRow : public CudfOperatorBase {
 
   bool isFinished() override;
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
  protected:
   void doAddInput(RowVectorPtr input) override;
   RowVectorPtr doGetOutput() override;

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -137,9 +137,7 @@ CudfFilterProject::CudfFilterProject(
   }
 }
 
-void CudfFilterProject::initialize() {
-  Operator::initialize();
-
+void CudfFilterProject::doInitialize() {
   std::vector<core::TypedExprPtr> allExprs;
   if (hasFilter_) {
     VELOX_CHECK_NOT_NULL(filter_);

--- a/velox/experimental/cudf/exec/CudfFilterProject.h
+++ b/velox/experimental/cudf/exec/CudfFilterProject.h
@@ -35,7 +35,7 @@ class CudfFilterProject : public CudfOperatorBase {
       const std::shared_ptr<const core::FilterNode>& filter,
       const std::shared_ptr<const core::ProjectNode>& project);
 
-  void initialize() override;
+  void doInitialize() override;
 
   bool needsInput() const override {
     return !input_;
@@ -48,10 +48,6 @@ class CudfFilterProject : public CudfOperatorBase {
   std::vector<std::unique_ptr<cudf::column>> project(
       std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
       cuda::stream_ref stream);
-
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
 
   bool isFinished() override;
 

--- a/velox/experimental/cudf/exec/CudfGroupId.h
+++ b/velox/experimental/cudf/exec/CudfGroupId.h
@@ -36,10 +36,6 @@ class CudfGroupId : public CudfOperatorBase {
 
   bool needsInput() const override;
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override {
     return noMoreInput_ && inputColumns_.empty();
   }

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -1461,9 +1461,7 @@ CudfVectorPtr CudfGroupby::finalizeStreamingGroupby() {
   return result;
 }
 
-void CudfGroupby::initialize() {
-  Operator::initialize();
-
+void CudfGroupby::doInitialize() {
   inputType_ = aggregationNode_->sources()[0]->outputType();
   ignoreNullKeys_ = aggregationNode_->ignoreNullKeys();
   setupGroupingKeyChannelProjections(

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -160,14 +160,10 @@ class CudfGroupby : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::AggregationNode> const& aggregationNode);
 
-  void initialize() override;
+  void doInitialize() override;
 
   bool needsInput() const override {
     return !noMoreInput_;
-  }
-
-  exec::BlockingReason isBlocked(ContinueFuture* /* unused */) override {
-    return exec::BlockingReason::kNotBlocked;
   }
 
   bool isFinished() override;

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -412,7 +412,7 @@ void CudfHashJoinBuild::doNoMoreInput() {
           std::make_pair(std::move(shared_tbls), std::move(hashObjects))));
 }
 
-exec::BlockingReason CudfHashJoinBuild::isBlocked(ContinueFuture* future) {
+exec::BlockingReason CudfHashJoinBuild::doIsBlocked(ContinueFuture* future) {
   if (!future_.valid()) {
     return exec::BlockingReason::kNotBlocked;
   }
@@ -508,9 +508,7 @@ void CudfHashJoinProbe::waitForBuildReady(cuda::stream_ref stream) {
   }
 }
 
-void CudfHashJoinProbe::initialize() {
-  Operator::initialize();
-
+void CudfHashJoinProbe::doInitialize() {
   if (!joinNode_->filter()) {
     return;
   }
@@ -2303,7 +2301,7 @@ bool CudfHashJoinProbe::skipProbeOnEmptyBuild() const {
       isRightSemiProjectJoin(joinType);
 }
 
-exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
+exec::BlockingReason CudfHashJoinProbe::doIsBlocked(ContinueFuture* future) {
   if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin() ||
        joinNode_->isFullJoin()) &&
       hashObject_.has_value()) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -106,7 +106,7 @@ class CudfHashJoinBuild : public CudfOperatorBase {
 
   bool needsInput() const override;
 
-  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+  exec::BlockingReason doIsBlocked(ContinueFuture* future) override;
 
   bool isFinished() override;
 
@@ -142,13 +142,13 @@ class CudfHashJoinProbe : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::HashJoinNode> joinNode);
 
-  void initialize() override;
+  void doInitialize() override;
 
   bool needsInput() const override;
 
   bool skipProbeOnEmptyBuild() const;
 
-  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+  exec::BlockingReason doIsBlocked(ContinueFuture* future) override;
 
   /// Returns true if the join type is supported by cudf hash join.
   /// Supported types:

--- a/velox/experimental/cudf/exec/CudfLimit.h
+++ b/velox/experimental/cudf/exec/CudfLimit.h
@@ -30,10 +30,6 @@ class CudfLimit : public CudfOperatorBase {
 
   bool needsInput() const override;
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override {
     return finished_ || (noMoreInput_ && input_ == nullptr);
   }

--- a/velox/experimental/cudf/exec/CudfLocalMerge.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalMerge.cpp
@@ -73,7 +73,7 @@ void CudfLocalMerge::addMergeSources() {
   }
 }
 
-exec::BlockingReason CudfLocalMerge::isBlocked(ContinueFuture* future) {
+exec::BlockingReason CudfLocalMerge::doIsBlocked(ContinueFuture* future) {
   addMergeSources();
 
   if (sources_.empty()) {

--- a/velox/experimental/cudf/exec/CudfLocalMerge.h
+++ b/velox/experimental/cudf/exec/CudfLocalMerge.h
@@ -40,11 +40,11 @@ class CudfLocalMerge : public CudfSourceOperatorBase {
       exec::DriverCtx* driverCtx,
       const std::shared_ptr<const core::LocalMergeNode>& localMergeNode);
 
-  exec::BlockingReason isBlocked(ContinueFuture* future) override;
-
   bool isFinished() override;
 
  protected:
+  exec::BlockingReason doIsBlocked(ContinueFuture* future) override;
+
   RowVectorPtr doGetOutput() override;
 
   void doClose() override;

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -276,7 +276,7 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
   }
 }
 
-exec::BlockingReason CudfLocalPartition::isBlocked(ContinueFuture* future) {
+exec::BlockingReason CudfLocalPartition::doIsBlocked(ContinueFuture* future) {
   if (!futures_.empty()) {
     auto blockingReason = blockingReasons_.front();
     *future = folly::collectAll(futures_.begin(), futures_.end()).unit();

--- a/velox/experimental/cudf/exec/CudfLocalPartition.h
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.h
@@ -48,7 +48,7 @@ class CudfLocalPartition : public CudfOperatorBase {
     return true;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+  exec::BlockingReason doIsBlocked(ContinueFuture* future) override;
 
   bool isFinished() override;
 

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.h
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.h
@@ -62,10 +62,6 @@ class CudfMarkDistinct : public CudfOperatorBase {
     return noMoreInput_ && input_ == nullptr;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
  protected:
   void doAddInput(RowVectorPtr input) override;
   RowVectorPtr doGetOutput() override;

--- a/velox/experimental/cudf/exec/CudfMemoryResource.cpp
+++ b/velox/experimental/cudf/exec/CudfMemoryResource.cpp
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/CudfMemoryResource.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/CustomMemoryResourceRegistry.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/core/QueryCtx.h"
+
+#include <rmm/cuda_device.hpp>
+
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace facebook::velox::cudf_velox::detail {
+
+CudfMemoryResourceImpl::CudfMemoryResourceImpl(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+    std::shared_ptr<memory::MemoryPool> pool,
+    std::shared_ptr<memory::CustomMemoryResource> resourceOwner)
+    : resourceOwner_(std::move(resourceOwner)),
+      pool_(std::move(pool)),
+      upstream_(std::move(upstream)) {
+  VELOX_CHECK_NOT_NULL(pool_);
+  VELOX_CHECK(pool_->isLeaf(), "cuDF memory accounting requires a leaf pool");
+  VELOX_CHECK(
+      pool_->threadSafe(),
+      "cuDF memory accounting requires a thread-safe pool");
+}
+
+void* CudfMemoryResourceImpl::allocate_sync(
+    std::size_t bytes,
+    std::size_t alignment) {
+  if (bytes == 0) {
+    return upstream_.allocate_sync(bytes, alignment);
+  }
+
+  pool_->reportExternalAllocation(bytes);
+  try {
+    return upstream_.allocate_sync(bytes, alignment);
+  } catch (...) {
+    pool_->reportExternalFree(bytes);
+    throw;
+  }
+}
+
+void CudfMemoryResourceImpl::deallocate_sync(
+    void* pointer,
+    std::size_t bytes,
+    std::size_t alignment) noexcept {
+  upstream_.deallocate_sync(pointer, bytes, alignment);
+  if (bytes != 0) {
+    pool_->reportExternalFree(bytes);
+  }
+}
+
+void* CudfMemoryResourceImpl::allocate(
+    cuda::stream_ref stream,
+    std::size_t bytes,
+    std::size_t alignment) {
+  if (bytes == 0) {
+    return upstream_.allocate(stream, bytes, alignment);
+  }
+
+  pool_->reportExternalAllocation(bytes);
+  try {
+    return upstream_.allocate(stream, bytes, alignment);
+  } catch (...) {
+    pool_->reportExternalFree(bytes);
+    throw;
+  }
+}
+
+void CudfMemoryResourceImpl::deallocate(
+    cuda::stream_ref stream,
+    void* pointer,
+    std::size_t bytes,
+    std::size_t alignment) noexcept {
+  upstream_.deallocate(stream, pointer, bytes, alignment);
+  if (bytes != 0) {
+    // reportExternalFree must not fail for a correctly paired RMM
+    // allocation. Any failure is an accounting invariant violation and, as
+    // required by the RMM resource contract, terminates this noexcept path.
+    pool_->reportExternalFree(bytes);
+  }
+}
+
+} // namespace facebook::velox::cudf_velox::detail
+
+namespace facebook::velox::cudf_velox {
+
+CudfMemoryResource::CudfMemoryResource(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+    std::shared_ptr<memory::MemoryPool> pool,
+    std::shared_ptr<memory::CustomMemoryResource> resourceOwner)
+    : SharedBase(
+          cuda::mr::make_shared_resource<detail::CudfMemoryResourceImpl>(
+              std::move(upstream),
+              std::move(pool),
+              std::move(resourceOwner))) {}
+
+namespace {
+
+class CudfExchangeMemoryResource {
+ public:
+  CudfExchangeMemoryResource(
+      std::shared_ptr<memory::MemoryPool> queryRootPool,
+      std::shared_ptr<memory::CustomMemoryResource> resourceOwner,
+      cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+      int device)
+      : resourceOwner_(std::move(resourceOwner)),
+        queryRootPool_(std::move(queryRootPool)),
+        pool_(queryRootPool_->addLeafChild(
+            "ucxExchange.device." + std::to_string(device))),
+        upstream_(std::move(upstream)),
+        resource_(upstream_, pool_, resourceOwner_),
+        device_(device) {}
+
+  bool matches(
+      const std::shared_ptr<memory::MemoryPool>& queryRootPool,
+      const std::shared_ptr<memory::CustomMemoryResource>& resourceOwner,
+      const cuda::mr::any_resource<cuda::mr::device_accessible>& upstream,
+      int device) const {
+    return queryRootPool_ == queryRootPool && resourceOwner_ == resourceOwner &&
+        upstream_ == upstream && device_ == device;
+  }
+
+  rmm::device_async_resource_ref resource() {
+    return rmm::device_async_resource_ref{resource_};
+  }
+
+  const std::shared_ptr<memory::MemoryPool>& pool() const {
+    return pool_;
+  }
+
+ private:
+  // The entry retains the query's custom root and backing resource after the
+  // QueryCtx is destroyed so packed buffers can cross task boundaries safely.
+  // Declaration order keeps borrowed allocator/arbitrator state alive last.
+  std::shared_ptr<memory::CustomMemoryResource> resourceOwner_;
+  std::shared_ptr<memory::MemoryPool> queryRootPool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_;
+  CudfMemoryResource resource_;
+  const int device_;
+};
+
+struct ExchangeResourceKey {
+  memory::MemoryPool* queryRootPool;
+  memory::CustomMemoryResource* resourceOwner;
+  int device;
+
+  bool operator==(const ExchangeResourceKey& other) const {
+    return queryRootPool == other.queryRootPool &&
+        resourceOwner == other.resourceOwner && device == other.device;
+  }
+};
+
+struct ExchangeResourceKeyHash {
+  size_t operator()(const ExchangeResourceKey& key) const {
+    const auto poolHash = std::hash<memory::MemoryPool*>{}(key.queryRootPool);
+    const auto ownerHash =
+        std::hash<memory::CustomMemoryResource*>{}(key.resourceOwner);
+    const auto deviceHash = std::hash<int>{}(key.device);
+    const auto poolAndOwnerHash =
+        poolHash ^ (ownerHash + 0x9e3779b9 + (poolHash << 6) + (poolHash >> 2));
+    return poolAndOwnerHash ^
+        (deviceHash + 0x9e3779b9 + (poolAndOwnerHash << 6) +
+         (poolAndOwnerHash >> 2));
+  }
+};
+
+struct ExchangeResourceEntry {
+  explicit ExchangeResourceEntry(
+      std::unique_ptr<CudfExchangeMemoryResource> resource)
+      : resource(std::move(resource)) {}
+
+  std::unique_ptr<CudfExchangeMemoryResource> resource;
+  std::unordered_set<const core::QueryCtx*> activeQueries;
+};
+
+std::mutex exchangeResourceMutex;
+std::unordered_map<
+    ExchangeResourceKey,
+    std::unique_ptr<ExchangeResourceEntry>,
+    ExchangeResourceKeyHash>
+    exchangeResources;
+
+void pruneInactiveExchangeResourcesLocked() {
+  for (auto it = exchangeResources.begin(); it != exchangeResources.end();) {
+    const auto& entry = *it->second;
+    if (entry.activeQueries.empty() &&
+        entry.resource->pool()->usedBytes() == 0) {
+      it = exchangeResources.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void retireExchangeResource(
+    ExchangeResourceKey key,
+    const core::QueryCtx* queryCtx) {
+  std::lock_guard<std::mutex> lock(exchangeResourceMutex);
+  auto it = exchangeResources.find(key);
+  if (it == exchangeResources.end()) {
+    return;
+  }
+  it->second->activeQueries.erase(queryCtx);
+  if (it->second->activeQueries.empty() &&
+      it->second->resource->pool()->usedBytes() == 0) {
+    exchangeResources.erase(it);
+  }
+}
+
+} // namespace
+
+CudfMemoryResourceRegistry::Resources::Resources(
+    cuda::mr::any_resource<cuda::mr::device_accessible> tempUpstream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> outputUpstream,
+    std::shared_ptr<memory::MemoryPool> pool,
+    std::shared_ptr<memory::CustomMemoryResource> resourceOwner)
+    : resourceOwner{std::move(resourceOwner)},
+      tempUpstream{std::move(tempUpstream)},
+      outputUpstream{std::move(outputUpstream)},
+      temp{this->tempUpstream, pool, this->resourceOwner} {
+  if (this->tempUpstream != this->outputUpstream) {
+    output.emplace(this->outputUpstream, std::move(pool), this->resourceOwner);
+  }
+}
+
+bool CudfMemoryResourceRegistry::Resources::matches(
+    const cuda::mr::any_resource<cuda::mr::device_accessible>& tempUpstream,
+    const cuda::mr::any_resource<cuda::mr::device_accessible>& outputUpstream,
+    const std::shared_ptr<memory::CustomMemoryResource>& resourceOwner) const {
+  return this->resourceOwner == resourceOwner &&
+      this->tempUpstream == tempUpstream &&
+      this->outputUpstream == outputUpstream;
+}
+
+CudfMemoryResourceRegistry::ResourceRefs
+CudfMemoryResourceRegistry::Resources::refs() {
+  auto tempRef = rmm::device_async_resource_ref{temp};
+  return {
+      tempRef,
+      output.has_value() ? rmm::device_async_resource_ref{*output} : tempRef};
+}
+
+CudfMemoryResourceRegistry::ResourceRefs
+CudfMemoryResourceRegistry::resourcesFor(
+    const cuda::mr::any_resource<cuda::mr::device_accessible>& tempUpstream,
+    const cuda::mr::any_resource<cuda::mr::device_accessible>& outputUpstream,
+    std::shared_ptr<memory::MemoryPool> pool,
+    std::shared_ptr<memory::CustomMemoryResource> resourceOwner) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto* poolKey = pool.get();
+  auto it = resources_.find(poolKey);
+  if (it != resources_.end()) {
+    VELOX_CHECK(
+        it->second->matches(tempUpstream, outputUpstream, resourceOwner),
+        "A cuDF pool cannot be reused with different upstream resources or "
+        "a different CustomMemoryResource owner");
+    return it->second->refs();
+  }
+
+  // Construct before inserting so a throwing constructor cannot leave a null
+  // entry that poisons the next lookup for this pool.
+  auto resources = std::make_unique<Resources>(
+      tempUpstream, outputUpstream, std::move(pool), std::move(resourceOwner));
+  auto [insertedIt, inserted] =
+      resources_.emplace(poolKey, std::move(resources));
+  VELOX_CHECK(inserted, "Duplicate cuDF memory resource pool");
+  return insertedIt->second->refs();
+}
+
+std::optional<rmm::device_async_resource_ref> cudfExchangeOutputMemoryResource(
+    core::QueryCtx& queryCtx) {
+  auto queryRootPool = queryCtx.customPool(std::string{kCudfMemoryResourceTag});
+  if (!queryRootPool) {
+    return std::nullopt;
+  }
+
+  auto perQueryRegistry =
+      queryCtx.registry<memory::CustomMemoryResourceRegistry::Registry>(
+          memory::kCustomMemoryResourceRegistryKey);
+  auto& registry = perQueryRegistry
+      ? *perQueryRegistry
+      : memory::CustomMemoryResourceRegistry::global();
+  auto resourceOwner = registry.find(std::string{kCudfMemoryResourceTag});
+  VELOX_CHECK_NOT_NULL(
+      resourceOwner,
+      "Query has a gpu custom pool but no registered gpu "
+      "CustomMemoryResource");
+  VELOX_CHECK(
+      output_mr_.has_value(), "cuDF output memory resource is not initialized");
+
+  const auto device = rmm::get_current_cuda_device().value();
+  const ExchangeResourceKey key{
+      queryRootPool.get(), resourceOwner.get(), device};
+  std::lock_guard<std::mutex> lock(exchangeResourceMutex);
+  pruneInactiveExchangeResourcesLocked();
+
+  auto it = exchangeResources.find(key);
+  if (it == exchangeResources.end()) {
+    auto resource = std::make_unique<CudfExchangeMemoryResource>(
+        queryRootPool, resourceOwner, output_mr_.value(), device);
+    auto entry = std::make_unique<ExchangeResourceEntry>(std::move(resource));
+    auto [insertedIt, inserted] =
+        exchangeResources.emplace(key, std::move(entry));
+    VELOX_CHECK(inserted, "Duplicate cuDF exchange memory resource");
+    it = insertedIt;
+  } else {
+    VELOX_CHECK(
+        it->second->resource->matches(
+            queryRootPool, resourceOwner, output_mr_.value(), device),
+        "A query GPU root and CUDA device cannot be reused with a different "
+        "CustomMemoryResource owner or cuDF output upstream resource");
+  }
+
+  auto* queryCtxPtr = std::addressof(queryCtx);
+  if (it->second->activeQueries.find(queryCtxPtr) ==
+      it->second->activeQueries.end()) {
+    queryCtx.addReleaseCallback(
+        [key, queryCtxPtr]() { retireExchangeResource(key, queryCtxPtr); });
+    it->second->activeQueries.insert(queryCtxPtr);
+  }
+  return it->second->resource->resource();
+}
+
+std::shared_ptr<memory::MemoryPool> cudfExchangeMemoryPool(
+    const core::QueryCtx& queryCtx) {
+  auto queryRootPool = queryCtx.customPool(std::string{kCudfMemoryResourceTag});
+  if (!queryRootPool) {
+    return nullptr;
+  }
+
+  auto perQueryRegistry =
+      queryCtx.registry<memory::CustomMemoryResourceRegistry::Registry>(
+          memory::kCustomMemoryResourceRegistryKey);
+  auto& registry = perQueryRegistry
+      ? *perQueryRegistry
+      : memory::CustomMemoryResourceRegistry::global();
+  auto resourceOwner = registry.find(std::string{kCudfMemoryResourceTag});
+  VELOX_CHECK_NOT_NULL(
+      resourceOwner,
+      "Query has a gpu custom pool but no registered gpu "
+      "CustomMemoryResource");
+
+  const ExchangeResourceKey key{
+      queryRootPool.get(),
+      resourceOwner.get(),
+      rmm::get_current_cuda_device().value()};
+  std::lock_guard<std::mutex> lock(exchangeResourceMutex);
+  auto it = exchangeResources.find(key);
+  return it == exchangeResources.end() ? nullptr : it->second->resource->pool();
+}
+
+bool tryResetCudfExchangeMemoryResource() {
+  std::lock_guard<std::mutex> lock(exchangeResourceMutex);
+  pruneInactiveExchangeResourcesLocked();
+  return exchangeResources.empty();
+}
+
+void resetCudfExchangeMemoryResource() {
+  std::lock_guard<std::mutex> lock(exchangeResourceMutex);
+  for (const auto& [_, entry] : exchangeResources) {
+    VELOX_CHECK(
+        entry->activeQueries.empty(),
+        "Cannot tear down the cuDF UCX exchange resource while query contexts "
+        "are still active");
+    VELOX_CHECK_EQ(
+        entry->resource->pool()->usedBytes(),
+        0,
+        "Cannot tear down the cuDF UCX exchange resource while packed buffers "
+        "are still alive");
+  }
+  exchangeResources.clear();
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfMemoryResource.cpp
+++ b/velox/experimental/cudf/exec/CudfMemoryResource.cpp
@@ -49,6 +49,7 @@ CudfMemoryResourceImpl::CudfMemoryResourceImpl(
 void* CudfMemoryResourceImpl::allocate_sync(
     std::size_t bytes,
     std::size_t alignment) {
+  liveAllocations_.fetch_add(1, std::memory_order_release);
   if (bytes == 0) {
     return upstream_.allocate_sync(bytes, alignment);
   }
@@ -58,6 +59,7 @@ void* CudfMemoryResourceImpl::allocate_sync(
     return upstream_.allocate_sync(bytes, alignment);
   } catch (...) {
     pool_->reportExternalFree(bytes);
+    liveAllocations_.fetch_sub(1, std::memory_order_release);
     throw;
   }
 }
@@ -70,12 +72,14 @@ void CudfMemoryResourceImpl::deallocate_sync(
   if (bytes != 0) {
     pool_->reportExternalFree(bytes);
   }
+  liveAllocations_.fetch_sub(1, std::memory_order_release);
 }
 
 void* CudfMemoryResourceImpl::allocate(
     cuda::stream_ref stream,
     std::size_t bytes,
     std::size_t alignment) {
+  liveAllocations_.fetch_add(1, std::memory_order_release);
   if (bytes == 0) {
     return upstream_.allocate(stream, bytes, alignment);
   }
@@ -85,6 +89,7 @@ void* CudfMemoryResourceImpl::allocate(
     return upstream_.allocate(stream, bytes, alignment);
   } catch (...) {
     pool_->reportExternalFree(bytes);
+    liveAllocations_.fetch_sub(1, std::memory_order_release);
     throw;
   }
 }
@@ -101,6 +106,7 @@ void CudfMemoryResourceImpl::deallocate(
     // required by the RMM resource contract, terminates this noexcept path.
     pool_->reportExternalFree(bytes);
   }
+  liveAllocations_.fetch_sub(1, std::memory_order_release);
 }
 
 } // namespace facebook::velox::cudf_velox::detail
@@ -149,6 +155,13 @@ class CudfExchangeMemoryResource {
 
   const std::shared_ptr<memory::MemoryPool>& pool() const {
     return pool_;
+  }
+
+  // True when nothing allocated through this resource is still live. Checks
+  // the allocation count rather than the pool's usedBytes(), which does not
+  // see zero-byte allocations.
+  bool isQuiescent() const {
+    return resource_->liveAllocations() == 0;
   }
 
  private:
@@ -207,8 +220,7 @@ std::unordered_map<
 void pruneInactiveExchangeResourcesLocked() {
   for (auto it = exchangeResources.begin(); it != exchangeResources.end();) {
     const auto& entry = *it->second;
-    if (entry.activeQueries.empty() &&
-        entry.resource->pool()->usedBytes() == 0) {
+    if (entry.activeQueries.empty() && entry.resource->isQuiescent()) {
       it = exchangeResources.erase(it);
     } else {
       ++it;
@@ -226,7 +238,7 @@ void retireExchangeResource(
   }
   it->second->activeQueries.erase(queryCtx);
   if (it->second->activeQueries.empty() &&
-      it->second->resource->pool()->usedBytes() == 0) {
+      it->second->resource->isQuiescent()) {
     exchangeResources.erase(it);
   }
 }

--- a/velox/experimental/cudf/exec/CudfMemoryResource.h
+++ b/velox/experimental/cudf/exec/CudfMemoryResource.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/memory/CustomMemoryResource.h"
+#include "velox/common/memory/MemoryPool.h"
+
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+
+namespace facebook::velox::core {
+class QueryCtx;
+}
+
+namespace facebook::velox::cudf_velox {
+
+/// Custom memory resource tag used for cuDF device memory accounting.
+inline constexpr std::string_view kCudfMemoryResourceTag{"gpu"};
+inline constexpr std::string_view kCudfMemoryResourceRegistryKey{
+    "cudfMemoryResource"};
+
+namespace detail {
+
+/// An RMM-compatible resource that delegates device allocation to 'upstream'
+/// and reports logical live bytes to a Velox leaf MemoryPool.
+///
+/// The implementation is held by cuda::mr::shared_resource. As a result, RMM
+/// containers that copy this resource through cuda::mr::any_resource retain
+/// the pool, custom resource, and upstream resource until their final
+/// deallocation.
+class CudfMemoryResourceImpl {
+ public:
+  CudfMemoryResourceImpl(
+      cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+      std::shared_ptr<memory::MemoryPool> pool,
+      std::shared_ptr<memory::CustomMemoryResource> resourceOwner);
+
+  CudfMemoryResourceImpl(const CudfMemoryResourceImpl&) = delete;
+  CudfMemoryResourceImpl& operator=(const CudfMemoryResourceImpl&) = delete;
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment);
+
+  void deallocate_sync(
+      void* pointer,
+      std::size_t bytes,
+      std::size_t alignment) noexcept;
+
+  void*
+  allocate(cuda::stream_ref stream, std::size_t bytes, std::size_t alignment);
+
+  void deallocate(
+      cuda::stream_ref stream,
+      void* pointer,
+      std::size_t bytes,
+      std::size_t alignment) noexcept;
+
+  bool operator==(const CudfMemoryResourceImpl& other) const noexcept {
+    return this == std::addressof(other);
+  }
+
+  bool operator!=(const CudfMemoryResourceImpl& other) const noexcept {
+    return !(*this == other);
+  }
+
+  friend void get_property(
+      const CudfMemoryResourceImpl&,
+      cuda::mr::device_accessible) noexcept {}
+
+ private:
+  // Declared first so it is destroyed last. MemoryPool borrows its allocator
+  // and arbitrator from this object.
+  std::shared_ptr<memory::CustomMemoryResource> resourceOwner_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_;
+};
+
+} // namespace detail
+
+/// Copyable, owning RMM resource that accounts allocations in a Velox pool.
+class CudfMemoryResource
+    : public cuda::mr::shared_resource<detail::CudfMemoryResourceImpl> {
+  using SharedBase = cuda::mr::shared_resource<detail::CudfMemoryResourceImpl>;
+
+ public:
+  CudfMemoryResource(
+      cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+      std::shared_ptr<memory::MemoryPool> pool,
+      std::shared_ptr<memory::CustomMemoryResource> resourceOwner = nullptr);
+
+  friend void get_property(
+      const CudfMemoryResource&,
+      cuda::mr::device_accessible) noexcept {}
+};
+
+static_assert(
+    cuda::mr::resource_with<CudfMemoryResource, cuda::mr::device_accessible>);
+
+/// Query-scoped owner for reporting resources. cuDF APIs accept non-owning
+/// resource refs, so the resource objects must outlive output columns that can
+/// survive their producing operator.
+class CudfMemoryResourceRegistry {
+ public:
+  struct ResourceRefs {
+    rmm::device_async_resource_ref temp;
+    rmm::device_async_resource_ref output;
+  };
+
+  ResourceRefs resourcesFor(
+      const cuda::mr::any_resource<cuda::mr::device_accessible>& tempUpstream,
+      const cuda::mr::any_resource<cuda::mr::device_accessible>& outputUpstream,
+      std::shared_ptr<memory::MemoryPool> pool,
+      std::shared_ptr<memory::CustomMemoryResource> resourceOwner);
+
+ private:
+  struct Resources {
+    Resources(
+        cuda::mr::any_resource<cuda::mr::device_accessible> tempUpstream,
+        cuda::mr::any_resource<cuda::mr::device_accessible> outputUpstream,
+        std::shared_ptr<memory::MemoryPool> pool,
+        std::shared_ptr<memory::CustomMemoryResource> resourceOwner);
+
+    bool matches(
+        const cuda::mr::any_resource<cuda::mr::device_accessible>& tempUpstream,
+        const cuda::mr::any_resource<cuda::mr::device_accessible>&
+            outputUpstream,
+        const std::shared_ptr<memory::CustomMemoryResource>& resourceOwner)
+        const;
+
+    ResourceRefs refs();
+
+    // Declared before reporting resources so the borrowed allocator and
+    // arbitrator remain alive through pool and resource teardown.
+    std::shared_ptr<memory::CustomMemoryResource> resourceOwner;
+    cuda::mr::any_resource<cuda::mr::device_accessible> tempUpstream;
+    cuda::mr::any_resource<cuda::mr::device_accessible> outputUpstream;
+    CudfMemoryResource temp;
+    std::optional<CudfMemoryResource> output;
+  };
+
+  std::mutex mutex_;
+  std::unordered_map<memory::MemoryPool*, std::unique_ptr<Resources>>
+      resources_;
+};
+
+std::optional<rmm::device_async_resource_ref> cudfExchangeOutputMemoryResource(
+    core::QueryCtx& queryCtx);
+
+std::shared_ptr<memory::MemoryPool> cudfExchangeMemoryPool(
+    const core::QueryCtx& queryCtx);
+
+/// Releases retired exchange resources that have no live packed buffers.
+/// Returns true when no active or in-use exchange resources remain.
+bool tryResetCudfExchangeMemoryResource();
+
+/// Strict test/shutdown helper. Fails if any query or packed buffer is active.
+void resetCudfExchangeMemoryResource();
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfMemoryResource.h
+++ b/velox/experimental/cudf/exec/CudfMemoryResource.h
@@ -22,6 +22,7 @@
 
 #include <cuda/memory_resource>
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -86,12 +87,20 @@ class CudfMemoryResourceImpl {
       const CudfMemoryResourceImpl&,
       cuda::mr::device_accessible) noexcept {}
 
+  /// Returns the number of allocations handed out and not yet deallocated.
+  /// Unlike the pool's usedBytes(), this counts zero-byte allocations, which
+  /// are passed through to the upstream resource without being accounted.
+  int64_t liveAllocations() const noexcept {
+    return liveAllocations_.load(std::memory_order_acquire);
+  }
+
  private:
   // Declared first so it is destroyed last. MemoryPool borrows its allocator
   // and arbitrator from this object.
   std::shared_ptr<memory::CustomMemoryResource> resourceOwner_;
   std::shared_ptr<memory::MemoryPool> pool_;
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream_;
+  std::atomic<int64_t> liveAllocations_{0};
 };
 
 } // namespace detail

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -260,7 +260,7 @@ void CudfNestedLoopJoinBuild::doNoMoreInput() {
               std::shared_ptr<cudf::table>(std::move(table)), buildRowCount}));
 }
 
-exec::BlockingReason CudfNestedLoopJoinBuild::isBlocked(
+exec::BlockingReason CudfNestedLoopJoinBuild::doIsBlocked(
     ContinueFuture* future) {
   if (!future_.valid()) {
     return exec::BlockingReason::kNotBlocked;
@@ -307,10 +307,9 @@ CudfNestedLoopJoinProbe::CudfNestedLoopJoinProbe(
       CudfJoinOutputLayout(probeType_, buildType_, outputType_, joinType_);
 }
 
-void CudfNestedLoopJoinProbe::initialize() {
+void CudfNestedLoopJoinProbe::doInitialize() {
   // Filter construction is deferred from the ctor to avoid memory allocation
   // during driver initialization. Mirrors #17045 for CudfHashJoinProbe.
-  Operator::initialize();
 
   if (!joinNode_->joinCondition()) {
     return;
@@ -492,7 +491,7 @@ bool CudfNestedLoopJoinProbe::isFinished() {
   return false;
 }
 
-exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
+exec::BlockingReason CudfNestedLoopJoinProbe::doIsBlocked(
     ContinueFuture* future) {
   // For right/full join: after build data is available, also block on peer
   // probes finishing (allPeersFinished barrier in noMoreInput).

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -310,7 +310,6 @@ CudfNestedLoopJoinProbe::CudfNestedLoopJoinProbe(
 void CudfNestedLoopJoinProbe::doInitialize() {
   // Filter construction is deferred from the ctor to avoid memory allocation
   // during driver initialization. Mirrors #17045 for CudfHashJoinProbe.
-
   if (!joinNode_->joinCondition()) {
     return;
   }

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -115,7 +115,7 @@ class CudfNestedLoopJoinBuild : public CudfOperatorBase {
 
   bool needsInput() const override;
 
-  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+  exec::BlockingReason doIsBlocked(ContinueFuture* future) override;
 
   bool isFinished() override;
 
@@ -179,11 +179,11 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::NestedLoopJoinNode> joinNode);
 
-  void initialize() override;
+  void doInitialize() override;
 
   bool needsInput() const override;
 
-  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+  exec::BlockingReason doIsBlocked(ContinueFuture* future) override;
 
   bool isFinished() override;
 

--- a/velox/experimental/cudf/exec/CudfOperator.cpp
+++ b/velox/experimental/cudf/exec/CudfOperator.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/CudfMemoryResource.h"
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+
+#include "velox/common/memory/CustomMemoryResourceRegistry.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/Task.h"
+
+#include <mutex>
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+std::shared_ptr<memory::CustomMemoryResource> cudfMemoryResourceOwner(
+    const core::QueryCtx& queryCtx) {
+  auto perQuery =
+      queryCtx.registry<memory::CustomMemoryResourceRegistry::Registry>(
+          memory::kCustomMemoryResourceRegistryKey);
+  auto& registry =
+      perQuery ? *perQuery : memory::CustomMemoryResourceRegistry::global();
+  return registry.find(std::string(kCudfMemoryResourceTag));
+}
+
+std::shared_ptr<CudfMemoryResourceRegistry> cudfMemoryResourceRegistry(
+    core::QueryCtx& queryCtx) {
+  if (auto registry = queryCtx.registry<CudfMemoryResourceRegistry>(
+          kCudfMemoryResourceRegistryKey)) {
+    return registry;
+  }
+
+  // QueryCtx does not currently offer an atomic get-or-create operation for
+  // registries. Serialize this cuDF-local lazy initialization and recheck.
+  static std::mutex initMutex;
+  std::lock_guard<std::mutex> lock(initMutex);
+  if (auto registry = queryCtx.registry<CudfMemoryResourceRegistry>(
+          kCudfMemoryResourceRegistryKey)) {
+    return registry;
+  }
+  auto registry = std::make_shared<CudfMemoryResourceRegistry>();
+  queryCtx.setRegistry(kCudfMemoryResourceRegistryKey, registry);
+  return registry;
+}
+
+} // namespace
+
+CudfOperatorBase::CudfOperatorBase(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    RowTypePtr outputType,
+    const core::PlanNodeId& planNodeId,
+    const std::string& operatorName,
+    std::optional<nvtx3::color> color,
+    NvtxMethodFlag nvtxMethods,
+    std::optional<common::SpillConfig> spillConfig,
+    std::optional<std::shared_ptr<const core::PlanNode>> /*planNode*/)
+    : Operator(
+          driverCtx,
+          std::move(outputType),
+          operatorId,
+          planNodeId,
+          operatorName,
+          std::move(spillConfig)),
+      NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
+      className_(operatorName),
+      nvtxMethods_(nvtxMethods) {
+  auto* gpuPool = customPool(kCudfMemoryResourceTag);
+  if (gpuPool == nullptr) {
+    return;
+  }
+
+  auto queryCtx = driverCtx->task->queryCtx();
+  auto resourceOwner = cudfMemoryResourceOwner(*queryCtx);
+  VELOX_CHECK_NOT_NULL(
+      resourceOwner,
+      "No CustomMemoryResource registered for tag: {}",
+      kCudfMemoryResourceTag);
+  VELOX_CHECK(
+      mr_.has_value() && output_mr_.has_value(),
+      "cuDF memory resources must be initialized before creating operators");
+
+  auto resources = cudfMemoryResourceRegistry(*queryCtx)->resourcesFor(
+      *mr_, *output_mr_, gpuPool->shared_from_this(), std::move(resourceOwner));
+  tempMemoryResource_ = resources.temp;
+  outputMemoryResource_ = resources.output;
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOperator.cpp
+++ b/velox/experimental/cudf/exec/CudfOperator.cpp
@@ -59,6 +59,31 @@ std::shared_ptr<CudfMemoryResourceRegistry> cudfMemoryResourceRegistry(
 
 } // namespace
 
+CudfOperatorMemoryResources CudfOperatorMemoryResources::resolve(
+    exec::DriverCtx* driverCtx,
+    memory::MemoryPool* gpuPool) {
+  CudfOperatorMemoryResources memoryResources;
+  if (gpuPool == nullptr) {
+    return memoryResources;
+  }
+
+  auto queryCtx = driverCtx->task->queryCtx();
+  auto resourceOwner = cudfMemoryResourceOwner(*queryCtx);
+  VELOX_CHECK_NOT_NULL(
+      resourceOwner,
+      "No CustomMemoryResource registered for tag: {}",
+      kCudfMemoryResourceTag);
+  VELOX_CHECK(
+      mr_.has_value() && output_mr_.has_value(),
+      "cuDF memory resources must be initialized before creating operators");
+
+  auto resources = cudfMemoryResourceRegistry(*queryCtx)->resourcesFor(
+      *mr_, *output_mr_, gpuPool->shared_from_this(), std::move(resourceOwner));
+  memoryResources.temp_ = resources.temp;
+  memoryResources.output_ = resources.output;
+  return memoryResources;
+}
+
 CudfOperatorBase::CudfOperatorBase(
     int32_t operatorId,
     exec::DriverCtx* driverCtx,
@@ -78,26 +103,32 @@ CudfOperatorBase::CudfOperatorBase(
           std::move(spillConfig)),
       NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
       className_(operatorName),
-      nvtxMethods_(nvtxMethods) {
-  auto* gpuPool = customPool(kCudfMemoryResourceTag);
-  if (gpuPool == nullptr) {
-    return;
-  }
+      nvtxMethods_(nvtxMethods),
+      memoryResources_(
+          CudfOperatorMemoryResources::resolve(
+              driverCtx,
+              customPool(kCudfMemoryResourceTag))) {}
 
-  auto queryCtx = driverCtx->task->queryCtx();
-  auto resourceOwner = cudfMemoryResourceOwner(*queryCtx);
-  VELOX_CHECK_NOT_NULL(
-      resourceOwner,
-      "No CustomMemoryResource registered for tag: {}",
-      kCudfMemoryResourceTag);
-  VELOX_CHECK(
-      mr_.has_value() && output_mr_.has_value(),
-      "cuDF memory resources must be initialized before creating operators");
-
-  auto resources = cudfMemoryResourceRegistry(*queryCtx)->resourcesFor(
-      *mr_, *output_mr_, gpuPool->shared_from_this(), std::move(resourceOwner));
-  tempMemoryResource_ = resources.temp;
-  outputMemoryResource_ = resources.output;
-}
+CudfSourceOperatorBase::CudfSourceOperatorBase(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    RowTypePtr outputType,
+    const core::PlanNodeId& planNodeId,
+    const std::string& operatorName,
+    std::optional<nvtx3::color> color,
+    NvtxMethodFlag nvtxMethods)
+    : SourceOperator(
+          driverCtx,
+          std::move(outputType),
+          operatorId,
+          planNodeId,
+          operatorName),
+      NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
+      className_(operatorName),
+      nvtxMethods_(nvtxMethods),
+      memoryResources_(
+          CudfOperatorMemoryResources::resolve(
+              driverCtx,
+              customPool(kCudfMemoryResourceTag))) {}
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -54,6 +54,44 @@ inline NvtxMethodFlag operator&(NvtxMethodFlag a, NvtxMethodFlag b) {
       static_cast<EnumT>(a) & static_cast<EnumT>(b));
 }
 
+/// Per-operator cuDF memory resources that charge device allocations to the
+/// operator's `gpu` custom pool. Both members stay empty for queries that do
+/// not configure such a pool, leaving the process-wide resources in effect.
+class CudfOperatorMemoryResources {
+ public:
+  /// Resolves the resources charging 'gpuPool'. A null 'gpuPool' yields an
+  /// empty instance.
+  static CudfOperatorMemoryResources resolve(
+      exec::DriverCtx* driverCtx,
+      memory::MemoryPool* gpuPool);
+
+  /// Installs the resources for as long as the returned scope lives.
+  [[nodiscard]] ScopedCudfMemoryResources scoped() const {
+    return ScopedCudfMemoryResources{temporaryResource(), outputResource()};
+  }
+
+ private:
+  rmm::device_async_resource_ref temporaryResource() const {
+    if (temp_.has_value()) {
+      return *temp_;
+    }
+    // Deliberately not get_temp_mr(): that resolves to the thread-local
+    // temporary dispatcher, which delegates back here, so installing it as the
+    // scope's resource would nest the dispatcher inside itself.
+    VELOX_CHECK(
+        mr_.has_value(),
+        "cuDF memory resources are not initialized; call registerCudf() first");
+    return rmm::device_async_resource_ref{*mr_};
+  }
+
+  rmm::device_async_resource_ref outputResource() const {
+    return output_.has_value() ? *output_ : get_output_mr();
+  }
+
+  std::optional<rmm::device_async_resource_ref> temp_;
+  std::optional<rmm::device_async_resource_ref> output_;
+};
+
 /// The user defined operator will inherit this operator, the operator accepts
 /// CudfOperator and output CudfVector.
 class CudfOperator : public NvtxHelper {
@@ -70,8 +108,9 @@ class CudfOperator : public NvtxHelper {
 /// All cuDF operators MUST extend this class rather than extending
 /// exec::Operator and NvtxHelper directly. This class implements the template
 /// method pattern:
-/// the public operator interface methods (addInput, getOutput, noMoreInput,
-/// close) are marked final and must NOT be overridden by derived classes.
+/// the public operator interface methods (initialize, isBlocked, addInput,
+/// getOutput, noMoreInput, close) are marked final and must NOT be overridden
+/// by derived classes.
 /// Instead, derived classes should ONLY override the corresponding protected
 /// do* virtual methods:
 ///   - doInitialize() -- performs subclass initialization
@@ -120,7 +159,6 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
           std::nullopt);
 
   void initialize() final {
-    ensureCudaContextForThread();
     auto memoryResources = scopedMemoryResources();
     Operator::initialize();
     doInitialize();
@@ -128,7 +166,6 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* future) final {
-    ensureCudaContextForThread();
     auto memoryResources = scopedMemoryResources();
     auto reason = doIsBlocked(future);
     checkCudaErrorInDebug();
@@ -176,8 +213,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
 
  protected:
   [[nodiscard]] ScopedCudfMemoryResources scopedMemoryResources() const {
-    return ScopedCudfMemoryResources{
-        tempMemoryResource(), outputMemoryResource()};
+    return memoryResources_.scoped();
   }
 
   virtual void doInitialize() {}
@@ -199,21 +235,9 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
  private:
-  rmm::device_async_resource_ref tempMemoryResource() const {
-    return tempMemoryResource_.has_value()
-        ? *tempMemoryResource_
-        : rmm::device_async_resource_ref{mr_.value()};
-  }
-
-  rmm::device_async_resource_ref outputMemoryResource() const {
-    return outputMemoryResource_.has_value() ? *outputMemoryResource_
-                                             : get_output_mr();
-  }
-
   const std::string className_;
   const NvtxMethodFlag nvtxMethods_;
-  std::optional<rmm::device_async_resource_ref> tempMemoryResource_;
-  std::optional<rmm::device_async_resource_ref> outputMemoryResource_;
+  const CudfOperatorMemoryResources memoryResources_;
 };
 
 /// Base class for cuDF source operators (first operator in a Driver pipeline).
@@ -224,6 +248,8 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
 /// close with NVTX profiling and checkCudaErrorInDebug.
 ///
 /// Derived classes override:
+///   - doIsBlocked()   -- reports subclass blocking state; called by
+///   isBlocked()
 ///   - doGetOutput()   -- produces output rows; called by getOutput()
 ///   - doClose()       -- releases resources; called by close()
 ///                        (defaults to SourceOperator::close())
@@ -237,19 +263,18 @@ class CudfSourceOperatorBase : public exec::SourceOperator, public NvtxHelper {
       const std::string& operatorName,
       std::optional<nvtx3::color> color = std::nullopt,
       NvtxMethodFlag nvtxMethods = NvtxMethodFlag::kGetOutput |
-          NvtxMethodFlag::kClose)
-      : SourceOperator(
-            driverCtx,
-            outputType,
-            operatorId,
-            planNodeId,
-            operatorName),
-        NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
-        className_(operatorName),
-        nvtxMethods_(nvtxMethods) {}
+          NvtxMethodFlag::kClose);
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) final {
+    auto memoryResources = scopedMemoryResources();
+    auto reason = doIsBlocked(future);
+    checkCudaErrorInDebug();
+    return reason;
+  }
 
   RowVectorPtr getOutput() final {
     ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
     auto result = doGetOutput();
@@ -261,6 +286,7 @@ class CudfSourceOperatorBase : public exec::SourceOperator, public NvtxHelper {
     // close() may run on a different thread than construction so bind the
     // context here too.
     ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kClose, className_);
     doClose();
@@ -268,6 +294,14 @@ class CudfSourceOperatorBase : public exec::SourceOperator, public NvtxHelper {
   }
 
  protected:
+  [[nodiscard]] ScopedCudfMemoryResources scopedMemoryResources() const {
+    return memoryResources_.scoped();
+  }
+
+  virtual exec::BlockingReason doIsBlocked(ContinueFuture* /*future*/) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
   virtual RowVectorPtr doGetOutput() = 0;
 
   virtual void doClose() {
@@ -277,6 +311,7 @@ class CudfSourceOperatorBase : public exec::SourceOperator, public NvtxHelper {
  private:
   const std::string className_;
   const NvtxMethodFlag nvtxMethods_;
+  const CudfOperatorMemoryResources memoryResources_;
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -74,6 +74,8 @@ class CudfOperator : public NvtxHelper {
 /// close) are marked final and must NOT be overridden by derived classes.
 /// Instead, derived classes should ONLY override the corresponding protected
 /// do* virtual methods:
+///   - doInitialize() -- performs subclass initialization
+///   - doIsBlocked()  -- reports subclass blocking state
 ///   - doAddInput()    -- receives input rows; called by addInput()
 ///   - doGetOutput()   -- produces output rows; called by getOutput()
 ///   - doNoMoreInput() -- signals end of input; called by noMoreInput()
@@ -81,8 +83,9 @@ class CudfOperator : public NvtxHelper {
 ///   - doClose()       -- releases resources; called by close()
 ///                        (defaults to Operator::close())
 ///
-/// This design ensures that NVTX profiling ranges are applied uniformly
-/// across all operators without each subclass having to manage them. The
+/// This design scopes cuDF memory resources around every lifecycle call and
+/// applies NVTX profiling ranges uniformly. Subclasses override doInitialize()
+/// and doIsBlocked() instead of the final public methods. The
 /// nvtxMethods bitmask (NvtxMethodFlag) lets operators suppress NVTX ranges
 /// for do* methods they do not override, keeping nsys profiles clean.
 ///
@@ -114,20 +117,27 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
       NvtxMethodFlag nvtxMethods = NvtxMethodFlag::kAll,
       std::optional<common::SpillConfig> spillConfig = std::nullopt,
       std::optional<std::shared_ptr<const core::PlanNode>> planNode =
-          std::nullopt)
-      : Operator(
-            driverCtx,
-            outputType,
-            operatorId,
-            planNodeId,
-            operatorName,
-            spillConfig),
-        NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
-        className_(operatorName),
-        nvtxMethods_(nvtxMethods) {}
+          std::nullopt);
+
+  void initialize() final {
+    ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
+    Operator::initialize();
+    doInitialize();
+    checkCudaErrorInDebug();
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) final {
+    ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
+    auto reason = doIsBlocked(future);
+    checkCudaErrorInDebug();
+    return reason;
+  }
 
   void addInput(RowVectorPtr input) final {
     ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kAddInput, className_);
     doAddInput(std::move(input));
@@ -136,6 +146,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
 
   RowVectorPtr getOutput() final {
     ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
     auto result = doGetOutput();
@@ -145,6 +156,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
 
   void noMoreInput() final {
     ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kNoMoreInput, className_);
     doNoMoreInput();
@@ -155,6 +167,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
     // close() may run on a different thread than construction so bind the
     // context here too.
     ensureCudaContextForThread();
+    auto memoryResources = scopedMemoryResources();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kClose, className_);
     doClose();
@@ -162,6 +175,17 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
  protected:
+  [[nodiscard]] ScopedCudfMemoryResources scopedMemoryResources() const {
+    return ScopedCudfMemoryResources{
+        tempMemoryResource(), outputMemoryResource()};
+  }
+
+  virtual void doInitialize() {}
+
+  virtual exec::BlockingReason doIsBlocked(ContinueFuture* /*future*/) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
   virtual void doAddInput(RowVectorPtr input) = 0;
 
   virtual RowVectorPtr doGetOutput() = 0;
@@ -175,8 +199,20 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
  private:
+  rmm::device_async_resource_ref tempMemoryResource() const {
+    return tempMemoryResource_.has_value() ? *tempMemoryResource_
+                                           : get_temp_mr();
+  }
+
+  rmm::device_async_resource_ref outputMemoryResource() const {
+    return outputMemoryResource_.has_value() ? *outputMemoryResource_
+                                             : get_output_mr();
+  }
+
   const std::string className_;
   const NvtxMethodFlag nvtxMethods_;
+  std::optional<rmm::device_async_resource_ref> tempMemoryResource_;
+  std::optional<rmm::device_async_resource_ref> outputMemoryResource_;
 };
 
 /// Base class for cuDF source operators (first operator in a Driver pipeline).

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -200,8 +200,9 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
 
  private:
   rmm::device_async_resource_ref tempMemoryResource() const {
-    return tempMemoryResource_.has_value() ? *tempMemoryResource_
-                                           : get_temp_mr();
+    return tempMemoryResource_.has_value()
+        ? *tempMemoryResource_
+        : rmm::device_async_resource_ref{mr_.value()};
   }
 
   rmm::device_async_resource_ref outputMemoryResource() const {

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -44,10 +44,6 @@ class CudfOrderBy : public CudfOperatorBase {
     return !finished_;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override {
     return finished_;
   }

--- a/velox/experimental/cudf/exec/CudfReduce.cpp
+++ b/velox/experimental/cudf/exec/CudfReduce.cpp
@@ -864,9 +864,7 @@ CudfReduce::CudfReduce(
           exec::isPartialOutput(aggregationNode->step()) &&
           !hasFinalAggs(aggregationNode->aggregates())) {}
 
-void CudfReduce::initialize() {
-  Operator::initialize();
-
+void CudfReduce::doInitialize() {
   inputType_ = aggregationNode_->sources()[0]->outputType();
 
   numAggregates_ = aggregationNode_->aggregates().size();

--- a/velox/experimental/cudf/exec/CudfReduce.h
+++ b/velox/experimental/cudf/exec/CudfReduce.h
@@ -77,14 +77,10 @@ class CudfReduce : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::AggregationNode> const& aggregationNode);
 
-  void initialize() override;
+  void doInitialize() override;
 
   bool needsInput() const override {
     return !noMoreInput_;
-  }
-
-  exec::BlockingReason isBlocked(ContinueFuture* /* unused */) override {
-    return exec::BlockingReason::kNotBlocked;
   }
 
   bool isFinished() override;

--- a/velox/experimental/cudf/exec/CudfTopN.h
+++ b/velox/experimental/cudf/exec/CudfTopN.h
@@ -35,10 +35,6 @@ class CudfTopN : public CudfOperatorBase {
     return !noMoreInput_;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override;
 
  protected:

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -43,13 +43,13 @@ class CudfTopNRowNumber : public CudfOperatorBase {
     return !noMoreInput_;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override;
 
  protected:
+  exec::BlockingReason doIsBlocked(ContinueFuture* /*future*/) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
   void doAddInput(RowVectorPtr input) override;
   RowVectorPtr doGetOutput() override;
   void doNoMoreInput() override;

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -46,10 +46,6 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   bool isFinished() override;
 
  protected:
-  exec::BlockingReason doIsBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   void doAddInput(RowVectorPtr input) override;
   RowVectorPtr doGetOutput() override;
   void doNoMoreInput() override;

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -84,10 +84,6 @@ class CudfWindow : public CudfOperatorBase {
     return !noMoreInput_;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
   bool isFinished() override;
 
  protected:

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -27,6 +27,7 @@
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/prefetch_resource_adaptor.hpp>
 
@@ -38,6 +39,12 @@
 #include <string_view>
 
 namespace facebook::velox::cudf_velox {
+namespace {
+
+thread_local std::optional<rmm::device_async_resource_ref> scopedTempMr;
+thread_local std::optional<rmm::device_async_resource_ref> scopedOutputMr;
+
+} // namespace
 
 cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
     std::string_view mode,
@@ -135,8 +142,29 @@ cuda::stream_ref getDefaultStreamForCurrentThread() {
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> output_mr_;
 
+rmm::device_async_resource_ref get_temp_mr() {
+  return scopedTempMr.has_value() ? *scopedTempMr
+                                  : rmm::mr::get_current_device_resource_ref();
+}
+
 rmm::device_async_resource_ref get_output_mr() {
-  return output_mr_.value();
+  if (scopedOutputMr.has_value()) {
+    return *scopedOutputMr;
+  }
+  return rmm::device_async_resource_ref{output_mr_.value()};
+}
+
+ScopedCudfMemoryResources::ScopedCudfMemoryResources(
+    rmm::device_async_resource_ref tempMr,
+    rmm::device_async_resource_ref outputMr)
+    : previousTempMr_(scopedTempMr), previousOutputMr_(scopedOutputMr) {
+  scopedTempMr = tempMr;
+  scopedOutputMr = outputMr;
+}
+
+ScopedCudfMemoryResources::~ScopedCudfMemoryResources() {
+  scopedTempMr = previousTempMr_;
+  scopedOutputMr = previousOutputMr_;
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -35,14 +35,141 @@
 
 #include <common/base/Exceptions.h>
 
+#include <cstddef>
 #include <cstdlib>
+#include <memory>
+#include <mutex>
 #include <string_view>
+#include <unordered_map>
+#include <utility>
 
 namespace facebook::velox::cudf_velox {
 namespace {
 
 thread_local std::optional<rmm::device_async_resource_ref> scopedTempMr;
 thread_local std::optional<rmm::device_async_resource_ref> scopedOutputMr;
+
+class ThreadLocalTemporaryMemoryResourceImpl {
+ public:
+  explicit ThreadLocalTemporaryMemoryResourceImpl(
+      cuda::mr::any_resource<cuda::mr::device_accessible> fallback)
+      : fallback_(std::move(fallback)) {}
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment) {
+    auto resource = currentResource();
+    auto* pointer = resource.allocate_sync(bytes, alignment);
+    try {
+      rememberAllocation(pointer, bytes, resource);
+    } catch (...) {
+      resource.deallocate_sync(pointer, bytes, alignment);
+      throw;
+    }
+    return pointer;
+  }
+
+  void deallocate_sync(
+      void* pointer,
+      std::size_t bytes,
+      std::size_t alignment) noexcept {
+    resourceForDeallocation(pointer, bytes)
+        .deallocate_sync(pointer, bytes, alignment);
+  }
+
+  void*
+  allocate(cuda::stream_ref stream, std::size_t bytes, std::size_t alignment) {
+    auto resource = currentResource();
+    auto* pointer = resource.allocate(stream, bytes, alignment);
+    try {
+      rememberAllocation(pointer, bytes, resource);
+    } catch (...) {
+      resource.deallocate(stream, pointer, bytes, alignment);
+      throw;
+    }
+    return pointer;
+  }
+
+  void deallocate(
+      cuda::stream_ref stream,
+      void* pointer,
+      std::size_t bytes,
+      std::size_t alignment) noexcept {
+    resourceForDeallocation(pointer, bytes)
+        .deallocate(stream, pointer, bytes, alignment);
+  }
+
+  bool operator==(
+      const ThreadLocalTemporaryMemoryResourceImpl& other) const noexcept {
+    return this == std::addressof(other);
+  }
+
+  bool operator!=(
+      const ThreadLocalTemporaryMemoryResourceImpl& other) const noexcept {
+    return !(*this == other);
+  }
+
+  friend void get_property(
+      const ThreadLocalTemporaryMemoryResourceImpl&,
+      cuda::mr::device_accessible) noexcept {}
+
+ private:
+  rmm::device_async_resource_ref currentResource() {
+    return scopedTempMr.has_value() ? *scopedTempMr
+                                    : rmm::device_async_resource_ref{fallback_};
+  }
+
+  void rememberAllocation(
+      void* pointer,
+      std::size_t bytes,
+      rmm::device_async_resource_ref resource) {
+    if (bytes == 0) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto inserted = allocations_.emplace(pointer, resource).second;
+    VELOX_CHECK(inserted, "Duplicate outstanding cuDF temporary allocation");
+  }
+
+  rmm::device_async_resource_ref resourceForDeallocation(
+      void* pointer,
+      std::size_t bytes) noexcept {
+    if (bytes == 0) {
+      return currentResource();
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = allocations_.find(pointer);
+    VELOX_CHECK(
+        it != allocations_.end(),
+        "Unknown cuDF temporary allocation during deallocation");
+    auto resource = it->second;
+    allocations_.erase(it);
+    return resource;
+  }
+
+  cuda::mr::any_resource<cuda::mr::device_accessible> fallback_;
+  std::mutex mutex_;
+  std::unordered_map<void*, rmm::device_async_resource_ref> allocations_;
+};
+
+class ThreadLocalTemporaryMemoryResource
+    : public cuda::mr::shared_resource<ThreadLocalTemporaryMemoryResourceImpl> {
+  using SharedBase =
+      cuda::mr::shared_resource<ThreadLocalTemporaryMemoryResourceImpl>;
+
+ public:
+  explicit ThreadLocalTemporaryMemoryResource(
+      cuda::mr::any_resource<cuda::mr::device_accessible> fallback)
+      : SharedBase(
+            cuda::mr::make_shared_resource<
+                ThreadLocalTemporaryMemoryResourceImpl>(std::move(fallback))) {}
+
+  friend void get_property(
+      const ThreadLocalTemporaryMemoryResource&,
+      cuda::mr::device_accessible) noexcept {}
+};
+
+static_assert(cuda::mr::resource_with<
+              ThreadLocalTemporaryMemoryResource,
+              cuda::mr::device_accessible>);
 
 } // namespace
 
@@ -152,6 +279,12 @@ rmm::device_async_resource_ref get_output_mr() {
     return *scopedOutputMr;
   }
   return rmm::device_async_resource_ref{output_mr_.value()};
+}
+
+cuda::mr::any_resource<cuda::mr::device_accessible>
+createThreadLocalTemporaryMemoryResource(
+    cuda::mr::any_resource<cuda::mr::device_accessible> fallback) {
+  return ThreadLocalTemporaryMemoryResource{std::move(fallback)};
 }
 
 ScopedCudfMemoryResources::ScopedCudfMemoryResources(

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -126,9 +126,17 @@ class ThreadLocalTemporaryMemoryResourceImpl {
     }
     std::lock_guard<std::mutex> lock(mutex_);
     const auto inserted = allocations_.emplace(pointer, resource).second;
-    VELOX_CHECK(inserted, "Duplicate outstanding cuDF temporary allocation");
+    VELOX_CHECK(
+        inserted,
+        "Duplicate outstanding cuDF temporary allocation: {} bytes at {}",
+        bytes,
+        pointer);
   }
 
+  // A miss here means an allocation was not routed through this dispatcher,
+  // which would make the deallocation charge the wrong pool. There is no
+  // correct resource to fall back to, so as required by the RMM resource
+  // contract this noexcept path terminates rather than guess.
   rmm::device_async_resource_ref resourceForDeallocation(
       void* pointer,
       std::size_t bytes) noexcept {
@@ -139,7 +147,9 @@ class ThreadLocalTemporaryMemoryResourceImpl {
     auto it = allocations_.find(pointer);
     VELOX_CHECK(
         it != allocations_.end(),
-        "Unknown cuDF temporary allocation during deallocation");
+        "Unknown cuDF temporary allocation during deallocation: {} bytes at {}",
+        bytes,
+        pointer);
     auto resource = it->second;
     allocations_.erase(it);
     return resource;

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -37,6 +37,21 @@ rmm::device_async_resource_ref get_temp_mr();
 /// Returns the memory resource designated for output vector allocations.
 rmm::device_async_resource_ref get_output_mr();
 
+/// Creates the process-wide cuDF resource used for APIs that still allocate
+/// temporary storage through cudf::get_current_device_resource_ref(). While a
+/// ScopedCudfMemoryResources is active, allocations and deallocations are
+/// dispatched to its temporary resource. Outside a scope they use 'fallback'.
+///
+/// This is a transitional bridge until every cuDF API accepts temp_mr. Only
+/// operational allocations whose allocation call occurs inside the cuDF API
+/// scope may use this resource. The selected resource is remembered for
+/// deallocation on any thread, but remains non-owning and must outlive the
+/// allocation. Returned columns and tables must use the explicit owning output
+/// resource instead.
+[[nodiscard]] cuda::mr::any_resource<cuda::mr::device_accessible>
+createThreadLocalTemporaryMemoryResource(
+    cuda::mr::any_resource<cuda::mr::device_accessible> fallback);
+
 /// Installs per-call temporary and output resources for helpers that use
 /// get_temp_mr() and get_output_mr(). The selected resource objects themselves
 /// carry accounting identity, so allocations remain correctly attributed when

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -31,8 +31,33 @@ extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
     output_mr_;
 
+/// Returns the memory resource designated for temporary allocations.
+rmm::device_async_resource_ref get_temp_mr();
+
 /// Returns the memory resource designated for output vector allocations.
 rmm::device_async_resource_ref get_output_mr();
+
+/// Installs per-call temporary and output resources for helpers that use
+/// get_temp_mr() and get_output_mr(). The selected resource objects themselves
+/// carry accounting identity, so allocations remain correctly attributed when
+/// cuDF uses a different thread or stream after receiving the resource ref.
+class ScopedCudfMemoryResources {
+ public:
+  ScopedCudfMemoryResources(
+      rmm::device_async_resource_ref tempMr,
+      rmm::device_async_resource_ref outputMr);
+  ~ScopedCudfMemoryResources();
+
+  ScopedCudfMemoryResources(const ScopedCudfMemoryResources&) = delete;
+  ScopedCudfMemoryResources& operator=(const ScopedCudfMemoryResources&) =
+      delete;
+  ScopedCudfMemoryResources(ScopedCudfMemoryResources&&) = delete;
+  ScopedCudfMemoryResources& operator=(ScopedCudfMemoryResources&&) = delete;
+
+ private:
+  std::optional<rmm::device_async_resource_ref> previousTempMr_;
+  std::optional<rmm::device_async_resource_ref> previousOutputMr_;
+};
 
 /// Creates a memory resource based on the given mode.
 ///
@@ -41,6 +66,14 @@ rmm::device_async_resource_ref get_output_mr();
 /// resource.
 [[nodiscard]] cuda::mr::any_resource<cuda::mr::device_accessible>
 createMemoryResource(std::string_view mode, int percent);
+
+/// Releases retired UCX exchange resources with no live packed buffers.
+/// Returns true when no active or in-use exchange resources remain.
+bool tryResetCudfExchangeMemoryResource();
+
+/// Tears down all process-owned UCX exchange resources. There must be no
+/// active query users or live packed buffers.
+void resetCudfExchangeMemoryResource();
 
 /// Returns the global CUDA stream pool used by cudf.
 [[nodiscard]] cudf::detail::cuda_stream_pool& cudfGlobalStreamPool();

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -31,7 +31,12 @@ extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
     output_mr_;
 
-/// Returns the memory resource designated for temporary allocations.
+/// Returns the temporary resource selected for the current cuDF call, falling
+/// back to RMM's current device resource outside an operator call.
+///
+/// Also declared in CudfNoDefaults.h. That header cannot be included here: it
+/// poisons cudf's implicit stream and resource getters, which the translation
+/// units including this header call explicitly.
 rmm::device_async_resource_ref get_temp_mr();
 
 /// Returns the memory resource designated for output vector allocations.
@@ -84,6 +89,10 @@ createMemoryResource(std::string_view mode, int percent);
 
 /// Releases retired UCX exchange resources with no live packed buffers.
 /// Returns true when no active or in-use exchange resources remain.
+///
+/// Defined in CudfMemoryResource.cpp and declared in both headers: callers of
+/// this one cannot include CudfMemoryResource.h, which drags in cudf headers
+/// that redefine the getters CudfNoDefaults.h poisons.
 bool tryResetCudfExchangeMemoryResource();
 
 /// Tears down all process-owned UCX exchange resources. There must be no

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -357,6 +357,12 @@ void registerCudf() {
 }
 
 void unregisterCudf() {
+  if (!tryResetCudfExchangeMemoryResource()) {
+    LOG(WARNING)
+        << "Retaining active or in-use cuDF UCX exchange memory resources; "
+           "they become reclaimable after their queries and packed buffers "
+           "are released";
+  }
   output_mr_.reset();
   mr_.reset();
   // Undo registerCudf()'s operator adapter registration.

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -323,16 +323,17 @@ void registerCudf() {
   VELOX_CHECK_GE(contextDevice, 0, "Failed to get current CUDA device ordinal");
   setCudfContextDevice(contextDevice);
 
-  const std::string mrMode = CudfConfig::getInstance().memoryResource;
-  auto mr = cudf_velox::createMemoryResource(
-      mrMode, CudfConfig::getInstance().memoryPercent);
-  cudf::set_current_device_resource(mr);
+  const auto& config = CudfConfig::getInstance();
+  const std::string mrMode = config.memoryResource;
+  auto mr = cudf_velox::createMemoryResource(mrMode, config.memoryPercent);
+  cudf::set_current_device_resource(
+      cudf_velox::createThreadLocalTemporaryMemoryResource(mr));
   mr_ = std::move(mr);
 
-  const auto& outputMrMode = CudfConfig::getInstance().outputMemoryResource;
+  const auto& outputMrMode = config.outputMemoryResource;
   if (!outputMrMode.empty() && outputMrMode != mrMode) {
-    output_mr_ = cudf_velox::createMemoryResource(
-        outputMrMode, CudfConfig::getInstance().memoryPercent);
+    output_mr_ =
+        cudf_velox::createMemoryResource(outputMrMode, config.memoryPercent);
   } else {
     output_mr_ = mr_;
   }

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -108,6 +108,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_memory_resource_test
+  SOURCES Main.cpp CudfMemoryResourceTest.cpp
+  LIBS velox_cudf_exec velox_memory
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_split_reader_test
   SOURCES Main.cpp CudfSplitReaderTest.cpp
   LIBS velox_cudf_exec_test_lib velox_cudf_hive_connector

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -114,6 +114,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_operator_memory_tracking_test
+  SOURCES Main.cpp CudfOperatorMemoryTrackingTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_memory
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_split_reader_test
   SOURCES Main.cpp CudfSplitReaderTest.cpp
   LIBS velox_cudf_exec_test_lib velox_cudf_hive_connector

--- a/velox/experimental/cudf/tests/CudfMemoryResourceTest.cpp
+++ b/velox/experimental/cudf/tests/CudfMemoryResourceTest.cpp
@@ -1,0 +1,600 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/CudfMemoryResource.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/memory/CustomMemoryResourceRegistry.h"
+#include "velox/common/memory/MallocAllocator.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryArbitrator.h"
+#include "velox/core/QueryCtx.h"
+
+#include <cudf/column/column.hpp>
+#include <cudf/contiguous_split.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/device_buffer.hpp>
+
+#include <folly/ScopeGuard.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <future>
+#include <memory>
+#include <new>
+#include <optional>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+struct HostBackedResourceState {
+  std::atomic<bool> failNextAllocation{false};
+  std::atomic<bool> failNextCopy{false};
+};
+
+/// Host-backed test resource satisfying the device-accessible resource
+/// concept. Tests only exercise resource delegation and never dereference the
+/// allocation from device code.
+class HostBackedDeviceResource {
+ public:
+  explicit HostBackedDeviceResource(
+      std::shared_ptr<HostBackedResourceState> state)
+      : state_(std::move(state)) {}
+
+  HostBackedDeviceResource(const HostBackedDeviceResource& other)
+      : state_(other.state_) {
+    if (state_->failNextCopy.exchange(false)) {
+      throw std::runtime_error{"injected resource copy failure"};
+    }
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment) {
+    if (state_->failNextAllocation.exchange(false)) {
+      throw std::bad_alloc{};
+    }
+    return ::operator new(bytes, std::align_val_t(alignment));
+  }
+
+  void deallocate_sync(
+      void* pointer,
+      std::size_t /*bytes*/,
+      std::size_t alignment) noexcept {
+    ::operator delete(pointer, std::align_val_t(alignment));
+  }
+
+  void* allocate(
+      cuda::stream_ref /*stream*/,
+      std::size_t bytes,
+      std::size_t alignment) {
+    return allocate_sync(bytes, alignment);
+  }
+
+  void deallocate(
+      cuda::stream_ref /*stream*/,
+      void* pointer,
+      std::size_t bytes,
+      std::size_t alignment) noexcept {
+    deallocate_sync(pointer, bytes, alignment);
+  }
+
+  bool operator==(const HostBackedDeviceResource& other) const noexcept {
+    return state_ == other.state_;
+  }
+
+  bool operator!=(const HostBackedDeviceResource& other) const noexcept {
+    return !(*this == other);
+  }
+
+  friend void get_property(
+      const HostBackedDeviceResource&,
+      cuda::mr::device_accessible) noexcept {}
+
+ private:
+  std::shared_ptr<HostBackedResourceState> state_;
+};
+
+cuda::mr::any_resource<cuda::mr::device_accessible> makeTestUpstream(
+    const std::shared_ptr<HostBackedResourceState>& state) {
+  return HostBackedDeviceResource{state};
+}
+
+std::shared_ptr<memory::CustomMemoryResource> makeCustomResource(
+    int64_t capacity = 1L << 30) {
+  memory::MemoryAllocator::Options options;
+  options.capacity = capacity;
+  return std::make_shared<memory::CustomMemoryResource>(
+      std::string{kCudfMemoryResourceTag},
+      std::make_shared<memory::MallocAllocator>(options),
+      memory::MemoryArbitrator::create({}),
+      []() { return memory::MemoryReclaimer::create(0); },
+      capacity);
+}
+
+std::shared_ptr<core::QueryCtx> makeTrackedQueryCtx(
+    const std::shared_ptr<memory::CustomMemoryResource>& resource,
+    const std::string& queryId,
+    const std::string& rootName = "") {
+  auto root = memory::memoryManager()->addCustomRootPool(
+      (rootName.empty() ? queryId : rootName) + ".gpu", resource);
+  auto queryCtx = core::QueryCtx::Builder()
+                      .queryId(queryId)
+                      .customPool(std::string{kCudfMemoryResourceTag}, root)
+                      .build();
+  auto registry = memory::CustomMemoryResourceRegistry::createRegistry(nullptr);
+  registry->insert(std::string{kCudfMemoryResourceTag}, resource);
+  queryCtx->setRegistry<memory::CustomMemoryResourceRegistry::Registry>(
+      memory::kCustomMemoryResourceRegistryKey, registry);
+  return queryCtx;
+}
+
+std::unique_ptr<cudf::table> makeDeviceTable(rmm::cuda_stream_view stream) {
+  std::array<int32_t, 4> values{{1, 2, 3, 4}};
+  rmm::device_buffer data(
+      values.size() * sizeof(int32_t),
+      stream,
+      cudf::get_current_device_resource_ref());
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      data.data(),
+      values.data(),
+      values.size() * sizeof(int32_t),
+      cudaMemcpyHostToDevice,
+      stream.value()));
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(
+      std::make_unique<cudf::column>(
+          cudf::data_type{cudf::type_id::INT32},
+          static_cast<cudf::size_type>(values.size()),
+          std::move(data),
+          rmm::device_buffer{},
+          0));
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+class CudfMemoryResourceTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::initialize({});
+  }
+};
+
+TEST_F(CudfMemoryResourceTest, ReportsAcrossThreadsAndRollsBackFailure) {
+  auto root = memory::memoryManager()->addRootPool();
+  auto pool = root->addLeafChild("cudfMemoryResourceTest");
+  auto state = std::make_shared<HostBackedResourceState>();
+  CudfMemoryResource reportingResource{makeTestUpstream(state), pool};
+  cuda::mr::any_resource<cuda::mr::device_accessible> ownedResource{
+      rmm::device_async_resource_ref{reportingResource}};
+
+  constexpr std::size_t kBytes = 256;
+  void* allocation = nullptr;
+  std::thread allocateThread([&] {
+    allocation = ownedResource.allocate(
+        rmm::cuda_stream_default, kBytes, alignof(std::max_align_t));
+  });
+  allocateThread.join();
+
+  EXPECT_NE(allocation, nullptr);
+  EXPECT_EQ(pool->usedBytes(), kBytes);
+
+  std::thread deallocateThread([&] {
+    ownedResource.deallocate(
+        rmm::cuda_stream_default,
+        allocation,
+        kBytes,
+        alignof(std::max_align_t));
+  });
+  deallocateThread.join();
+  EXPECT_EQ(pool->usedBytes(), 0);
+
+  auto* synchronousAllocation =
+      ownedResource.allocate_sync(kBytes, alignof(std::max_align_t));
+  EXPECT_EQ(pool->usedBytes(), kBytes);
+  ownedResource.deallocate_sync(
+      synchronousAllocation, kBytes, alignof(std::max_align_t));
+  EXPECT_EQ(pool->usedBytes(), 0);
+
+  state->failNextAllocation = true;
+  EXPECT_THROW(
+      ownedResource.allocate(
+          rmm::cuda_stream_default, kBytes, alignof(std::max_align_t)),
+      std::bad_alloc);
+  EXPECT_EQ(pool->usedBytes(), 0);
+}
+
+TEST_F(CudfMemoryResourceTest, RetainsCompleteCustomPoolHierarchyAndOwner) {
+  auto state = std::make_shared<HostBackedResourceState>();
+  auto owner = makeCustomResource();
+  auto root = memory::memoryManager()->addCustomRootPool(
+      "cudfMemoryResourceOwnershipRoot", owner);
+  auto taskPool = root->addAggregateChild("task");
+  auto nodePool = taskPool->addAggregateChild("node");
+  auto operatorPool = nodePool->addLeafChild("operator");
+
+  std::weak_ptr<memory::CustomMemoryResource> weakOwner = owner;
+  std::weak_ptr<memory::MemoryPool> weakRoot = root;
+  std::weak_ptr<memory::MemoryPool> weakOperatorPool = operatorPool;
+  std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
+      retainedResource;
+  {
+    CudfMemoryResource reportingResource{
+        makeTestUpstream(state), operatorPool, owner};
+    retainedResource.emplace(reportingResource);
+  }
+
+  constexpr std::size_t kBytes = 192;
+  auto* allocation = retainedResource->allocate(
+      rmm::cuda_stream_default, kBytes, alignof(std::max_align_t));
+  EXPECT_EQ(operatorPool->usedBytes(), kBytes);
+
+  operatorPool.reset();
+  nodePool.reset();
+  taskPool.reset();
+  root.reset();
+  owner.reset();
+
+  EXPECT_FALSE(weakOwner.expired());
+  EXPECT_FALSE(weakRoot.expired());
+  EXPECT_FALSE(weakOperatorPool.expired());
+
+  retainedResource->deallocate(
+      rmm::cuda_stream_default, allocation, kBytes, alignof(std::max_align_t));
+  EXPECT_EQ(weakOperatorPool.lock()->usedBytes(), 0);
+  retainedResource.reset();
+
+  EXPECT_TRUE(weakOperatorPool.expired());
+  EXPECT_TRUE(weakRoot.expired());
+  EXPECT_TRUE(weakOwner.expired());
+}
+
+TEST_F(CudfMemoryResourceTest, RejectsAggregateAccountingPool) {
+  auto root = memory::memoryManager()->addRootPool();
+  auto state = std::make_shared<HostBackedResourceState>();
+  EXPECT_THROW(
+      (CudfMemoryResource{makeTestUpstream(state), root}), VeloxRuntimeError);
+}
+
+TEST_F(CudfMemoryResourceTest, RejectsNonThreadSafeAccountingPool) {
+  auto root = memory::memoryManager()->addRootPool();
+  auto pool = root->addLeafChild("nonThreadSafe", false);
+  auto state = std::make_shared<HostBackedResourceState>();
+  EXPECT_THROW(
+      (CudfMemoryResource{makeTestUpstream(state), pool}), VeloxRuntimeError);
+}
+
+TEST_F(CudfMemoryResourceTest, ReservationAndExternalAccountingCoexist) {
+  auto root = memory::memoryManager()->addRootPool();
+  auto pool = root->addLeafChild("cudfMemoryResourceReservationTest");
+  auto state = std::make_shared<HostBackedResourceState>();
+  CudfMemoryResource resource{makeTestUpstream(state), pool};
+
+  constexpr std::size_t kBytes = 256;
+  ASSERT_TRUE(pool->maybeReserve(kBytes * 2));
+  auto* allocation = resource.allocate(
+      rmm::cuda_stream_default, kBytes, alignof(std::max_align_t));
+  EXPECT_EQ(pool->usedBytes(), kBytes);
+  resource.deallocate(
+      rmm::cuda_stream_default, allocation, kBytes, alignof(std::max_align_t));
+  EXPECT_EQ(pool->usedBytes(), 0);
+  pool->release();
+  EXPECT_EQ(pool->reservedBytes(), 0);
+}
+
+TEST_F(CudfMemoryResourceTest, RegistryConstructionFailureIsRetryable) {
+  CudfMemoryResourceRegistry registry;
+  auto root = memory::memoryManager()->addRootPool();
+  auto pool = root->addLeafChild("cudfMemoryResourceRegistryRetryTest");
+  auto state = std::make_shared<HostBackedResourceState>();
+  auto upstream = makeTestUpstream(state);
+
+  state->failNextCopy = true;
+  EXPECT_THROW(
+      registry.resourcesFor(upstream, upstream, pool, nullptr),
+      std::runtime_error);
+
+  auto resources = registry.resourcesFor(upstream, upstream, pool, nullptr);
+  EXPECT_EQ(resources.temp, resources.output);
+}
+
+TEST_F(CudfMemoryResourceTest, RegistryValidatesStableInputs) {
+  CudfMemoryResourceRegistry registry;
+  auto owner = makeCustomResource();
+  auto otherOwner = makeCustomResource();
+  auto root = memory::memoryManager()->addCustomRootPool(
+      "cudfMemoryResourceRegistryStableRoot", owner);
+  auto pool = root->addLeafChild("operator");
+  auto stateA = std::make_shared<HostBackedResourceState>();
+  auto stateB = std::make_shared<HostBackedResourceState>();
+  auto upstreamA = makeTestUpstream(stateA);
+  auto upstreamB = makeTestUpstream(stateB);
+
+  auto resources = registry.resourcesFor(upstreamA, upstreamA, pool, owner);
+  EXPECT_EQ(resources.temp, resources.output);
+  auto repeated = registry.resourcesFor(upstreamA, upstreamA, pool, owner);
+  EXPECT_EQ(resources.temp, repeated.temp);
+
+  EXPECT_THROW(
+      registry.resourcesFor(upstreamB, upstreamA, pool, owner),
+      VeloxRuntimeError);
+  EXPECT_THROW(
+      registry.resourcesFor(upstreamA, upstreamA, pool, otherOwner),
+      VeloxRuntimeError);
+}
+
+TEST_F(CudfMemoryResourceTest, RegistryUsesDistinctOutputWrapperWhenNeeded) {
+  CudfMemoryResourceRegistry registry;
+  auto root = memory::memoryManager()->addRootPool();
+  auto pool = root->addLeafChild("cudfMemoryResourceDistinctWrappersTest");
+  auto stateA = std::make_shared<HostBackedResourceState>();
+  auto stateB = std::make_shared<HostBackedResourceState>();
+  auto resources = registry.resourcesFor(
+      makeTestUpstream(stateA), makeTestUpstream(stateB), pool, nullptr);
+  EXPECT_NE(resources.temp, resources.output);
+}
+
+TEST_F(CudfMemoryResourceTest, RegistryKeepsReferencedResourceAlive) {
+  auto registry = std::make_unique<CudfMemoryResourceRegistry>();
+  auto root = memory::memoryManager()->addRootPool();
+  auto pool = root->addLeafChild("cudfMemoryResourceRegistryTest");
+  std::weak_ptr<memory::MemoryPool> weakPool = pool;
+  auto state = std::make_shared<HostBackedResourceState>();
+  auto upstream = makeTestUpstream(state);
+  auto resources =
+      registry->resourcesFor(upstream, upstream, std::move(pool), nullptr);
+
+  constexpr std::size_t kBytes = 128;
+  auto* allocation = resources.output.allocate(
+      rmm::cuda_stream_default, kBytes, alignof(std::max_align_t));
+  EXPECT_EQ(weakPool.lock()->usedBytes(), kBytes);
+  resources.output.deallocate(
+      rmm::cuda_stream_default, allocation, kBytes, alignof(std::max_align_t));
+
+  EXPECT_FALSE(weakPool.expired());
+  registry.reset();
+  EXPECT_TRUE(weakPool.expired());
+}
+
+TEST_F(CudfMemoryResourceTest, ScopedSelectionSupportsNesting) {
+  auto stateA = std::make_shared<HostBackedResourceState>();
+  auto stateB = std::make_shared<HostBackedResourceState>();
+  cuda::mr::any_resource<cuda::mr::device_accessible> resourceA{
+      makeTestUpstream(stateA)};
+  cuda::mr::any_resource<cuda::mr::device_accessible> resourceB{
+      makeTestUpstream(stateB)};
+  rmm::device_async_resource_ref refA{resourceA};
+  rmm::device_async_resource_ref refB{resourceB};
+
+  ScopedCudfMemoryResources outer{refA, refB};
+  EXPECT_EQ(get_temp_mr(), refA);
+  EXPECT_EQ(get_output_mr(), refB);
+
+  {
+    ScopedCudfMemoryResources inner{refB, refA};
+    EXPECT_EQ(get_temp_mr(), refB);
+    EXPECT_EQ(get_output_mr(), refA);
+  }
+
+  EXPECT_EQ(get_temp_mr(), refA);
+  EXPECT_EQ(get_output_mr(), refB);
+}
+
+TEST_F(CudfMemoryResourceTest, ScopedSelectionIsThreadLocal) {
+  auto stateA = std::make_shared<HostBackedResourceState>();
+  auto stateB = std::make_shared<HostBackedResourceState>();
+  cuda::mr::any_resource<cuda::mr::device_accessible> resourceA{
+      makeTestUpstream(stateA)};
+  cuda::mr::any_resource<cuda::mr::device_accessible> resourceB{
+      makeTestUpstream(stateB)};
+  rmm::device_async_resource_ref refA{resourceA};
+  rmm::device_async_resource_ref refB{resourceB};
+
+  std::promise<void> childReady;
+  std::promise<void> releaseChild;
+  auto releaseFuture = releaseChild.get_future().share();
+  std::atomic<bool> childSawOwnResources{false};
+
+  ScopedCudfMemoryResources mainScope{refA, refA};
+  std::thread child([&] {
+    ScopedCudfMemoryResources childScope{refB, refB};
+    childSawOwnResources = get_temp_mr() == refB && get_output_mr() == refB;
+    childReady.set_value();
+    releaseFuture.wait();
+    childSawOwnResources = childSawOwnResources && get_temp_mr() == refB &&
+        get_output_mr() == refB;
+  });
+
+  childReady.get_future().wait();
+  EXPECT_EQ(get_temp_mr(), refA);
+  EXPECT_EQ(get_output_mr(), refA);
+  releaseChild.set_value();
+  child.join();
+  EXPECT_TRUE(childSawOwnResources);
+}
+
+TEST_F(CudfMemoryResourceTest, ExchangeResourceRequiresTrackedQuery) {
+  auto queryCtx = core::QueryCtx::Builder().queryId("untracked").build();
+  EXPECT_FALSE(cudfExchangeOutputMemoryResource(*queryCtx).has_value());
+  EXPECT_EQ(cudfExchangeMemoryPool(*queryCtx), nullptr);
+}
+
+TEST_F(CudfMemoryResourceTest, ExchangeResourcesAreScopedByQueryRoot) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA device available";
+  }
+
+  resetCudfExchangeMemoryResource();
+  auto savedOutputMr = output_mr_;
+  output_mr_ = createMemoryResource("cuda", 0);
+  SCOPE_EXIT {
+    resetCudfExchangeMemoryResource();
+    output_mr_ = std::move(savedOutputMr);
+  };
+
+  auto ownerA = makeCustomResource();
+  auto ownerB = makeCustomResource();
+  auto queryCtxA = makeTrackedQueryCtx(
+      ownerA, "same-exchange-query", "exchange-query-root-a");
+  auto queryCtxB = makeTrackedQueryCtx(
+      ownerB, "same-exchange-query", "exchange-query-root-b");
+
+  auto exchangeMrA = cudfExchangeOutputMemoryResource(*queryCtxA);
+  auto exchangeMrB = cudfExchangeOutputMemoryResource(*queryCtxB);
+  ASSERT_TRUE(exchangeMrA.has_value());
+  ASSERT_TRUE(exchangeMrB.has_value());
+  EXPECT_NE(*exchangeMrA, *exchangeMrB);
+
+  auto exchangePoolA = cudfExchangeMemoryPool(*queryCtxA);
+  auto exchangePoolB = cudfExchangeMemoryPool(*queryCtxB);
+  ASSERT_NE(exchangePoolA, nullptr);
+  ASSERT_NE(exchangePoolB, nullptr);
+  EXPECT_NE(exchangePoolA, exchangePoolB);
+
+  int originalDevice = 0;
+  CUDF_CUDA_TRY(cudaGetDevice(&originalDevice));
+  SCOPE_EXIT {
+    cudaSetDevice(originalDevice);
+  };
+  if (deviceCount > 1) {
+    const auto otherDevice = (originalDevice + 1) % deviceCount;
+    CUDF_CUDA_TRY(cudaSetDevice(otherDevice));
+    auto exchangeMrOtherDevice = cudfExchangeOutputMemoryResource(*queryCtxA);
+    ASSERT_TRUE(exchangeMrOtherDevice.has_value());
+    EXPECT_NE(*exchangeMrA, *exchangeMrOtherDevice);
+    auto exchangePoolOtherDevice = cudfExchangeMemoryPool(*queryCtxA);
+    ASSERT_NE(exchangePoolOtherDevice, nullptr);
+    EXPECT_NE(exchangePoolA, exchangePoolOtherDevice);
+    CUDF_CUDA_TRY(cudaSetDevice(originalDevice));
+  }
+
+  EXPECT_THROW(resetCudfExchangeMemoryResource(), VeloxRuntimeError);
+  EXPECT_FALSE(tryResetCudfExchangeMemoryResource());
+
+  queryCtxA.reset();
+  queryCtxB.reset();
+  exchangePoolA.reset();
+  exchangePoolB.reset();
+  EXPECT_TRUE(tryResetCudfExchangeMemoryResource());
+}
+
+TEST_F(CudfMemoryResourceTest, PackedGpuMemoryIsChargedToExchangePool) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA device available";
+  }
+
+  resetCudfExchangeMemoryResource();
+  auto savedOutputMr = output_mr_;
+  output_mr_ = createMemoryResource("cuda", 0);
+  SCOPE_EXIT {
+    resetCudfExchangeMemoryResource();
+    output_mr_ = std::move(savedOutputMr);
+  };
+
+  auto owner = makeCustomResource();
+  std::weak_ptr<memory::CustomMemoryResource> weakOwner = owner;
+  auto queryCtx = makeTrackedQueryCtx(owner, "exchange-accounting");
+  std::weak_ptr<memory::MemoryPool> weakQueryPool =
+      queryCtx->customPool(std::string{kCudfMemoryResourceTag});
+  auto exchangeMr = cudfExchangeOutputMemoryResource(*queryCtx);
+  ASSERT_TRUE(exchangeMr.has_value());
+  auto exchangePool = cudfExchangeMemoryPool(*queryCtx);
+  ASSERT_NE(exchangePool, nullptr);
+
+  rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+  auto table = makeDeviceTable(stream);
+  auto packed = cudf::pack(table->view(), stream, *exchangeMr);
+  stream.synchronize();
+
+  ASSERT_NE(packed.gpu_data, nullptr);
+  const auto packedBytes = packed.gpu_data->size();
+  ASSERT_GT(packedBytes, 0);
+  EXPECT_EQ(exchangePool->usedBytes(), packedBytes);
+  EXPECT_EQ(weakQueryPool.lock()->usedBytes(), packedBytes);
+
+  queryCtx.reset();
+  owner.reset();
+  EXPECT_FALSE(weakQueryPool.expired());
+  EXPECT_FALSE(weakOwner.expired());
+  EXPECT_EQ(exchangePool->usedBytes(), packedBytes);
+  EXPECT_THROW(resetCudfExchangeMemoryResource(), VeloxRuntimeError);
+  EXPECT_FALSE(tryResetCudfExchangeMemoryResource());
+
+  packed.gpu_data.reset();
+  EXPECT_EQ(exchangePool->usedBytes(), 0);
+  EXPECT_EQ(weakQueryPool.lock()->usedBytes(), 0);
+  exchangePool.reset();
+  EXPECT_TRUE(tryResetCudfExchangeMemoryResource());
+  EXPECT_TRUE(weakQueryPool.expired());
+  EXPECT_TRUE(weakOwner.expired());
+}
+
+TEST_F(CudfMemoryResourceTest, UnregisterRetainsBusyExchangeResourceSafely) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA device available";
+  }
+
+  ASSERT_FALSE(cudfIsRegistered());
+  resetCudfExchangeMemoryResource();
+  auto savedTempMr = mr_;
+  auto savedOutputMr = output_mr_;
+  mr_ = createMemoryResource("cuda", 0);
+  output_mr_ = createMemoryResource("cuda", 0);
+  SCOPE_EXIT {
+    tryResetCudfExchangeMemoryResource();
+    mr_ = std::move(savedTempMr);
+    output_mr_ = std::move(savedOutputMr);
+  };
+
+  auto owner = makeCustomResource();
+  auto queryCtx = makeTrackedQueryCtx(owner, "busy-unregister");
+  auto exchangeMr = cudfExchangeOutputMemoryResource(*queryCtx);
+  ASSERT_TRUE(exchangeMr.has_value());
+  auto exchangePool = cudfExchangeMemoryPool(*queryCtx);
+  ASSERT_NE(exchangePool, nullptr);
+
+  rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+  auto table = makeDeviceTable(stream);
+  auto packed = cudf::pack(table->view(), stream, *exchangeMr);
+  stream.synchronize();
+  ASSERT_NE(packed.gpu_data, nullptr);
+  ASSERT_GT(packed.gpu_data->size(), 0);
+
+  queryCtx.reset();
+  owner.reset();
+  EXPECT_FALSE(tryResetCudfExchangeMemoryResource());
+  EXPECT_NO_THROW(unregisterCudf());
+  EXPECT_FALSE(cudfIsRegistered());
+  EXPECT_FALSE(mr_.has_value());
+  EXPECT_FALSE(output_mr_.has_value());
+  EXPECT_GT(exchangePool->usedBytes(), 0);
+
+  packed.gpu_data.reset();
+  EXPECT_EQ(exchangePool->usedBytes(), 0);
+  exchangePool.reset();
+  EXPECT_TRUE(tryResetCudfExchangeMemoryResource());
+}
+
+} // namespace
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/CudfMemoryResourceTest.cpp
+++ b/velox/experimental/cudf/tests/CudfMemoryResourceTest.cpp
@@ -29,6 +29,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
 
+#include <rmm/cuda_stream.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <folly/ScopeGuard.h>
@@ -37,6 +38,7 @@
 #include <array>
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <new>
@@ -51,6 +53,9 @@ namespace {
 struct HostBackedResourceState {
   std::atomic<bool> failNextAllocation{false};
   std::atomic<bool> failNextCopy{false};
+  std::atomic<std::uintptr_t> allocationStream{0};
+  std::atomic<std::uintptr_t> deallocationStream{0};
+  std::atomic<int64_t> liveBytes{0};
 };
 
 /// Host-backed test resource satisfying the device-accessible resource
@@ -73,28 +78,31 @@ class HostBackedDeviceResource {
     if (state_->failNextAllocation.exchange(false)) {
       throw std::bad_alloc{};
     }
-    return ::operator new(bytes, std::align_val_t(alignment));
+    auto* allocation = ::operator new(bytes, std::align_val_t(alignment));
+    state_->liveBytes.fetch_add(bytes);
+    return allocation;
   }
 
   void deallocate_sync(
       void* pointer,
-      std::size_t /*bytes*/,
+      std::size_t bytes,
       std::size_t alignment) noexcept {
+    state_->liveBytes.fetch_sub(bytes);
     ::operator delete(pointer, std::align_val_t(alignment));
   }
 
-  void* allocate(
-      cuda::stream_ref /*stream*/,
-      std::size_t bytes,
-      std::size_t alignment) {
+  void*
+  allocate(cuda::stream_ref stream, std::size_t bytes, std::size_t alignment) {
+    state_->allocationStream = reinterpret_cast<std::uintptr_t>(stream.get());
     return allocate_sync(bytes, alignment);
   }
 
   void deallocate(
-      cuda::stream_ref /*stream*/,
+      cuda::stream_ref stream,
       void* pointer,
       std::size_t bytes,
       std::size_t alignment) noexcept {
+    state_->deallocationStream = reinterpret_cast<std::uintptr_t>(stream.get());
     deallocate_sync(pointer, bytes, alignment);
   }
 
@@ -187,10 +195,12 @@ TEST_F(CudfMemoryResourceTest, ReportsAcrossThreadsAndRollsBackFailure) {
       rmm::device_async_resource_ref{reportingResource}};
 
   constexpr std::size_t kBytes = 256;
+  rmm::cuda_stream allocationStream;
+  rmm::cuda_stream deallocationStream;
   void* allocation = nullptr;
   std::thread allocateThread([&] {
     allocation = ownedResource.allocate(
-        rmm::cuda_stream_default, kBytes, alignof(std::max_align_t));
+        allocationStream.view().value(), kBytes, alignof(std::max_align_t));
   });
   allocateThread.join();
 
@@ -199,13 +209,20 @@ TEST_F(CudfMemoryResourceTest, ReportsAcrossThreadsAndRollsBackFailure) {
 
   std::thread deallocateThread([&] {
     ownedResource.deallocate(
-        rmm::cuda_stream_default,
+        deallocationStream.view().value(),
         allocation,
         kBytes,
         alignof(std::max_align_t));
   });
   deallocateThread.join();
   EXPECT_EQ(pool->usedBytes(), 0);
+  EXPECT_EQ(
+      state->allocationStream,
+      reinterpret_cast<std::uintptr_t>(allocationStream.view().value()));
+  EXPECT_EQ(
+      state->deallocationStream,
+      reinterpret_cast<std::uintptr_t>(deallocationStream.view().value()));
+  EXPECT_NE(state->allocationStream, state->deallocationStream);
 
   auto* synchronousAllocation =
       ownedResource.allocate_sync(kBytes, alignof(std::max_align_t));
@@ -396,6 +413,136 @@ TEST_F(CudfMemoryResourceTest, ScopedSelectionSupportsNesting) {
 
   EXPECT_EQ(get_temp_mr(), refA);
   EXPECT_EQ(get_output_mr(), refB);
+}
+
+TEST_F(
+    CudfMemoryResourceTest,
+    CurrentResourceRoutesOperationalAllocationsButNotOutputs) {
+  constexpr std::size_t kTempBytes = 256;
+  constexpr std::size_t kOutputBytes = 512;
+  constexpr auto kAlignment = alignof(std::max_align_t);
+
+  auto fallbackState = std::make_shared<HostBackedResourceState>();
+  auto fallbackResource = makeTestUpstream(fallbackState);
+  rmm::device_async_resource_ref fallbackRef{fallbackResource};
+  auto globalTemporaryResource =
+      createThreadLocalTemporaryMemoryResource(fallbackResource);
+  auto previousResource =
+      cudf::set_current_device_resource(globalTemporaryResource);
+  SCOPE_EXIT {
+    cudf::set_current_device_resource(std::move(previousResource));
+  };
+
+  auto root = memory::memoryManager()->addRootPool();
+  auto tempPool = root->addLeafChild("tlsTemp");
+  auto outputPool = root->addLeafChild("explicitOutput");
+  auto tempState = std::make_shared<HostBackedResourceState>();
+  auto outputState = std::make_shared<HostBackedResourceState>();
+  CudfMemoryResource tempResource{makeTestUpstream(tempState), tempPool};
+  CudfMemoryResource outputResource{makeTestUpstream(outputState), outputPool};
+  rmm::device_async_resource_ref tempRef{tempResource};
+  rmm::device_async_resource_ref outputRef{outputResource};
+
+  auto currentResource = cudf::get_current_device_resource_ref();
+  auto* fallbackAllocation =
+      currentResource.allocate_sync(kTempBytes, kAlignment);
+  EXPECT_EQ(fallbackState->liveBytes, kTempBytes);
+  EXPECT_EQ(tempPool->usedBytes(), 0);
+  currentResource.deallocate_sync(fallbackAllocation, kTempBytes, kAlignment);
+  EXPECT_EQ(fallbackState->liveBytes, 0);
+
+  // This is the path used by operators without a custom GPU pool. Their temp
+  // scope must use the underlying configured resource, not the process-wide
+  // dispatcher itself, to avoid recursive dispatch.
+  {
+    ScopedCudfMemoryResources untrackedScope{fallbackRef, outputRef};
+    auto* untrackedAllocation = currentResource.allocate(
+        rmm::cuda_stream_default, kTempBytes, kAlignment);
+    EXPECT_EQ(fallbackState->liveBytes, kTempBytes);
+    EXPECT_EQ(tempPool->usedBytes(), 0);
+    currentResource.deallocate(
+        rmm::cuda_stream_default, untrackedAllocation, kTempBytes, kAlignment);
+  }
+  EXPECT_EQ(fallbackState->liveBytes, 0);
+
+  void* tempAllocation = nullptr;
+  void* outputAllocation = nullptr;
+  {
+    ScopedCudfMemoryResources scope{tempRef, outputRef};
+    tempAllocation = currentResource.allocate(
+        rmm::cuda_stream_default, kTempBytes, kAlignment);
+    EXPECT_EQ(tempPool->usedBytes(), kTempBytes);
+    EXPECT_EQ(outputPool->usedBytes(), 0);
+    EXPECT_EQ(fallbackState->liveBytes, 0);
+
+    outputAllocation =
+        outputRef.allocate(rmm::cuda_stream_default, kOutputBytes, kAlignment);
+    EXPECT_EQ(tempPool->usedBytes(), kTempBytes);
+    EXPECT_EQ(outputPool->usedBytes(), kOutputBytes);
+  }
+
+  // The dispatcher remembers which non-owning temp resource allocated the
+  // pointer, so the deallocation does not depend on the current TLS scope.
+  EXPECT_EQ(tempPool->usedBytes(), kTempBytes);
+  currentResource.deallocate(
+      rmm::cuda_stream_default, tempAllocation, kTempBytes, kAlignment);
+  EXPECT_EQ(tempPool->usedBytes(), 0);
+
+  // Explicit output resources independently carry their accounting identity
+  // and can likewise be deallocated after the operational TLS scope has ended.
+  EXPECT_EQ(outputPool->usedBytes(), kOutputBytes);
+  outputRef.deallocate(
+      rmm::cuda_stream_default, outputAllocation, kOutputBytes, kAlignment);
+  EXPECT_EQ(outputPool->usedBytes(), 0);
+}
+
+TEST_F(CudfMemoryResourceTest, CurrentResourceUsesCallingThreadScope) {
+  constexpr std::size_t kBytes = 384;
+  constexpr auto kAlignment = alignof(std::max_align_t);
+
+  auto fallbackState = std::make_shared<HostBackedResourceState>();
+  auto globalTemporaryResource =
+      createThreadLocalTemporaryMemoryResource(makeTestUpstream(fallbackState));
+  rmm::device_async_resource_ref currentResource{globalTemporaryResource};
+
+  auto root = memory::memoryManager()->addRootPool();
+  auto mainPool = root->addLeafChild("mainThreadTemp");
+  auto childPool = root->addLeafChild("childThreadTemp");
+  auto mainState = std::make_shared<HostBackedResourceState>();
+  auto childState = std::make_shared<HostBackedResourceState>();
+  CudfMemoryResource mainResource{makeTestUpstream(mainState), mainPool};
+  CudfMemoryResource childResource{makeTestUpstream(childState), childPool};
+  rmm::device_async_resource_ref mainRef{mainResource};
+  rmm::device_async_resource_ref childRef{childResource};
+
+  std::promise<void*> childAllocation;
+  auto childAllocationFuture = childAllocation.get_future();
+  std::thread child([&] {
+    ScopedCudfMemoryResources childScope{childRef, childRef};
+    auto* allocation =
+        currentResource.allocate(rmm::cuda_stream_default, kBytes, kAlignment);
+    childAllocation.set_value(allocation);
+  });
+
+  auto* allocationFromChild = childAllocationFuture.get();
+  child.join();
+  {
+    ScopedCudfMemoryResources mainScope{mainRef, mainRef};
+    auto* allocation =
+        currentResource.allocate(rmm::cuda_stream_default, kBytes, kAlignment);
+    EXPECT_EQ(mainPool->usedBytes(), kBytes);
+    EXPECT_EQ(childPool->usedBytes(), kBytes);
+    EXPECT_EQ(fallbackState->liveBytes, 0);
+    currentResource.deallocate(
+        rmm::cuda_stream_default, allocation, kBytes, kAlignment);
+  }
+
+  EXPECT_EQ(mainPool->usedBytes(), 0);
+  EXPECT_EQ(childPool->usedBytes(), kBytes);
+  currentResource.deallocate(
+      rmm::cuda_stream_default, allocationFromChild, kBytes, kAlignment);
+  EXPECT_EQ(childPool->usedBytes(), 0);
+  EXPECT_EQ(fallbackState->liveBytes, 0);
 }
 
 TEST_F(CudfMemoryResourceTest, ScopedSelectionIsThreadLocal) {

--- a/velox/experimental/cudf/tests/CudfOperatorMemoryTrackingTest.cpp
+++ b/velox/experimental/cudf/tests/CudfOperatorMemoryTrackingTest.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/CudfMemoryResource.h"
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+
+#include "velox/common/memory/CustomMemoryResourceRegistry.h"
+#include "velox/common/memory/MallocAllocator.h"
+#include "velox/common/memory/MemoryArbitrator.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/Task.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <folly/ScopeGuard.h>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+std::shared_ptr<memory::CustomMemoryResource> makeCustomResource() {
+  constexpr int64_t kCapacity = 1L << 30;
+  memory::MemoryAllocator::Options options;
+  options.capacity = kCapacity;
+  return std::make_shared<memory::CustomMemoryResource>(
+      std::string{kCudfMemoryResourceTag},
+      std::make_shared<memory::MallocAllocator>(options),
+      memory::MemoryArbitrator::create({}),
+      []() { return memory::MemoryReclaimer::create(0); },
+      kCapacity);
+}
+
+class TestCudfOperator final : public CudfOperatorBase {
+ public:
+  struct OutputAllocation {
+    void* pointer;
+    std::size_t bytes;
+    rmm::device_async_resource_ref resource;
+  };
+
+  TestCudfOperator(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      RowTypePtr outputType,
+      const core::PlanNodeId& planNodeId)
+      : CudfOperatorBase(
+            operatorId,
+            driverCtx,
+            std::move(outputType),
+            planNodeId,
+            "TestCudfOperator") {}
+
+  bool needsInput() const override {
+    return true;
+  }
+
+  bool isFinished() override {
+    return false;
+  }
+
+  memory::MemoryPool* gpuPool() const {
+    return customPool(kCudfMemoryResourceTag);
+  }
+
+  OutputAllocation releaseOutputAllocation() {
+    VELOX_CHECK(outputAllocation_.has_value());
+    return std::exchange(outputAllocation_, std::nullopt).value();
+  }
+
+ protected:
+  void doInitialize() override {
+    exerciseLegacyTemporaryAllocation();
+  }
+
+  exec::BlockingReason doIsBlocked(ContinueFuture* /*future*/) override {
+    exerciseLegacyTemporaryAllocation();
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  void doAddInput(RowVectorPtr /*input*/) override {
+    exerciseLegacyTemporaryAllocation();
+  }
+
+  RowVectorPtr doGetOutput() override {
+    exerciseLegacyTemporaryAllocation();
+    constexpr std::size_t kOutputBytes = 512;
+    constexpr auto kAlignment = alignof(std::max_align_t);
+    auto outputResource = get_output_mr();
+    auto* output = outputResource.allocate(
+        rmm::cuda_stream_default, kOutputBytes, kAlignment);
+    outputAllocation_.emplace(
+        OutputAllocation{output, kOutputBytes, outputResource});
+    return nullptr;
+  }
+
+  void doNoMoreInput() override {
+    exerciseLegacyTemporaryAllocation();
+    Operator::noMoreInput();
+  }
+
+  void doClose() override {
+    exerciseLegacyTemporaryAllocation();
+    Operator::close();
+  }
+
+ private:
+  void exerciseLegacyTemporaryAllocation() {
+    constexpr std::size_t kTempBytes = 256;
+    constexpr auto kAlignment = alignof(std::max_align_t);
+    auto currentResource = cudf::get_current_device_resource_ref();
+    auto* temporary = currentResource.allocate(
+        rmm::cuda_stream_default, kTempBytes, kAlignment);
+    currentResource.deallocate(
+        rmm::cuda_stream_default, temporary, kTempBytes, kAlignment);
+  }
+
+  std::optional<OutputAllocation> outputAllocation_;
+};
+
+class CudfOperatorMemoryTrackingTest : public exec::test::OperatorTestBase {};
+
+TEST_F(
+    CudfOperatorMemoryTrackingTest,
+    scopesEveryLifecycleMethodAndKeepsOutputsTracked) {
+  auto resourceOwner = makeCustomResource();
+  auto gpuRoot = memory::memoryManager()->addCustomRootPool(
+      "cudfOperatorMemoryTracking.gpu", resourceOwner);
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(driverExecutor_.get())
+                      .queryId("cudf-operator-memory-tracking")
+                      .customPool(std::string{kCudfMemoryResourceTag}, gpuRoot)
+                      .build();
+  auto customResources =
+      memory::CustomMemoryResourceRegistry::createRegistry(nullptr);
+  customResources->insert(std::string{kCudfMemoryResourceTag}, resourceOwner);
+  queryCtx->setRegistry<memory::CustomMemoryResourceRegistry::Registry>(
+      memory::kCustomMemoryResourceRegistryKey, customResources);
+
+  const core::PlanNodeId planNodeId{"values"};
+  auto input = makeRowVector({makeFlatVector<int64_t>({1})});
+  core::PlanFragment planFragment;
+  planFragment.planNode =
+      std::make_shared<core::ValuesNode>(planNodeId, std::vector{input});
+  auto task = exec::Task::create(
+      "CudfOperatorMemoryTrackingTest",
+      std::move(planFragment),
+      0,
+      queryCtx,
+      exec::Task::ExecutionMode::kParallel);
+  auto driver = exec::Driver::testingCreate(
+      std::make_unique<exec::DriverCtx>(task, 0, 0, 0, 0));
+
+  auto upstream = createMemoryResource("cuda", 0);
+  auto savedTempMr = mr_;
+  auto savedOutputMr = output_mr_;
+  auto previousCurrentResource = cudf::set_current_device_resource(
+      createThreadLocalTemporaryMemoryResource(upstream));
+  mr_ = upstream;
+  output_mr_ = upstream;
+  SCOPE_EXIT {
+    output_mr_ = std::move(savedOutputMr);
+    mr_ = std::move(savedTempMr);
+    cudf::set_current_device_resource(std::move(previousCurrentResource));
+  };
+
+  std::optional<TestCudfOperator::OutputAllocation> outputAllocation;
+  memory::MemoryPool* gpuPool{nullptr};
+  {
+    TestCudfOperator testOperator{
+        0,
+        driver->driverCtx(),
+        std::dynamic_pointer_cast<const RowType>(input->type()),
+        planNodeId};
+    gpuPool = testOperator.gpuPool();
+    ASSERT_NE(gpuPool, nullptr);
+
+    testOperator.initialize();
+    ContinueFuture future;
+    EXPECT_EQ(
+        testOperator.isBlocked(&future), exec::BlockingReason::kNotBlocked);
+    testOperator.addInput(nullptr);
+    EXPECT_EQ(testOperator.getOutput(), nullptr);
+    testOperator.noMoreInput();
+    testOperator.close();
+
+    outputAllocation = testOperator.releaseOutputAllocation();
+    EXPECT_EQ(gpuPool->usedBytes(), outputAllocation->bytes);
+    const auto stats = gpuPool->stats();
+    EXPECT_EQ(stats.numExternalAllocs, 7);
+    EXPECT_EQ(stats.numExternalFrees, 6);
+  }
+
+  outputAllocation->resource.deallocate(
+      rmm::cuda_stream_default,
+      outputAllocation->pointer,
+      outputAllocation->bytes,
+      alignof(std::max_align_t));
+  EXPECT_EQ(gpuPool->usedBytes(), 0);
+}
+
+} // namespace
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/CudfOperatorMemoryTrackingTest.cpp
+++ b/velox/experimental/cudf/tests/CudfOperatorMemoryTrackingTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/cudf/exec/CudfMemoryResource.h"
 #include "velox/experimental/cudf/exec/CudfOperator.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
 
 #include "velox/common/memory/CustomMemoryResourceRegistry.h"
 #include "velox/common/memory/MallocAllocator.h"
@@ -138,7 +139,20 @@ class TestCudfOperator final : public CudfOperatorBase {
   std::optional<OutputAllocation> outputAllocation_;
 };
 
-class CudfOperatorMemoryTrackingTest : public exec::test::OperatorTestBase {};
+class CudfOperatorMemoryTrackingTest : public exec::test::OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    // The operator lifecycle methods bind the cuDF context to the calling
+    // thread, which requires the registration-time device to be recorded.
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+};
 
 TEST_F(
     CudfOperatorMemoryTrackingTest,
@@ -206,9 +220,13 @@ TEST_F(
 
     outputAllocation = testOperator.releaseOutputAllocation();
     EXPECT_EQ(gpuPool->usedBytes(), outputAllocation->bytes);
+    // Each of initialize, isBlocked, addInput, getOutput, noMoreInput and
+    // close makes one temporary allocation and frees it; getOutput makes one
+    // more that the test holds past close().
+    constexpr int32_t kLifecycleTemporaries = 6;
     const auto stats = gpuPool->stats();
-    EXPECT_EQ(stats.numExternalAllocs, 7);
-    EXPECT_EQ(stats.numExternalFrees, 6);
+    EXPECT_EQ(stats.numExternalAllocs, kLifecycleTemporaries + 1);
+    EXPECT_EQ(stats.numExternalFrees, kLifecycleTemporaries);
   }
 
   outputAllocation->resource.deallocate(

--- a/velox/experimental/ucx-exchange/CMakeLists.txt
+++ b/velox/experimental/ucx-exchange/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(ucx REQUIRED)
 target_link_libraries(
   velox_ucx_exchange
   PUBLIC ucxx::ucxx ucx::ucp nvtx3::nvtx3-cpp
-  PRIVATE cudf::cudf CUDA::cudart CUDA::cuda_driver Folly::folly velox_core ucx::ucs
+  PRIVATE cudf::cudf CUDA::cudart CUDA::cuda_driver Folly::folly velox_core velox_cudf_exec ucx::ucs
 )
 
 if(VELOX_BUILD_TESTING)

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -19,6 +19,7 @@
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
+#include "velox/experimental/cudf/exec/CudfMemoryResource.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
@@ -71,6 +72,9 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
       targetRowsPerChunk_(ctx->queryConfig().ucxPartitionedOutputBatchRows()) {
+  exchangeOutputMemoryResource_ =
+      cudfExchangeOutputMemoryResource(*ctx->task->queryCtx());
+
   this->initPartitionKeys(planNode);
   auto sources = planNode->sources();
   std::vector<std::string> inNames, outNames;
@@ -165,8 +169,8 @@ void UcxPartitionedOutput::flushPending() {
         equalPartition(tableView, stream);
       }
     } else {
-      auto packedCols = cudf::pack(
-          tableView, stream, cudf::get_current_device_resource_ref());
+      auto packedCols =
+          cudf::pack(tableView, stream, exchangeOutputMemoryResource());
       stream.synchronize();
       auto packedColsPtr = std::make_unique<cudf::packed_columns>(
           std::move(packedCols.metadata), std::move(packedCols.gpu_data));
@@ -329,12 +333,18 @@ void UcxPartitionedOutput::equalPartition(
   splitAndEnqueue(tableView, offsets, stream);
 }
 
+rmm::device_async_resource_ref
+UcxPartitionedOutput::exchangeOutputMemoryResource() const {
+  return exchangeOutputMemoryResource_.value_or(
+      cudf::get_current_device_resource_ref());
+}
+
 void UcxPartitionedOutput::splitAndEnqueue(
     cudf::table_view tableView,
     std::vector<cudf::size_type> offsets,
     rmm::cuda_stream_view stream) {
   auto contiguousTables = cudf::contiguous_split(
-      tableView, offsets, stream, cudf::get_current_device_resource_ref());
+      tableView, offsets, stream, exchangeOutputMemoryResource());
 
   // Synchronize the stream to ensure CUDA operations complete before enqueuing.
   // UCXX/UCX is not stream-aware, so without syncing, data could be sent before

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
@@ -20,6 +20,10 @@
 #include "velox/experimental/cudf/vector/CudfVector.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 
+#include <rmm/resource_ref.hpp>
+
+#include <optional>
+
 namespace facebook::velox::ucx_exchange {
 
 /// This is the cudf equivalent of the PartitionedOutput operator for cudf.
@@ -87,6 +91,9 @@ class UcxPartitionedOutput : public exec::Operator,
       std::vector<cudf::size_type> offsets,
       rmm::cuda_stream_view stream);
 
+  rmm::device_async_resource_ref exchangeOutputMemoryResource() const;
+
+  std::optional<rmm::device_async_resource_ref> exchangeOutputMemoryResource_;
   const std::weak_ptr<UcxOutputQueueManager> queueManager_;
   std::vector<column_index_t> partitionKeyIndices_;
   const size_t numPartitions_;


### PR DESCRIPTION
Adapted from  https://github.com/devavret/velox/commit/afd2ac2dae38a3edfd9be5445013596927064f18 

## Summary
- Wraps cuDF temporary and output RMM resources with query-owned resources that charge allocations to each operator's existing `gpu` custom memory pool.
- Scopes those resources around the complete cuDF operator lifecycle, so allocations and cross-thread frees retain the producing operator's pool identity. This covers both `CudfOperatorBase` and `CudfSourceOperatorBase`, so `CudfLocalMerge` is accounted too.
- Replaces cuDF's process-wide current device resource with a thread-local dispatcher, so temporaries that cuDF allocates implicitly (without being passed an `mr`) are also charged to the operator that caused them. The dispatcher keeps a pointer-keyed map so a temporary freed on another thread still routes back to the resource that allocated it.
- Accounts packed UCX output against a query-scoped exchange pool while preserving current behavior when no `gpu` custom pool is configured.
- Adds coverage for allocation rollback, cross-thread deallocation, resource lifetime, nested/thread-local scoping, packed exchange buffers, and per-operator lifecycle accounting.

## Depends on #18973
`QueryCtx::addReleaseCallback()` appends to a `std::deque` without holding `mutex_`. This PR adds a second concurrent caller (the exchange resource registers a callback the first time a query allocates), which makes the existing race reachable — it segfaults on 9 of 10 runs in a targeted test. [#18973](https://github.com/facebookincubator/velox/pull/18973) fixes it in `QueryCtx`; the fix is cherry-picked here so this branch stands up on its own, and will drop out on rebase once that merges.

## On the dispatcher's lock
The dispatcher's map is guarded by a single mutex taken on every implicit temporary allocation and free, which looks alarming. Measured on an RTX 5880 Ada with `velox_cudf_temporary_memory_resource_benchmark`, it costs 5-25% over calling the upstream resource directly. The allocator underneath dominates: with no dispatcher at all, `async` mode goes from 561ns to 5972ns per alloc/free pair between 1 and 8 threads, and `pool` mode from 380ns to 2467ns. Both serialize internally, so replacing the mutex with a lock-free or sharded structure would chase a fraction of that 5-25% against a bottleneck we do not control. Left as-is deliberately; the benchmark is included so this can be revisited against numbers rather than intuition.

## Relationship to #18344
This is a smaller architectural alternative to [#18344](https://github.com/facebookincubator/velox/pull/18344). It uses Velox's existing custom `MemoryPool` hierarchy instead of adding a separate GPU ledger, allocation-owner hierarchy, plan-path resolver, and NVTX counter publisher.

An embedding remains responsible for installing the `gpu` custom root and its capacity policy.

Connector allocations and stateful cuDF APIs that do not accept a memory-resource argument remain outside this narrower accounting path. This draft is intended to validate the custom-pool direction before expanding that coverage.
