### PR TITLE
fix(nimble): Keep nulls in dictionary reads without AVX2 (#18621)

### DIFF
--- a/velox/dwio/nimble/encodings/common/Encoding.h
+++ b/velox/dwio/nimble/encodings/common/Encoding.h
@@ -528,6 +528,25 @@ void readDenseMaterializedIndices(
       /*sourceBegin=*/valueOutputOffset,
       rawOuterNonNullRows,
       rawOutputValues);
+
+  // Nulls were materialized into the reader's read-range bitmap only.
+  // `resultNulls()' hands that bitmap back while `returnReaderNulls_' holds,
+  // but `setReturnNullsMode' clears the flag whenever `useBulkPath()' is false
+  // -- notably on a platform without AVX2, where every read takes that branch.
+  // `resultNulls()' then returns the output-indexed `resultNulls_', which
+  // nothing on this path writes, so the output would silently lose its nulls.
+  // Copy the read-range nulls across, mirroring what
+  // `readSparseMaterializedIndices' does for the sparse row set.
+  if (!visitor.reader().returnReaderNulls()) {
+    auto* rawResultNulls = visitor.reader().rawResultNulls();
+    NIMBLE_CHECK_NOT_NULL(
+        rawResultNulls,
+        "prepareResultNulls must allocate result nulls before the dense index "
+        "path writes them");
+    velox::bits::copyBits(
+        rawNulls, readOffset, rawResultNulls, valueOutputOffset, numReadRows);
+    visitor.reader().setHasNulls();
+  }
   visitor.addNumValues(numReadRows);
   visitor.setRowIndex(visitor.numRows());
 }

--- a/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -4238,9 +4238,16 @@ TEST_P(ReadWithVisitorNonLegacyTest, readDenseMaterializedIndicesWithNulls) {
 
   ASSERT_EQ(reader->numValues(), 0);
 
-  // Call the helper with nulls.
+  // Call the helper with nulls. prepareResultNulls must mirror what
+  // ChunkedDecoder wires up in production: the dense index path materializes
+  // nulls into the read-range bitmap only, so it needs an allocated,
+  // output-indexed result-nulls buffer to copy them into whenever
+  // returnReaderNulls_ is false -- as it is here, the scan spec carries a
+  // filter.
   ReadWithVisitorParams params{.numScanned = 0};
-  params.prepareResultNulls = [] {};
+  params.prepareResultNulls = [&] {
+    reader->prepareNulls(rows, /*hasNulls=*/true, /*extraRows=*/8);
+  };
   detail::readDenseMaterializedIndices(
       *encoding,
       visitor,

--- a/velox/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -36,7 +36,12 @@
 #include "velox/vector/DictionaryVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+#include <fmt/format.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include <tuple>
+
+DECLARE_bool(avx2); // NOLINT
 
 namespace facebook::nimble {
 namespace {
@@ -44,10 +49,27 @@ namespace {
 using namespace facebook::velox;
 
 // Tests for StringColumnReader covering VARCHAR and VARBINARY edge cases.
-class StringColumnReaderTest : public ::testing::Test,
-                               public velox::test::VectorTestBase,
-                               public ::testing::WithParamInterface<bool> {
+//
+// Parameterized on (stringDecoderZeroCopy, avx2). The avx2 dimension exists
+// because `process::hasAvx2()' feeds `SelectiveColumnReader::useBulkPath()',
+// which in turn decides whether nulls are returned from the reader's
+// read-range bitmap or from the output-indexed result bitmap. aarch64 always
+// takes the false branch, so without this dimension the entire fallback is
+// unexercised on x86 CI.
+class StringColumnReaderTest
+    : public ::testing::Test,
+      public velox::test::VectorTestBase,
+      public ::testing::WithParamInterface<std::tuple<bool, bool>> {
  protected:
+  void SetUp() override {
+    savedAvx2_ = FLAGS_avx2;
+    FLAGS_avx2 = std::get<1>(GetParam()); // NOLINT
+  }
+
+  void TearDown() override {
+    FLAGS_avx2 = savedAvx2_; // NOLINT
+  }
+
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(
         velox::memory::MemoryManager::Options{});
@@ -178,6 +200,7 @@ class StringColumnReaderTest : public ::testing::Test,
       std::make_shared<io::IoStatistics>()};
   const std::shared_ptr<io::IoStatistics> metadataIoStats_{
       std::make_shared<io::IoStatistics>()};
+  bool savedAvx2_{true};
 };
 
 // Returns the encoding of a vector, loading through lazy wrappers if present.
@@ -289,7 +312,7 @@ void validateWithEncodingChecks(
 
 // Strings shorter than StringView::kInlineSize (12 bytes).
 TEST_P(StringColumnReaderTest, shortStrings) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto input = makeRowVector({
       makeFlatVector<std::string>(
           100, [](auto i) { return std::to_string(i); }),
@@ -302,7 +325,7 @@ TEST_P(StringColumnReaderTest, shortStrings) {
 
 // Strings longer than inline size.
 TEST_P(StringColumnReaderTest, longStrings) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   const std::string prefix(20, 'x');
   auto input = makeRowVector({
       makeFlatVector<std::string>(
@@ -316,7 +339,7 @@ TEST_P(StringColumnReaderTest, longStrings) {
 
 // Alternating short and long strings.
 TEST_P(StringColumnReaderTest, mixedLengthStrings) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   const std::string longPrefix(20, 'y');
   auto input = makeRowVector({
       makeFlatVector<std::string>(
@@ -334,7 +357,7 @@ TEST_P(StringColumnReaderTest, mixedLengthStrings) {
 
 // Strings with null values.
 TEST_P(StringColumnReaderTest, stringsWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto input = makeRowVector({
       makeFlatVector<std::string>(
           100, [](auto i) { return "str_" + std::to_string(i); }, nullEvery(5)),
@@ -347,7 +370,7 @@ TEST_P(StringColumnReaderTest, stringsWithNulls) {
 
 // All-null string column.
 TEST_P(StringColumnReaderTest, allNullStrings) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto input = makeRowVector({
       makeConstant<StringView>(std::nullopt, 50),
   });
@@ -364,7 +387,7 @@ TEST_P(StringColumnReaderTest, allNullStrings) {
 
 // All empty "" strings.
 TEST_P(StringColumnReaderTest, emptyStrings) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto input = makeRowVector({
       makeFlatVector<std::string>(50, [](auto) { return ""; }),
   });
@@ -376,7 +399,7 @@ TEST_P(StringColumnReaderTest, emptyStrings) {
 
 // VARBINARY type (shares reader with VARCHAR).
 TEST_P(StringColumnReaderTest, varbinaryColumn) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto input = makeRowVector({
       makeFlatVector<std::string>(
           50,
@@ -398,7 +421,7 @@ TEST_P(StringColumnReaderTest, varbinaryColumn) {
 
 // BytesValues filter on string column.
 TEST_P(StringColumnReaderTest, stringBytesFilter) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto c0 = makeFlatVector<std::string>(
       100, [](auto i) { return "val_" + std::to_string(i % 10); });
   auto input = makeRowVector({c0});
@@ -415,7 +438,7 @@ TEST_P(StringColumnReaderTest, stringBytesFilter) {
 
 // BytesRange filter on string column.
 TEST_P(StringColumnReaderTest, stringBytesRangeFilter) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto c0 = makeFlatVector<std::string>(
       100, [](auto i) { return "val_" + std::to_string(i % 10); });
   auto input = makeRowVector({c0});
@@ -436,7 +459,7 @@ TEST_P(StringColumnReaderTest, stringBytesRangeFilter) {
 // the struct reader and that the sibling column's values are correctly
 // filtered.
 TEST_P(StringColumnReaderTest, stringFilterWithSiblingColumn) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   const int numRows = 100;
   auto filterCol = makeFlatVector<std::string>(
       numRows, [](auto i) { return "val_" + std::to_string(i % 10); });
@@ -475,7 +498,7 @@ TEST_P(StringColumnReaderTest, stringFilterWithSiblingColumn) {
 }
 
 TEST_P(StringColumnReaderTest, fsstWithSiblingFilter) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "FSST is only available in the current encoding factory.";
   }
@@ -537,7 +560,7 @@ TEST_P(StringColumnReaderTest, fsstWithSiblingFilter) {
 
 // Filter that passes all rows — verifies no-op filtering doesn't corrupt.
 TEST_P(StringColumnReaderTest, stringFilterPassesAll) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto c0 = makeFlatVector<std::string>(
       100, [](auto i) { return "val_" + std::to_string(i % 5); });
   auto input = makeRowVector({c0});
@@ -553,7 +576,7 @@ TEST_P(StringColumnReaderTest, stringFilterPassesAll) {
 
 // Filter that passes no rows — verifies empty output is handled correctly.
 TEST_P(StringColumnReaderTest, stringFilterPassesNone) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   auto c0 = makeFlatVector<std::string>(
       100, [](auto i) { return "val_" + std::to_string(i % 5); });
   auto input = makeRowVector({c0});
@@ -573,7 +596,7 @@ TEST_P(StringColumnReaderTest, stringFilterPassesNone) {
 
 // Filter with nulls — nulls should not pass BytesValues filter.
 TEST_P(StringColumnReaderTest, stringFilterWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   std::vector<std::optional<std::string>> data(100);
   for (int i = 0; i < 100; ++i) {
     if (i % 5 == 0) {
@@ -601,7 +624,7 @@ TEST_P(StringColumnReaderTest, stringFilterWithNulls) {
 // Fuzz test: filter on dict-encoded string column with random data shapes,
 // null rates, filter selectivities, and batch sizes.
 TEST_P(StringColumnReaderTest, fuzzFilterDictionary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary filter path requires stringDecoderZeroCopy";
   }
@@ -682,7 +705,7 @@ TEST_P(StringColumnReaderTest, fuzzFilterDictionary) {
 
 // Small batch sizes to exercise skip positioning.
 TEST_P(StringColumnReaderTest, stringSkipAndRead) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   const std::string longPrefix(15, 'z');
   auto input = makeRowVector({
       makeFlatVector<std::string>(
@@ -702,7 +725,7 @@ TEST_P(StringColumnReaderTest, stringSkipAndRead) {
 // a chunk boundary. Without the onChunkLoad callback, alphabet_ would retain
 // stale string_views from the previous chunk, producing corrupted output.
 TEST_P(StringColumnReaderTest, skipAcrossChunkBoundary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     // Dict vector path requires stringDecoderZeroCopy.
     return;
@@ -755,7 +778,7 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundary) {
 //   Read 3 (rows 400-599): chunk 2 has enough rows, dict path re-entered.
 //     Must rebuild alphabet from chunk 2, not reuse stale chunk 1 alphabet.
 TEST_P(StringColumnReaderTest, flatFallbackClearsDictionaryState) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     return;
   }
@@ -802,7 +825,7 @@ TEST_P(StringColumnReaderTest, flatFallbackClearsDictionaryState) {
 // decoder loads a new chunk. The dictionary state must be rebuilt from
 // the new chunk's encoding.
 TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryMidFile) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -877,7 +900,7 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryMidFile) {
 // row gaps. The string column takes the dict path (no filter on its own
 // scanSpec), and the visitor's gap-skipping logic is exercised.
 TEST_P(StringColumnReaderTest, skipWithinChunkReturnsDictionary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -923,7 +946,7 @@ TEST_P(StringColumnReaderTest, skipWithinChunkReturnsDictionary) {
 // Two scenarios: (1) skip within a batch crosses the boundary, (2) entire
 // batch rejected by filter causes a between-batch skip across the boundary.
 TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1090,7 +1113,7 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
 // dictionaryConvertible() after prepareRead and falls back to the flat path
 // (FLAT output encoding).
 TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkip) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1176,7 +1199,7 @@ TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkip) {
 // nulls decoder (nextBools), that double prepareRead reads the null stream
 // twice and misplaces the nulls.
 TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkipWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1262,7 +1285,7 @@ TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkipWithNulls) {
 // abandons at entry. Isolates whether the no-skip abandon (prepareRead then
 // abandon, no between-batch skip) corrupts nulls.
 TEST_P(StringColumnReaderTest, abandonDictionaryNoSkipWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1311,7 +1334,7 @@ TEST_P(StringColumnReaderTest, abandonDictionaryNoSkipWithNulls) {
 // output map gets phantom/missing entries. Plain-null columns survive this, so
 // only the flatmap in-map path exposes it.
 TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkipFlatMap) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1427,7 +1450,7 @@ EncodingLayoutTree makeSecondChildRleDictionaryLayoutTree() {
 // preserve-gated RLE<Dictionary> is the shape that flips modes with the load
 // flag; a plain Dictionary chunk is dict-convertible regardless.)
 TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryRleDictionaryPreserved) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1539,7 +1562,7 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryRleDictionaryPreserved) {
 TEST_P(
     StringColumnReaderTest,
     abandonAndPreserveAcrossRleDictionaryAndTrivialChunks) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1766,7 +1789,7 @@ TEST_P(
 // Read batch spans chunk boundary. With multi-chunk dictionary support,
 // the batch crosses the boundary and merges alphabets from both chunks.
 TEST_P(StringColumnReaderTest, readAcrossChunkBoundary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1814,7 +1837,7 @@ TEST_P(StringColumnReaderTest, readAcrossChunkBoundary) {
 // Each stripe has a different alphabet. The reader must rebuild dictionary
 // state when crossing stripes.
 TEST_P(StringColumnReaderTest, readAcrossStripeBoundary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1867,7 +1890,7 @@ TEST_P(StringColumnReaderTest, readAcrossStripeBoundary) {
 }
 
 TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -1990,7 +2013,7 @@ TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
 TEST_P(
     StringColumnReaderTest,
     flatMapStringDictionaryPathExternalNullsBareDict) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2128,7 +2151,7 @@ TEST_P(
 // index reading across chunk boundaries with inMap nulls. Key 2 is absent
 // in some rows (inMap=0), and the batch spans two chunks.
 TEST_P(StringColumnReaderTest, flatMapStringDictionaryPathMultiChunk) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2245,7 +2268,7 @@ TEST_P(StringColumnReaderTest, flatMapStringDictionaryPathMultiChunk) {
 // chunks, exercising readIndicesWithVisitor across chunk boundaries in
 // ChunkedDecoder's loop.
 TEST_P(StringColumnReaderTest, mainlyConstantDictionaryMultiChunk) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2310,7 +2333,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryMultiChunk) {
 
 // Same as above but with nulls.
 TEST_P(StringColumnReaderTest, mainlyConstantDictionaryMultiChunkWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2369,7 +2392,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryMultiChunkWithNulls) {
 // Basic mainly-constant string read: ~95% common value with a small other
 // alphabet. Naturally triggers Nullable<MainlyConstant<Dictionary>> encoding.
 TEST_P(StringColumnReaderTest, mainlyConstantDictionary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2400,7 +2423,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionary) {
 
 // Mainly-constant string with nulls.
 TEST_P(StringColumnReaderTest, mainlyConstantDictionaryWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2433,7 +2456,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryWithNulls) {
 // Mainly-constant across stripe boundaries: two stripes with different
 // common values and different "other" alphabets.
 TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAcrossStripes) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2514,7 +2537,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAcrossStripes) {
 // common value) and the second half is all null, so the second read batch has
 // no non-null rows and calls materializeIndices(0).
 TEST_P(StringColumnReaderTest, mainlyConstantAllNullReadRange) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2565,7 +2588,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantAllNullReadRange) {
 // must be emitted as null values. The dictionary filter+extract path must
 // produce one output row per null row, not drop them.
 TEST_P(StringColumnReaderTest, dictionaryIsNullFilterProjected) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2621,7 +2644,7 @@ TEST_P(StringColumnReaderTest, dictionaryIsNullFilterProjected) {
 // The second batch is the no-null sparse read whose filterDictionaryIndices
 // must not be misled by the stale buffer.
 TEST_P(StringColumnReaderTest, dictionaryFilterSparseNoNullsAfterNullBatch) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2698,7 +2721,7 @@ TEST_P(StringColumnReaderTest, dictionaryFilterSparseNoNullsAfterNullBatch) {
 // non-contiguous row set produced by a sibling column's filter. The surviving
 // (null) rows and their row mapping must be correct.
 TEST_P(StringColumnReaderTest, dictionaryIsNullFilterSparseRows) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2758,7 +2781,7 @@ TEST_P(StringColumnReaderTest, dictionaryIsNullFilterSparseRows) {
 // chunked layouts: each batch fits within a single chunk, so the dictionary
 // state (alphabet, indices) remains valid for the entire read.
 TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAlignedChunks) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2821,7 +2844,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAlignedChunks) {
 
 // Same as mainlyConstantDictionaryAlignedChunks but with nulls.
 TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAlignedChunksWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2884,7 +2907,7 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAlignedChunksWithNulls) {
 // encoding layout to create RLE wrapping Dictionary for string values
 // with repeated patterns (natural RLE runs).
 TEST_P(StringColumnReaderTest, rleDictionaryVector) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2962,7 +2985,7 @@ EncodingLayoutTree makeRleDictionaryLayoutTree() {
 // rather than restart at 0. The run length (50) does not divide the batch size
 // (75), so a run straddles a next() boundary and forces the resume path.
 TEST_P(StringColumnReaderTest, rleDictionaryMidRunBatchResume) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -2988,7 +3011,7 @@ TEST_P(StringColumnReaderTest, rleDictionaryMidRunBatchResume) {
 // original residue-dependent failure (seed 1031254216). The inner RLE runs
 // cover the dense non-null values, which must still resume correctly mid-run.
 TEST_P(StringColumnReaderTest, rleDictionaryMidRunBatchResumeWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3019,7 +3042,7 @@ TEST_P(StringColumnReaderTest, rleDictionaryMidRunBatchResumeWithNulls) {
 // within a stripe, read with a batch size (70) that both splits runs mid-run
 // inside a chunk and produces a batch spanning the chunk boundary.
 TEST_P(StringColumnReaderTest, rleDictionaryMidRunResumeAcrossChunk) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3060,7 +3083,7 @@ TEST_P(StringColumnReaderTest, rleDictionaryMidRunResumeAcrossChunk) {
 
 // Constant string encoding — all values identical.
 TEST_P(StringColumnReaderTest, constantDictionary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3087,7 +3110,7 @@ TEST_P(StringColumnReaderTest, constantDictionary) {
 
 // Constant string with nulls — constant non-null value, some rows null.
 TEST_P(StringColumnReaderTest, constantDictionaryWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3125,7 +3148,7 @@ TEST_P(StringColumnReaderTest, constantDictionaryWithNulls) {
 // numValues from the Constant chunk causes setNumRows to truncate outputRows,
 // silently dropping rows that passed the filter in the first chunk.
 TEST_P(StringColumnReaderTest, filterOnlyMultiChunkNumValuesSync) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   const std::string targetValue = "MATCH";
 
   // Chunk 1: all rows match the filter -> Constant encoding.
@@ -3215,7 +3238,7 @@ TEST_P(StringColumnReaderTest, filterOnlyMultiChunkNumValuesSync) {
 DEBUG_ONLY_TEST_P(
     StringColumnReaderTest,
     chunkTransitionInvalidatesDictionaryState) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3299,7 +3322,7 @@ DEBUG_ONLY_TEST_P(
 
 // Verifies the dictionary alphabet size via TestValue injection.
 DEBUG_ONLY_TEST_P(StringColumnReaderTest, dictionaryPathAlphabetSize) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3345,7 +3368,7 @@ DEBUG_ONLY_TEST_P(StringColumnReaderTest, dictionaryPathAlphabetSize) {
 // non-dict chunk at the boundary, and must expand already-read dict
 // indices to flat StringViews before reading the rest as flat.
 TEST_P(StringColumnReaderTest, flatEncodingFallback) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3391,7 +3414,7 @@ TEST_P(StringColumnReaderTest, flatEncodingFallback) {
 // bitmap. Regression test for a bug where shifting nullsInReadRange_ in
 // place would corrupt the result nulls returned by getValues.
 TEST_P(StringColumnReaderTest, flatEncodingFallbackWithNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3445,7 +3468,7 @@ TEST_P(StringColumnReaderTest, flatEncodingFallbackWithNulls) {
 // Variable read range scenarios testing transitions between multi-chunk
 // dict reads, mid-chunk dict reads, and flat reads.
 TEST_P(StringColumnReaderTest, variableReadRangeTransitions) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3666,7 +3689,7 @@ TEST_P(StringColumnReaderTest, variableReadRangeTransitions) {
 // and the flat fallback's prepareNulls cleared the dict portion's nulls,
 // which the sparse path writes into resultNulls_.
 TEST_P(StringColumnReaderTest, sparseRowsAcrossChunkAbandonPreservesNulls) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3743,7 +3766,7 @@ TEST_P(StringColumnReaderTest, sparseRowsAcrossChunkAbandonPreservesNulls) {
 // output offset left by the dict portion (numValues_), on top of preserving
 // the dict portion's nulls.
 TEST_P(StringColumnReaderTest, sparseRowsAcrossChunkAbandonNullsBothPortions) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3830,7 +3853,7 @@ TEST_P(StringColumnReaderTest, sparseRowsAcrossChunkAbandonNullsBothPortions) {
 TEST_P(
     StringColumnReaderTest,
     sparseRowsAcrossChunkAbandonNullsOnlyInFlatPortion) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -3908,7 +3931,7 @@ TEST_P(
 // TODO: Add mixed dict/non-dict chunks once the reactive fallback is
 // validated (seed 1373641041).
 TEST_P(StringColumnReaderTest, fuzzMultiChunkDictionary) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -4012,7 +4035,7 @@ TEST_P(StringColumnReaderTest, fuzzMultiChunkDictionary) {
 // with randomized chunk shapes, batch sizes, and null patterns. Runs for
 // both param values (legacy does flat reads, zero-copy may take dict path).
 TEST_P(StringColumnReaderTest, fuzzMultiChunkReadCorrectness) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
 
   for (int run = 0; run < 5; ++run) {
     // Deterministic by default; set env VELOX_TEST_USE_RANDOM_SEED=1 for a
@@ -4100,7 +4123,7 @@ TEST_P(StringColumnReaderTest, fuzzMultiChunkReadCorrectness) {
 // nulls into an unallocated resultNulls_ -> crash. Exercises the
 // dictionary-index read path (readDictionaryIndices).
 TEST_P(StringColumnReaderTest, multiChunkLateNullPreparationDictPath) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
@@ -4189,7 +4212,7 @@ TEST_P(StringColumnReaderTest, multiChunkLateNullPreparationDictPath) {
 // unique values force Trivial, so c1 goes through readWithVisitorFast rather
 // than the dictionary-index path.
 TEST_P(StringColumnReaderTest, multiChunkLateNullPreparationFlatPath) {
-  const bool stringDecoderZeroCopy = GetParam();
+  const bool stringDecoderZeroCopy = std::get<0>(GetParam());
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Repro requires the dict-vector flags";
   }
@@ -4264,9 +4287,12 @@ TEST_P(StringColumnReaderTest, multiChunkLateNullPreparationFlatPath) {
 INSTANTIATE_TEST_CASE_P(
     StringColumnReaderTestSuite,
     StringColumnReaderTest,
-    testing::Values(false, true),
-    [](const testing::TestParamInfo<bool>& info) {
-      return info.param ? "zeroCopy" : "legacy";
+    testing::Combine(testing::Bool(), testing::Bool()),
+    [](const testing::TestParamInfo<std::tuple<bool, bool>>& info) {
+      return fmt::format(
+          "{}_{}",
+          std::get<0>(info.param) ? "zeroCopy" : "legacy",
+          std::get<1>(info.param) ? "avx2" : "noAvx2");
     });
 
 } // namespace


### PR DESCRIPTION
Summary:

Reading a Nimble string column that keeps its dictionary encoding dropped every null on any platform where `process::hasAvx2()` is false, which is all of aarch64. A 200-row column holding `always_the_same` with a null every 7th row came back as a `DictionaryVector` carrying no null flags, so row 0 read as `always_the_same` instead of null.

The dense dictionary-index path wrote nulls only into the reader's read-range bitmap. It then relied on `returnReaderNulls_` to hand that bitmap back from `resultNulls()`. `setReturnNullsMode` clears that flag whenever `useBulkPath()` is false, and `process::hasAvx2()` makes that permanent off AVX2. `resultNulls()` then returns the output-indexed buffer instead, which nothing on this path filled. It now copies the read-range nulls into that buffer, the way the sparse row-set path already did.

Reviewed By: vandreykiv

Differential Revision: D116833280


