### PR TITLE
fix(kll): Reject unsafe sketch sizes

### DIFF
--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -277,7 +277,9 @@ KllSketch<T, A, C>::KllSketch(uint32_t k, const A& allocator, uint32_t seed)
       n_(0),
       items_(allocator),
       levels_(2, AllocU32(allocator)),
-      isLevelZeroSorted_(false) {}
+      isLevelZeroSorted_(false) {
+  VELOX_USER_CHECK_LE(k_, kMaxK, "K must be at most {}: {}", kMaxK, k_);
+}
 
 template <typename T, typename A, typename C>
 KllSketch<T, A, C>::KllSketch(const A& allocator, uint32_t seed)
@@ -292,6 +294,7 @@ void KllSketch<T, A, C>::setK(uint32_t k) {
     return;
   }
   VELOX_CHECK_EQ(n_, 0);
+  VELOX_USER_CHECK_LE(k, kMaxK, "K must be at most {}: {}", kMaxK, k);
   k_ = k;
   levels_.resize(2);
 }
@@ -329,15 +332,15 @@ uint32_t KllSketch<T, A, C>::insertPosition() {
     const uint8_t level = findLevelToCompact();
 
     if (level == numLevels() - 1) {
-      if (int delta =
-              detail::computeTotalCapacity(k_, numLevels()) - items_.size();
-          delta > 0) {
+      const auto totalCapacity = detail::computeTotalCapacity(k_, numLevels());
+      if (items_.size() < totalCapacity) {
         // Level zero must be under-populated (otherwise `findLevelToCompact()`
         // would return 0). Grow geometrically instead of materializing the
         // entire theoretical capacity. This keeps sparse, compacted sketches
         // small while preserving amortized linear growth.
-        const auto growth =
-            std::min<uint32_t>(delta, std::max<uint32_t>(items_.size(), 1));
+        const auto delta = totalCapacity - items_.size();
+        const auto growth = static_cast<uint32_t>(
+            std::min<size_t>(delta, std::max<size_t>(items_.size(), 1)));
         shiftItems(growth);
         return --levels_[0];
       }
@@ -751,6 +754,7 @@ KllSketch<T, A, C> KllSketch<T, A, C>::fromView(
     const detail::View<T>& view,
     const A& allocator,
     uint32_t seed) {
+  VELOX_USER_CHECK_LE(view.k, kMaxK, "K must be at most {}: {}", kMaxK, view.k);
   KllSketch<T, A, C> ans(allocator, seed);
   ans.k_ = view.k;
   ans.n_ = view.n;

--- a/velox/functions/lib/KllSketch.cpp
+++ b/velox/functions/lib/KllSketch.cpp
@@ -14,12 +14,26 @@
  * limitations under the License.
  */
 
+#include <cmath>
+#include <limits>
+
 #include "velox/functions/lib/KllSketch.h"
 
 namespace facebook::velox::functions::kll {
 
-uint32_t kFromEpsilon(double eps) {
-  return ceil(exp(1.0285 * log(2.296 / eps)));
+uint32_t kFromEpsilon(double epsilon) {
+  VELOX_USER_CHECK(
+      std::isfinite(epsilon) && epsilon > 0,
+      "Accuracy must be positive and finite: {}",
+      epsilon);
+  const auto k = std::ceil(std::exp(1.0285 * std::log(2.296 / epsilon)));
+  VELOX_USER_CHECK(
+      std::isfinite(k) && k <= kMaxK,
+      "Accuracy is too small: {} produces K {}, but maximum K is {}",
+      epsilon,
+      k,
+      kMaxK);
+  return static_cast<uint32_t>(k);
 }
 
 namespace detail {
@@ -42,11 +56,18 @@ double powerOfTwoThirds(int n) {
 } // namespace
 
 uint32_t computeTotalCapacity(uint32_t k, uint8_t numLevels) {
-  uint32_t total = 0;
+  uint64_t total = 0;
   for (uint8_t h = 0; h < numLevels; ++h) {
     total += levelCapacity(k, numLevels, h);
+    VELOX_CHECK_LE(
+        total,
+        std::numeric_limits<uint32_t>::max(),
+        "KLL total capacity exceeds uint32_t: k={}, numLevels={}, total={}",
+        k,
+        numLevels,
+        total);
   }
-  return total;
+  return static_cast<uint32_t>(total);
 }
 
 uint32_t levelCapacity(uint32_t k, uint8_t numLevels, uint8_t height) {

--- a/velox/functions/lib/KllSketch.h
+++ b/velox/functions/lib/KllSketch.h
@@ -48,6 +48,10 @@ struct View {
 
 constexpr uint32_t kDefaultK = 200;
 
+/// Largest power-of-two K whose total capacity fits in uint32_t for all
+/// supported level counts.
+constexpr uint32_t kMaxK = 1U << 30;
+
 /// Estimate the proper k value to ensure the error bound epsilon.
 uint32_t kFromEpsilon(double epsilon);
 

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -16,7 +16,9 @@
 
 #include <gtest/gtest.h>
 #include <fstream>
+#include <limits>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/functions/lib/KllSketch.h"
@@ -223,6 +225,46 @@ TEST_F(KllSketchTest, mergeEmpty) {
 
 TEST_F(KllSketchTest, kFromEpsilon) {
   EXPECT_EQ(kFromEpsilon(kEpsilon), kDefaultK);
+  EXPECT_EQ(kFromEpsilon(1e-5), 326'408);
+  VELOX_ASSERT_THROW(
+      kFromEpsilon(1e-9),
+      "Accuracy is too small: 1e-09 produces K 4243845673, but maximum K is 1073741824");
+  VELOX_ASSERT_THROW(
+      kFromEpsilon(0), "Accuracy must be positive and finite: 0");
+  VELOX_ASSERT_THROW(
+      kFromEpsilon(std::numeric_limits<double>::infinity()),
+      "Accuracy must be positive and finite: inf");
+}
+
+TEST_F(KllSketchTest, maxK) {
+  KllSketch<double> sketch(kMaxK);
+  VELOX_ASSERT_THROW(
+      KllSketch<double>(kMaxK + 1), "K must be at most 1073741824: 1073741825");
+  VELOX_ASSERT_THROW(
+      sketch.setK(kMaxK + 1), "K must be at most 1073741824: 1073741825");
+}
+
+TEST_F(KllSketchTest, totalCapacityOverflow) {
+  VELOX_ASSERT_THROW(
+      detail::computeTotalCapacity(std::numeric_limits<uint32_t>::max(), 2),
+      "KLL total capacity exceeds uint32_t");
+}
+
+TEST_F(KllSketchTest, mergeSparseSketchAtMaxK) {
+  KllSketch<int64_t> result(kMaxK, {}, 0);
+  result.merge(KllSketch<int64_t>::fromRepeatedValue(0, 67'001, kMaxK, {}, 0));
+  result.insert(13);
+  EXPECT_LT(result.serializedByteSize(), 1024);
+
+  for (int i = 1; i < 3; ++i) {
+    result.merge(
+        KllSketch<int64_t>::fromRepeatedValue(i, 67'001, kMaxK, {}, i));
+  }
+
+  EXPECT_EQ(result.totalCount(), 3 * 67'001 + 1);
+  result.finish();
+  EXPECT_EQ(result.estimateQuantile(0), 0);
+  EXPECT_EQ(result.estimateQuantile(1), 13);
 }
 
 TEST_F(KllSketchTest, serialize) {

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -77,6 +77,7 @@ struct PrestoAccuracyPolicy {
     VELOX_USER_CHECK(
         0 < inputAccuracy && inputAccuracy <= 1,
         "Accuracy must be between 0 and 1");
+    functions::kll::kFromEpsilon(inputAccuracy);
     if (accuracy == kMissingNormalizedValue) {
       accuracy = inputAccuracy;
     } else {

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -466,6 +466,20 @@ TEST_F(ApproxPercentileTest, finalAggregateAccuracy) {
   assertQuery(op, "SELECT 5");
 }
 
+TEST_F(ApproxPercentileTest, tinyAccuracy) {
+  auto rows = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3}), makeConstant<double>(1e-9, 3)});
+  auto plan = PlanBuilder()
+                  .values({rows})
+                  .singleAggregation({}, {"approx_percentile(c0, 0.5, c1)"})
+                  .planNode();
+
+  AssertQueryBuilder query(plan);
+  VELOX_ASSERT_THROW(
+      query.copyResults(pool()),
+      "Accuracy is too small: 1e-09 produces K 4243845673, but maximum K is 1073741824");
+}
+
 TEST_F(ApproxPercentileTest, nonFlatPercentileArray) {
   auto indices = AlignedBuffer::allocate<vector_size_t>(3, pool());
   auto rawIndices = indices->asMutable<vector_size_t>();


### PR DESCRIPTION
Summary:
Queries such as `SELECT approx_percentile(x, 0.5, 1e-9) FROM t` could compute `K=4,243,845,673` and overflow 32-bit capacity accounting during sparse merges. The resulting work-level write could corrupt allocator metadata and abort the process.

Cap `K` at `1 << 30`, the largest power-of-two whose worst-case capacity fits in `uint32_t`. Validate all K entry points, keep capacity differences unsigned, reject non-finite accuracy, and fail before narrowing an overflowing total capacity.

Reviewed By: Yuhta

Differential Revision: D116952076


