### PR TITLE
misc(nimble): Make DeltaBlock reject unsorted input as incompatible (#18631) (#18631)

### DIFF
--- a/velox/dwio/nimble/encodings/DeltaBlockEncoding.h
+++ b/velox/dwio/nimble/encodings/DeltaBlockEncoding.h
@@ -24,6 +24,7 @@
 #include <type_traits>
 
 #include <fmt/format.h>
+#include <folly/CPortability.h>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/nimble/common/Buffer.h"
@@ -461,7 +462,10 @@ std::string_view DeltaBlockEncoding<T>::encode(
     uint64_t maxDelta{0};
     for (uint32_t i = start + 1; i < end; ++i) {
       const auto curr = DeltaBlockEncoding<T>::toOrdered(values[i]);
-      NIMBLE_CHECK_GE(curr, prev, "DeltaBlock requires non-decreasing values.");
+      if (FOLLY_UNLIKELY(curr < prev)) {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "DeltaBlock requires non-decreasing values.");
+      }
       maxDelta = std::max(maxDelta, curr - prev);
       prev = curr;
     }

--- a/velox/dwio/nimble/encodings/tests/DeltaBlockEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/DeltaBlockEncodingTest.cpp
@@ -310,5 +310,12 @@ TEST_F(DeltaBlockEncodingTest, estimateUsesVarintPrefixSize) {
 
 TEST_F(DeltaBlockEncodingTest, encodeRejectsUnsortedValues) {
   const std::vector<int32_t> input{-1, -2};
-  EXPECT_THROW(createEncoding(input), nimble::NimbleException);
+  try {
+    createEncoding(input);
+    FAIL() << "DeltaBlockEncoding should reject unsorted values.";
+  } catch (const nimble::NimbleUserError& error) {
+    EXPECT_EQ(error.errorCode(), nimble::error_code::IncompatibleEncoding);
+    EXPECT_EQ(
+        error.errorMessage(), "DeltaBlock requires non-decreasing values.");
+  }
 }


### PR DESCRIPTION
Summary: nimble_encoding_eval can try `DeltaBlock` when evaluating integer features, but normal trait streams are not guaranteed to be sorted. In that case DeltaBlock is simply not a compatible candidate.

Differential Revision: D117024954

Pulled By: duxiao1212
