### PR TITLE
feat(nimble): Add shared dictionary config (#18636)

### DIFF
--- a/velox/dwio/nimble/velox/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/CMakeLists.txt
@@ -14,6 +14,15 @@
 add_library(nimble_velox_common SchemaUtils.cpp SchemaUtils.h)
 target_link_libraries(nimble_velox_common nimble_common velox_type Folly::folly fmt::fmt)
 
+add_library(nimble_velox_shared_dictionary_config SharedDictionaryConfig.cpp)
+target_link_libraries(
+  nimble_velox_shared_dictionary_config
+  nimble_common
+  nimble_encodings
+  nimble_tablet_reader
+  velox_type
+)
+
 add_library(nimble_velox_schema SchemaTypes.cpp SchemaTypes.h)
 target_link_libraries(nimble_velox_schema nimble_common Folly::folly)
 

--- a/velox/dwio/nimble/velox/SharedDictionaryConfig.cpp
+++ b/velox/dwio/nimble/velox/SharedDictionaryConfig.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/type/Subfield.h"
+
+namespace facebook::nimble {
+namespace {
+
+velox::common::Subfield parseFieldPath(
+    const std::string& fieldPath,
+    std::string_view configType) {
+  NIMBLE_USER_CHECK(
+      !fieldPath.empty(),
+      "Shared dictionary {} path must not be empty.",
+      configType);
+  velox::common::Subfield subfield;
+  try {
+    subfield = velox::common::Subfield{fieldPath};
+  } catch (const velox::VeloxException&) {
+    NIMBLE_USER_FAIL(
+        "Shared dictionary {} path '{}' must start with a field name.",
+        configType,
+        fieldPath);
+  }
+  NIMBLE_USER_CHECK(
+      subfield.valid(),
+      "Shared dictionary {} path '{}' must start with a field name.",
+      configType,
+      fieldPath);
+  return subfield;
+}
+
+void validateValueStreamPath(
+    const std::string& fieldPath,
+    std::string_view configType) {
+  const auto subfield = parseFieldPath(fieldPath, configType);
+  for (const auto& pathElement : subfield.path()) {
+    NIMBLE_USER_CHECK(
+        pathElement->is(velox::common::SubfieldKind::kNestedField) ||
+            pathElement->is(velox::common::SubfieldKind::kAllSubscripts),
+        "Shared dictionary {} path '{}' only supports nested row fields and "
+        "all-subscript array/map elements.",
+        configType,
+        fieldPath);
+  }
+}
+
+velox::common::Subfield validateFlatMapColumnPath(
+    const std::string& fieldPath) {
+  auto subfield = parseFieldPath(fieldPath, "flat-map column");
+  NIMBLE_USER_CHECK_EQ(
+      subfield.path().size(),
+      1,
+      "Shared dictionary flat-map column path '{}' must be a top-level writer "
+      "input column.",
+      fieldPath);
+  return subfield;
+}
+
+void validateValueSubfield(const std::string& valueSubfield) {
+  if (valueSubfield.empty()) {
+    return;
+  }
+  const auto subfield =
+      parseFieldPath(valueSubfield, "flat-map value subfield");
+  for (const auto& pathElement : subfield.path()) {
+    NIMBLE_USER_CHECK(
+        pathElement->is(velox::common::SubfieldKind::kNestedField) ||
+            pathElement->is(velox::common::SubfieldKind::kAllSubscripts),
+        "Shared dictionary flat-map value subfield '{}' only supports nested "
+        "row fields and all-subscript array/map elements.",
+        valueSubfield);
+  }
+}
+
+} // namespace
+
+SharedDictionaryConfigBuilder::SharedDictionaryConfigBuilder(
+    SharedDictionaryEncodingConfig&& config)
+    : config_{std::move(config)} {}
+
+SharedDictionaryConfigBuilder SharedDictionaryEncodingConfig::builder(
+    SharedDictionaryEncodingConfig&& config) {
+  return SharedDictionaryConfigBuilder{std::move(config)};
+}
+
+SharedDictionaryConfigBuilder&
+SharedDictionaryConfigBuilder::setExternalResolver(
+    std::shared_ptr<const ExternalDictionaryResolver> externalResolver) {
+  config_.externalResolver = std::move(externalResolver);
+  return *this;
+}
+
+SharedDictionaryConfigBuilder&
+SharedDictionaryConfigBuilder::addColumnDictionary(
+    std::string fieldPath,
+    SharedDictionaryConfig dictionary) {
+  validateValueStreamPath(fieldPath, "column");
+
+  const auto duplicate = std::any_of(
+      config_.columns.begin(),
+      config_.columns.end(),
+      [&](const auto& candidate) { return candidate.fieldPath == fieldPath; });
+  NIMBLE_USER_CHECK(
+      !duplicate,
+      "Duplicate shared dictionary column configuration for path '{}'.",
+      fieldPath);
+  config_.columns.push_back(
+      ColumnDictionary{
+          .fieldPath = std::move(fieldPath),
+          .dictionary = std::move(dictionary)});
+  return *this;
+}
+
+SharedDictionaryConfigBuilder&
+SharedDictionaryConfigBuilder::addFlatmapValueDictionary(
+    std::string fieldPath,
+    int64_t key,
+    SharedDictionaryConfig dictionary,
+    std::string valueSubfield) {
+  const auto subfield = validateFlatMapColumnPath(fieldPath);
+  validateValueSubfield(valueSubfield);
+
+  auto column = std::find_if(
+      config_.flatMapColumns.begin(),
+      config_.flatMapColumns.end(),
+      [&](const auto& candidate) { return candidate.fieldPath == fieldPath; });
+  if (column == config_.flatMapColumns.end()) {
+    config_.flatMapColumns.push_back(
+        FlatmapColumnDictionary{.fieldPath = fieldPath, .keys = {}});
+    column = std::prev(config_.flatMapColumns.end());
+  }
+
+  const auto duplicate = std::any_of(
+      column->keys.begin(), column->keys.end(), [&](const auto& item) {
+        return item.key == key && item.valueSubfield == valueSubfield;
+      });
+  NIMBLE_USER_CHECK(
+      !duplicate,
+      "Duplicate shared dictionary flat-map value configuration for path '{}', "
+      "key {}, and value subfield '{}'.",
+      fieldPath,
+      key,
+      valueSubfield);
+  column->keys.push_back(
+      FlatmapKeyDictionary{
+          .key = key,
+          .valueSubfield = std::move(valueSubfield),
+          .dictionary = std::move(dictionary)});
+  return *this;
+}
+
+SharedDictionaryEncodingConfig SharedDictionaryConfigBuilder::build() {
+  return std::move(config_);
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/SharedDictionaryConfig.h
+++ b/velox/dwio/nimble/velox/SharedDictionaryConfig.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/tablet/SharedDictionaryReader.h"
+
+namespace facebook::nimble {
+
+class SharedDictionaryConfigBuilder;
+
+/// Shared dictionary writer configuration for one value stream.
+struct SharedDictionaryConfig {
+  /// Where the dictionary alphabet is stored or resolved.
+  SharedDictionaryScope scope{SharedDictionaryScope::Stripe};
+  /// Dictionary id within File or External scope. Stripe scope assigns this
+  /// from the generated auxiliary alphabet stream.
+  uint32_t dictionaryId{};
+  /// Resolves a provided alphabet instead of building one from written values.
+  bool useExternalAlphabet{false};
+  /// Candidate encodings for alphabets stored in this file.
+  std::vector<EncodingType> alphabetEncodings;
+};
+
+/// Shared dictionary settings for one regular column value stream.
+struct ColumnDictionary {
+  /// Velox subfield from the writer input root to the configured value stream.
+  /// Use `[*]` to traverse array elements or map values.
+  std::string fieldPath;
+
+  /// Dictionary encoding settings for the resolved value stream.
+  SharedDictionaryConfig dictionary;
+};
+
+/// Shared dictionary settings for one flat-map key.
+struct FlatmapKeyDictionary {
+  /// Flat-map key to configure.
+  int64_t key{};
+
+  /// Velox subfield below the keyed flat-map value. Empty selects the key
+  /// value itself. Non-empty paths start with a field name; use `[*]` to
+  /// traverse array elements or map values below that field.
+  std::string valueSubfield;
+
+  /// Dictionary encoding settings for the key value stream.
+  SharedDictionaryConfig dictionary;
+};
+
+/// Shared dictionary settings for one top-level flat-map column.
+struct FlatmapColumnDictionary {
+  /// Row-field path from the writer input root to the configured flat-map
+  /// column. This currently names a top-level writer input column.
+  std::string fieldPath;
+
+  /// Per-key shared dictionary settings.
+  std::vector<FlatmapKeyDictionary> keys;
+};
+
+/// Shared dictionary writer configuration for regular columns and flat-map
+/// value streams in a file.
+struct SharedDictionaryEncodingConfig {
+  /// Regular columns eligible for shared dictionary encoding. Paths may use
+  /// `[*]` to select array elements or map values before a nested field. The
+  /// resolved value must be an integer scalar, or an array whose element is an
+  /// integer scalar. For File scope, callers are responsible for assigning a
+  /// unique dictionaryId per configured value stream.
+  std::vector<ColumnDictionary> columns;
+
+  /// Top-level flat-map columns eligible for shared dictionary encoding.
+  /// Non-empty valueSubfield paths start with a field name and may use `[*]`
+  /// below that field to select array elements or map values. The configured
+  /// value stream must resolve to an integer scalar, or an array whose element
+  /// is an integer scalar. For File scope, callers are responsible for
+  /// assigning a unique dictionaryId per configured key value stream.
+  std::vector<FlatmapColumnDictionary> flatMapColumns;
+
+  /// Supplies external alphabets for External shared dictionary configurations
+  /// and File configurations that set useExternalAlphabet.
+  std::shared_ptr<const ExternalDictionaryResolver> externalResolver;
+
+  /// Returns true when no value streams request shared dictionary encoding.
+  bool empty() const {
+    return columns.empty() && flatMapColumns.empty();
+  }
+
+  /// Creates a builder, optionally seeded from an existing config.
+  static SharedDictionaryConfigBuilder builder(
+      SharedDictionaryEncodingConfig&& config = {});
+};
+
+/// Builder for SharedDictionaryEncodingConfig.
+class SharedDictionaryConfigBuilder {
+ public:
+  /// Creates a builder seeded from config.
+  explicit SharedDictionaryConfigBuilder(
+      SharedDictionaryEncodingConfig&& config = {});
+
+  /// Sets the resolver used by external dictionaries and provided file
+  /// alphabets.
+  SharedDictionaryConfigBuilder& setExternalResolver(
+      std::shared_ptr<const ExternalDictionaryResolver> externalResolver);
+
+  /// Adds dictionary settings for one regular column value stream.
+  SharedDictionaryConfigBuilder& addColumnDictionary(
+      std::string fieldPath,
+      SharedDictionaryConfig dictionary);
+
+  /// Adds dictionary settings for one top-level flat-map key value stream.
+  SharedDictionaryConfigBuilder& addFlatmapValueDictionary(
+      std::string fieldPath,
+      int64_t key,
+      SharedDictionaryConfig dictionary,
+      std::string valueSubfield = "");
+
+  /// Returns the completed config.
+  SharedDictionaryEncodingConfig build();
+
+ private:
+  SharedDictionaryEncodingConfig config_;
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(
   RowRangeTest.cpp
   SchemaTest.cpp
   SchemaUtilsTest.cpp
+  SharedDictionaryConfigTest.cpp
   SharedDictionaryWriterTest.cpp
   StreamChunkerTest.cpp
   StreamDataTest.cpp
@@ -94,6 +95,7 @@ target_link_libraries(
   nimble_velox_schema_utils
   nimble_writer_test_utils
   nimble_velox_reader
+  nimble_velox_shared_dictionary_config
   nimble_writer
   nimble_velox_layout_planner
   nimble_velox_stats_fb

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryConfigTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryConfigTest.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
+
+namespace facebook::nimble {
+namespace {
+
+TEST(SharedDictionaryConfigTest, defaultValues) {
+  SharedDictionaryConfig dictionary;
+  EXPECT_EQ(dictionary.scope, SharedDictionaryScope::Stripe);
+  EXPECT_EQ(dictionary.dictionaryId, 0);
+  EXPECT_FALSE(dictionary.useExternalAlphabet);
+  EXPECT_TRUE(dictionary.alphabetEncodings.empty());
+
+  SharedDictionaryEncodingConfig config;
+  EXPECT_TRUE(config.empty());
+  EXPECT_TRUE(config.columns.empty());
+  EXPECT_TRUE(config.flatMapColumns.empty());
+  EXPECT_EQ(config.externalResolver, nullptr);
+}
+
+TEST(SharedDictionaryConfigTest, config) {
+  const auto config =
+      SharedDictionaryEncodingConfig::builder()
+          .addColumnDictionary(
+              "value",
+              SharedDictionaryConfig{
+                  .scope = SharedDictionaryScope::Stripe, .dictionaryId = 5})
+          .addColumnDictionary(
+              "nested.value",
+              SharedDictionaryConfig{
+                  .scope = SharedDictionaryScope::External, .dictionaryId = 9})
+          .addColumnDictionary(
+              "nested.items[*].value",
+              SharedDictionaryConfig{
+                  .scope = SharedDictionaryScope::File, .dictionaryId = 11})
+          .addFlatmapValueDictionary(
+              "features",
+              /*key=*/42,
+              SharedDictionaryConfig{
+                  .scope = SharedDictionaryScope::File,
+                  .dictionaryId = 17,
+                  .useExternalAlphabet = true,
+                  .alphabetEncodings = {EncodingType::FixedBitWidth}},
+              "items[*].score")
+          .build();
+
+  EXPECT_FALSE(config.empty());
+  ASSERT_EQ(config.columns.size(), 3);
+  ASSERT_EQ(config.flatMapColumns.size(), 1);
+  EXPECT_EQ(config.externalResolver, nullptr);
+
+  EXPECT_EQ(config.columns[0].fieldPath, "value");
+  EXPECT_EQ(config.columns[0].dictionary.scope, SharedDictionaryScope::Stripe);
+  EXPECT_EQ(config.columns[0].dictionary.dictionaryId, 5);
+
+  EXPECT_EQ(config.columns[1].fieldPath, "nested.value");
+  EXPECT_EQ(
+      config.columns[1].dictionary.scope, SharedDictionaryScope::External);
+  EXPECT_EQ(config.columns[1].dictionary.dictionaryId, 9);
+
+  EXPECT_EQ(config.columns[2].fieldPath, "nested.items[*].value");
+  EXPECT_EQ(config.columns[2].dictionary.scope, SharedDictionaryScope::File);
+  EXPECT_EQ(config.columns[2].dictionary.dictionaryId, 11);
+
+  const auto& columnDictionary = config.flatMapColumns[0];
+  EXPECT_EQ(columnDictionary.fieldPath, "features");
+  ASSERT_EQ(columnDictionary.keys.size(), 1);
+  const auto& keyDictionary = columnDictionary.keys[0];
+  EXPECT_EQ(keyDictionary.key, 42);
+  EXPECT_EQ(keyDictionary.valueSubfield, "items[*].score");
+  EXPECT_EQ(keyDictionary.dictionary.scope, SharedDictionaryScope::File);
+  EXPECT_EQ(keyDictionary.dictionary.dictionaryId, 17);
+  EXPECT_TRUE(keyDictionary.dictionary.useExternalAlphabet);
+  EXPECT_EQ(
+      keyDictionary.dictionary.alphabetEncodings,
+      std::vector<EncodingType>{EncodingType::FixedBitWidth});
+}
+
+TEST(SharedDictionaryConfigTest, builderSeedsExistingConfig) {
+  const auto seedConfig =
+      SharedDictionaryEncodingConfig::builder()
+          .addColumnDictionary(
+              "value",
+              SharedDictionaryConfig{
+                  .scope = SharedDictionaryScope::Stripe, .dictionaryId = 5})
+          .build();
+  auto configCopy = seedConfig;
+
+  const auto config =
+      SharedDictionaryEncodingConfig::builder(std::move(configCopy))
+          .addFlatmapValueDictionary(
+              "features",
+              /*key=*/10,
+              SharedDictionaryConfig{
+                  .scope = SharedDictionaryScope::External, .dictionaryId = 9})
+          .build();
+
+  ASSERT_EQ(config.columns.size(), seedConfig.columns.size());
+  ASSERT_EQ(config.flatMapColumns.size(), 1);
+  EXPECT_EQ(config.columns[0].fieldPath, seedConfig.columns[0].fieldPath);
+  EXPECT_EQ(
+      config.columns[0].dictionary.scope,
+      seedConfig.columns[0].dictionary.scope);
+  EXPECT_EQ(
+      config.columns[0].dictionary.dictionaryId,
+      seedConfig.columns[0].dictionary.dictionaryId);
+  EXPECT_TRUE(seedConfig.flatMapColumns.empty());
+  EXPECT_EQ(config.flatMapColumns[0].fieldPath, "features");
+  ASSERT_EQ(config.flatMapColumns[0].keys.size(), 1);
+  EXPECT_EQ(config.flatMapColumns[0].keys[0].key, 10);
+}
+
+TEST(SharedDictionaryConfigTest, builderRejectsDuplicateTargets) {
+  auto config =
+      SharedDictionaryEncodingConfig::builder()
+          .addColumnDictionary("nested.value", SharedDictionaryConfig{})
+          .addFlatmapValueDictionary(
+              "features", /*key=*/42, SharedDictionaryConfig{})
+          .addFlatmapValueDictionary(
+              "features",
+              /*key=*/42,
+              SharedDictionaryConfig{},
+              "items[*].value")
+          .build();
+  auto builder = SharedDictionaryEncodingConfig::builder(std::move(config));
+
+  NIMBLE_ASSERT_USER_THROW(
+      builder.addColumnDictionary("nested.value", SharedDictionaryConfig{}),
+      "Duplicate shared dictionary column configuration for path "
+      "'nested.value'.");
+  NIMBLE_ASSERT_USER_THROW(
+      builder.addFlatmapValueDictionary(
+          "features", /*key=*/42, SharedDictionaryConfig{}),
+      "Duplicate shared dictionary flat-map value configuration for path "
+      "'features', key 42, and value subfield ''.");
+  NIMBLE_ASSERT_USER_THROW(
+      builder.addFlatmapValueDictionary(
+          "features", /*key=*/42, SharedDictionaryConfig{}, "items[*].value"),
+      "Duplicate shared dictionary flat-map value configuration for path "
+      "'features', key 42, and value subfield 'items[*].value'.");
+}
+
+TEST(SharedDictionaryConfigTest, builderRejectsInvalidPaths) {
+  struct TestCase {
+    std::string_view name;
+    std::string_view fieldPath;
+    bool flatMap;
+    std::string_view expectedMessage;
+  };
+
+  const std::vector<TestCase> testCases{
+      {
+          .name = "empty column path",
+          .fieldPath = "",
+          .flatMap = false,
+          .expectedMessage = "Shared dictionary column path must not be empty.",
+      },
+      {
+          .name = "column path with subscript",
+          .fieldPath = "features[10]",
+          .flatMap = false,
+          .expectedMessage =
+              "Shared dictionary column path 'features[10]' only supports "
+              "nested row fields and all-subscript array/map elements.",
+      },
+      {
+          .name = "empty flat-map path",
+          .fieldPath = "",
+          .flatMap = true,
+          .expectedMessage =
+              "Shared dictionary flat-map column path must not be empty.",
+      },
+      {
+          .name = "nested flat-map path",
+          .fieldPath = "nested.features",
+          .flatMap = true,
+          .expectedMessage =
+              "Shared dictionary flat-map column path 'nested.features' must "
+              "be a top-level writer input column.",
+      },
+      {
+          .name = "flat-map path with subscript",
+          .fieldPath = "features[10]",
+          .flatMap = true,
+          .expectedMessage =
+              "Shared dictionary flat-map column path 'features[10]' must be "
+              "a top-level writer input column.",
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    auto builder = SharedDictionaryEncodingConfig::builder();
+    if (testCase.flatMap) {
+      NIMBLE_ASSERT_USER_THROW(
+          builder.addFlatmapValueDictionary(
+              std::string{testCase.fieldPath},
+              /*key=*/10,
+              SharedDictionaryConfig{}),
+          testCase.expectedMessage);
+    } else {
+      NIMBLE_ASSERT_USER_THROW(
+          builder.addColumnDictionary(
+              std::string{testCase.fieldPath}, SharedDictionaryConfig{}),
+          testCase.expectedMessage);
+    }
+  }
+}
+
+TEST(SharedDictionaryConfigTest, builderRejectsInvalidValueSubfields) {
+  struct TestCase {
+    std::string_view name;
+    std::string_view valueSubfield;
+    std::string_view expectedMessage;
+  };
+
+  const std::vector<TestCase> testCases{
+      {
+          .name = "map key subscript",
+          .valueSubfield = "items[10].value",
+          .expectedMessage =
+              "Shared dictionary flat-map value subfield 'items[10].value' "
+              "only supports nested row fields and all-subscript array/map "
+              "elements.",
+      },
+      {
+          .name = "leading wildcard",
+          .valueSubfield = "[*].value",
+          .expectedMessage =
+              "Shared dictionary flat-map value subfield path '[*].value' "
+              "must start with a field name.",
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    auto builder = SharedDictionaryEncodingConfig::builder();
+    NIMBLE_ASSERT_USER_THROW(
+        builder.addFlatmapValueDictionary(
+            "features",
+            /*key=*/10,
+            SharedDictionaryConfig{},
+            std::string{testCase.valueSubfield}),
+        testCase.expectedMessage);
+  }
+}
+
+} // namespace
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Add the shared dictionary encoding config object and builder used to describe regular-column and top-level flat-map value dictionary targets. The builder validates configured field paths through Velox `Subfield` before writer integration consumes them.

Reviewed By: tanjialiang

Differential Revision: D116374169


