### PR TITLE
fix(nimble): Drop read-only PFOR from dispatch fuzzer test

### DIFF
--- a/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
@@ -288,9 +288,12 @@ TEST_F(
   options.seed = 1;
   options.randomizeWriterConfig = false;
   NimbleWriterFuzzer fuzzer(options, *rootPool_);
+
+  // PFOR is integral-only but is also read-only, so it is rejected by the
+  // writer config parser before dispatch is reached.
+  // `TypesTest.ReadOnlyEncoding` covers that property.
   for (const auto encodingType :
        {EncodingType::DeltaBlock,
-        EncodingType::PFOR,
         EncodingType::SimdForBitpack,
         EncodingType::Huffman}) {
     SCOPED_TRACE(toString(encodingType));


### PR DESCRIPTION
Summary:
`EncodingDispatchConsistencyTest.withholdsIntegralOnlyEncodingsFromNullableFloat`
crashes on master:

```
terminate called after throwing an instance of 'facebook::nimble::NimbleUserError'
Error Message: Unknown encoding 'PFOR' in nimble.encoding_selection_config.
Location: parseEncodings@velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp:55
```

The test loops over integral-only encodings and asserts each one comes back
`kNotApplied` for a nullable float column. `PFOR` no longer reaches that
dispatch check: D116963165 brought GitHub's `common/Types.cpp` inward, which
declares `kReadOnlyEncodingTypes = {EncodingType::PFOR}`, so the writer config
parser rejects `PFOR` outright and the resulting `NimbleUserError` is uncaught.

`EncodingDispatchConsistencyTest.cpp` has no counterpart on GitHub, so the
sync had nothing to update it with. Confirmed by A/B: at the pre-land parent
`4087cd72be16` there is no `kReadOnlyEncodingTypes` and the test passes; on
master it crashes.

A read-only encoding cannot be applied to any column, so it says nothing about
whether integral-only encodings are withheld from nullable floats. Dropping it
restores the property this test actually owns. No coverage is lost:
`TypesTest.ReadOnlyEncoding` already asserts `isReadOnlyEncoding(PFOR)` for
both the enum and string overloads.

`PFOR` remains readable, so the read-path fuzzer in
`fuzzer/encoding/EncodingViewFuzzerTest.cpp` still instantiates
`PFOREncoding<T>` and is unaffected.

Differential Revision: D117043730


