### PR TITLE
fix(cuDF): Avoid copying single cuDF concat batches in CudfBatchConcat

### DIFF
--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -82,6 +82,17 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 
   // Merge tables if there are enough rows
   if (!buffer_.empty() && (currentNumRows_ >= targetRows_ || noMoreInput_)) {
+    // Concatenating a single column-bearing input only materializes a copy of
+    // the same table. Pass it through unchanged. Zero-column inputs still need
+    // the batching helper below to preserve their row count and enforce the
+    // maximum batch-size threshold.
+    if (buffer_.size() == 1 && outputType_->size() > 0) {
+      auto output = std::move(buffer_.front());
+      buffer_.clear();
+      currentNumRows_ = 0;
+      return output;
+    }
+
     // Use stream from existing buffer vectors
     const auto outputStream = buffer_[0]->stream();
     auto outputVectors = getConcatenatedCudfVectorsBatched(

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -15,7 +15,10 @@
  */
 
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfBatchConcat.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -81,6 +84,41 @@ class CudfBatchConcatTest : public OperatorTestBase {
     return opIt->second.get();
   }
 };
+
+TEST_F(CudfBatchConcatTest, singleColumnBearingInputPassesThrough) {
+  updateCudfConfig(/*min=*/4, /*max=*/std::nullopt);
+
+  auto input = makeRowVector({makeFlatSequence<int64_t>(0, 4)});
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .singleAggregation({}, {"sum(c0)"})
+                  .planNode();
+
+  core::PlanFragment planFragment;
+  planFragment.planNode = plan;
+  auto task = Task::create(
+      "CudfBatchConcatTest_singleColumnBearingInputPassesThrough",
+      std::move(planFragment),
+      0,
+      core::QueryCtx::create(executor_.get()),
+      Task::ExecutionMode::kParallel);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  CudfBatchConcat concat(0, &driverCtx, plan);
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto table = with_arrow::toCudfTable(
+      input, pool(), stream, cudf::get_current_device_resource_ref());
+  auto cudfInput = std::make_shared<CudfVector>(
+      pool(), input->type(), input->size(), std::move(table), stream);
+
+  concat.addInput(cudfInput);
+  auto output = concat.getOutput();
+
+  ASSERT_NE(output, nullptr);
+  EXPECT_EQ(output.get(), cudfInput.get())
+      << "A single column-bearing input must not be materialized by concat";
+  concat.close();
+}
 
 // Verifies that CudfBatchConcat is inserted before aggregation and reduces
 // the number of batches reaching the aggregation operator.
@@ -410,4 +448,34 @@ TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
   EXPECT_EQ(concatIt->second->inputVectors, 3);
   EXPECT_EQ(concatIt->second->outputVectors, 2)
       << "30 zero-column rows should be split into 20-row and 10-row batches";
+}
+
+TEST_F(CudfBatchConcatTest, singleZeroColumnBatchSplitsAtMaxThreshold) {
+  updateCudfConfig(/*min=*/30, /*max=*/20);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  auto data = makeRowVector({makeFlatSequence<int64_t>(0, 30)});
+  createDuckDbTable({data});
+
+  core::PlanNodeId aggNodeId;
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .filter("c0 >= 0")
+                  .project({})
+                  .singleAggregation({}, {"count(*)"})
+                  .capturePlanNodeId(aggNodeId)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .maxDrivers(1)
+                  .assertResults("SELECT count(*) FROM tmp WHERE c0 >= 0");
+
+  auto planStats = toPlanStats(task->taskStats());
+  auto& nodeStats = planStats.at(aggNodeId);
+  auto concatIt = nodeStats.operatorStats.find("CudfBatchConcat");
+  ASSERT_NE(concatIt, nodeStats.operatorStats.end());
+  EXPECT_EQ(concatIt->second->inputVectors, 1);
+  EXPECT_EQ(concatIt->second->outputVectors, 2)
+      << "A 30-row zero-column input should be split into 20 and 10 rows";
 }


### PR DESCRIPTION
This PR avoids unnecessary GPU-to-GPU copies in CudfBatchConcat by not calling cudf::concatenate if there is only one batch.