### PR TITLE
fix: VectorHasher timestamp precision handling in value-id paths

### DIFF
--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -664,6 +664,11 @@ void VectorHasher::analyzeValue(int128_t value) {
   }
 }
 
+void VectorHasher::analyzeValue(Timestamp value) {
+  updateTimestampRange(value);
+  analyzeValue(timestampAsInt128(value));
+}
+
 template <>
 void VectorHasher::analyzeValue(StringView value) {
   int size = value.size();
@@ -980,7 +985,7 @@ void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
     setDistinctOverflow();
     return;
   }
-  if (typeKind_ == TypeKind::HUGEINT) {
+  if (usesInt128DistinctValues()) {
     hasHugeintValue_ |= other.hasHugeintValue_;
 
     for (const auto& entry : other.uniqueHugeintValues_) {

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -363,7 +363,7 @@ class VectorHasher {
   // true if no values have been added.
   bool empty() const {
     const bool hasSeenValue =
-        typeKind_ == TypeKind::HUGEINT ? hasHugeintValue_ : hasRange_;
+        hasRange_ || (usesInt128DistinctValues() && hasHugeintValue_);
     return !hasSeenValue && numDistinct() == 0;
   }
 
@@ -386,9 +386,44 @@ class VectorHasher {
     return size == 0 ? word : word + (1L << (size * 8));
   }
 
+  bool usesInt128DistinctValues() const {
+    return typeKind_ == TypeKind::HUGEINT || typeKind_ == TypeKind::TIMESTAMP;
+  }
+
+  // Pack timestamps injectively for exact distinct value ids. This is not
+  // order-preserving because negative seconds are cast to uint64_t.
+  static int128_t timestampAsInt128(Timestamp timestamp) {
+    return HugeInt::build(
+        static_cast<uint64_t>(timestamp.getSeconds()), timestamp.getNanos());
+  }
+
+  // Use millisecond range encoding only when conversion is lossless and safe.
+  static bool tryTimestampToMillis(Timestamp timestamp, int64_t& millis) {
+    if (timestamp.getNanos() % Timestamp::kNanosecondsInMillisecond != 0 ||
+        timestamp < Timestamp::minMillis() ||
+        timestamp > Timestamp::maxMillis()) {
+      return false;
+    }
+    millis = timestamp.toMillis();
+    return true;
+  }
+
+  void updateTimestampRange(Timestamp timestamp) {
+    if (rangeOverflow_) {
+      return;
+    }
+
+    int64_t millis;
+    if (FOLLY_UNLIKELY(!tryTimestampToMillis(timestamp, millis))) {
+      setRangeOverflow();
+    } else {
+      updateRange(millis);
+    }
+  }
+
   size_t numDistinct() const {
-    return typeKind_ == TypeKind::HUGEINT ? uniqueHugeintValues_.size()
-                                          : uniqueValues_.size();
+    return usesInt128DistinctValues() ? uniqueHugeintValues_.size()
+                                      : uniqueValues_.size();
   }
 
   void clearDistinctValues() {
@@ -405,10 +440,6 @@ class VectorHasher {
         "HUGEINT values must use the int128_t overloads instead of narrowing "
         "to int64_t.");
     return value;
-  }
-
-  inline int64_t toInt64(Timestamp timestamp) const {
-    return timestamp.toMillis();
   }
 
   // Sets the data statistics from 'other'. Does not set the mapping mode.
@@ -513,11 +544,23 @@ class VectorHasher {
 
   void analyzeValue(int128_t value);
 
+  void analyzeValue(Timestamp value);
+
   template <typename T>
   bool tryMapToRangeSimd(
       const T* values,
       const SelectivityVector& rows,
       uint64_t* result);
+
+  bool
+  tryMapInt64ToRange(int64_t int64Value, vector_size_t row, uint64_t* result) {
+    if (int64Value > max_ || int64Value < min_) {
+      return false;
+    }
+    const auto hash = int64Value - min_ + 1;
+    result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+    return true;
+  }
 
   template <typename T>
   bool tryMapToRange(
@@ -541,14 +584,10 @@ class VectorHasher {
 
       bool inRange = true;
       rows.testSelected([&](vector_size_t row) {
-        auto int64Value = toInt64(values[row]);
-        if (int64Value > max_ || int64Value < min_) {
+        if (!tryMapInt64ToRange(toInt64(values[row]), row, result)) {
           inRange = false;
           return false;
         }
-        auto hash = int64Value - min_ + 1;
-        result[row] =
-            multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
         return true;
       });
 
@@ -665,8 +704,9 @@ class VectorHasher {
   // True if 'min_' and 'max_' are initialized.
   bool hasRange_ = false;
 
-  // True if at least one HUGEINT value has been observed. This stays true even
-  // after distinct values overflow and uniqueHugeintValues_ is cleared.
+  // True if at least one value stored in uniqueHugeintValues_ has been
+  // observed. This map is also reused for exact timestamp value ids. The flag
+  // stays true even after distinct values overflow and the set is cleared.
   bool hasHugeintValue_ = false;
 
   // True when range or distinct mapping is not possible or practical.
@@ -681,7 +721,8 @@ class VectorHasher {
   folly::F14FastSet<UniqueValue, UniqueValueHasher, UniqueValueComparer>
       uniqueValues_;
 
-  // Table for mapping distinct hugeint values to small ints.
+  // Table for mapping distinct 128-bit values to small ints. Used for HUGEINT
+  // and exact timestamp value ids.
   folly::F14FastMap<int128_t, uint32_t> uniqueHugeintValues_;
 
   // Memory for unique string values.
@@ -762,9 +803,12 @@ inline uint64_t VectorHasher::lookupValueId(StringView value) const {
 
 template <>
 inline uint64_t VectorHasher::lookupValueId(Timestamp timestamp) const {
-  return timestamp.getNanos() % 1'000'000 != 0
-      ? kUnmappable
-      : lookupValueId(timestamp.toMillis());
+  if (isRange_) {
+    int64_t millis;
+    return tryTimestampToMillis(timestamp, millis) ? lookupValueId(millis)
+                                                   : kUnmappable;
+  }
+  return lookupValueId(timestampAsInt128(timestamp));
 }
 
 template <>
@@ -773,15 +817,46 @@ inline uint64_t VectorHasher::valueId(bool value) {
 }
 template <>
 inline uint64_t VectorHasher::valueId(Timestamp value) {
-  if (FOLLY_UNLIKELY(
-          value.getNanos() % Timestamp::kNanosecondsInMillisecond != 0)) {
-    // The timestamp is in nanosecond or microsecond precision. The values are
-    // not mappable to milliseconds without precision loss.
-    setRangeOverflow();
-    setDistinctOverflow();
-    return kUnmappable;
+  if (isRange_) {
+    int64_t millis;
+    if (FOLLY_UNLIKELY(!tryTimestampToMillis(value, millis))) {
+      setRangeOverflow();
+      return kUnmappable;
+    }
+    return valueId(millis);
   }
-  return valueId(value.toMillis());
+
+  updateTimestampRange(value);
+  return valueId(timestampAsInt128(value));
+}
+
+template <>
+inline bool VectorHasher::tryMapToRange(
+    const Timestamp* values,
+    const SelectivityVector& rows,
+    uint64_t* result) {
+  VELOX_DCHECK(isRange_);
+  if (!isRange_) {
+    return false;
+  }
+
+  bool inRange = true;
+  rows.testSelected([&](vector_size_t row) {
+    const auto value = values[row];
+    int64_t millis;
+    if (FOLLY_UNLIKELY(!tryTimestampToMillis(value, millis))) {
+      inRange = false;
+      return false;
+    }
+
+    if (!tryMapInt64ToRange(millis, row, result)) {
+      inRange = false;
+      return false;
+    }
+    return true;
+  });
+
+  return inRange;
 }
 
 template <>

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -53,11 +53,13 @@ struct HashTableBenchmarkParams {
       int64_t size,
       int32_t hitrate,
       int32_t keySpacing = 1,
-      int32_t _numWays = 10)
+      int32_t _numWays = 10,
+      TypePtr buildType = ROW({"k1"}, {BIGINT()}))
       : title(std::move(title)),
         buildSize(size),
         size(100 * (size / _numWays) / hitrate),
         numWays(_numWays),
+        buildType(std::move(buildType)),
         insertPct(hitrate),
         keySpacing(keySpacing) {}
 
@@ -376,6 +378,15 @@ class HashTableBenchmark : public VectorTestBase {
             },
             nullptr);
 
+      case TypeKind::TIMESTAMP:
+        return vectorMaker_->flatVector<Timestamp>(
+            size,
+            [&](vector_size_t row) {
+              return Timestamp::fromMillis(
+                  params_.keySpacing * (sequence + row));
+            },
+            nullptr);
+
       case TypeKind::VARCHAR: {
         auto strings = BaseVector::create<FlatVector<StringView>>(
             VARCHAR(), size, pool_.get());
@@ -655,6 +666,13 @@ int main(int argc, char** argv) {
 
       HashTableBenchmarkParams("HitVid10K", 10000, 100, 1000),
       HashTableBenchmarkParams("MissVid10K", 10000, 5, 1000),
+      HashTableBenchmarkParams(
+          "TimestampHitVid10K",
+          10000,
+          100,
+          1000,
+          10,
+          ROW({"k1"}, {TIMESTAMP()})),
 
       HashTableBenchmarkParams("Hit4M", 4000000, 100),
       HashTableBenchmarkParams("Miss4M", 4000000, 5),

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -850,6 +850,45 @@ TEST_F(AggregationTest, rangeToDistinct) {
       " GROUP BY c0, c1, c2, c3, c4, c5");
 }
 
+TEST_F(AggregationTest, timestampRangeToDistinct) {
+  // Start in millisecond range mode, then switch to exact distinct value ids.
+  auto firstBatch = makeRowVector({
+      makeFlatVector<Timestamp>(
+          {Timestamp::fromMillis(1),
+           Timestamp::fromMillis(2),
+           Timestamp::fromMillis(1)}),
+  });
+  auto secondBatch = makeRowVector({
+      makeFlatVector<Timestamp>(
+          {Timestamp::fromMicros(1'001),
+           Timestamp::fromMicros(1'999),
+           Timestamp::fromMicros(1'001)}),
+  });
+
+  core::PlanNodeId aggNodeId;
+  auto plan = PlanBuilder()
+                  .values({firstBatch, secondBatch})
+                  .singleAggregation({"c0"}, {"count(1)"})
+                  .capturePlanNodeId(aggNodeId)
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeFlatVector<Timestamp>(
+          {Timestamp::fromMillis(1),
+           Timestamp::fromMillis(2),
+           Timestamp::fromMicros(1'001),
+           Timestamp::fromMicros(1'999)}),
+      makeFlatVector<int64_t>({2, 1, 2, 1}),
+  });
+
+  auto task = AssertQueryBuilder(plan).maxDrivers(1).assertResults(expected);
+  const auto runtimeStats =
+      toPlanStats(task->taskStats()).at(aggNodeId).customStats;
+  EXPECT_EQ(
+      static_cast<int64_t>(BaseHashTable::HashMode::kArray),
+      runtimeStats.at(std::string(BaseHashTable::kHashMode)).sum);
+}
+
 TEST_F(AggregationTest, allKeyTypes) {
   // Covers different key types. Unlike the integer/string tests, the
   // hash table begins life in the generic mode, not array or

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -1031,6 +1031,198 @@ TEST_F(VectorHasherTest, int128BoundaryCollisionsForRows) {
   }
 }
 
+TEST_F(VectorHasherTest, timestampRangePrecision) {
+  auto millisecondsVector = makeFlatVector<Timestamp>(
+      {Timestamp::fromMillis(1), Timestamp::fromMillis(2)});
+  SelectivityVector rows(millisecondsVector->size());
+  raw_vector<uint64_t> result(millisecondsVector->size());
+
+  auto hasher = exec::VectorHasher::create(TIMESTAMP(), 0);
+  hasher->decode(*millisecondsVector, rows);
+  ASSERT_FALSE(hasher->computeValueIds(rows, result));
+
+  uint64_t asRange;
+  uint64_t asDistinct;
+  hasher->cardinality(0, asRange, asDistinct);
+  ASSERT_EQ(3, asRange);
+  ASSERT_EQ(3, asDistinct);
+
+  ASSERT_EQ(3, hasher->enableValueRange(1, 0));
+
+  hasher->decode(*millisecondsVector, rows);
+  ASSERT_TRUE(hasher->computeValueIds(rows, result));
+
+  // Timestamp in range value-id mode must not map sub-millisecond values by
+  // truncating them with toMillis(). Exact distinct value ids remain usable.
+  auto subMillisecondVector =
+      makeFlatVector<Timestamp>({Timestamp::fromMicros(1'001)});
+  SelectivityVector subMillisecondRows(subMillisecondVector->size());
+  result.resize(subMillisecondVector->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  hasher->decode(*subMillisecondVector, subMillisecondRows);
+  EXPECT_FALSE(hasher->computeValueIds(subMillisecondRows, result));
+  EXPECT_TRUE(hasher->mayUseValueIds());
+
+  hasher->cardinality(0, asRange, asDistinct);
+  EXPECT_EQ(VectorHasher::kRangeTooLarge, asRange);
+  EXPECT_EQ(4, asDistinct);
+
+  ASSERT_EQ(4, hasher->enableValueIds(1, 0));
+
+  auto exactValues = makeFlatVector<Timestamp>(
+      {Timestamp::fromMillis(1),
+       Timestamp::fromMicros(1'001),
+       Timestamp::fromMillis(2)});
+  SelectivityVector exactRows(exactValues->size());
+  result.resize(exactValues->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  hasher->decode(*exactValues, exactRows);
+  ASSERT_TRUE(hasher->computeValueIds(exactRows, result));
+  EXPECT_NE(0, result[0]);
+  EXPECT_NE(0, result[1]);
+  EXPECT_NE(0, result[2]);
+  EXPECT_NE(result[0], result[1]);
+  EXPECT_NE(result[0], result[2]);
+  EXPECT_NE(result[1], result[2]);
+}
+
+TEST_F(VectorHasherTest, timestampAnalyzePrecision) {
+  constexpr int32_t kValueOffset = 0;
+  constexpr int32_t kNullByte = sizeof(Timestamp);
+  constexpr int32_t kRowSize = sizeof(Timestamp) + 1;
+  constexpr uint8_t kNullMask = 1;
+
+  alignas(Timestamp) std::array<char, kRowSize> rowData;
+  rowData.fill(0);
+  std::vector<char*> groups{rowData.data()};
+
+  auto timestamp = Timestamp::fromMicros(1'001);
+  memcpy(groups[0] + kValueOffset, &timestamp, sizeof(Timestamp));
+
+  // Row-wise analyze must not collect range stats by truncating
+  // sub-millisecond timestamps with toMillis(). Exact distinct value ids remain
+  // usable.
+  auto rowHasher = exec::VectorHasher::create(TIMESTAMP(), 0);
+  rowHasher->analyze(groups.data(), 1, kValueOffset, kNullByte, kNullMask);
+
+  uint64_t asRange;
+  uint64_t asDistinct;
+  rowHasher->cardinality(0, asRange, asDistinct);
+  EXPECT_EQ(VectorHasher::kRangeTooLarge, asRange);
+  EXPECT_EQ(2, asDistinct);
+  EXPECT_TRUE(rowHasher->mayUseValueIds());
+
+  ASSERT_EQ(2, rowHasher->enableValueIds(1, 0));
+  raw_vector<uint64_t> rowResult(1);
+  ASSERT_TRUE(rowHasher->computeValueIdsForRows(
+      groups.data(), 1, kValueOffset, kNullByte, kNullMask, rowResult));
+  EXPECT_NE(0, rowResult[0]);
+}
+
+TEST_F(VectorHasherTest, timestampRangeStatsNotEmpty) {
+  auto vector = makeFlatVector<Timestamp>(
+      {Timestamp::fromMillis(1), Timestamp::fromMillis(2)});
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> result(vector->size());
+
+  auto hasher = exec::VectorHasher::create(TIMESTAMP(), 0);
+  hasher->decode(*vector, rows);
+  ASSERT_FALSE(hasher->computeValueIds(rows, result));
+
+  hasher->resetStats();
+  ASSERT_FALSE(hasher->empty());
+
+  VectorHasher mergedHasher(TIMESTAMP(), 0);
+  mergedHasher.merge(*hasher, VectorHasher::kMaxDistinct);
+
+  uint64_t asRange;
+  uint64_t asDistinct;
+  mergedHasher.cardinality(0, asRange, asDistinct);
+  EXPECT_EQ(3, asRange);
+  EXPECT_EQ(1, asDistinct);
+  EXPECT_TRUE(mergedHasher.mayUseValueIds());
+}
+
+TEST_F(VectorHasherTest, timestampMergePrecision) {
+  auto subMillisecondVector =
+      makeFlatVector<Timestamp>({Timestamp::fromMicros(1'001)});
+  SelectivityVector subMillisecondRows(subMillisecondVector->size());
+  raw_vector<uint64_t> result(subMillisecondVector->size());
+
+  VectorHasher subMillisecondHasher(TIMESTAMP(), 0);
+  subMillisecondHasher.decode(*subMillisecondVector, subMillisecondRows);
+  ASSERT_FALSE(
+      subMillisecondHasher.computeValueIds(subMillisecondRows, result));
+  ASSERT_TRUE(subMillisecondHasher.mayUseValueIds());
+
+  // Range precision loss is not an empty state. Exact distinct stats must be
+  // propagated through merge().
+  auto millisecondsVector =
+      makeFlatVector<Timestamp>({Timestamp::fromMillis(1)});
+  SelectivityVector millisecondRows(millisecondsVector->size());
+  result.resize(millisecondsVector->size());
+
+  VectorHasher millisecondHasher(TIMESTAMP(), 0);
+  millisecondHasher.decode(*millisecondsVector, millisecondRows);
+  ASSERT_FALSE(millisecondHasher.computeValueIds(millisecondRows, result));
+  ASSERT_TRUE(millisecondHasher.mayUseValueIds());
+
+  millisecondHasher.merge(subMillisecondHasher, VectorHasher::kMaxDistinct);
+
+  uint64_t asRange;
+  uint64_t asDistinct;
+  millisecondHasher.cardinality(0, asRange, asDistinct);
+  EXPECT_EQ(VectorHasher::kRangeTooLarge, asRange);
+  EXPECT_EQ(3, asDistinct);
+  EXPECT_TRUE(millisecondHasher.mayUseValueIds());
+}
+
+TEST_F(VectorHasherTest, timestampLookupPrecision) {
+  auto build = makeFlatVector<Timestamp>(
+      {Timestamp::fromMillis(1),
+       Timestamp::fromMicros(1'001),
+       Timestamp::fromMicros(1'999)});
+  SelectivityVector rows(build->size());
+  raw_vector<uint64_t> result(build->size());
+
+  auto hasher = exec::VectorHasher::create(TIMESTAMP(), 0);
+  hasher->decode(*build, rows);
+  ASSERT_FALSE(hasher->computeValueIds(rows, result));
+
+  uint64_t asRange;
+  uint64_t asDistinct;
+  hasher->cardinality(0, asRange, asDistinct);
+  ASSERT_EQ(VectorHasher::kRangeTooLarge, asRange);
+  ASSERT_EQ(4, asDistinct);
+  ASSERT_EQ(4, hasher->enableValueIds(1, 0));
+
+  auto probe = makeFlatVector<Timestamp>(
+      {Timestamp::fromMicros(1'001),
+       Timestamp::fromMicros(1'999),
+       Timestamp::fromMillis(1),
+       Timestamp::fromMicros(1'002)});
+  SelectivityVector probeRows(probe->size());
+  result.resize(probe->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  VectorHasher::ScratchMemory scratch;
+  hasher->lookupValueIds(*probe, probeRows, scratch, result);
+
+  EXPECT_TRUE(probeRows.isValid(0));
+  EXPECT_TRUE(probeRows.isValid(1));
+  EXPECT_TRUE(probeRows.isValid(2));
+  EXPECT_FALSE(probeRows.isValid(3));
+  EXPECT_EQ(probeRows.countSelected(), 3);
+  EXPECT_NE(0, result[0]);
+  EXPECT_NE(0, result[1]);
+  EXPECT_NE(0, result[2]);
+  EXPECT_NE(result[0], result[1]);
+  EXPECT_NE(result[0], result[2]);
+  EXPECT_NE(result[1], result[2]);
+}
+
 TEST_F(VectorHasherTest, computeValueIdsInteger) {
   testComputeValueIds<int32_t>(false);
   testComputeValueIds<int32_t>(true);


### PR DESCRIPTION
#### Background

VectorHasher maps timestamps to value ids using millisecond precision. The 
direct `valueId(Timestamp)` and `lookupValueId(Timestamp)` paths already reject 
timestamps that cannot be represented losslessly in milliseconds, but the range 
fast path and row-wise analyze path could call `toInt64(Timestamp)`, which 
uses `timestamp.toMillis()` directly. This could silently map distinct sub-
millisecond timestamps to the same millisecond value id while still reporting that
value-id mapping was usable.

#### Changes

This PR fixes the issue by:
 - Keeping timestamp range encoding limited to values that can be represented
 losslessly in milliseconds.
- Using exact 128-bit (seconds, nanos) encoding for timestamp distinct value IDs.
- Preserving distinct value-id fast paths when timestamp range mode is not applicable.

Issue related: https://github.com/facebookincubator/velox/issues/18597.