### PR TITLE
fix(rpc): Recover the congestion window after an overload backs it off (#18603)

### DIFF
--- a/velox/exec/rpc/CongestionController.cpp
+++ b/velox/exec/rpc/CongestionController.cpp
@@ -22,9 +22,10 @@
 namespace facebook::velox::exec::rpc {
 
 void CongestionController::onError() {
-  const auto prevEffective = effective_;
-  effective_ = std::max<int64_t>(effective_ / 2, minWindow_);
-  if (effective_ < prevEffective) {
+  const int64_t prevLimit = limit();
+  effective_ =
+      std::max<double>(effective_ / 2.0, static_cast<double>(minWindow_));
+  if (limit() < prevLimit) {
     ++numShrinks_;
   }
   // Drop the in-progress sample window so partial pre-overload samples don't
@@ -71,13 +72,14 @@ void CongestionController::onSample(int64_t rttNs) {
   // sqrt headroom keeps probing upward when latency is flat (gradient ~ 1), so
   // the window is never pinned by a fixed ceiling. stepCoef_ scales how hard it
   // probes (1.0 = the plain sqrt headroom).
-  const double headroom =
-      stepCoef_ * std::sqrt(static_cast<double>(effective_));
-  const auto newWindow = static_cast<int64_t>(
-      static_cast<double>(effective_) * gradient + headroom);
-  const auto prevEffective = effective_;
-  effective_ = std::clamp(newWindow, minWindow_, maxWindow_);
-  if (effective_ < prevEffective) {
+  const double headroom = stepCoef_ * std::sqrt(effective_);
+  const double newWindow = effective_ * gradient + headroom;
+  const int64_t prevLimit = limit();
+  effective_ = std::clamp<double>(
+      newWindow,
+      static_cast<double>(minWindow_),
+      static_cast<double>(maxWindow_));
+  if (limit() < prevLimit) {
     ++numShrinks_;
   }
 

--- a/velox/exec/rpc/CongestionController.h
+++ b/velox/exec/rpc/CongestionController.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 
 namespace facebook::velox::exec::rpc {
@@ -37,6 +38,23 @@ namespace facebook::velox::exec::rpc {
 /// signal is the per-window *minimum* RTT, which is robust to per-request size
 /// variance (e.g. variable LLM output length) because only queueing lifts the
 /// fastest request in a window.
+///
+/// The window is carried as a double and reported as its floor. That is load
+/// bearing, not a style choice: one recomputation changes the window by
+/// stepCoef*sqrt(w) - w*(1 - gradient), which is well under 1 for most (w,
+/// gradient) pairs. Rounding that to an integer every window discards the
+/// increment, so an integer-valued window stalls whenever
+///   stepCoef*sqrt(w) < w*(1 - gradient) + 1,
+/// which at w = 1 with the default stepCoef holds for every gradient below 1.
+/// Accumulating in floating point lets the sub-unit steps add up, and the
+/// window tracks the law instead of freezing. While the baseline is
+/// held, the law has the fixed point
+///   w* = stepCoef^2 / (1 - gradient)^2,
+/// which is how to size stepCoef against a backend that needs at least N
+/// concurrent requests to reach its throughput knee: stepCoef >= sqrt(N) *
+/// (1 - gradient). That fixed point governs the transient only — under
+/// sustained elevation the baseline EMA absorbs the new latency, the gradient
+/// returns toward 1, and the window resumes probing upward by design.
 ///
 /// A window constructed with startWindow == maxWindow that is never fed a
 /// sample stays fixed at that value — this is how callers pin a deterministic
@@ -65,28 +83,35 @@ class CongestionController {
   /// @param stepCoef Multiplier on the sqrt(window) additive-increase headroom
   ///        (default 1.0); lower values converge tighter at small windows.
   ///        Clamped to >= 0 (a negative coefficient would shrink on probe).
-  ///        A value < 1 can pin the window at small sizes because the update
-  ///        truncates to an integer (e.g. stepCoef 0.5 at window 1: 1 + 0.5 ->
-  ///        1); keep >= 1 unless minimal ramp-up is intended.
-  /// maxWindow is clamped to >= 1 first so the minWindow clamp range is always
-  /// valid (a < 1 ceiling would make std::clamp undefined). maxWindow is
-  /// internal and never < 1 at any current call site; this is defense in depth.
+  ///        The window accumulates in floating point, so a value < 1 still
+  ///        grows; it just takes more windows to cross each integer. Size it
+  ///        against the concurrency a backend needs to reach its throughput
+  ///        knee -- see the fixed point in the class comment above.
+  /// maxWindow is clamped into [1, kMaxWindowCeiling] first so the minWindow
+  /// clamp range is always valid (a < 1 ceiling would make std::clamp
+  /// undefined) and so the ceiling round-trips through the double accumulator
+  /// exactly. Both bounds are defense in depth: maxWindow is internal and no
+  /// current call site is outside them.
   CongestionController(
       int64_t startWindow,
       int64_t maxWindow,
       int64_t minWindow = 1,
       double stepCoef = 1.0)
-      : maxWindow_{std::max<int64_t>(maxWindow, 1)},
+      : maxWindow_{std::clamp<int64_t>(maxWindow, 1, kMaxWindowCeiling)},
         minWindow_{std::clamp<int64_t>(minWindow, int64_t{1}, maxWindow_)},
         stepCoef_{std::max(0.0, stepCoef)},
         // Clamp the starting window into [minWindow_, maxWindow_] so limit()
         // is in range from construction, before the first onError/onSample.
-        effective_{std::clamp<int64_t>(startWindow, minWindow_, maxWindow_)} {}
+        effective_{std::clamp<double>(
+            static_cast<double>(startWindow),
+            static_cast<double>(minWindow_),
+            static_cast<double>(maxWindow_))} {}
 
   /// Returns the current admission limit (max in-flight units before
-  /// backpressure).
+  /// backpressure): the floor of the accumulated window, never below
+  /// minWindow.
   int64_t limit() const {
-    return effective_;
+    return static_cast<int64_t>(std::floor(effective_));
   }
 
   /// Returns the learned baseline RTT (nanos), or 0 before the first full
@@ -110,6 +135,13 @@ class CongestionController {
   void onSample(int64_t rttNs);
 
  private:
+  // Largest ceiling the window may take. 2^53 is the last integer a double
+  // represents exactly, so effective_ never exceeds a value that converts back
+  // to int64_t. rpc.congestion.max_window is user-settable and unbounded;
+  // INT64_MAX would round *up* to 2^63 as a double, and converting that back is
+  // undefined (x86 yields INT64_MIN, which would stall dispatch outright).
+  static constexpr int64_t kMaxWindowCeiling = int64_t{1} << 53;
+
   // Samples accumulated before each gradient recomputation.
   static constexpr int64_t kSamplesPerWindow = 8;
   // EMA weight applied to the observed RTT when tracking the baseline.
@@ -121,8 +153,9 @@ class CongestionController {
   int64_t minWindow_{1};
   // Multiplier on the sqrt(window) additive-increase headroom.
   double stepCoef_{1.0};
-  // Current admission limit (the value limit() returns).
-  int64_t effective_{1};
+  // Accumulated admission window. Fractional so sub-unit growth is not lost
+  // between recomputations; limit() reports its floor.
+  double effective_{1.0};
 
   // Slow EMA of per-window minimum RTT (nanos); 0 until the first window.
   int64_t baselineRttNs_{0};

--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -31,8 +31,9 @@ namespace facebook::velox::exec::rpc {
 
 namespace {
 // Safety ceiling for the BATCH latency-gradient window. The gradient backs off
-// as soon as queueing lifts RTT, well before this bound, so it caps
-// pathological growth rather than tuning throughput.
+// whenever queueing lifts RTT above the baseline, but the baseline EMA absorbs
+// sustained elevation and the window then resumes probing upward, so against a
+// backend that never visibly slows down this bound is what stops growth.
 constexpr int64_t kBatchMaxWindow = 256;
 
 // Monotonic now() in nanos for RTT measurement. steady_clock (not wall-clock)

--- a/velox/exec/rpc/tests/CongestionControllerTest.cpp
+++ b/velox/exec/rpc/tests/CongestionControllerTest.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 namespace facebook::velox::exec::rpc {
 namespace {
 
@@ -247,6 +249,94 @@ TEST(CongestionControllerTest, baselineTracksSustainedLatencyAndRecovers) {
     feedWindow(window, 2'000'000);
   }
   EXPECT_GT(window.limit(), 4);
+}
+
+// Mild latency elevation must move the window off the floor. One
+// recomputation changes it by stepCoef*sqrt(w) - w*(1 - gradient); at w = 1
+// with gradient 0.8 that is +0.8, and an integer-valued window truncated 1.8
+// back to 1 and discarded it, every window, forever. Accumulating in floating
+// point lets those sub-unit steps add up. Measured over 200 windows of the
+// same input: 1 before this change, 1024 after.
+TEST(CongestionControllerTest, mildCongestionMovesWindowOffTheFloor) {
+  auto window = CongestionController{1, 1024};
+  feedWindow(window, 1'000'000); // baseline = 1ms
+  // A few windows at 1.25ms: gradient ~0.8, before the baseline has chased it.
+  for (int round = 0; round < 5; ++round) {
+    feedWindow(window, 1'250'000);
+  }
+  EXPECT_GT(window.limit(), 1);
+
+  // Sustained, the baseline absorbs the elevation and the window keeps
+  // probing; the point is that it climbs at all, not where it stops.
+  for (int round = 0; round < 195; ++round) {
+    feedWindow(window, 1'250'000);
+  }
+  EXPECT_GE(window.limit(), 16);
+}
+
+// A caller-supplied ceiling must not push the window past what a double
+// converts back to. rpc.congestion.max_window is user-settable and unbounded,
+// and static_cast<double>(INT64_MAX) rounds *up* to 2^63; converting that back
+// to int64_t is undefined and yields INT64_MIN on x86, which would report a
+// negative admission limit and stall dispatch outright.
+TEST(CongestionControllerTest, hugeCeilingStillReportsAPositiveLimit) {
+  for (int64_t ceiling :
+       {std::numeric_limits<int64_t>::max(),
+        std::numeric_limits<int64_t>::max() - 1,
+        (int64_t{1} << 62)}) {
+    auto window = CongestionController{ceiling, ceiling};
+    EXPECT_GT(window.limit(), 0) << "ceiling=" << ceiling;
+    // Growth must not break it either.
+    feedWindow(window, 1'000'000);
+    feedWindow(window, 1'000'000);
+    EXPECT_GT(window.limit(), 0) << "after growth, ceiling=" << ceiling;
+  }
+}
+
+// numShrinks counts observable back-off, not accumulator wobble. Carrying the
+// window as a double means it can fall by a fraction of a unit while limit()
+// is unchanged; counting those would inflate the rpcCongestionShrinks runtime
+// stat and report back-off that never happened.
+TEST(CongestionControllerTest, shrinkCountTracksTheReportedLimit) {
+  auto window = CongestionController{8, 1024};
+  feedWindow(window, 1'000'000); // baseline = 1ms
+
+  // Alternate mild elevation and recovery so the accumulator moves both ways
+  // in sub-unit steps. Count only the times the reported limit actually fell.
+  int64_t observedDrops = 0;
+  for (int round = 0; round < 60; ++round) {
+    const int64_t before = window.limit();
+    feedWindow(window, (round % 2 == 0) ? 1'400'000 : 1'000'000);
+    if (window.limit() < before) {
+      ++observedDrops;
+    }
+  }
+  EXPECT_EQ(window.numShrinks(), observedDrops);
+}
+
+// A backend that batches internally gets *faster* as concurrency rises until
+// it reaches its knee. The window must climb through that region: latency
+// falling as the window grows reads as gradient 1, which is the grow signal.
+// This one is a regression guard, not evidence for the fractional-window fix:
+// it passes with and without it, because at gradient 1 the step is already a
+// whole unit.
+// The risk this pins down is the composite one -- a window parked below the
+// knee sees the backend's worst latency, which then looks like congestion.
+TEST(CongestionControllerTest, climbsThroughBatchingKnee) {
+  constexpr int64_t kKnee = 6;
+  auto window = CongestionController{1, 1024};
+  // Latency model: 10ms at a window of 1, falling to 1ms at the knee, then
+  // rising again with queueing beyond it.
+  auto rttFor = [](int64_t windowSize) -> int64_t {
+    if (windowSize <= kKnee) {
+      return 10'000'000 - (windowSize - 1) * 1'800'000;
+    }
+    return 1'000'000 + (windowSize - kKnee) * 500'000;
+  };
+  for (int round = 0; round < 100; ++round) {
+    feedWindow(window, rttFor(window.limit()));
+  }
+  EXPECT_GE(window.limit(), kKnee);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

The congestion window is an `int64_t`, and every recomputation truncates. That
only rounds down, so a shrink always lands while growth is discarded unless it
clears the next integer. A growth step is `stepCoef*sqrt(w) - w*(1 - gradient)`,
so the window stalls whenever

    stepCoef*sqrt(w) < w*(1 - gradient) + 1.

PER_ROW seeds the window at its ceiling and only shrinks from there, so this
bites on the way back: once an overload has halved the window down, it climbs
again only through windows whose step clears an integer. While latency stays
above baseline the step never does, and the window sits at the floor after the
backend has recovered. BATCH starts at 2 and has to climb, so it is exposed for
its whole life.

Keep the window as a `double`, floor it in `limit()`. No API change, same clamp
to `[minWindow, maxWindow]`.

`numShrinks_` compared the raw double, so a fractional dip that left `limit()`
alone still counted as a shrink and inflated `rpcCongestionShrinks`. It compares
the reported limit now.

Carrying the window as a `double` also constrains the ceiling: `maxWindow` comes
from a session property, and a value near `INT64_MAX` rounds up to 2^63 as a
double, which converts back out of range. It is clamped to 2^53, the last
integer a double holds exactly.

To pin the window back on a running cluster, the ceiling is already a
registered session property -- no new build required:

    SET SESSION native_rpc_congestion_max_window = 4;

Measured on a 5000-row `fb_embedding` BATCH query: the window reports 4 with
the cap set, against 12..16 with it unset. For PER_ROW the same knob is also
the starting window, so lowering it lowers baseline concurrency as well.

Reviewed By: abhinavmuk04

Differential Revision: D116798431


