### PR TITLE
feat(nimble): Add shared dictionary catalog reader

### DIFF
--- a/velox/dwio/nimble/common/Exceptions.h
+++ b/velox/dwio/nimble/common/Exceptions.h
@@ -162,14 +162,17 @@ NIMBLE_DECLARE_CHECK_FAIL_TEMPLATES(::facebook::nimble::NimbleInternalError);
 // Verify an expected file format conditions.
 // the file is corrupted (e.g. passed magic number and version verification, but
 // got unexpected format). This will trigger a user error.
-#define NIMBLE_CHECK_FILE(condition, ...)              \
-  if (UNLIKELY(!(condition))) {                        \
-    NIMBLE_RAISE_USER_ERROR(                           \
-        #condition,                                    \
-        ::facebook::nimble::error_code::CorruptedFile, \
-        /* retryable */ false,                         \
-        __VA_ARGS__);                                  \
+#define _NIMBLE_CHECK_FILE_IMPL(condition, conditionString, ...) \
+  if (UNLIKELY(!(condition))) {                                  \
+    NIMBLE_RAISE_USER_ERROR(                                     \
+        conditionString,                                         \
+        ::facebook::nimble::error_code::CorruptedFile,           \
+        /* retryable */ false,                                   \
+        __VA_ARGS__);                                            \
   }
+
+#define NIMBLE_CHECK_FILE(condition, ...) \
+  _NIMBLE_CHECK_FILE_IMPL(condition, #condition, ##__VA_ARGS__)
 
 // Should be raised when we don't expect to hit a code path, but we did. This
 // means a bug in Nimble.
@@ -248,6 +251,10 @@ NIMBLE_DECLARE_CHECK_FAIL_TEMPLATES(::facebook::nimble::NimbleInternalError);
 #define _NIMBLE_CHECK_OP(expr1, expr2, op, ...) \
   _NIMBLE_CHECK_OP_HELPER(_NIMBLE_CHECK_IMPL, expr1, expr2, op, ##__VA_ARGS__)
 
+#define _NIMBLE_CHECK_FILE_OP(expr1, expr2, op, ...) \
+  _NIMBLE_CHECK_OP_HELPER(                           \
+      _NIMBLE_CHECK_FILE_IMPL, expr1, expr2, op, ##__VA_ARGS__)
+
 #define _NIMBLE_USER_CHECK_IMPL(expr, exprStr, ...)    \
   _NIMBLE_CHECK_AND_THROW_IMPL(                        \
       exprStr,                                         \
@@ -269,6 +276,20 @@ NIMBLE_DECLARE_CHECK_FAIL_TEMPLATES(::facebook::nimble::NimbleInternalError);
 #define NIMBLE_CHECK_EQ(e1, e2, ...) _NIMBLE_CHECK_OP(e1, e2, ==, ##__VA_ARGS__)
 #define NIMBLE_CHECK_NE(e1, e2, ...) _NIMBLE_CHECK_OP(e1, e2, !=, ##__VA_ARGS__)
 
+// Comparison check macros - corrupted file errors
+#define NIMBLE_CHECK_FILE_GT(e1, e2, ...) \
+  _NIMBLE_CHECK_FILE_OP(e1, e2, >, ##__VA_ARGS__)
+#define NIMBLE_CHECK_FILE_GE(e1, e2, ...) \
+  _NIMBLE_CHECK_FILE_OP(e1, e2, >=, ##__VA_ARGS__)
+#define NIMBLE_CHECK_FILE_LT(e1, e2, ...) \
+  _NIMBLE_CHECK_FILE_OP(e1, e2, <, ##__VA_ARGS__)
+#define NIMBLE_CHECK_FILE_LE(e1, e2, ...) \
+  _NIMBLE_CHECK_FILE_OP(e1, e2, <=, ##__VA_ARGS__)
+#define NIMBLE_CHECK_FILE_EQ(e1, e2, ...) \
+  _NIMBLE_CHECK_FILE_OP(e1, e2, ==, ##__VA_ARGS__)
+#define NIMBLE_CHECK_FILE_NE(e1, e2, ...) \
+  _NIMBLE_CHECK_FILE_OP(e1, e2, !=, ##__VA_ARGS__)
+
 // Comparison check macros - user errors
 #define NIMBLE_USER_CHECK_GT(e1, e2, ...) \
   _NIMBLE_USER_CHECK_OP(e1, e2, >, ##__VA_ARGS__)
@@ -287,6 +308,8 @@ NIMBLE_DECLARE_CHECK_FAIL_TEMPLATES(::facebook::nimble::NimbleInternalError);
 #define NIMBLE_CHECK_NULL(e, ...) NIMBLE_CHECK((e) == nullptr, ##__VA_ARGS__)
 #define NIMBLE_CHECK_NOT_NULL(e, ...) \
   NIMBLE_CHECK((e) != nullptr, ##__VA_ARGS__)
+#define NIMBLE_CHECK_FILE_NOT_NULL(e, ...) \
+  NIMBLE_CHECK_FILE((e) != nullptr, ##__VA_ARGS__)
 #define NIMBLE_USER_CHECK_NULL(e, ...) \
   NIMBLE_USER_CHECK((e) == nullptr, ##__VA_ARGS__)
 #define NIMBLE_USER_CHECK_NOT_NULL(e, ...) \

--- a/velox/dwio/nimble/common/tests/ExceptionTests.cpp
+++ b/velox/dwio/nimble/common/tests/ExceptionTests.cpp
@@ -77,6 +77,22 @@ void verifyException(
   }
 }
 
+template <typename Check>
+void verifyFileComparisonFailure(
+    Check&& check,
+    std::string_view comparedValues,
+    std::string_view message) {
+  try {
+    check();
+    FAIL() << "Should have thrown";
+  } catch (const nimble::NimbleUserError& exception) {
+    EXPECT_EQ(exception.errorCode(), "CORRUPTED_FILE");
+    EXPECT_EQ(exception.errorSource(), "USER");
+    EXPECT_NE(exception.errorMessage().find(comparedValues), std::string::npos);
+    EXPECT_NE(exception.errorMessage().find(message), std::string::npos);
+  }
+}
+
 TEST(ExceptionTests, format) {
   verifyException(
       nimble::NimbleUserError(
@@ -357,6 +373,57 @@ TEST(ExceptionTests, checkNull) {
 
   // Test NIMBLE_CHECK_NOT_NULL - should not throw when pointer is valid
   NIMBLE_CHECK_NOT_NULL(validPtr);
+}
+
+TEST(ExceptionTests, checkFileNotNull) {
+  int* nullPointer = nullptr;
+  int value = 42;
+  int* validPointer = &value;
+
+  try {
+    NIMBLE_CHECK_FILE_NOT_NULL(nullPointer, "Invalid file pointer");
+    FAIL() << "Should have thrown";
+  } catch (const nimble::NimbleUserError& exception) {
+    EXPECT_EQ(exception.errorCode(), "CORRUPTED_FILE");
+    EXPECT_EQ(exception.errorSource(), "USER");
+    EXPECT_EQ(exception.errorMessage(), "Invalid file pointer");
+  }
+
+  NIMBLE_CHECK_FILE_NOT_NULL(validPointer);
+}
+
+TEST(ExceptionTests, checkFileComparisons) {
+  verifyFileComparisonFailure(
+      [] { NIMBLE_CHECK_FILE_GT(5, 10, "Invalid greater-than value"); },
+      "(5 vs. 10)",
+      "Invalid greater-than value");
+  verifyFileComparisonFailure(
+      [] { NIMBLE_CHECK_FILE_GE(3, 5, "Invalid greater-or-equal value"); },
+      "(3 vs. 5)",
+      "Invalid greater-or-equal value");
+  verifyFileComparisonFailure(
+      [] { NIMBLE_CHECK_FILE_LT(10, 5, "Invalid less-than value"); },
+      "(10 vs. 5)",
+      "Invalid less-than value");
+  verifyFileComparisonFailure(
+      [] { NIMBLE_CHECK_FILE_LE(8, 3, "Invalid less-or-equal value"); },
+      "(8 vs. 3)",
+      "Invalid less-or-equal value");
+  verifyFileComparisonFailure(
+      [] { NIMBLE_CHECK_FILE_EQ(5, 10, "Mismatched file value"); },
+      "(5 vs. 10)",
+      "Mismatched file value");
+  verifyFileComparisonFailure(
+      [] { NIMBLE_CHECK_FILE_NE(7, 7, "Duplicate file value"); },
+      "(7 vs. 7)",
+      "Duplicate file value");
+
+  NIMBLE_CHECK_FILE_GT(10, 5);
+  NIMBLE_CHECK_FILE_GE(5, 5);
+  NIMBLE_CHECK_FILE_LT(3, 8);
+  NIMBLE_CHECK_FILE_LE(4, 4);
+  NIMBLE_CHECK_FILE_EQ(7, 7);
+  NIMBLE_CHECK_FILE_NE(7, 8);
 }
 
 TEST(ExceptionTests, checkNullWithMessage) {

--- a/velox/dwio/nimble/common/tests/GTestUtils.h
+++ b/velox/dwio/nimble/common/tests/GTestUtils.h
@@ -52,6 +52,17 @@
   NIMBLE_ASSERT_THROW_IMPL(                                  \
       facebook::nimble::NimbleUserError, _expression, _errorMessage)
 
+#define NIMBLE_ASSERT_FILE_THROW(_expression, _errorMessage)                   \
+  try {                                                                        \
+    static_cast<void>(_expression);                                            \
+    FAIL() << "Expected a corrupted file exception";                           \
+  } catch (const facebook::nimble::NimbleUserError& exception) {               \
+    ASSERT_EQ(exception.errorCode(), "CORRUPTED_FILE");                        \
+    ASSERT_NE(exception.errorMessage().find(_errorMessage), std::string::npos) \
+        << "Expected error message to contain '" << (_errorMessage)            \
+        << "', but received '" << exception.errorMessage() << "'.";            \
+  }
+
 #define NIMBLE_ASSERT_RUNTIME_THROW(_expression, _errorMessage) \
   NIMBLE_ASSERT_THROW_IMPL(                                     \
       facebook::nimble::NimbleRuntimeError, _expression, _errorMessage)

--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(
   MainlyConstantEncoding.cpp
   PrefixEncoding.cpp
   RLEEncoding.cpp
+  SharedDictionaryCatalog.cpp
+  SharedDictionaryEncoding.cpp
   SharedDictionaryTypes.cpp
   SparseBoolEncoding.cpp
   TrivialEncoding.cpp

--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -120,10 +120,30 @@ target_compile_definitions(
     fsst_decompress=nimble_fsst_decompress
 )
 
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/SharedDictionary.fbs"
+  ""
+  nimble_shared_dictionary_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  ""
+)
+add_library(nimble_shared_dictionary_fb INTERFACE)
+target_include_directories(
+  nimble_shared_dictionary_fb
+  INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
+)
+add_dependencies(
+  nimble_shared_dictionary_fb
+  nimble_shared_dictionary_schema_fb
+)
+
 target_link_libraries(
   nimble_encodings
   nimble_compression
   nimble_common
+  nimble_shared_dictionary_fb
   velox_common_base
   velox_fastpforlib
   fsst

--- a/velox/dwio/nimble/encodings/SharedDictionary.fbs
+++ b/velox/dwio/nimble/encodings/SharedDictionary.fbs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace facebook.nimble.serialization;
+
+/// Associates a value stream with a dictionary in the containing scope list.
+table SharedDictionaryReference {
+  /// Logical value stream whose shared-dictionary indices require this
+  /// dictionary.
+  value_stream_id:uint32;
+
+  /// Identifier interpreted according to the containing scope list. It is an
+  /// auxiliary stream ID for stripe scope, an entry ID for file scope, and a
+  /// resolver-defined ID for external scope.
+  dictionary_id:uint32;
+
+  /// Nimble DataType of the dictionary values.
+  data_type:uint8;
+}
+
+/// Locates one file-scope dictionary alphabet by its absolute file byte range.
+table FileDictionary {
+  /// Identifier referenced by file_dictionary_references.
+  dictionary_id:uint32;
+
+  /// Nimble DataType of the encoded values.
+  data_type:uint8;
+
+  /// Absolute file byte range containing the encoded alphabet.
+  offset:uint64;
+  length:uint32;
+}
+
+/// Shared dictionary metadata stored in the tablet optional section.
+table SharedDictionaryCatalog {
+  /// Value streams mapped to stripe-local auxiliary dictionary streams.
+  stripe_dictionary_references:[SharedDictionaryReference];
+
+  /// Value streams mapped to alphabets stored in file_dictionaries. Multiple
+  /// value streams may reference the same file dictionary.
+  file_dictionary_references:[SharedDictionaryReference];
+
+  /// Value streams mapped to dictionaries supplied by an external resolver.
+  external_dictionary_references:[SharedDictionaryReference];
+
+  /// Locations of file-scope dictionary alphabets indexed by dictionary_id.
+  file_dictionaries:[FileDictionary];
+}
+
+root_type SharedDictionaryCatalog;

--- a/velox/dwio/nimble/encodings/SharedDictionaryCatalog.cpp
+++ b/velox/dwio/nimble/encodings/SharedDictionaryCatalog.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
+
+#include <utility>
+
+#include "flatbuffers/flatbuffers.h"
+#include "folly/container/F14Set.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryGenerated.h"
+
+namespace facebook::nimble {
+namespace {
+
+using SerializedDictionaryReferences = flatbuffers::Vector<
+    flatbuffers::Offset<serialization::SharedDictionaryReference>>;
+using CatalogIndex = folly::F14FastMap<uint32_t, size_t>;
+
+auto serializeReferences(
+    flatbuffers::FlatBufferBuilder& builder,
+    std::span<const SharedDictionaryReference> references,
+    folly::F14FastSet<uint32_t>& streamIds) {
+  return builder.CreateVector<
+      flatbuffers::Offset<serialization::SharedDictionaryReference>>(
+      references.size(), [&](size_t i) {
+        const auto& reference = references[i];
+        NIMBLE_CHECK(
+            streamIds.insert(reference.valueStreamId).second,
+            "Duplicate shared dictionary value stream {}.",
+            reference.valueStreamId);
+        NIMBLE_CHECK_NE(
+            reference.dictionaryId,
+            kInvalidSharedDictionaryId,
+            "Shared dictionary reference requires a valid dictionary id.");
+        return serialization::CreateSharedDictionaryReference(
+            builder,
+            reference.valueStreamId,
+            reference.dictionaryId,
+            static_cast<uint8_t>(reference.dataType));
+      });
+}
+
+void validateFileDictionaries(
+    std::span<const SharedDictionaryReference> references,
+    std::span<const FileDictionary> fileDictionaries) {
+  CatalogIndex fileDictionaryIndices;
+  fileDictionaryIndices.reserve(fileDictionaries.size());
+  for (size_t i = 0; i < fileDictionaries.size(); ++i) {
+    const auto& fileDictionary = fileDictionaries[i];
+    NIMBLE_CHECK_GT(
+        fileDictionary.length,
+        0,
+        "File dictionary must contain a non-empty alphabet.");
+    NIMBLE_CHECK(
+        fileDictionaryIndices.emplace(fileDictionary.dictionaryId, i).second,
+        "Duplicate file shared dictionary ID {}.",
+        fileDictionary.dictionaryId);
+  }
+
+  for (const auto& reference : references) {
+    const auto fileDictionaryEntry =
+        fileDictionaryIndices.find(reference.dictionaryId);
+    NIMBLE_CHECK(
+        fileDictionaryEntry != fileDictionaryIndices.end(),
+        "File shared dictionary {} does not exist.",
+        reference.dictionaryId);
+    NIMBLE_CHECK_EQ(
+        fileDictionaries[fileDictionaryEntry->second].dataType,
+        reference.dataType,
+        "File shared dictionary {} has an inconsistent type.",
+        reference.dictionaryId);
+  }
+}
+
+void parseReferences(
+    const SerializedDictionaryReferences* serializedReferences,
+    std::vector<SharedDictionaryReference>& references,
+    CatalogIndex& referenceIndices,
+    folly::F14FastSet<uint32_t>& streamIds) {
+  if (serializedReferences == nullptr) {
+    return;
+  }
+  references.reserve(serializedReferences->size());
+  referenceIndices.reserve(serializedReferences->size());
+  for (const auto* serializedReference : *serializedReferences) {
+    NIMBLE_CHECK_FILE_NOT_NULL(
+        serializedReference,
+        "Shared dictionary catalog contains an invalid reference.");
+    SharedDictionaryReference reference{
+        .valueStreamId = serializedReference->value_stream_id(),
+        .dictionaryId = serializedReference->dictionary_id(),
+        .dataType = static_cast<DataType>(serializedReference->data_type())};
+    NIMBLE_CHECK_FILE_NE(
+        reference.dictionaryId,
+        kInvalidSharedDictionaryId,
+        "Shared dictionary value stream {} has an invalid dictionary ID.",
+        reference.valueStreamId);
+    NIMBLE_CHECK_FILE(
+        streamIds.insert(reference.valueStreamId).second,
+        "Duplicate shared dictionary value stream {}.",
+        reference.valueStreamId);
+    referenceIndices.emplace(reference.valueStreamId, references.size());
+    references.push_back(reference);
+  }
+}
+
+template <typename Entry>
+const Entry* findEntry(
+    const std::vector<Entry>& entries,
+    const CatalogIndex& indices,
+    uint32_t id) {
+  const auto entry = indices.find(id);
+  return entry == indices.end() ? nullptr : &entries[entry->second];
+}
+
+} // namespace
+
+std::string SharedDictionaryCatalog::serialize(
+    std::span<const SharedDictionaryReference> stripeDictionaryReferences,
+    std::span<const SharedDictionaryReference> fileDictionaryReferences,
+    std::span<const SharedDictionaryReference> externalDictionaryReferences,
+    std::span<const FileDictionary> fileDictionaries) {
+  NIMBLE_CHECK(
+      !stripeDictionaryReferences.empty() ||
+          !fileDictionaryReferences.empty() ||
+          !externalDictionaryReferences.empty() || !fileDictionaries.empty(),
+      "Shared dictionary catalog must contain at least one entry.");
+  flatbuffers::FlatBufferBuilder builder;
+  folly::F14FastSet<uint32_t> streamIds;
+  const auto stripeDictionaryReferencesOffset =
+      serializeReferences(builder, stripeDictionaryReferences, streamIds);
+  const auto fileDictionaryReferencesOffset =
+      serializeReferences(builder, fileDictionaryReferences, streamIds);
+  const auto externalDictionaryReferencesOffset =
+      serializeReferences(builder, externalDictionaryReferences, streamIds);
+  validateFileDictionaries(fileDictionaryReferences, fileDictionaries);
+
+  const auto fileDictionariesOffset =
+      builder.CreateVector<flatbuffers::Offset<serialization::FileDictionary>>(
+          fileDictionaries.size(), [&](size_t i) {
+            const auto& fileDictionary = fileDictionaries[i];
+            return serialization::CreateFileDictionary(
+                builder,
+                fileDictionary.dictionaryId,
+                static_cast<uint8_t>(fileDictionary.dataType),
+                fileDictionary.offset,
+                fileDictionary.length);
+          });
+  const auto root = serialization::CreateSharedDictionaryCatalog(
+      builder,
+      stripeDictionaryReferencesOffset,
+      fileDictionaryReferencesOffset,
+      externalDictionaryReferencesOffset,
+      fileDictionariesOffset);
+  serialization::FinishSharedDictionaryCatalogBuffer(builder, root);
+  return std::string{
+      reinterpret_cast<const char*>(builder.GetBufferPointer()),
+      builder.GetSize()};
+}
+
+SharedDictionaryCatalog SharedDictionaryCatalog::deserialize(
+    std::string_view catalog) {
+  flatbuffers::Verifier verifier{
+      reinterpret_cast<const uint8_t*>(catalog.data()), catalog.size()};
+  NIMBLE_CHECK_FILE(
+      serialization::VerifySharedDictionaryCatalogBuffer(verifier),
+      "Invalid shared dictionary catalog.");
+  const auto* serializedCatalog =
+      serialization::GetSharedDictionaryCatalog(catalog.data());
+
+  SharedDictionaryCatalog parsed;
+  folly::F14FastSet<uint32_t> streamIds;
+  parseReferences(
+      serializedCatalog->stripe_dictionary_references(),
+      parsed.stripeDictionaryReferences_,
+      parsed.stripeDictionaryReferenceIndices_,
+      streamIds);
+  parseReferences(
+      serializedCatalog->file_dictionary_references(),
+      parsed.fileDictionaryReferences_,
+      parsed.fileDictionaryReferenceIndices_,
+      streamIds);
+  parseReferences(
+      serializedCatalog->external_dictionary_references(),
+      parsed.externalDictionaryReferences_,
+      parsed.externalDictionaryReferenceIndices_,
+      streamIds);
+
+  if (const auto* serializedFileDictionaries =
+          serializedCatalog->file_dictionaries()) {
+    parsed.fileDictionaries_.reserve(serializedFileDictionaries->size());
+    parsed.fileDictionaryIndices_.reserve(serializedFileDictionaries->size());
+    for (const auto* serializedFileDictionary : *serializedFileDictionaries) {
+      NIMBLE_CHECK_FILE_NOT_NULL(
+          serializedFileDictionary,
+          "Shared dictionary catalog contains an invalid file dictionary.");
+      NIMBLE_CHECK_FILE_GT(
+          serializedFileDictionary->length(),
+          0,
+          "File dictionary {} has no alphabet.",
+          serializedFileDictionary->dictionary_id());
+      FileDictionary fileDictionary{
+          .dictionaryId = serializedFileDictionary->dictionary_id(),
+          .dataType =
+              static_cast<DataType>(serializedFileDictionary->data_type()),
+          .offset = serializedFileDictionary->offset(),
+          .length = serializedFileDictionary->length()};
+      NIMBLE_CHECK_FILE(
+          parsed.fileDictionaryIndices_
+              .emplace(
+                  fileDictionary.dictionaryId, parsed.fileDictionaries_.size())
+              .second,
+          "Duplicate file shared dictionary ID {}.",
+          fileDictionary.dictionaryId);
+      parsed.fileDictionaries_.push_back(std::move(fileDictionary));
+    }
+  }
+  for (const auto& reference : parsed.fileDictionaryReferences_) {
+    const auto* fileDictionary =
+        parsed.findFileDictionary(reference.dictionaryId);
+    NIMBLE_CHECK_FILE(
+        fileDictionary != nullptr,
+        "File shared dictionary {} does not exist.",
+        reference.dictionaryId);
+    NIMBLE_CHECK_FILE_EQ(
+        fileDictionary->dataType,
+        reference.dataType,
+        "File shared dictionary {} has an inconsistent type.",
+        reference.dictionaryId);
+  }
+  return parsed;
+}
+
+const SharedDictionaryReference*
+SharedDictionaryCatalog::findStripeDictionaryReference(
+    uint32_t valueStreamId) const {
+  return findEntry(
+      stripeDictionaryReferences_,
+      stripeDictionaryReferenceIndices_,
+      valueStreamId);
+}
+
+const SharedDictionaryReference*
+SharedDictionaryCatalog::findFileDictionaryReference(
+    uint32_t valueStreamId) const {
+  return findEntry(
+      fileDictionaryReferences_,
+      fileDictionaryReferenceIndices_,
+      valueStreamId);
+}
+
+const SharedDictionaryReference*
+SharedDictionaryCatalog::findExternalDictionaryReference(
+    uint32_t valueStreamId) const {
+  return findEntry(
+      externalDictionaryReferences_,
+      externalDictionaryReferenceIndices_,
+      valueStreamId);
+}
+
+const FileDictionary* SharedDictionaryCatalog::findFileDictionary(
+    uint32_t dictionaryId) const {
+  return findEntry(fileDictionaries_, fileDictionaryIndices_, dictionaryId);
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/SharedDictionaryCatalog.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryCatalog.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "folly/container/F14Map.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryTypes.h"
+
+namespace facebook::nimble {
+
+/// Location of a file dictionary parsed from a shared dictionary catalog.
+struct FileDictionary {
+  /// Dictionary identifier within the file scope.
+  uint32_t dictionaryId{};
+  /// Nimble type of the alphabet values.
+  DataType dataType{DataType::Undefined};
+  /// Absolute file offset of the encoded alphabet.
+  uint64_t offset{};
+  /// Byte length of the encoded alphabet.
+  uint32_t length{};
+};
+
+/// References a dictionary from a value stream within one catalog scope.
+struct SharedDictionaryReference {
+  /// Logical stream whose values use this dictionary.
+  uint32_t valueStreamId{};
+  /// Dictionary identifier interpreted within the reference scope.
+  uint32_t dictionaryId{kInvalidSharedDictionaryId};
+  /// Nimble type of the dictionary values.
+  DataType dataType{DataType::Undefined};
+};
+
+/// Immutable parsed contents of the shared dictionary section.
+class SharedDictionaryCatalog {
+ public:
+  /// Serializes value-stream references and file dictionary locations.
+  static std::string serialize(
+      std::span<const SharedDictionaryReference> stripeDictionaryReferences,
+      std::span<const SharedDictionaryReference> fileDictionaryReferences,
+      std::span<const SharedDictionaryReference> externalDictionaryReferences,
+      std::span<const FileDictionary> fileDictionaries);
+
+  /// Deserializes and validates shared dictionary metadata.
+  static SharedDictionaryCatalog deserialize(std::string_view catalog);
+
+  const std::vector<SharedDictionaryReference>& stripeDictionaryReferences()
+      const {
+    return stripeDictionaryReferences_;
+  }
+
+  const std::vector<SharedDictionaryReference>& fileDictionaryReferences()
+      const {
+    return fileDictionaryReferences_;
+  }
+
+  const std::vector<SharedDictionaryReference>& externalDictionaryReferences()
+      const {
+    return externalDictionaryReferences_;
+  }
+
+  const std::vector<FileDictionary>& fileDictionaries() const {
+    return fileDictionaries_;
+  }
+
+  /// Finds a stripe dictionary reference by value stream ID.
+  const SharedDictionaryReference* findStripeDictionaryReference(
+      uint32_t valueStreamId) const;
+
+  /// Finds a file dictionary reference by value stream ID.
+  const SharedDictionaryReference* findFileDictionaryReference(
+      uint32_t valueStreamId) const;
+
+  /// Finds an external dictionary reference by value stream ID.
+  const SharedDictionaryReference* findExternalDictionaryReference(
+      uint32_t valueStreamId) const;
+
+  /// Finds a file dictionary by dictionary ID.
+  const FileDictionary* findFileDictionary(uint32_t dictionaryId) const;
+
+ private:
+  // References to stripe-local dictionary streams.
+  std::vector<SharedDictionaryReference> stripeDictionaryReferences_;
+  // Value-stream bindings. Multiple streams may share one file dictionary.
+  std::vector<SharedDictionaryReference> fileDictionaryReferences_;
+  // References resolved by an external provider.
+  std::vector<SharedDictionaryReference> externalDictionaryReferences_;
+  // File-scope alphabet locations.
+  std::vector<FileDictionary> fileDictionaries_;
+
+  // Entry positions indexed by their lookup IDs.
+  folly::F14FastMap<uint32_t, size_t> stripeDictionaryReferenceIndices_;
+  folly::F14FastMap<uint32_t, size_t> fileDictionaryReferenceIndices_;
+  folly::F14FastMap<uint32_t, size_t> externalDictionaryReferenceIndices_;
+  folly::F14FastMap<uint32_t, size_t> fileDictionaryIndices_;
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/SharedDictionaryEncoding.cpp
+++ b/velox/dwio/nimble/encodings/SharedDictionaryEncoding.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+
+namespace facebook::nimble {
+
+SharedDictionaryAlphabet::SharedDictionaryAlphabet(
+    std::string_view encoded,
+    const Encoding::Options& options,
+    std::shared_ptr<const void> encodedAlphabetOwner,
+    velox::memory::MemoryPool* pool)
+    : encodedAlphabetOwner_{std::move(encodedAlphabetOwner)},
+      dataType_{EncodingPrefix::dataType(encoded)},
+      encodingType_{EncodingPrefix::encodingType(encoded)},
+      entryPayload_{*velox::checkedNotNull(pool)},
+      entries_{nullptr},
+      entryView_{
+          supportsEncodingView(encodingType_)
+              ? createEncodingView(encoded, pool, options)
+              : nullptr} {
+  if (entryView_ != nullptr) {
+    entryCount_ = entryView_->rowCount();
+    return;
+  }
+
+  // No view for this encoding, so decode every entry once and serve lookups
+  // from the decoded buffer instead.
+  auto encoding = EncodingFactory{options}.create(
+      *pool, encoded, [this](uint32_t size) -> void* {
+        return entryPayload_.reserve(size);
+      });
+  NIMBLE_CHECK_EQ(
+      encoding->dataType(),
+      dataType_,
+      "Shared dictionary alphabet has an inconsistent data type.");
+  entryCount_ = encoding->rowCount();
+  if (entryCount_ == 0) {
+    return;
+  }
+  decodeEntries(*encoding, pool);
+}
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+SharedDictionaryAlphabet::create(
+    std::string_view encodedAlphabet,
+    std::shared_ptr<const void> encodedAlphabetOwner,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_NOT_NULL(pool);
+  NIMBLE_CHECK_NOT_NULL(encodedAlphabetOwner);
+  NIMBLE_CHECK_FILE(
+      !encodedAlphabet.empty(), "Shared dictionary alphabet is empty.");
+  auto alphabet =
+      std::shared_ptr<SharedDictionaryAlphabet>{new SharedDictionaryAlphabet{
+          encodedAlphabet,
+          Encoding::Options{},
+          std::move(encodedAlphabetOwner),
+          pool}};
+  NIMBLE_CHECK_GT(
+      alphabet->entryCount(), 0, "Shared dictionary alphabet has no entries.");
+  return alphabet;
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
@@ -34,6 +34,7 @@
 #include "velox/common/Casts.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/DataTypeDispatch.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Varint.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryTypes.h"
@@ -183,11 +184,15 @@ class PreservedDictionaryEncodingSelectionPolicy final
 /// the stream; the rest are decoded once into pool backed storage, so any
 /// encoding can store an alphabet. Alphabets stay uncompressed either way,
 /// because compression is invisible to supportsEncodingView() and would make
-/// that choice unreliable. Like every other Nimble encoding, the alphabet only
-/// views the encoded bytes, so the caller must keep them alive for as long as
-/// the alphabet is used.
+/// that choice unreliable.
 class SharedDictionaryAlphabet {
  public:
+  /// Creates an alphabet backed by bytes kept alive by encodedAlphabetOwner.
+  static std::shared_ptr<const SharedDictionaryAlphabet> create(
+      std::string_view encodedAlphabet,
+      std::shared_ptr<const void> encodedAlphabetOwner,
+      velox::memory::MemoryPool* pool);
+
   /// Serializes alphabet entries into the form the constructor accepts.
   ///
   /// candidateEncodings restricts the encoding selection policy. An empty list
@@ -229,38 +234,6 @@ class SharedDictionaryAlphabet {
     return estimate.value();
   }
 
-  /// Wraps a serialized alphabet in a view that reads entries by index.
-  SharedDictionaryAlphabet(
-      std::string_view encoded,
-      const Encoding::Options& options,
-      velox::memory::MemoryPool* pool)
-      : dataType_{EncodingPrefix::dataType(encoded)},
-        encodingType_{EncodingPrefix::encodingType(encoded)},
-        entryCount_{
-            EncodingPrefix::readRowCount(encoded, options.useVarintRowCount)},
-        entryPayload_{*velox::checkedNotNull(pool)},
-        entries_{nullptr},
-        entryView_{
-            supportsEncodingView(encodingType_)
-                ? createEncodingView(encoded, pool, options)
-                : nullptr} {
-    if (entryView_ != nullptr || entryCount_ == 0) {
-      return;
-    }
-    // No view for this encoding, so decode every entry once and serve lookups
-    // from the decoded buffer instead.
-    auto encoding = EncodingFactory{options}.create(
-        *pool, encoded, [this](uint32_t size) -> void* {
-          return entryPayload_.reserve(size);
-        });
-    NIMBLE_CHECK_EQ(
-        encoding->dataType(),
-        dataType_,
-        "Shared dictionary alphabet has an inconsistent data type.");
-    NIMBLE_DCHECK_EQ(encoding->rowCount(), entryCount_);
-    decodeEntries(*encoding, pool);
-  }
-
   /// Returns the Nimble data type shared by all alphabet entries.
   DataType dataType() const {
     return dataType_;
@@ -275,16 +248,6 @@ class SharedDictionaryAlphabet {
   /// it so a rewritten local dictionary keeps the layout it came from.
   EncodingType encodingType() const {
     return encodingType_;
-  }
-
-  /// Testing hook: true when lookups read directly from an EncodingView.
-  bool testingUsesEncodingView() const {
-    return entryView_ != nullptr;
-  }
-
-  /// Testing hook: true when lookups read from entries decoded up front.
-  bool testingUsesDecodedEntries() const {
-    return entries_ != nullptr;
   }
 
   /// Returns the entry stored at index. T must match dataType().
@@ -321,7 +284,23 @@ class SharedDictionaryAlphabet {
     }
   }
 
+  /// Testing hook: true when lookups read directly from an EncodingView.
+  bool testingUsesEncodingView() const {
+    return entryView_ != nullptr;
+  }
+
+  /// Testing hook: true when lookups read from entries decoded up front.
+  bool testingUsesDecodedEntries() const {
+    return entries_ != nullptr;
+  }
+
  private:
+  SharedDictionaryAlphabet(
+      std::string_view encoded,
+      const Encoding::Options& options,
+      std::shared_ptr<const void> encodedAlphabetOwner,
+      velox::memory::MemoryPool* pool);
+
   void decodeEntries(Encoding& encoding, velox::memory::MemoryPool* pool) {
     NIMBLE_RETURN_BY_DATA_TYPE_OR(
         // The macro's default case handles Undefined.
@@ -395,9 +374,11 @@ class SharedDictionaryAlphabet {
         "Shared dictionary alphabet has unexpected type.");
   }
 
+  // Keeps borrowed encoded bytes alive when create() receives an owner.
+  const std::shared_ptr<const void> encodedAlphabetOwner_;
   const DataType dataType_;
   const EncodingType encodingType_;
-  const uint32_t entryCount_;
+  uint32_t entryCount_{0};
   // entryView_ and entries_ are mutually exclusive lookup modes. entryPayload_
   // is used by decoded entry storage when variable-width values in entries_
   // need owned payload bytes.
@@ -530,7 +511,9 @@ SharedDictionaryEncoding<T>::SharedDictionaryEncoding(
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>{pool, data, options} {
   static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
-  NIMBLE_CHECK_NOT_NULL(options.sharedDictionaryResolver);
+  NIMBLE_CHECK_NOT_NULL(
+      options.sharedDictionaryResolver,
+      "Shared dictionary encoding requires a resolver.");
 
   const char* pos = data.data() + this->dataOffset();
   scope_ = readSharedDictionaryScope(data, pos);
@@ -688,7 +671,9 @@ std::string_view SharedDictionaryEncoding<T>::slice(
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
   NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
-  NIMBLE_CHECK_NOT_NULL(options.sharedDictionaryResolver);
+  NIMBLE_CHECK_NOT_NULL(
+      options.sharedDictionaryResolver,
+      "Shared dictionary slicing requires a resolver.");
   const char* pos = encoded.data() +
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
   const auto scope = readSharedDictionaryScope(encoded, pos);

--- a/velox/dwio/nimble/encodings/SharedDictionaryTypes.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryTypes.h
@@ -87,12 +87,10 @@ struct SharedDictionaryEncodingInput {
 /// SharedDictionaryEncoding.h, which owns the encoding machinery it needs.
 class SharedDictionaryAlphabet;
 
-/// Resolves a dictionary ID within the current reader or writer context.
+/// Resolves a dictionary ID within the current encoding context.
 ///
-/// File-scope writers use the resolved alphabet as logical dictionary values
-/// and serialize it through Nimble encoding for the file catalog. They do not
-/// accept or reuse resolver-provided encoded bytes. External-scope dictionaries
-/// are resolver-owned and are not serialized into the Nimble file.
+/// Decoders bind this to the file and stripe being read. Writers use it for
+/// prebuilt alphabets supplied outside the value stream being encoded.
 class SharedDictionaryResolver {
  public:
   virtual ~SharedDictionaryResolver() = default;

--- a/velox/dwio/nimble/encodings/tests/SharedDictionaryCatalogTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SharedDictionaryCatalogTest.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <span>
+
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
+
+namespace facebook::nimble {
+namespace {
+
+class SharedDictionaryCatalogTest : public testing::Test {
+ protected:
+  static void expectReference(
+      const SharedDictionaryReference& reference,
+      uint32_t valueStreamId,
+      uint32_t dictionaryId,
+      DataType dataType) {
+    EXPECT_EQ(reference.valueStreamId, valueStreamId);
+    EXPECT_EQ(reference.dictionaryId, dictionaryId);
+    EXPECT_EQ(reference.dataType, dataType);
+  }
+
+  static void expectFileDictionary(
+      const FileDictionary& fileDictionary,
+      uint32_t dictionaryId,
+      DataType dataType,
+      uint64_t offset,
+      uint32_t length) {
+    EXPECT_EQ(fileDictionary.dictionaryId, dictionaryId);
+    EXPECT_EQ(fileDictionary.dataType, dataType);
+    EXPECT_EQ(fileDictionary.offset, offset);
+    EXPECT_EQ(fileDictionary.length, length);
+  }
+};
+
+TEST_F(SharedDictionaryCatalogTest, roundTripsReferencesAndFileDictionaries) {
+  const std::array stripeReferences{SharedDictionaryReference{
+      .valueStreamId = 10, .dictionaryId = 100, .dataType = DataType::Int32}};
+  const std::array fileReferences{SharedDictionaryReference{
+      .valueStreamId = 20, .dictionaryId = 7, .dataType = DataType::Int32}};
+  const std::array externalReferences{SharedDictionaryReference{
+      .valueStreamId = 30, .dictionaryId = 11, .dataType = DataType::Int64}};
+  const std::array fileDictionaries{FileDictionary{
+      .dictionaryId = 7,
+      .dataType = DataType::Int32,
+      .offset = 123,
+      .length = 45}};
+
+  struct TestCase {
+    const char* name;
+    bool hasStripeReference;
+    bool hasFileReference;
+    bool hasExternalReference;
+  };
+  const std::array testCases{
+      TestCase{"stripeOnly", true, false, false},
+      TestCase{"fileOnly", false, true, false},
+      TestCase{"externalOnly", false, false, true},
+      TestCase{"stripeAndFile", true, true, false},
+      TestCase{"stripeAndExternal", true, false, true},
+      TestCase{"fileAndExternal", false, true, true},
+      TestCase{"allScopes", true, true, true}};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    const auto catalog = SharedDictionaryCatalog::deserialize(
+        SharedDictionaryCatalog::serialize(
+            testCase.hasStripeReference
+                ? std::span<const SharedDictionaryReference>{stripeReferences}
+                : std::span<const SharedDictionaryReference>{},
+            testCase.hasFileReference
+                ? std::span<const SharedDictionaryReference>{fileReferences}
+                : std::span<const SharedDictionaryReference>{},
+            testCase.hasExternalReference
+                ? std::span<const SharedDictionaryReference>{externalReferences}
+                : std::span<const SharedDictionaryReference>{},
+            testCase.hasFileReference
+                ? std::span<const FileDictionary>{fileDictionaries}
+                : std::span<const FileDictionary>{}));
+
+    ASSERT_EQ(
+        catalog.stripeDictionaryReferences().size(),
+        testCase.hasStripeReference ? 1 : 0);
+    ASSERT_EQ(
+        catalog.fileDictionaryReferences().size(),
+        testCase.hasFileReference ? 1 : 0);
+    ASSERT_EQ(
+        catalog.externalDictionaryReferences().size(),
+        testCase.hasExternalReference ? 1 : 0);
+    ASSERT_EQ(
+        catalog.fileDictionaries().size(), testCase.hasFileReference ? 1 : 0);
+
+    const auto* stripeReference = catalog.findStripeDictionaryReference(10);
+    if (testCase.hasStripeReference) {
+      ASSERT_NE(stripeReference, nullptr);
+      expectReference(*stripeReference, 10, 100, DataType::Int32);
+    } else {
+      EXPECT_EQ(stripeReference, nullptr);
+    }
+
+    const auto* fileReference = catalog.findFileDictionaryReference(20);
+    const auto* fileDictionary = catalog.findFileDictionary(7);
+    if (testCase.hasFileReference) {
+      ASSERT_NE(fileReference, nullptr);
+      expectReference(*fileReference, 20, 7, DataType::Int32);
+      ASSERT_NE(fileDictionary, nullptr);
+      expectFileDictionary(*fileDictionary, 7, DataType::Int32, 123, 45);
+    } else {
+      EXPECT_EQ(fileReference, nullptr);
+      EXPECT_EQ(fileDictionary, nullptr);
+    }
+
+    const auto* externalReference = catalog.findExternalDictionaryReference(30);
+    if (testCase.hasExternalReference) {
+      ASSERT_NE(externalReference, nullptr);
+      expectReference(*externalReference, 30, 11, DataType::Int64);
+    } else {
+      EXPECT_EQ(externalReference, nullptr);
+    }
+
+    EXPECT_EQ(catalog.findStripeDictionaryReference(999), nullptr);
+    EXPECT_EQ(catalog.findFileDictionaryReference(999), nullptr);
+    EXPECT_EQ(catalog.findExternalDictionaryReference(999), nullptr);
+    EXPECT_EQ(catalog.findFileDictionary(999), nullptr);
+  }
+}
+
+TEST_F(SharedDictionaryCatalogTest, rejectsEmptyCatalog) {
+  NIMBLE_ASSERT_THROW(
+      SharedDictionaryCatalog::serialize({}, {}, {}, {}),
+      "Shared dictionary catalog must contain at least one entry.");
+}
+
+TEST_F(SharedDictionaryCatalogTest, rejectsDuplicateValueStreamAcrossScopes) {
+  const std::array stripeReferences{SharedDictionaryReference{
+      .valueStreamId = 10, .dictionaryId = 100, .dataType = DataType::Int32}};
+  const std::array fileReferences{SharedDictionaryReference{
+      .valueStreamId = 10, .dictionaryId = 7, .dataType = DataType::Int32}};
+
+  NIMBLE_ASSERT_THROW(
+      SharedDictionaryCatalog::serialize(
+          stripeReferences, fileReferences, {}, {}),
+      "Duplicate shared dictionary value stream 10.");
+}
+
+TEST_F(SharedDictionaryCatalogTest, rejectsInvalidReferenceDictionaryId) {
+  const std::array references{SharedDictionaryReference{
+      .valueStreamId = 10,
+      .dictionaryId = kInvalidSharedDictionaryId,
+      .dataType = DataType::Int32}};
+
+  NIMBLE_ASSERT_THROW(
+      SharedDictionaryCatalog::serialize(references, {}, {}, {}),
+      "Shared dictionary reference requires a valid dictionary id.");
+}
+
+TEST_F(SharedDictionaryCatalogTest, rejectsFileDictionaryWithoutAlphabet) {
+  const std::array fileDictionaries{FileDictionary{
+      .dictionaryId = 7,
+      .dataType = DataType::Int32,
+      .offset = 123,
+      .length = 0}};
+
+  NIMBLE_ASSERT_THROW(
+      SharedDictionaryCatalog::serialize({}, {}, {}, fileDictionaries),
+      "File dictionary must contain a non-empty alphabet.");
+}
+
+TEST_F(SharedDictionaryCatalogTest, rejectsMissingFileDictionary) {
+  const std::array fileReferences{SharedDictionaryReference{
+      .valueStreamId = 20, .dictionaryId = 7, .dataType = DataType::Int32}};
+
+  NIMBLE_ASSERT_THROW(
+      SharedDictionaryCatalog::serialize({}, fileReferences, {}, {}),
+      "File shared dictionary 7 does not exist.");
+}
+
+TEST_F(SharedDictionaryCatalogTest, rejectsFileDictionaryTypeMismatch) {
+  const std::array fileReferences{SharedDictionaryReference{
+      .valueStreamId = 20, .dictionaryId = 7, .dataType = DataType::Int32}};
+  const std::array fileDictionaries{FileDictionary{
+      .dictionaryId = 7,
+      .dataType = DataType::Int64,
+      .offset = 123,
+      .length = 45}};
+
+  NIMBLE_ASSERT_THROW(
+      SharedDictionaryCatalog::serialize(
+          {}, fileReferences, {}, fileDictionaries),
+      "File shared dictionary 7 has an inconsistent type.");
+}
+
+TEST_F(SharedDictionaryCatalogTest, rejectsDuplicateFileDictionaryId) {
+  const std::array fileDictionaries{
+      FileDictionary{
+          .dictionaryId = 7,
+          .dataType = DataType::Int32,
+          .offset = 123,
+          .length = 45},
+      FileDictionary{
+          .dictionaryId = 7,
+          .dataType = DataType::Int32,
+          .offset = 168,
+          .length = 9}};
+
+  NIMBLE_ASSERT_THROW(
+      SharedDictionaryCatalog::serialize({}, {}, {}, fileDictionaries),
+      "Duplicate file shared dictionary ID 7.");
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
@@ -33,6 +33,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
@@ -73,6 +74,23 @@ class TestSharedDictionaryResolver final : public SharedDictionaryResolver {
 
  private:
   const uint32_t dictionaryId_;
+  const std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
+};
+
+class SingleAlphabetResolver final : public SharedDictionaryResolver {
+ public:
+  explicit SingleAlphabetResolver(
+      std::shared_ptr<const SharedDictionaryAlphabet> alphabet)
+      : alphabet_{std::move(alphabet)} {}
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      SharedDictionaryScope /*scope*/,
+      uint32_t /*dictionaryId*/,
+      DataType /*dataType*/) const final {
+    return alphabet_;
+  }
+
+ private:
   const std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
 };
 
@@ -173,12 +191,16 @@ std::span<const T> valueSpan(const std::vector<T>& values) {
   return {values.data(), values.size()};
 }
 
-TEST_F(SharedDictionaryEncodingTest, alphabetPublicApi) {
+TEST_F(SharedDictionaryEncodingTest, alphabetBasic) {
   const std::vector<int32_t> values{10, 20, 30};
   const std::vector<EncodingType> candidateEncodings{
       EncodingType::FixedBitWidth};
-  const auto alphabet = test::createSharedDictionaryAlphabet<int32_t>(
-      values, candidateEncodings, pool_.get());
+  const auto encoded = SharedDictionaryAlphabet::encode<int32_t>(
+      values, candidateEncodings, *buffer_);
+  auto encodedAlphabetOwner = std::make_shared<const std::string>(encoded);
+  const std::string_view encodedAlphabet{*encodedAlphabetOwner};
+  const auto alphabet = SharedDictionaryAlphabet::create(
+      encodedAlphabet, std::move(encodedAlphabetOwner), pool_.get());
 
   EXPECT_EQ(alphabet->dataType(), DataType::Int32);
   EXPECT_EQ(alphabet->entryCount(), values.size());
@@ -193,6 +215,28 @@ TEST_F(SharedDictionaryEncodingTest, alphabetPublicApi) {
 
   const std::vector<TypeTraits<int32_t>::physicalType> expected{30, 10, 20};
   EXPECT_EQ(materialized, expected);
+}
+
+TEST_F(SharedDictionaryEncodingTest, alphabetOwnerKeepsViewBytesAlive) {
+  std::shared_ptr<const SharedDictionaryAlphabet> alphabet;
+  {
+    Buffer buffer{*pool_};
+    const std::vector<int32_t> values{10, 20, 30};
+    const auto encoded = SharedDictionaryAlphabet::encode<int32_t>(
+        values, std::array{EncodingType::FixedBitWidth}, buffer);
+    auto encodedAlphabetOwner = std::make_shared<const std::string>(encoded);
+    const std::string_view encodedAlphabet{*encodedAlphabetOwner};
+    alphabet = SharedDictionaryAlphabet::create(
+        encodedAlphabet, std::move(encodedAlphabetOwner), pool_.get());
+  }
+
+  ASSERT_NE(alphabet, nullptr);
+  EXPECT_TRUE(alphabet->testingUsesEncodingView());
+  EXPECT_FALSE(alphabet->testingUsesDecodedEntries());
+  const auto poolBytesAfterCreate = pool_->usedBytes();
+  EXPECT_EQ(alphabet->entryCount(), 3);
+  EXPECT_EQ(alphabet->physicalValueAt<int32_t>(2), 30);
+  EXPECT_EQ(pool_->usedBytes(), poolBytesAfterCreate);
 }
 
 TEST_F(SharedDictionaryEncodingTest, alphabetSelectsEncodingFromCandidates) {
@@ -372,6 +416,30 @@ TEST_F(SharedDictionaryEncodingTest, publicApiMaterializesAndSkipsRows) {
   encoding->materialize(2, suffix.data());
   const std::vector<int32_t> expectedSuffix{40, 20};
   EXPECT_EQ(std::vector<int32_t>(suffix.begin(), suffix.end()), expectedSuffix);
+}
+
+TEST_F(SharedDictionaryEncodingTest, encodingRejectsInvalidResolver) {
+  const auto encoded = test::encodeSharedDictionary(*buffer_, {0});
+
+  {
+    SCOPED_TRACE("missing resolver");
+    NIMBLE_ASSERT_THROW(
+        createEncoding(encoded),
+        "Shared dictionary encoding requires a resolver.");
+  }
+
+  {
+    SCOPED_TRACE("resolver type mismatch");
+    const std::vector<int64_t> alphabetValues{10, 20};
+    Encoding::Options options;
+    options.sharedDictionaryResolver = std::make_shared<SingleAlphabetResolver>(
+        test::createSharedDictionaryAlphabet<int64_t>(
+            alphabetValues, std::span<const EncodingType>{}, pool_.get()));
+
+    NIMBLE_ASSERT_THROW(
+        createEncoding(encoded, options),
+        "Shared dictionary 7 has unexpected type.");
+  }
 }
 
 TEST_F(SharedDictionaryEncodingTest, sliceConvertsToLocalDictionary) {

--- a/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h
+++ b/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h
@@ -17,9 +17,10 @@
 
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <span>
+#include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "velox/dwio/nimble/common/Buffer.h"
@@ -30,26 +31,19 @@
 
 namespace facebook::nimble::test {
 
-/// Encodes values and returns an alphabet reading them back. The returned
-/// alphabet owns the buffer holding its encoded bytes, so callers do not have
-/// to keep one alive themselves.
+/// Encodes values and returns an alphabet reading them back.
 template <typename T>
 std::shared_ptr<const SharedDictionaryAlphabet> createSharedDictionaryAlphabet(
     std::span<const T> values,
     std::span<const EncodingType> candidateEncodings,
     velox::memory::MemoryPool* pool) {
-  struct OwnedAlphabet {
-    Buffer buffer;
-    std::optional<SharedDictionaryAlphabet> alphabet;
-
-    explicit OwnedAlphabet(velox::memory::MemoryPool* pool) : buffer{*pool} {}
-  };
-
-  auto owned = std::make_shared<OwnedAlphabet>(pool);
-  const auto encoded = SharedDictionaryAlphabet::encode<T>(
-      values, candidateEncodings, owned->buffer);
-  owned->alphabet.emplace(encoded, Encoding::Options{}, pool);
-  return {owned, &owned->alphabet.value()};
+  Buffer buffer{*pool};
+  const auto encoded =
+      SharedDictionaryAlphabet::encode<T>(values, candidateEncodings, buffer);
+  auto encodedAlphabetOwner = std::make_shared<const std::string>(encoded);
+  const std::string_view encodedAlphabet{*encodedAlphabetOwner};
+  return SharedDictionaryAlphabet::create(
+      encodedAlphabet, std::move(encodedAlphabetOwner), pool);
 }
 
 class TestSharedDictionarySelectionPolicy final

--- a/velox/dwio/nimble/tablet/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/CMakeLists.txt
@@ -185,6 +185,7 @@ target_link_libraries(
 add_library(
   nimble_tablet_reader
   FileLayout.cpp
+  SharedDictionaryReader.cpp
   StripeGroup.cpp
   TabletReader.cpp
   TabletReader.h

--- a/velox/dwio/nimble/tablet/SharedDictionaryReader.cpp
+++ b/velox/dwio/nimble/tablet/SharedDictionaryReader.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/tablet/SharedDictionaryReader.h"
+
+#include <utility>
+
+#include "velox/common/Casts.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/tablet/TabletReader.h"
+
+namespace facebook::nimble {
+
+std::unique_ptr<const SharedDictionaryReaderFactory>
+SharedDictionaryReaderFactory::create(
+    std::string_view catalog,
+    std::shared_ptr<const ExternalDictionaryResolver> externalResolver,
+    const TabletReader* tabletReader,
+    velox::memory::MemoryPool* pool) {
+  return std::unique_ptr<SharedDictionaryReaderFactory>(
+      new SharedDictionaryReaderFactory{
+          catalog,
+          std::move(externalResolver),
+          /*tabletReader=*/tabletReader,
+          /*pool=*/pool});
+}
+
+SharedDictionaryReaderFactory::SharedDictionaryReaderFactory(
+    std::string_view catalog,
+    std::shared_ptr<const ExternalDictionaryResolver> externalResolver,
+    const TabletReader* tabletReader,
+    velox::memory::MemoryPool* pool)
+    : tabletReader_{velox::checkedNotNull(tabletReader)},
+      pool_{velox::checkedNotNull(pool)},
+      externalResolver_{std::move(externalResolver)},
+      catalog_{SharedDictionaryCatalog::deserialize(catalog)},
+      cache_{
+          [this](AlphabetCacheKey cacheKey) { return loadAlphabet(cacheKey); },
+          /*pinEntries=*/true} {}
+
+std::optional<uint32_t> SharedDictionaryReaderFactory::dictionaryStreamId(
+    uint32_t valueStreamId) const {
+  const auto* reference = catalog_.findStripeDictionaryReference(valueStreamId);
+  return reference == nullptr
+      ? std::nullopt
+      : std::optional<uint32_t>{reference->dictionaryId};
+}
+
+std::vector<std::optional<uint32_t>>
+SharedDictionaryReaderFactory::dictionaryStreamIds(
+    std::span<const uint32_t> valueStreamIds) const {
+  if (catalog_.stripeDictionaryReferences().empty()) {
+    return {};
+  }
+
+  std::vector<std::optional<uint32_t>> dictionaryStreamIds;
+  for (size_t i = 0; i < valueStreamIds.size(); ++i) {
+    const auto* reference =
+        catalog_.findStripeDictionaryReference(valueStreamIds[i]);
+    if (reference != nullptr) {
+      if (dictionaryStreamIds.empty()) {
+        dictionaryStreamIds.resize(valueStreamIds.size());
+      }
+      dictionaryStreamIds[i] = reference->dictionaryId;
+    }
+  }
+  return dictionaryStreamIds;
+}
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+SharedDictionaryReaderFactory::resolveAlphabet(uint32_t valueStreamId) const {
+  const auto* fileReference =
+      catalog_.findFileDictionaryReference(valueStreamId);
+  if (fileReference != nullptr) {
+    return cache_.getOrCreate(alphabetCacheKey(
+        SharedDictionaryScope::File,
+        fileReference->dictionaryId,
+        fileReference->dataType));
+  }
+
+  const auto* externalReference =
+      catalog_.findExternalDictionaryReference(valueStreamId);
+  return externalReference == nullptr ? nullptr
+                                      : cache_.getOrCreate(alphabetCacheKey(
+                                            SharedDictionaryScope::External,
+                                            externalReference->dictionaryId,
+                                            externalReference->dataType));
+}
+
+SharedDictionaryReaderFactory::AlphabetCacheKey
+SharedDictionaryReaderFactory::alphabetCacheKey(
+    SharedDictionaryScope scope,
+    uint32_t dictionaryId,
+    DataType dataType) {
+  return (static_cast<uint64_t>(static_cast<uint8_t>(scope)) << 40) |
+      (static_cast<uint64_t>(static_cast<uint8_t>(dataType)) << 32) |
+      dictionaryId;
+}
+
+SharedDictionaryReaderFactory::AlphabetPtr
+SharedDictionaryReaderFactory::loadAlphabet(AlphabetCacheKey cacheKey) const {
+  const auto scope =
+      toSharedDictionaryScope(static_cast<uint8_t>(cacheKey >> 40));
+  const auto dataType =
+      static_cast<DataType>(static_cast<uint8_t>(cacheKey >> 32));
+  const auto dictionaryId = static_cast<uint32_t>(cacheKey);
+
+  AlphabetPtr alphabet;
+  switch (scope) {
+    case SharedDictionaryScope::Stripe:
+      NIMBLE_UNREACHABLE("Stripe dictionaries are decoded by the reader.");
+    case SharedDictionaryScope::File: {
+      const auto* fileDictionary = catalog_.findFileDictionary(dictionaryId);
+      NIMBLE_CHECK_FILE_NOT_NULL(
+          fileDictionary,
+          "File shared dictionary {} does not exist.",
+          dictionaryId);
+      NIMBLE_CHECK_FILE_LE(
+          fileDictionary->offset,
+          tabletReader_->fileSize_,
+          "File shared dictionary {} points outside the tablet.",
+          dictionaryId);
+      NIMBLE_CHECK_FILE_LE(
+          fileDictionary->length,
+          tabletReader_->fileSize_ - fileDictionary->offset,
+          "File shared dictionary {} points outside the tablet.",
+          dictionaryId);
+      std::shared_ptr<const MetadataBuffer> encodedAlphabetOwner{
+          tabletReader_->readMetadata(
+              MetadataSection{
+                  fileDictionary->offset,
+                  fileDictionary->length,
+                  CompressionType::Uncompressed,
+                  fileDictionary->length})};
+      const auto encodedAlphabet = encodedAlphabetOwner->content();
+      alphabet = SharedDictionaryAlphabet::create(
+          encodedAlphabet, std::move(encodedAlphabetOwner), pool_);
+      NIMBLE_CHECK_FILE_EQ(
+          alphabet->dataType(),
+          fileDictionary->dataType,
+          "File shared dictionary {} has an inconsistent type.",
+          dictionaryId);
+      break;
+    }
+    case SharedDictionaryScope::External:
+      NIMBLE_USER_CHECK_NOT_NULL(
+          externalResolver_,
+          "External shared dictionary {} requires an ExternalDictionaryResolver.",
+          dictionaryId);
+      alphabet = externalResolver_->resolve(dictionaryId, dataType);
+      break;
+  }
+
+  NIMBLE_CHECK_NOT_NULL(alphabet);
+  return alphabet;
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/tablet/SharedDictionaryReader.h
+++ b/velox/dwio/nimble/tablet/SharedDictionaryReader.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
+#include "velox/dwio/nimble/tablet/MetadataCache.h"
+
+namespace facebook::nimble {
+
+class TabletReader;
+
+/// Resolves External shared dictionaries referenced by a tablet.
+class ExternalDictionaryResolver {
+ public:
+  virtual ~ExternalDictionaryResolver() = default;
+
+  virtual std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      uint32_t dictionaryId,
+      DataType dataType) const = 0;
+};
+
+/// Resolves file-wide value-stream bindings and caches decoded alphabets.
+class SharedDictionaryReaderFactory {
+ public:
+  /// Creates and initializes a reader factory from serialized catalog data.
+  static std::unique_ptr<const SharedDictionaryReaderFactory> create(
+      std::string_view catalog,
+      std::shared_ptr<const ExternalDictionaryResolver> externalResolver,
+      const TabletReader* tabletReader,
+      velox::memory::MemoryPool* pool);
+
+  /// Returns whether the tablet contains file or external dictionaries.
+  bool hasGlobalDictionaries() const {
+    return !catalog_.fileDictionaryReferences().empty() ||
+        !catalog_.externalDictionaryReferences().empty();
+  }
+
+  /// Returns whether the tablet contains stripe dictionary bindings.
+  bool hasStripeDictionaries() const {
+    return !catalog_.stripeDictionaryReferences().empty();
+  }
+
+  /// Returns the stripe dictionary stream for a value stream, if any.
+  std::optional<uint32_t> dictionaryStreamId(uint32_t valueStreamId) const;
+
+  /// Returns stripe dictionary streams for value streams. Returns empty when
+  /// none of the supplied streams uses a stripe dictionary.
+  std::vector<std::optional<uint32_t>> dictionaryStreamIds(
+      std::span<const uint32_t> valueStreamIds) const;
+
+  /// Returns the file or external alphabet for a value stream, if any.
+  std::shared_ptr<const SharedDictionaryAlphabet> resolveAlphabet(
+      uint32_t valueStreamId) const;
+
+ private:
+  using AlphabetPtr = std::shared_ptr<const SharedDictionaryAlphabet>;
+  using AlphabetCacheKey = uint64_t;
+
+  // Parses the catalog and configures lazy alphabet loading.
+  SharedDictionaryReaderFactory(
+      std::string_view catalog,
+      std::shared_ptr<const ExternalDictionaryResolver> externalResolver,
+      const TabletReader* tabletReader,
+      velox::memory::MemoryPool* pool);
+
+  // Packs a scope, type, and dictionary ID into a cache key.
+  static AlphabetCacheKey alphabetCacheKey(
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId,
+      DataType dataType);
+
+  // Loads and decodes a file or external alphabet on first use.
+  AlphabetPtr loadAlphabet(AlphabetCacheKey cacheKey) const;
+
+  // Tablet that owns file-scope alphabet ranges.
+  const TabletReader* const tabletReader_;
+  // Pool used to decode alphabet entries.
+  velox::memory::MemoryPool* const pool_;
+  // Optional provider for dictionaries not stored in the tablet.
+  const std::shared_ptr<const ExternalDictionaryResolver> externalResolver_;
+  // Immutable scope bindings and file dictionary locations.
+  const SharedDictionaryCatalog catalog_;
+
+  // Decoded file and external alphabets retained for the reader lifetime.
+  mutable MetadataCache<AlphabetCacheKey, const SharedDictionaryAlphabet>
+      cache_;
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/tablet/TabletReader.cpp
+++ b/velox/dwio/nimble/tablet/TabletReader.cpp
@@ -25,6 +25,7 @@
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/tablet/FooterGenerated.h"
 #include "velox/dwio/nimble/tablet/IndexGenerated.h"
+#include "velox/dwio/nimble/tablet/SharedDictionaryReader.h"
 #include "velox/dwio/nimble/tablet/StripeGroup.h"
 
 #include "flatbuffers/flatbuffers.h"
@@ -257,6 +258,39 @@ TabletReader::TabletReader(
   init(options);
 }
 
+TabletReader::~TabletReader() = default;
+
+bool TabletReader::hasGlobalDictionaries() const {
+  return sharedDictionaryReaderFactory_ != nullptr &&
+      sharedDictionaryReaderFactory_->hasGlobalDictionaries();
+}
+
+bool TabletReader::hasStripeDictionaries() const {
+  return sharedDictionaryReaderFactory_ != nullptr &&
+      sharedDictionaryReaderFactory_->hasStripeDictionaries();
+}
+
+std::optional<uint32_t> TabletReader::stripeDictionaryStreamId(
+    uint32_t valueStreamId) const {
+  return sharedDictionaryReaderFactory_ == nullptr
+      ? std::nullopt
+      : sharedDictionaryReaderFactory_->dictionaryStreamId(valueStreamId);
+}
+
+std::vector<std::optional<uint32_t>> TabletReader::stripeDictionaryStreamIds(
+    std::span<const uint32_t> valueStreamIds) const {
+  return sharedDictionaryReaderFactory_ == nullptr
+      ? std::vector<std::optional<uint32_t>>{}
+      : sharedDictionaryReaderFactory_->dictionaryStreamIds(valueStreamIds);
+}
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+TabletReader::resolveDictionaryAlphabet(uint32_t valueStreamId) const {
+  return sharedDictionaryReaderFactory_ == nullptr
+      ? nullptr
+      : sharedDictionaryReaderFactory_->resolveAlphabet(valueStreamId);
+}
+
 void TabletReader::init(const Options& options) {
   fileSize_ = file_->size();
   NIMBLE_CHECK_FILE(
@@ -294,6 +328,7 @@ void TabletReader::init(const Options& options) {
 
   initStripes(footerView, footerOffset);
   initFeatures();
+  initSharedDictionaries(options);
   initIndexDescriptors();
   initClusterIndex();
   initChunkStats(footerView, footerOffset);
@@ -420,6 +455,7 @@ bool TabletReader::initFromCache(const Options& options) {
 
   initStripes();
   initFeatures();
+  initSharedDictionaries(options);
   initIndexDescriptors();
   initClusterIndex();
   initChunkStats();
@@ -479,6 +515,13 @@ void TabletReader::cacheMetadata(
   if (auto featuresIt = optionalSections_.find(std::string{kFeaturesSection});
       featuresIt != optionalSections_.end()) {
     cacheSection(featuresIt->second);
+  }
+
+  if (sharedDictionaryReaderFactory_ != nullptr) {
+    auto sharedDictionaryIt =
+        optionalSections_.find(std::string{kSharedDictionarySection});
+    NIMBLE_CHECK(sharedDictionaryIt != optionalSections_.end());
+    cacheSection(sharedDictionaryIt->second);
   }
 
   if (clusterIndex_ != nullptr || denseIndexRegistry_ != nullptr) {
@@ -706,10 +749,24 @@ void TabletReader::initFeatures() {
   features_ = FileFeatures::deserialize(section->content());
 }
 
+void TabletReader::initSharedDictionaries(const Options& options) {
+  auto section = loadOptionalSection(
+      std::string{kSharedDictionarySection}, /*keepCache=*/false);
+  if (!section.has_value()) {
+    return;
+  }
+
+  sharedDictionaryReaderFactory_ = SharedDictionaryReaderFactory::create(
+      section->content(),
+      options.externalResolver,
+      /*tabletReader=*/this,
+      /*pool=*/pool_);
+}
+
 std::vector<std::string> TabletReader::preloadSectionNames(
     const Options& options) const {
   std::vector<std::string> names;
-  names.reserve(options.preloadOptionalSections.size() + 2);
+  names.reserve(options.preloadOptionalSections.size() + 3);
   auto addName = [&names](std::string name) {
     if (std::find(names.begin(), names.end(), name) == names.end()) {
       names.emplace_back(std::move(name));
@@ -722,6 +779,7 @@ std::vector<std::string> TabletReader::preloadSectionNames(
     addName(std::string{kIndexSection});
   }
   addName(std::string{kFeaturesSection});
+  addName(std::string{kSharedDictionarySection});
   return names;
 }
 

--- a/velox/dwio/nimble/tablet/TabletReader.h
+++ b/velox/dwio/nimble/tablet/TabletReader.h
@@ -63,6 +63,10 @@
 
 namespace facebook::nimble {
 
+class SharedDictionaryReaderFactory;
+class SharedDictionaryAlphabet;
+class ExternalDictionaryResolver;
+
 namespace test {
 class TabletReaderTestHelper;
 } // namespace test
@@ -119,6 +123,8 @@ using index::ClusterIndex;
 ///  the stream identifier provided in the input vector.
 class TabletReader {
  public:
+  ~TabletReader();
+
   /// Options for configuring TabletReader behavior.
   struct Options {
     /// Speculative tail read size (0 = adaptive mode that reads postscript
@@ -192,6 +198,9 @@ class TabletReader {
     /// bytes bypass the async data cache. Defaults to the largest entry an
     /// SsdRun can describe, so every cached entry can reach SSD.
     uint32_t maxCacheEntrySize{1U << velox::cache::SsdRun::kSizeBits};
+
+    /// Resolves External shared integer dictionaries referenced by this file.
+    std::shared_ptr<const ExternalDictionaryResolver> externalResolver;
   };
 
   /// Compute checksum from the beginning of the file all the way to footer
@@ -386,7 +395,28 @@ class TabletReader {
 
   StripeIdentifier stripeIdentifier(uint32_t stripeIndex) const;
 
+  /// Returns whether any value stream uses a file or external dictionary.
+  bool hasGlobalDictionaries() const;
+
+  /// Returns whether any value stream uses a stripe dictionary.
+  bool hasStripeDictionaries() const;
+
+  /// Returns the stripe-local dictionary stream used by a value stream.
+  std::optional<uint32_t> stripeDictionaryStreamId(
+      uint32_t valueStreamId) const;
+
+  /// Returns stripe-local dictionary streams for the supplied value streams.
+  /// Returns empty when none uses a stripe dictionary.
+  std::vector<std::optional<uint32_t>> stripeDictionaryStreamIds(
+      std::span<const uint32_t> valueStreamIds) const;
+
+  /// Resolves the file or external alphabet bound to a value stream.
+  std::shared_ptr<const SharedDictionaryAlphabet> resolveDictionaryAlphabet(
+      uint32_t valueStreamId) const;
+
  private:
+  friend class SharedDictionaryReaderFactory;
+
   TabletReader(
       std::shared_ptr<velox::ReadFile> readFile,
       MemoryPool& pool,
@@ -501,8 +531,10 @@ class TabletReader {
 
   void initFeatures();
 
-  // Returns the list of optional section names to preload: the user-specified
-  // sections plus the index section if present.
+  // Creates dictionary lookup state from the preloaded optional section.
+  void initSharedDictionaries(const Options& options);
+
+  // Returns user-specified and built-in optional sections to preload.
   std::vector<std::string> preloadSectionNames(const Options& options) const;
 
   // Reads and decompresses a metadata section via MetadataInput.
@@ -579,6 +611,9 @@ class TabletReader {
   mutable folly::Synchronized<
       std::unordered_map<std::string, std::unique_ptr<MetadataBuffer>>>
       optionalSectionsCache_;
+
+  std::unique_ptr<const SharedDictionaryReaderFactory>
+      sharedDictionaryReaderFactory_;
 
   friend class TabletHelper;
   friend class test::TabletReaderTestHelper;

--- a/velox/dwio/nimble/tablet/TabletWriter.cpp
+++ b/velox/dwio/nimble/tablet/TabletWriter.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/nimble/tablet/TabletWriter.h"
 
+#include <limits>
+
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
@@ -435,17 +437,27 @@ MetadataSection TabletWriter::createMetadataSection(std::string_view metadata) {
   return MetadataSection{offset, size, compressionType, uncompressedSize};
 }
 
+std::pair<uint64_t, uint32_t> TabletWriter::writeSegments(
+    const std::vector<std::string_view>& segments) {
+  checkNotClosed();
+  const auto offset = file_->size();
+  for (const auto segment : segments) {
+    writeWithChecksum(segment);
+  }
+  const auto length = file_->size() - offset;
+  NIMBLE_CHECK_LE(
+      length,
+      std::numeric_limits<uint32_t>::max(),
+      "Raw data section exceeds uint32_t size.");
+  return {offset, static_cast<uint32_t>(length)};
+}
+
 void TabletWriter::invokeCloseCallback() {
   if (options_.closeCallback == nullptr) {
     return;
   }
   auto writeDataFn = [this](const std::vector<std::string_view>& segments) {
-    const auto offset = file_->size();
-    for (const auto& segment : segments) {
-      writeWithChecksum(segment);
-    }
-    return std::make_pair(
-        offset, static_cast<uint32_t>(file_->size() - offset));
+    return writeSegments(segments);
   };
   auto createMetadataFn = [this](std::string_view metadata) {
     return createMetadataSection(metadata);
@@ -461,12 +473,7 @@ void TabletWriter::invokeStripeGroupFlushCallback() {
     return;
   }
   auto writeDataFn = [this](const std::vector<std::string_view>& segments) {
-    const auto offset = file_->size();
-    for (const auto& segment : segments) {
-      writeWithChecksum(segment);
-    }
-    return std::make_pair(
-        offset, static_cast<uint32_t>(file_->size() - offset));
+    return writeSegments(segments);
   };
   auto createMetadataFn = [this](std::string_view metadata) {
     return createMetadataSection(metadata);

--- a/velox/dwio/nimble/tablet/TabletWriter.h
+++ b/velox/dwio/nimble/tablet/TabletWriter.h
@@ -170,6 +170,11 @@ class TabletWriter {
   // to decide whether to compress.
   CompressionType writeMetadata(std::string_view metadata);
 
+  // Writes raw data segments contiguously and returns their file offset and
+  // total byte length.
+  std::pair<uint64_t, uint32_t> writeSegments(
+      const std::vector<std::string_view>& segments);
+
   // Write stripe group metadata entry and also add that to footer sections if
   // exceeds metadata flush size.
   void tryWriteStripeGroup(bool force = false);

--- a/velox/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   FileFeaturesTest.cpp
   FileLayoutTest.cpp
   MetadataBufferTest.cpp
+  SharedDictionaryReaderTest.cpp
   TabletTest.cpp
   TabletTestUtils.h
 )

--- a/velox/dwio/nimble/tablet/tests/SharedDictionaryReaderTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/SharedDictionaryReaderTest.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/tablet/SharedDictionaryReader.h"
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "velox/common/file/File.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/common/tests/TestUtils.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/tablet/Constants.h"
+#include "velox/dwio/nimble/tablet/TabletWriter.h"
+#include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+
+namespace facebook::nimble {
+namespace {
+
+class TestDictionaryResolver final : public ExternalDictionaryResolver {
+ public:
+  explicit TestDictionaryResolver(
+      std::shared_ptr<const SharedDictionaryAlphabet> alphabet)
+      : alphabet_{std::move(alphabet)} {}
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      uint32_t dictionaryId,
+      DataType dataType) const final {
+    ++resolveCount_;
+    dictionaryId_ = dictionaryId;
+    dataType_ = dataType;
+    return alphabet_;
+  }
+
+  uint32_t resolveCount() const {
+    return resolveCount_;
+  }
+
+  uint32_t dictionaryId() const {
+    return dictionaryId_;
+  }
+
+  DataType dataType() const {
+    return dataType_;
+  }
+
+ private:
+  const std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
+  mutable uint32_t resolveCount_{0};
+  mutable uint32_t dictionaryId_{kInvalidSharedDictionaryId};
+  mutable DataType dataType_{DataType::Undefined};
+};
+
+class SharedDictionaryReaderTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() final {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::string encodeAlphabet(std::span<const int32_t> values) {
+    Buffer buffer{*pool_};
+    return std::string{SharedDictionaryAlphabet::encode<int32_t>(
+        values, std::array{EncodingType::Trivial}, buffer)};
+  }
+
+  std::shared_ptr<const SharedDictionaryAlphabet> createAlphabet(
+      std::span<const int32_t> values) {
+    auto owner = std::make_shared<const std::string>(encodeAlphabet(values));
+    const std::string_view encodedAlphabet{*owner};
+    return SharedDictionaryAlphabet::create(
+        encodedAlphabet, std::move(owner), pool_.get());
+  }
+
+  std::shared_ptr<TabletReader> createTablet(
+      std::optional<std::string> catalog,
+      std::shared_ptr<const ExternalDictionaryResolver> resolver = nullptr) {
+    auto file = std::make_shared<std::string>();
+    velox::InMemoryWriteFile writeFile{file.get()};
+    auto writer = TabletWriter::create(&writeFile, *pool_, {});
+    if (catalog.has_value()) {
+      writer->writeOptionalSection(
+          std::string{kSharedDictionarySection}, *catalog);
+    }
+    writer->close();
+
+    auto options = test::makeTestTabletOptions(pool_.get());
+    options.externalResolver = std::move(resolver);
+    files_.push_back(file);
+    auto readFile =
+        std::make_shared<testing::InMemoryTrackableReadFile>(*file, true);
+    return TabletReader::create(readFile, pool_.get(), options);
+  }
+
+  std::shared_ptr<TabletReader> createTabletWithSharedDictionarySection(
+      std::span<const SharedDictionaryReference> stripeDictionaryReferences,
+      std::span<const SharedDictionaryReference> fileDictionaryReferences,
+      uint32_t fileDictionaryId,
+      std::string_view fileEncodedAlphabet) {
+    auto file = std::make_shared<std::string>();
+    velox::InMemoryWriteFile writeFile{file.get()};
+    TabletWriter::Options writerOptions;
+    writerOptions.closeCallback =
+        [&](const WriteDataFn& writeDataFn,
+            const CreateMetadataSectionFn& /*createMetadataFn*/,
+            const WriteOptionalSectionFn& writeMetadataFn) {
+          const auto [offset, length] =
+              writeDataFn(std::vector<std::string_view>{fileEncodedAlphabet});
+          const std::array fileDictionaries{FileDictionary{
+              .dictionaryId = fileDictionaryId,
+              .dataType = DataType::Int32,
+              .offset = offset,
+              .length = length}};
+          const auto catalog = SharedDictionaryCatalog::serialize(
+              stripeDictionaryReferences,
+              fileDictionaryReferences,
+              {},
+              fileDictionaries);
+          writeMetadataFn(std::string{kSharedDictionarySection}, catalog);
+        };
+    auto writer =
+        TabletWriter::create(&writeFile, *pool_, std::move(writerOptions));
+    writer->close();
+
+    auto options = test::makeTestTabletOptions(pool_.get());
+    files_.push_back(file);
+    return TabletReader::create(
+        std::make_shared<testing::InMemoryTrackableReadFile>(*file, true),
+        pool_.get(),
+        options);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<std::shared_ptr<std::string>> files_;
+};
+
+TEST_F(SharedDictionaryReaderTest, noCatalog) {
+  auto tablet = createTablet(std::nullopt);
+
+  EXPECT_FALSE(tablet->hasStripeDictionaries());
+  EXPECT_FALSE(tablet->hasGlobalDictionaries());
+  EXPECT_FALSE(tablet->stripeDictionaryStreamId(10).has_value());
+  EXPECT_TRUE(tablet->stripeDictionaryStreamIds(std::array<uint32_t, 2>{10, 20})
+                  .empty());
+  EXPECT_EQ(tablet->resolveDictionaryAlphabet(10), nullptr);
+}
+
+TEST_F(SharedDictionaryReaderTest, basic) {
+  constexpr uint32_t kStripeValueStreamId = 10;
+  constexpr uint32_t kDictionaryStreamId = 100;
+  constexpr uint32_t kFileValueStreamId = 20;
+  constexpr uint32_t kSecondFileValueStreamId = 21;
+  constexpr uint32_t kFileDictionaryId = 7;
+  const std::array<int32_t, 3> values{10, 20, 30};
+  const auto fileEncodedAlphabet = encodeAlphabet(values);
+  const std::array stripeDictionaryReferences{SharedDictionaryReference{
+      .valueStreamId = kStripeValueStreamId,
+      .dictionaryId = kDictionaryStreamId,
+      .dataType = DataType::Int32}};
+  const std::array fileDictionaryReferences{
+      SharedDictionaryReference{
+          .valueStreamId = kFileValueStreamId,
+          .dictionaryId = kFileDictionaryId,
+          .dataType = DataType::Int32},
+      SharedDictionaryReference{
+          .valueStreamId = kSecondFileValueStreamId,
+          .dictionaryId = kFileDictionaryId,
+          .dataType = DataType::Int32}};
+
+  auto tablet = createTabletWithSharedDictionarySection(
+      stripeDictionaryReferences,
+      fileDictionaryReferences,
+      kFileDictionaryId,
+      fileEncodedAlphabet);
+
+  EXPECT_TRUE(tablet->hasStripeDictionaries());
+  EXPECT_TRUE(tablet->hasGlobalDictionaries());
+  EXPECT_EQ(
+      tablet->stripeDictionaryStreamId(kStripeValueStreamId),
+      kDictionaryStreamId);
+  EXPECT_FALSE(
+      tablet->stripeDictionaryStreamId(kFileValueStreamId).has_value());
+
+  const std::array valueStreamIds{
+      uint32_t{999}, kStripeValueStreamId, kFileValueStreamId};
+  const auto dictionaryStreamIds =
+      tablet->stripeDictionaryStreamIds(valueStreamIds);
+  ASSERT_EQ(dictionaryStreamIds.size(), valueStreamIds.size());
+  EXPECT_FALSE(dictionaryStreamIds[0].has_value());
+  EXPECT_EQ(dictionaryStreamIds[1], kDictionaryStreamId);
+  EXPECT_FALSE(dictionaryStreamIds[2].has_value());
+
+  EXPECT_EQ(tablet->resolveDictionaryAlphabet(kStripeValueStreamId), nullptr);
+  const auto alphabet = tablet->resolveDictionaryAlphabet(kFileValueStreamId);
+  ASSERT_NE(alphabet, nullptr);
+  EXPECT_EQ(alphabet->entryCount(), values.size());
+  EXPECT_EQ(alphabet->physicalValueAt<int32_t>(1), 20);
+  EXPECT_EQ(tablet->resolveDictionaryAlphabet(kFileValueStreamId), alphabet);
+  EXPECT_EQ(
+      tablet->resolveDictionaryAlphabet(kSecondFileValueStreamId), alphabet);
+}
+
+TEST_F(SharedDictionaryReaderTest, rejectsFileDictionaryOutsideTablet) {
+  constexpr uint32_t kValueStreamId = 20;
+  constexpr uint32_t kDictionaryId = 7;
+  const std::array fileReferences{SharedDictionaryReference{
+      .valueStreamId = kValueStreamId,
+      .dictionaryId = kDictionaryId,
+      .dataType = DataType::Int32}};
+  const std::array fileDictionaries{FileDictionary{
+      .dictionaryId = kDictionaryId,
+      .dataType = DataType::Int32,
+      .offset = std::numeric_limits<uint64_t>::max(),
+      .length = 1}};
+  auto tablet = createTablet(
+      SharedDictionaryCatalog::serialize(
+          {}, fileReferences, {}, fileDictionaries));
+
+  NIMBLE_ASSERT_FILE_THROW(
+      tablet->resolveDictionaryAlphabet(kValueStreamId),
+      "File shared dictionary 7 points outside the tablet.");
+}
+
+TEST_F(SharedDictionaryReaderTest, cachesFileAlphabet) {
+  constexpr uint32_t kValueStreamId = 20;
+  constexpr uint32_t kSecondValueStreamId = 21;
+  constexpr uint32_t kDictionaryId = 7;
+  const std::array<int32_t, 2> values{40, 50};
+  const auto fileEncodedAlphabet = encodeAlphabet(values);
+  const std::array fileDictionaryReferences{
+      SharedDictionaryReference{
+          .valueStreamId = kValueStreamId,
+          .dictionaryId = kDictionaryId,
+          .dataType = DataType::Int32},
+      SharedDictionaryReference{
+          .valueStreamId = kSecondValueStreamId,
+          .dictionaryId = kDictionaryId,
+          .dataType = DataType::Int32}};
+
+  auto tablet = createTabletWithSharedDictionarySection(
+      std::span<const SharedDictionaryReference>{},
+      fileDictionaryReferences,
+      kDictionaryId,
+      fileEncodedAlphabet);
+
+  EXPECT_FALSE(tablet->hasStripeDictionaries());
+  EXPECT_TRUE(tablet->hasGlobalDictionaries());
+  const auto alphabet = tablet->resolveDictionaryAlphabet(kValueStreamId);
+  ASSERT_NE(alphabet, nullptr);
+  EXPECT_EQ(alphabet->physicalValueAt<int32_t>(0), 40);
+  EXPECT_EQ(tablet->resolveDictionaryAlphabet(kValueStreamId), alphabet);
+  EXPECT_EQ(tablet->resolveDictionaryAlphabet(kSecondValueStreamId), alphabet);
+}
+
+TEST_F(SharedDictionaryReaderTest, rejectsMissingExternalResolver) {
+  constexpr uint32_t kValueStreamId = 30;
+  constexpr uint32_t kDictionaryId = 11;
+  const std::array externalReferences{SharedDictionaryReference{
+      .valueStreamId = kValueStreamId,
+      .dictionaryId = kDictionaryId,
+      .dataType = DataType::Int32}};
+  auto tablet = createTablet(
+      SharedDictionaryCatalog::serialize({}, {}, externalReferences, {}));
+
+  NIMBLE_ASSERT_USER_THROW(
+      tablet->resolveDictionaryAlphabet(kValueStreamId),
+      "External shared dictionary 11 requires an ExternalDictionaryResolver.");
+}
+
+TEST_F(SharedDictionaryReaderTest, cachesExternalAlphabet) {
+  constexpr uint32_t kValueStreamId = 30;
+  constexpr uint32_t kDictionaryId = 11;
+  const std::array externalDictionaryReferences{SharedDictionaryReference{
+      .valueStreamId = kValueStreamId,
+      .dictionaryId = kDictionaryId,
+      .dataType = DataType::Int32}};
+  const std::array<int32_t, 2> values{40, 50};
+  auto resolver =
+      std::make_shared<TestDictionaryResolver>(createAlphabet(values));
+  const auto catalog = SharedDictionaryCatalog::serialize(
+      {}, {}, externalDictionaryReferences, {});
+  auto tablet = createTablet(catalog, resolver);
+
+  EXPECT_FALSE(tablet->hasStripeDictionaries());
+  EXPECT_TRUE(tablet->hasGlobalDictionaries());
+  const auto alphabet = tablet->resolveDictionaryAlphabet(kValueStreamId);
+  ASSERT_NE(alphabet, nullptr);
+  EXPECT_EQ(alphabet->physicalValueAt<int32_t>(0), 40);
+  EXPECT_EQ(tablet->resolveDictionaryAlphabet(kValueStreamId), alphabet);
+  EXPECT_EQ(resolver->resolveCount(), 1);
+  EXPECT_EQ(resolver->dictionaryId(), kDictionaryId);
+  EXPECT_EQ(resolver->dataType(), DataType::Int32);
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
@@ -244,13 +244,16 @@ void expectAlphabetEntries(
       alphabetChunk.rowCount, static_cast<uint32_t>(expectedValues.size()));
   ASSERT_EQ(alphabetChunk.content.size(), 1);
 
-  const SharedDictionaryAlphabet alphabet{
-      alphabetChunk.content.front(), Encoding::Options{}, pool};
+  auto encodedAlphabetOwner =
+      std::make_shared<const std::string>(alphabetChunk.content.front());
+  const std::string_view encodedAlphabet{*encodedAlphabetOwner};
+  const auto alphabet = SharedDictionaryAlphabet::create(
+      encodedAlphabet, std::move(encodedAlphabetOwner), pool);
   std::vector<uint32_t> alphabetIndices(expectedValues.size());
   std::iota(alphabetIndices.begin(), alphabetIndices.end(), 0);
   std::vector<TypeTraits<int32_t>::physicalType> entries(
       alphabetIndices.size());
-  alphabet.materialize<int32_t>(alphabetIndices, entries.data());
+  alphabet->materialize<int32_t>(alphabetIndices, entries.data());
   EXPECT_EQ(entries, physicalValues(expectedValues));
 }
 
@@ -532,15 +535,18 @@ TEST_F(SharedDictionaryWriterTest, stripeAlphabetRoundTripsThroughReader) {
     ASSERT_TRUE(encodedAlphabet.has_value());
     ASSERT_EQ(encodedAlphabet->content.size(), 1);
 
-    const SharedDictionaryAlphabet alphabet{
-        encodedAlphabet->content.front(), Encoding::Options{}, pool_.get()};
-    EXPECT_EQ(alphabet.dataType(), DataType::Int32);
-    EXPECT_EQ(alphabet.entryCount(), pattern.size());
+    auto encodedAlphabetOwner =
+        std::make_shared<const std::string>(encodedAlphabet->content.front());
+    const std::string_view encodedAlphabetView{*encodedAlphabetOwner};
+    const auto alphabet = SharedDictionaryAlphabet::create(
+        encodedAlphabetView, std::move(encodedAlphabetOwner), pool_.get());
+    EXPECT_EQ(alphabet->dataType(), DataType::Int32);
+    EXPECT_EQ(alphabet->entryCount(), pattern.size());
 
     std::vector<uint32_t> indices(pattern.size());
     std::iota(indices.begin(), indices.end(), 0);
     std::vector<TypeTraits<int32_t>::physicalType> entries(indices.size());
-    alphabet.materialize<int32_t>(indices, entries.data());
+    alphabet->materialize<int32_t>(indices, entries.data());
 
     const std::vector<TypeTraits<int32_t>::physicalType> expected{
         pattern.begin(), pattern.end()};


### PR DESCRIPTION
Summary:
Add a read-only shared dictionary catalog that parses stripe, file, and external value-stream mappings from the tablet metadata section. Retain file-alphabet storage by offset and length and cache decoded file and external alphabets.

Initialize the catalog reader from TabletReader and expose lookup APIs for stripe dictionary streams and global dictionary alphabets. Add focused coverage for catalog validation, shared file alphabets, out-of-bounds file regions, missing external resolvers, and external alphabet caching.

Reviewed By: HuamengJiang, tanjialiang

Differential Revision: D115789498


