### PR TITLE
fix(rpc): Release retained input vectors in RPCOperator::close() (#18610)

### DIFF
--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -781,9 +781,16 @@ bool RPCOperator::startDrain() {
 void RPCOperator::close() {
   recordRuntimeStats();
 
-  // Release resources explicitly. RPCState may be held alive by in-flight
-  // RPC callbacks (via shared_ptr capture), but we release our reference
-  // so that input batch memory can be freed as soon as possible.
+  // Release resources explicitly. RPCState may be held alive by in-flight RPC
+  // callbacks (via shared_ptr capture), so dropping our reference is not enough
+  // to free the input vectors: those belong to upstream operators' memory pools
+  // and must be released here, on the driver thread, while those pools are
+  // still alive. Otherwise the retained reservation makes the arbitrator's
+  // reservedBytes() == 0 check throw from ~MemoryPoolImpl() and terminate the
+  // worker, or a late callback frees into pools that are already gone.
+  if (state_ != nullptr) {
+    state_->releaseAllInputBatches();
+  }
   state_.reset();
   function_.reset();
   claimedRows_.clear();

--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -125,6 +125,16 @@ std::vector<VectorPtr> RPCState::getInputBatchColumns(
   return inputBatches_[batchIndex].flatColumns;
 }
 
+void RPCState::releaseAllInputBatches() {
+  std::lock_guard<std::mutex> l(mutex_);
+  for (auto& batch : inputBatches_) {
+    batch.flatColumns.clear();
+    batch.activeRowCount = 0;
+  }
+  RPC_STATE_VLOG(1) << "releaseAllInputBatches: dropped "
+                    << inputBatches_.size() << " input batches";
+}
+
 void RPCState::releaseRows(int32_t batchIndex, int64_t count) {
   std::lock_guard<std::mutex> l(mutex_);
   VELOX_CHECK_LT(

--- a/velox/exec/rpc/RPCState.h
+++ b/velox/exec/rpc/RPCState.h
@@ -183,6 +183,22 @@ class RPCState {
   /// When all rows are released, the batch columns are freed.
   void releaseRows(int32_t batchIndex, int64_t count);
 
+  /// Drop every retained input vector, regardless of activeRowCount.
+  ///
+  /// Called from RPCOperator::close() on the driver thread. In-flight RPC
+  /// callbacks hold a shared_ptr to this object, so it can outlive the
+  /// operator, the Task and the query's memory pools. The input vectors were
+  /// allocated from upstream operators' pools, so holding them past teardown
+  /// leaves a non-zero reservation on those pools; the arbitrator's
+  /// pool->reservedBytes() == 0 check then throws from ~MemoryPoolImpl() and
+  /// terminates the worker. If instead the last callback lands after the pools
+  /// are gone, ~RPCState() frees into freed memory.
+  ///
+  /// Safe to call while RPCs are outstanding: completion callbacks only
+  /// deposit RPCResponse values and never read flatColumns, which is read
+  /// solely by the driver thread when building output.
+  void releaseAllInputBatches();
+
   // ===== PER_ROW mode API =====
 
   /// Add a pending row with its RPC future and location in the input batch.

--- a/velox/exec/rpc/tests/RPCStateTest.cpp
+++ b/velox/exec/rpc/tests/RPCStateTest.cpp
@@ -44,7 +44,10 @@
 #include "velox/exec/rpc/RPCState.h"
 
 #include <folly/futures/Promise.h>
+#include <folly/synchronization/CallOnce.h>
 #include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
 
 #include <atomic>
 #include <chrono>
@@ -368,6 +371,42 @@ TEST_F(RPCStateTest, inputBatchStorageAndRelease) {
 
   // Release all rows from batch 2 at once.
   state_->releaseRows(batchIdx2, 2);
+}
+
+// A crashed worker's stack: an abandoned AI query tears down the Task while an
+// RPC is still in flight; the callback holds a shared_ptr<RPCState>, so the
+// retained input vectors outlive the pools that allocated them. Either the
+// arbitrator's reservedBytes() == 0 check throws from ~MemoryPoolImpl() and
+// terminates the worker, or the late callback frees into pools already gone.
+// close() must therefore drop the vectors itself, on the driver thread, and
+// not rely on the reference count reaching zero in time.
+TEST_F(RPCStateTest, releaseAllInputBatchesDropsVectorsWhileStateIsStillHeld) {
+  // This binary does not stand up a MemoryManager; do it once for this test.
+  static folly::once_flag initOnce;
+  folly::call_once(initOnce, [] { memory::MemoryManager::initialize({}); });
+  auto pool = memory::memoryManager()->addLeafPool("releaseAllInputBatches");
+  VectorPtr vector = BaseVector::create(BIGINT(), 8, pool.get());
+
+  // Two batches, one still holding "active" rows: the abandoned-query case,
+  // where releaseRows() never runs because the rows are never output.
+  state_->storeInputBatch(std::vector<VectorPtr>{vector}, /*rowCount=*/4);
+  state_->storeInputBatch(std::vector<VectorPtr>{vector}, /*rowCount=*/4);
+  EXPECT_GT(vector.use_count(), 1);
+
+  // Stand in for an in-flight callback still holding the state alive.
+  auto callbackRef = state_;
+
+  state_->releaseAllInputBatches();
+
+  // The state object survives, but owns none of the pool-backed memory: this
+  // test holds the only remaining reference to the vector.
+  EXPECT_EQ(vector.use_count(), 1);
+  EXPECT_TRUE(state_->getInputBatchColumns(0).empty());
+  EXPECT_TRUE(state_->getInputBatchColumns(1).empty());
+
+  // Idempotent — close() may run after rows were already released.
+  state_->releaseAllInputBatches();
+  EXPECT_EQ(vector.use_count(), 1);
 }
 
 TEST_F(RPCStateTest, batchRowLocationsCarriedThrough) {


### PR DESCRIPTION
Summary:

Workers crash when a Task is torn down while its RPCs are still in flight. Two
distinct signatures — an abort out of the memory arbitrator and a segfault on an
RPC executor thread — are both this one bug.

`RPCState` holds `std::vector<InputBatchRef>`, each carrying
`std::vector<VectorPtr> flatColumns` — input vectors allocated from *upstream*
operators' memory pools. In-flight RPC completion callbacks capture a
`shared_ptr<RPCState>` to keep the state alive, so the state can outlive the
operator. `close()` only dropped the operator's own reference:

    // ...we release our reference so that input batch memory can be freed
    // as soon as possible.
    state_.reset();

When a callback still holds a reference, that frees nothing. `Operator::close()`
returns, the Task tears down, and the retained vectors keep a reservation on
pools that are being destroyed. Two ways to die:

- The arbitrator's `VELOX_CHECK_EQ(pool->reservedBytes(), 0)` in
  `SharedArbitrator::removePool` throws from inside `~MemoryPoolImpl()`, so
  cleanup `std::terminate`s the worker. This is the abort majority, and it
  needs no callback to ever land.
- Or the callback lands later, `~RPCState()` runs on an RPC executor thread,
  and `MemoryPoolImpl::free()` writes into pools that are already gone. This
  is the segfault minority, and the only signature carrying `exec::rpc` frames.

Release the vectors where their pools are still alive: `close()` now calls
`RPCState::releaseAllInputBatches()`, which clears every `flatColumns` under
`mutex_`, before dropping the reference. A late callback then keeps a state
object that owns no pool memory, and its destructor is safe on any thread.

Safe while RPCs are outstanding: completion callbacks only deposit
`RPCResponse` values. `flatColumns` is read solely by the driver thread when
building output — `getInputBatchColumns()` has exactly two callers, both on
that path — and by then the driver is done. The clear mirrors what
`releaseRows()` already does under the same lock when a batch's last row is
output; early teardown is precisely the case where that never runs.

Not a regression from a recent change: nothing has touched `velox/exec/rpc/` in
over a month. What varies is how often a Task is destroyed with RPCs still
outstanding, which is a property of the workload rather than of this code — so
the same build can sit at a low crash rate for a long stretch and then climb
sharply without anything in `velox/exec/rpc/` having moved.

Reviewed By: gggrace14

Differential Revision: D116849394


