### PR TITLE
fix(dwio): Add later children to the ScanSpec stable child order

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -543,6 +543,7 @@ void IcebergSplitReader::prepareSplit(
             resolveEqualityColumns(deleteFile);
 
         if (!equalityColumnNames.empty()) {
+          checkEqualityDeleteColumnsAreReadable(equalityColumnNames);
           equalityDeleteFileReaders_.push_back(
               std::make_unique<EqualityDeleteFileReader>(
                   deleteFile,
@@ -711,6 +712,36 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
   names.insert(names.end(), extraNames.begin(), extraNames.end());
   types.insert(types.end(), extraTypes.begin(), extraTypes.end());
   readerOutputType_ = ROW(std::move(names), std::move(types));
+}
+
+void IcebergSplitReader::checkEqualityDeleteColumnsAreReadable(
+    const std::vector<std::string>& equalityColumnNames) const {
+  // A split covering no stripe or row group builds no reader tree, so no
+  // subscript is set.
+  if (splitOffset_ == static_cast<uint64_t>(dwio::common::RowReader::kAtEnd)) {
+    return;
+  }
+
+  for (const auto& name : equalityColumnNames) {
+    auto* fieldSpec = scanSpec_->childByName(name);
+    VELOX_CHECK_NOT_NULL(
+        fieldSpec, "Iceberg equality delete column has no scan spec: {}", name);
+    VELOX_CHECK(
+        fieldSpec->projectOut(),
+        "Iceberg equality delete column is not projected out: {}",
+        name);
+    VELOX_CHECK(
+        readerOutputType_->containsChild(name),
+        "Iceberg equality delete column is missing from the reader output "
+        "type: {}",
+        name);
+    // A constant carries its own value and needs no reader. Otherwise a
+    // negative subscript means the selective reader tree has none.
+    VELOX_CHECK(
+        fieldSpec->isConstant() || fieldSpec->subscript() >= 0,
+        "Iceberg equality delete column has no column reader: {}",
+        name);
+  }
 }
 
 std::pair<std::vector<std::string>, std::vector<TypePtr>>

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -735,14 +735,10 @@ void IcebergSplitReader::checkEqualityDeleteColumnsAreReadable(
         "Iceberg equality delete column is missing from the reader output "
         "type: {}",
         name);
-    // A constant carries its own value and needs no reader. Otherwise a
-    // negative subscript means the selective reader tree has none.
-    //
-    // A positive subscript can be stale rather than current: a struct reader
-    // skips a child that is not read from the file without clearing the
-    // subscript, so a spec shared across splits can still carry the one a
-    // previous split's tree assigned. Such a column passes here while having
-    // no reader in this tree.
+    // A constant carries its own value and needs no reader; otherwise a
+    // negative subscript means the tree has none. Best-effort: a struct reader
+    // skips a child not read from the file without clearing the subscript, so a
+    // stale positive value from an earlier split's tree also passes.
     VELOX_CHECK(
         fieldSpec->isConstant() || fieldSpec->subscript() >= 0,
         "Iceberg equality delete column has no column reader: {}",

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -716,9 +716,9 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
 
 void IcebergSplitReader::checkEqualityDeleteColumnsAreReadable(
     const std::vector<std::string>& equalityColumnNames) const {
-  // A split covering no stripe or row group builds no reader tree, so no
-  // subscript is set.
-  if (splitOffset_ == static_cast<uint64_t>(dwio::common::RowReader::kAtEnd)) {
+  // A split covering no stripe or row group builds no reader tree, which
+  // 'nextRowNumber()' reports by returning 'kAtEnd'. Nothing to check.
+  if (static_cast<int64_t>(splitOffset_) == dwio::common::RowReader::kAtEnd) {
     return;
   }
 
@@ -737,6 +737,12 @@ void IcebergSplitReader::checkEqualityDeleteColumnsAreReadable(
         name);
     // A constant carries its own value and needs no reader. Otherwise a
     // negative subscript means the selective reader tree has none.
+    //
+    // A positive subscript can be stale rather than current: a struct reader
+    // skips a child that is not read from the file without clearing the
+    // subscript, so a spec shared across splits can still carry the one a
+    // previous split's tree assigned. Such a column passes here while having
+    // no reader in this tree.
     VELOX_CHECK(
         fieldSpec->isConstant() || fieldSpec->subscript() >= 0,
         "Iceberg equality delete column has no column reader: {}",

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -154,6 +154,10 @@ class IcebergSplitReader : public FileSplitReader {
   // 'equalityColumnNames', which would silently match no row to delete.
   // 'configureEqualityDeleteColumns' establishes what is checked, so a failure
   // is an internal error.
+  //
+  // Reads the subscripts that building the reader tree assigns, so call this
+  // only once 'nextRowNumber()' has forced the first stripe or row group of
+  // the split to load.
   void checkEqualityDeleteColumnsAreReadable(
       const std::vector<std::string>& equalityColumnNames) const;
 

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -150,6 +150,13 @@ class IcebergSplitReader : public FileSplitReader {
   // projection naturally drops them from the operator output.
   void configureEqualityDeleteColumns();
 
+  // Fails if the reader tree for the current split cannot supply one of
+  // 'equalityColumnNames', which would silently match no row to delete.
+  // 'configureEqualityDeleteColumns' establishes what is checked, so a failure
+  // is an internal error.
+  void checkEqualityDeleteColumnsAreReadable(
+      const std::vector<std::string>& equalityColumnNames) const;
+
   // Names of scan-spec children that 'configureEqualityDeleteColumns'
   // pre-installed a partition-value constant on for the current split.
   // Mirrors the Java 'PARTITION_KEY' column-type distinction in

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -153,11 +153,8 @@ class IcebergSplitReader : public FileSplitReader {
   // Fails if the reader tree for the current split cannot supply one of
   // 'equalityColumnNames', which would silently match no row to delete.
   // 'configureEqualityDeleteColumns' establishes what is checked, so a failure
-  // is an internal error.
-  //
-  // Reads the subscripts that building the reader tree assigns, so call this
-  // only once 'nextRowNumber()' has forced the first stripe or row group of
-  // the split to load.
+  // is an internal error. Reads subscripts the reader tree assigns, so call it
+  // only once 'nextRowNumber()' has loaded the first stripe or row group.
   void checkEqualityDeleteColumnsAreReadable(
       const std::vector<std::string>& equalityColumnNames) const;
 

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -265,6 +265,100 @@ TEST_P(EqualityDeleteFileReaderTestP, equalityColumnNotInProjection) {
   assertEqualResults({expected}, {result});
 }
 
+// A delete column that only a later split needs: 'id' enters the scan spec
+// when the second split is prepared, and its delete still applies.
+TEST_P(EqualityDeleteFileReaderTestP, equalityDeleteColumnAddedBySecondSplit) {
+  auto tableType = ROW({{"id", BIGINT()}, {"value", VARCHAR()}});
+  // 'id' is outside the projection, so only the delete file puts it in the
+  // scan spec.
+  auto outputType = ROW("value", VARCHAR());
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({6, 8})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+  auto icebergDeleteFile =
+      makeDeleteFile(eqDeleteFile->getPath(), {1}, GetParam().format);
+
+  // Three files of five rows, ids 0-14 with values 'a' through 'o'. Only the
+  // second carries the delete. 'dataFiles' keeps the temp files alive.
+  constexpr int32_t kNumFiles = 3;
+  constexpr int32_t kRowsPerFile = 5;
+  constexpr int32_t kFileWithDelete = 1;
+  std::vector<std::shared_ptr<common::testutil::TempFilePath>> dataFiles;
+  std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  for (int32_t file = 0; file < kNumFiles; ++file) {
+    std::vector<int64_t> ids(kRowsPerFile);
+    std::vector<std::string> values(kRowsPerFile);
+    for (auto i = 0; i < kRowsPerFile; ++i) {
+      ids[i] = file * kRowsPerFile + i;
+      values[i] = std::string(1, static_cast<char>('a' + ids[i]));
+    }
+    dataFiles.push_back(writeDataFileP(
+        {makeRowVector(
+            {"id", "value"},
+            {
+                makeFlatVector<int64_t>(ids),
+                makeFlatVector<std::string>(values),
+            })},
+        {1, 2}));
+    auto fileSplits = file == kFileWithDelete
+        ? makeSplitsP(dataFiles.back()->getPath(), {icebergDeleteFile})
+        : makeSplitsP(dataFiles.back()->getPath());
+    splits.insert(splits.end(), fileSplits.begin(), fileSplits.end());
+  }
+
+  // One driver and no preloading make the splits share one ScanSpec. With
+  // preloading each gets its own and the shared path goes untested.
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan)
+                    .splits(splits)
+                    .maxDrivers(1)
+                    .config(core::QueryConfig::kMaxSplitPreloadPerDriver, "0")
+                    .copyResults(pool());
+
+  // Only the second split loses rows, id=6 ('g') and id=8 ('i').
+  auto expected = makeRowVector(
+      {"value"},
+      {makeFlatVector<std::string>(
+          {"a", "b", "c", "d", "e", "f", "h", "j", "k", "l", "m", "n", "o"})});
+
+  assertEqualResults({expected}, {result});
+}
+
+// A split whose byte range starts past the last stripe or row group: nothing
+// is read, so no reader tree is built for the delete column.
+TEST_P(EqualityDeleteFileReaderTestP, equalityDeleteSplitCoveringNoRows) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto data = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4}),
+          makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
+      });
+  auto dataFile = writeDataFileP({data}, {1, 2});
+
+  auto deleteData = makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 3})});
+  auto eqDeleteFile = writeDataFileP({deleteData}, {1});
+  auto icebergDeleteFile =
+      makeDeleteFile(eqDeleteFile->getPath(), {1}, GetParam().format);
+
+  // All rows sit in one stripe or row group at the head of the file, so the
+  // second half of the byte range covers none of them.
+  auto splits = makeIcebergSplits(
+      dataFile->getPath(),
+      {icebergDeleteFile},
+      /*partitionKeys=*/{},
+      /*splitCount=*/2);
+  ASSERT_EQ(splits.size(), 2);
+
+  auto plan = makeIcebergTableScanPlan(outputType, tableType);
+  auto result =
+      AssertQueryBuilder(plan).splits({splits.back()}).copyResults(pool());
+
+  EXPECT_EQ(result->size(), 0);
+}
+
 /// Two delete files targeting the same column not in the projection.
 TEST_P(EqualityDeleteFileReaderTestP, multipleDeleteFilesSameMissingColumn) {
   auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -327,8 +327,8 @@ TEST_P(EqualityDeleteFileReaderTestP, equalityDeleteColumnAddedBySecondSplit) {
 // A split whose byte range starts past the last stripe or row group: nothing
 // is read, so no reader tree is built for the delete column.
 TEST_P(EqualityDeleteFileReaderTestP, equalityDeleteSplitCoveringNoRows) {
-  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
-  auto outputType = ROW({"value"}, {VARCHAR()});
+  auto tableType = ROW({{"id", BIGINT()}, {"value", VARCHAR()}});
+  auto outputType = ROW("value", VARCHAR());
 
   auto data = makeRowVector(
       {"id", "value"},

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -37,14 +37,17 @@ std::string_view ScanSpec::columnTypeString(ScanSpec::ColumnType columnType) {
 }
 
 ScanSpec* ScanSpec::getOrCreateChild(const std::string& name) {
+  std::lock_guard<std::mutex> l(mutex_);
   if (auto it = this->childByFieldName_.find(name);
       it != this->childByFieldName_.end()) {
     return it->second;
   }
-  this->children_.push_back(std::make_unique<ScanSpec>(name));
-  auto* child = this->children_.back().get();
-  this->childByFieldName_[child->fieldName()] = child;
-  return child;
+  this->children_.push_back(std::make_shared<ScanSpec>(name));
+  const auto& child = this->children_.back();
+  this->childByFieldName_[child->fieldName()] = child.get();
+  stableOrder_.push_back(child);
+  stableChildren_.reset();
+  return child.get();
 }
 
 ScanSpec* ScanSpec::getOrCreateChild(const Subfield& subfield) {
@@ -120,8 +123,6 @@ void ScanSpec::reorder() {
   if (children_.empty()) {
     return;
   }
-  // Make sure 'stableChildren_' is initialized.
-  stableChildren();
   std::sort(
       children_.begin(),
       children_.end(),
@@ -139,13 +140,12 @@ void ScanSpec::enableFilterInSubTree(bool value) {
   }
 }
 
-const std::vector<ScanSpec*>& ScanSpec::stableChildren() {
+ScanSpec::StableChildren ScanSpec::stableChildren() {
   std::lock_guard<std::mutex> l(mutex_);
-  if (stableChildren_.empty()) {
-    stableChildren_.reserve(children_.size());
-    for (auto& child : children_) {
-      stableChildren_.push_back(child.get());
-    }
+  if (stableChildren_ == nullptr) {
+    stableChildren_ =
+        std::make_shared<const std::vector<std::shared_ptr<ScanSpec>>>(
+            stableOrder_);
   }
   return stableChildren_;
 }

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -37,7 +37,7 @@ std::string_view ScanSpec::columnTypeString(ScanSpec::ColumnType columnType) {
 }
 
 ScanSpec* ScanSpec::getOrCreateChild(const std::string& name) {
-  std::lock_guard<std::mutex> l(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   if (auto it = this->childByFieldName_.find(name);
       it != this->childByFieldName_.end()) {
     return it->second;
@@ -141,7 +141,9 @@ void ScanSpec::enableFilterInSubTree(bool value) {
 }
 
 ScanSpec::StableChildren ScanSpec::stableChildren() {
-  std::lock_guard<std::mutex> l(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
+  // Every child goes into both vectors. The prefix property depends on it.
+  VELOX_DCHECK_EQ(children_.size(), stableOrder_.size());
   if (stableChildren_ == nullptr) {
     stableChildren_ =
         std::make_shared<const std::vector<std::shared_ptr<ScanSpec>>>(

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -38,6 +38,19 @@ namespace common {
 /// SelectiveColumnReader. This is owned by the TableScan Operator and
 /// is passed to SelectiveColumnReaders at construction.  This is
 /// mutable by readers to reflect filter order and other adaptations.
+///
+/// One scan owns a spec and is the only thread that adds children, reorders
+/// them and sets filters. That thread adds children mid-scan, when a split is
+/// the first to reference a column outside the projection. A preloaded split
+/// builds its own spec on the preloading thread and hands it over whole, so
+/// there is one owner at a time.
+///
+/// 'stableChildren()' is the one accessor another thread may call, to build the
+/// next reader tree while the owner reads; that tree construction also sets
+/// 'subscript_' on the children the snapshot lists. Only the
+/// add-versus-snapshot pairing is synchronized, by 'mutex_'. 'children()',
+/// 'childByName()' and 'hasFilter()' read 'children_' and 'childByFieldName_'
+/// unlocked, so calling any of them concurrently with an add is a data race.
 class ScanSpec {
  public:
   enum class ColumnType : int8_t {
@@ -206,9 +219,10 @@ class ScanSpec {
   /// Returns the ScanSpec corresponding to 'name'. Creates it if needed without
   /// any intermediate level.
   ///
-  /// Locks only to keep an add from interleaving with 'stableChildren()'.
-  /// Building a spec tree is otherwise single threaded: 'addField' sets the
-  /// channel after the add, and readers walk 'children_' unlocked.
+  /// Must be called on the owning thread. Taking 'mutex_' only keeps an add
+  /// from interleaving with 'stableChildren()'; it does not make concurrent
+  /// adds safe, since a caller finishes the child after this returns, as
+  /// 'addField' does when it sets 'projectOut_' and 'channel_'.
   ScanSpec* getOrCreateChild(const std::string& name);
 
   /// Returns the ScanSpec corresponding to 'subfield'. Creates it if
@@ -492,8 +506,9 @@ class ScanSpec {
 
   bool disableStatsBasedFilterReorder_{false};
 
-  // Serializes an add in 'getOrCreateChild' with the snapshot in
-  // 'stableChildren()'. Nothing else; 'reorder()' sorts 'children_' unlocked.
+  // Orders an add in 'getOrCreateChild' against the snapshot in
+  // 'stableChildren()', which is the only cross-thread pairing. Guards nothing
+  // else: 'reorder()' sorts 'children_' and the accessors read it unlocked.
   std::mutex mutex_;
 
   // Number of times read is called on the corresponding reader. This

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -39,18 +39,16 @@ namespace common {
 /// is passed to SelectiveColumnReaders at construction.  This is
 /// mutable by readers to reflect filter order and other adaptations.
 ///
-/// One scan owns a spec and is the only thread that adds children, reorders
-/// them and sets filters. That thread adds children mid-scan, when a split is
-/// the first to reference a column outside the projection. A preloaded split
-/// builds its own spec on the preloading thread and hands it over whole, so
-/// there is one owner at a time.
+/// Not thread safe. One scan owns a spec and alone adds children, reorders
+/// them and sets filters; a preloaded split builds its own and hands it over
+/// whole. Only 'stableChildren()' is called from another thread, by read-ahead
+/// building the next reader tree, which also writes 'subscript_' on the
+/// children it lists.
 ///
-/// 'stableChildren()' is the one accessor another thread may call, to build the
-/// next reader tree while the owner reads; that tree construction also sets
-/// 'subscript_' on the children the snapshot lists. Only the
-/// add-versus-snapshot pairing is synchronized, by 'mutex_'. 'children()',
-/// 'childByName()' and 'hasFilter()' read 'children_' and 'childByFieldName_'
-/// unlocked, so calling any of them concurrently with an add is a data race.
+/// Adding a child needs exclusive access. 'mutex_' only keeps the snapshot
+/// container consistent: a child is published before its caller configures it,
+/// and 'children()', 'childByName()' and 'hasFilter()' read unlocked. The
+/// mid-scan add runs during split preparation, which never overlaps a snapshot.
 class ScanSpec {
  public:
   enum class ColumnType : int8_t {
@@ -198,12 +196,9 @@ class ScanSpec {
   using StableChildren =
       std::shared_ptr<const std::vector<std::shared_ptr<ScanSpec>>>;
 
-  /// Returns 'children' in a stable order. May be used for parallel
-  /// construction and read-ahead of reader trees while the main user
-  /// of 'this' is running. 'children_' may be reordered while running
-  /// but the tree being constructed must see a single, unchanging
-  /// order. A snapshot never changes; a child added later appears at the end
-  /// of a later one.
+  /// Returns 'children' in an order that never changes, for building a reader
+  /// tree while a running scan reorders 'children_'. A child added later
+  /// appears at the end of a later snapshot.
   StableChildren stableChildren();
 
   /// Returns a read sequence number. This can b used for tagging
@@ -217,12 +212,8 @@ class ScanSpec {
   uint64_t newRead();
 
   /// Returns the ScanSpec corresponding to 'name'. Creates it if needed without
-  /// any intermediate level.
-  ///
-  /// Must be called on the owning thread. Taking 'mutex_' only keeps an add
-  /// from interleaving with 'stableChildren()'; it does not make concurrent
-  /// adds safe, since a caller finishes the child after this returns, as
-  /// 'addField' does when it sets 'projectOut_' and 'channel_'.
+  /// any intermediate level. Requires exclusive access: the child is reachable
+  /// through 'stableChildren()' before the caller configures it.
   ScanSpec* getOrCreateChild(const std::string& name);
 
   /// Returns the ScanSpec corresponding to 'subfield'. Creates it if
@@ -506,9 +497,8 @@ class ScanSpec {
 
   bool disableStatsBasedFilterReorder_{false};
 
-  // Orders an add in 'getOrCreateChild' against the snapshot in
-  // 'stableChildren()', which is the only cross-thread pairing. Guards nothing
-  // else: 'reorder()' sorts 'children_' and the accessors read it unlocked.
+  // Keeps 'stableOrder_' and 'stableChildren_' consistent across an add.
+  // Guards nothing else.
   std::mutex mutex_;
 
   // Number of times read is called on the corresponding reader. This
@@ -554,8 +544,7 @@ class ScanSpec {
   std::vector<std::shared_ptr<ScanSpec>> children_;
 
   // Children in the order they were added, never reordered. Append-only, so an
-  // earlier snapshot is a prefix of a later one. Not handed out;
-  // 'stableChildren_' publishes a copy.
+  // earlier snapshot is a prefix of a later one.
   std::vector<std::shared_ptr<ScanSpec>> stableOrder_;
 
   // Snapshot of 'stableOrder_' handed to reader trees. Never mutated once

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -181,12 +181,17 @@ class ScanSpec {
     return children_;
   }
 
-  /// Returns 'children in a stable order. May be used for parallel
+  /// Snapshot handed to reader trees. Shares ownership of the specs it lists.
+  using StableChildren =
+      std::shared_ptr<const std::vector<std::shared_ptr<ScanSpec>>>;
+
+  /// Returns 'children' in a stable order. May be used for parallel
   /// construction and read-ahead of reader trees while the main user
   /// of 'this' is running. 'children_' may be reordered while running
   /// but the tree being constructed must see a single, unchanging
-  /// order.
-  const std::vector<ScanSpec*>& stableChildren();
+  /// order. A snapshot never changes; a child added later appears at the end
+  /// of a later one.
+  StableChildren stableChildren();
 
   /// Returns a read sequence number. This can b used for tagging
   /// lazy vectors with a generation number so that we can check that
@@ -200,6 +205,10 @@ class ScanSpec {
 
   /// Returns the ScanSpec corresponding to 'name'. Creates it if needed without
   /// any intermediate level.
+  ///
+  /// Locks only to keep an add from interleaving with 'stableChildren()'.
+  /// Building a spec tree is otherwise single threaded: 'addField' sets the
+  /// channel after the add, and readers walk 'children_' unlocked.
   ScanSpec* getOrCreateChild(const std::string& name);
 
   /// Returns the ScanSpec corresponding to 'subfield'. Creates it if
@@ -483,7 +492,8 @@ class ScanSpec {
 
   bool disableStatsBasedFilterReorder_{false};
 
-  // Serializes stableChildren().
+  // Serializes an add in 'getOrCreateChild' with the snapshot in
+  // 'stableChildren()'. Nothing else; 'reorder()' sorts 'children_' unlocked.
   std::mutex mutex_;
 
   // Number of times read is called on the corresponding reader. This
@@ -528,10 +538,14 @@ class ScanSpec {
 
   std::vector<std::shared_ptr<ScanSpec>> children_;
 
-  // Read-only copy of children, not subject to reordering. Used when
-  // asynchronously constructing reader trees for read-ahead, while
-  // 'children_' is reorderable by a running scan.
-  std::vector<ScanSpec*> stableChildren_;
+  // Children in the order they were added, never reordered. Append-only, so an
+  // earlier snapshot is a prefix of a later one. Not handed out;
+  // 'stableChildren_' publishes a copy.
+  std::vector<std::shared_ptr<ScanSpec>> stableOrder_;
+
+  // Snapshot of 'stableOrder_' handed to reader trees. Never mutated once
+  // published: an add drops it and the next 'stableChildren()' republishes.
+  StableChildren stableChildren_;
 
   folly::F14FastMap<std::string, ScanSpec*> childByFieldName_;
 

--- a/velox/dwio/common/tests/ScanSpecTest.cpp
+++ b/velox/dwio/common/tests/ScanSpecTest.cpp
@@ -21,16 +21,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <atomic>
-#include <thread>
-
 namespace facebook::velox::common {
 namespace {
 
-using testing::Each;
 using testing::ElementsAre;
 using testing::Pointer;
-using testing::SizeIs;
 
 class ScanSpecTest : public testing::Test, public test::VectorTestBase {
  protected:
@@ -221,37 +216,6 @@ TEST_F(ScanSpecTest, stableChildrenRepublishedAfterAdd) {
   EXPECT_THAT(
       *scanSpec.stableChildren(),
       ElementsAre(Pointer(first), Pointer(second), Pointer(third)));
-}
-
-// Two threads calling getOrCreateChild() for one name must get one child. A
-// lookup outside the insert's lock lets both miss and both create.
-TEST_F(ScanSpecTest, getOrCreateChildConcurrently) {
-  constexpr int32_t kNumThreads = 4;
-  constexpr int32_t kNumIterations = 10;
-  for (int32_t iteration = 0; iteration < kNumIterations; ++iteration) {
-    ScanSpec scanSpec("<root>");
-    // Releases every thread at once, widening the lookup-to-insert window.
-    std::atomic_bool start{false};
-    std::vector<ScanSpec*> children(kNumThreads);
-    std::vector<std::thread> threads;
-    threads.reserve(kNumThreads);
-    for (int32_t i = 0; i < kNumThreads; ++i) {
-      threads.emplace_back([&, i] {
-        while (!start.load(std::memory_order_acquire)) {
-          std::this_thread::yield();
-        }
-        children[i] = scanSpec.getOrCreateChild("c0");
-      });
-    }
-    start.store(true, std::memory_order_release);
-    for (auto& thread : threads) {
-      thread.join();
-    }
-    ASSERT_THAT(scanSpec.children(), SizeIs(1));
-    auto* child = scanSpec.childByName("c0");
-    ASSERT_EQ(child, scanSpec.children()[0].get());
-    EXPECT_THAT(children, Each(child));
-  }
 }
 
 class TypedScanSpecTest : public testing::TestWithParam<TypePtr>,

--- a/velox/dwio/common/tests/ScanSpecTest.cpp
+++ b/velox/dwio/common/tests/ScanSpecTest.cpp
@@ -18,10 +18,19 @@
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
 
 namespace facebook::velox::common {
 namespace {
+
+using testing::Each;
+using testing::ElementsAre;
+using testing::Pointer;
+using testing::SizeIs;
 
 class ScanSpecTest : public testing::Test, public test::VectorTestBase {
  protected:
@@ -161,6 +170,88 @@ TEST_F(ScanSpecTest, testFilterOnConstant) {
         child.setFilter(std::make_shared<IsNotNull>());
       },
       false);
+}
+
+// A child added after the first reader tree was built appears at the end of
+// stableChildren().
+TEST_F(ScanSpecTest, stableChildrenAfterAddingChild) {
+  ScanSpec scanSpec("<root>");
+  scanSpec.addField("c0", 0);
+  scanSpec.addField("c1", 1);
+
+  auto* first = scanSpec.childByName("c0");
+  auto* second = scanSpec.childByName("c1");
+  const auto beforeAdd = scanSpec.stableChildren();
+  EXPECT_THAT(*beforeAdd, ElementsAre(Pointer(first), Pointer(second)));
+
+  auto* third = scanSpec.addField("c2", 2);
+  EXPECT_THAT(
+      *scanSpec.stableChildren(),
+      ElementsAre(Pointer(first), Pointer(second), Pointer(third)));
+
+  // The snapshot a reader tree is walking is never mutated.
+  EXPECT_THAT(*beforeAdd, ElementsAre(Pointer(first), Pointer(second)));
+
+  // 'c2' is the only child with a filter, so it sorts to the front. The
+  // stable order must not follow.
+  scanSpec.childByName("c2")->setFilter(
+      std::make_shared<BigintRange>(10, 20, false));
+  scanSpec.resetCachedValues(true);
+  ASSERT_EQ(scanSpec.children().front().get(), third);
+  EXPECT_THAT(
+      *scanSpec.stableChildren(),
+      ElementsAre(Pointer(first), Pointer(second), Pointer(third)));
+}
+
+// An add drops the published snapshot. The next call republishes the whole
+// order, held or not.
+TEST_F(ScanSpecTest, stableChildrenRepublishedAfterAdd) {
+  ScanSpec scanSpec("<root>");
+  auto* first = scanSpec.addField("c0", 0);
+  // Published and dropped, so nothing holds it when 'c1' is added.
+  EXPECT_THAT(*scanSpec.stableChildren(), ElementsAre(Pointer(first)));
+
+  auto* second = scanSpec.addField("c1", 1);
+  const auto held = scanSpec.stableChildren();
+  EXPECT_THAT(*held, ElementsAre(Pointer(first), Pointer(second)));
+
+  // Held this time, so adding 'c2' must leave 'held' alone.
+  auto* third = scanSpec.addField("c2", 2);
+  EXPECT_THAT(*held, ElementsAre(Pointer(first), Pointer(second)));
+  EXPECT_THAT(
+      *scanSpec.stableChildren(),
+      ElementsAre(Pointer(first), Pointer(second), Pointer(third)));
+}
+
+// Two threads calling getOrCreateChild() for one name must get one child. A
+// lookup outside the insert's lock lets both miss and both create.
+TEST_F(ScanSpecTest, getOrCreateChildConcurrently) {
+  constexpr int32_t kNumThreads = 4;
+  constexpr int32_t kNumIterations = 10;
+  for (int32_t iteration = 0; iteration < kNumIterations; ++iteration) {
+    ScanSpec scanSpec("<root>");
+    // Releases every thread at once, widening the lookup-to-insert window.
+    std::atomic_bool start{false};
+    std::vector<ScanSpec*> children(kNumThreads);
+    std::vector<std::thread> threads;
+    threads.reserve(kNumThreads);
+    for (int32_t i = 0; i < kNumThreads; ++i) {
+      threads.emplace_back([&, i] {
+        while (!start.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        children[i] = scanSpec.getOrCreateChild("c0");
+      });
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+      thread.join();
+    }
+    ASSERT_THAT(scanSpec.children(), SizeIs(1));
+    auto* child = scanSpec.childByName("c0");
+    ASSERT_EQ(child, scanSpec.children()[0].get());
+    EXPECT_THAT(children, Each(child));
+  }
 }
 
 class TypedScanSpecTest : public testing::TestWithParam<TypePtr>,

--- a/velox/dwio/common/tests/ScanSpecTest.cpp
+++ b/velox/dwio/common/tests/ScanSpecTest.cpp
@@ -167,8 +167,7 @@ TEST_F(ScanSpecTest, testFilterOnConstant) {
       false);
 }
 
-// A child added after the first reader tree was built appears at the end of
-// stableChildren().
+// A child added after a snapshot was taken appears at the end of the next one.
 TEST_F(ScanSpecTest, stableChildrenAfterAddingChild) {
   ScanSpec scanSpec("<root>");
   scanSpec.addField("c0", 0);

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -64,10 +64,11 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
   // A reader tree may be constructed while the ScanSpec is being used
   // for another read. This happens when the next stripe is being
   // prepared while the previous one is reading.
-  auto& childSpecs = scanSpec.stableChildren();
+  const auto stableChildren = scanSpec.stableChildren();
+  const auto& childSpecs = *stableChildren;
   const auto& rowType = requestedType_->asRow();
   for (auto i = 0; i < childSpecs.size(); ++i) {
-    auto* childSpec = childSpecs[i];
+    const auto& childSpec = childSpecs[i];
     if (childSpec->isConstant() || isChildMissing(*childSpec)) {
       childSpec->setSubscript(kConstantChildSpecSubscript);
       continue;

--- a/velox/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/velox/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -438,7 +438,8 @@ folly::F14FastSet<std::string> SelectiveNimbleRowReader::computeLazyIoColumns(
   auto* scanSpec = options.scanSpec().get();
   VELOX_CHECK_NOT_NULL(scanSpec);
   const auto& remainingFilterColumns = options.remainingFilterColumns();
-  for (auto* childSpec : scanSpec->stableChildren()) {
+  const auto stableChildren = scanSpec->stableChildren();
+  for (const auto& childSpec : *stableChildren) {
     if (childSpec->isConstant() || !childSpec->readFromFile()) {
       continue;
     }

--- a/velox/dwio/nimble/velox/selective/StructColumnReader.cpp
+++ b/velox/dwio/nimble/velox/selective/StructColumnReader.cpp
@@ -67,7 +67,8 @@ StructColumnReader::StructColumnReader(
   if (params.hasLazyIoColumns()) {
     lazyInput_ = params.streams().createLazyInput();
   }
-  for (auto* childSpec : scanSpec.stableChildren()) {
+  const auto stableChildren = scanSpec.stableChildren();
+  for (const auto& childSpec : *stableChildren) {
     if (childSpec->isConstant() || isChildMissing(*childSpec)) {
       childSpec->setSubscript(kConstantChildSpecSubscript);
       continue;

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -177,9 +177,10 @@ StructColumnReader::StructColumnReader(
           fileType,
           params,
           scanSpec) {
-  auto& childSpecs = scanSpec_->stableChildren();
+  const auto stableChildren = scanSpec_->stableChildren();
+  const auto& childSpecs = *stableChildren;
   for (auto i = 0; i < childSpecs.size(); ++i) {
-    auto childSpec = childSpecs[i];
+    const auto& childSpec = childSpecs[i];
     if (childSpec->isConstant() || isChildMissing(*childSpec)) {
       childSpec->setSubscript(kConstantChildSpecSubscript);
       continue;
@@ -222,17 +223,19 @@ void StructColumnReader::applyMissingFieldPolicy(
     return;
   }
 
-  auto& childSpecs = scanSpec_->stableChildren();
+  const auto stableChildren = scanSpec_->stableChildren();
+  const auto& childSpecs = *stableChildren;
   if (childSpecs.empty()) {
     nullStructForMissingFields_ = true;
     return;
   }
 
-  if (std::all_of(childSpecs.begin(), childSpecs.end(), [&](auto* childSpec) {
-        return childSpec->columnType() ==
-            common::ScanSpec::ColumnType::kRegular &&
-            isChildMissing(*childSpec);
-      })) {
+  if (std::all_of(
+          childSpecs.begin(), childSpecs.end(), [&](const auto& childSpec) {
+            return childSpec->columnType() ==
+                common::ScanSpec::ColumnType::kRegular &&
+                isChildMissing(*childSpec);
+          })) {
     nullStructForMissingFields_ = true;
   }
 }

--- a/velox/experimental/wave/exec/tests/utils/TestFormatReader.cpp
+++ b/velox/experimental/wave/exec/tests/utils/TestFormatReader.cpp
@@ -276,9 +276,10 @@ class TestStructColumnReader : public StructColumnReader {
     // A reader tree may be constructed while the ScanSpec is being used
     // for another read. This happens when the next stripe is being
     // prepared while the previous one is reading.
-    auto& childSpecs = scanSpec.stableChildren();
+    const auto stableChildren = scanSpec.stableChildren();
+    const auto& childSpecs = *stableChildren;
     for (auto i = 0; i < childSpecs.size(); ++i) {
-      auto childSpec = childSpecs[i];
+      const auto& childSpec = childSpecs[i];
       if (isChildConstant(*childSpec)) {
         VELOX_NYI();
         continue;


### PR DESCRIPTION
An Iceberg equality delete is silently ignored when the split carrying it is the first split to need the delete column. Nothing throws and no error is logged — the rows the delete names simply come back.

For an Iceberg table of `(id, value)` read as:

    SELECT value FROM t

split into three files, where only the second has an equality delete file on `id`. The query never projects `id`, so the scan learns that the column exists only when that second split is prepared. The delete does not apply, and its rows are returned.

A table scan on one driver reuses a single `ScanSpec` for every split it reads. A reader tree is built from `ScanSpec::stableChildren()`, which was filled in on first use and never refreshed when the spec itself changed. Once the second split added `id`, every reader tree built after that was still handed the list from the first split, so the tree for that split had no reader for `id` and the equality delete had nothing to match against.

Adding a child now drops that list, and the next caller republishes it instead of mutating the copy already handed out, so a reader tree that is mid-construction keeps the order it started with. Children are appended in the order they were added and never reordered, which makes an earlier list a prefix of a later one, so the positions an in-flight tree already assigned stay correct. The list is returned by value, so a caller keeps its own copy alive for as long as it walks it.

The lock this adds covers one pairing, an add against publishing the list, and nothing further. `ScanSpec` does not become thread safe. The class instead states the contract it relies on — one owning thread adds children, reorders them and sets filters — and names the accessors that read `children_` unlocked.

`IcebergSplitReader` no longer depends on the order alone. Preparing a split fails now if the scan spec cannot supply a column that an equality delete file names, so this class of bug is a loud failure rather than a wrong answer. The check is best-effort, and says so where it sits. It reads the subscripts that building the reader tree assigns, so it runs only once the first stripe or row group has loaded. A spec still carrying a subscript from an earlier split's tree passes it too. `configureEqualityDeleteColumns()` establishes what the check looks for, earlier in the same call, so no query or table shape reaches the failure. It guards the invariant against a future regression, which is also why no test trips it.

**Test plan:** `EqualityDeleteFileReaderTestP.equalityDeleteColumnAddedBySecondSplit` runs the three-split scan above end to end, and returns two extra rows without the fix. One driver with split preload disabled is what makes the splits share a single `ScanSpec`; with preload on, each split gets its own spec and the bug does not reproduce. `ScanSpecTest` covers the snapshot on its own, without going through a reader.

An end-to-end test covering the same scenario through Presto is in
prestodb/presto#28445.
