### PR TITLE
misc(nimble): Capitalize Nimble in the Types.h header comment

### DIFF
--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -24,7 +24,7 @@
 
 #include <fmt/format.h>
 
-// Single file containing all the types and enums in nimble, as well as some
+// Single file containing all the types and enums in Nimble, as well as some
 // templates for mapping between those types and C++ types.
 //
 // A note on types: For all of our enum classes, we assume the number of


### PR DESCRIPTION
Summary:
One-word comment fix.

Landed only to smoke-test the fbcode to GitHub export path for Nimble files,
after the Diff Train fixup and the restore on top of it landed (D115111041,
D116662027). Nothing depends on this change.

Differential Revision: D116863570


