### PR TITLE
feat(nimble): Add external dictionary build tool and library (#18634)

### DIFF
--- a/velox/dwio/nimble/tools/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/CMakeLists.txt
@@ -15,6 +15,25 @@ add_library(nimble_tools_common EncodingUtilities.cpp EncodingUtilities.h)
 
 target_link_libraries(nimble_tools_common nimble_common nimble_tablet_reader nimble_column_stats)
 
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/ExternalDictionary.fbs"
+  ""
+  nimble_external_dictionary_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  ""
+)
+add_library(nimble_external_dictionary_fb INTERFACE)
+target_include_directories(
+  nimble_external_dictionary_fb
+  INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
+)
+add_dependencies(
+  nimble_external_dictionary_fb
+  nimble_external_dictionary_schema_fb
+)
+
 add_library(nimble_dump_lib NimbleDumpLib.cpp NimbleDumpLib.h)
 target_link_libraries(
   nimble_dump_lib
@@ -52,6 +71,17 @@ target_link_libraries(
   nimble_column_stats
   velox_file
   velox_memory
+)
+
+add_library(nimble_external_dictionary_builder ExternalDictionaryBuilder.cpp)
+target_link_libraries(
+  nimble_external_dictionary_builder
+  nimble_external_dictionary_fb
+  nimble_common
+  nimble_encodings
+  velox_file
+  velox_memory
+  Folly::folly
 )
 
 # Only the libraries are built. The command line front-ends (NimbleDump.cpp,

--- a/velox/dwio/nimble/tools/ExternalDictionary.fbs
+++ b/velox/dwio/nimble/tools/ExternalDictionary.fbs
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace facebook.nimble.serialization;
+
+/// Standalone external dictionary artifact produced by the build tool.
+table ExternalDictionary {
+  /// Nimble DataType of the dictionary values.
+  data_type:uint8;
+
+  /// Root encoding type used by encoded_alphabet.
+  alphabet_encoding_type:uint8;
+
+  /// Whether the builder sorted unique values before encoding the alphabet.
+  sort_values:bool;
+
+  /// Number of unique values encoded in encoded_alphabet.
+  value_count:uint64;
+
+  /// Nimble-encoded dictionary alphabet bytes.
+  encoded_alphabet:[ubyte];
+}
+
+root_type ExternalDictionary;

--- a/velox/dwio/nimble/tools/ExternalDictionaryBuilder.cpp
+++ b/velox/dwio/nimble/tools/ExternalDictionaryBuilder.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/tools/ExternalDictionaryBuilder.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "flatbuffers/flatbuffers.h"
+#include "folly/container/F14Set.h"
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/tools/ExternalDictionaryGenerated.h"
+
+namespace facebook::nimble {
+namespace {
+
+inline constexpr size_t kMaxEncodedAlphabetBytes =
+    std::numeric_limits<uint32_t>::max();
+
+std::string_view encodedAlphabetView(
+    const flatbuffers::Vector<uint8_t>* encodedAlphabet) {
+  NIMBLE_CHECK_FILE_NOT_NULL(
+      encodedAlphabet, "External dictionary artifact has no alphabet.");
+  NIMBLE_CHECK_FILE_GT(
+      encodedAlphabet->size(),
+      0,
+      "External dictionary artifact has an empty alphabet.");
+  return {
+      reinterpret_cast<const char*>(encodedAlphabet->data()),
+      encodedAlphabet->size()};
+}
+
+template <typename T>
+Vector<T> makeAlphabet(
+    const Vector<T>& source,
+    bool sortValues,
+    velox::memory::MemoryPool* pool) {
+  Vector<T> alphabet{pool};
+  alphabet.reserve(source.size());
+
+  if (sortValues) {
+    alphabet.resize(source.size());
+    std::copy(source.begin(), source.end(), alphabet.begin());
+    std::sort(alphabet.begin(), alphabet.end());
+    alphabet.resize(
+        std::unique(alphabet.begin(), alphabet.end()) - alphabet.begin());
+    return alphabet;
+  }
+
+  folly::F14FastSet<T> seen;
+  for (auto value : source) {
+    if (seen.insert(value).second) {
+      alphabet.push_back(value);
+    }
+  }
+  return alphabet;
+}
+
+template <typename T>
+std::unique_ptr<EncodingSelectionPolicy<T>> createAlphabetPolicy(
+    const ExternalDictionaryBuilder::Options& options) {
+  NIMBLE_USER_CHECK(
+      !options.alphabetEncoding.has_value() || options.readFactors.empty(),
+      "alphabet_encoding and read_factors cannot both be set.");
+
+  std::vector<std::pair<EncodingType, float>> readFactors;
+  if (options.alphabetEncoding.has_value()) {
+    readFactors = {{*options.alphabetEncoding, 1.0f}};
+  } else if (!options.readFactors.empty()) {
+    readFactors = options.readFactors;
+  } else {
+    readFactors =
+        ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
+  }
+
+  ManualEncodingSelectionPolicyFactory factory{
+      std::move(readFactors), /*compressionOptions=*/std::nullopt};
+  return std::unique_ptr<EncodingSelectionPolicy<T>>(
+      static_cast<EncodingSelectionPolicy<T>*>(
+          factory.createPolicy(TypeTraits<T>::dataType).release()));
+}
+
+template <typename T>
+ExternalDictionary buildAlphabet(
+    const Vector<T>& source,
+    const ExternalDictionaryBuilder::Options& options,
+    velox::memory::MemoryPool* pool) {
+  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+
+  NIMBLE_CHECK_NOT_NULL(pool);
+  auto alphabet = makeAlphabet<T>(source, options.sortValues, pool);
+  NIMBLE_USER_CHECK(
+      !alphabet.empty(), "External dictionary alphabet input is empty.");
+
+  auto buffer = std::make_unique<Buffer>(*pool);
+  const auto encoded = EncodingFactory::encode<T>(
+      createAlphabetPolicy<T>(options),
+      std::span<const T>{alphabet.data(), alphabet.size()},
+      *buffer);
+  std::string encodedAlphabet{encoded};
+  return {
+      .dataType = TypeTraits<T>::dataType,
+      .alphabetEncodingType = EncodingPrefix::encodingType(encodedAlphabet),
+      .sortValues = options.sortValues,
+      .valueCount = alphabet.size(),
+      .encodedAlphabet = std::move(encodedAlphabet),
+  };
+}
+
+} // namespace
+
+ExternalDictionaryBuilder::ExternalDictionaryBuilder(
+    velox::memory::MemoryPool* pool)
+    : pool_{pool} {
+  NIMBLE_CHECK_NOT_NULL(pool_);
+}
+
+#define BUILD_EXTERNAL_DICTIONARY_ALPHABET(type)                  \
+  ExternalDictionary ExternalDictionaryBuilder::build(            \
+      const Vector<type>& source, const Options& options) const { \
+    return buildAlphabet<type>(source, options, pool_);           \
+  }
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(int8_t)
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(uint8_t)
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(int16_t)
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(uint16_t)
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(int32_t)
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(uint32_t)
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(int64_t)
+BUILD_EXTERNAL_DICTIONARY_ALPHABET(uint64_t)
+#undef BUILD_EXTERNAL_DICTIONARY_ALPHABET
+
+std::string ExternalDictionaryBuilder::serialize(
+    const ExternalDictionary& alphabet) const {
+  NIMBLE_USER_CHECK(
+      !alphabet.encodedAlphabet.empty(),
+      "External dictionary alphabet is empty.");
+  NIMBLE_USER_CHECK_LE(
+      alphabet.encodedAlphabet.size(),
+      kMaxEncodedAlphabetBytes,
+      "External dictionary alphabet exceeds uint32_t size.");
+  NIMBLE_USER_CHECK_EQ(
+      EncodingPrefix::dataType(alphabet.encodedAlphabet),
+      alphabet.dataType,
+      "External dictionary data type does not match the encoded alphabet.");
+  NIMBLE_USER_CHECK_EQ(
+      EncodingPrefix::encodingType(alphabet.encodedAlphabet),
+      alphabet.alphabetEncodingType,
+      "External dictionary encoding type does not match the encoded alphabet.");
+  NIMBLE_USER_CHECK_EQ(
+      EncodingPrefix::readRowCount(
+          alphabet.encodedAlphabet, /*useVarint=*/false),
+      alphabet.valueCount,
+      "External dictionary value count does not match the encoded alphabet.");
+
+  flatbuffers::FlatBufferBuilder builder;
+  const auto encodedAlphabet = builder.CreateVector(
+      reinterpret_cast<const uint8_t*>(alphabet.encodedAlphabet.data()),
+      alphabet.encodedAlphabet.size());
+  const auto root = serialization::CreateExternalDictionary(
+      builder,
+      static_cast<uint8_t>(alphabet.dataType),
+      static_cast<uint8_t>(alphabet.alphabetEncodingType),
+      alphabet.sortValues,
+      alphabet.valueCount,
+      encodedAlphabet);
+  serialization::FinishExternalDictionaryBuffer(builder, root);
+  return {
+      reinterpret_cast<const char*>(builder.GetBufferPointer()),
+      builder.GetSize()};
+}
+
+ExternalDictionary ExternalDictionaryBuilder::deserialize(
+    std::string_view data) const {
+  return deserializeImpl(data);
+}
+
+ExternalDictionary ExternalDictionaryBuilder::deserializeImpl(
+    std::string_view data) const {
+  flatbuffers::Verifier verifier{
+      reinterpret_cast<const uint8_t*>(data.data()), data.size()};
+  NIMBLE_CHECK_FILE(
+      serialization::VerifyExternalDictionaryBuffer(verifier),
+      "Invalid external dictionary artifact.");
+
+  const auto* serialized = serialization::GetExternalDictionary(data.data());
+  NIMBLE_CHECK_FILE_NOT_NULL(
+      serialized, "External dictionary artifact is missing its root.");
+  const auto encodedAlphabet =
+      encodedAlphabetView(serialized->encoded_alphabet());
+  const auto dataType = static_cast<DataType>(serialized->data_type());
+  const auto alphabetEncodingType =
+      static_cast<EncodingType>(serialized->alphabet_encoding_type());
+  NIMBLE_CHECK_FILE_EQ(
+      EncodingPrefix::dataType(encodedAlphabet),
+      dataType,
+      "External dictionary data type does not match the encoded alphabet.");
+  NIMBLE_CHECK_FILE_EQ(
+      EncodingPrefix::encodingType(encodedAlphabet),
+      alphabetEncodingType,
+      "External dictionary encoding type does not match the encoded alphabet.");
+  NIMBLE_CHECK_FILE_EQ(
+      serialized->value_count(),
+      EncodingPrefix::readRowCount(encodedAlphabet, /*useVarint=*/false),
+      "External dictionary value count does not match the encoded alphabet.");
+
+  return {
+      .dataType = dataType,
+      .alphabetEncodingType = alphabetEncodingType,
+      .sortValues = serialized->sort_values(),
+      .valueCount = serialized->value_count(),
+      .encodedAlphabet = std::string{encodedAlphabet},
+  };
+}
+
+ExternalDictionary ExternalDictionaryBuilder::deserializeFromFile(
+    std::string_view path) const {
+  const auto file =
+      velox::filesystems::getFileSystem(path, nullptr)->openFileForRead(path);
+  const auto data = file->pread(/*offset=*/0, file->size());
+  return deserialize(data);
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/tools/ExternalDictionaryBuilder.h
+++ b/velox/dwio/nimble/tools/ExternalDictionaryBuilder.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/common/EncodingType.h"
+
+namespace facebook::nimble {
+
+/// Encoded external dictionary alphabet and its standalone artifact metadata.
+struct ExternalDictionary {
+  /// Nimble type of the dictionary values.
+  DataType dataType{DataType::Undefined};
+
+  /// Root encoding type used by the serialized alphabet.
+  EncodingType alphabetEncodingType{};
+
+  /// Whether the artifact builder sorted unique values before encoding.
+  bool sortValues{true};
+
+  /// Number of unique values encoded in encodedAlphabet.
+  uint64_t valueCount{};
+
+  /// Encoded alphabet bytes.
+  std::string encodedAlphabet;
+};
+
+/// Builds, serializes, and loads standalone external dictionary artifacts.
+class ExternalDictionaryBuilder {
+ public:
+  /// Options for building an encoded external dictionary alphabet.
+  struct Options {
+    /// Whether to sort unique values before encoding the alphabet.
+    bool sortValues{true};
+
+    /// Optional forced alphabet encoding. When unset, readFactors or default
+    /// encoding selection picks the alphabet encoding.
+    std::optional<EncodingType> alphabetEncoding;
+
+    /// Optional parsed manual read factors used by encoding selection.
+    std::vector<std::pair<EncodingType, float>> readFactors;
+  };
+
+  explicit ExternalDictionaryBuilder(velox::memory::MemoryPool* pool);
+
+  /// Builds an encoded alphabet from typed integer values. Duplicates are
+  /// removed using sorted order or first-seen order based on options.
+  ExternalDictionary build(const Vector<int8_t>& source, const Options& options)
+      const;
+  ExternalDictionary build(
+      const Vector<uint8_t>& source,
+      const Options& options) const;
+  ExternalDictionary build(
+      const Vector<int16_t>& source,
+      const Options& options) const;
+  ExternalDictionary build(
+      const Vector<uint16_t>& source,
+      const Options& options) const;
+  ExternalDictionary build(
+      const Vector<int32_t>& source,
+      const Options& options) const;
+  ExternalDictionary build(
+      const Vector<uint32_t>& source,
+      const Options& options) const;
+  ExternalDictionary build(
+      const Vector<int64_t>& source,
+      const Options& options) const;
+  ExternalDictionary build(
+      const Vector<uint64_t>& source,
+      const Options& options) const;
+
+  /// Serializes a standalone external dictionary artifact.
+  std::string serialize(const ExternalDictionary& alphabet) const;
+
+  /// Deserializes an artifact from serialized bytes.
+  ExternalDictionary deserialize(std::string_view data) const;
+
+  /// Reads an artifact file and returns its encoded alphabet.
+  ExternalDictionary deserializeFromFile(std::string_view path) const;
+
+ private:
+  ExternalDictionary deserializeImpl(std::string_view data) const;
+
+  // Pool used for temporary alphabet buffers and loaded alphabet storage.
+  velox::memory::MemoryPool* const pool_;
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/tools/ExternalDictionaryBuilderMain.cpp
+++ b/velox/dwio/nimble/tools/ExternalDictionaryBuilderMain.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+#include <istream>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include <glog/logging.h>
+#include "folly/Conv.h"
+
+#include "common/init/light.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/DataTypeDispatch.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/tools/ExternalDictionaryBuilder.h"
+
+DEFINE_string(
+    input,
+    "",
+    "Input file containing whitespace-delimited dictionary values.");
+DEFINE_string(output, "", "Output external dictionary artifact file.");
+DEFINE_string(data_type, "", "Integer data type, e.g. Int32 or Uint64.");
+DEFINE_bool(
+    sort_values,
+    true,
+    "Sort the unique alphabet values before encoding.");
+DEFINE_string(
+    alphabet_encoding,
+    "",
+    "Forced alphabet encoding. Empty uses encoding selection.");
+DEFINE_string(read_factors, "", "Read factors to use for encoding selection.");
+
+namespace facebook::nimble {
+namespace {
+
+template <typename T>
+T parseValue(std::string_view text) {
+  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  if constexpr (std::is_signed_v<T>) {
+    const auto value = folly::to<int64_t>(text);
+    NIMBLE_USER_CHECK_GE(
+        value,
+        static_cast<int64_t>(std::numeric_limits<T>::min()),
+        "Value {} is below {} range.",
+        text,
+        toString(TypeTraits<T>::dataType));
+    NIMBLE_USER_CHECK_LE(
+        value,
+        static_cast<int64_t>(std::numeric_limits<T>::max()),
+        "Value {} is above {} range.",
+        text,
+        toString(TypeTraits<T>::dataType));
+    return static_cast<T>(value);
+  } else {
+    const auto value = folly::to<uint64_t>(text);
+    NIMBLE_USER_CHECK_LE(
+        value,
+        static_cast<uint64_t>(std::numeric_limits<T>::max()),
+        "Value {} is above {} range.",
+        text,
+        toString(TypeTraits<T>::dataType));
+    return static_cast<T>(value);
+  }
+}
+
+template <typename T>
+Vector<T> readValues(std::istream& input, velox::memory::MemoryPool* pool) {
+  Vector<T> values{pool};
+  std::string value;
+  // Treat spaces and newlines the same, so callers can use one value per line
+  // or a compact space-delimited file.
+  while (input >> value) {
+    values.push_back(parseValue<T>(value));
+  }
+  return values;
+}
+
+template <typename T>
+Vector<T> readInput(velox::memory::MemoryPool* pool) {
+  NIMBLE_USER_CHECK(!FLAGS_input.empty(), "input is required.");
+  std::ifstream file{FLAGS_input};
+  NIMBLE_USER_CHECK(
+      file.is_open(),
+      "Unable to open shared dictionary input '{}'.",
+      FLAGS_input);
+  return readValues<T>(file, pool);
+}
+
+DataType parseDataType(std::string_view dataType) {
+  NIMBLE_USER_CHECK(!dataType.empty(), "data_type is required.");
+#define DATA_TYPE(type)                                   \
+  if (dataType == toString(TypeTraits<type>::dataType)) { \
+    return TypeTraits<type>::dataType;                    \
+  }
+  DATA_TYPE(int8_t)
+  DATA_TYPE(uint8_t)
+  DATA_TYPE(int16_t)
+  DATA_TYPE(uint16_t)
+  DATA_TYPE(int32_t)
+  DATA_TYPE(uint32_t)
+  DATA_TYPE(int64_t)
+  DATA_TYPE(uint64_t)
+#undef DATA_TYPE
+  NIMBLE_USER_FAIL("Unsupported external dictionary data type '{}'.", dataType);
+}
+
+template <typename T>
+std::string buildExternalDictionaryArtifact(
+    const ExternalDictionaryBuilder::Options& options) {
+  auto pool =
+      velox::memory::memoryManager()->addLeafPool("external_dictionary_build");
+  const ExternalDictionaryBuilder builder{pool.get()};
+  const auto source = readInput<T>(pool.get());
+  const auto alphabet = builder.build(source, options);
+  return builder.serialize(alphabet);
+}
+
+std::string buildExternalDictionaryArtifact(
+    DataType dataType,
+    const ExternalDictionaryBuilder::Options& options) {
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE_OR(
+      dataType,
+      Type,
+      buildExternalDictionaryArtifact<Type>(options),
+      NIMBLE_USER_FAIL(
+          "Unsupported external dictionary data type '{}'.",
+          toString(dataType)));
+}
+
+void writeOutput(std::string_view serializedDictionary) {
+  NIMBLE_USER_CHECK(!FLAGS_output.empty(), "output is required.");
+  std::ofstream output{FLAGS_output, std::ios::binary};
+  NIMBLE_USER_CHECK(
+      output.is_open(),
+      "Unable to open external dictionary output '{}'.",
+      FLAGS_output);
+  output.write(serializedDictionary.data(), serializedDictionary.size());
+  NIMBLE_USER_CHECK(
+      output.good(),
+      "Failed to write external dictionary output '{}'.",
+      FLAGS_output);
+}
+
+} // namespace
+} // namespace facebook::nimble
+
+int main(int argc, char* argv[]) {
+  auto init = facebook::init::InitFacebookLight{&argc, &argv};
+  facebook::velox::memory::MemoryManager::initialize({});
+  facebook::velox::filesystems::registerLocalFileSystem();
+  using namespace facebook::nimble;
+
+  ExternalDictionaryBuilder::Options options{
+      .sortValues = FLAGS_sort_values,
+  };
+  if (!FLAGS_alphabet_encoding.empty()) {
+    options.alphabetEncoding = toEncodingType(FLAGS_alphabet_encoding);
+  }
+  if (!FLAGS_read_factors.empty()) {
+    options.readFactors =
+        ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
+            FLAGS_read_factors);
+  }
+
+  const auto dictionaryArtifact =
+      buildExternalDictionaryArtifact(parseDataType(FLAGS_data_type), options);
+  writeOutput(dictionaryArtifact);
+  LOG(INFO) << "Wrote external dictionary artifact " << FLAGS_output << " ("
+            << dictionaryArtifact.size() << " bytes).";
+  return 0;
+}

--- a/velox/dwio/nimble/tools/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/tests/CMakeLists.txt
@@ -23,3 +23,20 @@ target_link_libraries(
   gtest
   gtest_main
 )
+
+add_executable(
+  external_dictionary_builder_tests
+  ExternalDictionaryBuilderTest.cpp
+)
+add_test(external_dictionary_builder_tests external_dictionary_builder_tests)
+target_link_libraries(
+  external_dictionary_builder_tests
+  nimble_external_dictionary_builder
+  nimble_encodings
+  nimble_common
+  velox_file
+  velox_memory
+  velox_test_util
+  gtest
+  gtest_main
+)

--- a/velox/dwio/nimble/tools/tests/ExternalDictionaryBuilderTest.cpp
+++ b/velox/dwio/nimble/tools/tests/ExternalDictionaryBuilderTest.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempFilePath.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/tools/ExternalDictionaryBuilder.h"
+
+namespace facebook::nimble {
+namespace {
+
+class ExternalDictionaryBuilderTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    if (!velox::memory::MemoryManager::testInstance()) {
+      velox::memory::MemoryManager::initialize({});
+    }
+    velox::filesystems::registerLocalFileSystem();
+  }
+
+  void SetUp() final {
+    auto* memoryManager = velox::memory::memoryManager();
+    VELOX_CHECK_NOT_NULL(memoryManager);
+    pool_ = memoryManager->addLeafPool("external_builder_test");
+  }
+
+  template <typename T>
+  std::vector<T> materializeAlphabet(ExternalDictionary encodedAlphabet) {
+    auto encodedAlphabetOwner = std::make_shared<const std::string>(
+        std::move(encodedAlphabet.encodedAlphabet));
+    const std::string_view encodedAlphabetView{*encodedAlphabetOwner};
+    const auto alphabet = SharedDictionaryAlphabet::create(
+        encodedAlphabetView, std::move(encodedAlphabetOwner), pool_.get());
+    Vector<T> values{pool_.get()};
+    alphabet->materializeAll<T>(values);
+    return {values.data(), values.data() + values.size()};
+  }
+
+  template <typename T>
+  std::vector<T> materializeAlphabet(const SharedDictionaryAlphabet& alphabet) {
+    Vector<T> values{pool_.get()};
+    alphabet.materializeAll<T>(values);
+    return {values.data(), values.data() + values.size()};
+  }
+
+  ExternalDictionaryBuilder dictionaryBuilder() const {
+    return ExternalDictionaryBuilder{pool_.get()};
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(ExternalDictionaryBuilderTest, buildsSortedUniqueAlphabet) {
+  const Vector<int32_t> source{pool_.get(), {30, 10, 20, 10}};
+  const ExternalDictionaryBuilder::Options options;
+  const auto builder = dictionaryBuilder();
+
+  auto encodedAlphabet = builder.build(source, options);
+
+  EXPECT_EQ(encodedAlphabet.dataType, DataType::Int32);
+  EXPECT_EQ(
+      encodedAlphabet.alphabetEncodingType,
+      EncodingPrefix::encodingType(encodedAlphabet.encodedAlphabet));
+  EXPECT_TRUE(encodedAlphabet.sortValues);
+  EXPECT_EQ(encodedAlphabet.valueCount, 3);
+  EXPECT_EQ(
+      materializeAlphabet<int32_t>(std::move(encodedAlphabet)),
+      std::vector<int32_t>({10, 20, 30}));
+}
+
+TEST_F(
+    ExternalDictionaryBuilderTest,
+    preservesFirstSeenOrderWhenSortingDisabled) {
+  const Vector<int32_t> source{pool_.get(), {30, 10, 20, 10}};
+  const ExternalDictionaryBuilder::Options options{
+      .sortValues = false,
+  };
+  const auto builder = dictionaryBuilder();
+
+  auto encodedAlphabet = builder.build(source, options);
+
+  EXPECT_FALSE(encodedAlphabet.sortValues);
+  EXPECT_EQ(encodedAlphabet.valueCount, 3);
+  EXPECT_EQ(
+      materializeAlphabet<int32_t>(std::move(encodedAlphabet)),
+      std::vector<int32_t>({30, 10, 20}));
+}
+
+TEST_F(ExternalDictionaryBuilderTest, usesForcedAlphabetEncoding) {
+  const Vector<uint32_t> source{pool_.get(), {1, 2, 3}};
+  const ExternalDictionaryBuilder::Options options{
+      .alphabetEncoding = EncodingType::FixedBitWidth,
+  };
+  const auto builder = dictionaryBuilder();
+
+  const auto encodedAlphabet = builder.build(source, options);
+
+  EXPECT_EQ(encodedAlphabet.dataType, DataType::Uint32);
+  EXPECT_EQ(encodedAlphabet.alphabetEncodingType, EncodingType::FixedBitWidth);
+  EXPECT_EQ(encodedAlphabet.valueCount, 3);
+  EXPECT_EQ(
+      EncodingPrefix::encodingType(encodedAlphabet.encodedAlphabet),
+      EncodingType::FixedBitWidth);
+}
+
+TEST_F(ExternalDictionaryBuilderTest, serializesAndLoadsExternalDictionary) {
+  const Vector<int32_t> source{pool_.get(), {30, 10, 20, 10}};
+  const ExternalDictionaryBuilder::Options options{
+      .sortValues = false,
+      .alphabetEncoding = EncodingType::FixedBitWidth,
+  };
+  const auto builder = dictionaryBuilder();
+
+  const auto encodedAlphabet = builder.build(source, options);
+  const auto data = builder.serialize(encodedAlphabet);
+  auto loadedAlphabet = builder.deserialize(data);
+
+  EXPECT_EQ(loadedAlphabet.dataType, DataType::Int32);
+  EXPECT_EQ(loadedAlphabet.alphabetEncodingType, EncodingType::FixedBitWidth);
+  EXPECT_FALSE(loadedAlphabet.sortValues);
+  EXPECT_EQ(loadedAlphabet.valueCount, 3);
+  EXPECT_EQ(
+      materializeAlphabet<int32_t>(std::move(loadedAlphabet)),
+      std::vector<int32_t>({30, 10, 20}));
+}
+
+TEST_F(ExternalDictionaryBuilderTest, deserializesExternalDictionaryFromFile) {
+  const Vector<int32_t> source{pool_.get(), {30, 10, 20, 10}};
+  const auto builder = dictionaryBuilder();
+
+  struct TestCase {
+    std::string name;
+    bool sortValues;
+    EncodingType alphabetEncoding;
+    std::vector<int32_t> expectedValues;
+  };
+
+  for (const auto& testCase : std::vector<TestCase>{
+           {
+               .name = "sorted_fixed_bit_width",
+               .sortValues = true,
+               .alphabetEncoding = EncodingType::FixedBitWidth,
+               .expectedValues = {10, 20, 30},
+           },
+           {
+               .name = "first_seen_fixed_bit_width",
+               .sortValues = false,
+               .alphabetEncoding = EncodingType::FixedBitWidth,
+               .expectedValues = {30, 10, 20},
+           },
+           {
+               .name = "sorted_trivial",
+               .sortValues = true,
+               .alphabetEncoding = EncodingType::Trivial,
+               .expectedValues = {10, 20, 30},
+           },
+           {
+               .name = "first_seen_trivial",
+               .sortValues = false,
+               .alphabetEncoding = EncodingType::Trivial,
+               .expectedValues = {30, 10, 20},
+           },
+       }) {
+    SCOPED_TRACE(testCase.name);
+    const ExternalDictionaryBuilder::Options options{
+        .sortValues = testCase.sortValues,
+        .alphabetEncoding = testCase.alphabetEncoding,
+    };
+    const auto encodedAlphabet = builder.build(source, options);
+    const auto data = builder.serialize(encodedAlphabet);
+    const auto tempFile = velox::common::testutil::TempFilePath::create();
+    tempFile->append(data);
+
+    auto loadedAlphabet = builder.deserializeFromFile(tempFile->getPath());
+
+    EXPECT_EQ(loadedAlphabet.dataType, DataType::Int32);
+    EXPECT_EQ(loadedAlphabet.alphabetEncodingType, testCase.alphabetEncoding);
+    EXPECT_EQ(loadedAlphabet.sortValues, testCase.sortValues);
+    EXPECT_EQ(loadedAlphabet.valueCount, 3);
+    EXPECT_EQ(
+        materializeAlphabet<int32_t>(std::move(loadedAlphabet)),
+        testCase.expectedValues);
+  }
+}
+
+TEST_F(ExternalDictionaryBuilderTest, rejectsInvalidInputs) {
+  const ExternalDictionaryBuilder::Options options;
+  const Vector<int32_t> source{pool_.get(), {1}};
+  const Vector<int32_t> emptySource{pool_.get()};
+  const auto builder = dictionaryBuilder();
+
+  NIMBLE_ASSERT_USER_THROW(
+      builder.build(emptySource, options),
+      "External dictionary alphabet input is empty.");
+
+  const ExternalDictionaryBuilder::Options conflictingOptions{
+      .alphabetEncoding = EncodingType::FixedBitWidth,
+      .readFactors = {{EncodingType::Trivial, 1.0f}},
+  };
+  NIMBLE_ASSERT_USER_THROW(
+      builder.build(source, conflictingOptions),
+      "alphabet_encoding and read_factors cannot both be set.");
+}
+
+} // namespace
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Add `external_dictionary_build`, a CLI plus reusable builder/loader library for producing standalone external dictionary artifacts from typed integer input. The builder validates input, optionally sorts/deduplicates values, and encodes the unique alphabet with either a forced encoding or normal encoding selection.

The artifact is a FlatBuffer carrying only portable alphabet metadata: data type, root alphabet encoding type, sort mode, value count, and encoded alphabet bytes. It intentionally does not store a dictionary id; ids are meaningful only in the metastore/resolver context that binds an artifact to a dictionary.

Add loader APIs that reconstruct a `SharedDictionaryAlphabet` from artifact bytes or a file so external resolvers can use the artifact directly.

Reviewed By: HuamengJiang, tanjialiang

Differential Revision: D116135074


