### PR TITLE
fix(iceberg): Default value parse issue for DATE and TIMESTAMP

### DIFF
--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -31,7 +31,8 @@ VectorPtr newConstantFromString(
     const std::optional<std::string>& value,
     velox::memory::MemoryPool* pool,
     bool isLocalTimestamp,
-    bool isDaysSinceEpoch) {
+    bool isDaysSinceEpoch,
+    bool isMicrosSinceEpoch) {
   if (!value.has_value()) {
     return BaseVector::createNullConstant(type, 1, pool);
   }
@@ -40,8 +41,10 @@ VectorPtr newConstantFromString(
       PartitionValue::fromString(
           value.value(),
           *type,
-          isLocalTimestamp ? PartitionValue::TimestampMode::kLocalTime
-                           : PartitionValue::TimestampMode::kUtc,
+          isMicrosSinceEpoch
+              ? PartitionValue::TimestampMode::kMicrosSinceEpoch
+              : (isLocalTimestamp ? PartitionValue::TimestampMode::kLocalTime
+                                  : PartitionValue::TimestampMode::kUtc),
           isDaysSinceEpoch ? PartitionValue::DateMode::kDaysSinceEpoch
                            : PartitionValue::DateMode::kIsoString),
       1,

--- a/velox/connectors/hive/FileSplitReader.h
+++ b/velox/connectors/hive/FileSplitReader.h
@@ -69,6 +69,8 @@ namespace facebook::velox::connector::hive {
 /// @param isDaysSinceEpoch If true and type is DATE, treats the string value as
 /// an integer representing days since epoch (used by Iceberg). If false, parses
 /// the string as a date string in ISO 8601 format (used by Hive).
+/// @param isMicrosSinceEpoch If true and type is TIMESTAMP or TIMESTAMP_UTC,
+/// treats the string value as an integer representing microseconds since epoch.
 ///
 /// @return A constant vector of size 1 containing the converted value, or a
 /// null constant if value is nullopt.
@@ -78,7 +80,8 @@ VectorPtr newConstantFromString(
     const std::optional<std::string>& value,
     velox::memory::MemoryPool* pool,
     bool isLocalTimestamp,
-    bool isDaysSinceEpoch);
+    bool isDaysSinceEpoch,
+    bool isMicrosSinceEpoch = false);
 
 class FileConfig;
 

--- a/velox/connectors/hive/PartitionValue.cpp
+++ b/velox/connectors/hive/PartitionValue.cpp
@@ -37,19 +37,25 @@ Variant fromStringImpl(
   using NativeType = typename TypeTraits<kind>::NativeType;
 
   if (type.isDate()) {
-    const auto days = dateMode == PartitionValue::DateMode::kDaysSinceEpoch
-        ? folly::to<int32_t>(value)
-        : DATE()->toDays(value);
-    return Variant(days);
+    if (dateMode == PartitionValue::DateMode::kDaysSinceEpoch) {
+      auto days = folly::tryTo<int32_t>(value);
+      VELOX_USER_CHECK(
+          days.hasValue(),
+          "Failed to parse DATE value '{}' as days since epoch",
+          value);
+      return Variant(days.value());
+    }
+    return Variant(DATE()->toDays(value));
   }
 
   if constexpr (kind == TypeKind::TIMESTAMP) {
-    // For Iceberg, timestamp partition values are stored as microseconds since
-    // the Unix epoch (not as a formatted timestamp string).
-    if (dateMode == PartitionValue::DateMode::kDaysSinceEpoch) {
-      auto micros = folly::to<int64_t>(value);
-      auto ts = Timestamp::fromMicros(micros);
-      return Variant(ts);
+    if (timestampMode == PartitionValue::TimestampMode::kMicrosSinceEpoch) {
+      auto micros = folly::tryTo<int64_t>(value);
+      VELOX_USER_CHECK(
+          micros.hasValue(),
+          "Failed to parse TIMESTAMP value '{}' as microseconds since epoch",
+          value);
+      return Variant(Timestamp::fromMicros(micros.value()));
     }
   }
 

--- a/velox/connectors/hive/PartitionValue.cpp
+++ b/velox/connectors/hive/PartitionValue.cpp
@@ -43,6 +43,16 @@ Variant fromStringImpl(
     return Variant(days);
   }
 
+  if constexpr (kind == TypeKind::TIMESTAMP) {
+    // For Iceberg, timestamp partition values are stored as microseconds since
+    // the Unix epoch (not as a formatted timestamp string).
+    if (dateMode == PartitionValue::DateMode::kDaysSinceEpoch) {
+      auto micros = folly::to<int64_t>(value);
+      auto ts = Timestamp::fromMicros(micros);
+      return Variant(ts);
+    }
+  }
+
   if constexpr (
       std::is_same_v<NativeType, int64_t> ||
       std::is_same_v<NativeType, int128_t>) {

--- a/velox/connectors/hive/PartitionValue.h
+++ b/velox/connectors/hive/PartitionValue.h
@@ -40,6 +40,9 @@ class PartitionValue {
 
     /// Interprets the value as UTC. No shift.
     kUtc,
+
+    /// Parses an integer count of microseconds since the epoch.
+    kMicrosSinceEpoch,
   };
 
   enum class DateMode {
@@ -57,8 +60,9 @@ class PartitionValue {
   /// - REAL, DOUBLE: a floating point literal.
   /// - DECIMAL: a decimal literal, scaled by the type's scale.
   /// - VARCHAR, VARBINARY: taken verbatim.
-  /// - TIMESTAMP: parsed as TimestampParseMode::kPrestoCast, then shifted per
-  ///   'timestampMode'.
+  /// - TIMESTAMP: parsed as TimestampParseMode::kPrestoCast, shifted per
+  ///   'timestampMode', or parsed as epoch microseconds when
+  ///   'timestampMode' is kMicrosSinceEpoch.
   /// - DATE: parsed per 'dateMode'.
   ///
   /// Fails for a non-scalar type, and for a value that does not parse as

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -48,6 +48,12 @@ class IcebergColumnHandle : public HiveColumnHandle {
     return icebergMetadata_;
   }
 
+  /// Initial default value for an Iceberg V3 added column.
+  ///
+  /// The coordinator supplies this using its internal epoch-duration encoding,
+  /// not the Iceberg table metadata JSON literal form: DATE defaults are passed
+  /// as days since epoch and TIMESTAMP/TIMESTAMP_UTC defaults are passed as
+  /// microseconds since epoch, both serialized as decimal strings.
   const std::optional<std::string>& initialDefaultValue() const {
     return initialDefaultValue_;
   }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -1106,9 +1106,9 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
                 it->second->initialDefaultValue().value(),
                 connectorQueryCtx_->memoryPool(),
                 readTimestampAsLocalTime,
-                false));
+                true));
           } else {
-            // Fall back to NULL if no default value.
+            // Fall back to NULL if no default value
             VELOX_CHECK_NOT_NULL(
                 columnType, "Column '{}' not found in table schema", fieldName);
             childSpec->setConstantValue(

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -1101,14 +1101,22 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
           auto columnType = tableSchema->findChild(fieldName);
           if (it != handleByName.end() &&
               it->second->initialDefaultValue().has_value()) {
+            const auto& icebergMetadata = it->second->icebergMetadata();
+            VELOX_USER_CHECK(
+                !icebergMetadata.timestampUnit.has_value() ||
+                    icebergMetadata.timestampUnit.value() != "NANOS",
+                "Iceberg initial default for column '{}' uses unsupported "
+                "timestamp unit NANOS",
+                fieldName);
             childSpec->setConstantValue(newConstantFromString(
                 columnType,
                 it->second->initialDefaultValue().value(),
                 connectorQueryCtx_->memoryPool(),
                 readTimestampAsLocalTime,
-                true));
+                true,
+                columnType->kind() == TypeKind::TIMESTAMP));
           } else {
-            // Fall back to NULL if no default value
+            // Fall back to NULL if no default value.
             VELOX_CHECK_NOT_NULL(
                 columnType, "Column '{}' not found in table schema", fieldName);
             childSpec->setConstantValue(

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
 
 #include <algorithm>
+#include <string>
 
 #include <folly/Singleton.h>
 #include <folly/lang/Bits.h>
@@ -183,16 +184,20 @@ class IcebergReadTest : public test::IcebergTestBase {
       const std::vector<RowVectorPtr>& data,
       const std::vector<RowVectorPtr>& expected,
       const std::unordered_map<std::string, std::string>& sessionProperties =
-          {}) {
+          {},
+      const std::optional<std::string>& filter = std::nullopt) {
     auto dataFilePath = TempFilePath::create();
     writeToFile(dataFilePath->getPath(), data);
-    auto plan = exec::test::PlanBuilder()
-                    .startTableScan(test::kIcebergConnectorId)
-                    .outputType(outputType)
-                    .dataColumns(scanSpecType)
-                    .assignments(assignments)
-                    .endTableScan()
-                    .planNode();
+    auto planBuilder = exec::test::PlanBuilder()
+                           .startTableScan(test::kIcebergConnectorId)
+                           .outputType(outputType)
+                           .dataColumns(scanSpecType)
+                           .assignments(assignments)
+                           .endTableScan();
+    if (filter.has_value()) {
+      planBuilder.filter(*filter);
+    }
+    auto plan = planBuilder.planNode();
 
     exec::test::AssertQueryBuilder(plan)
         .connectorSessionProperties(
@@ -730,6 +735,12 @@ TEST_F(IcebergReadTest, fileValueOverridesDefault) {
 }
 
 TEST_F(IcebergReadTest, addColumnWithDefaultAllTypes) {
+  // Iceberg V3 initial-default values are encoded in the Iceberg-native binary
+  // representation serialised as decimal strings:
+  //   DATE      -> integer days since Unix epoch  (e.g. 19737 = 2024-01-15)
+  //   TIMESTAMP -> integer microseconds since Unix epoch
+  //                (e.g. 1705314600000000 = 2024-01-15 10:30:00 UTC)
+  // All other types use their natural string representations.
   auto newRowType =
       ROW({"c0",
            "tiny_val",
@@ -781,10 +792,12 @@ TEST_F(IcebergReadTest, addColumnWithDefaultAllTypes) {
       DECIMAL(38, 10),
       11,
       "123456789012345678901234567.8901234567");
-  assignments["date_val"] =
-      makeIcebergHandle("date_val", DATE(), 12, "2024-01-15");
-  assignments["timestamp_val"] = makeIcebergHandle(
-      "timestamp_val", TIMESTAMP(), 13, "2024-01-15 10:30:00");
+  // DATE default: 19737 days since 1970-01-01 == 2024-01-15.
+  assignments["date_val"] = makeIcebergHandle("date_val", DATE(), 12, "19737");
+  // TIMESTAMP default: 1705314600000000 microseconds since epoch
+  // == 2024-01-15 10:30:00 UTC.
+  assignments["timestamp_val"] =
+      makeIcebergHandle("timestamp_val", TIMESTAMP(), 13, "1705314600000000");
 
   std::vector<RowVectorPtr> expectedVectors = {makeRowVector(
       newRowType->names(),
@@ -817,6 +830,39 @@ TEST_F(IcebergReadTest, addColumnWithDefaultAllTypes) {
       dataVectors,
       expectedVectors,
       {{HiveConfig::kReadTimestampPartitionValueAsLocalTimeSession, "false"}});
+}
+
+TEST_F(IcebergReadTest, addColumnWithDefaultDateAndTimestampFilter) {
+  auto newRowType =
+      ROW({"c0", "date_val", "timestamp_val"}, {BIGINT(), DATE(), TIMESTAMP()});
+
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3})})};
+
+  ColumnHandleMap assignments;
+  assignments["c0"] = makeIcebergHandle("c0", BIGINT(), 1);
+  assignments["date_val"] = makeIcebergHandle("date_val", DATE(), 2, "19737");
+  assignments["timestamp_val"] =
+      makeIcebergHandle("timestamp_val", TIMESTAMP(), 3, "1705314600000000");
+
+  std::vector<RowVectorPtr> expectedVectors = {makeRowVector(
+      {"c0", "date_val", "timestamp_val"},
+      {dataVectors[0]->childAt(0),
+       makeFlatVector<int32_t>({19737, 19737, 19737}, DATE()),
+       makeFlatVector<Timestamp>(
+           {Timestamp(1705314600, 0),
+            Timestamp(1705314600, 0),
+            Timestamp(1705314600, 0)})})};
+
+  assertDefaultValues(
+      newRowType,
+      newRowType,
+      assignments,
+      dataVectors,
+      expectedVectors,
+      {{HiveConfig::kReadTimestampPartitionValueAsLocalTimeSession, "false"}},
+      "date_val = DATE '2024-01-15' AND "
+      "timestamp_val = TIMESTAMP '2024-01-15 10:30:00.000'");
 }
 
 TEST_F(IcebergReadTest, addColumnWithInvalidDefault) {

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -185,19 +185,19 @@ class IcebergReadTest : public test::IcebergTestBase {
       const std::vector<RowVectorPtr>& expected,
       const std::unordered_map<std::string, std::string>& sessionProperties =
           {},
-      const std::optional<std::string>& filter = std::nullopt) {
+      const std::optional<std::string>& scanFilter = std::nullopt) {
     auto dataFilePath = TempFilePath::create();
     writeToFile(dataFilePath->getPath(), data);
-    auto planBuilder = exec::test::PlanBuilder()
-                           .startTableScan(test::kIcebergConnectorId)
-                           .outputType(outputType)
-                           .dataColumns(scanSpecType)
-                           .assignments(assignments)
-                           .endTableScan();
-    if (filter.has_value()) {
-      planBuilder.filter(*filter);
+    exec::test::PlanBuilder planBuilder;
+    auto& tableScanBuilder =
+        planBuilder.startTableScan(test::kIcebergConnectorId)
+            .outputType(outputType)
+            .dataColumns(scanSpecType)
+            .assignments(assignments);
+    if (scanFilter.has_value()) {
+      tableScanBuilder.remainingFilter(*scanFilter);
     }
-    auto plan = planBuilder.planNode();
+    auto plan = tableScanBuilder.endTableScan().planNode();
 
     exec::test::AssertQueryBuilder(plan)
         .connectorSessionProperties(

--- a/velox/connectors/hive/tests/PartitionValueTest.cpp
+++ b/velox/connectors/hive/tests/PartitionValueTest.cpp
@@ -112,6 +112,33 @@ TEST(PartitionValueTest, timestampModes) {
       unshifted);
 }
 
+TEST(PartitionValueTest, timestampMicrosSinceEpoch) {
+  EXPECT_EQ(
+      toVariant(
+          "1705314600000000", TIMESTAMP(), TimestampMode::kMicrosSinceEpoch)
+          .value<TypeKind::TIMESTAMP>(),
+      Timestamp(1705314600, 0));
+  EXPECT_EQ(
+      toVariant("-1", TIMESTAMP(), TimestampMode::kMicrosSinceEpoch)
+          .value<TypeKind::TIMESTAMP>(),
+      Timestamp(-1, 999999000));
+  EXPECT_EQ(
+      toVariant(
+          "1705314600000000", TIMESTAMP_UTC(), TimestampMode::kMicrosSinceEpoch)
+          .value<TypeKind::TIMESTAMP>(),
+      Timestamp(1705314600, 0));
+}
+
+TEST(PartitionValueTest, invalidEpochEncodings) {
+  VELOX_ASSERT_USER_THROW(
+      toVariant(
+          "not-a-date", DATE(), TimestampMode::kUtc, DateMode::kDaysSinceEpoch),
+      "Failed to parse DATE value 'not-a-date' as days since epoch");
+  VELOX_ASSERT_USER_THROW(
+      toVariant("not-a-ts", TIMESTAMP(), TimestampMode::kMicrosSinceEpoch),
+      "Failed to parse TIMESTAMP value 'not-a-ts' as microseconds since epoch");
+}
+
 TEST(PartitionValueTest, filterOnConvertedValue) {
   const common::BigintRange bigintRange(10, 20, /*nullAllowed=*/false);
   EXPECT_TRUE(applyFilter(bigintRange, toVariant("15", BIGINT())));


### PR DESCRIPTION
Fixes default value parsing issue for DATE and TIMESTAMP columns. Iceberg already stores them in epoch duration. While applying default values too, we need to apply the same and not try to convert them assuming they are in String format.

Presto E2E tests PR: https://github.com/prestodb/presto/pull/28380