### PR TITLE
feat(nimble): Merge Writer and Deserializer with fbcode

### DIFF
--- a/velox/dwio/nimble/serializer/Deserializer.cpp
+++ b/velox/dwio/nimble/serializer/Deserializer.cpp
@@ -407,32 +407,38 @@ void Deserializer::initialize(
     deserializers_[offset] = decoder.get();
   }
 
-  // Pre-size stream presence-tracking state once. Both vectors are bounded
-  // by maxOffset because every value-stream anchor offset is a Type main
-  // descriptor offset already in deserializerMap_. Sizing here (rather than
-  // grow-on-demand inside createDeserializersForType) avoids repeated
-  // reallocations and lets the per-batch hot path skip a bounds check.
   if (!inMapChildTypes_.empty()) {
     streamPresentFlags_.resize(maxOffset + 1, false);
     valueOffsetToInMap_.resize(maxOffset + 1, kInvalidInMapOffset);
     // Populate the reverse-lookup table: for each top-level FlatMap child,
-    // record its inMap stream offset at every one of its value-stream
+    // record its inMap stream offset at every one of its presence-stream
     // anchors. The per-batch in-map inference reads this to map a present
-    // value anchor back to its owning child without re-walking the schema.
+    // child stream back to its owning child without re-walking the schema.
     //
-    // visitValueStreamLeaves visits ALL value-stream offsets in the child
-    // subtree (Row recurses all children; FlatMap recurses all children).
+    // Value leaves are not enough for omitted in-map inference: a child present
+    // in every row with all-null values may only have null/container/nested
+    // in-map streams to prove an omitted all-true in-map stream. Therefore,
+    // visitPresenceStreamOffsets records all data-bearing offsets in the child
+    // subtree, including Row/FlatMap null streams and nested FlatMap in-map
+    // streams.
     // Relies on RowFieldWriter writing every field over the same
-    // OrderedRanges, so sibling Row children populate in lockstep — if any
+    // OrderedRanges, so sibling Row children populate in lockstep; if any
     // sibling's value stream is present in a batch, all are. If a future
     // writer ever made Row children conditionally absent, the in-map
     // inference below would over-attribute presence to keys whose first
     // child was absent but a sibling was present.
     for (const auto& [inMapOffset, childType] : inMapChildTypes_) {
-      visitValueStreamLeaves(
+      visitPresenceStreamOffsets(
           *childType,
-          [this, _inMapOffset = inMapOffset](offset_size valueOffset) {
-            valueOffsetToInMap_[valueOffset] = _inMapOffset;
+          [this, _inMapOffset = inMapOffset](offset_size presenceOffset) {
+            // This lookup is only indexed by presentStreamOffsets_, which is
+            // populated from decoded streams and therefore bounded by
+            // deserializerMap_. visitPresenceStreamOffsets() walks schema
+            // anchors too, including projected-away streams with no decoder.
+            if (presenceOffset >= valueOffsetToInMap_.size()) {
+              return false;
+            }
+            valueOffsetToInMap_[presenceOffset] = _inMapOffset;
             return false;
           });
     }

--- a/velox/dwio/nimble/serializer/Deserializer.h
+++ b/velox/dwio/nimble/serializer/Deserializer.h
@@ -314,8 +314,8 @@ class Deserializer {
   static constexpr uint32_t kInvalidInMapOffset =
       std::numeric_limits<uint32_t>::max();
 
-  // Reverse lookup from a FlatMap child value-stream offset to its in-map
-  // stream offset. Entries that are not FlatMap child value streams use
+  // Reverse lookup from a FlatMap child presence-stream offset to its in-map
+  // stream offset. Entries that are not FlatMap child presence streams use
   // kInvalidInMapOffset.
   std::vector<uint32_t> valueOffsetToInMap_;
 

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -1665,6 +1665,102 @@ TEST_F(WriterTest, memoryReclaimPath) {
   ASSERT_TRUE(reclaimEntered.load());
 }
 
+namespace {
+// A spill config is what makes the writer reclaimable at all, so the tests
+// below set one rather than short-circuiting on the null check.
+velox::common::SpillConfig makeReclaimSpillConfig() {
+  velox::common::SpillConfig spillConfig;
+  spillConfig.writerFlushThresholdSize = 1 << 20;
+  return spillConfig;
+}
+
+// Mirrors what SharedArbitrator does when it walks a task's pools: ask every
+// child that carries a reclaimer how much it could free. Returns the number of
+// reclaimers queried.
+int32_t queryChildReclaimers(velox::memory::MemoryPool& parent) {
+  int32_t queried = 0;
+  parent.visitChildren([&](velox::memory::MemoryPool* child) {
+    auto* reclaimer = child->reclaimer();
+    if (reclaimer != nullptr) {
+      uint64_t reclaimableBytes{1};
+      EXPECT_FALSE(reclaimer->reclaimableBytes(*child, reclaimableBytes));
+      EXPECT_EQ(reclaimableBytes, 0);
+      ++queried;
+    }
+    return true;
+  });
+  return queried;
+}
+} // namespace
+
+// The writer installs its reclaimer while `pool_` is initialized, several
+// members before the state that reclaimer reads. Arbitration triggered by any
+// allocation in between -- the writer's own context allocates a 1MB Buffer, and
+// a concurrent driver can arbitrate at any moment -- reaches the reclaimer
+// first. Drives that through the reclaimer factory, which the writer invokes
+// for `encodingMemoryPool_` and for the context: after the reclaimer is live on
+// the pool, before the writer is built.
+TEST_F(WriterTest, reclaimableBytesDuringConstruction) {
+  auto rootPool = velox::memory::memoryManager()->addRootPool(
+      "reclaimDuringConstruction",
+      64L << 20,
+      velox::memory::MemoryReclaimer::create());
+  auto writerPool = rootPool->addAggregateChild(
+      "writer", velox::memory::MemoryReclaimer::create());
+
+  auto type = velox::ROW({{"simple_int", velox::INTEGER()}});
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+
+  const auto spillConfig = makeReclaimSpillConfig();
+  int32_t queriedDuringConstruction = 0;
+  nimble::WriterOptions writerOptions{
+      .reclaimerFactory =
+          [&]() -> std::unique_ptr<velox::memory::MemoryReclaimer> {
+        queriedDuringConstruction += queryChildReclaimers(*writerPool);
+        return nullptr;
+      },
+      .spillConfig = &spillConfig};
+
+  nimble::Writer writer(
+      type, std::move(writeFile), *writerPool, std::move(writerOptions));
+
+  // The first factory call happens before the pool exists; the later ones see
+  // it, and are the ones that matter.
+  EXPECT_GT(queriedDuringConstruction, 0);
+  writer.close();
+}
+
+// A closed writer has no stripe left to flush, so it must stop advertising its
+// reserved bytes as reclaimable -- otherwise the arbitrator picks the pool as a
+// candidate, suspends the driver, and reclaimBytes() turns it away. Also covers
+// the teardown ordering: `context_` is destroyed ahead of `pool_`, so anything
+// the reclaimer reads has to outlive the writer's members.
+TEST_F(WriterTest, reclaimableBytesAfterClose) {
+  auto rootPool = velox::memory::memoryManager()->addRootPool(
+      "reclaimAfterClose", 64L << 20, velox::memory::MemoryReclaimer::create());
+  auto writerPool = rootPool->addAggregateChild(
+      "writer", velox::memory::MemoryReclaimer::create());
+
+  auto type = velox::ROW({{"simple_int", velox::INTEGER()}});
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+
+  const auto spillConfig = makeReclaimSpillConfig();
+  nimble::Writer writer(
+      type,
+      std::move(writeFile),
+      *writerPool,
+      nimble::WriterOptions{.spillConfig = &spillConfig});
+  for (const auto& batch :
+       generateBatches(type, 2, 100, 20221110, *leafPool_)) {
+    writer.write(batch);
+  }
+  writer.close();
+
+  EXPECT_GT(queryChildReclaimers(*writerPool), 0);
+}
+
 TEST_F(WriterTest, flushHugeStrings) {
   nimble::WriterOptions writerOptions{.flushPolicyFactory = []() {
     return std::make_unique<nimble::StripeRawSizeFlushPolicy>(1 * 1024 * 1024);
@@ -4324,6 +4420,63 @@ TEST_F(WriterTest, chunkSizeStatsPopulatedWhenChunkingTriggered) {
   EXPECT_GT(chunkSizeBytes.count, 0);
   EXPECT_GT(chunkSizeBytes.sum, 0);
   EXPECT_LE(chunkSizeBytes.min, chunkSizeBytes.max);
+}
+
+TEST_F(WriterTest, smallMaxChunkSizeProducesMultipleChunks) {
+  const auto type =
+      velox::ROW({{"c0", velox::BIGINT()}, {"c1", velox::VARCHAR()}});
+
+  nimble::WriterOptions options{
+      .minStreamChunkRawSize = 0,
+      .maxStreamChunkRawSize = 2048,
+      .flushPolicyFactory = []() -> std::unique_ptr<nimble::FlushPolicy> {
+        return std::make_unique<nimble::StripeRawSizeFlushPolicy>(256ULL << 20);
+      },
+      .enableChunking = true,
+      .enableChunkIndex = true,
+  };
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::Writer writer(
+      type, std::move(writeFile), *rootPool_, std::move(options));
+
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = 5000, .nullRatio = 0.1, .stringLength = 50},
+      leafPool_.get(),
+      42);
+  for (int i = 0; i < 4; ++i) {
+    writer.write(fuzzer.fuzzInputRow(type));
+  }
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  ASSERT_EQ(1, tablet->stripeCount());
+
+  auto stripeId = tablet->stripeIdentifier(0);
+  const auto streamCount = tablet->streamCount(stripeId);
+  bool foundMultiChunkStream = false;
+  for (uint32_t s = 0; s < streamCount; ++s) {
+    auto streamLoaders = tablet->load(stripeId, std::array<uint32_t, 1>{s});
+    if (streamLoaders.empty() || !streamLoaders[0]) {
+      continue;
+    }
+    nimble::InMemoryChunkedStream chunked{
+        *leafPool_, std::move(streamLoaders[0])};
+    uint32_t chunkCount = 0;
+    while (chunked.hasNext()) {
+      chunked.nextChunk();
+      ++chunkCount;
+    }
+    if (chunkCount > 1) {
+      foundMultiChunkStream = true;
+      LOG(INFO) << "stream " << s << ": " << chunkCount << " chunks";
+    }
+  }
+  EXPECT_TRUE(foundMultiChunkStream)
+      << "Expected at least one stream with multiple chunks at maxStreamChunkRawSize=2048";
 }
 
 TEST_F(WriterTest, chunkSizeStatsEmptyWhenChunkingNotTriggered) {

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -4427,13 +4427,13 @@ TEST_F(WriterTest, smallMaxChunkSizeProducesMultipleChunks) {
       velox::ROW({{"c0", velox::BIGINT()}, {"c1", velox::VARCHAR()}});
 
   nimble::WriterOptions options{
+      .enableChunkIndex = true,
       .minStreamChunkRawSize = 0,
       .maxStreamChunkRawSize = 2048,
       .flushPolicyFactory = []() -> std::unique_ptr<nimble::FlushPolicy> {
         return std::make_unique<nimble::StripeRawSizeFlushPolicy>(256ULL << 20);
       },
       .enableChunking = true,
-      .enableChunkIndex = true,
   };
 
   std::string file;

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -1167,6 +1167,7 @@ Writer::Writer(
       // TODO(T283224280): report statistics for omitted cluster index key
       // columns too, instead of leaving them out of the file metadata.
       rowType_{velox::asRowType(storedDataType_)},
+      spillConfig_{options.spillConfig},
       pool_{MemoryPoolHolder::create(
           pool,
           [&](auto& pool) {
@@ -1293,7 +1294,14 @@ Writer::Writer(
   setState(State::kRunning);
 }
 
-Writer::~Writer() {}
+Writer::~Writer() {
+  // The reclaimer installed on `pool_` outlives every member it reaches, since
+  // `pool_` is destroyed last. Leaving the writer running would let a
+  // concurrent arbitration request flush a writer whose members are gone.
+  if (isRunning()) {
+    setState(State::kAborted);
+  }
+}
 
 void Writer::write(const velox::VectorPtr& input) {
   checkRunning();
@@ -1663,12 +1671,15 @@ bool Writer::reclaimableBytes(
     const velox::memory::MemoryPool& pool,
     uint64_t& reclaimableBytes) const {
   reclaimableBytes = 0;
-  if (!canReclaim()) {
+  // Only a running writer can flush a stripe, which is the sole way this pool
+  // gives memory back. Reporting bytes in any other state makes the arbitrator
+  // pick this pool as a candidate, suspend the driver, and then be turned away
+  // by the same check in reclaimBytes().
+  if (!canReclaim() || !isRunning()) {
     return false;
   }
   const auto reservedBytes = pool.reservedBytes();
-  if (reservedBytes <
-      context_->options().spillConfig->writerFlushThresholdSize) {
+  if (reservedBytes < spillConfig_->writerFlushThresholdSize) {
     return false;
   }
   reclaimableBytes = reservedBytes;
@@ -1687,8 +1698,7 @@ uint64_t Writer::reclaimBytes(
     return 0;
   }
 
-  const auto flushThreshold =
-      context_->options().spillConfig->writerFlushThresholdSize;
+  const auto flushThreshold = spillConfig_->writerFlushThresholdSize;
   return velox::memory::MemoryReclaimer::run(
       [&]() {
         int64_t reclaimedBytes{0};
@@ -1716,7 +1726,7 @@ uint64_t Writer::reclaimBytes(
 }
 
 bool Writer::canReclaim() const {
-  return context_->options().spillConfig != nullptr;
+  return spillConfig_ != nullptr;
 }
 
 namespace {
@@ -2191,7 +2201,7 @@ bool Writer::writeChunks(
               this->encodingScratchBufferPool(index);
           auto* encodingBufferPool = this->encodingBufferPool(index);
           barrier.add([&,
-                       streamData = streamData.get(),
+                       streamDataPtr = streamData.get(),
                        encodedStream,
                        encodingScratchBufferPool,
                        encodingBufferPool,
@@ -2199,7 +2209,7 @@ bool Writer::writeChunks(
             uint64_t startCpuNs = velox::process::threadCpuNanos();
             uint64_t streamSize = 0;
             if (encodeStreamChunk(
-                    *streamData,
+                    *streamDataPtr,
                     minChunkSize,
                     maxChunkSize,
                     ensureFullChunks,

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -329,6 +329,12 @@ class Writer : public velox::dwio::common::Writer {
   // rebuilds a TypeWithId tree from it to line statistics up with pre-order
   // node ids.
   const velox::RowTypePtr rowType_;
+  // Read by the memory reclaimer, which goes live on `pool_` below before the
+  // rest of the writer is built and stays reachable until `pool_` is
+  // destroyed. Declared ahead of `pool_` so it brackets that whole window;
+  // `context_` does not, and reaching the spill config through it is what let
+  // arbitration fault during construction and teardown.
+  const velox::common::SpillConfig* const spillConfig_;
   MemoryPoolHolder pool_;
   MemoryPoolHolder encodingMemoryPool_;
   const std::unique_ptr<detail::WriterContext> context_;


### PR DESCRIPTION
## Summary

`writer/Writer.{h,cpp}`, `serializer/Deserializer.{h,cpp}` and
`velox/tests/WriterTest.cpp` were held back from the Nimble sync in #18614
because both trees had changed them independently, so neither side's version
could simply overwrite the other. This merges them. Tracked in T285669132.

## Writer carries work in both directions

**Inbound, the reclaimer's spill config.** `Writer` gains

```cpp
const velox::common::SpillConfig* const spillConfig_;
MemoryPoolHolder pool_;
```

declared ahead of `pool_` so it is live before the reclaimer is installed on
that pool and stays valid until the pool is destroyed, initialized from the
writer options, and read by `canReclaim`, `reclaimableBytes` and
`reclaimBytes` in place of `context_->options().spillConfig`. `context_` does
not bracket the reclaimer's lifetime, and reaching the spill config through it
is what let arbitration fault during construction and teardown.

**Outbound, this tree's encoding layout validation is preserved.** #18547 added
`validateEncodingLayout`, `validateEncodingLayoutTree` and the rejection of
PFOR for new writes, none of which fbcode has. That work stays and should now
travel inward on the next import.

`serializer/Deserializer.{h,cpp}` merges the same way, and `WriterTest.cpp`
gains the coverage from both sides.

## Why this could not ride along with #18614

Splitting a header from its implementation is exactly what broke that pull
request. The sync carried `Writer.h`, which declares a `const` member, while
`Writer.cpp` was held back and so never initialized it:

```
Writer.cpp:1153:1: error: uninitialized const member in
  'const struct velox::common::SpillConfig* const' [-fpermissive]
```

Initializing it without also moving the three reclaimer reads would have
compiled while leaving the member dead and the arbitration bug in place, so
`Writer.h` was dropped from #18614 and both files are merged together here
instead.

## Verification

Built and tested with the `ubuntu-bundled-deps` workflow's own invocation
rather than a hand rolled one: Ubuntu 24.04, GCC 13.3.0,
`BUILD_PROFILE=ubuntu-bundled-deps`, `VELOX_DEPENDENCY_SOURCE=BUNDLED` with the
`Boost_SOURCE` / `gflags_SOURCE` / `ICU_SOURCE` overrides, the same
`MAKEFLAGS`, a full `make debug`, then
`ctest -j 8 --output-on-failure --no-tests=error`.

Results are being added to this description as they land. Note that
`Ubuntu debug with bundled dependencies` is the only job that sets
`VELOX_ENABLE_NIMBLE=ON`, so it is the only CI check that compiles any of this;
it now runs on Nimble changes thanks to the path filter added in #18614.
