### PR TITLE
refactor(nimble): Rename file features to properties (#18616)

### DIFF
--- a/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
@@ -1130,7 +1130,7 @@ SerializationTest::SerializeResult SerializationTest::serializeTablet(
     auto headerIOBuf = serde::createTabletChunkHeader(
         {.rowCount = stripeRows,
          .streamEncodingUsesVarintRowCount =
-             tablet->features().compactRowCountEncoding(),
+             tablet->properties().compactRowCountEncoding(),
          .streamHasChunkHeader = true,
          .rowRange = RowRange{0, stripeRows}});
     std::string headerBuf(
@@ -5021,7 +5021,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxHighParallelism) {
     auto headerIOBuf = serde::createTabletChunkHeader(
         {.rowCount = stripeRows,
          .streamEncodingUsesVarintRowCount =
-             tablet->features().compactRowCountEncoding(),
+             tablet->properties().compactRowCountEncoding(),
          .streamHasChunkHeader = true,
          .rowRange = RowRange{0, stripeRows}});
     std::string headerBuf(
@@ -5137,7 +5137,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxConcurrentDeserializers) {
       auto headerIOBuf = serde::createTabletChunkHeader(
           {.rowCount = stripeRows,
            .streamEncodingUsesVarintRowCount =
-               tablet->features().compactRowCountEncoding(),
+               tablet->properties().compactRowCountEncoding(),
            .streamHasChunkHeader = true,
            .rowRange = RowRange{0, stripeRows}});
       std::string headerBuf(
@@ -5301,7 +5301,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxFlatMapWithParallelDecode) {
     auto headerIOBuf = serde::createTabletChunkHeader(
         {.rowCount = stripeRows,
          .streamEncodingUsesVarintRowCount =
-             tablet->features().compactRowCountEncoding(),
+             tablet->properties().compactRowCountEncoding(),
          .streamHasChunkHeader = true,
          .rowRange = RowRange{0, stripeRows}});
     std::string headerBuf(
@@ -5415,7 +5415,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxRepeatedBatches) {
     auto headerIOBuf = serde::createTabletChunkHeader(
         {.rowCount = stripeRows,
          .streamEncodingUsesVarintRowCount =
-             tablet->features().compactRowCountEncoding(),
+             tablet->properties().compactRowCountEncoding(),
          .streamHasChunkHeader = true,
          .rowRange = RowRange{0, stripeRows}});
     std::string headerBuf(

--- a/velox/dwio/nimble/tablet/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/CMakeLists.txt
@@ -97,20 +97,20 @@ target_include_directories(
 add_dependencies(nimble_bloom_filter_fb nimble_bloom_filter_schema_fb)
 
 build_flatbuffers(
-  "${CMAKE_CURRENT_SOURCE_DIR}/Features.fbs"
+  "${CMAKE_CURRENT_SOURCE_DIR}/FileProperties.fbs"
   ""
-  nimble_features_schema_fb
+  nimble_file_properties_schema_fb
   ""
   "${CMAKE_CURRENT_BINARY_DIR}"
   ""
   ""
 )
-add_library(nimble_features_fb INTERFACE)
+add_library(nimble_file_properties_fb INTERFACE)
 target_include_directories(
-  nimble_features_fb
+  nimble_file_properties_fb
   INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
 )
-add_dependencies(nimble_features_fb nimble_features_schema_fb)
+add_dependencies(nimble_file_properties_fb nimble_file_properties_schema_fb)
 
 build_flatbuffers(
   "${CMAKE_CURRENT_SOURCE_DIR}/HashIndex.fbs"
@@ -147,7 +147,7 @@ add_dependencies(nimble_sorted_index_fb nimble_sorted_index_schema_fb)
 add_library(
   nimble_tablet_common
   Compression.cpp
-  FileFeatures.cpp
+  FileProperties.cpp
   MetadataBuffer.cpp
   MetadataInput.cpp
   Postscript.cpp
@@ -155,7 +155,7 @@ add_library(
   MetadataInput.h
   MetadataCache.h
   MetadataBuffer.h
-  FileFeatures.h
+  FileProperties.h
   Constants.h
   Compression.h
   Chunk.h
@@ -163,7 +163,7 @@ add_library(
 )
 target_link_libraries(
   nimble_tablet_common
-  nimble_features_fb
+  nimble_file_properties_fb
   nimble_footer_fb
   nimble_common
   velox_caching

--- a/velox/dwio/nimble/tablet/Constants.h
+++ b/velox/dwio/nimble/tablet/Constants.h
@@ -38,7 +38,7 @@ constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
 constexpr std::string_view kIndexSection = "columnar.indexes";
 constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
-constexpr std::string_view kFeaturesSection = "columnar.features";
+constexpr std::string_view kPropertiesSection = "columnar.properties";
 constexpr std::string_view kSharedDictionarySection =
     "columnar.shared_dictionaries";
 

--- a/velox/dwio/nimble/tablet/FileProperties.cpp
+++ b/velox/dwio/nimble/tablet/FileProperties.cpp
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/dwio/nimble/tablet/FileFeatures.h"
+#include "velox/dwio/nimble/tablet/FileProperties.h"
 
 #include "velox/dwio/nimble/common/Exceptions.h"
-#include "velox/dwio/nimble/tablet/FeaturesGenerated.h"
+#include "velox/dwio/nimble/tablet/FilePropertiesGenerated.h"
 
 #include "flatbuffers/flatbuffers.h"
 
@@ -24,7 +24,7 @@
 
 namespace facebook::nimble {
 
-FileFeatures::FileFeatures(
+FileProperties::FileProperties(
     bool compactRowCountEncoding,
     bool clusterIndexKeyColumnStorageOmitted,
     std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage)
@@ -38,7 +38,7 @@ FileFeatures::FileFeatures(
       "clusterIndexKeyColumnStorageOmitted must match clusterIndexKeyColumnsWithOmittedStorage presence");
 }
 
-std::string FileFeatures::serialize() const {
+std::string FileProperties::serialize() const {
   flatbuffers::FlatBufferBuilder builder;
 
   flatbuffers::Offset<serialization::CompactEncoding> compactEncodingOffset;
@@ -56,7 +56,7 @@ std::string FileFeatures::serialize() const {
           });
 
   builder.Finish(
-      serialization::CreateFeatures(
+      serialization::CreateFileProperties(
           builder,
           clusterIndexKeyColumnStorageOmitted_,
           clusterIndexKeyColumnsWithOmittedStorage,
@@ -67,8 +67,8 @@ std::string FileFeatures::serialize() const {
       builder.GetSize()};
 }
 
-FileFeatures FileFeatures::deserialize(std::string_view data) {
-  const auto* serialized = flatbuffers::GetRoot<serialization::Features>(
+FileProperties FileProperties::deserialize(std::string_view data) {
+  const auto* serialized = flatbuffers::GetRoot<serialization::FileProperties>(
       reinterpret_cast<const uint8_t*>(data.data()));
 
   bool compactRowCountEncoding{false};
@@ -88,7 +88,7 @@ FileFeatures FileFeatures::deserialize(std::string_view data) {
       serialized->cluster_index_key_column_storage_omitted(),
       !clusterIndexKeyColumnsWithOmittedStorage.empty(),
       "cluster_index_key_column_storage_omitted must match cluster_index_key_columns_with_omitted_storage presence");
-  return FileFeatures{
+  return FileProperties{
       compactRowCountEncoding,
       serialized->cluster_index_key_column_storage_omitted(),
       std::move(clusterIndexKeyColumnsWithOmittedStorage)};

--- a/velox/dwio/nimble/tablet/FileProperties.fbs
+++ b/velox/dwio/nimble/tablet/FileProperties.fbs
@@ -23,9 +23,9 @@ table CompactEncoding {
   row_count:bool = false;
 }
 
-/// File-level feature state needed by readers before feature-specific optional
-/// metadata is loaded.
-table Features {
+/// File-level properties needed by readers before other optional metadata is
+/// loaded.
+table FileProperties {
   /// Whether cluster index key columns were omitted from normal data storage.
   cluster_index_key_column_storage_omitted:bool = false;
 
@@ -36,4 +36,4 @@ table Features {
   compact_encoding:CompactEncoding;
 }
 
-root_type Features;
+root_type FileProperties;

--- a/velox/dwio/nimble/tablet/FileProperties.h
+++ b/velox/dwio/nimble/tablet/FileProperties.h
@@ -21,11 +21,11 @@
 
 namespace facebook::nimble {
 
-/// File-level feature state that readers need before loading feature-specific
-/// optional metadata.
-class FileFeatures {
+/// File-level properties that readers need before loading other optional
+/// metadata.
+class FileProperties {
  public:
-  FileFeatures(
+  FileProperties(
       bool compactRowCountEncoding,
       bool clusterIndexKeyColumnStorageOmitted,
       std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage);
@@ -46,11 +46,12 @@ class FileFeatures {
     return clusterIndexKeyColumnsWithOmittedStorage_;
   }
 
-  /// Serializes file features into the `columnar.features` optional section.
+  /// Serializes file properties into the `columnar.properties` optional
+  /// section.
   std::string serialize() const;
 
-  /// Deserializes the `columnar.features` optional section.
-  static FileFeatures deserialize(std::string_view data);
+  /// Deserializes the `columnar.properties` optional section.
+  static FileProperties deserialize(std::string_view data);
 
  private:
   bool compactRowCountEncoding_{false};

--- a/velox/dwio/nimble/tablet/TabletReader.cpp
+++ b/velox/dwio/nimble/tablet/TabletReader.cpp
@@ -327,7 +327,7 @@ void TabletReader::init(const Options& options) {
   loadSections(sections);
 
   initStripes(footerView, footerOffset);
-  initFeatures();
+  initProperties();
   initSharedDictionaries(options);
   initIndexDescriptors();
   initClusterIndex();
@@ -454,7 +454,7 @@ bool TabletReader::initFromCache(const Options& options) {
   loadSections(sections);
 
   initStripes();
-  initFeatures();
+  initProperties();
   initSharedDictionaries(options);
   initIndexDescriptors();
   initClusterIndex();
@@ -512,9 +512,10 @@ void TabletReader::cacheMetadata(
     cacheSection(toMetadataSection(stripeGroups->Get(0)));
   }
 
-  if (auto featuresIt = optionalSections_.find(std::string{kFeaturesSection});
-      featuresIt != optionalSections_.end()) {
-    cacheSection(featuresIt->second);
+  if (auto propertiesIt =
+          optionalSections_.find(std::string{kPropertiesSection});
+      propertiesIt != optionalSections_.end()) {
+    cacheSection(propertiesIt->second);
   }
 
   if (sharedDictionaryReaderFactory_ != nullptr) {
@@ -739,14 +740,14 @@ void TabletReader::initOptionalSections() {
   }
 }
 
-void TabletReader::initFeatures() {
+void TabletReader::initProperties() {
   auto section =
-      loadOptionalSection(std::string{kFeaturesSection}, /*keepCache=*/true);
+      loadOptionalSection(std::string{kPropertiesSection}, /*keepCache=*/true);
   if (!section.has_value()) {
     return;
   }
 
-  features_ = FileFeatures::deserialize(section->content());
+  properties_ = FileProperties::deserialize(section->content());
 }
 
 void TabletReader::initSharedDictionaries(const Options& options) {
@@ -778,7 +779,7 @@ std::vector<std::string> TabletReader::preloadSectionNames(
   if (options.loadClusterIndex || options.loadDenseIndexes) {
     addName(std::string{kIndexSection});
   }
-  addName(std::string{kFeaturesSection});
+  addName(std::string{kPropertiesSection});
   addName(std::string{kSharedDictionarySection});
   return names;
 }

--- a/velox/dwio/nimble/tablet/TabletReader.h
+++ b/velox/dwio/nimble/tablet/TabletReader.h
@@ -39,8 +39,8 @@
 #include "velox/dwio/nimble/index/IndexConstants.h"
 #include "velox/dwio/nimble/index/IndexLookup.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
-#include "velox/dwio/nimble/tablet/FileFeatures.h"
 #include "velox/dwio/nimble/tablet/FileLayout.h"
+#include "velox/dwio/nimble/tablet/FileProperties.h"
 #include "velox/dwio/nimble/tablet/MetadataBuffer.h"
 #include "velox/dwio/nimble/tablet/MetadataCache.h"
 #include "velox/dwio/nimble/tablet/MetadataInput.h"
@@ -274,9 +274,9 @@ class TabletReader {
     return clusterIndex_.get();
   }
 
-  /// Returns file-level feature state. Missing section means default features.
-  const FileFeatures& features() const {
-    return features_;
+  /// Returns file-level properties. Missing section means default properties.
+  const FileProperties& properties() const {
+    return properties_;
   }
 
   /// Finds the dense index matching the given columns, or nullptr if none.
@@ -529,7 +529,7 @@ class TabletReader {
   // Parses optional sections metadata from footer into optionalSections_ map.
   void initOptionalSections();
 
-  void initFeatures();
+  void initProperties();
 
   // Creates dictionary lookup state from the preloaded optional section.
   void initSharedDictionaries(const Options& options);
@@ -599,7 +599,7 @@ class TabletReader {
   // Index related fields.
   std::vector<index::IndexDescriptor> indexDescriptors_;
   std::unique_ptr<ClusterIndex> clusterIndex_;
-  FileFeatures features_{false, false, {}};
+  FileProperties properties_{false, false, {}};
 
   std::unique_ptr<index::DenseIndexRegistry> denseIndexRegistry_;
 

--- a/velox/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 add_executable(
   nimble_tablet_tests
   CompressionTest.cpp
-  FileFeaturesTest.cpp
+  FilePropertiesTest.cpp
   FileLayoutTest.cpp
   MetadataBufferTest.cpp
   SharedDictionaryReaderTest.cpp

--- a/velox/dwio/nimble/tablet/tests/FilePropertiesTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/FilePropertiesTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/dwio/nimble/tablet/FileFeatures.h"
+#include "velox/dwio/nimble/tablet/FileProperties.h"
 
 #include <gtest/gtest.h>
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
-#include "velox/dwio/nimble/tablet/FeaturesGenerated.h"
+#include "velox/dwio/nimble/tablet/FilePropertiesGenerated.h"
 
 #include "flatbuffers/flatbuffers.h"
 
@@ -27,24 +27,24 @@
 namespace facebook::nimble {
 namespace {
 
-TEST(FileFeaturesTest, basic) {
-  FileFeatures features{/*compactRowCountEncoding=*/false,
-                        /*clusterIndexKeyColumnStorageOmitted=*/false,
-                        /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
+TEST(FilePropertiesTest, basic) {
+  FileProperties features{/*compactRowCountEncoding=*/false,
+                          /*clusterIndexKeyColumnStorageOmitted=*/false,
+                          /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
 
-  const auto decoded = FileFeatures::deserialize(features.serialize());
+  const auto decoded = FileProperties::deserialize(features.serialize());
   EXPECT_FALSE(decoded.compactRowCountEncoding());
   EXPECT_FALSE(decoded.clusterIndexKeyColumnStorageOmitted());
   EXPECT_TRUE(decoded.clusterIndexKeyColumnsWithOmittedStorage().empty());
 }
 
-TEST(FileFeaturesTest, roundTripKeyColumnsWithOmittedStorage) {
-  FileFeatures features{
+TEST(FilePropertiesTest, roundTripKeyColumnsWithOmittedStorage) {
+  FileProperties features{
       /*compactRowCountEncoding=*/false,
       /*clusterIndexKeyColumnStorageOmitted=*/true,
       /*clusterIndexKeyColumnsWithOmittedStorage=*/{"key0", "key1"}};
 
-  const auto decoded = FileFeatures::deserialize(features.serialize());
+  const auto decoded = FileProperties::deserialize(features.serialize());
   EXPECT_FALSE(decoded.compactRowCountEncoding());
   EXPECT_TRUE(decoded.clusterIndexKeyColumnStorageOmitted());
   EXPECT_EQ(
@@ -52,39 +52,39 @@ TEST(FileFeaturesTest, roundTripKeyColumnsWithOmittedStorage) {
       (std::vector<std::string>{"key0", "key1"}));
 }
 
-TEST(FileFeaturesTest, roundTripCompactRowCountEncoding) {
-  FileFeatures enabled{/*compactRowCountEncoding=*/true,
-                       /*clusterIndexKeyColumnStorageOmitted=*/false,
-                       /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
+TEST(FilePropertiesTest, roundTripCompactRowCountEncoding) {
+  FileProperties enabled{/*compactRowCountEncoding=*/true,
+                         /*clusterIndexKeyColumnStorageOmitted=*/false,
+                         /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
 
-  auto decoded = FileFeatures::deserialize(enabled.serialize());
+  auto decoded = FileProperties::deserialize(enabled.serialize());
   EXPECT_TRUE(decoded.compactRowCountEncoding());
 
-  FileFeatures disabled{/*compactRowCountEncoding=*/false,
-                        /*clusterIndexKeyColumnStorageOmitted=*/false,
-                        /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
+  FileProperties disabled{/*compactRowCountEncoding=*/false,
+                          /*clusterIndexKeyColumnStorageOmitted=*/false,
+                          /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
 
-  decoded = FileFeatures::deserialize(disabled.serialize());
+  decoded = FileProperties::deserialize(disabled.serialize());
   EXPECT_FALSE(decoded.compactRowCountEncoding());
 }
 
-TEST(FileFeaturesTest, rejectsConstructedOmittedStorageWithoutColumns) {
+TEST(FilePropertiesTest, rejectsConstructedOmittedStorageWithoutColumns) {
   NIMBLE_ASSERT_THROW(
-      FileFeatures(
+      FileProperties(
           /*compactRowCountEncoding=*/false,
           /*clusterIndexKeyColumnStorageOmitted=*/true,
           /*clusterIndexKeyColumnsWithOmittedStorage=*/{}),
       "clusterIndexKeyColumnStorageOmitted must match clusterIndexKeyColumnsWithOmittedStorage presence");
 
   NIMBLE_ASSERT_THROW(
-      FileFeatures(
+      FileProperties(
           /*compactRowCountEncoding=*/false,
           /*clusterIndexKeyColumnStorageOmitted=*/false,
           /*clusterIndexKeyColumnsWithOmittedStorage=*/{"key0"}),
       "clusterIndexKeyColumnStorageOmitted must match clusterIndexKeyColumnsWithOmittedStorage presence");
 }
 
-TEST(FileFeaturesTest, rejectsOmittedStorageWithoutColumns) {
+TEST(FilePropertiesTest, rejectsOmittedStorageWithoutColumns) {
   auto serialized =
       [](bool clusterIndexKeyColumnStorageOmitted,
          std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage) {
@@ -98,7 +98,7 @@ TEST(FileFeaturesTest, rejectsOmittedStorageWithoutColumns) {
                       clusterIndexKeyColumnsWithOmittedStorage[i]);
                 });
         builder.Finish(
-            serialization::CreateFeatures(
+            serialization::CreateFileProperties(
                 builder,
                 clusterIndexKeyColumnStorageOmitted,
                 columns,
@@ -119,7 +119,7 @@ TEST(FileFeaturesTest, rejectsOmittedStorageWithoutColumns) {
         testing::Message() << "clusterIndexKeyColumnStorageOmitted="
                            << testCase.clusterIndexKeyColumnStorageOmitted);
     NIMBLE_ASSERT_THROW(
-        FileFeatures::deserialize(serialized(
+        FileProperties::deserialize(serialized(
             testCase.clusterIndexKeyColumnStorageOmitted,
             testCase.clusterIndexKeyColumnsWithOmittedStorage)),
         "cluster_index_key_column_storage_omitted must match cluster_index_key_columns_with_omitted_storage presence");

--- a/velox/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -4250,10 +4250,10 @@ TEST_P(TabletTest, features) {
 
   auto tablet = createTabletReader(file);
 
-  EXPECT_TRUE(tablet->features().compactRowCountEncoding());
-  EXPECT_TRUE(tablet->features().clusterIndexKeyColumnStorageOmitted());
+  EXPECT_TRUE(tablet->properties().compactRowCountEncoding());
+  EXPECT_TRUE(tablet->properties().clusterIndexKeyColumnStorageOmitted());
   EXPECT_EQ(
-      tablet->features().clusterIndexKeyColumnsWithOmittedStorage(),
+      tablet->properties().clusterIndexKeyColumnsWithOmittedStorage(),
       (std::vector<std::string>{"id"}));
 }
 

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -207,7 +207,7 @@ NimbleIndexProjector::NimbleIndexProjector(
               .streamVersion = SerializationVersion::kTablet,
               .streamHasChunkHeader = true,
               .streamsUseVarintRowCount =
-                  tablet_->features().compactRowCountEncoding(),
+                  tablet_->properties().compactRowCountEncoding(),
           })} {
   NIMBLE_CHECK_NOT_NULL(
       clusterIndex_, "NimbleIndexProjector requires a tablet with an index");
@@ -953,7 +953,7 @@ void NimbleIndexProjector::buildResult(Result& result) {
       response.slices.emplace_back(assembleStripeSlice(
           packedStripe.rowRange.numRows(),
           packedStripe.requiresNullBarrier,
-          tablet_->features().compactRowCountEncoding(),
+          tablet_->properties().compactRowCountEncoding(),
           packedStripe.streamHasChunkHeader,
           packedRelativeRange,
           packedStripe.body.cloneAsValue(),

--- a/velox/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/velox/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -36,7 +36,7 @@ namespace {
 
 Encoding::Options encodingOptions(const TabletReader& tablet) {
   Encoding::Options options;
-  options.useVarintRowCount = tablet.features().compactRowCountEncoding();
+  options.useVarintRowCount = tablet.properties().compactRowCountEncoding();
   return options;
 }
 

--- a/velox/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/velox/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -46,7 +46,7 @@ namespace {
 
 Encoding::Options encodingOptions(const TabletReader& tablet) {
   Encoding::Options options;
-  options.useVarintRowCount = tablet.features().compactRowCountEncoding();
+  options.useVarintRowCount = tablet.properties().compactRowCountEncoding();
   return options;
 }
 
@@ -739,8 +739,8 @@ SelectiveNimbleReader::createIndexReader(
 
 void SelectiveNimbleReader::validateOmittedKeyColumnStorageAccess(
     const dwio::common::RowReaderOptions& options) const {
-  const auto& features = readerBase_->tablet().features();
-  if (!features.clusterIndexKeyColumnStorageOmitted()) {
+  const auto& properties = readerBase_->tablet().properties();
+  if (!properties.clusterIndexKeyColumnStorageOmitted()) {
     return;
   }
 
@@ -748,7 +748,7 @@ void SelectiveNimbleReader::validateOmittedKeyColumnStorageAccess(
                                                   : readerBase_->fileSchema();
   const auto* scanSpec = options.scanSpec().get();
   for (const auto& column :
-       features.clusterIndexKeyColumnsWithOmittedStorage()) {
+       properties.clusterIndexKeyColumnsWithOmittedStorage()) {
     NIMBLE_USER_CHECK(
         !outputType->containsChild(column),
         "Cluster index key column '{}' cannot be projected because this file stores it only in the cluster index key stream",

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -6373,7 +6373,7 @@ TEST_F(WriterTest, compactRowCountEncodingIsPersistedAsFileFeature) {
         writeWithCompactRowCountEncoding(enabled));
     auto tablet = nimble::TabletReader::create(
         readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
-    EXPECT_EQ(tablet->features().compactRowCountEncoding(), enabled);
+    EXPECT_EQ(tablet->properties().compactRowCountEncoding(), enabled);
   }
 }
 
@@ -6415,9 +6415,9 @@ TEST_P(WriterIndexTest, omitClusterIndexKeyColumnStorage) {
   EXPECT_EQ(
       tablet->clusterIndex()->indexColumns(),
       (std::vector<std::string>{"key_col"}));
-  EXPECT_TRUE(tablet->features().clusterIndexKeyColumnStorageOmitted());
+  EXPECT_TRUE(tablet->properties().clusterIndexKeyColumnStorageOmitted());
   EXPECT_EQ(
-      tablet->features().clusterIndexKeyColumnsWithOmittedStorage(),
+      tablet->properties().clusterIndexKeyColumnsWithOmittedStorage(),
       (std::vector<std::string>{"key_col"}));
 
   auto tabletOptions = makeTestTabletOptions(leafPool_.get());
@@ -6426,9 +6426,10 @@ TEST_P(WriterIndexTest, omitClusterIndexKeyColumnStorage) {
       nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
   EXPECT_EQ(tabletWithoutIndex->clusterIndex(), nullptr);
   EXPECT_TRUE(
-      tabletWithoutIndex->features().clusterIndexKeyColumnStorageOmitted());
+      tabletWithoutIndex->properties().clusterIndexKeyColumnStorageOmitted());
   EXPECT_EQ(
-      tabletWithoutIndex->features().clusterIndexKeyColumnsWithOmittedStorage(),
+      tabletWithoutIndex->properties()
+          .clusterIndexKeyColumnsWithOmittedStorage(),
       (std::vector<std::string>{"key_col"}));
 
   nimble::VeloxReader reader(readFile.get(), *leafPool_);

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -41,7 +41,7 @@
 #include "velox/dwio/nimble/index/IndexSerialization.h"
 #include "velox/dwio/nimble/index/SortedIndexWriter.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
-#include "velox/dwio/nimble/tablet/FileFeatures.h"
+#include "velox/dwio/nimble/tablet/FileProperties.h"
 #include "velox/dwio/nimble/tablet/IndexGenerated.h"
 #include "velox/dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "velox/dwio/nimble/velox/ChunkedStreamWriter.h"
@@ -1250,7 +1250,7 @@ Writer::Writer(
                    const WriteDataFn& writeDataFn,
                    const CreateMetadataSectionFn& createMetadataFn,
                    const WriteOptionalSectionFn& writeMetadataFn) {
-                 writeFeatures(writeMetadataFn);
+                 writeProperties(writeMetadataFn);
                  writeIndexes(writeDataFn, createMetadataFn, writeMetadataFn);
                }})},
       bufferPolicy_{
@@ -1492,7 +1492,7 @@ void Writer::addIndexKey(const velox::VectorPtr& input) {
   }
 }
 
-void Writer::writeFeatures(const WriteOptionalSectionFn& writeMetadataFn) {
+void Writer::writeProperties(const WriteOptionalSectionFn& writeMetadataFn) {
   const bool compactRowCountEncoding =
       context_->options().experimentalCompactRowCountEncoding;
   bool clusterIndexKeyColumnStorageOmitted{false};
@@ -1508,12 +1508,12 @@ void Writer::writeFeatures(const WriteOptionalSectionFn& writeMetadataFn) {
   }
 
   const auto serialized =
-      FileFeatures{
+      FileProperties{
           compactRowCountEncoding,
           clusterIndexKeyColumnStorageOmitted,
           std::move(clusterIndexKeyColumnsWithOmittedStorage)}
           .serialize();
-  writeMetadataFn(std::string(kFeaturesSection), serialized);
+  writeMetadataFn(std::string(kPropertiesSection), serialized);
 }
 
 void Writer::writeIndexes(

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -190,7 +190,7 @@ class Writer : public velox::dwio::common::Writer {
   // Adds index keys to all configured index writers.
   void addIndexKey(const velox::VectorPtr& input);
 
-  void writeFeatures(const WriteOptionalSectionFn& writeMetadataFn);
+  void writeProperties(const WriteOptionalSectionFn& writeMetadataFn);
 
   // Returns the vector written to data streams. When cluster index key column
   // storage is omitted, this is a top-level row projection excluding key

--- a/velox/dwio/nimble/writer/WriterOptions.h
+++ b/velox/dwio/nimble/writer/WriterOptions.h
@@ -112,7 +112,7 @@ struct WriterOptions {
   bool experimentalOmitClusterIndexKeyColumnStorage{false};
 
   /// Enables compact varint row-count encoding for encoded data streams. The
-  /// value is persisted in file features so readers can select the matching
+  /// value is persisted in file properties so readers can select the matching
   /// decoding behavior.
   /// EXPERIMENTAL: Compact row-count encoding is not production-ready. Do not
   /// enable for production tables without consulting the Nimble team (oncall:


### PR DESCRIPTION
Summary:

Rename the file-level optional metadata wrapper from `FileFeatures` to `FileProperties` and move the section from `columnar.features` to `columnar.properties`. Update the tablet reader/writer APIs and FlatBuffer schema names to match.

Update the RexDB RecordIO-to-Nimble benchmark to use `clusterIndexKeyColumnStorageOmitted` naming, expose `--cluster_index_key_column_storage_omitted`, keep the old flag as a deprecated alias, and log the property value in the conversion summary.

Reviewed By: duxiao1212, HuamengJiang

Differential Revision: D114541110
