### PR TITLE
fix: Coerce non-boolean AND and OR arguments to boolean (#18605)

### DIFF
--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -399,6 +399,8 @@ TypePtr ConjunctExpr::resolveType(const std::vector<TypePtr>& argTypes) {
       "Conjunct expressions expect at least one argument, received: {}",
       argTypes.size());
 
+  // An UNKNOWN argument cannot be evaluated, but it is allowed here because
+  // the conjunct may short-circuit before reaching it.
   for (const auto& argType : argTypes) {
     VELOX_CHECK(
         argType->kind() == TypeKind::BOOLEAN ||
@@ -413,6 +415,35 @@ TypePtr ConjunctExpr::resolveType(const std::vector<TypePtr>& argTypes) {
 TypePtr ConjunctCallToSpecialForm::resolveType(
     const std::vector<TypePtr>& argTypes) {
   return ConjunctExpr::resolveType(argTypes);
+}
+
+TypePtr ConjunctCallToSpecialForm::resolveTypeWithCoercions(
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
+  VELOX_CHECK_GT(
+      argTypes.size(),
+      0,
+      "Conjunct expressions expect at least one argument, received: {}",
+      argTypes.size());
+
+  coercions.clear();
+  coercions.resize(argTypes.size());
+
+  for (auto i = 0; i < argTypes.size(); ++i) {
+    if (argTypes[i]->kind() == TypeKind::BOOLEAN) {
+      continue;
+    }
+
+    // A null literal argument types as UNKNOWN and coerces to boolean.
+    VELOX_CHECK(
+        coercer.coerce(argTypes[i], BOOLEAN()).has_value(),
+        "Conjunct expression argument is not coercible to BOOLEAN: {}",
+        argTypes[i]->toString());
+    coercions[i] = BOOLEAN();
+  }
+
+  return BOOLEAN();
 }
 
 ExprPtr ConjunctCallToSpecialForm::constructSpecialForm(

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -115,6 +115,11 @@ class ConjunctCallToSpecialForm : public FunctionCallToSpecialForm {
 
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
+  TypePtr resolveTypeWithCoercions(
+      const std::vector<TypePtr>& argTypes,
+      std::vector<TypePtr>& coercions,
+      const TypeCoercer& coercer) override;
+
   ExprPtr constructSpecialForm(
       const TypePtr& type,
       std::vector<ExprPtr>&& compiledChildren,

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -1123,6 +1123,29 @@ TEST_F(FunctionRegistryTest, resolveSwitchWithCoercions) {
   testSpecialFormCannotResolve("switch", {INTEGER(), BIGINT(), BIGINT()});
 }
 
+TEST_F(FunctionRegistryTest, resolveConjunctWithCoercions) {
+  auto resolve = [](const std::string& name,
+                    const std::vector<TypePtr>& argTypes) {
+    std::vector<TypePtr> coercions;
+    auto type = resolveCallableSpecialFormWithCoercions(
+        name, argTypes, coercions, TypeCoercer::defaults());
+    return std::make_pair(type, coercions);
+  };
+
+  // A null literal argument, which types as UNKNOWN, coerces to boolean.
+  auto [andType, andCoercions] = resolve("and", {UNKNOWN(), BOOLEAN()});
+  VELOX_EXPECT_EQ_TYPES(andType, BOOLEAN());
+  EXPECT_THAT(andCoercions, testing::ElementsAre(BOOLEAN(), nullptr));
+
+  auto [orType, orCoercions] = resolve("or", {BOOLEAN(), UNKNOWN()});
+  VELOX_EXPECT_EQ_TYPES(orType, BOOLEAN());
+  EXPECT_THAT(orCoercions, testing::ElementsAre(nullptr, BOOLEAN()));
+
+  // An argument of any other type does not.
+  testSpecialFormCannotResolve("and", {BOOLEAN(), INTEGER()});
+  testSpecialFormCannotResolve("or", {VARCHAR(), BOOLEAN()});
+}
+
 TEST_F(FunctionRegistryTest, resolveCaseWithCoercions) {
   // subject, WHEN, THEN, WHEN, THEN, ELSE. The THEN clauses coerce in neither
   // direction, so they and the ELSE meet at a common decimal.


### PR DESCRIPTION
Summary:

`and` and `or` accept an argument of UNKNOWN type when resolving types, but cannot evaluate one. For example:

  SELECT x AND true FROM (SELECT NULL AS x)

builds a plan, then fails during evaluation with:

  (UNKNOWN vs. BOOLEAN)
  Expression: vector->typeKind() == TypeKind::BOOLEAN
  Function: getFlatBool

A NULL literal projected as a column types as UNKNOWN, so ordinary queries hit this. Presto returns NULL for that query.

Arguments now go through the type coercer: one that is not boolean is coerced to BOOLEAN, and UNKNOWN is the only type that coerces. Type resolution keeps accepting an UNKNOWN
argument when there is no coercer, because a conjunct may short-circuit before it evaluates that argument.

Reviewed By: xiaoxmeng

Differential Revision: D116833145


