### PR TITLE
fix: Coerce a non-boolean SWITCH condition to boolean

### DIFF
--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -264,10 +264,18 @@ TypePtr resolveTypeInt(
     const auto& conditionType = argTypes[i * 2];
     const auto& thenType = argTypes[i * 2 + 1];
 
-    VELOX_CHECK_EQ(
-        conditionType->kind(),
-        TypeKind::BOOLEAN,
-        "Condition of  SWITCH statement is not bool");
+    if (!conditionType->isBoolean()) {
+      VELOX_CHECK(
+          allowedCoercions,
+          "Condition of  SWITCH statement is not bool: {}",
+          conditionType->toString());
+      // A null literal condition types as UNKNOWN, which coerces to boolean.
+      VELOX_CHECK(
+          coercer.coerce(conditionType, BOOLEAN()).has_value(),
+          "Condition of  SWITCH statement is not coercible to bool: {}",
+          conditionType->toString());
+      coercions[i * 2] = BOOLEAN();
+    }
 
     if (*thenType != *resultType) {
       const auto common = allowedCoercions

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -1111,6 +1111,16 @@ TEST_F(FunctionRegistryTest, resolveSwitchWithCoercions) {
       {BOOLEAN(), DECIMAL(8, 5), BOOLEAN(), DECIMAL(12, 2), INTEGER()},
       DECIMAL(15, 5),
       {nullptr, DECIMAL(15, 5), nullptr, DECIMAL(15, 5), DECIMAL(15, 5)});
+
+  // A null literal condition, which types as UNKNOWN, coerces to boolean.
+  testSpecialFormCoercions(
+      "switch",
+      {UNKNOWN(), BIGINT(), BOOLEAN(), BIGINT(), BIGINT()},
+      BIGINT(),
+      {BOOLEAN(), nullptr, nullptr, nullptr, nullptr});
+
+  // A condition of any other type does not.
+  testSpecialFormCannotResolve("switch", {INTEGER(), BIGINT(), BIGINT()});
 }
 
 TEST_F(FunctionRegistryTest, resolveCaseWithCoercions) {


### PR DESCRIPTION
Summary:
`SELECT IF(x, 'a') FROM (SELECT NULL AS x)` failed to resolve:

```
(UNKNOWN vs. BOOLEAN) Condition of  SWITCH statement is not bool
```

A `NULL` literal projected as a column types as UNKNOWN, so an IF or CASE over
it presents an UNKNOWN condition. Presto accepts this and treats the condition
as false: `if(x, 'a')` returns NULL and `CASE WHEN x THEN 1 ELSE 2 END`
returns 2.

Type resolution for SWITCH required the condition to be BOOLEAN outright.
Route a non-boolean condition through the type coercer instead, the same way
`then` clauses already go through it, and record the coercion to BOOLEAN.
UNKNOWN coerces to BOOLEAN; other types do not, so `IF(1, 'a', 'b')` is still
rejected. Coercions have to be allowed for this path at all, so a caller that
resolves without them sees the original failure.

Differential Revision: D116830086


