### PR TITLE
fix(nimble): Preserve nulls in dense bulk reads

### DIFF
--- a/velox/dwio/nimble/encodings/common/Encoding.h
+++ b/velox/dwio/nimble/encodings/common/Encoding.h
@@ -687,6 +687,20 @@ void readWithVisitorFast(
     auto numNonNulls = velox::simd::indicesOfSetBits(
         nulls, visitor.rowIndex(), visitor.numRows(), outerRows.data());
     outerRows.resize(numNonNulls);
+    if constexpr (kOutputNulls) {
+      if (numNonNulls != numRows) {
+        if (!visitor.reader().returnReaderNulls()) {
+          params.prepareResultNulls();
+          velox::bits::copyBits(
+              nulls,
+              visitor.rowIndex(),
+              visitor.reader().rawResultNulls(),
+              visitor.rowIndex(),
+              numRows);
+        }
+        visitor.setHasNulls();
+      }
+    }
     if (outerRows.empty()) {
       if constexpr (kOutputNulls) {
         visitor.addNumValues(numRows);

--- a/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -748,6 +748,14 @@ TEST_P(ReadWithVisitorTest, denseNoFilterWithNulls) {
   // Every row is "output" since there is no filter.
   EXPECT_EQ(child->numValues(), kRows);
   EXPECT_TRUE(child->hasNulls());
+
+  std::vector<vector_size_t> rowNumbers(kRows);
+  std::iota(rowNumbers.begin(), rowNumbers.end(), 0);
+  VectorPtr result;
+  child->getValues(RowSet(rowNumbers.data(), rowNumbers.size()), &result);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(result->isNullAt(i), i % 7 == 0) << "row " << i;
+  }
 }
 
 // ===========================================================================


### PR DESCRIPTION
Summary: Bugfix: Dense nullable reads using an `AlwaysTrue` visitor could return an all-valid vector even when the input contained nulls. The bulk path now copies the read-range null bitmap when the reader cannot return that buffer directly, then marks the result as nullable.

Differential Revision: D116851691


