### PR TITLE
feat: Add Spark-dialect map_from_arrays to Velox (#18630)

### DIFF
--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -46,10 +46,15 @@ Map Functions
 
 .. spark:function:: map_from_arrays(array(K), array(V)) -> map(K,V)
 
-    Creates a map with a pair of the given key/value arrays. All elements in keys should not be null.
-    If key size != value size will throw exception that key and value must have the same length.::
+    Creates a map by pairing up the given key and value arrays. Returns NULL if either array is
+    NULL. Throws if a top-level key is NULL, or if the two arrays have different lengths. Array and
+    row keys may contain nested NULL values. When a key is repeated, the behavior depends on the
+    ``throw_exception_on_duplicate_map_keys`` configuration
+    property: if true, throws; otherwise the last value wins and the key keeps the position of its
+    first occurrence. ::
 
         SELECT map_from_arrays(array(1.0, 3.0), array('2', '4')); -- {1.0 -> 2, 3.0 -> 4}
+        SELECT map_from_arrays(array(2, 1, 2), array('a', 'b', 'c')); -- {2 -> 'c', 1 -> 'b'}
 
 .. spark:function:: map_from_entries(array(struct(K,V))) -> map(K,V)
 

--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <map>
+
+#include <fmt/core.h>
+
 #include <velox/common/base/Exceptions.h>
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 // The description of the map function in Spark
@@ -30,6 +36,12 @@
 
 namespace facebook::velox::functions::sparksql {
 namespace {
+
+constexpr const char* kNullKeyErrorMessage = "Cannot use null as map key!";
+
+std::string duplicateKeyErrorMessage(std::string_view duplicateKey) {
+  return fmt::format("Duplicate map key ({}) was found.", duplicateKey);
+}
 
 void setKeysAndValuesResult(
     vector_size_t mapSize,
@@ -47,10 +59,10 @@ void setKeysAndValuesResult(
   for (vector_size_t i = 0; i < mapSize; i++) {
     decoded.get()->decode(*args[i * 2], rows);
     context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
-      VELOX_USER_CHECK(!decoded->isNullAt(row), "Cannot use null as map key!");
+      VELOX_USER_CHECK(!decoded->isNullAt(row), kNullKeyErrorMessage);
       const auto offset = offsets[row];
       const auto size = sizes[row];
-      bool duplicate = false;
+      bool duplicate{false};
       if (size < mapSize) {
         // Check if the current key at position i is duplicated in any later
         // position. When a duplicate is found, mark this occurrence as
@@ -119,7 +131,7 @@ class MapFunction : public exec::VectorFunction {
         std::max<vector_size_t>(keysResult->size(), valuesResult->size());
     vector_size_t offset = baseOffset;
 
-    bool throwExceptionOnDuplicateMapKeys = false;
+    bool throwExceptionOnDuplicateMapKeys{false};
     if (auto* ctx = context.execCtx()->queryCtx()) {
       throwExceptionOnDuplicateMapKeys =
           ctx->queryConfig().throwExceptionOnDuplicateMapKeys();
@@ -127,14 +139,13 @@ class MapFunction : public exec::VectorFunction {
 
     // Check for duplicate keys and set size & offsets.
     rows.applyToSelected([&](vector_size_t row) {
-      vector_size_t duplicateCnt = 0;
+      vector_size_t duplicateCnt{0};
       for (vector_size_t i = 0; i < mapSize; i++) {
         for (vector_size_t j = i + 1; j < mapSize; j++) {
           if (args[i * 2]->equalValueAt(args[j * 2].get(), row, row)) {
             if (throwExceptionOnDuplicateMapKeys) {
               auto duplicateKey = args[i * 2]->toString(row);
-              VELOX_USER_FAIL(
-                  "Duplicate map key ({}) was found.", duplicateKey);
+              VELOX_USER_FAIL("{}", duplicateKeyErrorMessage(duplicateKey));
             }
             // The key at position i is superseded by a later occurrence and
             // will be dropped by setKeysAndValuesResult (LAST_WIN). Count this
@@ -183,6 +194,372 @@ class MapFunction : public exec::VectorFunction {
     return signatures;
   }
 };
+
+// Decoded inputs and output buffers threaded through the per-row build loop of
+// map_from_arrays.
+struct MapFromArraysBuffers {
+  const DecodedVector* decodedKeys;
+  const DecodedVector* decodedValues;
+  const ArrayVector* keysArray;
+  const ArrayVector* valuesArray;
+  const DecodedVector* decodedKeyElements;
+  bool throwExceptionOnDuplicateMapKeys;
+  vector_size_t* rawOffsets;
+  vector_size_t* rawSizes;
+  vector_size_t* rawKeysIndices;
+  vector_size_t* rawValuesIndices;
+};
+
+// Assigns each distinct key of a row the index of the entry slot claimed by
+// the key's first occurrence. Rejects a top-level null key and, under
+// EXCEPTION, a repeated key.
+class KeyDeduplicator {
+ public:
+  KeyDeduplicator(
+      const DecodedVector& decodedKeys,
+      bool throwExceptionOnDuplicateMapKeys)
+      : decodedKeys_{decodedKeys},
+        mayHaveNullKeys_{decodedKeys.mayHaveNulls()},
+        throwExceptionOnDuplicateMapKeys_{throwExceptionOnDuplicateMapKeys},
+        slotByKey_{KeyComparator{&decodedKeys}} {}
+
+  void startRow() {
+    slotByKey_.clear();
+    numSlots_ = 0;
+  }
+
+  // Returns the slot a repeated key already owns, or nullopt when the key is
+  // new and has claimed the next slot.
+  std::optional<vector_size_t> findOrInsert(vector_size_t elementIndex) {
+    if (mayHaveNullKeys_) {
+      VELOX_USER_CHECK(
+          !decodedKeys_.isNullAt(elementIndex), kNullKeyErrorMessage);
+    }
+
+    const auto [it, inserted] = slotByKey_.emplace(elementIndex, numSlots_);
+    if (!inserted) {
+      VELOX_USER_CHECK(
+          !throwExceptionOnDuplicateMapKeys_,
+          "{}",
+          duplicateKeyErrorMessage(
+              decodedKeys_.base()->toString(decodedKeys_.index(elementIndex))));
+      return it->second;
+    }
+    ++numSlots_;
+    return std::nullopt;
+  }
+
+ private:
+  // The default compare flags use the same kNullAsValue handling as
+  // BaseVector::equalValueAt, so equality here matches the dedup contract.
+  struct KeyComparator {
+    const DecodedVector* decodedKeys;
+
+    bool operator()(vector_size_t lhs, vector_size_t rhs) const {
+      const auto* keys = decodedKeys->base();
+      return keys->compare(
+                 keys, decodedKeys->index(lhs), decodedKeys->index(rhs)) < 0;
+    }
+  };
+
+  const DecodedVector& decodedKeys_;
+  const bool mayHaveNullKeys_;
+  const bool throwExceptionOnDuplicateMapKeys_;
+  std::map<vector_size_t, vector_size_t, KeyComparator> slotByKey_;
+  vector_size_t numSlots_{0};
+};
+
+// Fills the offsets, sizes and key/value index buffers of 'buffers' for 'rows'
+// and returns the number of map entries written.
+vector_size_t buildMapEntries(
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const MapFromArraysBuffers& buffers) {
+  KeyDeduplicator keyDeduplicator{
+      *buffers.decodedKeyElements, buffers.throwExceptionOnDuplicateMapKeys};
+  vector_size_t numEntries{0};
+  context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+    const auto keysIndex = buffers.decodedKeys->index(row);
+    const auto valuesIndex = buffers.decodedValues->index(row);
+    const auto numKeys = buffers.keysArray->sizeAt(keysIndex);
+    VELOX_USER_CHECK_EQ(
+        numKeys,
+        buffers.valuesArray->sizeAt(valuesIndex),
+        "The key array and value array of MapData must have the same length.");
+
+    const auto keysOffset = buffers.keysArray->offsetAt(keysIndex);
+    const auto valuesOffset = buffers.valuesArray->offsetAt(valuesIndex);
+
+    // A row that throws below leaves 'numEntries' unchanged, so the slots it
+    // partially filled are reused by the next row and its size stays zero.
+    buffers.rawOffsets[row] = numEntries;
+    keyDeduplicator.startRow();
+
+    vector_size_t numDistinctKeys{0};
+    for (vector_size_t i = 0; i < numKeys; ++i) {
+      const auto elementIndex = keysOffset + i;
+      if (const auto slot = keyDeduplicator.findOrInsert(elementIndex)) {
+        buffers.rawValuesIndices[numEntries + slot.value()] = valuesOffset + i;
+        continue;
+      }
+
+      buffers.rawKeysIndices[numEntries + numDistinctKeys] = elementIndex;
+      buffers.rawValuesIndices[numEntries + numDistinctKeys] = valuesOffset + i;
+      ++numDistinctKeys;
+    }
+
+    buffers.rawSizes[row] = numDistinctKeys;
+    numEntries += numDistinctKeys;
+  });
+  return numEntries;
+}
+
+// Builds the result buffers when the key array is constant across rows, so slot
+// assignment is computed once and a row writes only its value indices.
+vector_size_t buildMapEntriesForConstantKeys(
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const MapFromArraysBuffers& buffers) {
+  const auto keysIndex = buffers.decodedKeys->index(rows.begin());
+  const auto numKeys = buffers.keysArray->sizeAt(keysIndex);
+  const auto keysOffset = buffers.keysArray->offsetAt(keysIndex);
+
+  // Slot occupied by the key at each position of the constant array, and the
+  // key element index occupying each slot.
+  std::vector<vector_size_t> slotOfPosition(numKeys);
+  std::vector<vector_size_t> slotKeyIndices(numKeys);
+  vector_size_t numDistinctKeys{0};
+  KeyDeduplicator keyDeduplicator{
+      *buffers.decodedKeyElements, buffers.throwExceptionOnDuplicateMapKeys};
+  keyDeduplicator.startRow();
+  try {
+    for (vector_size_t i = 0; i < numKeys; ++i) {
+      const auto elementIndex = keysOffset + i;
+      if (const auto slot = keyDeduplicator.findOrInsert(elementIndex)) {
+        slotOfPosition[i] = slot.value();
+        continue;
+      }
+
+      slotKeyIndices[numDistinctKeys] = elementIndex;
+      slotOfPosition[i] = numDistinctKeys;
+      ++numDistinctKeys;
+    }
+  } catch (const VeloxException&) {
+    // A bad key fails every row, since they all share the key array.
+    context.setErrors(rows, std::current_exception());
+    return 0;
+  }
+
+  vector_size_t numEntries{0};
+  context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+    const auto valuesIndex = buffers.decodedValues->index(row);
+    VELOX_USER_CHECK_EQ(
+        numKeys,
+        buffers.valuesArray->sizeAt(valuesIndex),
+        "The key array and value array of MapData must have the same length.");
+
+    const auto valuesOffset = buffers.valuesArray->offsetAt(valuesIndex);
+    buffers.rawOffsets[row] = numEntries;
+    buffers.rawSizes[row] = numDistinctKeys;
+    for (vector_size_t slot = 0; slot < numDistinctKeys; ++slot) {
+      buffers.rawKeysIndices[numEntries + slot] = slotKeyIndices[slot];
+    }
+    // Input order, so under LAST_WIN a repeated key's later value overwrites
+    // the earlier one.
+    for (vector_size_t i = 0; i < numKeys; ++i) {
+      buffers.rawValuesIndices[numEntries + slotOfPosition[i]] =
+          valuesOffset + i;
+    }
+    numEntries += numDistinctKeys;
+  });
+  return numEntries;
+}
+
+// Throws on a null key or a repeated key. Used by the zero-copy path, which
+// builds no entry indices.
+void checkNullAndDuplicateKeys(
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const ArrayVector& keysArray,
+    const DecodedVector& decodedKeyElements) {
+  // Only runs under EXCEPTION, so a repeat always throws.
+  KeyDeduplicator keyDeduplicator{
+      decodedKeyElements, /*throwExceptionOnDuplicateMapKeys=*/true};
+  context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+    const auto numKeys = keysArray.sizeAt(row);
+    const auto keysOffset = keysArray.offsetAt(row);
+    keyDeduplicator.startRow();
+
+    for (vector_size_t i = 0; i < numKeys; ++i) {
+      keyDeduplicator.findOrInsert(keysOffset + i);
+    }
+  });
+}
+
+// Can only take the fast path if keys and values have an equal number of arrays
+// and the offsets and sizes of these arrays match 1:1. The map must be well
+// formed for all elements, also ones not in 'rows' in apply(). This is because
+// canonicalize() will touch all elements in any case.
+bool canTakeFastPath(
+    const ArrayVector& keys,
+    const ArrayVector& values,
+    const SelectivityVector& rows) {
+  VELOX_CHECK_GE(keys.size(), rows.end());
+  VELOX_CHECK_GE(values.size(), rows.end());
+  if (keys.size() != values.size()) {
+    return false;
+  }
+  for (vector_size_t row = 0; row < keys.size(); ++row) {
+    if (keys.isNullAt(row)) {
+      continue;
+    }
+
+    if (values.isNullAt(row)) {
+      return false;
+    }
+
+    if (keys.offsetAt(row) != values.offsetAt(row) ||
+        keys.sizeAt(row) != values.sizeAt(row)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Implements Spark's map_from_arrays(array(K), array(V)) -> map(K,V). Entries
+// are inserted in array order. A repeated key raises DUPLICATED_MAP_KEY, or
+// under LAST_WIN overwrites the value of its first occurrence in place, so the
+// key keeps that first position.
+class MapFromArraysFunction : public exec::VectorFunction {
+ public:
+  explicit MapFromArraysFunction(bool throwExceptionOnDuplicateMapKeys)
+      : throwExceptionOnDuplicateMapKeys_{throwExceptionOnDuplicateMapKeys} {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 2);
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto* decodedKeys = decodedArgs.at(0);
+    auto* decodedValues = decodedArgs.at(1);
+
+    auto* keysArray = decodedKeys->base()->as<ArrayVector>();
+    auto* valuesArray = decodedValues->base()->as<ArrayVector>();
+    const auto& keysElements = keysArray->elements();
+    const auto keyElementRows = toElementRows(
+        keysElements->size(),
+        rows,
+        keysArray,
+        decodedKeys->nulls(&rows),
+        decodedKeys->indices());
+    exec::LocalDecodedVector decodedKeyElements(
+        context, *keysElements, keyElementRows);
+
+    // Under EXCEPTION no row can shrink, so the result can reference the input
+    // arrays instead of building entry indices.
+    if (throwExceptionOnDuplicateMapKeys_ && decodedKeys->isIdentityMapping() &&
+        decodedValues->isIdentityMapping() &&
+        canTakeFastPath(*keysArray, *valuesArray, rows)) {
+      exec::LocalSelectivityVector remainingRows(context, rows);
+      checkNullAndDuplicateKeys(
+          *remainingRows, context, *keysArray, *decodedKeyElements);
+      context.deselectErrors(*remainingRows);
+
+      auto mapVector = std::make_shared<MapVector>(
+          context.pool(),
+          outputType,
+          keysArray->nulls(),
+          rows.end(),
+          keysArray->offsets(),
+          keysArray->sizes(),
+          keysElements,
+          valuesArray->elements());
+      context.moveOrCopyResult(mapVector, *remainingRows, result);
+      return;
+    }
+
+    // Deduplication can only shrink a row, so the total number of keys is an
+    // upper bound on the number of entries in the result.
+    vector_size_t maxNumEntries{0};
+    rows.applyToSelected([&](vector_size_t row) {
+      maxNumEntries += keysArray->sizeAt(decodedKeys->index(row));
+    });
+
+    auto* pool = context.pool();
+    BufferPtr offsets = allocateOffsets(rows.end(), pool);
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    BufferPtr sizes = allocateSizes(rows.end(), pool);
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    BufferPtr keysIndices = allocateIndices(maxNumEntries, pool);
+    auto* rawKeysIndices = keysIndices->asMutable<vector_size_t>();
+    BufferPtr valuesIndices = allocateIndices(maxNumEntries, pool);
+    auto* rawValuesIndices = valuesIndices->asMutable<vector_size_t>();
+
+    exec::LocalSelectivityVector remainingRows(context, rows);
+
+    const MapFromArraysBuffers buffers{
+        .decodedKeys = decodedKeys,
+        .decodedValues = decodedValues,
+        .keysArray = keysArray,
+        .valuesArray = valuesArray,
+        .decodedKeyElements = decodedKeyElements.get(),
+        .throwExceptionOnDuplicateMapKeys = throwExceptionOnDuplicateMapKeys_,
+        .rawOffsets = rawOffsets,
+        .rawSizes = rawSizes,
+        .rawKeysIndices = rawKeysIndices,
+        .rawValuesIndices = rawValuesIndices,
+    };
+    const auto numEntries = decodedKeys->isConstantMapping()
+        ? buildMapEntriesForConstantKeys(*remainingRows, context, buffers)
+        : buildMapEntries(*remainingRows, context, buffers);
+
+    context.deselectErrors(*remainingRows);
+
+    auto mapVector = std::make_shared<MapVector>(
+        context.pool(),
+        outputType,
+        nullptr,
+        rows.end(),
+        std::move(offsets),
+        std::move(sizes),
+        BaseVector::wrapInDictionary(
+            nullptr, std::move(keysIndices), numEntries, keysElements),
+        BaseVector::wrapInDictionary(
+            nullptr,
+            std::move(valuesIndices),
+            numEntries,
+            valuesArray->elements()));
+    context.moveOrCopyResult(mapVector, *remainingRows, result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // array(K), array(V) -> map(K,V)
+    return {
+        exec::FunctionSignatureBuilder()
+            .knownTypeVariable("K")
+            .typeVariable("V")
+            .returnType("map(K,V)")
+            .argumentType("array(K)")
+            .argumentType("array(V)")
+            .build(),
+    };
+  }
+
+ private:
+  const bool throwExceptionOnDuplicateMapKeys_;
+};
+
+std::shared_ptr<exec::VectorFunction> makeMapFromArrays(
+    const std::string& /*name*/,
+    const std::vector<exec::VectorFunctionArg>& /*inputArgs*/,
+    const core::QueryConfig& config) {
+  return std::make_shared<MapFromArraysFunction>(
+      config.throwExceptionOnDuplicateMapKeys());
+}
 } // namespace
 
 VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
@@ -190,4 +567,11 @@ VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     MapFunction::signatures(),
     exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<MapFunction>());
+
+// Default null behavior applies: Spark's MapFromArrays is NullIntolerant, so a
+// null key or value array yields a null map.
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_map_from_arrays,
+    MapFromArraysFunction::signatures(),
+    makeMapFromArrays);
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterMap.cpp
+++ b/velox/functions/sparksql/registration/RegisterMap.cpp
@@ -24,8 +24,6 @@ extern void registerElementAtFunction(
     bool enableCaching);
 
 void registerSparkMapFunctions(const std::string& prefix) {
-  VELOX_REGISTER_VECTOR_FUNCTION(
-      udf_map_allow_duplicates, prefix + "map_from_arrays");
   registerMapFromEntriesFunction(
       prefix + "map_from_entries", /*throwForNull=*/false);
   // Spark and Presto share map_filter and transform_values: the lambda
@@ -45,6 +43,8 @@ namespace sparksql {
 void registerMapFunctions(const std::string& prefix) {
   registerSparkMapFunctions(prefix);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_map_from_arrays, prefix + "map_from_arrays");
   // This is the semantics of spark.sql.ansi.enabled = false.
   registerElementAtFunction(prefix + "element_at", true);
   registerSize(prefix + "size");

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(
   MakeDecimalTest.cpp
   MakeTimestampTest.cpp
   MapConcatTest.cpp
+  MapFromArraysTest.cpp
   MapFromEntriesTest.cpp
   MapTest.cpp
   MaskTest.cpp

--- a/velox/functions/sparksql/tests/MapFromArraysTest.cpp
+++ b/velox/functions/sparksql/tests/MapFromArraysTest.cpp
@@ -1,0 +1,648 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cmath>
+#include <cstdint>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class MapFromArraysTest : public SparkFunctionBaseTest {
+ protected:
+  void testMapFromArrays(
+      const VectorPtr& keys,
+      const VectorPtr& values,
+      const VectorPtr& expected) {
+    auto result =
+        evaluate("map_from_arrays(c0, c1)", makeRowVector({keys, values}));
+    ::facebook::velox::test::assertEqualVectors(expected, result);
+  }
+
+  void testMapFromArraysFails(
+      const VectorPtr& keys,
+      const VectorPtr& values,
+      const std::string& errorMessage) {
+    VELOX_ASSERT_USER_THROW(
+        evaluate("map_from_arrays(c0, c1)", makeRowVector({keys, values})),
+        errorMessage);
+  }
+
+  // Sets the Spark 'spark.sql.mapKeyDedupPolicy' equivalent query config.
+  void setThrowExceptionOnDuplicateMapKeys(bool value) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kThrowExceptionOnDuplicateMapKeys,
+         value ? "true" : "false"},
+    });
+  }
+};
+
+TEST_F(MapFromArraysTest, basic) {
+  auto keys = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 3]",
+      "[4, 5]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20, 30]",
+      "[40, 50]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{1: 10, 2: 20, 3: 30}",
+      "{4: 40, 5: 50}",
+  });
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, emptyArrays) {
+  auto keys = makeArrayVectorFromJson<int64_t>({"[]"});
+  auto values = makeArrayVectorFromJson<int64_t>({"[]"});
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({"{}"});
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, nullInputArray) {
+  auto keys = makeArrayVectorFromJson<int64_t>({
+      "null",
+      "[1, 2]",
+      "[3]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20]",
+      "null",
+      "[30]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "null",
+      "null",
+      "{3: 30}",
+  });
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, lastWinDuplicateKeys) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto keys = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 1]",
+      "[3, 4]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20, 30]",
+      "[40, 50]",
+  });
+  // Key 1 appears twice; the last value (30) wins and the map holds a single
+  // entry per distinct key.
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{1: 30, 2: 20}",
+      "{3: 40, 4: 50}",
+  });
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, lastWinPreservesFirstKeyPosition) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto keys = makeArrayVectorFromJson<int64_t>({"[2, 1, 2]"});
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20, 30]"});
+  auto data = makeRowVector({keys, values});
+
+  // Spark's ArrayBasedMapBuilder overwrites the value of the first occurrence
+  // in place, so the repeated key stays at its first position and the entries
+  // keep insertion order. Pinned via map_keys/map_values because map equality
+  // ignores entry order.
+  ::facebook::velox::test::assertEqualVectors(
+      makeArrayVectorFromJson<int64_t>({"[2, 1]"}),
+      evaluate("map_keys(map_from_arrays(c0, c1))", data));
+  ::facebook::velox::test::assertEqualVectors(
+      makeArrayVectorFromJson<int64_t>({"[30, 20]"}),
+      evaluate("map_values(map_from_arrays(c0, c1))", data));
+}
+
+TEST_F(MapFromArraysTest, lastWinKeyRepeatedThreeOrMoreTimes) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto keys = makeArrayVectorFromJson<int64_t>({
+      "[7, 7, 7]",
+      "[8, 8, 8, 8]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 3]",
+      "[4, 5, 6, 7]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{7: 3}",
+      "{8: 7}",
+  });
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, throwOnDuplicateKeys) {
+  setThrowExceptionOnDuplicateMapKeys(true);
+
+  auto keys = makeArrayVectorFromJson<int64_t>({"[1, 2, 1]"});
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20, 30]"});
+  testMapFromArraysFails(keys, values, "Duplicate map key (1) was found.");
+}
+
+// Under EXCEPTION no row can shrink, so the result references the input arrays
+// instead of building an entry index for each side. The tests below cover that
+// path; the ones above only reach its error cases.
+TEST_F(MapFromArraysTest, throwPolicyWithoutDuplicates) {
+  setThrowExceptionOnDuplicateMapKeys(true);
+
+  auto keys = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 3]",
+      "[]",
+      "[4, 5]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20, 30]",
+      "[]",
+      "[40, 50]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{1: 10, 2: 20, 3: 30}",
+      "{}",
+      "{4: 40, 5: 50}",
+  });
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, throwPolicyComplexTypeKeys) {
+  setThrowExceptionOnDuplicateMapKeys(true);
+
+  auto keys = makeNestedArrayVectorFromJson<int64_t>({
+      "[[1, 2], [3, 4]]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20]"});
+  auto expected = makeMapVector(
+      {0},
+      makeArrayVectorFromJson<int64_t>({"[1, 2]", "[3, 4]"}),
+      makeFlatVector<int64_t>({10, 20}));
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, throwPolicyTryDeselectsFailedRows) {
+  setThrowExceptionOnDuplicateMapKeys(true);
+
+  auto keys = makeArrayVectorFromJson<int64_t>({
+      "[1, 1]",
+      "[2, null]",
+      "[3, 4]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20]",
+      "[30, 40]",
+      "[50, 60]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "null",
+      "null",
+      "{3: 50, 4: 60}",
+  });
+  ::facebook::velox::test::assertEqualVectors(
+      expected,
+      evaluate("try(map_from_arrays(c0, c1))", makeRowVector({keys, values})));
+}
+
+TEST_F(MapFromArraysTest, nullKey) {
+  auto keys = makeArrayVectorFromJson<int64_t>({"[1, null]"});
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20]"});
+  testMapFromArraysFails(keys, values, "Cannot use null as map key!");
+
+  setThrowExceptionOnDuplicateMapKeys(true);
+  testMapFromArraysFails(keys, values, "Cannot use null as map key!");
+}
+
+TEST_F(MapFromArraysTest, mismatchedArrayLengths) {
+  auto keys = makeArrayVectorFromJson<int64_t>({"[1, 2, 3]"});
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20]"});
+  testMapFromArraysFails(
+      keys,
+      values,
+      "The key array and value array of MapData must have the same length.");
+}
+
+TEST_F(MapFromArraysTest, complexTypeKeys) {
+  auto keys = makeNestedArrayVectorFromJson<int64_t>({
+      "[[1, 2], [3, 4]]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20]"});
+  auto expected = makeMapVector(
+      {0},
+      makeArrayVectorFromJson<int64_t>({"[1, 2]", "[3, 4]"}),
+      makeFlatVector<int64_t>({10, 20}));
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, complexTypeKeysDuplicate) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto keys = makeNestedArrayVectorFromJson<int64_t>({
+      "[[1, 2], [1, 2]]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20]"});
+  auto expected = makeMapVector(
+      {0},
+      makeArrayVectorFromJson<int64_t>({"[1, 2]"}),
+      makeFlatVector<int64_t>({20}));
+  testMapFromArrays(keys, values, expected);
+
+  setThrowExceptionOnDuplicateMapKeys(true);
+  testMapFromArraysFails(keys, values, "Duplicate map key ({1, 2}) was found.");
+}
+
+TEST_F(MapFromArraysTest, arrayKeysWithNestedNulls) {
+  auto keyElements = makeNullableArrayVector<int64_t>(
+      std::vector<std::vector<std::optional<int64_t>>>{
+          {1, std::nullopt},
+          {2, std::nullopt},
+          {1, std::nullopt},
+      });
+  auto keys = makeArrayVector({0}, keyElements);
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20, 30]"});
+
+  setThrowExceptionOnDuplicateMapKeys(false);
+  auto expected = makeMapVector(
+      {0},
+      makeNullableArrayVector<int64_t>(
+          std::vector<std::vector<std::optional<int64_t>>>{
+              {1, std::nullopt},
+              {2, std::nullopt},
+          }),
+      makeFlatVector<int64_t>({30, 20}));
+  testMapFromArrays(keys, values, expected);
+
+  setThrowExceptionOnDuplicateMapKeys(true);
+  testMapFromArraysFails(keys, values, "Duplicate map key ({1, null})");
+}
+
+TEST_F(MapFromArraysTest, rowKeysWithNestedNulls) {
+  auto keyElements = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 1}),
+      makeNullableFlatVector<int64_t>({
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+      }),
+  });
+  auto keys = makeArrayVector({0}, keyElements);
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20, 30]"});
+
+  setThrowExceptionOnDuplicateMapKeys(false);
+  auto expected = makeMapVector(
+      {0},
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2}),
+          makeNullableFlatVector<int64_t>({
+              std::nullopt,
+              std::nullopt,
+          }),
+      }),
+      makeFlatVector<int64_t>({30, 20}));
+  testMapFromArrays(keys, values, expected);
+
+  setThrowExceptionOnDuplicateMapKeys(true);
+  testMapFromArraysFails(keys, values, "Duplicate map key");
+}
+
+TEST_F(MapFromArraysTest, dictionaryEncodedKeyElements) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto baseElements = makeFlatVector<int64_t>({1, 2});
+  auto encodedElements = BaseVector::wrapInDictionary(
+      nullptr, makeIndices({0, 1, 0}), 3, baseElements);
+  auto keys = makeArrayVector({0}, encodedElements);
+  auto values = makeArrayVectorFromJson<int64_t>({"[10, 20, 30]"});
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({"{1: 30, 2: 20}"});
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, allRowsNullInput) {
+  auto keys = makeAllNullArrayVector(2, BIGINT());
+  auto values = makeArrayVectorFromJson<int64_t>({"[1]", "[2]"});
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({"null", "null"});
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, dictionaryEncodedInputs) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto baseKeys = makeArrayVectorFromJson<int64_t>({
+      "[1, 2]",
+      "[3, 3, 4]",
+  });
+  auto baseValues = makeArrayVectorFromJson<int64_t>({
+      "[10, 20]",
+      "[30, 40, 50]",
+  });
+  // Rows are read out of order and the second base row is read twice, so the
+  // per-row sizes and offsets must come from the decoded index, not the row.
+  auto indices = makeIndices({1, 0, 1});
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{3: 40, 4: 50}",
+      "{1: 10, 2: 20}",
+      "{3: 40, 4: 50}",
+  });
+  testMapFromArrays(
+      wrapInDictionary(indices, 3, baseKeys),
+      wrapInDictionary(indices, 3, baseValues),
+      expected);
+}
+
+TEST_F(MapFromArraysTest, dictionaryEncodedInputsThrowPolicy) {
+  setThrowExceptionOnDuplicateMapKeys(true);
+
+  // Under EXCEPTION a row cannot shrink, so the result is otherwise expressible
+  // as a reference to the input arrays. Only the encoding rules that out here,
+  // and the result must follow the dictionary order rather than the order the
+  // rows sit in the base vector.
+  //
+  // Wrapping only the keys defeats the shared-wrapping peel that would
+  // otherwise hand the function two identity-mapped vectors. Every row is the
+  // same length, so the base and the values still agree on offset and size and
+  // the alignment check alone would let this through.
+  auto baseKeys = makeArrayVectorFromJson<int64_t>({
+      "[1, 2]",
+      "[3, 4]",
+      "[5, 6]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20]",
+      "[30, 40]",
+      "[50, 60]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{5: 10, 6: 20}",
+      "{3: 30, 4: 40}",
+      "{1: 50, 2: 60}",
+  });
+  testMapFromArrays(
+      wrapInDictionary(makeIndices({2, 1, 0}), 3, baseKeys), values, expected);
+}
+
+TEST_F(MapFromArraysTest, constantEncodedKeys) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto baseKeys = makeArrayVectorFromJson<int64_t>({"[1, 2, 1]"});
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20, 30]",
+      "[40, 50, 60]",
+      "[70, 80, 90]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{1: 30, 2: 20}",
+      "{1: 60, 2: 50}",
+      "{1: 90, 2: 80}",
+  });
+  testMapFromArrays(
+      BaseVector::wrapInConstant(3, 0, baseKeys), values, expected);
+}
+
+TEST_F(MapFromArraysTest, encodedKeysPreserveFirstKeyPosition) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto assertOrder = [&](const VectorPtr& keys,
+                         const ArrayVectorPtr& values,
+                         const ArrayVectorPtr& expectedKeys,
+                         const ArrayVectorPtr& expectedValues) {
+    auto data = makeRowVector({keys, values});
+    ::facebook::velox::test::assertEqualVectors(
+        expectedKeys, evaluate("map_keys(map_from_arrays(c0, c1))", data));
+    ::facebook::velox::test::assertEqualVectors(
+        expectedValues, evaluate("map_values(map_from_arrays(c0, c1))", data));
+  };
+
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20, 30]",
+      "[40, 50, 60]",
+      "[70, 80, 90]",
+  });
+
+  auto constantKeys = makeArrayVectorFromJson<int64_t>({"[2, 1, 2]"});
+  assertOrder(
+      BaseVector::wrapInConstant(3, 0, constantKeys),
+      values,
+      makeArrayVectorFromJson<int64_t>({"[2, 1]", "[2, 1]", "[2, 1]"}),
+      makeArrayVectorFromJson<int64_t>({
+          "[30, 20]",
+          "[60, 50]",
+          "[90, 80]",
+      }));
+
+  auto dictionaryBaseKeys = makeArrayVectorFromJson<int64_t>({
+      "[8, 7, 8]",
+      "[2, 1, 2]",
+  });
+  assertOrder(
+      wrapInDictionary(makeIndices({1, 0, 1}), 3, dictionaryBaseKeys),
+      values,
+      makeArrayVectorFromJson<int64_t>({"[2, 1]", "[8, 7]", "[2, 1]"}),
+      makeArrayVectorFromJson<int64_t>({
+          "[30, 20]",
+          "[60, 50]",
+          "[90, 80]",
+      }));
+}
+
+TEST_F(MapFromArraysTest, constantEncodedKeysThrowOnDuplicate) {
+  setThrowExceptionOnDuplicateMapKeys(true);
+
+  // The key array is shared by every row, so a duplicate in it fails all of
+  // them rather than just the row that happened to be inspected first.
+  auto baseKeys = makeArrayVectorFromJson<int64_t>({"[1, 2, 1]"});
+  auto keys = BaseVector::wrapInConstant(2, 0, baseKeys);
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20, 30]",
+      "[40, 50, 60]",
+  });
+  testMapFromArraysFails(keys, values, "Duplicate map key (1) was found.");
+
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({"null", "null"});
+  ::facebook::velox::test::assertEqualVectors(
+      expected,
+      evaluate("try(map_from_arrays(c0, c1))", makeRowVector({keys, values})));
+}
+
+TEST_F(MapFromArraysTest, constantEncodedKeysMismatchedLengths) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  // The length check stays per-row even though the keys are shared, and a row
+  // that fails it must not shift the offsets of the rows after it.
+  auto baseKeys = makeArrayVectorFromJson<int64_t>({"[1, 2]"});
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20]",
+      "[30]",
+      "[40, 50]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{1: 10, 2: 20}",
+      "null",
+      "{1: 40, 2: 50}",
+  });
+  ::facebook::velox::test::assertEqualVectors(
+      expected,
+      evaluate(
+          "try(map_from_arrays(c0, c1))",
+          makeRowVector({BaseVector::wrapInConstant(3, 0, baseKeys), values})));
+}
+
+TEST_F(MapFromArraysTest, tryDeselectsFailedRows) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  // Rows 0 and 1 fail on a length mismatch and a null key respectively. Both
+  // sit before rows that succeed, so a failed row must not shift the offsets
+  // of the rows that follow it.
+  auto keys = makeArrayVectorFromJson<int64_t>({
+      "[1, 2, 3]",
+      "[4, null]",
+      "[5, 5]",
+      "[6]",
+  });
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20]",
+      "[40, 50]",
+      "[60, 70]",
+      "[80]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "null",
+      "null",
+      "{5: 70}",
+      "{6: 80}",
+  });
+  ::facebook::velox::test::assertEqualVectors(
+      expected,
+      evaluate("try(map_from_arrays(c0, c1))", makeRowVector({keys, values})));
+}
+
+TEST_F(MapFromArraysTest, resultSize) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  // Each branch writes a disjoint subset of rows into the same result vector,
+  // so the second call has to extend a partially populated result.
+  auto condition = makeFlatVector<int64_t>({1, 2, 3});
+  auto keys = makeArrayVectorFromJson<int64_t>({"[1, 1]", "[2]", "[3, 3]"});
+  auto values = makeArrayVectorFromJson<int64_t>({
+      "[10, 20]",
+      "[30]",
+      "[40, 41]",
+  });
+  auto expected = makeMapVectorFromJson<int64_t, int64_t>({
+      "{10: 1, 20: 1}",
+      "{30: 2}",
+      "{3: 41}",
+  });
+  ::facebook::velox::test::assertEqualVectors(
+      expected,
+      evaluate(
+          "if(greaterthan(c2, 2), map_from_arrays(c0, c1), map_from_arrays(c1, c0))",
+          makeRowVector({keys, values, condition})));
+}
+
+TEST_F(MapFromArraysTest, wideKeyArray) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  // Deduplication orders keys by BaseVector::compare. This checks correctness
+  // at a width the pairwise scan it replaced could not serve in reasonable
+  // time; it is NOT a performance guard. A slower strategy still produces the
+  // right answer here, so a regression would pass rather than fail.
+  constexpr vector_size_t kNumKeys = 50'000;
+  constexpr vector_size_t kNumDistinctKeys = kNumKeys / 2;
+
+  auto keys = makeArrayVector<int64_t>(
+      1,
+      [=](auto /*row*/) { return kNumKeys; },
+      [=](auto index) { return index % kNumDistinctKeys; });
+  auto values = makeArrayVector<int64_t>(
+      1,
+      [=](auto /*row*/) { return kNumKeys; },
+      [](auto index) { return index; });
+
+  // Every key occurs exactly twice, so LAST_WIN keeps the value from the
+  // second half of the array.
+  auto expected = makeMapVector<int64_t, int64_t>(
+      1,
+      [=](auto /*row*/) { return kNumDistinctKeys; },
+      [](auto index) { return index; },
+      [=](auto index) { return index + kNumDistinctKeys; });
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, wideComplexTypeKeyArray) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  // Complex keys cannot be hashed on a primitive value, so they order by
+  // BaseVector::compare instead. Same intent as wideKeyArray: correctness at a
+  // width the pairwise scan could not serve, not a performance guard.
+  constexpr vector_size_t kNumKeys = 2'000;
+  constexpr vector_size_t kNumDistinctKeys = kNumKeys / 2;
+
+  auto keys = makeArrayVector(
+      {0},
+      makeArrayVector<int64_t>(
+          kNumKeys,
+          [](auto /*row*/) { return 1; },
+          [=](auto index) { return index % kNumDistinctKeys; }));
+  auto values = makeArrayVector<int64_t>(
+      1,
+      [=](auto /*row*/) { return kNumKeys; },
+      [](auto index) { return index; });
+
+  // Every key occurs exactly twice, so LAST_WIN keeps the value from the second
+  // half while the key holds the position of its first occurrence.
+  auto expected = makeMapVector(
+      {0},
+      makeArrayVector<int64_t>(
+          kNumDistinctKeys,
+          [](auto /*row*/) { return 1; },
+          [](auto index) { return index; }),
+      makeFlatVector<int64_t>(
+          kNumDistinctKeys, [](auto row) { return row + kNumDistinctKeys; }));
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, stringKeys) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  auto keys = makeArrayVector<std::string>({{"a", "b", "a", ""}});
+  auto values = makeArrayVectorFromJson<int64_t>({"[1, 2, 3, 4]"});
+  auto expected =
+      makeMapVector<std::string, int64_t>({{{"a", 3}, {"b", 2}, {"", 4}}});
+  testMapFromArrays(keys, values, expected);
+}
+
+TEST_F(MapFromArraysTest, floatingPointKeys) {
+  setThrowExceptionOnDuplicateMapKeys(false);
+
+  // Pins the equality the deduplication inherits from BaseVector: NaNs are
+  // equal to each other, and negative zero is equal to positive zero. Spark
+  // instead keys on Double.equals and treats -0.0 as distinct from 0.0; that
+  // divergence is Velox-wide and tracked separately.
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+  auto keys = makeArrayVector<double>({{0.0, -0.0, kNaN, kNaN, 1.5}});
+  auto values = makeArrayVectorFromJson<int64_t>({"[1, 2, 3, 4, 5]"});
+  auto expected = makeMapVector(
+      {0},
+      makeFlatVector<double>({0.0, kNaN, 1.5}),
+      makeFlatVector<int64_t>({2, 4, 5}));
+  testMapFromArrays(keys, values, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Summary:

`map_from_arrays` is a Spark-only SQL name, but Velox bound it to the Presto
implementation class `MapFunction<AllowDuplicateKeys=true>`
(`prestosql/Map.cpp`). That variant skips the duplicate-key check entirely: it
neither throws nor dedupes, emitting a MapVector that physically contains both
entries for a repeated key. The result is not a valid map, and `element_at`
then reads whichever entry it hits first.

This adds `MapFromArraysFunction` in `sparksql/Map.cpp`, mirroring Spark's
`ArrayBasedMapBuilder`:
- length mismatch and null keys throw, with Spark's wording
- under EXCEPTION, a repeated key raises DUPLICATED_MAP_KEY
- under LAST_WIN, the repeated key's value overwrites the value of its FIRST
  occurrence in place, so the key keeps its first position.

Nulls follow Spark rather than Presto: only a top-level null key is rejected.
Presto additionally rejects an indeterminate key — a complex key containing a
null — which Spark accepts. `BaseVector::equalValueAt` compares with
`kNullAsValue`, so dedup treats two such keys as equal, consistent with Spark.

Deduplication orders keys by `BaseVector::compare`, for every key type rather
than only the ones that cannot be hashed. `compare` already reports NaN equal
to NaN and `-0.0` equal to `0.0`, which is the same equality dedup owes
`equalValueAt`; a hashed fast path has to reproduce that agreement by hand, and
keeping one strategy removes that obligation along with the type dispatch.

Three choices keep the common paths cheap:
- registration is stateful, so the dedup policy is resolved once when the
  expression is compiled rather than read from the query config on every batch.
  The previous per-`apply()` read was guarded on a possibly-null `queryCtx` and
  silently defaulted to LAST_WIN.
- under EXCEPTION no row can shrink, so when both arguments are identity-mapped
  and their arrays agree on offset and size, the result references the input
  arrays directly — no entry index buffers and no dictionary wrap.
- a constant key array is deduped once instead of per row; a row then writes
  only its value indices.

**dedup logic and time complexity**
| key type | Spark | Presto | this diff |
| --- | --- | --- | --- |
| atomic, non-binary | `HashMap`, O(n) | sort, O(n log n) | ordered, O(n log n) |
| binary | `TreeMap`, O(n log n) | sort, O(n log n) | ordered, O(n log n) |
| complex | `TreeMap`, O(n log n) | sort, O(n log n) | ordered, O(n log n) |

The null-key scan is skipped when the key elements vector reports no nulls, and
the fast-path predicate keeps the name, contract and asserts of
`canTakeFastPath` in `prestosql/Map.cpp`, so the two read alike. `isNullAt` is
virtual, so the guard removes a call per key on the common path.

Reviewed By: kevinwilfong

Differential Revision: D115361136


