### PR TITLE
feat(nimble): Add shared dictionary catalog schema (#18620)

### DIFF
--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -120,10 +120,30 @@ target_compile_definitions(
     fsst_decompress=nimble_fsst_decompress
 )
 
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/SharedDictionary.fbs"
+  ""
+  nimble_shared_dictionary_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  ""
+)
+add_library(nimble_shared_dictionary_fb INTERFACE)
+target_include_directories(
+  nimble_shared_dictionary_fb
+  INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
+)
+add_dependencies(
+  nimble_shared_dictionary_fb
+  nimble_shared_dictionary_schema_fb
+)
+
 target_link_libraries(
   nimble_encodings
   nimble_compression
   nimble_common
+  nimble_shared_dictionary_fb
   velox_common_base
   velox_fastpforlib
   fsst

--- a/velox/dwio/nimble/encodings/SharedDictionary.fbs
+++ b/velox/dwio/nimble/encodings/SharedDictionary.fbs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace facebook.nimble.serialization;
+
+/// Associates a value stream with a dictionary in the containing scope list.
+table SharedDictionaryReference {
+  /// Logical value stream whose shared-dictionary indices require this
+  /// dictionary.
+  value_stream_id:uint32;
+
+  /// Identifier interpreted according to the containing scope list. It is an
+  /// auxiliary stream ID for stripe scope, an entry ID for file scope, and a
+  /// resolver-defined ID for external scope.
+  dictionary_id:uint32;
+
+  /// Nimble DataType of the dictionary values.
+  data_type:uint8;
+}
+
+/// Locates one file-scope dictionary alphabet by its absolute file byte range.
+table FileDictionary {
+  /// Identifier referenced by file_dictionary_references.
+  dictionary_id:uint32;
+
+  /// Nimble DataType of the encoded values.
+  data_type:uint8;
+
+  /// Absolute file byte range containing the encoded alphabet.
+  offset:uint64;
+  length:uint32;
+}
+
+/// Shared dictionary metadata stored in the tablet optional section.
+table SharedDictionaryCatalog {
+  /// Value streams mapped to stripe-local auxiliary dictionary streams.
+  stripe_dictionary_references:[SharedDictionaryReference];
+
+  /// Value streams mapped to alphabets stored in file_dictionaries. Multiple
+  /// value streams may reference the same file dictionary.
+  file_dictionary_references:[SharedDictionaryReference];
+
+  /// Value streams mapped to dictionaries supplied by an external resolver.
+  external_dictionary_references:[SharedDictionaryReference];
+
+  /// Locations of file-scope dictionary alphabets indexed by dictionary_id.
+  file_dictionaries:[FileDictionary];
+}
+
+root_type SharedDictionaryCatalog;


### PR DESCRIPTION
Summary:

Define the serialized metadata contract for mapping value streams to stripe, file, or external shared dictionaries. File-scoped entries use file byte ranges so readers can load alphabets on demand.

Generate and expose the FlatBuffers header in Buck and CMake builds.

Reviewed By: tanjialiang

Differential Revision: D115779347


