### PR TITLE
feat(torchwave): Common-subexpression elimination (#18623)

### DIFF
--- a/velox/experimental/torchwave/GraphView.cpp
+++ b/velox/experimental/torchwave/GraphView.cpp
@@ -123,6 +123,9 @@ void printGraphView(
       WaveConfig::get().elideClones) {
     elideReadOnlyClones(graph, waveGraphHolder->types());
   }
+  if (waveGraphHolder) {
+    commonSubexpressions(graph, waveGraphHolder->types());
+  }
   if (waveGraphHolder && WaveConfig::get().duplicateMetadata) {
     duplicateMetadataOps(graph, waveGraphHolder->types(), *waveGraphHolder);
   }

--- a/velox/experimental/torchwave/ParallelExpr.cpp
+++ b/velox/experimental/torchwave/ParallelExpr.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -23,6 +24,7 @@
 #include <ranges>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -35,6 +37,7 @@
 #include <folly/CppAttributes.h>
 #include <folly/ScopeGuard.h>
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 
 #include "velox/experimental/torchwave/ParallelExpr.h"
 
@@ -1127,6 +1130,289 @@ int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types) {
     LOG(INFO) << "pre-partition clone pass: elided " << elided << " clone(s)";
   }
   return elided;
+}
+
+namespace {
+
+// Appends 'text' as a length-prefixed token. The punctuation cseKey separates
+// its fields with also occurs inside the fields: constantToString renders a
+// string attribute, a device or a list with commas, brackets and equals signs
+// of its own. Concatenated raw, two different nodes could spell the same key
+// and be merged, which rewires readers to the wrong buffer -- a wrong result
+// rather than a missed optimization. A length prefix removes the ambiguity
+// without having to escape anything.
+void appendToken(std::string& key, std::string_view text) {
+  key += std::to_string(text.size());
+  key += ':';
+  key += text;
+}
+
+// Identity of a node for common-subexpression purposes: op, operands in order,
+// attributes, output arity. Output ids are deliberately absent -- they are what
+// a merge rewrites. Empty for a node that must never be merged: one carrying a
+// subgraph attribute, which has no value rendering to compare.
+std::string cseKey(NodeCP node) {
+  std::string key;
+  appendToken(key, node->target());
+  key += '(';
+  for (const auto& input : node->inputs()) {
+    appendToken(key, input.name);
+    key += '=';
+    // An id is digits only, so it needs no length prefix to stay unambiguous.
+    key += input.value != nullptr ? std::to_string(input.value->id()) : "null";
+    key += ',';
+  }
+  // Attribute order is not part of a node's identity, so compare them sorted.
+  // Sorting the already-tokenized rendering keeps the order canonical; which
+  // total order it is does not matter, only that it is deterministic.
+  std::vector<std::string> attrs;
+  attrs.reserve(node->attributes().size());
+  for (const auto& attr : node->attributes()) {
+    if (std::holds_alternative<std::unique_ptr<nativert::Graph>>(attr.value)) {
+      return {};
+    }
+    std::string rendered;
+    appendToken(rendered, attr.name);
+    rendered += '=';
+    appendToken(rendered, constantToString(attr.value));
+    attrs.push_back(std::move(rendered));
+  }
+  std::sort(attrs.begin(), attrs.end());
+  for (const auto& attr : attrs) {
+    key += attr;
+    key += ',';
+  }
+  key += ')';
+  key += std::to_string(node->outputs().size());
+  return key;
+}
+
+// A node is mergeable with an identical one when it is a pure function of its
+// operands. It must write nothing, and no operand's storage may be written
+// anywhere in the graph: a read is interchangeable with an earlier read only if
+// nothing modified the buffer in between, and this pass compares identity, not
+// position. An output that escapes as a graph output is left alone for the same
+// reason clone elision leaves it alone -- the caller would be handed a buffer
+// that other values also read.
+bool cseEligible(
+    NodeCP node,
+    const ValueTypes& types,
+    const folly::F14FastSet<ValueCP>& mutatedBases,
+    bool cseViews,
+    bool cseCompute) {
+  if (node->outputs().empty() || !dataMutatedInputs(node).empty() ||
+      inPlaceSelf(node) != nullptr) {
+    return false;
+  }
+  for (const auto* out : node->outputs()) {
+    if (out == nullptr || types.graphOutput(out)) {
+      return false;
+    }
+    // An output written in place somewhere later is no more interchangeable
+    // than a mutated operand: the survivor's buffer is not what the duplicate's
+    // readers expect once the write has run. The operand loop below does not
+    // cover it, because the write names the output of this node rather than
+    // anything this node reads.
+    if (mutatedBases.count(viewStorageBase(out)) > 0) {
+      return false;
+    }
+    // A TensorList's elements are the outputs of its sole prim.ListUnpack user,
+    // an invariant getListElements asserts on. Merging two list producers
+    // leaves the survivor's list with two users -- its own unpack and the
+    // dup's, which is dead but still counted -- and the next caller to ask for
+    // its elements throws. Sound merging here needs the dead unpack removed,
+    // which this pass does not do.
+    if (out->type().kind() == nativert::Type::Kind::TensorList) {
+      return false;
+    }
+  }
+  for (const auto& input : node->inputs()) {
+    if (input.value == nullptr ||
+        mutatedBases.count(viewStorageBase(input.value)) > 0) {
+      return false;
+    }
+  }
+  const Metadata* meta = Registry::metadata(node->target());
+  return (meta != nullptr && meta->isView()) ? cseViews : cseCompute;
+}
+
+// Points every reader of 'from' at 'to'.
+//
+// Graph::replaceAllUses walks the user list and TORCH_CHECKs that
+// Graph::replace found something to swap in every entry, which two things
+// break. A node reading the value in two argument positions is listed twice,
+// and replace swaps both occurrences on the first visit, so the second visit
+// finds nothing. And the list holds stale entries: nodes an earlier merge
+// repointed without the entry being dropped. Both are common once views merge,
+// where cat(t, t) and chains of repointed readers are the rule rather than the
+// exception. Normalizing the list to the nodes that really do read the value,
+// once each, is what makes the call safe.
+void replaceReaders(nativert::Graph& graph, ValueCP from, nativert::Value* to) {
+  auto* value = const_cast<nativert::Value*>(from);
+  std::vector<nativert::Node*> readers;
+  readers.reserve(value->users().size());
+  for (auto* user : value->users()) {
+    bool reads = false;
+    for (const auto& input : user->inputs()) {
+      if (input.value == value) {
+        reads = true;
+        break;
+      }
+    }
+    if (!reads) {
+      continue;
+    }
+    if (std::find(readers.begin(), readers.end(), user) == readers.end()) {
+      readers.push_back(user);
+    }
+  }
+  if (readers.size() != value->users().size()) {
+    // eraseUser drops every occurrence of a node, so clearing and re-adding
+    // leaves exactly the real readers, one entry apiece.
+    std::vector<nativert::Node*> current(
+        value->users().begin(), value->users().end());
+    for (auto* user : current) {
+      value->eraseUser(user);
+    }
+    for (auto* user : readers) {
+      value->addUser(user);
+    }
+  }
+  graph.replaceAllUses(value, to);
+}
+
+// Points every reader of 'dup's outputs at the matching output of 'keeper',
+// then offers each survivor to 'push' so consumers that only became congruent
+// through this merge get revisited. Returns false, having changed nothing, when
+// the two disagree on output arity: equal cseKeys make that impossible for
+// nodes of the same op, so it means they were never really congruent.
+bool mergeCseNode(
+    nativert::Graph& graph,
+    NodeCP keeper,
+    NodeCP dup,
+    const std::function<void(ValueCP)>& push) {
+  const auto& from = dup->outputs();
+  const auto& to = keeper->outputs();
+  if (from.size() != to.size()) {
+    return false;
+  }
+  // No TensorList output reaches here: cseEligible rejects any node that has
+  // one, so there are never element ids to remap alongside the list value.
+  for (size_t i = 0; i < from.size(); ++i) {
+    replaceReaders(graph, from[i], const_cast<nativert::Value*>(to[i]));
+    push(to[i]);
+  }
+  return true;
+}
+
+} // namespace
+
+int64_t commonSubexpressions(nativert::Graph& graph, const ValueTypes& types) {
+  const bool cseViews = WaveConfig::get().cseViews;
+  const bool cseCompute = WaveConfig::get().cseCompute;
+  if (!cseViews && !cseCompute) {
+    return 0;
+  }
+
+  folly::F14FastSet<ValueCP> mutatedBases;
+  for (const auto& node : graph.nodes()) {
+    for (auto* mutated : dataMutatedInputs(&node)) {
+      if (mutated != nullptr) {
+        mutatedBases.insert(viewStorageBase(mutated));
+      }
+    }
+  }
+
+  std::deque<ValueCP> work;
+  folly::F14FastSet<ValueCP> queued;
+  auto push = [&](ValueCP value) {
+    if (value != nullptr && queued.insert(value).second) {
+      work.push_back(value);
+    }
+  };
+
+  // Program order of every node. The survivor of a merge has to be the earlier
+  // of the two: keeping the later one would leave the earlier one's consumers
+  // reading a value produced after them, which makeParallelNodes rejects. User
+  // lists are not in program order, so the first candidate a bucket sees is not
+  // necessarily the first in the graph.
+  folly::F14FastMap<NodeCP, size_t> order;
+  {
+    size_t index = 0;
+    for (const auto& node : graph.nodes()) {
+      order.emplace(&node, index++);
+    }
+  }
+
+  int64_t merged = 0;
+  auto mergeBucket = [&](folly::F14FastMap<std::string, NodeCP>& firstOf,
+                         NodeCP node) {
+    auto key = cseKey(node);
+    if (key.empty()) {
+      return;
+    }
+    // A value in this graph can be read by a node in a variant subgraph, which
+    // shows up in users() but is not in this graph's node list. Those are not
+    // ours to merge or to order.
+    if (!order.contains(node)) {
+      return;
+    }
+    auto [it, isNew] = firstOf.emplace(key, node);
+    if (isNew) {
+      return;
+    }
+    NodeCP keeper = it->second;
+    NodeCP dup = node;
+    if (order.at(dup) < order.at(keeper)) {
+      std::swap(keeper, dup);
+    }
+    if (mergeCseNode(graph, keeper, dup, push)) {
+      it->second = keeper;
+      ++merged;
+    }
+  };
+
+  // A node with no operands appears in no user list, so nothing would ever
+  // bring two of them together; bucket those once up front. Factory ops
+  // (aten.zeros and friends) are the case that matters.
+  {
+    folly::F14FastMap<std::string, NodeCP> firstOf;
+    for (const auto& node : graph.nodes()) {
+      if (node.inputs().empty() && !isDeadNode(&node) &&
+          cseEligible(&node, types, mutatedBases, cseViews, cseCompute)) {
+        mergeBucket(firstOf, &node);
+      }
+    }
+  }
+
+  // Congruent nodes have identical operands, so both appear in the user list of
+  // every value they read. Walking user lists is therefore complete for any
+  // node with an operand, and never hashes a node that has no possible partner.
+  for (const auto* value : graph.values()) {
+    if (value != nullptr && !value->users().empty()) {
+      push(value);
+    }
+  }
+
+  while (!work.empty()) {
+    ValueCP value = work.front();
+    work.pop_front();
+    queued.erase(value);
+    // Snapshot: merging rewires the list being walked.
+    std::vector<NodeCP> users(value->users().begin(), value->users().end());
+    folly::F14FastMap<std::string, NodeCP> firstOf;
+    for (NodeCP user : users) {
+      if (!isDeadNode(user) &&
+          cseEligible(user, types, mutatedBases, cseViews, cseCompute)) {
+        mergeBucket(firstOf, user);
+      }
+    }
+  }
+
+  if ((WaveConfig::get().trace & WaveConfig::kTiming) && merged > 0) {
+    LOG(INFO) << "pre-partition CSE: merged " << merged << " node(s)";
+  }
+  return merged;
 }
 
 namespace {

--- a/velox/experimental/torchwave/ParallelExpr.h
+++ b/velox/experimental/torchwave/ParallelExpr.h
@@ -35,6 +35,16 @@ namespace torch::wave {
 /// layers. Returns the number elided.
 int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types);
 
+/// Merges nodes that compute the same value from the same operands, to a
+/// fixpoint: merging two nodes can make their consumers congruent in turn. Only
+/// pure nodes participate -- nothing that writes, reads a buffer written
+/// elsewhere in the graph, or escapes as a graph output. Gated per category by
+/// WaveConfig::cseCompute and cseViews; a no-op when both are off.
+/// Call before partitioning, after the rewrites that create the duplicates, and
+/// before duplicateMetadataOps, whose duplicates this would otherwise undo.
+/// Returns the number of nodes merged away.
+int64_t commonSubexpressions(nativert::Graph& graph, const ValueTypes& types);
+
 /// Rematerializes each multiply-used metadata getter (sym_size / sym_numel) at
 /// its use sites, so it stops being a shared value the partitioner has to
 /// materialize as a top-level output. Only duplicates a getter whose operand is

--- a/velox/experimental/torchwave/WaveConfig.cpp
+++ b/velox/experimental/torchwave/WaveConfig.cpp
@@ -86,6 +86,8 @@ std::string WaveConfig::toString() const {
   addBool("scanOutputReturnBarrier", &WaveConfig::scanOutputReturnBarrier);
   addBool("freeIntermediates", &WaveConfig::freeIntermediates);
   addBool("inputContiguous", &WaveConfig::inputContiguous);
+  addBool("cseCompute", &WaveConfig::cseCompute);
+  addBool("cseViews", &WaveConfig::cseViews);
   addBool("mkSelect", &WaveConfig::mkSelect);
   addBool("stepLastUse", &WaveConfig::stepLastUse);
   addBool("syncEachStep", &WaveConfig::syncEachStep);

--- a/velox/experimental/torchwave/WaveConfig.h
+++ b/velox/experimental/torchwave/WaveConfig.h
@@ -238,6 +238,14 @@ struct WaveConfig {
   // actually contiguous and throws otherwise. Off by default.
   bool inputContiguous{false};
 
+  // Merge nodes that compute the same thing from the same operands, before
+  // partitioning. Split in two because the two halves pay off differently: the
+  // compute half removes real work, while the view half only removes graph
+  // nodes -- and duplicating views per consumer is something duplicateMetadata
+  // does on purpose, so merging them can work against the partitioner.
+  bool cseCompute{false};
+  bool cseViews{false};
+
   // If true, cooperative-grid mode expands tw.masked_select_jagged into its
   // multi-kernel stages instead of the single-node cg form. The stages reserve
   // the output list to the exact selected count, which the cg form cannot do:

--- a/velox/experimental/torchwave/WaveGraph.cpp
+++ b/velox/experimental/torchwave/WaveGraph.cpp
@@ -246,6 +246,12 @@ WaveGraph::WaveGraph(ModelContext* modelContext)
     elideReadOnlyClones(*graph_, types_);
   }
 
+  // Merge equal computations. After the rewrites above, which are what create
+  // most of the duplicates (an op rewritten once per consumer), and before
+  // duplicateMetadataOps below, which deliberately inserts duplicates this
+  // would undo.
+  commonSubexpressions(*graph_, types_);
+
   // Last of the pre-partition passes: the clone CSE above merges equal values,
   // which would undo the duplicates this inserts.
   if (WaveConfig::get().duplicateMetadata) {

--- a/velox/experimental/torchwave/tests/CompileTest.cpp
+++ b/velox/experimental/torchwave/tests/CompileTest.cpp
@@ -1004,6 +1004,209 @@ return(%r)
   EXPECT_GT(countSteps(*standaloneGraph), fusedSteps)
       << standalonePlan.describe();
 }
+// True when the node producing %<name> reads the same value twice, i.e. its
+// two operands were merged. Asking the consumer rather than counting nodes is
+// what keeps the answer independent of whether the merged-away node is later
+// swept from the graph.
+bool operandsMerged(nativert::Graph& graph, std::string_view name) {
+  for (const auto& node : graph.nodes()) {
+    for (const auto* out : node.outputs()) {
+      if (out != nullptr && out->name() == name) {
+        EXPECT_EQ(node.inputs().size(), 2u) << name;
+        return node.inputs()[0].value == node.inputs()[1].value;
+      }
+    }
+  }
+  ADD_FAILURE() << "no node produces %" << name;
+  return false;
+}
+
+// Common-subexpression elimination, gated separately for compute and views.
+//
+// The graph pairs one duplicated add (compute) with one duplicated transpose
+// (a view), plus a third transpose whose dims differ. Each consumer takes the
+// two candidates as its two operands, so "were they merged" reduces to "are
+// this node's operands now the same value" -- which, unlike counting nodes,
+// does not depend on whether the merged-away node is later swept from the
+// graph.
+TEST_F(CompileTest, commonSubexpressions) {
+  auto f = [] { return makeTensorMeta(c10::ScalarType::Float, 2); };
+  std::unordered_map<std::string, torch::_export::TensorMeta> meta = {
+      {"a", f()},
+      {"b", f()},
+      {"s1", f()},
+      {"s2", f()},
+      {"m", f()},
+      {"t1", f()},
+      {"t2", f()},
+      {"t3", f()},
+      {"v", f()},
+      {"w", f()},
+      {"r", f()},
+      {"out", f()}};
+  const char* graphStr = R"(graph(%a, %b):
+%s1 = torch.ops.aten.add.Tensor(self=%a, other=%b)
+%s2 = torch.ops.aten.add.Tensor(self=%a, other=%b)
+%m = torch.ops.aten.add.Tensor(self=%s1, other=%s2)
+%t1 = torch.ops.aten.transpose.int(self=%b, dim0=0, dim1=1)
+%t2 = torch.ops.aten.transpose.int(self=%b, dim0=0, dim1=1)
+%t3 = torch.ops.aten.transpose.int(self=%b, dim0=1, dim1=0)
+%v = torch.ops.aten.add.Tensor(self=%t1, other=%t2)
+%w = torch.ops.aten.add.Tensor(self=%t1, other=%t3)
+%r = torch.ops.aten.add.Tensor(self=%v, other=%w)
+%out = torch.ops.aten.add.Tensor(self=%m, other=%r)
+return(%out)
+)";
+
+  auto savedCompute = WaveConfig::get().cseCompute;
+  auto savedViews = WaveConfig::get().cseViews;
+  auto restore = folly::makeGuard([&] {
+    WaveConfig::get().cseCompute = savedCompute;
+    WaveConfig::get().cseViews = savedViews;
+  });
+
+  struct Case {
+    bool compute;
+    bool views;
+  };
+  for (const Case c :
+       {Case{false, false},
+        Case{true, false},
+        Case{false, true},
+        Case{true, true}}) {
+    SCOPED_TRACE(fmt::format("cseCompute={} cseViews={}", c.compute, c.views));
+    WaveConfig::get().cseCompute = c.compute;
+    WaveConfig::get().cseViews = c.views;
+
+    auto waveGraph = compileGraphString(graphStr, meta);
+    ASSERT_NE(waveGraph, nullptr);
+    auto& graph = *waveGraph->graph();
+
+    // The duplicated add collapses only under cseCompute, the duplicated
+    // transpose only under cseViews: each flag governs its own category.
+    EXPECT_EQ(operandsMerged(graph, "m"), c.compute);
+    EXPECT_EQ(operandsMerged(graph, "v"), c.views);
+
+    // %t3 transposes the same tensor to the same result but spells its dims the
+    // other way round. The key compares attributes verbatim, so it never merges
+    // with %t1 -- this pass claims syntactic identity, not equivalence.
+    EXPECT_FALSE(operandsMerged(graph, "w"));
+
+    // The survivor must be the earlier of the two in program order. Keeping the
+    // later one leaves the earlier one's consumers reading a value produced
+    // after them, which makeParallelNodes rejects outright -- and user lists,
+    // which is what the pass walks, are not in program order.
+    for (const auto& node : graph.nodes()) {
+      size_t consumerPos = 0;
+      size_t pos = 0;
+      for (const auto& other : graph.nodes()) {
+        if (&other == &node) {
+          consumerPos = pos;
+          break;
+        }
+        ++pos;
+      }
+      for (const auto& input : node.inputs()) {
+        if (input.value == nullptr || input.value->producer() == nullptr) {
+          continue;
+        }
+        size_t producerPos = 0;
+        bool found = false;
+        pos = 0;
+        for (const auto& other : graph.nodes()) {
+          if (&other == input.value->producer()) {
+            producerPos = pos;
+            found = true;
+            break;
+          }
+          ++pos;
+        }
+        EXPECT_TRUE(!found || producerPos < consumerPos)
+            << node.target() << " reads %" << input.value->id()
+            << " produced later by " << input.value->producer()->target();
+      }
+    }
+  }
+}
+
+// Two nodes that compute the same thing from the same operands are still not
+// interchangeable if a buffer either of them touches is written in place: the
+// second one reads what the write left behind, and the first does not. The
+// pass compares identity, not position, so it refuses on the whole buffer --
+// a write anywhere in the graph disqualifies every node that reads or produces
+// it, whether or not the write falls between the two candidates.
+//
+// Three graphs, because the rule has to hold from both ends of a node and the
+// negative cases alone would be satisfied by a pass that merged nothing:
+//   operand   %c is written, and %c is an operand of both adds
+//   output    %s1 is written, and %s1 is what one of the adds produces
+//   unrelated %d is written, and neither add goes near it -- the control
+TEST_F(CompileTest, commonSubexpressionsMutation) {
+  auto savedCompute = WaveConfig::get().cseCompute;
+  auto savedViews = WaveConfig::get().cseViews;
+  auto restore = folly::makeGuard([&] {
+    WaveConfig::get().cseCompute = savedCompute;
+    WaveConfig::get().cseViews = savedViews;
+  });
+  WaveConfig::get().cseCompute = true;
+  WaveConfig::get().cseViews = true;
+
+  auto f = [] { return makeTensorMeta(c10::ScalarType::Float, 2); };
+  std::unordered_map<std::string, torch::_export::TensorMeta> meta = {
+      {"b", f()},
+      {"c", f()},
+      {"d", f()},
+      {"s1", f()},
+      {"s2", f()},
+      {"mut", f()},
+      {"out", f()}};
+
+  // %c is an operand of both adds and is written between them.
+  const char* operandStr = R"(graph(%b, %c, %d):
+%s1 = torch.ops.aten.add.Tensor(self=%b, other=%c)
+%mut = torch.ops.aten.add_.Tensor(self=%c, other=%b)
+%s2 = torch.ops.aten.add.Tensor(self=%b, other=%c)
+%out = torch.ops.aten.add.Tensor(self=%s1, other=%s2)
+return(%out)
+)";
+
+  // %s1 is what the first add produces, and it is written before the consumer
+  // reads either value. Merging would repoint %s2's reader at a buffer the
+  // write has since changed.
+  const char* outputStr = R"(graph(%b, %c, %d):
+%s1 = torch.ops.aten.add.Tensor(self=%b, other=%c)
+%s2 = torch.ops.aten.add.Tensor(self=%b, other=%c)
+%mut = torch.ops.aten.add_.Tensor(self=%s1, other=%b)
+%out = torch.ops.aten.add.Tensor(self=%s1, other=%s2)
+return(%out)
+)";
+
+  // The write lands on a buffer neither add reads or produces, so the two are
+  // interchangeable and must still merge. Without this case the two above
+  // would pass on a pass that had stopped merging altogether.
+  const char* unrelatedStr = R"(graph(%b, %c, %d):
+%s1 = torch.ops.aten.add.Tensor(self=%b, other=%c)
+%mut = torch.ops.aten.add_.Tensor(self=%d, other=%b)
+%s2 = torch.ops.aten.add.Tensor(self=%b, other=%c)
+%out = torch.ops.aten.add.Tensor(self=%s1, other=%s2)
+return(%out)
+)";
+
+  struct Case {
+    const char* name;
+    const char* graphStr;
+    bool merges;
+  };
+  for (const Case c :
+       {Case{"operand", operandStr, false},
+        Case{"output", outputStr, false},
+        Case{"unrelated", unrelatedStr, true}}) {
+    SCOPED_TRACE(c.name);
+    auto waveGraph = compileGraphString(c.graphStr, meta);
+    ASSERT_NE(waveGraph, nullptr);
+    EXPECT_EQ(operandsMerged(*waveGraph->graph(), "out"), c.merges);
+  }
+}
 } // namespace
 } // namespace torch::wave
 

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -202,6 +202,14 @@ DEFINE_bool(
     false,
     "Assume all model inputs, weights, and constants are contiguous in the graph optimizer; executeWave verifies and errors out if any is not contiguous");
 DEFINE_bool(
+    cse_compute,
+    false,
+    "Before partitioning, merge compute nodes that produce the same value from the same operands");
+DEFINE_bool(
+    cse_views,
+    false,
+    "Before partitioning, merge view nodes that produce the same value from the same operands");
+DEFINE_bool(
     mk_select,
     false,
     "In cg mode, expand tw.masked_select_jagged into its multi-kernel stages so the output list is sized to the exact selected count instead of the mask length");
@@ -619,6 +627,8 @@ void ExecutorTestBase::SetUpTestSuite() {
   WaveConfig::get().donateBuffers = FLAGS_donate_buffers;
   WaveConfig::get().donationCarryBytes = FLAGS_donation_carry_bytes;
   WaveConfig::get().inputContiguous = FLAGS_input_contiguous;
+  WaveConfig::get().cseCompute = FLAGS_cse_compute;
+  WaveConfig::get().cseViews = FLAGS_cse_views;
   WaveConfig::get().mkSelect = FLAGS_mk_select;
   if (!FLAGS_print_options.empty()) {
     NodePrinter::setDefaults(


### PR DESCRIPTION
Summary:

The rewrites that run before partitioning duplicate work: an op rewritten once per consumer leaves N identical nodes behind, and every one of them is compiled and run. One large preprocessing graph carries 96 copies of a single `aten.view.default`, 28 of one `aten.zeros`, and 17 of one `aten.sum.default`. Merging the duplicates takes that graph from 1706 compiled ops to 1613, about 5.5%. On a larger ads model the same pass merges 2310 nodes.

`commonSubexpressions` is a congruence closure driven by user lists. Two congruent nodes read the same values, so both appear in the user list of every value they read; bucketing each value's users by target, operands, attributes and output arity therefore finds every candidate that has an operand. A merge rewires the duplicate's uses and pushes the survivor's outputs back on the worklist, since consumers of merged values can become congruent in turn. A node with no operands appears in no user list, so factory ops such as `aten.zeros` are bucketed once up front.

Only pure nodes merge: nothing that writes, nothing that reads or produces a buffer some other node writes, and nothing that escapes as a graph output. Both ends of the node matter. A mutated operand is the obvious case; a mutated output is the same problem seen from the other side, since the survivor's buffer is not what the duplicate's readers expect once the write has run. The pass compares identity, not position, so it refuses on the whole buffer: a write anywhere in the graph disqualifies every node that touches it, whether or not the write falls between the two candidates. A read is interchangeable with an earlier read only when nothing modified the buffer in between, and settling that precisely would need an interval query this pass deliberately does without. A `TensorList` output is skipped as well. A list's elements are the outputs of its sole `prim.ListUnpack` user, so merging two list producers leaves the survivor with two users, and the next call to `getListElements` throws. The survivor of a merge is always the earlier of the two in program order. Keeping the later one would leave the earlier one's consumers reading a value produced after them, which `makeParallelNodes` rejects.

Rewiring goes through `replaceReaders` rather than `Graph::replaceAllUses` directly. `replaceAllUses` checks that every user-list entry had something to swap, and two things break that: a node reading the value twice is listed twice, and the first visit swaps both occurrences; and the list keeps stale entries for nodes an earlier merge already repointed. Both are ordinary once views merge, where `cat(t, t)` and chains of repointed readers are the rule. Normalizing the list to the real readers, once each, is what makes the call safe.

Two flags, both off by default, because the halves pay off differently. `cseCompute` removes real work. `cseViews` only removes graph nodes, and duplicating a view per consumer is something `duplicateMetadataOps` does on purpose, so merging views can work against the partitioner. The pass runs after the rewrites that create the duplicates and before `duplicateMetadataOps`.

Reviewed By: Yuhta

Differential Revision: D116647265


