### PR TITLE
fix(cudf): Accept mixed null payload encodings in decimal sum state

### DIFF
--- a/velox/experimental/cudf/exec/DecimalAggregationState.cpp
+++ b/velox/experimental/cudf/exec/DecimalAggregationState.cpp
@@ -82,17 +82,26 @@ DecimalSumStateColumns deserializeDecimalSumState(
 
   auto const nullCount = stateCol.nullable() ? stateCol.null_count() : 0;
   auto const payloadSize = strings.chars_size(stream);
-  // serializeDecimalSumState writes 32 bytes for every row (including nulls),
-  // but an Arrow round-trip compacts null rows to 0 bytes. Accept both.
+  // A null row's payload width is path dependent. serializeDecimalSumState
+  // writes kDecimalSumStateSize bytes for every row including nulls, while a
+  // velox/Arrow round trip compacts null rows to 0 bytes. Both encodings can
+  // occur in the same column: the streaming final aggregation concatenates its
+  // buffered (serialized) result with each newly arrived (round tripped) batch,
+  // so the payload size lands anywhere between the two extremes. Non-null rows
+  // are always kDecimalSumStateSize wide, and that is all
+  // unpackDecimalSumState requires -- it skips null rows and addresses payloads
+  // through the per-row offsets rather than a fixed stride.
   auto const fullPayloadSize =
       static_cast<int64_t>(numRows) * detail::kDecimalSumStateSize;
   auto const compactPayloadSize =
       static_cast<int64_t>(numRows - nullCount) * detail::kDecimalSumStateSize;
   VELOX_CHECK(
-      payloadSize == fullPayloadSize || payloadSize == compactPayloadSize,
-      "Decimal sum state requires payload size {} or {} (got {})",
-      fullPayloadSize,
+      payloadSize >= compactPayloadSize && payloadSize <= fullPayloadSize &&
+          payloadSize % detail::kDecimalSumStateSize == 0,
+      "Decimal sum state requires a payload size that is a multiple of {} between {} and {} (got {})",
+      detail::kDecimalSumStateSize,
       compactPayloadSize,
+      fullPayloadSize,
       payloadSize);
 
   auto offsetsView = strings.offsets();

--- a/velox/experimental/cudf/exec/DecimalAggregationState.cpp
+++ b/velox/experimental/cudf/exec/DecimalAggregationState.cpp
@@ -98,7 +98,7 @@ DecimalSumStateColumns deserializeDecimalSumState(
   VELOX_CHECK(
       payloadSize >= compactPayloadSize && payloadSize <= fullPayloadSize &&
           payloadSize % detail::kDecimalSumStateSize == 0,
-      "Decimal sum state requires a payload size that is a multiple of {} between {} and {} (got {})",
+      "Decimal sum state has an invalid payload size: expected a multiple of {} in [{}, {}], got {}",
       detail::kDecimalSumStateSize,
       compactPayloadSize,
       fullPayloadSize,

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -30,6 +30,7 @@
 #include "velox/type/DecimalUtil.h"
 
 #include <cudf/column/column_factories.hpp>
+#include <cudf/concatenate.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -1279,6 +1280,80 @@ TEST_F(CudfDecimalTest, decimalDeserializeSumStatePartialNullCompact) {
   EXPECT_EQ(outCount[0], 1);
   EXPECT_EQ(outSum[2], static_cast<__int128_t>(300));
   EXPECT_EQ(outCount[2], 2);
+}
+
+// Reproduces the TPC-DS Q1 failure in CudfGroupbyFINAL: the streaming final
+// aggregation concatenates its buffered result -- which came straight from
+// serializeDecimalSumState and so keeps a 32-byte payload for null rows -- with
+// each newly arrived batch, which was round tripped through velox and so has
+// its null rows compacted to 0 bytes. The concatenated state column mixes both
+// encodings, so its payload size is neither numRows * 32 nor
+// (numRows - nullCount) * 32 and a two-way equality check rejects it.
+TEST_F(CudfDecimalTest, decimalDeserializeSumStateMixedNullEncodings) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+
+  auto serialize = [&](const std::vector<int64_t>& sums,
+                       const std::vector<int64_t>& counts,
+                       const std::vector<bool>& sumValid) {
+    auto sumCol = makeDecimalColumn<int64_t>(sums, 2, &sumValid, stream);
+    auto countCol = makeInt64Column(counts, nullptr, stream);
+    return serializeDecimalSumState(
+        sumCol->view(), countCol->view(), stream, mr);
+  };
+
+  // Buffered side: row 1 is null and keeps its 32-byte payload.
+  auto fullState = serialize({100, 0, 300}, {1, 0, 2}, {true, false, true});
+
+  // Incoming side: same shape, but the velox round trip compacts its null row
+  // to a 0-byte payload.
+  auto incomingState = serialize({400, 0, 600}, {3, 0, 4}, {true, false, true});
+  auto veloxRow = with_arrow::toVeloxColumn(
+      cudf::table_view{{incomingState->view()}},
+      pool(),
+      ROW({{"s", VARBINARY()}}),
+      "s",
+      stream,
+      mr);
+  auto compactTable = with_arrow::toCudfTable(veloxRow, pool(), stream, mr);
+
+  auto mixed = cudf::concatenate(
+      std::vector<cudf::column_view>{
+          fullState->view(), compactTable->view().column(0)},
+      stream,
+      mr);
+
+  // Four non-null rows, plus the one null payload the buffered side kept: the
+  // payload size sits strictly between the compact and full extremes.
+  cudf::strings_column_view mixedStrings(mixed->view());
+  auto const numRows = static_cast<int64_t>(mixed->size());
+  auto const nullCount = static_cast<int64_t>(mixed->null_count());
+  EXPECT_EQ(numRows, 6);
+  EXPECT_EQ(nullCount, 2);
+  EXPECT_GT(
+      mixedStrings.chars_size(stream),
+      (numRows - nullCount) * 32); // 32 == kDecimalSumStateSize
+  EXPECT_LT(mixedStrings.chars_size(stream), numRows * 32);
+
+  auto result = deserializeDecimalSumState(mixed->view(), 2, stream);
+
+  auto outSum = copyColumnData<__int128_t>(result.sum->view(), stream);
+  auto outCount = copyColumnData<int64_t>(result.count->view(), stream);
+  auto outMask = copyNullMask(result.sum->view(), stream);
+
+  EXPECT_FALSE(isValidAt(outMask, 1));
+  EXPECT_FALSE(isValidAt(outMask, 4));
+  for (auto row : {0, 2, 3, 5}) {
+    EXPECT_TRUE(isValidAt(outMask, row));
+  }
+  EXPECT_EQ(outSum[0], static_cast<__int128_t>(100));
+  EXPECT_EQ(outCount[0], 1);
+  EXPECT_EQ(outSum[2], static_cast<__int128_t>(300));
+  EXPECT_EQ(outCount[2], 2);
+  EXPECT_EQ(outSum[3], static_cast<__int128_t>(400));
+  EXPECT_EQ(outCount[3], 3);
+  EXPECT_EQ(outSum[5], static_cast<__int128_t>(600));
+  EXPECT_EQ(outCount[5], 4);
 }
 
 // Trailing null: the offset for the last row equals chars_size, so the kernel


### PR DESCRIPTION
A decimal `sum` or `avg` fails during final aggregation when some groups aggregate to null. TPC-DS Q1 at scale factor 1000 fails with:

    Decimal sum state requires payload size 6795552 or 6764736 (got 6780544)

Every row in the rejected column is readable; only the total size is unexpected.

The width of a null row's payload depends on how the column was produced. `serializeDecimalSumState` writes `kDecimalSumStateSize` bytes for every row, nulls included. A velox to Arrow round trip drops a null row's payload instead. `CudfGroupby::computeFinalGroupbyStreaming` concatenates its buffered result with each arriving batch, so one column can carry both widths at once. Its total then falls between the two sizes the check accepted. #18030 widened that check from one accepted size to two for this same reason, but a column holding both remained rejected.

`unpackDecimalSumState` skips null rows and reads each payload through its own offset rather than a fixed stride. It therefore requires only that every non-null row is `kDecimalSumStateSize` wide, which a mixture satisfies. The check now accepts any total between the compact and full sizes that is a multiple of `kDecimalSumStateSize`.

That range test is necessary but not sufficient: a short non-null row paired with an extra full null row would cancel out in the total. The per-row width is asserted inside `unpackDecimalSumState`, which release builds compile out. Checking it in release would need a device-side reduction over the offsets, which this change leaves out.
