### PR TITLE
fix: Spark cast benchmark shutdown crash

### DIFF
--- a/velox/functions/sparksql/benchmarks/CastBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/CastBenchmark.cpp
@@ -44,14 +44,18 @@ core::TypedExprPtr makeCastExpr(
 // expression, e.g. when the input type is TIMESTAMP_UTC.
 void addTypedCastBenchmark(
     const std::string& name,
-    const RowVectorPtr& input,
+    const RowVectorPtr& inputVector,
     core::TypedExprPtr castExpr,
     core::ExecCtx& execCtx,
+    std::vector<std::shared_ptr<exec::ExprSet>>& typedExprSets,
     int32_t iterations) {
-  auto exprSet = std::make_shared<exec::ExprSet>(
-      std::vector<core::TypedExprPtr>{std::move(castExpr)}, &execCtx);
+  typedExprSets.push_back(
+      std::make_shared<exec::ExprSet>(
+          std::vector<core::TypedExprPtr>{std::move(castExpr)}, &execCtx));
+  auto* exprSet = typedExprSets.back().get();
+  auto* input = inputVector.get();
   folly::addBenchmark(__FILE__, name, [input, exprSet, &execCtx, iterations]() {
-    exec::EvalCtx evalCtx(&execCtx, exprSet.get(), input.get());
+    exec::EvalCtx evalCtx(&execCtx, exprSet, input);
     SelectivityVector rows(input->size());
     std::vector<VectorPtr> results(1);
 
@@ -140,17 +144,21 @@ int main(int argc, char** argv) {
 
   auto queryCtx = core::QueryCtx::create();
   core::ExecCtx execCtx(benchmarkBuilder.pool(), queryCtx.get());
+  std::vector<std::shared_ptr<exec::ExprSet>> typedExprSets;
+  typedExprSets.reserve(2);
   addTypedCastBenchmark(
       setName + "##cast_timestamp_as_timestamp_utc",
       timestampInput,
       makeCastExpr(TIMESTAMP(), "timestamp", TIMESTAMP_UTC()),
       execCtx,
+      typedExprSets,
       iterations);
   addTypedCastBenchmark(
       setName + "##cast_timestamp_utc_as_timestamp",
       timestampInput,
       makeCastExpr(TIMESTAMP_UTC(), "timestamp_utc", TIMESTAMP()),
       execCtx,
+      typedExprSets,
       iterations);
 
   benchmarkBuilder.registerBenchmarks();


### PR DESCRIPTION
The timestamp cast benchmarks captured owning Velox objects in 
`folly::addBenchmark`. Since Folly stores benchmark registrations globally,
these objects could be destroyed after the local pool/context, causing a
shutdown crash in `AlignedBuffer::freeToPool()`.

This PR keeps ownership in `main()` and makes the registered lambda capture 
only non-owning pointers, so Velox objects are destroyed while their 
pool/context are still valid.

Stack trace:
```
EXC_BAD_ACCESS (code=1, address=0x80)

#0  facebook::velox::AlignedBuffer::freeToPool() + 40
#1  facebook::velox::FlatVector<facebook::velox::Timestamp>::~FlatVector() + 288
#2  facebook::velox::RowVector::~RowVector() + 164
#3  std::__1::__function::__func<... addTypedCastBenchmark(...)::$_0 ...>::~__func() + 140
#4  std::__1::function<folly::detail::TimeIterData(unsigned int)>::~function()
#8  folly::detail::BenchmarkRegistration::~BenchmarkRegistration()
#12 std::__1::vector<folly::detail::BenchmarkRegistration>::clear()
#17 folly::detail::BenchmarkingStateBase::~BenchmarkingStateBase()
#19 folly::detail::BenchmarkingState<std::chrono::steady_clock>::~BenchmarkingState()
#20 __cxa_finalize_ranges
#21 exit
#24 start
```