### PR TITLE
fix: Scatter null-key join rows across hash join spill partitions

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -774,9 +774,24 @@ void HashBuild::computeSpillPartitions(const RowVectorPtr& input) {
     }
   }
 
+  // Right and full joins keep null-key rows in 'activeRows_' (they are
+  // emitted as misses); scatter them across spill partitions -- see
+  // SpillerBase::scatterNullKeyRows_.
+  const bool scatterNullKeys =
+      isRightJoin(joinType_) || isFullJoin(joinType_);
+  if (scatterNullKeys) {
+    spillNonNullActiveRows_ = activeRows_;
+    deselectRowsWithNulls(hashers, spillNonNullActiveRows_);
+  }
+
   spillPartitions_.resize(input->size());
   activeRows_.applyToSelected([&](int32_t row) {
-    spillPartitions_[row] = spiller_->hashBits().partition(hashes_[row]);
+    if (scatterNullKeys && !spillNonNullActiveRows_.isValid(row)) {
+      spillPartitions_[row] = spiller_->hashBits().partition(
+          folly::hasher<uint64_t>()(spillNullScatterSeq_++));
+    } else {
+      spillPartitions_[row] = spiller_->hashBits().partition(hashes_[row]);
+    }
   });
 }
 
@@ -1473,6 +1488,11 @@ HashBuildSpiller::HashBuildSpiller(
           spillStats),
       spillProbeFlag_(needRightSideJoin(joinType)) {
   VELOX_CHECK(container_->accumulators().empty());
+  // Right and full joins are the only types that retain null-key build rows
+  // (for miss output); scatter them so they cannot concentrate into one
+  // un-splittable spill partition. Null-aware join types (anti, left semi
+  // project) drop or short-circuit on null build keys before spilling.
+  scatterNullKeyRows_ = isRightJoin(joinType) || isFullJoin(joinType);
 }
 
 void HashBuildSpiller::spill() {

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -394,6 +394,11 @@ class HashBuild final : public Operator {
   // Reusable memory for spill partition calculation for input data.
   std::vector<uint32_t> spillPartitions_;
 
+  // Reusable selectivity vector and rotating sequence for scattering
+  // null-key rows across spill partitions (right and full joins only).
+  SelectivityVector spillNonNullActiveRows_;
+  uint64_t spillNullScatterSeq_{0};
+
   // Reusable memory for input spilling processing.
   std::vector<vector_size_t> numSpillInputs_;
   std::vector<BufferPtr> spillInputIndicesBuffers_;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -289,13 +289,17 @@ void HashProbe::maybeSetupInputSpiller(
   // operator itself won't trigger any spilling.
   inputSpiller_->setPartitionsSpilled(spillInputPartitionIds_);
 
+  // Null-key probe rows can never match; for non-null-aware joins their
+  // spill partition is semantically free, so scatter them instead of letting
+  // hash(null)'s constant concentrate them into one partition.
   spillPartitionFunction_ = std::make_unique<SpillPartitionFunction>(
       SpillPartitionIdLookup(
           spillInputPartitionIds_,
           spillConfig()->startPartitionBit,
           spillConfig()->numPartitionBits),
       probeType_,
-      keyChannels_);
+      keyChannels_,
+      /*scatterNullKeyRows=*/!nullAware_);
 
   // If we have received no more input signal from either source or restored
   // spill input, then we shall just finish the spiller and records the spilled

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -895,8 +895,9 @@ SpillPartitionId SpillPartitionIdLookup::partition(uint64_t hash) const {
 SpillPartitionFunction::SpillPartitionFunction(
     const SpillPartitionIdLookup& lookup,
     const RowTypePtr& inputType,
-    const std::vector<column_index_t>& keyChannels)
-    : lookup_(lookup) {
+    const std::vector<column_index_t>& keyChannels,
+    bool scatterNullKeyRows)
+    : lookup_(lookup), scatterNullKeyRows_(scatterNullKeyRows) {
   VELOX_CHECK(!keyChannels.empty(), "Key channels must not be empty.");
   hashers_.reserve(keyChannels.size());
   for (const auto channel : keyChannels) {
@@ -918,6 +919,23 @@ void SpillPartitionFunction::partition(
     auto& hasher = hashers_[i];
     hashers_[i]->decode(*input.childAt(hasher->channel()), rows_);
     hashers_[i]->hash(rows_, i > 0, hashes_);
+  }
+
+  if (scatterNullKeyRows_) {
+    // Null keys hash to a constant; scatter those rows instead of letting
+    // them concentrate in one partition. They can never match, so their
+    // partition assignment is semantically free.
+    for (const auto& hasher : hashers_) {
+      const auto& decoded = hasher->decodedVector();
+      if (!decoded.mayHaveNulls()) {
+        continue;
+      }
+      for (vector_size_t row = 0; row < size; ++row) {
+        if (decoded.isNullAt(row)) {
+          hashes_[row] = folly::hasher<uint64_t>()(nullScatterSeq_++);
+        }
+      }
+    }
   }
 
   partitionIds.resize(size);

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -433,10 +433,15 @@ class SpillPartitionIdLookup {
 /// vector.
 class SpillPartitionFunction {
  public:
+  /// 'scatterNullKeyRows': when true, rows with null join keys get rotating
+  /// partition assignments instead of hash-based ones (null keys hash to a
+  /// constant and would all land in one partition). Only legal for join types
+  /// where null keys can never match and carry no null-aware semantics.
   SpillPartitionFunction(
       const SpillPartitionIdLookup& lookup,
       const RowTypePtr& inputType,
-      const std::vector<column_index_t>& keyChannels);
+      const std::vector<column_index_t>& keyChannels,
+      bool scatterNullKeyRows = false);
 
   void partition(
       const RowVector& input,
@@ -444,6 +449,11 @@ class SpillPartitionFunction {
 
  private:
   const SpillPartitionIdLookup lookup_;
+
+  const bool scatterNullKeyRows_;
+
+  // Rotating sequence for scattering null-key rows.
+  uint64_t nullScatterSeq_{0};
 
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -85,6 +85,16 @@ void SpillerBase::spill(const RowContainerIterator* startRowIter) {
   checkEmptySpillRuns();
 }
 
+bool SpillerBase::rowHasNullKey(const char* row) const {
+  const auto numKeys = container_->keyTypes().size();
+  for (size_t i = 0; i < numKeys; ++i) {
+    if (RowContainer::isNullAt(row, container_->columnAt(i))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool SpillerBase::fillSpillRuns(RowContainerIterator* iterator) {
   checkEmptySpillRuns();
 
@@ -122,8 +132,14 @@ bool SpillerBase::fillSpillRuns(RowContainerIterator* iterator) {
       for (auto i = 0; i < numRows; ++i) {
         // TODO: consider to cache the hash bits in row container so we only
         // need to calculate them once.
+        uint64_t hash = hashes[i];
+        if (FOLLY_UNLIKELY(
+                scatterNullKeyRows_ && !isSinglePartition &&
+                rowHasNullKey(rows[i]))) {
+          hash = folly::hasher<uint64_t>()(nullScatterSeq_++);
+        }
         const auto partitionNum =
-            isSinglePartition ? 0 : bits_.partition(hashes[i]);
+            isSinglePartition ? 0 : bits_.partition(hash);
         VELOX_DCHECK_GE(partitionNum, 0);
         // TODO: Fully integrate nested spill id into spiller partitioning,
         // replacing integer based partitioning.

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -52,6 +52,22 @@ class SpillerBase {
   std::string toString() const;
 
  protected:
+  // Returns true if any join key column of 'row' is null. Only meaningful for
+  // spillers whose containers store join keys as their leading columns.
+  bool rowHasNullKey(const char* row) const;
+
+  // When true, rows with null join keys are assigned rotating spill
+  // partitions instead of hash-based ones. Null keys hash to a constant, so
+  // hash partitioning concentrates every null-key row into one partition
+  // which can never split at deeper spill levels. Null-key rows can never
+  // match the other side, so their partition assignment is semantically free.
+  // Set by HashBuildSpiller for right and full joins -- the only join types
+  // that retain null-key build rows (for miss output).
+  bool scatterNullKeyRows_{false};
+
+  // Rotating sequence for scattering null-key rows.
+  uint64_t nullScatterSeq_{0};
+
   SpillerBase(
       RowContainer* container,
       RowTypePtr rowType,

--- a/velox/exec/tests/HashJoinTestExtra.cpp
+++ b/velox/exec/tests/HashJoinTestExtra.cpp
@@ -3726,6 +3726,73 @@ DEBUG_ONLY_TEST_P(HashJoinTest, exceededMaxSpillLevel) {
       exceededMaxSpillLevelCount + 16);
 }
 
+TEST_P(HashJoinTest, fullJoinNullKeysSpillParity) {
+  // Null join keys hash to a constant, so hash-partitioned spilling routes
+  // every null-key row into one spill partition, which can never split at
+  // deeper spill levels. Full (and right) joins retain null-key build rows
+  // for miss output, so a null-heavy build side concentrates into an
+  // un-splittable partition; once the max spill level disables re-spilling,
+  // the whole null population must fit in memory at once (production
+  // signature: memory cap exceeded on restore). The fix scatters null-key
+  // rows across spill partitions -- they can never match, so their partition
+  // assignment is semantically free. This test pins result parity for a
+  // spilled full join with null-heavy keys on BOTH sides (build-side and
+  // probe-side scatter); the partition-balance discriminator lives in
+  // SpillerTest::nullKeyRowsSpillScatter.
+  const vector_size_t numBuildVectors = 8;
+  const vector_size_t buildVectorSize = 5'000;
+  std::vector<RowVectorPtr> buildVectors;
+  buildVectors.reserve(numBuildVectors);
+  for (auto v = 0; v < numBuildVectors; ++v) {
+    auto keys = makeFlatVector<int64_t>(
+        buildVectorSize,
+        [&](auto row) { return v * buildVectorSize + row; },
+        [](auto row) { return row % 10 != 0; }); // 90% null keys.
+    auto payloads = makeFlatVector<int64_t>(
+        buildVectorSize, [&](auto row) { return v * buildVectorSize + row; });
+    buildVectors.push_back(makeRowVector({"u_k", "u_p"}, {keys, payloads}));
+  }
+
+  const vector_size_t numProbeVectors = 2;
+  const vector_size_t probeVectorSize = 1'000;
+  std::vector<RowVectorPtr> probeVectors;
+  probeVectors.reserve(numProbeVectors);
+  for (auto v = 0; v < numProbeVectors; ++v) {
+    auto keys = makeFlatVector<int64_t>(
+        probeVectorSize,
+        [&](auto row) { return (v * probeVectorSize + row) * 10; },
+        [](auto row) { return row % 3 == 0; }); // ~30% null probe keys.
+    auto payloads = makeFlatVector<int64_t>(
+        probeVectorSize, [](auto row) { return row; });
+    probeVectors.push_back(makeRowVector({"t_k", "t_p"}, {keys, payloads}));
+  }
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .hashJoin(
+                      {"t_k"},
+                      {"u_k"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .planNode(),
+                      "",
+                      {"t_k", "t_p", "u_k", "u_p"},
+                      core::JoinType::kFull)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .planNode(plan)
+      .injectSpill(true)
+      .referenceQuery(
+          "SELECT t_k, t_p, u_k, u_p FROM t FULL OUTER JOIN u ON t_k = u_k")
+      .run();
+}
+
 TEST_P(HashJoinTest, maxSpillBytes) {
   const auto rowType =
       ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), VARCHAR()});

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -500,6 +500,37 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     int numFilledRows = 0;
     do {
       RowVectorPtr batch = makeDataset(rowType_, numRows, customizeData);
+      // The hash-placement checks in these tests predict each row's spill
+      // partition from its key hash. HashBuildSpiller deliberately scatters
+      // null-key rows for right and full joins (they can never match, and
+      // hash placement would concentrate them into one un-splittable
+      // partition), so keep fuzzed keys non-null here; null-key placement is
+      // covered by HashJoinBuildOnly::nullKeyRowsSpillScatter.
+      if (type_ == SpillerType::HASH_BUILD &&
+          (isRightJoin(joinType_) || isFullJoin(joinType_)) &&
+          !customizeData) {
+        for (int32_t k = 0; k < numKeys; ++k) {
+          const auto& keyVector = batch->childAt(k);
+          if (!keyVector->mayHaveNulls()) {
+            continue;
+          }
+          vector_size_t firstNonNull = -1;
+          for (vector_size_t i = 0; i < batch->size(); ++i) {
+            if (!keyVector->isNullAt(i)) {
+              firstNonNull = i;
+              break;
+            }
+          }
+          if (firstNonNull < 0) {
+            continue;
+          }
+          for (vector_size_t i = 0; i < batch->size(); ++i) {
+            if (keyVector->isNullAt(i)) {
+              keyVector->copy(keyVector.get(), i, firstNonNull, 1);
+            }
+          }
+        }
+      }
       if (!numRowsPerPartition.empty()) {
         for (int index = 0; index < numRows; ++index) {
           for (int i = 0; i < keys.size(); ++i) {
@@ -1423,6 +1454,66 @@ TEST_P(HashJoinBuildOnly, spillPartition) {
           spiller_.get(),
           {std::nullopt, std::nullopt, std::nullopt, std::optional(&rowIter)}),
       "");
+}
+
+TEST_P(HashJoinBuildOnly, nullKeyRowsSpillScatter) {
+  // Rows with null join keys hash to a constant, so hash-partitioned spilling
+  // puts every null-key row into ONE partition, and that partition can never
+  // split at deeper spill levels (its rows re-hash identically). Full and
+  // right joins retain null-key build rows for miss output (other join types
+  // drop them before they reach the container), so a null-heavy build side
+  // concentrates into an un-splittable partition and dies once the max spill
+  // level disables re-spilling. Null-key rows can never match any probe row,
+  // so their partition assignment is semantically free: HashBuildSpiller
+  // scatters them round-robin for those join types.
+  const int32_t numRows = 20'000;
+  auto makeNullHeavyData = [&]() {
+    setupSpillData(numKeys_, numRows, 1, [&](RowVectorPtr rows) {
+      for (int32_t k = 0; k < numKeys_; ++k) {
+        auto key = rows->childAt(k);
+        for (vector_size_t i = 0; i < rows->size(); ++i) {
+          if (i % 10 != 0) {
+            key->setNull(i, true);
+          }
+        }
+      }
+    });
+  };
+
+  auto maxPartitionShare = [&](core::JoinType joinType) -> double {
+    makeNullHeavyData();
+    // Initializes spillConfig_ (spill directory callback et al); the fixture
+    // spiller it creates is unused -- the join type under test is set below.
+    setupSpiller(100'000, 0, false);
+    auto spiller = std::make_unique<HashBuildSpiller>(
+        joinType,
+        std::nullopt,
+        rowContainer_.get(),
+        hashJoinTableSpillType(containerType_, joinType),
+        hashBits_,
+        &spillConfig_,
+        &spillStats_);
+    spiller->spill();
+    rowContainer_->clear();
+    SpillPartitionSet spillPartitionSet;
+    spiller->finishSpill(spillPartitionSet);
+    uint64_t total{0};
+    uint64_t maxPartition{0};
+    for (const auto& [id, partition] : spillPartitionSet) {
+      total += partition->size();
+      maxPartition = std::max<uint64_t>(maxPartition, partition->size());
+    }
+    VELOX_CHECK_GT(total, 0);
+    return static_cast<double>(maxPartition) / static_cast<double>(total);
+  };
+
+  // Full join: null-key build rows are retained for miss output and must be
+  // scattered -- no partition may dominate.
+  EXPECT_LE(maxPartitionShare(core::JoinType::kFull), 0.5);
+  // Inner join: null-key rows never reach the spiller in production (they are
+  // dropped before insert); partitioning stays purely hash-based, so a
+  // synthetic null-heavy container concentrates. This pins the fix's scope.
+  EXPECT_GE(maxPartitionShare(core::JoinType::kInner), 0.85);
 }
 
 TEST_P(HashJoinBuildOnly, writeBufferSize) {


### PR DESCRIPTION
`SpillerBase::fillSpillRuns`, `HashBuild::computeSpillPartitions` and `SpillPartitionFunction::partition` all assign spill partitions from the join-key hash. Null join keys hash to a constant, so **every null-key row lands in one spill partition, and that partition can never split at deeper spill levels** — its rows re-hash identically at every bit window. Once a restore exceeds `max_spill_level`, spilling is disabled for that operator, and the whole null-key population must fit in memory at once.

For join types that keep null-key rows across the spill boundary this is a deterministic memory-cap abort at scale: right and full joins retain null-key **build** rows for miss output, and outer joins pass null-key **probe** rows through. We hit this in production under Gluten with a ~450M-row `hash(null)` cell (a spine left join on a nullable session key, and a full outer join on nullable grain keys): the restore of the null partition exceeded the spill level limit, spilling was disabled, and the query died with `Exceeded memory pool capacity` regardless of partitioning depth.

## Fix

Null-key rows can never match the other side, so their spill-partition assignment is semantically free. Scatter them with a rotating rehashed sequence (`folly::hasher<uint64_t>()(seq++)`) at the three partitioning sites:

- `SpillerBase::fillSpillRuns` — container spills, via a new protected flag that `HashBuildSpiller` enables for **right and full joins** (the only join types whose containers retain null-key rows; all others drop them before insert);
- `HashBuild::computeSpillPartitions` — input-time spill routing, same join types;
- `SpillPartitionFunction` — probe input spill, enabled for **non-null-aware** joins.

Null-aware join types (anti, left semi project) are excluded: null keys carry real semantics there and short-circuit before spilling. Scattered rows restore into partitions whose key-hash range they don't match, which is harmless: build-side null rows are only ever emitted as misses, and probe-side null rows skip table lookup and emit null-extended per partition — each row lives in exactly one partition, so each is emitted exactly once.

## Testing

- New `SpillerTest/HashJoinBuildOnly.nullKeyRowsSpillScatter`: a 90%-null build side measured **91.5% of spilled bytes in one partition** before the fix (`Expected: (maxPartitionShare(kFull)) <= (0.5), actual: 0.915...`); bounded after. An inner-type spiller keeps pure hash placement, pinning the fix's scope.
- New `HashJoinTest.fullJoinNullKeysSpillParity`: result parity for a spilled full join with null-heavy keys on both sides (build- and probe-side scatter).
- Existing hash-placement checks (`spillPartition`, `writeBufferSize`, `nonSortedSpillFunctions`, `readaheadTest`) now keep fuzzed keys non-null for the scattering join types — placement of null keys is deliberately no longer hash-predictable.
- Full HashJoinTest + HashJoinBridgeTest + SpillTest + spiller suites pass (455 tests across the affected areas, linux/aarch64 Release).
