### PR TITLE
fix(memory): Reject unsupported page size in MmapAllocator

### DIFF
--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -49,7 +49,8 @@ MmapAllocator::MmapAllocator(const Options& options)
   // and calls madvise() on individual pages, which requires the address and
   // length to line up with the OS's actual page size. NVIDIA's documented
   // recommended default page size for Grace / Grace-Hopper systems is 64KB,
-  // not 4KB (see https://docs.nvidia.com/dccpu/grace-perf-tuning-guide/os-settings.html),
+  // not 4KB (see
+  // https://docs.nvidia.com/dccpu/grace-perf-tuning-guide/os-settings.html),
   // and on such systems madvise() silently fails with EINVAL on sub-64KB
   // regions instead of throwing, which corrupts this allocator's internal
   // page-count accounting rather than surfacing a clear error. This isn't

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/memory/MmapAllocator.h"
 
 #include <sys/mman.h>
+#include <unistd.h>
 
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/Portability.h"
@@ -24,6 +25,11 @@
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
+bool MmapAllocator::isPageSizeSupported() {
+  return static_cast<uint64_t>(sysconf(_SC_PAGESIZE)) ==
+      AllocationTraits::kPageSize;
+}
+
 MmapAllocator::MmapAllocator(const Options& options)
     : MemoryAllocator(options.largestSizeClass),
       kind_(MemoryAllocator::Kind::kMmap),
@@ -39,6 +45,23 @@ MmapAllocator::MmapAllocator(const Options& options)
               AllocationTraits::numPages(
                   options.capacity - mallocReservedBytes_),
               64 * sizeClassSizes_.back())) {
+  // MmapAllocator tracks memory at AllocationTraits::kPageSize granularity
+  // and calls madvise() on individual pages, which requires the address and
+  // length to line up with the OS's actual page size. NVIDIA's documented
+  // recommended default page size for Grace / Grace-Hopper systems is 64KB,
+  // not 4KB (see https://docs.nvidia.com/dccpu/grace-perf-tuning-guide/os-settings.html),
+  // and on such systems madvise() silently fails with EINVAL on sub-64KB
+  // regions instead of throwing, which corrupts this allocator's internal
+  // page-count accounting rather than surfacing a clear error. This isn't
+  // Velox-specific: jemalloc has the identical >4KB-page limitation (see
+  // https://github.com/arangodb/arangodb/issues/22177). Fail fast here
+  // instead of silently corrupting state.
+  VELOX_CHECK(
+      isPageSizeSupported(),
+      "MmapAllocator requires the system page size to match AllocationTraits::kPageSize ({} bytes); system page size is {} bytes. Use MemoryAllocator::Kind::kMalloc on this system instead.",
+      AllocationTraits::kPageSize,
+      sysconf(_SC_PAGESIZE));
+
   for (const auto& size : sizeClassSizes_) {
     sizeClasses_.push_back(std::make_unique<SizeClass>(capacity_ / size, size));
   }

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -19,15 +19,31 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <cerrno>
+
+#include <folly/String.h>
+
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
+uint64_t MmapAllocator::systemPageSize() {
+  static const uint64_t pageSize = [] {
+    const long value{::sysconf(_SC_PAGESIZE)};
+    VELOX_CHECK_GT(
+        value,
+        0,
+        "Failed to determine the system page size: {}",
+        folly::errnoStr(errno));
+    return static_cast<uint64_t>(value);
+  }();
+  return pageSize;
+}
+
 bool MmapAllocator::isPageSizeSupported() {
-  return static_cast<uint64_t>(sysconf(_SC_PAGESIZE)) ==
-      AllocationTraits::kPageSize;
+  return systemPageSize() == AllocationTraits::kPageSize;
 }
 
 MmapAllocator::MmapAllocator(const Options& options)
@@ -61,7 +77,7 @@ MmapAllocator::MmapAllocator(const Options& options)
       isPageSizeSupported(),
       "MmapAllocator requires the system page size to match AllocationTraits::kPageSize ({} bytes); system page size is {} bytes. Use MemoryAllocator::Kind::kMalloc on this system instead.",
       AllocationTraits::kPageSize,
-      sysconf(_SC_PAGESIZE));
+      systemPageSize());
 
   for (const auto& size : sizeClassSizes_) {
     sizeClasses_.push_back(std::make_unique<SizeClass>(capacity_ / size, size));

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -55,6 +55,15 @@ class MmapAllocator : public MemoryAllocator {
 
   ~MmapAllocator();
 
+  /// Returns true if the system's page size matches
+  /// AllocationTraits::kPageSize, the granularity MmapAllocator assumes for
+  /// its mmap/madvise calls (see the constructor in MmapAllocator.cpp for
+  /// why this can be false). Construct a MallocAllocator instead when it
+  /// is; the constructor enforces this via VELOX_CHECK, so callers that
+  /// want to select an allocator kind without throwing should check this
+  /// first.
+  static bool isPageSizeSupported();
+
   Kind kind() const override {
     return kind_;
   }

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -55,13 +55,16 @@ class MmapAllocator : public MemoryAllocator {
 
   ~MmapAllocator();
 
-  /// Returns true if the system's page size matches
-  /// AllocationTraits::kPageSize, the granularity MmapAllocator assumes for
-  /// its mmap/madvise calls (see the constructor in MmapAllocator.cpp for
-  /// why this can be false). Construct a MallocAllocator instead when it
-  /// is; the constructor enforces this via VELOX_CHECK, so callers that
-  /// want to select an allocator kind without throwing should check this
-  /// first.
+  /// Returns the page size the OS reports, queried once on first call and
+  /// cached. Throws if the query fails.
+  static uint64_t systemPageSize();
+
+  /// Returns true if systemPageSize() matches AllocationTraits::kPageSize, the
+  /// granularity MmapAllocator assumes for its mmap/madvise calls (see the
+  /// constructor in MmapAllocator.cpp for why the two can differ). Construct a
+  /// MallocAllocator instead when it does not; the constructor enforces this
+  /// via VELOX_CHECK, so callers that want to select an allocator kind without
+  /// throwing should check this first.
   static bool isPageSizeSupported();
 
   Kind kind() const override {


### PR DESCRIPTION
`MmapAllocator` assumes the system page size is 4KB (`AllocationTraits::kPageSize`) for its `madvise()` calls. On hosts where it isn't — notably NVIDIA Grace / Grace-Hopper, whose [documented recommended default](https://docs.nvidia.com/dccpu/grace-perf-tuning-guide/os-settings.html) is 64KB — `madvise()` fails with `EINVAL` and the allocator's internal page-count accounting silently drifts out of sync instead of erroring.

This adds `MmapAllocator::systemPageSize()` (queried via `sysconf(_SC_PAGESIZE)` once and cached) and `MmapAllocator::isPageSizeSupported()`, and checks the latter in the constructor. Construction now fails immediately with a clear, actionable message instead of corrupting state later.

This does **not** make `MmapAllocator` work on non-4KB-page systems — it converts silent corruption into a loud error. The real fix (generalizing the page-size assumption) is tracked in #18617.

Found while validating aarch64 support (#18587). The `AbfsFileSystemTest` teardown fix that was originally part of this PR has been split out to #18687.

## Test plan

Confirmed on an aarch64 host with a 64KB-page kernel (`getconf PAGESIZE` = 65536) that `MmapAllocator` construction now throws a clear `VELOX_CHECK` message instead of later producing corrupted `numMapped()` accounting. On standard 4KB-page hosts the check is a no-op.
