### PR TITLE
fix(function): Fix LIKE crash on truncated UTF-8 patterns (#18622)

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1900,7 +1900,7 @@ class PatternStringIterator {
   // Return true if the cursor is advanced successfully, false otherwise(reached
   // the end of the pattern string).
   bool next() {
-    if (nextStart_ == pattern_.size()) {
+    if (nextStart_ >= pattern_.size()) {
       return false;
     }
 
@@ -1938,9 +1938,18 @@ class PatternStringIterator {
       } else {
         charKind_ = CharKind::kNormal;
 
-        // Unicode.
+        // Unicode. Advance a single byte when the sequence is invalid or
+        // truncated: it must not run past the end of the pattern, and the
+        // bytes that follow can still be pattern syntax, for example the '%'
+        // at the end of '%abc\xf0%'.
         if (currentChar & 0x80) {
-          auto numBytes = unicodeCharLength(pattern_.data() + currentStart_);
+          int numBytes = 1;
+          if (utf8proc_codepoint(
+                  pattern_.data() + currentStart_,
+                  pattern_.data() + pattern_.size(),
+                  numBytes) < 0) {
+            numBytes = 1;
+          }
           nextStart_ = currentStart_ + numBytes;
         } else {
           nextStart_ = currentStart_ + 1;

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -736,6 +736,40 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKindUnicode) {
   testPattern("%%你好%世界", PatternKind::kGeneric, "");
 }
 
+// A pattern built per row, such as '%' || lower(name) || '%', is not constant,
+// so it is parsed by LikeGeneric on every row.
+TEST_F(Re2FunctionsTest, likeTruncatedUnicodePattern) {
+  auto input =
+      makeFlatVector<std::string>({"abc\xc3", "abc", "xxabc\xf0yy", "abcyy"});
+  auto pattern = makeFlatVector<std::string>(
+      {"abc\xc3", "abc\xc3", "%abc\xf0%", "%abc\xf0%"});
+  auto result = evaluate("like(c0, c1)", makeRowVector({input, pattern}));
+  // Rows 1 and 2 differ only in whether the input carries the truncated byte;
+  // likewise rows 3 and 4.
+  assertEqualVectors(makeFlatVector<bool>({true, false, true, false}), result);
+}
+
+TEST_F(Re2FunctionsTest, likeDeterminePatternKindTruncatedUnicode) {
+  auto testPattern = [&](std::string_view pattern,
+                         PatternKind patternKind,
+                         std::string_view fixedPattern) {
+    // Heap-allocate the pattern so ASAN traps a read past its last byte.
+    const std::vector<char> buffer(pattern.begin(), pattern.end());
+    PatternMetadata patternMetadata = determinePatternKind(
+        std::string_view(buffer.data(), buffer.size()), std::nullopt);
+    EXPECT_EQ(patternMetadata.patternKind(), patternKind);
+    EXPECT_EQ(patternMetadata.fixedPattern(), fixedPattern);
+  };
+
+  // Lead byte announces 2 bytes, only 1 byte remains.
+  testPattern("abc\xc3", PatternKind::kFixed, "abc\xc3");
+  // Lead byte announces 3 bytes, only 2 bytes remain.
+  testPattern("abc\xe4\xbd", PatternKind::kFixed, "abc\xe4\xbd");
+  // The trailing '%' stays a wildcard: the truncated sequence consumes a
+  // single byte rather than swallowing what follows it.
+  testPattern("%abc\xf0%", PatternKind::kSubstring, "abc\xf0");
+}
+
 TEST_F(Re2FunctionsTest, likeDeterminePatternKindWithEscapeChar) {
   auto testPattern = [&](std::string_view pattern,
                          PatternKind patternKind,


### PR DESCRIPTION
Summary:

A `LIKE` whose pattern ends in an incomplete UTF-8 character crashed the process with a SIGSEGV.  The pattern `abc\xc3` is enough to trigger it: the lead byte `0xc3` announces a two-byte character, but only one byte remains.  Patterns built per row, such as `'%' || lower(name) || '%'`, reach this whenever a row holds text that is not valid UTF-8.

The character length came from the lead byte alone, so a truncated sequence moved the pattern cursor past the end of the buffer.  The parse loop stops only when the cursor is exactly equal to the pattern size, so it kept reading forward until it reached an unmapped page.  Take the length from `utf8proc_codepoint` instead, which is bounded by the end of the pattern and reports an invalid sequence.  An invalid or truncated sequence now advances a single byte, so whatever follows it is still read as pattern syntax: `%abc\xf0%` keeps its trailing `%` as a wildcard.

Reviewed By: kevinwilfong, amitkdutta

Differential Revision: D116947172


