### PR TITLE
refactor: Minor normalize gtest names for core

### DIFF
--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -393,7 +393,7 @@ TEST_F(SimdUtilTest, crc32) {
   EXPECT_EQ(checksum, 121285919);
 }
 
-TEST_F(SimdUtilTest, Batch64_assign) {
+TEST_F(SimdUtilTest, batch64Assign) {
   auto b = simd::Batch64<int32_t>::from({0, 1});
   EXPECT_EQ(b.data[0], 0);
   EXPECT_EQ(b.data[1], 1);
@@ -402,7 +402,7 @@ TEST_F(SimdUtilTest, Batch64_assign) {
   EXPECT_EQ(b.data[1], 1);
 }
 
-TEST_F(SimdUtilTest, Batch64_arithmetics) {
+TEST_F(SimdUtilTest, batch64Arithmetics) {
   auto b = simd::Batch64<int32_t>::from({0, 1});
   auto bb = b + 42;
   EXPECT_EQ(bb.data[0], 42);
@@ -412,7 +412,7 @@ TEST_F(SimdUtilTest, Batch64_arithmetics) {
   EXPECT_EQ(bb.data[1], 0);
 }
 
-TEST_F(SimdUtilTest, Batch64_memory) {
+TEST_F(SimdUtilTest, batch64Memory) {
   int32_t data[] = {0, 1};
   auto b = simd::Batch64<int32_t>::load_unaligned(data);
   EXPECT_EQ(b.data[0], 0);

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -791,7 +791,7 @@ class DynamicQuantilePatternTest
     : public StatsReporterTest,
       public testing::WithParamInterface<DynamicQuantilePatternTestCase> {};
 
-TEST_P(DynamicQuantilePatternTest, PatternScenarios) {
+TEST_P(DynamicQuantilePatternTest, patternScenarios) {
   const auto& testCase = GetParam();
   testCase.testFunc(this);
 }

--- a/velox/common/file/tests/FileUtilsTest.cpp
+++ b/velox/common/file/tests/FileUtilsTest.cpp
@@ -116,7 +116,7 @@ auto getReader(
 
 } // namespace
 
-TEST(CoalesceSegmentsTest, EmptyCase) {
+TEST(CoalesceSegmentsTest, emptyCase) {
   const Regions r = {};
 
   MockShouldCoalesce shouldCoalesce;
@@ -129,7 +129,7 @@ TEST(CoalesceSegmentsTest, EmptyCase) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeAll) {
+TEST(CoalesceSegmentsTest, mergeAll) {
   const Regions r = {{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}};
 
   MockShouldCoalesce shouldCoalesce;
@@ -146,7 +146,7 @@ TEST(CoalesceSegmentsTest, MergeAll) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeNone) {
+TEST(CoalesceSegmentsTest, mergeNone) {
   const Regions r = {{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}};
 
   MockShouldCoalesce shouldCoalesce;
@@ -164,7 +164,7 @@ TEST(CoalesceSegmentsTest, MergeNone) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeOdd) {
+TEST(CoalesceSegmentsTest, mergeOdd) {
   const Regions r = {{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}};
 
   auto isOdd = [](size_t i) { return i % 2 == 1; };
@@ -184,7 +184,7 @@ TEST(CoalesceSegmentsTest, MergeOdd) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeEven) {
+TEST(CoalesceSegmentsTest, mergeEven) {
   const Regions r = {{{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}}};
   auto isEven = [](size_t i) { return i % 2 == 0; };
 
@@ -203,7 +203,7 @@ TEST(CoalesceSegmentsTest, MergeEven) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceIfDistanceLETest, MultipleCases) {
+TEST(CoalesceIfDistanceLETest, multipleCases) {
   EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 1}, {1, 1}, 0));
   EXPECT_FALSE(willCoalesceIfDistanceLE(0, {0, 1}, {2, 1}, 0));
 
@@ -218,7 +218,7 @@ TEST(CoalesceIfDistanceLETest, MultipleCases) {
   EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 0}, {0, 1}, 0));
 }
 
-TEST(CoalesceIfDistanceLETest, MultipleSegments) {
+TEST(CoalesceIfDistanceLETest, multipleSegments) {
   uint64_t coalescedBytes = 0;
   auto willCoalesce = CoalesceIfDistanceLE(10, &coalescedBytes);
   EXPECT_TRUE(willCoalesce({0, 1}, {1, 1})); // 0
@@ -229,11 +229,11 @@ TEST(CoalesceIfDistanceLETest, MultipleSegments) {
   EXPECT_EQ(coalescedBytes, 19);
 }
 
-TEST(CoalesceIfDistanceLETest, SupportsNullArgument) {
+TEST(CoalesceIfDistanceLETest, supportsNullArgument) {
   EXPECT_NO_THROW(CoalesceIfDistanceLE(10, nullptr)({0, 10}, {20, 5})); // 10
 }
 
-TEST(CoalesceIfDistanceLETest, SegmentsMustBeSorted) {
+TEST(CoalesceIfDistanceLETest, segmentsMustBeSorted) {
   EXPECT_THROW(
       willCoalesceIfDistanceLE(0, {1, 1}, {0, 1}, 0),
       ::facebook::velox::VeloxRuntimeError);
@@ -248,7 +248,7 @@ TEST(CoalesceIfDistanceLETest, SegmentsMustBeSorted) {
       ::facebook::velox::VeloxRuntimeError);
 }
 
-TEST(CoalesceIfDistanceLETest, SegmentsCantOverlap) {
+TEST(CoalesceIfDistanceLETest, segmentsCantOverlap) {
   EXPECT_THROW(
       willCoalesceIfDistanceLE(0, {0, 1}, {0, 1}, 0),
       ::facebook::velox::VeloxRuntimeError);
@@ -271,7 +271,7 @@ TEST(CoalesceIfDistanceLETest, SegmentsCantOverlap) {
 
 class ReadToIOBufsTest : public testing::TestWithParam<bool> {};
 
-TEST_P(ReadToIOBufsTest, CanRead) {
+TEST_P(ReadToIOBufsTest, canRead) {
   Regions r = {{0, 1}, {5, 1}, {10, 6}, {16, 5}};
   std::vector<folly::IOBuf> iobufs;
   iobufs.reserve(r.size());

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -1523,7 +1523,7 @@ TEST_P(MemoryAllocatorTest, allocateZeroFilled) {
   ASSERT_TRUE(instance_->checkConsistency());
 }
 
-TEST_P(MemoryAllocatorTest, StlMemoryAllocator) {
+TEST_P(MemoryAllocatorTest, stlMemoryAllocator) {
   {
     std::vector<double, StlAllocator<double>> data(
         0, StlAllocator<double>(*pool_));

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -677,7 +677,7 @@ TEST_P(MemoryPoolTest, releasableMemory) {
   }
 }
 
-TEST_P(MemoryPoolTest, ReallocTestSameSize) {
+TEST_P(MemoryPoolTest, reallocTestSameSize) {
   auto manager = getMemoryManager();
   auto root = manager->addRootPool();
 
@@ -699,7 +699,7 @@ TEST_P(MemoryPoolTest, ReallocTestSameSize) {
   ASSERT_EQ(2 * kChunkSize, pool->stats().peakBytes);
 }
 
-TEST_P(MemoryPoolTest, ReallocTestHigher) {
+TEST_P(MemoryPoolTest, reallocTestHigher) {
   auto manager = getMemoryManager();
   auto root = manager->addRootPool();
 
@@ -720,7 +720,7 @@ TEST_P(MemoryPoolTest, ReallocTestHigher) {
   EXPECT_EQ(4 * kChunkSize, pool->stats().peakBytes);
 }
 
-TEST_P(MemoryPoolTest, ReallocTestLower) {
+TEST_P(MemoryPoolTest, reallocTestLower) {
   auto manager = getMemoryManager();
   auto root = manager->addRootPool();
   auto pool = root->addLeafChild("elastic_quota", isLeafThreadSafe_);
@@ -905,7 +905,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
   }
 }
 
-TEST(MemoryPoolTest, GetAlignment) {
+TEST(MemoryPoolTest, getAlignment) {
   {
     MemoryManager::Options options;
     options.allocatorCapacity = kMaxMemory;
@@ -972,7 +972,7 @@ TEST(MemoryPoolTest, allocateAlignedTracksUsage) {
   EXPECT_GT(pool->stats().numFrees, statsBefore.numFrees);
 }
 
-TEST_P(MemoryPoolTest, MemoryManagerGlobalCap) {
+TEST_P(MemoryPoolTest, memoryManagerGlobalCap) {
   MemoryManager::Options options;
   options.allocatorCapacity = 32L * MB;
   options.arbitratorCapacity = 32L * MB;

--- a/velox/common/serialization/tests/TestRegistry.cpp
+++ b/velox/common/serialization/tests/TestRegistry.cpp
@@ -21,7 +21,7 @@
 using namespace ::facebook::velox;
 
 namespace {
-TEST(Registry, SmartPointerFactoryWithNoArgument) {
+TEST(Registry, smartPointerFactoryWithNoArgument) {
   Registry<size_t, std::unique_ptr<size_t>()> registry;
 
   const size_t key = 0;
@@ -38,7 +38,7 @@ TEST(Registry, SmartPointerFactoryWithNoArgument) {
   EXPECT_EQ(*registry.Create(key), value);
 }
 
-TEST(Registry, ValueFactoryWithArguments) {
+TEST(Registry, valueFactoryWithArguments) {
   Registry<size_t, size_t(size_t, size_t)> registry;
 
   const size_t key = 0;

--- a/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
@@ -592,7 +592,7 @@ TEST_F(IcebergParquetStatsTest, mixedDoubleFloat) {
   EXPECT_FLOAT_EQ(maxFloatVal, -std::numeric_limits<float>::infinity());
 }
 
-TEST_F(IcebergParquetStatsTest, NaN) {
+TEST_F(IcebergParquetStatsTest, nan) {
   constexpr vector_size_t size = 1'000;
   constexpr int32_t expectedNulls = 500;
   constexpr int32_t doubleColId = 1;

--- a/velox/core/tests/StringTest.cpp
+++ b/velox/core/tests/StringTest.cpp
@@ -27,7 +27,7 @@ StringWriter createStringWriter(const std::string& str) {
 }
 } // namespace
 
-TEST(String, StringWriter) {
+TEST(String, stringWriter) {
   // Default constructor & empty string copy.
   {
     const std::string emptyString;

--- a/velox/exec/fuzzer/tests/LocalRunnerServiceTest.cpp
+++ b/velox/exec/fuzzer/tests/LocalRunnerServiceTest.cpp
@@ -158,7 +158,7 @@ class LocalRunnerServiceTest : public functions::test::FunctionBaseTest {
   RowVectorPtr testRowVectorWrapped_;
 };
 
-TEST_F(LocalRunnerServiceTest, ConvertToBatchesRoundTrip) {
+TEST_F(LocalRunnerServiceTest, convertToBatchesRoundTrip) {
   auto result = facebook::velox::runner::convertToBatches(
       {testRowVector_}, rootPool_.get());
 
@@ -199,7 +199,7 @@ TEST_F(LocalRunnerServiceTest, ConvertToBatchesRoundTrip) {
   assertEqualVectors(deserialized, testRowVector_);
 }
 
-TEST_F(LocalRunnerServiceTest, ServiceHandlerMockRequestIntegration) {
+TEST_F(LocalRunnerServiceTest, serviceHandlerMockRequestIntegration) {
   LocalRunnerServiceHandler handler;
 
   auto request = std::make_unique<ExecutePlanRequest>();
@@ -223,7 +223,7 @@ TEST_F(LocalRunnerServiceTest, ServiceHandlerMockRequestIntegration) {
   EXPECT_GT(batch.serializedData()->size(), 0);
 }
 
-TEST_F(LocalRunnerServiceTest, ServiceHandlerMockRequestIntegrationFailure) {
+TEST_F(LocalRunnerServiceTest, serviceHandlerMockRequestIntegrationFailure) {
   LocalRunnerServiceHandler handler;
 
   auto request = std::make_unique<ExecutePlanRequest>();

--- a/velox/exec/tests/TraceUtilTest.cpp
+++ b/velox/exec/tests/TraceUtilTest.cpp
@@ -83,7 +83,7 @@ TEST_F(TraceUtilTest, traceDir) {
   }
 }
 
-TEST_F(TraceUtilTest, OperatorTraceSummary) {
+TEST_F(TraceUtilTest, operatorTraceSummary) {
   exec::trace::OperatorTraceSummary summary;
   summary.opType = "summary";
   summary.inputRows = 100;

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -1931,7 +1931,7 @@ DEBUG_ONLY_TEST_F(WindowTest, reserveMemorySort) {
   }
 }
 
-TEST_F(WindowTest, NaNFrameBound) {
+TEST_F(WindowTest, nanFrameBound) {
   const auto kNan = std::numeric_limits<double>::quiet_NaN();
   auto data = makeRowVector(
       {"c0", "s0", "off0", "off1"},

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -86,7 +86,7 @@ TEST_F(GenericWriterTest, integer) {
       result);
 }
 
-TEST_F(GenericWriterTest, ArrayOfGeneric) {
+TEST_F(GenericWriterTest, arrayOfGeneric) {
   VectorPtr result;
   BaseVector::ensureWritable(
       SelectivityVector(2), ARRAY(BIGINT()), pool(), result);
@@ -127,7 +127,7 @@ struct ArrayTrimFunction {
   }
 };
 
-TEST_F(GenericWriterTest, ArrayTrim) {
+TEST_F(GenericWriterTest, arrayTrim) {
   registerFunction<
       ArrayTrimFunction,
       Array<Generic<T1>>,

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -107,7 +107,7 @@ TEST_F(StringWriterTest, copyFromCString) {
   ASSERT_EQ(vector->valueAt(0), "1 2 3 4 5 "_sv);
 }
 
-TEST_F(StringWriterTest, CheckSizeLimit) {
+TEST_F(StringWriterTest, checkSizeLimit) {
   auto vector = makeFlatVector<StringView>(4);
   auto writer = exec::StringWriter(vector.get(), 0);
 

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -1253,7 +1253,7 @@ TEST_F(StringImplTest, pad) {
 
 // Make sure that utf8proc_codepoint returns invalid codepoint (-1) for
 // incomplete character of length>1.
-TEST_F(StringImplTest, utf8proc_codepoint) {
+TEST_F(StringImplTest, utf8procCodepoint) {
   int size;
 
   std::string twoBytesChar = "\xdd\x81";

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -2548,7 +2548,7 @@ TEST_F(MinMaxByTest, nans) {
   testNanFloatValues<double>();
 }
 
-TEST_F(MinMaxByTest, TimestampWithTimezone) {
+TEST_F(MinMaxByTest, timestampWithTimezone) {
   auto data = makeRowVector(
       {// output column for min_by/max_by
        makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8}),

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -673,7 +673,7 @@ TEST_F(MinMaxTest, failOnUnorderableType) {
   }
 }
 
-TEST_F(MinMaxTest, TimestampWithTimezone) {
+TEST_F(MinMaxTest, timestampWithTimezone) {
   auto data = makeRowVector({
       makeFlatVector<int64_t>(
           {pack(-1, 2),

--- a/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
@@ -873,7 +873,7 @@ TEST_F(SetAggTest, nans) {
       {data}, {"c1"}, {"set_agg(c0)"}, {"array_sort(a0)", "c1"}, {expected});
 }
 
-TEST_F(SetAggTest, TimestampWithTimezone) {
+TEST_F(SetAggTest, timestampWithTimezone) {
   // Global aggregation, Primitive type.
   auto data = makeRowVector({
       makeFlatVector<int64_t>(

--- a/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
@@ -606,7 +606,7 @@ TEST_F(SetUnionTest, nans) {
       {data}, {"c1"}, {"set_union(c0)"}, {"array_sort(a0)", "c1"}, {expected});
 }
 
-TEST_F(SetUnionTest, TimestampWithTimeZone) {
+TEST_F(SetUnionTest, timestampWithTimeZone) {
   // Global aggregation, Primitive type.
   auto data = makeRowVector({
       makeArrayVector<int64_t>(

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -877,7 +877,7 @@ TEST_F(ArraySortTest, floatingPointExtremes) {
   testFloatingPoint<double>();
 }
 
-TEST_F(ArraySortTest, constant_desc_boolean) {
+TEST_F(ArraySortTest, constantDescBoolean) {
   auto data = makeRowVector({makeNullableArrayVector<bool>({
       {false, true, std::nullopt, false, true, false, false},
       {true, false, true, false, false, std::nullopt},

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -317,7 +317,7 @@ TEST_F(ArraysOverlapTest, dictionaryEncodedElementsInConstant) {
       {array});
 }
 
-TEST_F(ArraysOverlapTest, TimestampWithTimezone) {
+TEST_F(ArraysOverlapTest, timestampWithTimezone) {
   auto testArraysOverlap =
       [this](
           const std::vector<std::optional<int64_t>>& array1,

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -167,7 +167,7 @@ TEST_F(BinaryFunctionsTest, spookyHashV264) {
       spookyHashV264("more_than_12_characters_string"));
 }
 
-TEST_F(BinaryFunctionsTest, HmacSha1) {
+TEST_F(BinaryFunctionsTest, hmacSha1) {
   const auto hmacSha1 = [&](std::optional<std::string> arg,
                             std::optional<std::string> key) {
     return evaluateOnce<std::string>(
@@ -205,7 +205,7 @@ TEST_F(BinaryFunctionsTest, HmacSha1) {
   EXPECT_EQ(std::nullopt, hmacSha1("velox", std::nullopt));
 }
 
-TEST_F(BinaryFunctionsTest, HmacSha256) {
+TEST_F(BinaryFunctionsTest, hmacSha256) {
   const auto hmacSha256 = [&](std::optional<std::string> arg,
                               std::optional<std::string> key) {
     return evaluateOnce<std::string>(
@@ -237,7 +237,7 @@ TEST_F(BinaryFunctionsTest, HmacSha256) {
   EXPECT_EQ(std::nullopt, hmacSha256(std::nullopt, "velox"));
 }
 
-TEST_F(BinaryFunctionsTest, HmacSha512) {
+TEST_F(BinaryFunctionsTest, hmacSha512) {
   const auto hmacSha512 = [&](std::optional<std::string> arg,
                               std::optional<std::string> key) {
     return evaluateOnce<std::string>(
@@ -259,7 +259,7 @@ TEST_F(BinaryFunctionsTest, HmacSha512) {
 
 // Note: this test fails in a FIPS enabled environment because OpenSSL restricts
 // usage of MD5 for hmacs.
-TEST_F(BinaryFunctionsTest, HmacMd5) {
+TEST_F(BinaryFunctionsTest, hmacMd5) {
   const auto hmacMd5 = [&](std::optional<std::string> arg,
                            std::optional<std::string> key) {
     return evaluateOnce<std::string>(
@@ -367,7 +367,7 @@ TEST_F(BinaryFunctionsTest, xxhash128WithSeed) {
       xxhash128WithSeed("hashme", 0));
 }
 
-TEST_F(BinaryFunctionsTest, fnv1_32) {
+TEST_F(BinaryFunctionsTest, fnv132) {
   const auto fnv1_32 = [&](std::optional<std::string> arg) {
     return evaluateOnce<int32_t>("fnv1_32(c0)", VARBINARY(), arg);
   };
@@ -380,7 +380,7 @@ TEST_F(BinaryFunctionsTest, fnv1_32) {
   EXPECT_EQ(0x9f2263f3, fnv1_32(hexToDec("232706FC6BF50919")));
 }
 
-TEST_F(BinaryFunctionsTest, fnv1_64) {
+TEST_F(BinaryFunctionsTest, fnv164) {
   const auto fnv1_64 = [&](std::optional<std::string> arg) {
     return evaluateOnce<int64_t>("fnv1_64(c0)", VARBINARY(), arg);
   };
@@ -390,7 +390,7 @@ TEST_F(BinaryFunctionsTest, fnv1_64) {
   EXPECT_EQ(0x4a65ff96675a9f33L, fnv1_64(hexToDec("232706FC6BF50919")));
 }
 
-TEST_F(BinaryFunctionsTest, fnv1a_32) {
+TEST_F(BinaryFunctionsTest, fnv1a32) {
   const auto fnv1a_32 = [&](std::optional<std::string> arg) {
     return evaluateOnce<int32_t>("fnv1a_32(c0)", VARBINARY(), arg);
   };
@@ -404,7 +404,7 @@ TEST_F(BinaryFunctionsTest, fnv1a_32) {
   EXPECT_EQ(0x0951d55f, fnv1a_32(hexToDec("232706FC6BF50919")));
 }
 
-TEST_F(BinaryFunctionsTest, fnv1a_64) {
+TEST_F(BinaryFunctionsTest, fnv1a64) {
   const auto fnv1a_64 = [&](std::optional<std::string> arg) {
     return evaluateOnce<int64_t>("fnv1a_64(c0)", VARBINARY(), arg);
   };
@@ -975,7 +975,7 @@ TEST_F(BinaryFunctionsTest, lpad) {
   VELOX_ASSERT_USER_THROW(lpad("2312", 1, ""), "padString must not be empty");
 }
 
-TEST_F(BinaryFunctionsTest, murmur3_x64_128) {
+TEST_F(BinaryFunctionsTest, murmur3X64128) {
   const auto murmur3_x64_128 = [&](std::optional<std::string> arg) {
     return evaluateOnce<std::string>(
         "murmur3_x64_128(c0)", VARBINARY(), std::move(arg));

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -935,7 +935,7 @@ TEST_F(ComparisonsTest, nanComparison) {
   testNaN("", input, false);
 }
 
-TEST_F(ComparisonsTest, TimestampWithTimezone) {
+TEST_F(ComparisonsTest, timestampWithTimezone) {
   auto makeTimestampWithTimezone = [](int64_t millis, const std::string& tz) {
     return pack(millis, tz::getTimeZoneID(tz));
   };
@@ -1167,7 +1167,7 @@ TEST_F(ComparisonsTest, TimestampWithTimezone) {
            false}));
 }
 
-TEST_F(ComparisonsTest, IPPrefixType) {
+TEST_F(ComparisonsTest, ipPrefixType) {
   auto ipprefix = [](const std::string& ipprefixString) {
     auto tryIpPrefix = ipaddress::tryParseIpPrefixString(ipprefixString);
     return variant::row(
@@ -1449,7 +1449,7 @@ TEST_F(ComparisonsTest, IPPrefixType) {
   }
 }
 
-TEST_F(ComparisonsTest, IpAddressType) {
+TEST_F(ComparisonsTest, ipAddressType) {
   auto makeIpAdressFromString = [](std::string_view ipAddr) -> int128_t {
     auto ret = ipaddress::tryGetIPv6asInt128FromString(ipAddr);
     return ret.value();
@@ -1712,7 +1712,7 @@ TEST_F(ComparisonsTest, IpAddressType) {
            std::nullopt}));
 }
 
-TEST_F(ComparisonsTest, CustomComparisonWithGenerics) {
+TEST_F(ComparisonsTest, customComparisonWithGenerics) {
   // Tests that functions that support signatures with generics handle custom
   // comparison correctly.
   auto input = makeRowVector({

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -4993,7 +4993,7 @@ TEST_F(DateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
           "%y-%M-%e %T %p", TimestampWithTimezone(-20220915000, "-03:00")));
 }
 
-TEST_F(DateTimeFunctionsTest, test_week_year) {
+TEST_F(DateTimeFunctionsTest, testWeekYear) {
   const auto dateFormat = [&](std::optional<Timestamp> timestamp,
                               std::optional<std::string> format) {
     return evaluateOnce<std::string>("date_format(c0, c1)", timestamp, format);

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -216,7 +216,7 @@ TEST_F(IPAddressFunctionsTest, ipSubnetMax) {
       "2001:db8:85a3:1:1:8a2e:370:7334");
 }
 
-TEST_F(IPAddressFunctionsTest, IPSubnetRange) {
+TEST_F(IPAddressFunctionsTest, ipSubnetRange) {
   ASSERT_EQ("192.0.0.0", ipSubnetRangeMin("192.64.1.1/9"));
   ASSERT_EQ("192.127.255.255", ipSubnetRangeMax("192.64.1.1/9"));
   ASSERT_EQ("0.0.0.0", ipSubnetRangeMin("192.64.1.1/0"));
@@ -271,7 +271,7 @@ TEST_F(IPAddressFunctionsTest, IPSubnetRange) {
   ASSERT_EQ("64:ff9b::17", ipSubnetRangeMax("64:ff9b::17/128"));
 }
 
-TEST_F(IPAddressFunctionsTest, IPSubnetOfIPPrefix) {
+TEST_F(IPAddressFunctionsTest, ipSubnetOfIPPrefix) {
   EXPECT_EQ(isSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.144/30"), true);
   EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/64", "64:ffff::17/64"), false);
   EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/32", "64:ffff::17/24"), false);
@@ -298,7 +298,7 @@ TEST_F(IPAddressFunctionsTest, IPSubnetOfIPPrefix) {
   EXPECT_EQ(isSubnetOfIPPrefix("170.0.52.0/24", "170.0.52.0/22"), false);
 }
 
-TEST_F(IPAddressFunctionsTest, IPPrefixCollapseTest) {
+TEST_F(IPAddressFunctionsTest, ipPrefixCollapseTest) {
   auto makeIPPrefixFunc =
       [](const std::string& ipprefix) -> std::tuple<int128_t, int8_t> {
     auto ret = ipaddress::tryParseIpPrefixString(ipprefix);
@@ -553,7 +553,7 @@ TEST_F(IPAddressFunctionsTest, IPPrefixCollapseTest) {
   }
 }
 
-TEST_F(IPAddressFunctionsTest, IPPrefixSubnetsTest) {
+TEST_F(IPAddressFunctionsTest, ipPrefixSubnetsTest) {
   auto ipprefix = [](const std::string& ipprefixString) {
     auto tryIpPrefix = ipaddress::tryParseIpPrefixString(ipprefixString);
     return variant::row(
@@ -630,7 +630,7 @@ TEST_F(IPAddressFunctionsTest, IPPrefixSubnetsTest) {
   }
 }
 
-TEST_F(IPAddressFunctionsTest, IsPrivateIPTest) {
+TEST_F(IPAddressFunctionsTest, isPrivateIPTest) {
   const static std::vector<std::string> privateIpAddresses = {
       // The first and last IP address in each private range
       {"0.0.0.0"},

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -1112,7 +1112,7 @@ TEST_F(InPredicateTest, nans) {
   testNaNs<double>();
 }
 
-TEST_F(InPredicateTest, TimestampWithTimeZone) {
+TEST_F(InPredicateTest, timestampWithTimeZone) {
   // The millis ranges from 0-17, but after every 17th row we increment the time
   // zone ID, so that no two rows have the same millis and time zone.  However,
   // by the semantics of TimestampWithTimeZone's comparison, it's the same 17
@@ -1123,7 +1123,7 @@ TEST_F(InPredicateTest, TimestampWithTimeZone) {
   testConstantValues<int64_t>(TIMESTAMP_WITH_TIME_ZONE(), valueAt);
 }
 
-TEST_F(InPredicateTest, BadTimestampsWithTry) {
+TEST_F(InPredicateTest, badTimestampsWithTry) {
   // Test that errors thrown while evaluating the filter are propagated
   // correctly to the TRY.
   // We do this using the maximum possible timestamp value, when evaulating the

--- a/velox/functions/prestosql/tests/SplitToMapTest.cpp
+++ b/velox/functions/prestosql/tests/SplitToMapTest.cpp
@@ -80,7 +80,7 @@ TEST_F(SplitToMapTest, basic) {
   tryCallFunc(data);
 }
 
-TEST_F(SplitToMapTest, MultiCharKeyValueDelimiter) {
+TEST_F(SplitToMapTest, multiCharKeyValueDelimiter) {
   const auto callFunc = [&](const RowVectorPtr& input) {
     return evaluate("split_to_map(c0, ',', ';=')", input);
   };
@@ -129,7 +129,7 @@ TEST_F(SplitToMapTest, MultiCharKeyValueDelimiter) {
   tryCallFunc(data);
 }
 
-TEST_F(SplitToMapTest, MultiCharEntryDelimiter) {
+TEST_F(SplitToMapTest, multiCharEntryDelimiter) {
   const auto callFunc = [&](const RowVectorPtr& input) {
     return evaluate("split_to_map(c0, ';;', ';')", input);
   };

--- a/velox/functions/sparksql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/VarianceAggregationTest.cpp
@@ -95,7 +95,7 @@ TEST_F(VarianceAggregationTest, stddev) {
   testVarianceAggregate("stddev");
 }
 
-TEST_F(VarianceAggregationTest, stddev_samp) {
+TEST_F(VarianceAggregationTest, stddevSamp) {
   testVarianceAggregate("stddev_samp");
 }
 
@@ -103,7 +103,7 @@ TEST_F(VarianceAggregationTest, variance) {
   testVarianceAggregate("variance");
 }
 
-TEST_F(VarianceAggregationTest, var_samp) {
+TEST_F(VarianceAggregationTest, varSamp) {
   testVarianceAggregate("var_samp");
 }
 

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -325,7 +325,7 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   static constexpr double kInfDouble = std::numeric_limits<double>::infinity();
 };
 
-TEST_F(ArithmeticTest, UnaryMinus) {
+TEST_F(ArithmeticTest, unaryMinus) {
   EXPECT_EQ(unaryminus<int8_t>(1), -1);
   EXPECT_EQ(unaryminus<int16_t>(2), -2);
   EXPECT_EQ(unaryminus<int32_t>(3), -3);
@@ -361,7 +361,7 @@ TEST_F(ArithmeticTest, unaryMinusAnsi) {
   VELOX_ASSERT_THROW(unaryminus<int64_t>(INT64_MIN), "Arithmetic overflow");
 }
 
-TEST_F(ArithmeticTest, Divide) {
+TEST_F(ArithmeticTest, divide) {
   // Null cases.
   EXPECT_EQ(divide(std::nullopt, std::nullopt), std::nullopt);
   EXPECT_EQ(divide(std::nullopt, 1), std::nullopt);
@@ -529,7 +529,7 @@ class CeilFloorTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(CeilFloorTest, Limits) {
+TEST_F(CeilFloorTest, limits) {
   EXPECT_EQ(1, ceil<int64_t>(1));
   EXPECT_EQ(-1, ceil<int64_t>(-1));
   EXPECT_EQ(3, ceil<double>(2.878));

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -68,7 +68,7 @@ class HashTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(HashTest, String) {
+TEST_F(HashTest, string) {
   EXPECT_EQ(hash<std::string>("Spark"), 228093765);
   EXPECT_EQ(hash<std::string>(""), 142593372);
   EXPECT_EQ(hash<std::string>("abcdefghijklmnopqrstuvwxyz"), -1990933474);
@@ -88,11 +88,11 @@ TEST_F(HashTest, longDecimal) {
 
 // Spark CLI select timestamp_micros(12345678) to get the Timestamp.
 // select hash(Timestamp("1970-01-01 00:00:12.345678")) to get the hash value.
-TEST_F(HashTest, Timestamp) {
+TEST_F(HashTest, timestamp) {
   EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(12345678)), 1402875301);
 }
 
-TEST_F(HashTest, Int64) {
+TEST_F(HashTest, int64) {
   EXPECT_EQ(hash<int64_t>(0xcafecafedeadbeef), -256235155);
   EXPECT_EQ(hash<int64_t>(0xdeadbeefcafecafe), 673261790);
   EXPECT_EQ(hash<int64_t>(INT64_MAX), -1604625029);
@@ -103,7 +103,7 @@ TEST_F(HashTest, Int64) {
   EXPECT_EQ(hash<int64_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Int32) {
+TEST_F(HashTest, int32) {
   EXPECT_EQ(hash<int32_t>(0xdeadbeef), 141248195);
   EXPECT_EQ(hash<int32_t>(0xcafecafe), 638354558);
   EXPECT_EQ(hash<int32_t>(1), -559580957);
@@ -112,27 +112,27 @@ TEST_F(HashTest, Int32) {
   EXPECT_EQ(hash<int32_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Int16) {
+TEST_F(HashTest, int16) {
   EXPECT_EQ(hash<int16_t>(1), -559580957);
   EXPECT_EQ(hash<int16_t>(0), 933211791);
   EXPECT_EQ(hash<int16_t>(-1), -1604776387);
   EXPECT_EQ(hash<int16_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Int8) {
+TEST_F(HashTest, int8) {
   EXPECT_EQ(hash<int8_t>(1), -559580957);
   EXPECT_EQ(hash<int8_t>(0), 933211791);
   EXPECT_EQ(hash<int8_t>(-1), -1604776387);
   EXPECT_EQ(hash<int8_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Bool) {
+TEST_F(HashTest, bool) {
   EXPECT_EQ(hash<bool>(false), 933211791);
   EXPECT_EQ(hash<bool>(true), -559580957);
   EXPECT_EQ(hash<bool>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, StringInt32) {
+TEST_F(HashTest, stringInt32) {
   auto hash = [&](std::optional<std::string> a, std::optional<int32_t> b) {
     return evaluateOnce<int32_t>("hash(c0, c1)", a, b);
   };
@@ -143,7 +143,7 @@ TEST_F(HashTest, StringInt32) {
   EXPECT_EQ(hash("", 0), 1143746540);
 }
 
-TEST_F(HashTest, Double) {
+TEST_F(HashTest, double) {
   using limits = std::numeric_limits<double>;
 
   EXPECT_EQ(hash<double>(std::nullopt), 42);
@@ -155,7 +155,7 @@ TEST_F(HashTest, Double) {
   EXPECT_EQ(hash<double>(-limits::infinity()), 461104036);
 }
 
-TEST_F(HashTest, Float) {
+TEST_F(HashTest, float) {
   using limits = std::numeric_limits<float>;
 
   EXPECT_EQ(hash<float>(std::nullopt), 42);

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -126,7 +126,7 @@ class InTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(InTest, Int64) {
+TEST_F(InTest, int64) {
   EXPECT_EQ(in<int64_t>(1, {1, 2}), true);
   EXPECT_EQ(in<int64_t>(2, {1, 2}), true);
   EXPECT_EQ(in<int64_t>(3, {1, 2}), false);
@@ -137,7 +137,7 @@ TEST_F(InTest, Int64) {
   EXPECT_EQ(in<int64_t>(std::nullopt, {1, std::nullopt, 2}), std::nullopt);
 }
 
-TEST_F(InTest, Float) {
+TEST_F(InTest, float) {
   EXPECT_EQ(in<float>(1.0, {-1.0, 1.0, 2.0}), true);
   EXPECT_EQ(in<float>(0, {-1.0, 1.0}), false);
   EXPECT_EQ(in<float>(0, {std::nullopt, 1.0}), std::nullopt);
@@ -147,7 +147,7 @@ TEST_F(InTest, Float) {
   EXPECT_EQ(in<float>(std::nanf("1"), {kNan, -1.0, 0.0, 1.0}), true);
 }
 
-TEST_F(InTest, Double) {
+TEST_F(InTest, double) {
   EXPECT_EQ(in<double>(1.0, {-1.0, 1.0, 2.0}), true);
   EXPECT_EQ(in<double>(0, {-1.0, 1.0}), false);
   EXPECT_EQ(in<double>(-0.0, {-1.0, 0.0, 1.0}), true);
@@ -161,7 +161,7 @@ TEST_F(InTest, Double) {
   EXPECT_EQ(in<double>(-kInf, {kNan, -1.0, 0.0, 1.0, -kInf}), true);
 }
 
-TEST_F(InTest, String) {
+TEST_F(InTest, string) {
   EXPECT_EQ(in<std::string>("", {"", std::nullopt}), true);
   EXPECT_EQ(in<std::string>("a", {"", std::nullopt}), std::nullopt);
   EXPECT_EQ(in<std::string>("a", {"", "b"}), false);
@@ -173,7 +173,7 @@ TEST_F(InTest, String) {
       std::nullopt);
 }
 
-TEST_F(InTest, Timestamp) {
+TEST_F(InTest, timestamp) {
   EXPECT_EQ(
       in<Timestamp>(Timestamp(0, 0), {Timestamp(1, 0), std::nullopt}),
       std::nullopt);
@@ -193,12 +193,12 @@ TEST_F(InTest, Timestamp) {
       true);
 }
 
-TEST_F(InTest, Date) {
+TEST_F(InTest, date) {
   EXPECT_EQ(in<int32_t>(0, {1, std::nullopt}, DATE()), std::nullopt);
   EXPECT_EQ(in<int32_t>(0, {0}, DATE()), true);
 }
 
-TEST_F(InTest, Bool) {
+TEST_F(InTest, bool) {
   EXPECT_EQ(in<bool>(true, {true, false, std::nullopt}), true);
   EXPECT_EQ(in<bool>(true, {false, std::nullopt}), std::nullopt);
   EXPECT_EQ(in<bool>(true, {false}), false);
@@ -243,7 +243,7 @@ TEST_F(InTest, longDecimal) {
       true);
 }
 
-TEST_F(InTest, Const) {
+TEST_F(InTest, const) {
   const auto eval = [&](const std::string& expr) {
     return evaluateOnce<bool, bool>(expr, false);
   };
@@ -255,7 +255,7 @@ TEST_F(InTest, Const) {
 
 /// Test IN applied to first argument that is dictionary encoded, but has the
 /// same value in all requested rows.
-TEST_F(InTest, ConstantDictionary) {
+TEST_F(InTest, constantDictionary) {
   auto data = makeFlatVector<int32_t>({1, 2, 3, 4});
   EXPECT_EQ(
       evaluateOnce<bool>(

--- a/velox/functions/sparksql/tests/MapTest.cpp
+++ b/velox/functions/sparksql/tests/MapTest.cpp
@@ -45,7 +45,7 @@ class MapTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(MapTest, Basics) {
+TEST_F(MapTest, basics) {
   auto inputVector1 = makeNullableFlatVector<int64_t>({1, 2, 3});
   auto inputVector2 = makeNullableFlatVector<int64_t>({4, 5, 6});
   auto mapVector =
@@ -53,7 +53,7 @@ TEST_F(MapTest, Basics) {
   testMap("map(c0, c1)", {inputVector1, inputVector2}, mapVector);
 }
 
-TEST_F(MapTest, Nulls) {
+TEST_F(MapTest, nulls) {
   auto inputVector1 = makeNullableFlatVector<int64_t>({1, 2, 3});
   auto inputVector2 =
       makeNullableFlatVector<int64_t>({std::nullopt, 5, std::nullopt});

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -97,7 +97,7 @@ TEST_F(XxHash64Test, longDecimal) {
 // Spark CLI select timestamp_micros(12345678) to get the Timestamp.
 // select xxhash64(Timestamp("1970-01-01 00:00:12.345678")) to get the hash
 // value.
-TEST_F(XxHash64Test, Timestamp) {
+TEST_F(XxHash64Test, timestamp) {
   EXPECT_EQ(
       xxhash64<Timestamp>(Timestamp::fromMicros(12345678)), 782671362992292307);
 }

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -2145,7 +2145,7 @@ TEST_F(ArrowBridgeArrayImportAsViewerTest, timestampUtc) {
   testTimestampUtcRoundtrip();
 }
 
-TEST_F(ArrowBridgeArrayImportAsViewerTest, without_nulls_buffer) {
+TEST_F(ArrowBridgeArrayImportAsViewerTest, withoutNullsBuffer) {
   std::vector<std::optional<int64_t>> inputValues = {1, 2, 3, 4, 5};
   testImportWithoutNullsBuffer<int64_t>(inputValues, "l");
   testImportWithoutNullsBuffer<Timestamp>(inputValues, "tsn:");
@@ -2264,7 +2264,7 @@ TEST_F(ArrowBridgeArrayImportAsOwnerTest, timestampUtc) {
   testTimestampUtcRoundtrip();
 }
 
-TEST_F(ArrowBridgeArrayImportAsOwnerTest, without_nulls_buffer) {
+TEST_F(ArrowBridgeArrayImportAsOwnerTest, withoutNullsBuffer) {
   std::vector<std::optional<int64_t>> inputValues = {1, 2, 3, 4, 5};
   testImportWithoutNullsBuffer<int64_t>(inputValues, "l");
   testImportWithoutNullsBuffer<Timestamp>(inputValues, "tsn:");

--- a/velox/vector/tests/BiasVectorTest.cpp
+++ b/velox/vector/tests/BiasVectorTest.cpp
@@ -104,11 +104,11 @@ class BiasVectorOverflowTest : public BiasVectorTestBase {
 using inputTypes = ::testing::Types<int16_t, int32_t, int64_t>;
 VELOX_TYPED_TEST_SUITE(BiasVectorOverflowTest, inputTypes);
 
-TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int8) {
+TYPED_TEST(BiasVectorOverflowTest, maxOverflowTestDeltaInt8) {
   this->runMaxOverflowTest(std::numeric_limits<int8_t>::max());
 }
 
-TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int16) {
+TYPED_TEST(BiasVectorOverflowTest, maxOverflowTestDeltaInt16) {
   size_t delta = std::numeric_limits<int16_t>::max();
   if constexpr (std::is_same_v<TypeParam, int16_t>) {
     delta = std::numeric_limits<int8_t>::max();
@@ -116,7 +116,7 @@ TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int16) {
   this->runMaxOverflowTest(delta);
 }
 
-TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int32) {
+TYPED_TEST(BiasVectorOverflowTest, maxOverflowTestDeltaInt32) {
   using T = TypeParam;
   size_t delta = std::numeric_limits<int32_t>::max();
   if constexpr (std::is_same_v<T, int16_t>) {
@@ -130,11 +130,11 @@ TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int32) {
   this->runMaxOverflowTest(delta);
 }
 
-TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int8) {
+TYPED_TEST(BiasVectorOverflowTest, minOverflowTestDeltaInt8) {
   this->runMinOverflowTest(std::numeric_limits<int8_t>::max() + 1);
 }
 
-TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int16) {
+TYPED_TEST(BiasVectorOverflowTest, minOverflowTestDeltaInt16) {
   size_t delta = std::numeric_limits<int16_t>::max();
   if constexpr (std::is_same_v<TypeParam, int16_t>) {
     delta = std::numeric_limits<int8_t>::max();
@@ -143,7 +143,7 @@ TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int16) {
   this->runMinOverflowTest(delta);
 }
 
-TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int32) {
+TYPED_TEST(BiasVectorOverflowTest, minOverflowTestDeltaInt32) {
   using T = TypeParam;
   size_t delta = std::numeric_limits<int32_t>::max();
   if constexpr (std::is_same_v<T, int16_t>) {

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -100,11 +100,11 @@ void setValid_normal(bool setToValue) {
 
 } // namespace
 
-TEST(SelectivityVectorTest, setValid_true_normal) {
+TEST(SelectivityVectorTest, setValidTrueNormal) {
   setValid_normal(true);
 }
 
-TEST(SelectivityVectorTest, setValid_false_normal) {
+TEST(SelectivityVectorTest, setValidFalseNormal) {
   setValid_normal(false);
 }
 
@@ -271,11 +271,11 @@ void testEquals(
 
 } // namespace
 
-TEST(SelectivityVectorTest, operatorEquals_allEqual) {
+TEST(SelectivityVectorTest, operatorEqualsAllEqual) {
   testEquals(true /*expectEqual*/);
 }
 
-TEST(SelectivityVectorTest, operatorEquals_dataNotEqual) {
+TEST(SelectivityVectorTest, operatorEqualsDataNotEqual) {
   testEquals(
       false /*expectEqual*/, [](auto& vector) { vector.setValid(10, false); });
 }

--- a/velox/vector/tests/SimpleVectorTest.cpp
+++ b/velox/vector/tests/SimpleVectorTest.cpp
@@ -70,14 +70,14 @@ class SimpleVectorNonParameterizedTest : public SimpleVectorTest {
       {"àá"_sv, "abc"_sv, "xyz"_sv, "mno"_sv, "wv"_sv, "abc"_sv, "xyz"_sv};
 };
 
-TEST_F(SimpleVectorNonParameterizedTest, ConstantVectorTest) {
+TEST_F(SimpleVectorNonParameterizedTest, constantVectorTest) {
   ExpectedData<int64_t> expected(10, 123456);
   auto vector =
       maker_.encodedVector(VectorEncoding::Simple::CONSTANT, expected);
   assertVectorAndProperties(expected, vector);
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, ConstantVectorTestIsNull) {
+TEST_F(SimpleVectorNonParameterizedTest, constantVectorTestIsNull) {
   ExpectedData<int64_t> expected(10, std::nullopt);
   auto vector =
       maker_.encodedVector(VectorEncoding::Simple::CONSTANT, expected);
@@ -85,7 +85,7 @@ TEST_F(SimpleVectorNonParameterizedTest, ConstantVectorTestIsNull) {
 }
 
 // Single Entry Tests
-TEST_F(SimpleVectorNonParameterizedTest, SingleEntryIntegerVector) {
+TEST_F(SimpleVectorNonParameterizedTest, singleEntryIntegerVector) {
   for (auto t : kFullValueTypes) {
     LOG(INFO) << "Running:" << t;
     ExpectedData<int64_t> expected = {{123456}};
@@ -94,7 +94,7 @@ TEST_F(SimpleVectorNonParameterizedTest, SingleEntryIntegerVector) {
   }
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, SingleNullEntryIntegerVector) {
+TEST_F(SimpleVectorNonParameterizedTest, singleNullEntryIntegerVector) {
   for (auto t : kFullValueTypes) {
     LOG(INFO) << "Running:" << t;
     ExpectedData<int64_t> expected = {{std::nullopt}};
@@ -123,14 +123,14 @@ TEST_F(SimpleVectorNonParameterizedTest, roundTripSortedDescThenNullLastData) {
   }
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, BasicRoundTrip) {
+TEST_F(SimpleVectorNonParameterizedTest, basicRoundTrip) {
   auto expected =
       genTestDataWithSequences<int64_t>(1000, 100, true, true, 100, 10);
   auto vector = maker_.flatVectorNullable<int64_t>(expected.data());
   assertVectorAndProperties<int64_t>(expected.data(), vector);
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, ThreadSafeAsciiCompute) {
+TEST_F(SimpleVectorNonParameterizedTest, threadSafeAsciiCompute) {
   const size_t numRows{100};
   const size_t numThreads{10};
 

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -549,7 +549,7 @@ TEST_F(VectorCompareTest, compareNullAsIndeterminateRow) {
   }
 }
 
-TEST_F(VectorCompareTest, CompareWithNullChildVector) {
+TEST_F(VectorCompareTest, compareWithNullChildVector) {
   auto pool = memory::memoryManager()->addLeafPool();
   test::VectorMaker maker{pool.get()};
   auto rowType = ROW({"a", "b", "c"}, {INTEGER(), INTEGER(), INTEGER()});

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -756,7 +756,7 @@ TEST_F(VectorSaverTest, dictionaryRow) {
   testRoundTrip(fuzzer.fuzzDictionary(fuzzer.fuzzDictionary(flatVector)));
 }
 
-TEST_F(VectorSaverTest, LazyVector) {
+TEST_F(VectorSaverTest, lazyVector) {
   auto opts = fuzzerOptions();
   opts.nullRatio = 0.5;
   SCOPED_TRACE(fmt::format("seed: {}", seed_));


### PR DESCRIPTION
Minor normalize gtest names for `core`, `common`, `exec`, `expression`, `functions` etc directory.

Split of https://github.com/facebookincubator/velox/pull/17602.