### PR TITLE
feat: Add flat map support for map_subset (#18629)

### DIFF
--- a/velox/functions/prestosql/MapSubset.cpp
+++ b/velox/functions/prestosql/MapSubset.cpp
@@ -15,9 +15,285 @@
  */
 
 #include "velox/functions/prestosql/MapSubset.h"
+#include <folly/container/F14Set.h>
+#include "velox/expression/SimpleFunctionRegistry.h"
+#include "velox/expression/VectorFunction.h"
 #include "velox/functions/Registerer.h"
+#include "velox/vector/FlatMapVector.h"
 
 namespace facebook::velox::functions {
+namespace {
+
+// Wraps the flat map's distinct keys in a dictionary that exposes only the
+// first 'numKeys' channels listed in 'keyIndices'. Returns nullptr when no key
+// was selected; FlatMapVector's constructor turns that into an empty keys
+// vector.
+VectorPtr selectDistinctKeys(
+    const FlatMapVector& flatMap,
+    BufferPtr keyIndices,
+    vector_size_t numKeys) {
+  if (numKeys == 0) {
+    return nullptr;
+  }
+  keyIndices->setSize(numKeys * sizeof(vector_size_t));
+  return BaseVector::wrapInDictionary(
+      BufferPtr(nullptr),
+      std::move(keyIndices),
+      numKeys,
+      flatMap.distinctKeys());
+}
+
+BufferPtr copyIndices(const DecodedVector& decoded, memory::MemoryPool* pool) {
+  auto indices = allocateIndices(decoded.size(), pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < decoded.size(); ++i) {
+    rawIndices[i] = decoded.index(i);
+  }
+  return indices;
+}
+
+// Handles a constant list of search keys over an unwrapped flat map. Every row
+// selects the same channels, so the result keeps the input's map values and
+// in-map buffers as they are, which makes the projection zero copy.
+void applyFlatMap(
+    const DecodedVector& decodedKeys,
+    const FlatMapVector& flatMap,
+    const SelectivityVector& rows,
+    const TypePtr& outputType,
+    exec::EvalCtx& context,
+    VectorPtr& result) {
+  const auto& keysArray = *decodedKeys.base()->asUnchecked<ArrayVector>();
+  const auto& keyElements = keysArray.elements();
+
+  // All rows search for the same keys, so the first selected row describes the
+  // whole batch. The constant may point at any row of the base array, so the
+  // range comes from that row's offset rather than from a fixed zero.
+  vector_size_t begin{0};
+  vector_size_t end{0};
+  if (rows.hasSelections()) {
+    const auto keysIndex = decodedKeys.index(rows.begin());
+    begin = keysArray.offsetAt(keysIndex);
+    end = begin + keysArray.sizeAt(keysIndex);
+  }
+
+  auto keyIndices = allocateIndices(end - begin, context.pool());
+  auto* rawKeyIndices = keyIndices->asMutable<vector_size_t>();
+  std::vector<VectorPtr> mapValues;
+  std::vector<BufferPtr> inMaps;
+
+  // Walking the search keys rather than the flat map's channels keeps this
+  // proportional to the number of keys asked for, which is what makes the
+  // projection cheap on maps with many distinct keys.
+  folly::F14FastSet<column_index_t> selectedChannels;
+  selectedChannels.reserve(end - begin);
+
+  for (auto i = begin; i < end; ++i) {
+    if (keyElements->isNullAt(i)) {
+      continue;
+    }
+    const auto channel = flatMap.getKeyChannel(keyElements, i);
+    // Duplicated search keys must not produce duplicated map entries. The
+    // simple function implementations dedupe the same way, by collecting the
+    // search keys into a set and walking the map once.
+    if (!channel.has_value() || !selectedChannels.insert(*channel).second) {
+      continue;
+    }
+
+    rawKeyIndices[mapValues.size()] = static_cast<vector_size_t>(*channel);
+    mapValues.push_back(flatMap.mapValuesAt(*channel));
+    if (*channel < flatMap.inMaps().size()) {
+      inMaps.push_back(flatMap.inMaps()[*channel]);
+    } else {
+      // A missing in-map buffer means the key is present in every row, the
+      // same convention FlatMapVector::isInMap() follows.
+      inMaps.emplace_back(nullptr);
+    }
+  }
+
+  // Evaluated before the vectors below are moved from.
+  auto distinctKeys = selectDistinctKeys(
+      flatMap,
+      std::move(keyIndices),
+      static_cast<vector_size_t>(mapValues.size()));
+  auto localResult = std::make_shared<FlatMapVector>(
+      context.pool(),
+      outputType,
+      flatMap.nulls(),
+      flatMap.size(),
+      std::move(distinctKeys),
+      std::move(mapValues),
+      std::move(inMaps));
+
+  context.moveOrCopyResult(localResult, rows, result);
+}
+
+// Handles per-row search keys, a wrapped flat map, or both. Rows may ask for
+// different keys and two of them may share a flat map row, so the in-map
+// buffers are rebuilt in the output row space instead of being reused.
+void applyFlatMap(
+    const DecodedVector& decodedMap,
+    const DecodedVector& decodedKeys,
+    const FlatMapVector& flatMap,
+    const SelectivityVector& rows,
+    const TypePtr& outputType,
+    exec::EvalCtx& context,
+    VectorPtr& result) {
+  const auto numDistinctKeys = flatMap.numDistinctKeys();
+  const auto numRows = decodedMap.size();
+  const auto& keysArray = *decodedKeys.base()->asUnchecked<ArrayVector>();
+  const auto& keyElements = keysArray.elements();
+
+  std::vector<BufferPtr> inMapsByChannel(numDistinctKeys);
+
+  rows.applyToSelected([&](vector_size_t row) {
+    const auto mapRow = decodedMap.index(row);
+    const auto keysIndex = decodedKeys.index(row);
+    const auto begin = keysArray.offsetAt(keysIndex);
+    const auto end = begin + keysArray.sizeAt(keysIndex);
+
+    for (auto i = begin; i < end; ++i) {
+      if (keyElements->isNullAt(i)) {
+        continue;
+      }
+      const auto channel = flatMap.getKeyChannel(keyElements, i);
+      if (!channel.has_value() || !flatMap.isInMap(*channel, mapRow)) {
+        continue;
+      }
+      // Indexing by channel makes duplicated search keys idempotent.
+      auto& inMap = inMapsByChannel[*channel];
+      if (inMap == nullptr) {
+        inMap = AlignedBuffer::allocate<bool>(numRows, context.pool(), false);
+      }
+      bits::setBit(inMap->asMutable<uint64_t>(), row);
+    }
+  });
+
+  BufferPtr indices;
+  if (!decodedMap.isIdentityMapping()) {
+    indices = copyIndices(decodedMap, context.pool());
+  }
+
+  auto keyIndices = allocateIndices(numDistinctKeys, context.pool());
+  auto* rawKeyIndices = keyIndices->asMutable<vector_size_t>();
+  std::vector<VectorPtr> mapValues;
+  std::vector<BufferPtr> inMaps;
+
+  for (column_index_t channel = 0; channel < numDistinctKeys; ++channel) {
+    if (inMapsByChannel[channel] == nullptr) {
+      continue;
+    }
+    rawKeyIndices[mapValues.size()] = static_cast<vector_size_t>(channel);
+    const auto& values = flatMap.mapValuesAt(channel);
+    if (indices == nullptr) {
+      mapValues.push_back(values);
+    } else {
+      mapValues.push_back(
+          BaseVector::wrapInDictionary(
+              BufferPtr(nullptr), indices, numRows, values));
+    }
+    inMaps.push_back(std::move(inMapsByChannel[channel]));
+  }
+
+  // Evaluated before the vectors below are moved from.
+  auto distinctKeys = selectDistinctKeys(
+      flatMap,
+      std::move(keyIndices),
+      static_cast<vector_size_t>(mapValues.size()));
+
+  // Top level nulls are left to the engine: map_subset is a default-null
+  // function, so no row in 'rows' has a null map.
+  auto localResult = std::make_shared<FlatMapVector>(
+      context.pool(),
+      outputType,
+      nullptr,
+      numRows,
+      std::move(distinctKeys),
+      std::move(mapValues),
+      std::move(inMaps));
+
+  context.moveOrCopyResult(localResult, rows, result);
+}
+
+// Adds a FlatMapVector path to map_subset.
+//
+// On a flat map, map_subset is a projection of the map value channels whose
+// keys were requested, so the result is built as a FlatMapVector that shares
+// the input's map values instead of copying key/value pairs.
+//
+// The simple function implementations in MapSubset.h only understand
+// MapVector - VectorReader<Map<K, V>> casts the decoded base to MapVector
+// unchecked - so reaching them with a flat map crashes. This function shadows
+// them in the expression compiler and delegates to them for every encoding
+// other than FLAT_MAP.
+class MapSubsetVectorFunction : public exec::VectorFunction {
+ public:
+  explicit MapSubsetVectorFunction(
+      std::shared_ptr<exec::VectorFunction> mapVectorFunction)
+      : mapVectorFunction_{std::move(mapVectorFunction)} {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 2, "map_subset expects a map and an array.");
+
+    // wrappedVector() peels dictionary, constant and sequence wrappings and
+    // loads lazies through virtual dispatch, so the encoding is known without
+    // materializing decoded indices. Delegating from here leaves the
+    // MapVector path with the single decode the simple function does anyway.
+    if (args[0]->wrappedVector()->encoding() !=
+        VectorEncoding::Simple::FLAT_MAP) {
+      mapVectorFunction_->apply(rows, args, outputType, context, result);
+      return;
+    }
+
+    exec::LocalDecodedVector mapDecoder(context, *args[0], rows);
+    const auto& decodedMap = *mapDecoder.get();
+    exec::LocalDecodedVector keysDecoder(context, *args[1], rows);
+    const auto& decodedKeys = *keysDecoder.get();
+    const auto& flatMap = *decodedMap.base()->asUnchecked<FlatMapVector>();
+
+    if (decodedKeys.isConstantMapping() && decodedMap.isIdentityMapping()) {
+      applyFlatMap(decodedKeys, flatMap, rows, outputType, context, result);
+    } else {
+      applyFlatMap(
+          decodedMap, decodedKeys, flatMap, rows, outputType, context, result);
+    }
+  }
+
+ private:
+  const std::shared_ptr<exec::VectorFunction> mapVectorFunction_;
+};
+
+std::shared_ptr<exec::VectorFunction> makeMapSubset(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config) {
+  std::vector<TypePtr> inputTypes;
+  std::vector<VectorPtr> constantInputs;
+  inputTypes.reserve(inputArgs.size());
+  constantInputs.reserve(inputArgs.size());
+  for (const auto& arg : inputArgs) {
+    inputTypes.push_back(arg.type);
+    constantInputs.push_back(arg.constantValue);
+  }
+
+  auto simpleFunction =
+      exec::simpleFunctions().resolveFunction(name, inputTypes);
+  VELOX_USER_CHECK(
+      simpleFunction.has_value(),
+      "Scalar function not registered for the given input types: {}",
+      name);
+
+  return std::make_shared<MapSubsetVectorFunction>(
+      simpleFunction->createFunction()->createVectorFunction(
+          inputTypes, constantInputs, config));
+}
+
+} // namespace
+
 template <typename T>
 void registerMapSubsetPrimitive(const std::string& name) {
   registerFunction<
@@ -49,5 +325,25 @@ void registerMapSubset(const std::string& name) {
       Map<Generic<T1>, Generic<T2>>,
       Map<Generic<T1>, Generic<T2>>,
       Array<Generic<T1>>>({name});
+
+  // Must come after the simple functions above: the vector function shadows
+  // them in the expression compiler and resolves them as its fallback for
+  // non-flat-map inputs.
+  exec::registerStatefulVectorFunction(
+      name,
+      // map(K,V), array(K) -> map(K,V)
+      {exec::FunctionSignatureBuilder()
+           .typeVariable("K")
+           .typeVariable("V")
+           .returnType("map(K,V)")
+           .argumentType("map(K,V)")
+           .argumentType("array(K)")
+           .build()},
+      [name](
+          const std::string& /*name*/,
+          const std::vector<exec::VectorFunctionArg>& inputArgs,
+          const core::QueryConfig& config) {
+        return makeMapSubset(name, inputArgs, config);
+      });
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/MapSubset.h
+++ b/velox/functions/prestosql/MapSubset.h
@@ -235,6 +235,9 @@ struct MapSubsetFunction {
       searchKeys_;
 };
 
+/// Registers the simple functions above, plus a vector function under the same
+/// name that projects FlatMapVector inputs into a FlatMapVector result and
+/// delegates to the simple functions for every other encoding.
 void registerMapSubset(const std::string& name);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/MapSubsetTest.cpp
+++ b/velox/functions/prestosql/tests/MapSubsetTest.cpp
@@ -16,6 +16,8 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/vector/FlatMapVector.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox::test;
 
@@ -114,6 +116,24 @@ TEST_F(MapSubsetTest, bigintKey) {
 
   // Non-constant keys.
   result = evaluate("map_subset(c0, c1)", data);
+  assertEqualVectors(expected, result);
+
+  // Duplicate search keys. A key repeated in the search list must still appear
+  // at most once in the result, both for constant and non-constant keys.
+  result = evaluate("map_subset(c0, array_constructor(1, 3, 1, 5, 3))", data);
+  assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "map_subset(c0, c1)",
+      makeRowVector({
+          data->childAt(0),
+          makeArrayVectorFromJson<int64_t>({
+              "[1, 3, 1, 5]",
+              "[1, 3, 5, 7, 1]",
+              "[3, 5, 3]",
+              "[1, 3, 1]",
+          }),
+      }));
   assertEqualVectors(expected, result);
 
   // Empty list of keys. Expect empty maps.
@@ -289,6 +309,312 @@ TEST_F(MapSubsetTest, timestampWithTimeZone) {
       "map_subset(c0, c1)",
       makeRowVector({mapsWithRowKeys, lookupWithRowKeys}));
   assertEqualVectors(expectedWithRowKeys, result);
+}
+
+TEST_F(MapSubsetTest, flatMapConstantKeys) {
+  auto input = makeFlatMapVectorFromJson<int64_t, int32_t>({
+      "{1:10, 2:20, 3:null, 4:40}",
+      "{1:11, 3:33}",
+      "{}",
+      "{2:22, 4:44}",
+  });
+  auto data = makeRowVector({input});
+
+  auto result = evaluate("map_subset(c0, array_constructor(1, 3, 5))", data);
+
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 3:null}",
+          "{1:11, 3:33}",
+          "{}",
+          "{}",
+      }),
+      result);
+
+  // The whole point of the flat map path: the result stays a flat map and
+  // reuses the input's map values instead of copying key/value pairs.
+  ASSERT_EQ(result->encoding(), VectorEncoding::Simple::FLAT_MAP);
+  auto* flatResult = result->as<FlatMapVector>();
+  EXPECT_EQ(flatResult->numDistinctKeys(), 2);
+  EXPECT_EQ(
+      flatResult->projectKey<int64_t>(1).get(),
+      input->projectKey<int64_t>(1).get());
+  EXPECT_EQ(
+      flatResult->projectKey<int64_t>(3).get(),
+      input->projectKey<int64_t>(3).get());
+
+  // Empty list of keys. Expect empty maps.
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({"{}", "{}", "{}", "{}"}),
+      evaluate("map_subset(c0, array_constructor()::bigint[])", data));
+
+  // No requested key is present in the map.
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({"{}", "{}", "{}", "{}"}),
+      evaluate("map_subset(c0, array_constructor(7, 8))", data));
+
+  // Null and duplicate search keys.
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 3:null}",
+          "{1:11, 3:33}",
+          "{}",
+          "{}",
+      }),
+      evaluate(
+          "map_subset(c0, array_constructor(1, cast(null as bigint), 1, 3))",
+          data));
+
+  // A constant list of keys may point at any row of the base array, not just
+  // the first one, so the search range has to come from that row's offset.
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 3:null}",
+          "{1:11, 3:33}",
+          "{}",
+          "{}",
+      }),
+      evaluate(
+          "map_subset(c0, c1)",
+          makeRowVector({
+              input,
+              BaseVector::wrapInConstant(
+                  input->size(),
+                  1,
+                  makeArrayVectorFromJson<int64_t>({"[7]", "[1, 3]"})),
+          })));
+}
+
+TEST_F(MapSubsetTest, flatMapNonConstantKeys) {
+  auto data = makeRowVector({
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 2:20, 3:null, 4:40}",
+          "{1:11, 2:22, 3:33}",
+          "{1:12, 2:23}",
+          "{}",
+      }),
+      makeArrayVectorFromJson<int64_t>({
+          "[1, 3]",
+          "[2]",
+          "[5]",
+          "[1, 2]",
+      }),
+  });
+
+  auto result = evaluate("map_subset(c0, c1)", data);
+
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 3:null}",
+          "{2:22}",
+          "{}",
+          "{}",
+      }),
+      result);
+  EXPECT_EQ(result->encoding(), VectorEncoding::Simple::FLAT_MAP);
+
+  // Empty, null and duplicate search keys. A null search key list makes the
+  // whole row null.
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{}",
+          "{1:11, 2:22}",
+          "{2:23}",
+          "null",
+      }),
+      evaluate(
+          "map_subset(c0, c1)",
+          makeRowVector({
+              data->childAt(0),
+              makeArrayVectorFromJson<int64_t>({
+                  "[]",
+                  "[1, null, 2, 1]",
+                  "[2, 2]",
+                  "null",
+              }),
+          })));
+}
+
+TEST_F(MapSubsetTest, flatMapNulls) {
+  auto data = makeRowVector({
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 2:20}",
+          "null",
+          "{1:11, 2:null}",
+          "null",
+      }),
+      makeArrayVectorFromJson<int64_t>({
+          "[1]",
+          "[1]",
+          "[1, 2]",
+          "[2]",
+      }),
+  });
+
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10}",
+          "null",
+          "{1:11, 2:null}",
+          "null",
+      }),
+      evaluate("map_subset(c0, c1)", data));
+
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10}",
+          "null",
+          "{1:11}",
+          "null",
+      }),
+      evaluate("map_subset(c0, array_constructor(1))", data));
+}
+
+TEST_F(MapSubsetTest, flatMapVarcharKeys) {
+  auto data = makeRowVector({
+      makeFlatMapVectorFromJson<std::string, int32_t>({
+          "{\"apple\": 1, \"banana\": 2, \"Cucurbitaceae\": null}",
+          "{\"banana\": 2, \"orange\": 4}",
+      }),
+      makeArrayVectorFromJson<std::string>({
+          "[\"apple\", \"Cucurbitaceae\"]",
+          "[\"orange\", \"apple\"]",
+      }),
+  });
+
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<std::string, int32_t>({
+          "{\"apple\": 1, \"Cucurbitaceae\": null}",
+          "{}",
+      }),
+      evaluate(
+          "map_subset(c0, array_constructor('apple', 'Cucurbitaceae'))", data));
+
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<std::string, int32_t>({
+          "{\"apple\": 1, \"Cucurbitaceae\": null}",
+          "{\"orange\": 4}",
+      }),
+      evaluate("map_subset(c0, c1)", data));
+}
+
+TEST_F(MapSubsetTest, flatMapWrappedEncodings) {
+  auto input = makeFlatMapVectorFromJson<int64_t, int32_t>({
+      "{1:10, 2:20, 3:30}",
+      "{1:11, 3:33}",
+      "{2:22}",
+      "{}",
+      "{1:14, 2:24, 3:34}",
+      "{3:35}",
+      "{1:16, 2:26}",
+      "{2:27, 3:37}",
+      "{1:18}",
+      "{1:19, 2:29, 3:39}",
+  });
+  auto expected = makeFlatMapVectorFromJson<int64_t, int32_t>({
+      "{1:10, 3:30}",
+      "{1:11, 3:33}",
+      "{}",
+      "{}",
+      "{1:14, 3:34}",
+      "{3:35}",
+      "{1:16}",
+      "{3:37}",
+      "{1:18}",
+      "{1:19, 3:39}",
+  });
+
+  auto scattered = [](auto row) { return (row * 17 + 3) % 10; };
+  auto wrapped = wrapInDictionary(
+      makeIndices(input->size(), scattered), input->size(), input);
+
+  assertEqualVectors(
+      wrapInDictionary(
+          makeIndices(expected->size(), scattered), expected->size(), expected),
+      evaluate(
+          "map_subset(c0, array_constructor(1, 3))", makeRowVector({wrapped})));
+
+  // Non-constant search keys keep the dictionary from being peeled off, so the
+  // function has to translate the wrapping itself.
+  assertEqualVectors(
+      wrapInDictionary(
+          makeIndices(expected->size(), scattered), expected->size(), expected),
+      evaluate(
+          "map_subset(c0, c1)",
+          makeRowVector({
+              wrapped,
+              makeArrayVector<int64_t>(
+                  input->size(),
+                  [](auto /*row*/) { return 2; },
+                  [](auto /*row*/, auto index) { return index == 0 ? 1 : 3; }),
+          })));
+
+  // Rows sharing a flat map row but asking for different keys.
+  assertEqualVectors(
+      makeFlatMapVectorFromJson<int64_t, int32_t>({
+          "{1:10}",
+          "{2:20}",
+          "{3:30}",
+      }),
+      evaluate(
+          "map_subset(c0, c1)",
+          makeRowVector({
+              wrapInDictionary(makeIndices({0, 0, 0}), 3, input),
+              makeArrayVectorFromJson<int64_t>({"[1]", "[2]", "[3]"}),
+          })));
+
+  // Constant-encoded flat map.
+  assertEqualVectors(
+      BaseVector::wrapInConstant(5, 1, expected),
+      evaluate(
+          "map_subset(c0, array_constructor(1, 3))",
+          makeRowVector({BaseVector::wrapInConstant(5, 1, input)})));
+}
+
+TEST_F(MapSubsetTest, fuzzFlatMap) {
+  VectorFuzzer::Options options;
+  options.allowFlatMapVector = true;
+  VectorFuzzer fuzzer(options, pool());
+
+  constexpr vector_size_t kSize = 100;
+
+  for (auto iteration = 0; iteration < 50; ++iteration) {
+    SCOPED_TRACE(fmt::format("iteration: {}", iteration));
+
+    auto flatMap = fuzzer.fuzzFlatMap(BIGINT(), INTEGER(), kSize);
+    auto map = flatMap->toMapVector();
+
+    // Search for about half of the keys the flat map actually holds, so the
+    // result is neither everything nor nothing.
+    const auto* distinctKeys =
+        flatMap->distinctKeys()->as<SimpleVector<int64_t>>();
+    std::vector<int64_t> searchKeys;
+    for (vector_size_t i = 0; i < flatMap->numDistinctKeys(); i += 2) {
+      searchKeys.push_back(distinctKeys->valueAt(i));
+    }
+
+    const auto keySizeAt = [&](vector_size_t row) {
+      return searchKeys.empty() ? 0 : row % (searchKeys.size() + 1);
+    };
+    const auto keyAt = [&](vector_size_t row, vector_size_t index) {
+      return searchKeys[(row + index) % searchKeys.size()];
+    };
+
+    std::vector<std::pair<std::string, VectorPtr>> keyArguments = {
+        {"constant keys",
+         BaseVector::wrapInConstant(
+             kSize, 0, makeArrayVector<int64_t>({searchKeys}))},
+        {"per-row keys",
+         makeArrayVector<int64_t>(kSize, keySizeAt, keyAt, nullEvery(7))},
+    };
+
+    for (const auto& [name, keys] : keyArguments) {
+      SCOPED_TRACE(name);
+      assertEqualVectors(
+          evaluate("map_subset(c0, c1)", makeRowVector({map, keys})),
+          evaluate("map_subset(c0, c1)", makeRowVector({flatMap, keys})));
+    }
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

`map_subset` crashed with a SIGSEGV whenever its map argument was a `FlatMapVector`, because the simple function reads maps through `VectorReader<Map<K, V>>`, which dereferences an unchecked cast to `MapVector`.

A vector function now handles the flat map encoding and delegates every other encoding to the existing simple functions, leaving `MapVector` behavior unchanged. On a flat map the call is a channel projection, so the result is a `FlatMapVector` that shares the input's map values instead of copying key/value pairs.

Differential Revision: D116681772


