### PR TITLE
fix: Enable bulk reader path on aarch64 via hasSIMD() (#18609)

### DIFF
--- a/velox/common/process/ProcessBase.cpp
+++ b/velox/common/process/ProcessBase.cpp
@@ -25,6 +25,7 @@
 #include <folly/FileUtil.h>
 #include <folly/String.h>
 #include <gflags/gflags.h>
+#include <xsimd/xsimd.hpp>
 
 constexpr const char* kProcSelfCmdline = "/proc/self/cmdline";
 
@@ -111,6 +112,16 @@ bool avx2CpuFlag = folly::CpuId().avx2();
 bool hasAvx2() {
 #ifdef __AVX2__
   return avx2CpuFlag && FLAGS_avx2;
+#else
+  return false;
+#endif
+}
+
+bool hasSimd() {
+#if XSIMD_WITH_AVX2
+  return avx2CpuFlag && FLAGS_avx2;
+#elif XSIMD_WITH_NEON64
+  return true;
 #else
   return false;
 #endif

--- a/velox/common/process/ProcessBase.h
+++ b/velox/common/process/ProcessBase.h
@@ -46,6 +46,12 @@ uint64_t threadCpuNanos();
 /// by flag.
 bool hasAvx2();
 
+/// True if the platform has SIMD instructions suitable for the bulk reader
+/// path (xsimd-based, no raw intrinsics). On x86 this requires AVX2 and
+/// is gated by --avx2; on aarch64, NEON is always available and the bulk
+/// path is unconditionally enabled.
+bool hasSimd();
+
 /// True if the machine has Intel BMI2 instructions and these are not disabled
 /// by flag.
 bool hasBmi2();

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -540,7 +540,7 @@ bool nonNullRowsFromSparse(
 template <typename Visitor, bool hasNulls>
 bool useFastPath(Visitor& visitor) {
   return (!std::is_same_v<typename Visitor::DataType, int128_t>) &&
-      process::hasAvx2() && Visitor::FilterType::deterministic &&
+      process::hasSimd() && Visitor::FilterType::deterministic &&
       Visitor::kHasBulkPath &&
       (std::
            is_same_v<typename Visitor::FilterType, velox::common::AlwaysTrue> ||

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -432,7 +432,7 @@ class SelectiveColumnReader {
   /// is used at read time and is expected to produce the same result.
   bool useBulkPath() const {
     auto* filter = scanSpec_->filter();
-    return hasBulkPath() && process::hasAvx2() &&
+    return hasBulkPath() && process::hasSimd() &&
         (!filter ||
          (filter->isDeterministic() &&
           (!nullsInReadRange_ || !filter->testNull()))) &&

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -430,7 +430,7 @@ void SelectiveStringDirectColumnReader::readWithVisitor(
       std::is_same_v<typename TVisitor::Extract, dwio::common::ExtractToReader>;
   auto nulls = nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
 
-  if (process::hasAvx2() && isExtract) {
+  if (process::hasSimd() && isExtract) {
     if (nullsInReadRange_) {
       if (TVisitor::dense) {
         returnReaderNulls_ = true;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -566,7 +566,7 @@ void HashTable<ignoreNullKeys>::arrayGroupProbe(HashLookup& lookup) {
   auto hashes = lookup.hashes.data();
   auto groups = lookup.hits.data();
   int32_t i = 0;
-  if (process::hasAvx2() && simd::isDense(rows, numProbes)) {
+  if (process::hasSimd() && simd::isDense(rows, numProbes)) {
     auto allZero = xsimd::broadcast<int64_t>(0);
     constexpr int32_t kWidth = xsimd::batch<int64_t>::size;
     auto start = rows[0];


### PR DESCRIPTION
Summary:

On aarch64, `hasAvx2()` is compile-time false, which disables the
bulk/fast selective reader path (`useBulkPath`, `useFastPath`) and forces
every DWRF read through a scalar fallback. This fallback has a
correctness bug in the stride-pruning logic: under filter pushdown, it
incorrectly skips row-group strides that contain matching rows, silently
dropping data. The bug is reproducible on x86 with `--avx2=false`.

The bulk path uses zero raw x86 intrinsics — it is entirely xsimd-generic
(`xsimd::default_arch` resolves to NEON on ARM). The `hasAvx2()` gate was
preventing ARM from using code that is already portable.

This diff adds `process::hasSIMD()` which returns true on any platform
with xsimd-compatible SIMD (AVX2 on x86, NEON64 on aarch64), and
replaces all 4 `process::hasAvx2()` call sites:
- `SelectiveColumnReader::useBulkPath()` (prepare-time gate)
- `useFastPath()` in DecoderUtil.h (read-time gate)
- String extract fast path in SelectiveStringDirectColumnReader.cpp
- SIMD hash probe in HashTable.cpp

`hasAvx2()` and `hasBmi2()` are preserved for code that genuinely needs
x86-specific instructions (e.g. BitPackDecoder.h PDEP paths).

Reviewed By: Yuhta

Differential Revision: D116370772


