### PR TITLE
feat(nimble): Add shared integer dictionary encoding (#18637)

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -296,15 +296,17 @@ class SelectiveColumnReader {
     numValues_ = size;
   }
 
-  // The number of passing after filtering.
+  // The number of result rows after filtering.
   int32_t numRows() const {
     return outputRows_.size();
   }
 
-  // The number of values copied into the results.
+  // The number of result positions produced so far. This includes null
+  // positions; it is not the count of decoded non-null values.
   int32_t numValues() const {
     return numValues_;
   }
+
   void setNumRows(vector_size_t size) {
     outputRows_.resize(size);
   }

--- a/velox/dwio/nimble/encodings/SharedDictionaryEncoding.cpp
+++ b/velox/dwio/nimble/encodings/SharedDictionaryEncoding.cpp
@@ -42,6 +42,7 @@ SharedDictionaryAlphabet::SharedDictionaryAlphabet(
     std::shared_ptr<const void> encodedAlphabetOwner,
     velox::memory::MemoryPool* pool)
     : encodedAlphabetOwner_{std::move(encodedAlphabetOwner)},
+      encodedAlphabet_{encoded},
       dataType_{EncodingPrefix::dataType(encoded)},
       encodingType_{EncodingPrefix::encodingType(encoded)},
       entryPayload_{*velox::checkedNotNull(pool)},

--- a/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
@@ -40,6 +40,7 @@
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
@@ -298,6 +299,11 @@ class SharedDictionaryAlphabet {
     return encodingType_;
   }
 
+  /// Returns the encoded alphabet stream passed to create().
+  std::string_view encodedAlphabet() const {
+    return encodedAlphabet_;
+  }
+
   /// Returns the entry stored at index. T must match dataType().
   template <typename T>
   typename TypeTraits<T>::physicalType physicalValueAt(uint32_t index) const {
@@ -432,6 +438,7 @@ class SharedDictionaryAlphabet {
 
   // Keeps borrowed encoded bytes alive when create() receives an owner.
   const std::shared_ptr<const void> encodedAlphabetOwner_;
+  const std::string_view encodedAlphabet_;
   const DataType dataType_;
   const EncodingType encodingType_;
   uint32_t entryCount_{0};
@@ -500,6 +507,13 @@ class SharedDictionaryEncoding
   static std::string_view encode(
       std::span<const uint32_t> indices,
       const EncodingSelectionPolicyCreator& nestedPolicyCreator,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view encodeNullable(
+      EncodingSelection<physicalType>&& selection,
+      std::span<const physicalType> values,
+      std::span<const bool> nulls,
       Buffer& buffer,
       const Encoding::Options& options = {});
 
@@ -664,6 +678,34 @@ std::string_view SharedDictionaryEncoding<T>::encode(
       "Encoding size mismatch.");
 
   return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string_view SharedDictionaryEncoding<T>::encodeNullable(
+    EncodingSelection<physicalType>&& selection,
+    std::span<const physicalType> values,
+    std::span<const bool> nulls,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+
+  auto nullsPolicy = selection.template createNestedPolicy<bool>(
+      EncodingType::Nullable, EncodingIdentifiers::Nullable::Nulls);
+  NIMBLE_CHECK_NOT_NULL(nullsPolicy);
+  auto typedNullsPolicy = std::unique_ptr<EncodingSelectionPolicy<bool>>(
+      static_cast<EncodingSelectionPolicy<bool>*>(nullsPolicy.release()));
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  const auto serializedValues = EncodingFactory::encode<T>(
+      std::move(selection), values, scopedBuffer.get(), options);
+  const auto serializedNulls = EncodingFactory::encode<bool>(
+      std::move(typedNullsPolicy), nulls, scopedBuffer.get(), options);
+  return NullableEncoding<T>::encodeNullable(
+      static_cast<uint32_t>(nulls.size()),
+      serializedValues,
+      serializedNulls,
+      buffer,
+      options);
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/common/Encoding.h
+++ b/velox/dwio/nimble/encodings/common/Encoding.h
@@ -162,8 +162,8 @@ class Encoding {
 
     /// Direct alphabet for SharedDictionary encodings when the read path has
     /// already resolved the dictionary bound to this value stream.
-    std::shared_ptr<const SharedDictionaryAlphabet> sharedDictionaryAlphabet =
-        nullptr;
+    std::shared_ptr<const SharedDictionaryAlphabet> sharedDictionaryAlphabet{
+        nullptr};
 
     velox::io::IoCounter* decompressCounter() const {
       return decodingStats != nullptr ? &decodingStats->decompressCPUTimeNanos

--- a/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -284,9 +284,36 @@ std::string_view EncodingFactory::encode(
           selection, castedValues, buffer, options);
     }
     case EncodingType::SharedDictionary: {
+      if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+        const auto& sharedDictionaryInput = selection.sharedDictionaryInput();
+        NIMBLE_CHECK(
+            sharedDictionaryInput.has_value(),
+            "SharedDictionary encoding requires writer-provided dictionary "
+            "indices.");
+        NIMBLE_CHECK_EQ(
+            sharedDictionaryInput->indices.size(),
+            castedValues.size(),
+            "SharedDictionary index count differs from value count.");
+        EncodingSelectionPolicyCreator nestedPolicyCreator =
+            [&selection](DataType nestedDataType)
+            -> std::unique_ptr<EncodingSelectionPolicyBase> {
+          NIMBLE_CHECK_EQ(
+              nestedDataType,
+              DataType::Uint32,
+              "SharedDictionary index stream must use Uint32.");
+          return selection.template createNestedPolicy<uint32_t>(
+              EncodingType::SharedDictionary,
+              EncodingIdentifiers::SharedDictionary::Indices);
+        };
+        return SharedDictionaryEncoding<T>::encode(
+            sharedDictionaryInput->indices,
+            nestedPolicyCreator,
+            buffer,
+            options);
+      }
       NIMBLE_INCOMPATIBLE_ENCODING(
-          "SharedDictionary encoding requires writer-provided dictionary "
-          "indices.");
+          "SharedDictionary encoding only supports non-bool integer data "
+          "types.");
     }
     case EncodingType::FixedBitWidth: {
       if constexpr (isNumericType<physicalType>()) {
@@ -428,6 +455,15 @@ std::string_view EncodingFactory::encodeNullable(
     case EncodingType::Nullable: {
       return NullableEncoding<T>::encodeNullable(
           selection, physicalValues, nulls, buffer, options);
+    }
+    case EncodingType::SharedDictionary: {
+      if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+        return SharedDictionaryEncoding<T>::encodeNullable(
+            std::move(selection), physicalValues, nulls, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "SharedDictionary encoding only supports non-bool integer data "
+          "types.");
     }
     default: {
       NIMBLE_UNSUPPORTED(

--- a/velox/dwio/nimble/encodings/common/EncodingFactory.h
+++ b/velox/dwio/nimble/encodings/common/EncodingFactory.h
@@ -30,6 +30,9 @@ class EncodingSelection;
 template <typename T>
 class EncodingSelectionPolicy;
 
+template <typename T>
+class SharedDictionaryEncoding;
+
 class EncodingFactory {
  public:
   explicit EncodingFactory(Encoding::Options options = {})
@@ -118,6 +121,8 @@ class EncodingFactory {
   friend class EncodingSelection<double>;
   friend class EncodingSelection<bool>;
   friend class EncodingSelection<std::string_view>;
+  template <typename T>
+  friend class SharedDictionaryEncoding;
 };
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/selection/EncodingSelection.h
+++ b/velox/dwio/nimble/encodings/selection/EncodingSelection.h
@@ -71,6 +71,12 @@ namespace facebook::nimble {
 
 class EncodingSelectionPolicyBase;
 
+/// Writer-provided input for shared dictionary value-stream encoding.
+struct SharedDictionaryEncodingInput {
+  /// One dictionary index for each non-null input value.
+  std::span<const uint32_t> indices;
+};
+
 /// Type representing a selected encoding.
 /// This is the result type returned from the select() method of an encoding
 /// selection policy. Also provides access to the compression policies for
@@ -85,6 +91,8 @@ struct EncodingSelectionResult {
   std::optional<uint64_t> estimatedSize{};
   std::function<std::unique_ptr<CompressionPolicy>()> compressionPolicyFactory =
       []() { return std::make_unique<NoCompressionPolicy>(); };
+  /// Additional input required when encodingType is SharedDictionary.
+  std::optional<SharedDictionaryEncodingInput> sharedDictionaryInput{};
 };
 
 /// The EncodingSelection class is passed in to the encode() method of each
@@ -112,6 +120,11 @@ class EncodingSelection {
   std::unique_ptr<CompressionPolicy> compressionPolicy() const noexcept {
     auto policy = selectionResult_.compressionPolicyFactory();
     return policy;
+  }
+
+  const std::optional<SharedDictionaryEncodingInput>& sharedDictionaryInput()
+      const noexcept {
+    return selectionResult_.sharedDictionaryInput;
   }
 
   template <typename NestedT>

--- a/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <random>
 #include <span>
 #include <string>
 #include <string_view>
@@ -37,13 +38,16 @@
 #include "velox/dwio/nimble/common/NimbleException.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSizeEstimation.h"
 #include "velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryWriter.h"
 
 namespace facebook::nimble {
 namespace {
@@ -81,15 +85,23 @@ class SharedDictionaryEncodingTest : public ::testing::Test {
   }
 
   std::vector<int32_t> materialize(std::string_view encoded) {
-    auto encoding = createEncoding(encoded);
+    return materialize(encoded, Encoding::Options{});
+  }
+
+  std::vector<int32_t> materialize(
+      std::string_view encoded,
+      const Encoding::Options& options) {
+    auto encoding = createEncoding(encoded, options);
     Vector<int32_t> output{pool_.get(), encoding->rowCount()};
     encoding->materialize(encoding->rowCount(), output.data());
     return {output.begin(), output.end()};
   }
 
-  std::string encodeShared(const std::vector<uint32_t>& indices) {
+  std::string encodeShared(
+      const std::vector<uint32_t>& indices,
+      const Encoding::Options& options = {}) {
     const auto encoded = SharedDictionaryEncoding<int32_t>::encode(
-        indices, createNestedPolicy, *buffer_, Encoding::Options{});
+        indices, createNestedPolicy, *buffer_, options);
     return std::string{encoded};
   }
 
@@ -114,6 +126,12 @@ class SharedDictionaryEncodingTest : public ::testing::Test {
         EncodingPrefix::prefixSize(encoded, /*useVarint=*/false);
     const uint32_t alphabetBytes = encoding::readUint32(pos);
     pos += alphabetBytes;
+    return {pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)};
+  }
+
+  std::string_view sharedDictionaryIndices(std::string_view encoded) const {
+    const char* pos = encoded.data() +
+        EncodingPrefix::prefixSize(encoded, /*useVarint=*/false);
     return {pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)};
   }
 
@@ -160,6 +178,236 @@ template <typename T>
 std::span<const T> valueSpan(const std::vector<T>& values) {
   return {values.data(), values.size()};
 }
+
+using TestSharedDictionaryWriter = TypedSharedDictionaryWriter<int32_t>;
+using EncodingReadFactors = std::vector<std::pair<EncodingType, float>>;
+
+EncodingReadFactors dictionaryValueEncoding() {
+  return {{EncodingType::Dictionary, 1.0}};
+}
+
+EncodingReadFactors trivialPreferredValueEncoding() {
+  return {{EncodingType::Trivial, 0.01}, {EncodingType::Dictionary, 1000.0}};
+}
+
+EncodingSelectionPolicyCreator testEncodingSelectionPolicyCreator(
+    EncodingReadFactors valueEncodingReadFactors = dictionaryValueEncoding()) {
+  return
+      [valueEncodingReadFactors = std::move(valueEncodingReadFactors)](
+          DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        EncodingReadFactors encodingReadFactors;
+        switch (dataType) {
+          case DataType::Int32:
+            encodingReadFactors = valueEncodingReadFactors;
+            break;
+          case DataType::Uint32:
+            encodingReadFactors = {{EncodingType::FixedBitWidth, 1.0}};
+            break;
+          case DataType::Undefined:
+          case DataType::Int8:
+          case DataType::Uint8:
+          case DataType::Int16:
+          case DataType::Uint16:
+          case DataType::Int64:
+          case DataType::Uint64:
+          case DataType::Float:
+          case DataType::Double:
+          case DataType::Bool:
+          case DataType::String:
+            encodingReadFactors = {{EncodingType::Trivial, 1.0}};
+            break;
+        }
+        ManualEncodingSelectionPolicyFactory factory{
+            std::move(encodingReadFactors), std::nullopt};
+        return factory.createPolicy(dataType);
+      };
+}
+
+class TestDictionaryResolver final : public ExternalDictionaryResolver {
+ public:
+  TestDictionaryResolver(
+      uint32_t dictionaryId,
+      std::span<const int32_t> values,
+      velox::memory::MemoryPool* pool)
+      : dictionaryId_{dictionaryId},
+        alphabet_{test::createSharedDictionaryAlphabet<int32_t>(
+            values,
+            std::span<const EncodingType>{},
+            pool)} {}
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      uint32_t dictionaryId,
+      DataType dataType) const final {
+    if (dictionaryId != dictionaryId_ || dataType != DataType::Int32) {
+      return nullptr;
+    }
+    return alphabet_;
+  }
+
+  std::shared_ptr<const SharedDictionaryAlphabet> alphabet() const {
+    return alphabet_;
+  }
+
+ private:
+  const uint32_t dictionaryId_;
+  const std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
+};
+
+struct GeneratedEncodingBatch {
+  bool nullable{};
+  std::vector<int32_t> values;
+  std::unique_ptr<bool[]> notNulls;
+  size_t rowCount{};
+  std::vector<int32_t> expected;
+  std::string encoded;
+
+  std::span<const bool> notNullsSpan() const {
+    return {notNulls.get(), rowCount};
+  }
+};
+
+std::vector<int32_t> sharedDictionaryValueUniverse() {
+  constexpr int32_t kValueCount{256};
+  std::vector<int32_t> values;
+  values.reserve(kValueCount);
+  for (int32_t i{0}; i < kValueCount; ++i) {
+    values.push_back(i * 13 - 57);
+  }
+  return values;
+}
+
+int32_t randomValue(std::mt19937& rng, std::span<const int32_t> valueUniverse) {
+  std::uniform_int_distribution<size_t> valueIndex{0, valueUniverse.size() - 1};
+  return valueUniverse[valueIndex(rng)];
+}
+
+GeneratedEncodingBatch generateBatch(
+    std::mt19937& rng,
+    std::span<const int32_t> valueUniverse,
+    bool requireNonNullValue) {
+  GeneratedEncodingBatch batch;
+  std::uniform_int_distribution<size_t> rowCount{1, 64};
+  batch.rowCount = rowCount(rng);
+  batch.nullable = std::uniform_int_distribution<int>{0, 2}(rng) != 0;
+  batch.expected.reserve(batch.rowCount);
+
+  if (!batch.nullable) {
+    batch.values.reserve(batch.rowCount);
+    for (size_t i{0}; i < batch.rowCount; ++i) {
+      const auto value = randomValue(rng, valueUniverse);
+      batch.values.push_back(value);
+      batch.expected.push_back(value);
+    }
+    return batch;
+  }
+
+  batch.notNulls = std::make_unique<bool[]>(batch.rowCount);
+  const bool allNull = !requireNonNullValue &&
+      std::uniform_int_distribution<int>{0, 5}(rng) == 0;
+  for (size_t i{0}; i < batch.rowCount; ++i) {
+    const bool forcedNonNull = requireNonNullValue && i == 0;
+    const bool randomlyNonNull =
+        std::uniform_int_distribution<int>{0, 3}(rng) != 0;
+    const bool notNull = !allNull && (forcedNonNull || randomlyNonNull);
+    batch.notNulls[i] = notNull;
+    if (notNull) {
+      const auto value = randomValue(rng, valueUniverse);
+      batch.values.push_back(value);
+      batch.expected.push_back(value);
+      continue;
+    }
+    batch.expected.push_back(0);
+  }
+  return batch;
+}
+
+TestSharedDictionaryWriter::Options writerOptions(
+    SharedDictionaryScope scope,
+    uint32_t dictionaryId,
+    std::shared_ptr<const ExternalDictionaryResolver> resolver = nullptr,
+    EncodingReadFactors valueEncodingReadFactors = dictionaryValueEncoding()) {
+  return TestSharedDictionaryWriter::Options{
+      .scope = scope,
+      .dictionaryId = dictionaryId,
+      .useExternalAlphabet = false,
+      .alphabetEncodings = {},
+      .encodingSelectionPolicyCreator = testEncodingSelectionPolicyCreator(
+          std::move(valueEncodingReadFactors)),
+      .encodingOptions = Encoding::Options{},
+      .resolver = std::move(resolver)};
+}
+
+class SharedDictionaryWriterPolicyEncodingTest
+    : public SharedDictionaryEncodingTest,
+      public ::testing::WithParamInterface<SharedDictionaryScope> {
+ protected:
+  static constexpr uint32_t kDictionaryId{7};
+
+  TestSharedDictionaryWriter createWriter(
+      std::span<const int32_t> externalAlphabetValues,
+      EncodingReadFactors valueEncodingReadFactors =
+          dictionaryValueEncoding()) {
+    auto resolver = GetParam() == SharedDictionaryScope::External
+        ? std::make_shared<TestDictionaryResolver>(
+              kDictionaryId, externalAlphabetValues, pool_.get())
+        : nullptr;
+    externalResolver_ = resolver;
+    return TestSharedDictionaryWriter{
+        pool_.get(),
+        writerOptions(
+            GetParam(),
+            kDictionaryId,
+            std::move(resolver),
+            std::move(valueEncodingReadFactors))};
+  }
+
+  void encodeBatch(
+      TestSharedDictionaryWriter& writer,
+      size_t stripeIndex,
+      GeneratedEncodingBatch& batch) {
+    if (batch.nullable) {
+      batch.encoded = std::string{EncodingFactory::encodeNullable<int32_t>(
+          writer.createEncodingPolicy(stripeIndex),
+          batch.values,
+          batch.notNullsSpan(),
+          *buffer_,
+          Encoding::Options{})};
+      return;
+    }
+    batch.encoded = std::string{EncodingFactory::encode<int32_t>(
+        writer.createEncodingPolicy(stripeIndex),
+        batch.values,
+        *buffer_,
+        Encoding::Options{})};
+  }
+
+  void expectRoundTrip(
+      const GeneratedEncodingBatch& batch,
+      const Encoding::Options& options) {
+    EXPECT_EQ(materialize(batch.encoded, options), batch.expected);
+  }
+
+  Encoding::Options decodingOptions(TestSharedDictionaryWriter& writer) {
+    Encoding::Options options;
+    if (GetParam() == SharedDictionaryScope::External) {
+      NIMBLE_CHECK_NOT_NULL(externalResolver_);
+      options.sharedDictionaryAlphabet = externalResolver_->alphabet();
+      return options;
+    }
+
+    const auto alphabet = writer.encodeAlphabet(*buffer_);
+    NIMBLE_CHECK(alphabet.has_value(), "Expected shared dictionary alphabet.");
+    auto encodedAlphabetOwner =
+        std::make_shared<const std::string>(alphabet->content.front());
+    const std::string_view encodedAlphabet{*encodedAlphabetOwner};
+    options.sharedDictionaryAlphabet = SharedDictionaryAlphabet::create(
+        encodedAlphabet, std::move(encodedAlphabetOwner), pool_.get());
+    return options;
+  }
+
+ private:
+  std::shared_ptr<TestDictionaryResolver> externalResolver_;
+};
 
 TEST(SharedDictionaryScopeTest, scopeName) {
   struct Case {
@@ -242,6 +490,220 @@ TEST_F(
       "SharedDictionary encoding requires writer-provided dictionary indices.");
 }
 
+TEST_P(
+    SharedDictionaryWriterPolicyEncodingTest,
+    factoryEncodesSelectionWithWriterPolicy) {
+  const std::vector<int32_t> values{30, 10, 20, 30};
+  const std::vector<int32_t> alphabetValues{30, 10, 20};
+  const std::vector<uint32_t> indices{0, 1, 2, 0};
+  auto writer = createWriter(alphabetValues);
+
+  const auto encoded = EncodingFactory::encode<int32_t>(
+      writer.createEncodingPolicy(/*stripeIndex=*/0),
+      values,
+      *buffer_,
+      Encoding::Options{});
+
+  EXPECT_EQ(
+      EncodingPrefix::encodingType(encoded), EncodingType::SharedDictionary);
+  EXPECT_EQ(EncodingPrefix::dataType(encoded), DataType::Int32);
+  EXPECT_EQ(
+      EncodingPrefix::readRowCount(encoded, /*useVarint=*/false),
+      values.size());
+
+  const auto encodedIndices = sharedDictionaryIndices(encoded);
+  auto indicesEncoding = createEncoding(encodedIndices);
+  EXPECT_EQ(indicesEncoding->encodingType(), EncodingType::FixedBitWidth);
+  EXPECT_EQ(indicesEncoding->dataType(), DataType::Uint32);
+
+  Vector<uint32_t> materializedIndices{pool_.get(), indices.size()};
+  indicesEncoding->materialize(
+      static_cast<uint32_t>(indices.size()), materializedIndices.data());
+  EXPECT_EQ(
+      std::vector<uint32_t>(
+          materializedIndices.begin(), materializedIndices.end()),
+      indices);
+
+  EXPECT_TRUE(writer.usesDictionary());
+  EXPECT_TRUE(writer.hasUsedDictionary());
+  EXPECT_EQ(materialize(encoded, decodingOptions(writer)), values);
+}
+
+TEST_P(
+    SharedDictionaryWriterPolicyEncodingTest,
+    factoryEncodesNullableSelectionWithWriterPolicy) {
+  const std::vector<int32_t> values{30, 10, 20};
+  const std::vector<int32_t> alphabetValues{30, 10, 20};
+  const std::array<bool, 4> notNulls{true, false, true, true};
+  auto writer = createWriter(alphabetValues);
+
+  const auto encoded = EncodingFactory::encodeNullable<int32_t>(
+      writer.createEncodingPolicy(/*stripeIndex=*/0),
+      values,
+      notNulls,
+      *buffer_,
+      Encoding::Options{});
+
+  EXPECT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Nullable);
+  EXPECT_EQ(EncodingPrefix::dataType(encoded), DataType::Int32);
+  EXPECT_EQ(
+      EncodingPrefix::readRowCount(encoded, /*useVarint=*/false),
+      notNulls.size());
+
+  auto options = decodingOptions(writer);
+  auto encoding = createEncoding(encoded, options);
+  const auto* nullableEncoding =
+      dynamic_cast<const NullableEncoding<int32_t>*>(encoding.get());
+  ASSERT_NE(nullableEncoding, nullptr);
+  ASSERT_NE(nullableEncoding->nonNulls(), nullptr);
+  EXPECT_EQ(
+      nullableEncoding->nonNulls()->encodingType(),
+      EncodingType::SharedDictionary);
+
+  Vector<int32_t> output{pool_.get(), notNulls.size()};
+  encoding->materialize(notNulls.size(), output.data());
+
+  const std::vector<int32_t> expected{30, 0, 10, 20};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_P(
+    SharedDictionaryWriterPolicyEncodingTest,
+    factoryEncodesAllNullNullableWithWriterPolicy) {
+  const std::array<int32_t, 1> alphabetValues{0};
+  const std::array<int32_t, 0> values{};
+  const std::array<bool, 3> notNulls{false, false, false};
+  auto writer = createWriter(alphabetValues);
+
+  const auto encoded = EncodingFactory::encodeNullable<int32_t>(
+      writer.createEncodingPolicy(/*stripeIndex=*/0),
+      values,
+      notNulls,
+      *buffer_,
+      Encoding::Options{});
+
+  EXPECT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Nullable);
+  EXPECT_FALSE(writer.usesDictionary());
+  EXPECT_FALSE(writer.hasUsedDictionary());
+  if (GetParam() != SharedDictionaryScope::External) {
+    EXPECT_FALSE(writer.encodeAlphabet(*buffer_).has_value());
+  } else {
+    NIMBLE_ASSERT_THROW(
+        writer.encodeAlphabet(*buffer_),
+        "External shared dictionary 7 cannot encode an alphabet; its resolver "
+        "owns the alphabet.");
+  }
+
+  auto encoding = createEncoding(encoded);
+  const auto* nullableEncoding =
+      dynamic_cast<const NullableEncoding<int32_t>*>(encoding.get());
+  ASSERT_NE(nullableEncoding, nullptr);
+  ASSERT_NE(nullableEncoding->nonNulls(), nullptr);
+  EXPECT_NE(
+      nullableEncoding->nonNulls()->encodingType(),
+      EncodingType::SharedDictionary);
+  EXPECT_EQ(nullableEncoding->nonNulls()->rowCount(), 0);
+}
+
+TEST_P(
+    SharedDictionaryWriterPolicyEncodingTest,
+    generatedBatchesAcrossStripesRoundTrip) {
+  constexpr uint32_t kSeed{0x9E3779B9};
+  std::mt19937 rng{
+      kSeed + static_cast<uint32_t>(static_cast<uint8_t>(GetParam()))};
+  const auto valueUniverse = sharedDictionaryValueUniverse();
+  auto writer = createWriter(valueUniverse);
+  std::vector<GeneratedEncodingBatch> pendingBatches;
+
+  SCOPED_TRACE(
+      fmt::format(
+          "scope={}, seed={}",
+          SharedDictionaryScopeName::toName(GetParam()),
+          kSeed));
+
+  for (size_t stripeIndex{0}; stripeIndex < 12; ++stripeIndex) {
+    SCOPED_TRACE(fmt::format("stripe={}", stripeIndex));
+    std::uniform_int_distribution<size_t> batchCount{1, 3};
+    const auto batchesInStripe = batchCount(rng);
+
+    for (size_t batchIndex{0}; batchIndex < batchesInStripe; ++batchIndex) {
+      SCOPED_TRACE(fmt::format("batch={}", batchIndex));
+      auto batch = generateBatch(
+          rng,
+          valueUniverse,
+          /*requireNonNullValue=*/batchIndex == 0);
+      encodeBatch(writer, stripeIndex, batch);
+      pendingBatches.push_back(std::move(batch));
+    }
+
+    if (GetParam() == SharedDictionaryScope::Stripe) {
+      const auto options = decodingOptions(writer);
+      for (const auto& batch : pendingBatches) {
+        expectRoundTrip(batch, options);
+      }
+      pendingBatches.clear();
+    }
+  }
+
+  if (GetParam() != SharedDictionaryScope::Stripe) {
+    const auto options = decodingOptions(writer);
+    for (const auto& batch : pendingBatches) {
+      expectRoundTrip(batch, options);
+    }
+  }
+}
+
+TEST_F(
+    SharedDictionaryEncodingTest,
+    factoryEncodesRegularNullableWhenStripePolicyDoesNotSelectDictionary) {
+  auto writer = TestSharedDictionaryWriter{
+      pool_.get(),
+      writerOptions(
+          SharedDictionaryScope::Stripe,
+          /*dictionaryId=*/7,
+          nullptr,
+          trivialPreferredValueEncoding())};
+  const std::vector<int32_t> values{1, 2, 3, 4, 5};
+  const std::array<bool, 6> notNulls{true, true, false, true, true, true};
+
+  const auto encoded = EncodingFactory::encodeNullable<int32_t>(
+      writer.createEncodingPolicy(/*stripeIndex=*/0),
+      values,
+      notNulls,
+      *buffer_,
+      Encoding::Options{});
+
+  EXPECT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Nullable);
+  EXPECT_FALSE(writer.usesDictionary());
+  EXPECT_FALSE(writer.hasUsedDictionary());
+  EXPECT_FALSE(writer.encodeAlphabet(*buffer_).has_value());
+
+  auto encoding = createEncoding(encoded);
+  const auto* nullableEncoding =
+      dynamic_cast<const NullableEncoding<int32_t>*>(encoding.get());
+  ASSERT_NE(nullableEncoding, nullptr);
+  ASSERT_NE(nullableEncoding->nonNulls(), nullptr);
+  EXPECT_NE(
+      nullableEncoding->nonNulls()->encodingType(),
+      EncodingType::SharedDictionary);
+
+  Vector<int32_t> output{pool_.get(), notNulls.size()};
+  encoding->materialize(notNulls.size(), output.data());
+  const std::vector<int32_t> expected{1, 2, 0, 3, 4, 5};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Scopes,
+    SharedDictionaryWriterPolicyEncodingTest,
+    ::testing::Values(
+        SharedDictionaryScope::Stripe,
+        SharedDictionaryScope::File,
+        SharedDictionaryScope::External),
+    [](const ::testing::TestParamInfo<SharedDictionaryScope>& testInfo) {
+      return std::string{SharedDictionaryScopeName::toName(testInfo.param)};
+    });
+
 TEST_F(SharedDictionaryEncodingTest, alphabetOwnerKeepsViewBytesAlive) {
   std::shared_ptr<const SharedDictionaryAlphabet> alphabet;
   {
@@ -267,6 +729,7 @@ TEST_F(SharedDictionaryEncodingTest, retainsEncodedAlphabetOwner) {
   auto encodedAlphabetOwner = std::make_shared<const std::string>(
       SharedDictionaryAlphabet::encode<int32_t>(
           values, std::array{EncodingType::FixedBitWidth}, *buffer_));
+  const auto expectedEncodedAlphabet = *encodedAlphabetOwner;
   std::weak_ptr<const std::string> weakOwner = encodedAlphabetOwner;
 
   auto alphabet = SharedDictionaryAlphabet::create(
@@ -274,6 +737,7 @@ TEST_F(SharedDictionaryEncodingTest, retainsEncodedAlphabetOwner) {
   encodedAlphabetOwner.reset();
 
   EXPECT_FALSE(weakOwner.expired());
+  EXPECT_EQ(std::string{alphabet->encodedAlphabet()}, expectedEncodedAlphabet);
   EXPECT_EQ(alphabet->physicalValueAt<int32_t>(1), 20);
   alphabet.reset();
   EXPECT_TRUE(weakOwner.expired());

--- a/velox/dwio/nimble/serializer/Options.h
+++ b/velox/dwio/nimble/serializer/Options.h
@@ -241,10 +241,17 @@ struct SerializerOptions {
   /// FixedBitWidth.
   EncodingType streamIndicesEncodingType{EncodingType::FixedBitWidth};
 
+  /// Returns the default per-encoding options used by Serializer writes.
+  static Encoding::Options defaultEncodingOptions() {
+    Encoding::Options options;
+    options.useVarintRowCount = true;
+    return options;
+  }
+
   /// Per-encoding options passed to EncodingFactory::encode(). Controls
   /// format-level settings (varint row count) and per-encoding config
   /// (e.g., BlockBitPacking block size).
-  Encoding::Options encodingOptions{.useVarintRowCount = true};
+  Encoding::Options encodingOptions{defaultEncodingOptions()};
 
   /// Maximum number of scratch buffers retained by the serializer-owned
   /// nested encoding buffer pool. 0 disables nested encoding buffer caching.

--- a/velox/dwio/nimble/tablet/Constants.h
+++ b/velox/dwio/nimble/tablet/Constants.h
@@ -39,7 +39,6 @@ constexpr std::string_view kVectorizedStatsSection =
 constexpr std::string_view kIndexSection = "columnar.indexes";
 constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
 constexpr std::string_view kPropertiesSection = "columnar.properties";
-constexpr std::string_view kSharedDictionarySection =
-    "columnar.shared_dictionaries";
+constexpr std::string_view kDictionarySection = "columnar.dictionaries";
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/tablet/SharedDictionaryReader.cpp
+++ b/velox/dwio/nimble/tablet/SharedDictionaryReader.cpp
@@ -59,22 +59,20 @@ std::optional<uint32_t> SharedDictionaryReaderFactory::dictionaryStreamId(
       : std::optional<uint32_t>{reference->dictionaryId};
 }
 
-std::vector<std::optional<uint32_t>>
+folly::F14FastMap<uint32_t, uint32_t>
 SharedDictionaryReaderFactory::dictionaryStreamIds(
     std::span<const uint32_t> valueStreamIds) const {
   if (catalog_.stripeDictionaryReferences().empty()) {
     return {};
   }
 
-  std::vector<std::optional<uint32_t>> dictionaryStreamIds;
-  for (size_t i = 0; i < valueStreamIds.size(); ++i) {
+  folly::F14FastMap<uint32_t, uint32_t> dictionaryStreamIds;
+  dictionaryStreamIds.reserve(valueStreamIds.size());
+  for (const auto valueStreamId : valueStreamIds) {
     const auto* reference =
-        catalog_.findStripeDictionaryReference(valueStreamIds[i]);
+        catalog_.findStripeDictionaryReference(valueStreamId);
     if (reference != nullptr) {
-      if (dictionaryStreamIds.empty()) {
-        dictionaryStreamIds.resize(valueStreamIds.size());
-      }
-      dictionaryStreamIds[i] = reference->dictionaryId;
+      dictionaryStreamIds.emplace(valueStreamId, reference->dictionaryId);
     }
   }
   return dictionaryStreamIds;

--- a/velox/dwio/nimble/tablet/SharedDictionaryReader.h
+++ b/velox/dwio/nimble/tablet/SharedDictionaryReader.h
@@ -19,8 +19,8 @@
 #include <optional>
 #include <span>
 #include <string_view>
-#include <vector>
 
+#include "folly/container/F14Map.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
 #include "velox/dwio/nimble/tablet/MetadataCache.h"
@@ -50,7 +50,7 @@ class SharedDictionaryReaderFactory {
       velox::memory::MemoryPool* pool);
 
   /// Returns whether the tablet contains file or external dictionaries.
-  bool hasGlobalDictionaries() const {
+  bool hasFileOrExternalDictionaries() const {
     return !catalog_.fileDictionaryReferences().empty() ||
         !catalog_.externalDictionaryReferences().empty();
   }
@@ -63,9 +63,9 @@ class SharedDictionaryReaderFactory {
   /// Returns the stripe dictionary stream for a value stream, if any.
   std::optional<uint32_t> dictionaryStreamId(uint32_t valueStreamId) const;
 
-  /// Returns stripe dictionary streams for value streams. Returns empty when
-  /// none of the supplied streams uses a stripe dictionary.
-  std::vector<std::optional<uint32_t>> dictionaryStreamIds(
+  /// Returns value stream to stripe dictionary stream bindings. Returns empty
+  /// when none of the supplied streams uses a stripe dictionary.
+  folly::F14FastMap<uint32_t, uint32_t> dictionaryStreamIds(
       std::span<const uint32_t> valueStreamIds) const;
 
   /// Returns the file or external alphabet for a value stream, if any.

--- a/velox/dwio/nimble/tablet/TabletReader.cpp
+++ b/velox/dwio/nimble/tablet/TabletReader.cpp
@@ -95,6 +95,14 @@ TabletReader::Options TabletReader::configureOptions(
   tabletOptions.fileHandle = options.fileHandle();
   tabletOptions.cache = options.cache();
   tabletOptions.ioOptions = options;
+  if (const auto& formatOptions = options.formatSpecificOptions()) {
+    if (auto nimbleOptions =
+            std::dynamic_pointer_cast<const NimbleReaderOptions>(
+                formatOptions)) {
+      tabletOptions.externalDictionaryResolver =
+          nimbleOptions->externalDictionaryResolver;
+    }
+  }
 
   // TODO(T272495998): Temporary shim. Remove once HiveDataSource plumbs a
   // real `metadataIoStats` through `ReaderOptions` that the operator /
@@ -260,9 +268,9 @@ TabletReader::TabletReader(
 
 TabletReader::~TabletReader() = default;
 
-bool TabletReader::hasGlobalDictionaries() const {
+bool TabletReader::hasFileOrExternalDictionaries() const {
   return sharedDictionaryReaderFactory_ != nullptr &&
-      sharedDictionaryReaderFactory_->hasGlobalDictionaries();
+      sharedDictionaryReaderFactory_->hasFileOrExternalDictionaries();
 }
 
 bool TabletReader::hasStripeDictionaries() const {
@@ -277,10 +285,10 @@ std::optional<uint32_t> TabletReader::stripeDictionaryStreamId(
       : sharedDictionaryReaderFactory_->dictionaryStreamId(valueStreamId);
 }
 
-std::vector<std::optional<uint32_t>> TabletReader::stripeDictionaryStreamIds(
+folly::F14FastMap<uint32_t, uint32_t> TabletReader::stripeDictionaryStreamIds(
     std::span<const uint32_t> valueStreamIds) const {
   return sharedDictionaryReaderFactory_ == nullptr
-      ? std::vector<std::optional<uint32_t>>{}
+      ? folly::F14FastMap<uint32_t, uint32_t>{}
       : sharedDictionaryReaderFactory_->dictionaryStreamIds(valueStreamIds);
 }
 
@@ -520,7 +528,7 @@ void TabletReader::cacheMetadata(
 
   if (sharedDictionaryReaderFactory_ != nullptr) {
     auto sharedDictionaryIt =
-        optionalSections_.find(std::string{kSharedDictionarySection});
+        optionalSections_.find(std::string{kDictionarySection});
     NIMBLE_CHECK(sharedDictionaryIt != optionalSections_.end());
     cacheSection(sharedDictionaryIt->second);
   }
@@ -751,15 +759,15 @@ void TabletReader::initProperties() {
 }
 
 void TabletReader::initSharedDictionaries(const Options& options) {
-  auto section = loadOptionalSection(
-      std::string{kSharedDictionarySection}, /*keepCache=*/false);
+  auto section =
+      loadOptionalSection(std::string{kDictionarySection}, /*keepCache=*/false);
   if (!section.has_value()) {
     return;
   }
 
   sharedDictionaryReaderFactory_ = SharedDictionaryReaderFactory::create(
       section->content(),
-      options.externalResolver,
+      options.externalDictionaryResolver,
       /*tabletReader=*/this,
       /*pool=*/pool_);
 }
@@ -780,7 +788,7 @@ std::vector<std::string> TabletReader::preloadSectionNames(
     addName(std::string{kIndexSection});
   }
   addName(std::string{kPropertiesSection});
-  addName(std::string{kSharedDictionarySection});
+  addName(std::string{kDictionarySection});
   return names;
 }
 

--- a/velox/dwio/nimble/tablet/TabletReader.h
+++ b/velox/dwio/nimble/tablet/TabletReader.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "folly/Synchronized.h"
+#include "folly/container/F14Map.h"
 #include "velox/common/caching/FileHandle.h"
 #include "velox/common/file/File.h"
 #include "velox/common/io/Options.h"
@@ -66,6 +67,13 @@ namespace facebook::nimble {
 class SharedDictionaryReaderFactory;
 class SharedDictionaryAlphabet;
 class ExternalDictionaryResolver;
+
+/// Nimble-specific reader options carried through Velox common ReaderOptions.
+class NimbleReaderOptions : public velox::dwio::common::FormatSpecificOptions {
+ public:
+  /// Resolves External shared integer dictionaries referenced by this file.
+  std::shared_ptr<const ExternalDictionaryResolver> externalDictionaryResolver;
+};
 
 namespace test {
 class TabletReaderTestHelper;
@@ -200,7 +208,8 @@ class TabletReader {
     uint32_t maxCacheEntrySize{1U << velox::cache::SsdRun::kSizeBits};
 
     /// Resolves External shared integer dictionaries referenced by this file.
-    std::shared_ptr<const ExternalDictionaryResolver> externalResolver;
+    std::shared_ptr<const ExternalDictionaryResolver>
+        externalDictionaryResolver;
   };
 
   /// Compute checksum from the beginning of the file all the way to footer
@@ -396,7 +405,7 @@ class TabletReader {
   StripeIdentifier stripeIdentifier(uint32_t stripeIndex) const;
 
   /// Returns whether any value stream uses a file or external dictionary.
-  bool hasGlobalDictionaries() const;
+  bool hasFileOrExternalDictionaries() const;
 
   /// Returns whether any value stream uses a stripe dictionary.
   bool hasStripeDictionaries() const;
@@ -405,9 +414,9 @@ class TabletReader {
   std::optional<uint32_t> stripeDictionaryStreamId(
       uint32_t valueStreamId) const;
 
-  /// Returns stripe-local dictionary streams for the supplied value streams.
-  /// Returns empty when none uses a stripe dictionary.
-  std::vector<std::optional<uint32_t>> stripeDictionaryStreamIds(
+  /// Returns value stream to stripe-local dictionary stream bindings. Returns
+  /// empty when none of the supplied value streams uses a stripe dictionary.
+  folly::F14FastMap<uint32_t, uint32_t> stripeDictionaryStreamIds(
       std::span<const uint32_t> valueStreamIds) const;
 
   /// Resolves the file or external alphabet bound to a value stream.

--- a/velox/dwio/nimble/tablet/tests/SharedDictionaryReaderTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/SharedDictionaryReaderTest.cpp
@@ -41,6 +41,8 @@
 namespace facebook::nimble {
 namespace {
 
+constexpr uint64_t kMaxFooterIoBytes{1'024};
+
 class TestDictionaryResolver final : public ExternalDictionaryResolver {
  public:
   explicit TestDictionaryResolver(
@@ -106,13 +108,12 @@ class SharedDictionaryReaderTest : public ::testing::Test {
     velox::InMemoryWriteFile writeFile{file.get()};
     auto writer = TabletWriter::create(&writeFile, *pool_, {});
     if (catalog.has_value()) {
-      writer->writeOptionalSection(
-          std::string{kSharedDictionarySection}, *catalog);
+      writer->writeOptionalSection(std::string{kDictionarySection}, *catalog);
     }
     writer->close();
 
     auto options = test::makeTestTabletOptions(pool_.get());
-    options.externalResolver = std::move(resolver);
+    options.externalDictionaryResolver = std::move(resolver);
     files_.push_back(file);
     auto readFile =
         std::make_shared<testing::InMemoryTrackableReadFile>(*file, true);
@@ -120,6 +121,22 @@ class SharedDictionaryReaderTest : public ::testing::Test {
   }
 
   std::shared_ptr<TabletReader> createTabletWithSharedDictionarySection(
+      std::span<const SharedDictionaryReference> stripeDictionaryReferences,
+      std::span<const SharedDictionaryReference> fileDictionaryReferences,
+      uint32_t fileDictionaryId,
+      std::string_view fileEncodedAlphabet) {
+    return createTabletWithSharedDictionarySectionAndReadFile(
+               stripeDictionaryReferences,
+               fileDictionaryReferences,
+               fileDictionaryId,
+               fileEncodedAlphabet)
+        .first;
+  }
+
+  std::pair<
+      std::shared_ptr<TabletReader>,
+      std::shared_ptr<testing::InMemoryTrackableReadFile>>
+  createTabletWithSharedDictionarySectionAndReadFile(
       std::span<const SharedDictionaryReference> stripeDictionaryReferences,
       std::span<const SharedDictionaryReference> fileDictionaryReferences,
       uint32_t fileDictionaryId,
@@ -143,18 +160,18 @@ class SharedDictionaryReaderTest : public ::testing::Test {
               fileDictionaryReferences,
               {},
               fileDictionaries);
-          writeMetadataFn(std::string{kSharedDictionarySection}, catalog);
+          writeMetadataFn(std::string{kDictionarySection}, catalog);
         };
     auto writer =
         TabletWriter::create(&writeFile, *pool_, std::move(writerOptions));
     writer->close();
 
     auto options = test::makeTestTabletOptions(pool_.get());
+    options.maxFooterIoBytes = kMaxFooterIoBytes;
     files_.push_back(file);
-    return TabletReader::create(
-        std::make_shared<testing::InMemoryTrackableReadFile>(*file, true),
-        pool_.get(),
-        options);
+    auto readFile =
+        std::make_shared<testing::InMemoryTrackableReadFile>(*file, true);
+    return {TabletReader::create(readFile, pool_.get(), options), readFile};
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -165,7 +182,7 @@ TEST_F(SharedDictionaryReaderTest, noCatalog) {
   auto tablet = createTablet(std::nullopt);
 
   EXPECT_FALSE(tablet->hasStripeDictionaries());
-  EXPECT_FALSE(tablet->hasGlobalDictionaries());
+  EXPECT_FALSE(tablet->hasFileOrExternalDictionaries());
   EXPECT_FALSE(tablet->stripeDictionaryStreamId(10).has_value());
   EXPECT_TRUE(tablet->stripeDictionaryStreamIds(std::array<uint32_t, 2>{10, 20})
                   .empty());
@@ -201,21 +218,25 @@ TEST_F(SharedDictionaryReaderTest, basic) {
       fileEncodedAlphabet);
 
   EXPECT_TRUE(tablet->hasStripeDictionaries());
-  EXPECT_TRUE(tablet->hasGlobalDictionaries());
+  EXPECT_TRUE(tablet->hasFileOrExternalDictionaries());
   EXPECT_EQ(
       tablet->stripeDictionaryStreamId(kStripeValueStreamId),
       kDictionaryStreamId);
   EXPECT_FALSE(
       tablet->stripeDictionaryStreamId(kFileValueStreamId).has_value());
+  EXPECT_FALSE(tablet->stripeDictionaryStreamId(uint32_t{999}).has_value());
+  const std::array nonStripeValueStreamIds{uint32_t{999}, kFileValueStreamId};
+  EXPECT_TRUE(
+      tablet->stripeDictionaryStreamIds(nonStripeValueStreamIds).empty());
 
   const std::array valueStreamIds{
       uint32_t{999}, kStripeValueStreamId, kFileValueStreamId};
   const auto dictionaryStreamIds =
       tablet->stripeDictionaryStreamIds(valueStreamIds);
-  ASSERT_EQ(dictionaryStreamIds.size(), valueStreamIds.size());
-  EXPECT_FALSE(dictionaryStreamIds[0].has_value());
-  EXPECT_EQ(dictionaryStreamIds[1], kDictionaryStreamId);
-  EXPECT_FALSE(dictionaryStreamIds[2].has_value());
+  ASSERT_EQ(dictionaryStreamIds.size(), 1);
+  EXPECT_FALSE(dictionaryStreamIds.contains(uint32_t{999}));
+  EXPECT_EQ(dictionaryStreamIds.at(kStripeValueStreamId), kDictionaryStreamId);
+  EXPECT_FALSE(dictionaryStreamIds.contains(kFileValueStreamId));
 
   EXPECT_EQ(tablet->resolveDictionaryAlphabet(kStripeValueStreamId), nullptr);
   const auto alphabet = tablet->resolveDictionaryAlphabet(kFileValueStreamId);
@@ -264,19 +285,24 @@ TEST_F(SharedDictionaryReaderTest, cachesFileAlphabet) {
           .dictionaryId = kDictionaryId,
           .dataType = DataType::Int32}};
 
-  auto tablet = createTabletWithSharedDictionarySection(
-      std::span<const SharedDictionaryReference>{},
-      fileDictionaryReferences,
-      kDictionaryId,
-      fileEncodedAlphabet);
+  const auto [tablet, readFile] =
+      createTabletWithSharedDictionarySectionAndReadFile(
+          std::span<const SharedDictionaryReference>{},
+          fileDictionaryReferences,
+          kDictionaryId,
+          fileEncodedAlphabet);
 
   EXPECT_FALSE(tablet->hasStripeDictionaries());
-  EXPECT_TRUE(tablet->hasGlobalDictionaries());
+  EXPECT_TRUE(tablet->hasFileOrExternalDictionaries());
+  readFile->resetChunks();
   const auto alphabet = tablet->resolveDictionaryAlphabet(kValueStreamId);
   ASSERT_NE(alphabet, nullptr);
+  const auto readsAfterFirstResolve = readFile->chunks().size();
+  EXPECT_GT(readsAfterFirstResolve, 0);
   EXPECT_EQ(alphabet->physicalValueAt<int32_t>(0), 40);
   EXPECT_EQ(tablet->resolveDictionaryAlphabet(kValueStreamId), alphabet);
   EXPECT_EQ(tablet->resolveDictionaryAlphabet(kSecondValueStreamId), alphabet);
+  EXPECT_EQ(readFile->chunks().size(), readsAfterFirstResolve);
 }
 
 TEST_F(SharedDictionaryReaderTest, rejectsMissingExternalResolver) {
@@ -309,7 +335,7 @@ TEST_F(SharedDictionaryReaderTest, cachesExternalAlphabet) {
   auto tablet = createTablet(catalog, resolver);
 
   EXPECT_FALSE(tablet->hasStripeDictionaries());
-  EXPECT_TRUE(tablet->hasGlobalDictionaries());
+  EXPECT_TRUE(tablet->hasFileOrExternalDictionaries());
   const auto alphabet = tablet->resolveDictionaryAlphabet(kValueStreamId);
   ASSERT_NE(alphabet, nullptr);
   EXPECT_EQ(alphabet->physicalValueAt<int32_t>(0), 40);

--- a/velox/dwio/nimble/velox/LayoutPlanner.cpp
+++ b/velox/dwio/nimble/velox/LayoutPlanner.cpp
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 #include "velox/dwio/nimble/velox/LayoutPlanner.h"
+#include <algorithm>
 #include <cstdint>
+
+#include "velox/common/Casts.h"
 
 namespace facebook::nimble {
 
@@ -85,20 +88,18 @@ void appendAllNestedStreams(
 } // namespace
 
 DefaultLayoutPlanner::DefaultLayoutPlanner(
-    std::function<std::shared_ptr<const TypeBuilder>()> typeResolver,
+    const SchemaBuilder* schemaBuilder,
     const std::optional<std::vector<std::tuple<size_t, std::vector<int64_t>>>>&
         flatMapFeatureOrder)
-    : typeResolver_{std::move(typeResolver)},
+    : schemaBuilder_{velox::checkedNotNull(schemaBuilder)},
       flatMapFeatureOrder_{
           flatMapFeatureOrder.has_value()
               ? std::move(flatMapFeatureOrder.value())
-              : std::vector<std::tuple<size_t, std::vector<int64_t>>>{}} {
-  NIMBLE_CHECK_NOT_NULL(typeResolver_, "typeResolver is not supplied");
-}
+              : std::vector<std::tuple<size_t, std::vector<int64_t>>>{}} {}
 
 std::vector<Stream> DefaultLayoutPlanner::getLayout(
     std::vector<Stream>&& streams) {
-  auto type = typeResolver_();
+  const auto& type = schemaBuilder_->root();
   NIMBLE_CHECK_EQ(
       type->kind(),
       Kind::Row,
@@ -188,9 +189,21 @@ std::vector<Stream> DefaultLayoutPlanner::getLayout(
 
   auto tryAppendStream = [&offsetsToStreams, &layout](uint32_t offset) {
     auto it = offsetsToStreams.find(offset);
-    if (it != offsetsToStreams.end()) {
-      layout.emplace_back(std::move(*it->second));
-      offsetsToStreams.erase(it);
+    if (it == offsetsToStreams.end()) {
+      return false;
+    }
+    layout.emplace_back(std::move(*it->second));
+    offsetsToStreams.erase(it);
+    return true;
+  };
+  auto appendStream = [&](uint32_t offset) {
+    if (!tryAppendStream(offset)) {
+      return;
+    }
+    const auto dictionaryStreamOffset =
+        schemaBuilder_->sharedDictionaryStreamOffset(offset);
+    if (dictionaryStreamOffset.has_value()) {
+      tryAppendStream(dictionaryStreamOffset.value());
     }
   };
 
@@ -199,18 +212,18 @@ std::vector<Stream> DefaultLayoutPlanner::getLayout(
   // final ordered stream list.
 
   // First add the root's null stream
-  tryAppendStream(root.nullsDescriptor().offset());
+  appendStream(root.nullsDescriptor().offset());
 
   // Then, add all ordered flat maps
   for (auto offset : orderedFlatMapOffsets) {
-    tryAppendStream(offset);
+    appendStream(offset);
   }
 
   // Then add all remaining streams in the schema order.
   // 'tryAppendStream' will de-dup streams that were already added in previous
   // steps.
   for (auto offset : orderedAllOffsets) {
-    tryAppendStream(offset);
+    appendStream(offset);
   }
 
   NIMBLE_CHECK_EQ(streams.size(), layout.size(), "Stream count mismatch.");

--- a/velox/dwio/nimble/velox/LayoutPlanner.h
+++ b/velox/dwio/nimble/velox/LayoutPlanner.h
@@ -20,18 +20,23 @@
 
 namespace facebook::nimble {
 
+/// Orders streams according to the logical schema and configured FlatMap keys.
 class DefaultLayoutPlanner : public LayoutPlanner {
  public:
+  /// Creates a planner over a schema that may gain FlatMap streams.
   DefaultLayoutPlanner(
-      std::function<std::shared_ptr<const TypeBuilder>()> typeResolver,
+      const SchemaBuilder* schemaBuilder,
       const std::optional<
           std::vector<std::tuple<size_t, std::vector<int64_t>>>>&
           flatMapFeatureOrder);
 
+  /// Returns streams in their physical file order.
   virtual std::vector<Stream> getLayout(std::vector<Stream>&& streams) override;
 
  private:
-  std::function<std::shared_ptr<const TypeBuilder>()> typeResolver_;
+  // Provides the evolving logical schema and stripe dictionary bindings.
+  const SchemaBuilder* const schemaBuilder_;
+  // Preferred key order for configured top-level FlatMap columns.
   std::vector<std::tuple<size_t, std::vector<int64_t>>> flatMapFeatureOrder_;
 };
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/SchemaBuilder.cpp
+++ b/velox/dwio/nimble/velox/SchemaBuilder.cpp
@@ -223,6 +223,15 @@ const TypeBuilder& RowTypeBuilder::childAt(size_t index) const {
   return *children_[index];
 }
 
+const TypeBuilder& RowTypeBuilder::findChild(std::string_view name) const {
+  for (size_t i = 0; i < children_.size(); ++i) {
+    if (names_[i] == name) {
+      return *children_[i];
+    }
+  }
+  NIMBLE_USER_FAIL("Row child '{}' does not exist.", name);
+}
+
 const std::string& RowTypeBuilder::nameAt(size_t index) const {
   NIMBLE_CHECK_LT(index, children_.size(), "Index out of range.");
   return names_[index];
@@ -452,6 +461,38 @@ std::shared_ptr<FlatMapTypeBuilder> SchemaBuilder::createFlatMapTypeBuilder(
 
 offset_size SchemaBuilder::nodeCount() const {
   return currentOffset_;
+}
+
+offset_size SchemaBuilder::createSharedDictionaryStream(
+    offset_size valueStreamOffset) {
+  NIMBLE_CHECK_LT(
+      valueStreamOffset,
+      currentOffset_,
+      "Shared dictionary value stream is not allocated.");
+  NIMBLE_CHECK(
+      !sharedDictionaryStreamOffsets_.contains(valueStreamOffset),
+      "Value stream {} already has a shared dictionary stream.",
+      valueStreamOffset);
+  for (const auto& entry : sharedDictionaryStreamOffsets_) {
+    NIMBLE_CHECK(
+        valueStreamOffset != entry.second,
+        "Stream {} is already the shared dictionary stream for value stream {}; it cannot have its own shared dictionary stream.",
+        valueStreamOffset,
+        entry.first);
+  }
+  const auto dictionaryStreamOffset = allocateStreamOffset();
+  sharedDictionaryStreamOffsets_.emplace(
+      valueStreamOffset, dictionaryStreamOffset);
+  return dictionaryStreamOffset;
+}
+
+std::optional<offset_size> SchemaBuilder::sharedDictionaryStreamOffset(
+    offset_size valueStreamOffset) const {
+  const auto iterator = sharedDictionaryStreamOffsets_.find(valueStreamOffset);
+  if (iterator == sharedDictionaryStreamOffsets_.end()) {
+    return std::nullopt;
+  }
+  return iterator->second;
 }
 
 const std::shared_ptr<const TypeBuilder>& SchemaBuilder::root() const {

--- a/velox/dwio/nimble/velox/SchemaBuilder.h
+++ b/velox/dwio/nimble/velox/SchemaBuilder.h
@@ -16,7 +16,10 @@
 #pragma once
 
 #include <deque>
+#include <optional>
+#include <string_view>
 
+#include "folly/container/F14Map.h"
 #include "folly/container/F14Set.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/velox/SchemaTypes.h"
@@ -259,6 +262,8 @@ class RowTypeBuilder : public TypeBuilder {
   const StreamDescriptorBuilder& nullsDescriptor() const;
   size_t childrenCount() const;
   const TypeBuilder& childAt(size_t index) const;
+  /// Returns child with name, or throws if no child has that name.
+  const TypeBuilder& findChild(std::string_view name) const;
   const std::string& nameAt(size_t index) const;
   void addChild(std::string name, std::shared_ptr<TypeBuilder> child);
 
@@ -367,6 +372,13 @@ class SchemaBuilder {
 
   offset_size nodeCount() const;
 
+  /// Creates a stripe dictionary stream associated with a value stream.
+  offset_size createSharedDictionaryStream(offset_size valueStreamOffset);
+
+  /// Returns the stripe dictionary stream associated with a value stream.
+  std::optional<offset_size> sharedDictionaryStreamOffset(
+      offset_size valueStreamOffset) const;
+
   const std::shared_ptr<const TypeBuilder>& root() const;
 
  private:
@@ -385,7 +397,10 @@ class SchemaBuilder {
   // was attached to a parent of a different schema builder.
   // 2. Attaching a node more than once to a parent.
   folly::F14FastSet<std::shared_ptr<const TypeBuilder>> roots_;
-  offset_size currentOffset_ = 0;
+  // Used by the physical layout planner to colocate stripe dictionaries with
+  // their value streams. File and external dictionaries have no stream here.
+  folly::F14FastMap<offset_size, offset_size> sharedDictionaryStreamOffsets_;
+  offset_size currentOffset_{0};
 
   friend class ScalarTypeBuilder;
   friend class TimestampMicroNanoTypeBuilder;

--- a/velox/dwio/nimble/velox/SchemaTypes.h
+++ b/velox/dwio/nimble/velox/SchemaTypes.h
@@ -59,6 +59,29 @@ enum class Kind : uint8_t {
 std::string toString(ScalarKind kind);
 std::string toString(Kind kind);
 
+/// Returns true for signed and unsigned integer scalar kinds.
+inline bool isIntegerScalarKind(ScalarKind kind) {
+  switch (kind) {
+    case ScalarKind::Int8:
+    case ScalarKind::UInt8:
+    case ScalarKind::Int16:
+    case ScalarKind::UInt16:
+    case ScalarKind::Int32:
+    case ScalarKind::UInt32:
+    case ScalarKind::Int64:
+    case ScalarKind::UInt64:
+      return true;
+    case ScalarKind::Float:
+    case ScalarKind::Double:
+    case ScalarKind::Bool:
+    case ScalarKind::String:
+    case ScalarKind::Binary:
+    case ScalarKind::Undefined:
+      return false;
+  }
+  return false;
+}
+
 inline std::ostream& operator<<(std::ostream& os, ScalarKind kind) {
   return os << toString(kind);
 }

--- a/velox/dwio/nimble/velox/SharedDictionaryConfig.cpp
+++ b/velox/dwio/nimble/velox/SharedDictionaryConfig.cpp
@@ -29,26 +29,19 @@
 namespace facebook::nimble {
 namespace {
 
-velox::common::Subfield parseFieldPath(
-    const std::string& fieldPath,
-    std::string_view configType) {
+velox::common::Subfield parseFieldPath(const std::string& fieldPath) {
   NIMBLE_USER_CHECK(
-      !fieldPath.empty(),
-      "Shared dictionary {} path must not be empty.",
-      configType);
+      !fieldPath.empty(), "Shared dictionary path must not be empty.");
   velox::common::Subfield subfield;
   try {
     subfield = velox::common::Subfield{fieldPath};
   } catch (const velox::VeloxException&) {
     NIMBLE_USER_FAIL(
-        "Shared dictionary {} path '{}' must start with a field name.",
-        configType,
-        fieldPath);
+        "Shared dictionary path '{}' must start with a field name.", fieldPath);
   }
   NIMBLE_USER_CHECK(
       subfield.valid(),
-      "Shared dictionary {} path '{}' must start with a field name.",
-      configType,
+      "Shared dictionary path '{}' must start with a field name.",
       fieldPath);
   return subfield;
 }
@@ -56,7 +49,7 @@ velox::common::Subfield parseFieldPath(
 void validateValueStreamPath(
     const std::string& fieldPath,
     std::string_view configType) {
-  const auto subfield = parseFieldPath(fieldPath, configType);
+  const auto subfield = parseFieldPath(fieldPath);
   for (const auto& pathElement : subfield.path()) {
     NIMBLE_USER_CHECK(
         pathElement->is(velox::common::SubfieldKind::kNestedField) ||
@@ -70,7 +63,7 @@ void validateValueStreamPath(
 
 velox::common::Subfield validateFlatMapColumnPath(
     const std::string& fieldPath) {
-  auto subfield = parseFieldPath(fieldPath, "flat-map column");
+  auto subfield = parseFieldPath(fieldPath);
   NIMBLE_USER_CHECK_EQ(
       subfield.path().size(),
       1,
@@ -84,8 +77,7 @@ void validateValueSubfield(const std::string& valueSubfield) {
   if (valueSubfield.empty()) {
     return;
   }
-  const auto subfield =
-      parseFieldPath(valueSubfield, "flat-map value subfield");
+  const auto subfield = parseFieldPath(valueSubfield);
   for (const auto& pathElement : subfield.path()) {
     NIMBLE_USER_CHECK(
         pathElement->is(velox::common::SubfieldKind::kNestedField) ||
@@ -145,13 +137,13 @@ SharedDictionaryConfigBuilder::addFlatmapValueDictionary(
   validateValueSubfield(valueSubfield);
 
   auto column = std::find_if(
-      config_.flatMapColumns.begin(),
-      config_.flatMapColumns.end(),
+      config_.flatMaps.begin(),
+      config_.flatMaps.end(),
       [&](const auto& candidate) { return candidate.fieldPath == fieldPath; });
-  if (column == config_.flatMapColumns.end()) {
-    config_.flatMapColumns.push_back(
+  if (column == config_.flatMaps.end()) {
+    config_.flatMaps.push_back(
         FlatmapColumnDictionary{.fieldPath = fieldPath, .keys = {}});
-    column = std::prev(config_.flatMapColumns.end());
+    column = std::prev(config_.flatMaps.end());
   }
 
   const auto duplicate = std::any_of(

--- a/velox/dwio/nimble/velox/SharedDictionaryConfig.h
+++ b/velox/dwio/nimble/velox/SharedDictionaryConfig.h
@@ -43,7 +43,8 @@ struct SharedDictionaryConfig {
 /// Shared dictionary settings for one regular column value stream.
 struct ColumnDictionary {
   /// Velox subfield from the writer input root to the configured value stream.
-  /// Use `[*]` to traverse array elements or map values.
+  /// When the path resolves to an array or map, the dictionary applies to the
+  /// element or value stream recursively.
   std::string fieldPath;
 
   /// Dictionary encoding settings for the resolved value stream.
@@ -55,9 +56,9 @@ struct FlatmapKeyDictionary {
   /// Flat-map key to configure.
   int64_t key{};
 
-  /// Velox subfield below the keyed flat-map value. Empty selects the key
-  /// value itself. Non-empty paths start with a field name; use `[*]` to
-  /// traverse array elements or map values below that field.
+  /// Velox subfield below the keyed flat-map value. Empty selects the keyed
+  /// value itself; if that value is an array or map, the dictionary applies to
+  /// its element or value stream recursively.
   std::string valueSubfield;
 
   /// Dictionary encoding settings for the key value stream.
@@ -77,20 +78,20 @@ struct FlatmapColumnDictionary {
 /// Shared dictionary writer configuration for regular columns and flat-map
 /// value streams in a file.
 struct SharedDictionaryEncodingConfig {
-  /// Regular columns eligible for shared dictionary encoding. Paths may use
-  /// `[*]` to select array elements or map values before a nested field. The
-  /// resolved value must be an integer scalar, or an array whose element is an
-  /// integer scalar. For File scope, callers are responsible for assigning a
-  /// unique dictionaryId per configured value stream.
+  /// Regular columns eligible for shared dictionary encoding. The resolved
+  /// value must be an integer scalar, an array with an integer element stream,
+  /// or a map with an integer value stream. For File scope, callers are
+  /// responsible for assigning a unique dictionaryId per configured value
+  /// stream.
   std::vector<ColumnDictionary> columns;
 
   /// Top-level flat-map columns eligible for shared dictionary encoding.
-  /// Non-empty valueSubfield paths start with a field name and may use `[*]`
-  /// below that field to select array elements or map values. The configured
-  /// value stream must resolve to an integer scalar, or an array whose element
-  /// is an integer scalar. For File scope, callers are responsible for
-  /// assigning a unique dictionaryId per configured key value stream.
-  std::vector<FlatmapColumnDictionary> flatMapColumns;
+  /// valueSubfield paths resolve below the keyed value. The configured value
+  /// stream must be an integer scalar, an array with an integer element stream,
+  /// or a map with an integer value stream. For File scope, callers are
+  /// responsible for assigning a unique dictionaryId per configured key value
+  /// stream.
+  std::vector<FlatmapColumnDictionary> flatMaps;
 
   /// Supplies external alphabets for External shared dictionary configurations
   /// and File configurations that set useExternalAlphabet.
@@ -98,7 +99,7 @@ struct SharedDictionaryEncodingConfig {
 
   /// Returns true when no value streams request shared dictionary encoding.
   bool empty() const {
-    return columns.empty() && flatMapColumns.empty();
+    return columns.empty() && flatMaps.empty();
   }
 
   /// Creates a builder, optionally seeded from an existing config.

--- a/velox/dwio/nimble/velox/SharedDictionaryWriter.h
+++ b/velox/dwio/nimble/velox/SharedDictionaryWriter.h
@@ -20,29 +20,25 @@
 #include <optional>
 #include <span>
 #include <string>
-#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "folly/ScopeGuard.h"
-#include "folly/container/F14Map.h"
 #include "velox/common/Casts.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/DataTypeDispatch.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/Vector.h"
-#include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryBuilder.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
-#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
-#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingType.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/tablet/Chunk.h"
 #include "velox/dwio/nimble/tablet/SharedDictionaryReader.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
 #include "velox/dwio/nimble/velox/StreamData.h"
 
 namespace facebook::nimble {
@@ -66,13 +62,14 @@ class SharedDictionaryWriter {
     /// Uses an externally resolved logical alphabet instead of growing one
     /// while encoding values. External-scope dictionaries always resolve their
     /// alphabet this way; file-scope dictionaries use one when this is set,
-    /// then serialize it through Nimble encoding for file storage.
+    /// then store the resolved encoded alphabet as-is in the file.
     bool useExternalAlphabet{false};
 
     /// Restricts the encodings considered for the stored dictionary alphabet,
     /// as described by SharedDictionaryAlphabet::encode(). External
-    /// dictionaries do not store an alphabet in the file, so this only affects
-    /// stripe/file-owned alphabets.
+    /// dictionaries do not store an alphabet in the file. File dictionaries
+    /// with useExternalAlphabet store the resolved encoded alphabet as-is, so
+    /// this only affects stripe/file-owned alphabets.
     std::vector<EncodingType> alphabetEncodings;
 
     /// Creates encoding selection policies for nested index streams and stored
@@ -98,7 +95,7 @@ class SharedDictionaryWriter {
   /// Returns whether any chunk used the shared dictionary.
   virtual bool hasUsedDictionary() const = 0;
 
-  /// Serializes the writer-owned alphabet when the selected scope stores one.
+  /// Returns the alphabet bytes when the selected scope stores one.
   virtual std::optional<Chunk> encodeAlphabet(Buffer& buffer) = 0;
 
   /// Returns the dictionary id within scope().
@@ -128,85 +125,12 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
         "creator.");
   }
 
-  /// Encodes one value-stream chunk through SharedDictionaryEncoding,
-  /// as opposed to encodeAlphabet(), which serializes the dictionary itself.
-  ///
-  /// stripeIndex selects the stripe-local dictionary state to use and resets
-  /// stripe-scoped dictionaries at stripe boundaries. streamData provides the
-  /// raw non-null scalar values, optional null bitmap, and stream metadata used
-  /// for error messages. buffer owns any bytes appended by shared dictionary
-  /// encoding. Encoding options, including the optional buffer pool, are
-  /// captured in Options.
-  std::string_view encodeValues(
-      size_t stripeIndex,
-      const StreamData& streamData,
-      Buffer& buffer) {
-    NIMBLE_CHECK_GT(
-        streamData.rowCount(),
-        0,
-        "{} shared dictionary {} cannot encode an empty value stream.",
-        options_.scope,
-        options_.dictionaryId);
-
-    const auto nonNullValues = nonNullPhysicalValues(streamData);
-    const std::span<const T> nonNullLogicalValues{
-        reinterpret_cast<const T*>(nonNullValues.data()), nonNullValues.size()};
-    if (streamData.hasNullValues() && nonNullValues.empty()) {
-      // All-null nullable chunks have no values to add to or look up in the
-      // dictionary. Preserve the nullable shape and encode the empty value
-      // child through the regular path instead of creating an empty alphabet.
-      return EncodingFactory::encodeNullable<T>(
-          createDirectEncodingPolicy<T>(),
-          nonNullLogicalValues,
-          streamData.nonNulls(),
-          buffer,
-          options_.encodingOptions);
-    }
-
-    ensureBuilder(stripeIndex);
-
-    // File and external dictionaries never fall back to direct encoding.
-    if (options_.scope != SharedDictionaryScope::Stripe) {
-      return encodeDictionaryValues(
-          builder().lookup(nonNullLogicalValues),
-          nonNullValues,
-          streamData,
-          buffer);
-    }
-    // A stripe decides on its first chunk and the rest of the stripe follows.
-    if (useDictionary_.has_value()) {
-      if (!useDictionary_.value()) {
-        return encodeDirectValues(nonNullValues, streamData, buffer);
-      }
-      return encodeDictionaryValues(
-          builder().lookup(nonNullLogicalValues),
-          nonNullValues,
-          streamData,
-          buffer);
-    }
-
-    auto& dictionaryBuilder = builder();
-    auto mapping = dictionaryBuilder.lookup(nonNullLogicalValues);
-    auto directEncodingPolicy = createDirectEncodingPolicy<T>();
-    auto statistics = Statistics<physicalType>::create(nonNullValues);
-    const auto directEstimate =
-        directEncodingPolicy
-            ->select(nonNullValues, statistics, options_.encodingOptions)
-            .estimatedSize;
-    const auto dictionaryEstimate = estimateSharedDictionarySize(
-        dictionaryBuilder, mapping, options_.encodingOptions);
-
-    // Ties go to direct encoding, which needs no alphabet stream. A direct
-    // encoding nobody can size keeps the shared dictionary, whose cost is then
-    // the only one to compare.
-    if (directEstimate.has_value() &&
-        directEstimate.value() <= dictionaryEstimate) {
-      // Releasing the builder drops the entries this lookup inserted.
-      abandonStripeDictionary();
-      return encodeDirectValues(nonNullValues, streamData, buffer);
-    }
-    return encodeDictionaryValues(
-        std::move(mapping), nonNullValues, streamData, buffer);
+  /// Creates an encoding selection policy backed by this writer's dictionary
+  /// state for one value-stream chunk.
+  std::unique_ptr<::facebook::nimble::EncodingSelectionPolicy<T>>
+  createEncodingPolicy(size_t stripeIndex) {
+    return std::make_unique<DictionaryEncodingSelectionPolicy>(
+        this, stripeIndex);
   }
 
   /// Returns where the dictionary alphabet is stored or resolved.
@@ -234,8 +158,8 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
     return hasUsedDictionary_;
   }
 
-  /// Serializes the alphabet this writer owns, ready for the caller to store
-  /// as a stripe auxiliary stream or a file catalog entry.
+  /// Returns alphabet bytes, ready for the caller to store as a stripe
+  /// auxiliary stream or a file catalog entry.
   ///
   /// This consumes the current builder state. Stripe-scoped callers must call
   /// this at every stripe boundary before encoding the next stripe. File-scoped
@@ -243,12 +167,20 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
   /// encoded.
   ///
   /// Returns nullopt when there is nothing to store: a stripe that fell back to
-  /// direct encoding, a scope that has not encoded a value yet, or an external
-  /// dictionary, whose alphabet the resolver owns and the file never stores.
+  /// non-shared encoding or a scope that has not encoded a value yet. Throws
+  /// for external dictionaries, whose alphabets are resolver-owned and never
+  /// encoded into the file.
   /// Throws when the scope committed to shared dictionary encoding but holds no
   /// entries, which would produce a stream no reader could resolve, or when the
   /// active stripe/file dictionary was already finalized.
   std::optional<Chunk> encodeAlphabet(Buffer& buffer) final {
+    NIMBLE_CHECK_NE(
+        options_.scope,
+        SharedDictionaryScope::External,
+        "External shared dictionary {} cannot encode an alphabet; its "
+        "resolver owns the alphabet.",
+        options_.dictionaryId);
+
     checkAlphabetNotFinalized();
 
     SCOPE_EXIT {
@@ -256,10 +188,6 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
       useDictionary_.reset();
     };
 
-    // External alphabets are resolver owned and never stored in the file.
-    if (options_.scope == SharedDictionaryScope::External) {
-      return std::nullopt;
-    }
     SCOPE_EXIT {
       recordAlphabetFinalized();
     };
@@ -280,6 +208,13 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
           options_.scope,
           options_.dictionaryId);
     }
+    if (options_.useExternalAlphabet) {
+      NIMBLE_CHECK_EQ(options_.scope, SharedDictionaryScope::File);
+      NIMBLE_CHECK_NOT_NULL(externalAlphabet_);
+      return Chunk{
+          .rowCount = externalAlphabet_->entryCount(),
+          .content = {externalAlphabet_->encodedAlphabet()}};
+    }
     NIMBLE_CHECK_NOT_NULL(builder_);
     // Committing to shared dictionary encoding with nothing to store would
     // leave the encoded stream pointing at a dictionary the reader can never
@@ -293,7 +228,10 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
         options_.dictionaryId);
     const auto rowCount = static_cast<uint32_t>(alphabet.size());
     const auto encoded = SharedDictionaryAlphabet::encode<T>(
-        alphabet, options_.alphabetEncodings, buffer, options_.encodingOptions);
+        alphabet,
+        options_.alphabetEncodings,
+        buffer,
+        alphabetEncodingOptions());
     return Chunk{.rowCount = rowCount, .content = {encoded}};
   }
 
@@ -301,9 +239,167 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
   using physicalType = typename TypeTraits<T>::physicalType;
   using BuilderMapping = typename SharedDictionaryBuilder<T>::Mapping;
 
+  class DictionaryEncodingSelectionPolicy final
+      : public ::facebook::nimble::EncodingSelectionPolicy<T> {
+   public:
+    DictionaryEncodingSelectionPolicy(
+        TypedSharedDictionaryWriter* writer,
+        size_t stripeIndex)
+        : writer_{velox::checkedNotNull(writer)}, stripeIndex_{stripeIndex} {}
+
+    EncodingSelectionResult select(
+        std::span<const physicalType> values,
+        const Statistics<physicalType>& statistics,
+        const Encoding::Options& options) final {
+      NIMBLE_CHECK_GT(
+          values.size(),
+          0,
+          "{} shared dictionary {} cannot encode an empty value stream.",
+          writer_->options_.scope,
+          writer_->options_.dictionaryId);
+      return selectValues(values, statistics, options, std::nullopt);
+    }
+
+    EncodingSelectionResult selectNullable(
+        std::span<const physicalType> values,
+        std::span<const bool> notNulls,
+        const Statistics<physicalType>& statistics,
+        const Encoding::Options& options) final {
+      NIMBLE_CHECK_GT(
+          notNulls.size(),
+          0,
+          "{} shared dictionary {} cannot encode an empty value stream.",
+          writer_->options_.scope,
+          writer_->options_.dictionaryId);
+      return selectValues(values, statistics, options, notNulls);
+    }
+
+   private:
+    EncodingSelectionResult selectValues(
+        std::span<const physicalType> values,
+        const Statistics<physicalType>& statistics,
+        const Encoding::Options& options,
+        std::optional<std::span<const bool>> notNulls) {
+      if (notNulls.has_value() && values.empty()) {
+        return selectNonSharedEncoding(values, statistics, options, notNulls);
+      }
+
+      const std::span<const T> logicalValues{
+          reinterpret_cast<const T*>(values.data()), values.size()};
+      writer_->ensureBuilder(stripeIndex_);
+
+      if (writer_->options_.scope != SharedDictionaryScope::Stripe) {
+        return selectDictionary(logicalValues);
+      }
+      if (writer_->useDictionary_.has_value()) {
+        if (!writer_->useDictionary_.value()) {
+          return selectNonSharedEncoding(values, statistics, options, notNulls);
+        }
+        return selectDictionary(logicalValues);
+      }
+
+      // Decide against the regular value encoding, not the nullable wrapper.
+      const auto nonSharedSelection =
+          selectNonSharedEncoding(values, statistics, options);
+      if (nonSharedSelection.encodingType != EncodingType::Dictionary) {
+        writer_->abandonStripeDictionary();
+        if (notNulls.has_value()) {
+          return selectNonSharedEncoding(values, statistics, options, notNulls);
+        }
+        return nonSharedSelection;
+      }
+      return selectDictionary(logicalValues);
+    }
+
+    EncodingSelectionResult selectNonSharedEncoding(
+        std::span<const physicalType> values,
+        const Statistics<physicalType>& statistics,
+        const Encoding::Options& options,
+        std::optional<std::span<const bool>> notNulls = std::nullopt) {
+      auto policy =
+          writer_->createNonSharedEncodingPolicy(TypeTraits<T>::dataType);
+      nonSharedEncodingPolicy_ =
+          std::unique_ptr<::facebook::nimble::EncodingSelectionPolicy<T>>(
+              static_cast<::facebook::nimble::EncodingSelectionPolicy<T>*>(
+                  policy.release()));
+      writer_->validateNonSharedValuePolicy(*nonSharedEncodingPolicy_);
+      auto selection = notNulls.has_value()
+          ? nonSharedEncodingPolicy_->selectNullable(
+                values, *notNulls, statistics, options)
+          : nonSharedEncodingPolicy_->select(values, statistics, options);
+      NIMBLE_CHECK_NE(
+          selection.encodingType,
+          EncodingType::SharedDictionary,
+          "Regular encoding selection must not select SharedDictionary.");
+      return selection;
+    }
+
+    EncodingSelectionResult selectDictionary(std::span<const T> logicalValues) {
+      writer_->selectDictionary();
+      mapping_ = writer_->builder().lookup(logicalValues);
+      NIMBLE_CHECK_EQ(
+          mapping_->indices().size(),
+          logicalValues.size(),
+          "Shared dictionary index count differs from value count.");
+      return {
+          .encodingType = EncodingType::SharedDictionary,
+          .sharedDictionaryInput =
+              SharedDictionaryEncodingInput{.indices = mapping_->indices()}};
+    }
+
+    std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+        EncodingType parentEncodingType,
+        NestedEncodingIdentifier nestedEncodingIdentifier,
+        DataType nestedDataType) final {
+      if (parentEncodingType == EncodingType::SharedDictionary) {
+        NIMBLE_CHECK_EQ(
+            nestedEncodingIdentifier,
+            EncodingIdentifiers::SharedDictionary::Indices);
+        NIMBLE_CHECK_EQ(nestedDataType, DataType::Uint32);
+        return writer_->createNonSharedEncodingPolicy(nestedDataType);
+      }
+      if (parentEncodingType == EncodingType::Nullable) {
+        if (nestedEncodingIdentifier == EncodingIdentifiers::Nullable::Data) {
+          return createNestedNonSharedEncodingPolicy(
+              parentEncodingType, nestedEncodingIdentifier, nestedDataType);
+        }
+        NIMBLE_CHECK_EQ(
+            nestedEncodingIdentifier, EncodingIdentifiers::Nullable::Nulls);
+        NIMBLE_CHECK_EQ(nestedDataType, DataType::Bool);
+        // Nulls are an independent bitmap stream, not a child of the selected
+        // value encoding policy.
+        return writer_->createNonSharedEncodingPolicy(nestedDataType);
+      }
+      return createNestedNonSharedEncodingPolicy(
+          parentEncodingType, nestedEncodingIdentifier, nestedDataType);
+    }
+
+    std::unique_ptr<EncodingSelectionPolicyBase>
+    createNestedNonSharedEncodingPolicy(
+        EncodingType parentEncodingType,
+        NestedEncodingIdentifier nestedEncodingIdentifier,
+        DataType nestedDataType) {
+      NIMBLE_CHECK_NOT_NULL(
+          nonSharedEncodingPolicy_,
+          "Non-shared nested encoding policy requires a selected value "
+          "encoding policy.");
+      NIMBLE_RETURN_BY_DATA_TYPE(
+          // The macro's default case handles Undefined.
+          // @lint-ignore CLANGTIDY clang-diagnostic-switch-enum
+          nestedDataType,
+          NestedT,
+          nonSharedEncodingPolicy_->template create<NestedT>(
+              parentEncodingType, nestedEncodingIdentifier));
+    }
+
+    TypedSharedDictionaryWriter* const writer_;
+    const size_t stripeIndex_;
+    std::unique_ptr<EncodingSelectionPolicy<T>> nonSharedEncodingPolicy_;
+    std::optional<BuilderMapping> mapping_;
+  };
+
   // Updates the active stripe and creates the builder when this chunk can use
-  // one. Direct-abandoned and alphabet-emitted stripes intentionally keep no
-  // builder.
+  // one. Non-shared and alphabet-emitted stripes intentionally keep no builder.
   void ensureBuilder(size_t stripeIndex) {
     checkValuesNotFinalized(stripeIndex);
     if (stripeIndex_ == stripeIndex) {
@@ -384,8 +480,7 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
   // Rejects repeated alphabet finalization for the same active stripe. File
   // scope records the value stripe that finalized the one file-level alphabet.
   void checkAlphabetNotFinalized() const {
-    if (options_.scope == SharedDictionaryScope::External ||
-        !stripeIndex_.has_value() || lastFinalizedStripe_ != stripeIndex_) {
+    if (!stripeIndex_.has_value() || lastFinalizedStripe_ != stripeIndex_) {
       return;
     }
     NIMBLE_FAIL(
@@ -398,7 +493,7 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
   }
 
   // Records that the active stripe/file dictionary can no longer accept value
-  // chunks. Direct-fallback stripes record this too even though they emit no
+  // chunks. Non-shared stripes record this too even though they emit no
   // alphabet.
   void recordAlphabetFinalized() {
     if (!stripeIndex_.has_value()) {
@@ -407,29 +502,14 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
     lastFinalizedStripe_ = stripeIndex_;
   }
 
-  static std::span<const physicalType> nonNullPhysicalValues(
-      const StreamData& streamData) {
-    static_assert(sizeof(T) == sizeof(physicalType));
-    NIMBLE_CHECK_EQ(
-        streamData.data().size() % sizeof(T),
-        0,
-        "Shared dictionary writer value stream has incomplete values.");
-    // For nullable streams, StreamData stores only the non-null values in the
-    // data payload; rowCount() and nonNulls() retain the original row shape.
-    return EncodingPhysicalType<T>::asEncodingPhysicalTypeSpan(
-        std::span<const T>{
-            reinterpret_cast<const T*>(streamData.data().data()),
-            streamData.data().size() / sizeof(T)});
-  }
-
   // Marks the active scope as committed to shared dictionary encoding.
   void selectDictionary() {
     useDictionary_ = true;
     hasUsedDictionary_ = true;
   }
 
-  // Drops lookup-inserted stripe entries when the first chunk chooses direct
-  // encoding; the rest of the stripe stays direct.
+  // Drops lookup-inserted stripe entries when the first chunk chooses
+  // non-shared encoding; the rest of the stripe stays non-shared.
   void abandonStripeDictionary() {
     NIMBLE_CHECK_EQ(options_.scope, SharedDictionaryScope::Stripe);
     NIMBLE_CHECK_NOT_NULL(builder_);
@@ -437,119 +517,45 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
     useDictionary_ = false;
   }
 
-  uint64_t estimateSharedDictionarySize(
-      const SharedDictionaryBuilder<T>& builder,
-      const BuilderMapping& mapping,
-      const Encoding::Options& options) const {
-    // Indices address the alphabet, so their bit width follows the entry
-    // count. This mirrors how DictionaryEncoding sizes its own index stream,
-    // and avoids building Statistics over every index just to size them.
-    const auto indices = mapping.indices();
-    const auto entryCount = builder.alphabet().size();
-    NIMBLE_CHECK_GT(
-        entryCount,
-        0,
-        "{} shared dictionary {} has no entries to size.",
-        options_.scope,
-        options_.dictionaryId);
-    const auto indexEstimate = FixedBitWidthEncoding<uint32_t>::estimateSize(
-        indices.size(),
-        /*minValue=*/0,
-        entryCount - 1,
-        options);
-    const auto newEntryCount = mapping.newEntryCount();
-    uint64_t newEntryEstimate{0};
-    if (newEntryCount != 0) {
-      // Streaming builders append new entries, so they are the alphabet's tail.
-      newEntryEstimate = SharedDictionaryAlphabet::estimateSize<T>(
-          builder.alphabet().last(newEntryCount),
-          options_.alphabetEncodings,
-          options);
-    }
-    return EncodingPrefix::serializedSize(
-               static_cast<uint32_t>(indices.size()),
-               options.useVarintRowCount) +
-        indexEstimate + newEntryEstimate;
+  Encoding::Options alphabetEncodingOptions() const {
+    auto options = options_.encodingOptions;
+    // Stored alphabet streams do not carry the row-count encoding mode.
+    // SharedDictionaryAlphabet::create() decodes them with default options.
+    options.useVarintRowCount = false;
+    return options;
   }
 
-  std::string_view encodeDirectValues(
-      std::span<const physicalType> nonNullValues,
-      const StreamData& streamData,
-      Buffer& buffer) {
-    static_assert(sizeof(T) == sizeof(physicalType));
-    const std::span<const T> logicalNonNullValues{
-        reinterpret_cast<const T*>(nonNullValues.data()), nonNullValues.size()};
-    if (streamData.hasNullValues()) {
-      return EncodingFactory::encodeNullable<T>(
-          createDirectEncodingPolicy<T>(),
-          logicalNonNullValues,
-          streamData.nonNulls(),
-          buffer,
-          options_.encodingOptions);
-    }
-    return EncodingFactory::encode<T>(
-        createDirectEncodingPolicy<T>(),
-        logicalNonNullValues,
-        buffer,
-        options_.encodingOptions);
-  }
-
-  std::string_view encodeDictionaryValues(
-      BuilderMapping mapping,
-      std::span<const physicalType> nonNullValues,
-      const StreamData& streamData,
-      Buffer& buffer) {
-    selectDictionary();
-    NIMBLE_CHECK_EQ(
-        mapping.indices().size(),
-        nonNullValues.size(),
-        "Shared dictionary index count differs from value count.");
-    if (streamData.hasNullValues()) {
-      return encodeNullable(std::move(mapping), streamData.nonNulls(), buffer);
-    }
-    return SharedDictionaryEncoding<T>::encode(
-        mapping.indices(),
-        options_.encodingSelectionPolicyCreator,
-        buffer,
-        options_.encodingOptions);
-  }
-
-  // Encodes a nullable wrapper while keeping the non-null child in logical T.
-  std::string_view encodeNullable(
-      BuilderMapping mapping,
-      std::span<const bool> notNulls,
-      Buffer& buffer) {
-    auto* pool = &buffer.getMemoryPool();
-    ScopedEncodingBuffer scopedBuffer{
-        pool, options_.encodingOptions.encodingBufferPool};
-    const auto serializedNonNullValues = SharedDictionaryEncoding<T>::encode(
-        mapping.indices(),
-        options_.encodingSelectionPolicyCreator,
-        scopedBuffer.get(),
-        options_.encodingOptions);
-    const auto serializedNulls = EncodingFactory::encode<bool>(
-        createDirectEncodingPolicy<bool>(),
-        notNulls,
-        scopedBuffer.get(),
-        options_.encodingOptions);
-    return NullableEncoding<T>::encodeNullable(
-        static_cast<uint32_t>(notNulls.size()),
-        serializedNonNullValues,
-        serializedNulls,
-        buffer,
-        options_.encodingOptions);
-  }
-
-  template <typename PolicyT>
-  std::unique_ptr<::facebook::nimble::EncodingSelectionPolicy<PolicyT>>
-  createDirectEncodingPolicy() const {
-    auto policy =
-        options_.encodingSelectionPolicyCreator(TypeTraits<PolicyT>::dataType);
+  std::unique_ptr<EncodingSelectionPolicyBase> createNonSharedEncodingPolicy(
+      DataType dataType) const {
+    auto policy = options_.encodingSelectionPolicyCreator(dataType);
     NIMBLE_CHECK_NOT_NULL(policy);
-    return std::unique_ptr<
-        ::facebook::nimble::EncodingSelectionPolicy<PolicyT>>(
-        static_cast<::facebook::nimble::EncodingSelectionPolicy<PolicyT>*>(
-            policy.release()));
+    return policy;
+  }
+
+  // Stripe scope can select shared dictionary only when regular value
+  // selection can choose Dictionary. Manual policies expose that candidate set,
+  // so fail early for manual configs that remove this path.
+  template <typename PolicyT>
+  void validateNonSharedValuePolicy(
+      const ::facebook::nimble::EncodingSelectionPolicy<PolicyT>& policy)
+      const {
+    if (options_.scope != SharedDictionaryScope::Stripe) {
+      return;
+    }
+    const auto* manualPolicy =
+        dynamic_cast<const ManualEncodingSelectionPolicy<PolicyT>*>(&policy);
+    if (manualPolicy == nullptr) {
+      return;
+    }
+    for (const auto& readFactor :
+         manualPolicy->candidateEncodingReadFactors()) {
+      if (readFactor.first == EncodingType::Dictionary) {
+        return;
+      }
+    }
+    NIMBLE_USER_FAIL(
+        "Stripe shared dictionary selection requires regular Dictionary in "
+        "the non-shared value encoding candidates.");
   }
 
   SharedDictionaryBuilder<T>& builder() {
@@ -634,17 +640,19 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
   std::unique_ptr<SharedDictionaryBuilder<T>> builder_;
   // Stripe currently being encoded; unset until the first encode() call.
   std::optional<size_t> stripeIndex_;
-  // Active value stripe whose alphabet was finalized. For direct-fallback
-  // stripes, finalization emits no alphabet but still closes the stripe.
+  // Active value stripe whose alphabet was finalized. For non-shared stripes,
+  // finalization emits no alphabet but still closes the stripe.
   std::optional<size_t> lastFinalizedStripe_;
   // Encoding the active scope committed to, unset until its first chunk picks
-  // one. True keeps the shared dictionary; false stays direct for the rest of
-  // the stripe and emits no stripe alphabet. Stripe-scope dictionaries clear it
-  // at each stripe boundary, while file and external dictionaries decide once.
+  // one. True keeps the shared dictionary; false stays non-shared for the rest
+  // of the stripe and emits no stripe alphabet. Stripe-scope dictionaries clear
+  // it at each stripe boundary, while file and external dictionaries decide
+  // once.
   std::optional<bool> useDictionary_;
   // True once any chunk uses the dictionary. For stripe scope, this survives
   // per-stripe resets so final file metadata emits a binding when at least one
-  // stripe used the dictionary and omits it when every stripe stayed direct.
+  // stripe used the dictionary and omits it when every stripe stayed
+  // non-shared.
   bool hasUsedDictionary_{false};
 };
 

--- a/velox/dwio/nimble/velox/VeloxReader.cpp
+++ b/velox/dwio/nimble/velox/VeloxReader.cpp
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 #include "velox/dwio/nimble/velox/VeloxReader.h"
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <vector>
+#include "fmt/core.h"
+#include "folly/container/F14Map.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/common/OnDemandUnitLoader.h"
 #include "velox/dwio/common/UnitLoader.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/velox/ChunkedStreamDecoder.h"
 #include "velox/dwio/nimble/velox/MetadataGenerated.h"
@@ -68,13 +73,16 @@ class NimbleUnit : public velox::dwio::common::LoadUnit {
       uint32_t stripeId,
       const TabletReader& tabletReader,
       std::shared_ptr<const Type> schema,
-      std::shared_ptr<StreamLabels> streamLabels,
-      const std::vector<uint32_t>& streamIdentifiers)
+      std::shared_ptr<StreamLabels> valueStreamLabels,
+      const std::vector<uint32_t>& valueStreamIdentifiers)
       : tabletReader_{tabletReader},
         schema_{std::move(schema)},
-        streamLabels_{std::move(streamLabels)},
+        valueStreamLabels_{std::move(valueStreamLabels)},
         stripeId_{stripeId},
-        streamIdentifiers_{streamIdentifiers} {}
+        valueStreamIdentifiers_{valueStreamIdentifiers},
+        loadStreamIdentifiers_{valueStreamIdentifiers} {
+    addDictionaryStreams();
+  }
 
   // Perform the IO (read)
   void load() override;
@@ -94,16 +102,29 @@ class NimbleUnit : public velox::dwio::common::LoadUnit {
     return std::move(streamLoaders_);
   }
 
+  const folly::F14FastMap<uint32_t, uint32_t>& dictionaryStreamIds() const {
+    return dictionaryStreamIds_;
+  }
+
   const StripeLoadMetrics& getMetrics() const {
     return metrics_;
   }
 
  private:
+  // Appends projected dictionary streams.
+  void addDictionaryStreams();
+
   const TabletReader& tabletReader_;
   std::shared_ptr<const Type> schema_;
-  std::shared_ptr<StreamLabels> streamLabels_;
+  std::shared_ptr<StreamLabels> valueStreamLabels_;
   uint32_t stripeId_;
-  const std::vector<uint32_t>& streamIdentifiers_;
+  const std::vector<uint32_t>& valueStreamIdentifiers_;
+  // Projected value streams followed by auxiliary stripe dictionary streams.
+  std::vector<uint32_t> loadStreamIdentifiers_;
+  // Projected value stream IDs mapped to auxiliary dictionary stream IDs.
+  folly::F14FastMap<uint32_t, uint32_t> dictionaryStreamIds_;
+  // Dictionary stream labels keyed by auxiliary dictionary stream ID.
+  folly::F14FastMap<uint32_t, std::string> dictionaryStreamLabels_;
 
   // Lazy
   std::optional<uint64_t> ioSize_;
@@ -114,6 +135,35 @@ class NimbleUnit : public velox::dwio::common::LoadUnit {
   StripeLoadMetrics metrics_;
 };
 
+void NimbleUnit::addDictionaryStreams() {
+  NIMBLE_CHECK_EQ(
+      loadStreamIdentifiers_.size(),
+      valueStreamIdentifiers_.size(),
+      "Load streams must initially match projected streams.");
+  if (!tabletReader_.hasStripeDictionaries()) {
+    return;
+  }
+  NIMBLE_CHECK(dictionaryStreamIds_.empty());
+  dictionaryStreamIds_ =
+      tabletReader_.stripeDictionaryStreamIds(valueStreamIdentifiers_);
+  if (dictionaryStreamIds_.empty()) {
+    return;
+  }
+  size_t dictionaryLoaderIndex = loadStreamIdentifiers_.size();
+  const auto dictionaryStreamCount = dictionaryStreamIds_.size();
+  loadStreamIdentifiers_.resize(dictionaryLoaderIndex + dictionaryStreamCount);
+  for (const auto& entry : dictionaryStreamIds_) {
+    // TODO: Deduplicate equal dictionary stream IDs if value streams are
+    // allowed to share a stripe dictionary.
+    loadStreamIdentifiers_[dictionaryLoaderIndex++] = entry.second;
+    dictionaryStreamLabels_.emplace(
+        entry.second,
+        fmt::format(
+            "shared dictionary for {}",
+            valueStreamLabels_->streamLabel(entry.first)));
+  }
+}
+
 void NimbleUnit::load() {
   velox::CpuWallTiming timing{};
   {
@@ -123,9 +173,14 @@ void NimbleUnit::load() {
     }
     streamLoaders_ = tabletReader_.load(
         stripeIdentifier_.value(),
-        streamIdentifiers_,
-        [this](offset_size offset) {
-          return streamLabels_->streamLabel(offset);
+        loadStreamIdentifiers_,
+        [this](offset_size offset) -> std::string_view {
+          const auto dictionaryIt =
+              dictionaryStreamLabels_.find(static_cast<uint32_t>(offset));
+          if (dictionaryIt != dictionaryStreamLabels_.end()) {
+            return dictionaryIt->second;
+          }
+          return valueStreamLabels_->streamLabel(offset);
         });
   }
   metrics_.cpuUsec = timing.cpuNanos / 1000;
@@ -145,19 +200,21 @@ uint64_t NimbleUnit::getIoSize() {
     stripeIdentifier_ = tabletReader_.stripeIdentifier(stripeId_);
   }
   ioSize_ = tabletReader_.totalStreamSize(
-      stripeIdentifier_.value(), streamIdentifiers_);
+      stripeIdentifier_.value(), loadStreamIdentifiers_);
   return ioSize_.value();
 }
 
-// Default `TabletReader::Options` used by `VeloxReader`'s convenience
-// constructors: preload the schema section and attach a fresh `IoStatistics`.
-TabletReader::Options defaultTabletReaderOptions(
-    velox::memory::MemoryPool* pool) {
+// Builds `TabletReader::Options` for `VeloxReader`'s convenience constructors.
+TabletReader::Options tabletReaderOptions(
+    velox::memory::MemoryPool* pool,
+    std::shared_ptr<const ExternalDictionaryResolver>
+        externalDictionaryResolver) {
   TabletReader::Options options;
   options.preloadOptionalSections = {std::string(kSchemaSection)};
   options.ioOptions.emplace(pool)
       .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
       .setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+  options.externalDictionaryResolver = std::move(externalDictionaryResolver);
   return options;
 }
 
@@ -167,29 +224,29 @@ VeloxReader::VeloxReader(
     velox::ReadFile* file,
     velox::memory::MemoryPool& pool,
     std::shared_ptr<const velox::dwio::common::ColumnSelector> selector,
-    VeloxReadParams params)
+    const VeloxReadParams& params)
     : VeloxReader(
           TabletReader::create(
               std::shared_ptr<velox::ReadFile>(file, [](auto*) {}),
               &pool,
-              defaultTabletReaderOptions(&pool)),
+              tabletReaderOptions(&pool, params.externalDictionaryResolver)),
           pool,
           std::move(selector),
-          std::move(params)) {}
+          params) {}
 
 VeloxReader::VeloxReader(
     std::shared_ptr<velox::ReadFile> file,
     velox::memory::MemoryPool& pool,
     std::shared_ptr<const velox::dwio::common::ColumnSelector> selector,
-    VeloxReadParams params)
+    const VeloxReadParams& params)
     : VeloxReader(
           TabletReader::create(
               std::move(file),
               &pool,
-              defaultTabletReaderOptions(&pool)),
+              tabletReaderOptions(&pool, params.externalDictionaryResolver)),
           pool,
           std::move(selector),
-          std::move(params)) {}
+          params) {}
 
 VeloxReader::VeloxReader(
     std::shared_ptr<const TabletReader> tabletReader,
@@ -296,6 +353,46 @@ void VeloxReader::loadStripeIfAny() {
   }
 }
 
+VeloxReadParams::StreamEncodingFactory VeloxReader::createStreamEncodingFactory(
+    uint32_t valueStreamId,
+    std::unique_ptr<StreamLoader> dictionaryStream) const {
+  if (dictionaryStream == nullptr &&
+      !tabletReader_->hasFileOrExternalDictionaries()) {
+    return parameters_.encodingFactory;
+  }
+
+  std::shared_ptr<const SharedDictionaryAlphabet> dictionaryAlphabet;
+  if (dictionaryStream == nullptr) {
+    dictionaryAlphabet =
+        tabletReader_->resolveDictionaryAlphabet(valueStreamId);
+    if (dictionaryAlphabet == nullptr) {
+      return parameters_.encodingFactory;
+    }
+  }
+
+  // Match the selective reader path: resolve the per-stream alphabet directly
+  // when the first chunk is decoded. Streams with dictionary bindings are
+  // written consistently as shared-dictionary streams.
+  return [dictionaryStreamOwner =
+              std::shared_ptr<const StreamLoader>{std::move(dictionaryStream)},
+          _dictionaryAlphabet = std::move(dictionaryAlphabet)](
+             velox::memory::MemoryPool& pool,
+             std::string_view data,
+             std::function<void*(uint32_t)> stringBufferFactory) mutable {
+    Encoding::Options options;
+    if (_dictionaryAlphabet == nullptr) {
+      NIMBLE_CHECK_NOT_NULL(
+          dictionaryStreamOwner,
+          "Shared dictionary requires a stripe dictionary stream.");
+      _dictionaryAlphabet = SharedDictionaryAlphabet::create(
+          dictionaryStreamOwner->getStream(), dictionaryStreamOwner, &pool);
+    }
+    options.sharedDictionaryAlphabet = _dictionaryAlphabet;
+    return EncodingFactory().create(
+        pool, data, std::move(stringBufferFactory), options);
+  };
+}
+
 void VeloxReader::loadNextStripe() {
   if (loadedStripe_.has_value() && loadedStripe_.value() == nextStripe_) {
     // We are not reloading the current stripe, but we expect all
@@ -328,9 +425,20 @@ void VeloxReader::loadNextStripe() {
       metrics.totalStreamSize = nimbleUnit->getIoSize();
 
       auto streams = nimbleUnit->extractStreamLoaders();
-      decoders_.reserve(streams.size());
-      for (uint32_t i = 0; i < streams.size(); ++i) {
-        if (!streams[i]) {
+      const auto& dictionaryStreamIds = nimbleUnit->dictionaryStreamIds();
+      NIMBLE_CHECK_GE(streams.size(), offsets_.size());
+      folly::F14FastMap<uint32_t, uint32_t> dictionaryLoaderIndices;
+      if (!dictionaryStreamIds.empty()) {
+        dictionaryLoaderIndices.reserve(dictionaryStreamIds.size());
+        uint32_t dictionaryLoaderIndex = static_cast<uint32_t>(offsets_.size());
+        for (const auto& entry : dictionaryStreamIds) {
+          dictionaryLoaderIndices.emplace(entry.first, dictionaryLoaderIndex++);
+        }
+      }
+      decoders_.reserve(offsets_.size());
+      for (uint32_t i = 0; i < offsets_.size(); ++i) {
+        auto& stream = streams.at(i);
+        if (stream == nullptr) {
           // As this stream is not present in current stripe (might be present
           // in previous one) we set to nullptr, One of the case is where you
           // are projecting more fields in FlatMap than the stripe actually
@@ -338,11 +446,19 @@ void VeloxReader::loadNextStripe() {
           decoders_[offsets_[i]] = nullptr;
         } else {
           ++metrics.streamCount;
+          std::unique_ptr<StreamLoader> dictionaryStream;
+          const auto dictionaryIt = dictionaryLoaderIndices.find(offsets_[i]);
+          if (dictionaryIt != dictionaryLoaderIndices.end()) {
+            // Direct-encoded stripes can omit the dictionary stream even when
+            // the value stream has a stripe dictionary binding.
+            dictionaryStream = std::move(streams.at(dictionaryIt->second));
+          }
+          auto streamEncodingFactory = createStreamEncodingFactory(
+              offsets_[i], std::move(dictionaryStream));
           auto decoder = std::make_unique<ChunkedStreamDecoder>(
               pool_,
-              std::make_unique<InMemoryChunkedStream>(
-                  pool_, std::move(streams[i])),
-              parameters_.encodingFactory,
+              std::make_unique<InMemoryChunkedStream>(pool_, std::move(stream)),
+              std::move(streamEncodingFactory),
               parameters_.optimizeStringBufferHandling,
               *logger_);
           decoder->ensureLoaded();
@@ -543,11 +659,11 @@ std::unique_ptr<velox::dwio::common::UnitLoader> VeloxReader::getUnitLoader() {
 
   std::vector<std::unique_ptr<velox::dwio::common::LoadUnit>> units;
   units.reserve(lastStripe_ - firstStripe_);
-  const auto streamLabels = std::make_shared<StreamLabels>(schema_);
+  const auto valueStreamLabels = std::make_shared<StreamLabels>(schema_);
   for (uint32_t stripe = firstStripe_; stripe < lastStripe_; ++stripe) {
     units.push_back(
         std::make_unique<NimbleUnit>(
-            stripe, *tabletReader_, schema_, streamLabels, offsets_));
+            stripe, *tabletReader_, schema_, valueStreamLabels, offsets_));
   }
 
   if (parameters_.unitLoaderFactory) {

--- a/velox/dwio/nimble/velox/VeloxReader.h
+++ b/velox/dwio/nimble/velox/VeloxReader.h
@@ -68,18 +68,25 @@ struct VeloxReadParams : public FieldReaderParams {
   // If nullptr we'll use the default one, that doesn't pre-load stripes.
   std::shared_ptr<velox::dwio::common::UnitLoaderFactory> unitLoaderFactory{};
 
+  /// Resolves External shared integer dictionaries referenced by the file.
+  std::shared_ptr<const ExternalDictionaryResolver> externalDictionaryResolver;
+
+  /// Creates an encoding for one serialized stream chunk.
+  using StreamEncodingFactory = std::function<std::unique_ptr<Encoding>(
+      velox::memory::MemoryPool&,
+      std::string_view,
+      std::function<void*(uint32_t)>)>;
+
   // Used strictly for backward compatible migrations where the Encoding
   // implementations might have different read implementations, but
   // identical/backward compatible write behavior.
-  std::function<std::unique_ptr<Encoding>(
-      velox::memory::MemoryPool&,
-      std::string_view,
-      std::function<void*(uint32_t)>)>
-      encodingFactory = [](velox::memory::MemoryPool& pool,
-                           std::string_view data,
-                           std::function<void*(uint32_t)> stringBufferFactory)
+  StreamEncodingFactory encodingFactory =
+      [](velox::memory::MemoryPool& pool,
+         std::string_view data,
+         const std::function<void*(uint32_t)>& stringBufferFactory)
       -> std::unique_ptr<Encoding> {
-    return legacy::EncodingFactory().create(pool, data, stringBufferFactory);
+    return legacy::EncodingFactory().create(
+        pool, data, stringBufferFactory, Encoding::Options{});
   };
 };
 
@@ -92,14 +99,14 @@ class VeloxReader {
       velox::memory::MemoryPool& pool,
       std::shared_ptr<const velox::dwio::common::ColumnSelector> selector =
           nullptr,
-      VeloxReadParams params = {});
+      const VeloxReadParams& params = {});
 
   VeloxReader(
       std::shared_ptr<velox::ReadFile> file,
       velox::memory::MemoryPool& pool,
       std::shared_ptr<const velox::dwio::common::ColumnSelector> selector =
           nullptr,
-      VeloxReadParams params = {});
+      const VeloxReadParams& params = {});
 
   VeloxReader(
       std::shared_ptr<const TabletReader> tabletReader,
@@ -158,6 +165,11 @@ class VeloxReader {
  private:
   // Loads the next stripe's streams.
   void loadNextStripe();
+
+  // Returns the base encoding factory unless the stream has an alphabet.
+  VeloxReadParams::StreamEncodingFactory createStreamEncodingFactory(
+      uint32_t valueStreamId,
+      std::unique_ptr<StreamLoader> dictionaryStream) const;
 
   // True if the file contain zero rows.
   bool isEmptyFile() const {

--- a/velox/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/velox/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -20,6 +20,7 @@
 #include "velox/dwio/nimble/common/ChunkHeader.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/compression/Compression.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 
@@ -29,6 +30,16 @@ namespace facebook::nimble {
 
 using namespace facebook::velox;
 using velox::common::testutil::TestValue;
+
+void ChunkedDecoder::ensureSharedDictionaryAlphabet() {
+  if (dictionaryAlphabet_ != nullptr) {
+    return;
+  }
+  NIMBLE_CHECK_NOT_NULL(dictionaryAlphabetLoader_);
+  dictionaryAlphabet_ = dictionaryAlphabetLoader_();
+  dictionaryAlphabetLoader_ = nullptr;
+  NIMBLE_CHECK_NOT_NULL(dictionaryAlphabet_);
+}
 
 bool ChunkedDecoder::loadNextChunk(const ChunkBoundaryCallback& onChunkLoaded) {
   auto ret = ensureInput(kChunkHeaderSize);
@@ -76,8 +87,22 @@ bool ChunkedDecoder::loadNextChunk(const ChunkBoundaryCallback& onChunkLoaded) {
   // Copy, not reference.
   auto options = encodingFactory_->options();
   options.decodingStats = decodingStats_;
-  encoding_ =
-      encodingFactory_->create(*pool_, data, stringBufferFactory, options);
+  if (hasSharedDictionaryBinding()) {
+    NIMBLE_CHECK(
+        stringDecoderZeroCopy_,
+        "Shared dictionary encoding requires non-legacy encoding dispatch.");
+    ensureSharedDictionaryAlphabet();
+    NIMBLE_CHECK_NOT_NULL(dictionaryAlphabet_);
+    options.sharedDictionaryAlphabet = dictionaryAlphabet_;
+    // The legacy factory has no SharedDictionary concrete type. Use the native
+    // factory for dictionary-bound streams so nullable children can also use
+    // the alphabet.
+    encoding_ =
+        EncodingFactory().create(*pool_, data, stringBufferFactory, options);
+  } else {
+    encoding_ =
+        encodingFactory_->create(*pool_, data, stringBufferFactory, options);
+  }
   remainingValues_ = encoding_->rowCount();
   NIMBLE_CHECK_GT(remainingValues_, 0);
   VLOG(1) << encoding_->debugString();

--- a/velox/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/velox/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -18,9 +18,11 @@
 
 #include <functional>
 #include <optional>
+#include <string_view>
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/nimble/common/ChunkHeader.h"
+#include "velox/dwio/nimble/common/DataTypeDispatch.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/NullableEncoding.h"
@@ -28,6 +30,7 @@
 #include "velox/dwio/nimble/encodings/legacy/EncodingTrait.h"
 #include "velox/dwio/nimble/index/ChunkStatsGroup.h"
 #include "velox/dwio/nimble/velox/selective/NimbleData.h"
+#include "velox/dwio/nimble/velox/selective/ReaderBase.h"
 
 namespace facebook::nimble {
 
@@ -60,7 +63,8 @@ class ChunkedDecoder {
       const EncodingFactory* encodingFactory,
       velox::memory::MemoryPool* pool,
       bool stringDecoderZeroCopy = false,
-      velox::dwio::common::DecodingStats* decodingStats = nullptr)
+      velox::dwio::common::DecodingStats* decodingStats = nullptr,
+      DictionaryAlphabetLoader dictionaryAlphabetLoader = nullptr)
       : input_{std::move(input)},
         pool_{pool},
         decodeValuesWithNulls_{decodeValuesWithNulls},
@@ -70,7 +74,8 @@ class ChunkedDecoder {
         streamRowCount_{
             streamIndex_ ? std::optional<uint32_t>(streamIndex_->rowCount())
                          : std::nullopt},
-        decodingStats_{decodingStats} {
+        decodingStats_{decodingStats},
+        dictionaryAlphabetLoader_{std::move(dictionaryAlphabetLoader)} {
     NIMBLE_CHECK_NOT_NULL(input_);
     NIMBLE_CHECK_NOT_NULL(encodingFactory_);
   }
@@ -878,6 +883,17 @@ class ChunkedDecoder {
       int64_t numValues,
       const ChunkBoundaryCallback& onChunkBoundary);
 
+  // Creates and caches the shared dictionary alphabet the first time a shared
+  // dictionary chunk is loaded.
+  void ensureSharedDictionaryAlphabet();
+
+  // Returns true if this stream has a shared dictionary alphabet available or
+  // pending lazy load.
+  bool hasSharedDictionaryBinding() const {
+    return dictionaryAlphabet_ != nullptr ||
+        dictionaryAlphabetLoader_ != nullptr;
+  }
+
   const std::unique_ptr<velox::dwio::common::SeekableInputStream> input_;
   velox::memory::MemoryPool* const pool_;
   // When true, decode nullable values (for array/map length streams that
@@ -912,6 +928,11 @@ class ChunkedDecoder {
   // Per-column decoding statistics. Owned by SplitStats; valid for
   // the lifetime of this decoder.
   velox::dwio::common::DecodingStats* const decodingStats_{nullptr};
+  // Lazily resolves the alphabet bound to this stream. Reset after
+  // dictionaryAlphabet_ is loaded.
+  DictionaryAlphabetLoader dictionaryAlphabetLoader_;
+  // Cached alphabet returned by dictionaryAlphabetLoader_.
+  std::shared_ptr<const SharedDictionaryAlphabet> dictionaryAlphabet_;
   friend class ChunkedDecoderTestHelper;
 };
 

--- a/velox/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/velox/dwio/nimble/velox/selective/NimbleData.cpp
@@ -172,42 +172,48 @@ uint64_t NimbleData::skipNulls(uint64_t numValues, bool /*nullsOnly*/) {
 
 ChunkedDecoder NimbleData::makeScalarDecoder() {
   const auto streamId = nimbleType_->asScalar().scalarDescriptor().offset();
+  auto input = streams_->enqueue(static_cast<int>(streamId), lazyColumnIo_);
   return ChunkedDecoder(
-      streams_->enqueue(streamId, lazyColumnIo_),
-      streams_->streamIndex(streamId),
+      std::move(input),
+      streams_->streamIndex(static_cast<int>(streamId)),
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
       pool_,
       stringDecoderZeroCopy_,
-      decodingStats_);
+      decodingStats_,
+      streams_->dictionaryAlphabetLoader(streamId));
 }
 
 ChunkedDecoder NimbleData::makeMicrosDecoder() {
   VELOX_CHECK(nimbleType_->isTimestampMicroNano());
   const auto streamId =
       nimbleType_->asTimestampMicroNano().microsDescriptor().offset();
+  auto input = streams_->enqueue(static_cast<int>(streamId), lazyColumnIo_);
   return ChunkedDecoder(
-      streams_->enqueue(streamId, lazyColumnIo_),
-      streams_->streamIndex(streamId),
+      std::move(input),
+      streams_->streamIndex(static_cast<int>(streamId)),
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
       pool_,
       stringDecoderZeroCopy_,
-      decodingStats_);
+      decodingStats_,
+      streams_->dictionaryAlphabetLoader(streamId));
 }
 
 ChunkedDecoder NimbleData::makeNanosDecoder() {
   VELOX_CHECK(nimbleType_->isTimestampMicroNano());
   const auto streamId =
       nimbleType_->asTimestampMicroNano().nanosDescriptor().offset();
+  auto input = streams_->enqueue(static_cast<int>(streamId), lazyColumnIo_);
   return ChunkedDecoder(
-      streams_->enqueue(streamId, lazyColumnIo_),
-      streams_->streamIndex(streamId),
+      std::move(input),
+      streams_->streamIndex(static_cast<int>(streamId)),
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
       pool_,
       stringDecoderZeroCopy_,
-      decodingStats_);
+      decodingStats_,
+      streams_->dictionaryAlphabetLoader(streamId));
 }
 
 std::unique_ptr<ChunkedDecoder> NimbleData::makeLengthDecoder() {
@@ -238,7 +244,8 @@ std::unique_ptr<ChunkedDecoder> NimbleData::makeDecoder(
       encodingFactory_,
       pool_,
       stringDecoderZeroCopy_,
-      decodingStats_);
+      decodingStats_,
+      streams_->dictionaryAlphabetLoader(descriptor.offset()));
 }
 
 std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(

--- a/velox/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/velox/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/file/File.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/Reader.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SchemaUtils.h"
@@ -30,6 +31,52 @@ using namespace facebook::velox;
 
 namespace {
 const std::string kSchemaSectionString(kSchemaSection);
+
+class SeekableStreamLoader final : public StreamLoader {
+ public:
+  SeekableStreamLoader(
+      std::unique_ptr<dwio::common::SeekableInputStream> input,
+      uint64_t size,
+      memory::MemoryPool* pool)
+      : input_{std::move(input)} {
+    const void* data;
+    int32_t length;
+    const bool hasData = input_->Next(&data, &length);
+    NIMBLE_CHECK(hasData, "Shared dictionary stream ended early.");
+    NIMBLE_CHECK_GT(length, 0);
+    const auto contiguousSize = static_cast<uint64_t>(length);
+    NIMBLE_CHECK_LE(contiguousSize, size);
+    if (contiguousSize == size) {
+      stream_ = {static_cast<const char*>(data), size};
+      return;
+    }
+
+    buffer_ = AlignedBuffer::allocateExact<char>(size, pool);
+    std::memcpy(buffer_->asMutable<char>(), data, contiguousSize);
+    uint64_t copied{contiguousSize};
+    while (copied < size) {
+      const bool hasMoreData = input_->Next(&data, &length);
+      NIMBLE_CHECK(hasMoreData, "Shared dictionary stream ended early.");
+      NIMBLE_CHECK_GT(length, 0);
+      const auto chunkSize = static_cast<uint64_t>(length);
+      NIMBLE_CHECK_LE(copied + chunkSize, size);
+      std::memcpy(buffer_->asMutable<char>() + copied, data, chunkSize);
+      copied += chunkSize;
+    }
+    stream_ = {buffer_->as<char>(), buffer_->size()};
+  }
+
+  const std::string_view getStream() const final {
+    return stream_;
+  }
+
+ private:
+  // Keeps a contiguous range returned by Next() alive.
+  const std::unique_ptr<dwio::common::SeekableInputStream> input_;
+  // Allocated only when the input spans multiple ranges.
+  BufferPtr buffer_;
+  std::string_view stream_;
+};
 
 std::shared_ptr<const facebook::nimble::Type> loadSchema(
     const TabletReader& tablet) {
@@ -203,7 +250,65 @@ std::unique_ptr<dwio::common::SeekableInputStream> StripeStreams::enqueue(
   dwio::common::StreamIdentifier sid(streamId);
   auto& input =
       lazyColumnIo ? *lazyInput_->bufferedInput() : readerBase_->input();
-  return input.enqueue(*region, &sid);
+  auto valueInput = input.enqueue(*region, &sid);
+
+  const auto dictionaryStreamId =
+      readerBase_->tablet().stripeDictionaryStreamId(streamId);
+  if (!dictionaryStreamId.has_value()) {
+    return valueInput;
+  }
+  const auto dictionaryStreamOffset = dictionaryStreamId.value();
+  const auto dictionaryStreamRegion =
+      streamRegion(static_cast<int>(dictionaryStreamOffset));
+  // A value stream can use a stripe dictionary in some stripes and direct
+  // encoding in others. Direct-encoded stripes omit the dictionary stream.
+  if (!dictionaryStreamRegion.has_value()) {
+    return valueInput;
+  }
+  // Each projected value stream is enqueued once and owns a distinct stripe
+  // dictionary stream.
+  const auto valueStreamId = static_cast<uint32_t>(streamId);
+  NIMBLE_DCHECK(
+      !dictionaryInputs_.contains(valueStreamId),
+      "Stripe dictionary stream is already enqueued.");
+  dwio::common::StreamIdentifier dictionarySid{
+      static_cast<int>(dictionaryStreamOffset)};
+  dictionaryInputs_.emplace(
+      valueStreamId,
+      DictionaryInput{
+          input.enqueue(*dictionaryStreamRegion, &dictionarySid),
+          dictionaryStreamRegion->length});
+  return valueInput;
+}
+
+DictionaryAlphabetLoader StripeStreams::dictionaryAlphabetLoader(
+    uint32_t valueStreamId) {
+  NIMBLE_CHECK(stripeIdentifier_.has_value());
+  auto inputIt = dictionaryInputs_.find(valueStreamId);
+  if (inputIt != dictionaryInputs_.end()) {
+    auto dictionaryInput = std::move(inputIt->second);
+    dictionaryInputs_.erase(inputIt);
+    return [_dictionaryInput = std::move(dictionaryInput),
+            readerBase = readerBase_]() mutable {
+      std::shared_ptr<const StreamLoader> dictionaryStreamOwner =
+          std::make_shared<SeekableStreamLoader>(
+              std::move(_dictionaryInput.input),
+              _dictionaryInput.size,
+              readerBase->pool());
+      return SharedDictionaryAlphabet::create(
+          dictionaryStreamOwner->getStream(),
+          dictionaryStreamOwner,
+          readerBase->pool());
+    };
+  }
+  auto dictionaryAlphabet =
+      readerBase_->tablet().resolveDictionaryAlphabet(valueStreamId);
+  if (dictionaryAlphabet == nullptr) {
+    return nullptr;
+  }
+  return [_dictionaryAlphabet = std::move(dictionaryAlphabet)] {
+    return _dictionaryAlphabet;
+  };
 }
 
 std::vector<std::optional<StreamLocation>> StripeStreams::locateStreams(

--- a/velox/dwio/nimble/velox/selective/ReaderBase.h
+++ b/velox/dwio/nimble/velox/selective/ReaderBase.h
@@ -16,10 +16,13 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <span>
 #include <vector>
 
+#include "folly/Function.h"
+#include "folly/container/F14Map.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/nimble/index/ChunkStatsGroup.h"
@@ -32,6 +35,12 @@
 #include "velox/dwio/nimble/velox/stats/VectorizedStatistics.h"
 
 namespace facebook::nimble {
+
+class SharedDictionaryAlphabet;
+
+/// Loads a shared dictionary alphabet when its first encoded chunk is read.
+using DictionaryAlphabetLoader =
+    folly::Function<std::shared_ptr<const SharedDictionaryAlphabet>()>;
 
 class ReaderBase {
  public:
@@ -188,6 +197,7 @@ class StripeStreams {
   void setStripe(int stripe) {
     stripe_ = stripe;
     lazyInput_.reset();
+    dictionaryInputs_.clear();
     // Keep previous stripe's shared_ptrs (StripeGroup, ChunkStatsGroup)
     // alive while loading the new stripe. This prevents the weak-pointer
     // cache entries from expiring when consecutive stripes share the same
@@ -237,7 +247,19 @@ class StripeStreams {
 
   std::shared_ptr<index::StreamIndex> streamIndex(int streamId) const;
 
+  /// Returns a lazy alphabet loader for a value stream, or nullptr if it has
+  /// no dictionary binding in the current stripe.
+  DictionaryAlphabetLoader dictionaryAlphabetLoader(uint32_t valueStreamId);
+
  private:
+  struct DictionaryInput {
+    // Enqueued stripe dictionary stream held until its alphabet is first
+    // requested.
+    std::unique_ptr<velox::dwio::common::SeekableInputStream> input;
+    // Serialized byte length of the dictionary stream.
+    uint64_t size{};
+  };
+
   std::optional<velox::common::Region> streamRegion(int streamId) const;
 
   const std::shared_ptr<ReaderBase> readerBase_;
@@ -248,6 +270,8 @@ class StripeStreams {
   // guarded by the numReads_ version check.
   std::unique_ptr<LazyInput> lazyInput_;
   std::optional<StripeIdentifier> stripeIdentifier_;
+  // Inputs awaiting alphabet creation, keyed by projected value stream ID.
+  folly::F14FastMap<uint32_t, DictionaryInput> dictionaryInputs_;
 };
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/selective/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/selective/tests/CMakeLists.txt
@@ -36,7 +36,9 @@ target_link_libraries(
   nimble_velox_selective
   nimble_common_file_writer
   nimble_encoding_layout_test_helper
+  nimble_encodings_tests_utils
   nimble_index_test_base
+  nimble_shared_dictionary_test_utils
   velox_vector_test_lib
   velox_vector_fuzzer
   # See also the above VELOX_BUILD_TEST_UTILS=ON comment.

--- a/velox/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -30,6 +30,7 @@
 #include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
+#include "velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "velox/dwio/nimble/index/tests/ClusterIndexTestBase.h"
 #include "velox/dwio/nimble/velox/ChunkedStreamWriter.h"
 
@@ -376,6 +377,18 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
     }
 
     return {streamData, chunkInfos};
+  }
+
+  std::string encodeSharedDictionaryChunkedStream(
+      const std::vector<uint32_t>& indices) {
+    Buffer buffer{*pool_};
+    const auto encodedChunk = test::encodeSharedDictionary(buffer, indices);
+    ChunkedStreamWriter writer{buffer, {.type = CompressionType::Uncompressed}};
+    std::string streamData;
+    for (const auto& segment : writer.encode(encodedChunk)) {
+      streamData += segment;
+    }
+    return streamData;
   }
 
   static void verifyChunkCompressionTypes(
@@ -809,11 +822,58 @@ TEST_P(ChunkedDecoderDataTest, readsCompressedChunks) {
         pool_.get());
 
     std::vector<int32_t> result(chunks[0].size() + chunks[1].size());
-    decoder.nextIndices(result.data(), result.size(), nullptr);
+    decoder.nextIndices(
+        result.data(), static_cast<int64_t>(result.size()), nullptr);
 
     std::vector<int32_t> expected;
     expected.insert(expected.end(), chunks[0].size(), kFirstChunkValue);
     expected.insert(expected.end(), chunks[1].size(), kSecondChunkValue);
+    EXPECT_EQ(result, expected);
+  }
+}
+
+TEST_F(ChunkedDecoderDataTest, sharedDictionaryRequiresNonLegacyDispatch) {
+  const std::vector<int32_t> alphabet{10, 20, 30, 40};
+  const std::vector<uint32_t> indices{2, 0, 3, 1, 2};
+  const std::vector<int32_t> expected{30, 10, 40, 20, 30};
+  const auto streamData = encodeSharedDictionaryChunkedStream(indices);
+  auto makeAlphabetLoader = [&] {
+    auto sharedDictionaryAlphabet =
+        test::createSharedDictionaryAlphabet<int32_t>(
+            alphabet, /*candidateEncodings=*/{}, pool_.get());
+    return [sharedDictionaryAlphabet] { return sharedDictionaryAlphabet; };
+  };
+
+  {
+    ChunkedDecoder decoder(
+        std::make_unique<dwio::common::SeekableArrayInputStream>(
+            streamData.data(), streamData.size()),
+        /*streamIndex=*/nullptr,
+        /*decodeValuesWithNulls=*/false,
+        &encodingFactory(),
+        pool_.get(),
+        /*stringDecoderZeroCopy=*/false,
+        /*decodingStats=*/nullptr,
+        makeAlphabetLoader());
+    NIMBLE_ASSERT_THROW(
+        decoder.ensureLoaded(),
+        "Shared dictionary encoding requires non-legacy encoding dispatch");
+  }
+
+  {
+    ChunkedDecoder decoder(
+        std::make_unique<dwio::common::SeekableArrayInputStream>(
+            streamData.data(), streamData.size()),
+        /*streamIndex=*/nullptr,
+        /*decodeValuesWithNulls=*/false,
+        &encodingFactory(),
+        pool_.get(),
+        /*stringDecoderZeroCopy=*/true,
+        /*decodingStats=*/nullptr,
+        makeAlphabetLoader());
+    std::vector<int32_t> result(indices.size());
+    decoder.nextIndices(
+        result.data(), static_cast<int64_t>(result.size()), nullptr);
     EXPECT_EQ(result, expected);
   }
 }

--- a/velox/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
@@ -18,11 +18,17 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <optional>
+#include <set>
+#include <vector>
+
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/tests/TestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/tablet/FileLayout.h"
 #include "velox/dwio/nimble/tablet/TabletReaderCache.h"
 #include "velox/dwio/nimble/writer/FlushPolicy.h"
@@ -37,6 +43,10 @@ using namespace facebook;
 namespace {
 
 enum class CreationMode { kDirect, kCached };
+
+int32_t sharedDictionaryValue(velox::vector_size_t row) {
+  return row % 2 == 0 ? 0 : std::numeric_limits<int32_t>::max();
+}
 
 } // namespace
 
@@ -89,7 +99,11 @@ class ReaderBaseTest : public ::testing::TestWithParam<CreationMode> {
   }
 
   std::shared_ptr<ReaderBase> createReaderBase() {
-    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileData_);
+    return createReaderBase(fileData_);
+  }
+
+  std::shared_ptr<ReaderBase> createReaderBase(const std::string& fileData) {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileData);
     auto readerOpts = makeReaderOptions();
 
     switch (GetParam()) {
@@ -105,11 +119,70 @@ class ReaderBaseTest : public ::testing::TestWithParam<CreationMode> {
 
         auto input = std::make_unique<velox::dwio::common::BufferedInput>(
             readFile, *pool_);
-        return ReaderBase::create(
-            std::move(input), std::move(cached), readerOpts);
+        return ReaderBase::create(std::move(input), cached, readerOpts);
       }
     }
     VELOX_UNREACHABLE();
+  }
+
+  std::string writeSharedDictionaryFile(SharedDictionaryScope scope) {
+    std::string file;
+    velox::test::VectorMaker vectorMaker(pool_.get());
+    auto vector = vectorMaker.rowVector(
+        {"shared", "plain"},
+        {vectorMaker.mapVector<int64_t, int32_t>(
+             2'000,
+             [](auto /*row*/) { return 1; },
+             [](auto /*idx*/) { return 10; },
+             sharedDictionaryValue),
+         vectorMaker.flatVector<int32_t>(
+             2'000, [](auto row) { return row + 10'000; })});
+
+    WriterOptions writerOptions;
+    writerOptions.maxStreamChunkRawSize = 512;
+    writerOptions.minStreamChunkRawSize = 1;
+    writerOptions.encodingSelectionPolicyCreator = [](DataType dataType) {
+      std::vector<std::pair<EncodingType, float>> readFactors;
+      if (dataType == DataType::Uint32) {
+        readFactors = {{EncodingType::FixedBitWidth, 1.0}};
+      } else if (dataType == DataType::Int32) {
+        readFactors = {
+            {EncodingType::Trivial, 1.0}, {EncodingType::Dictionary, 1.0}};
+      } else {
+        readFactors = {{EncodingType::Trivial, 1.0}};
+      }
+      return ManualEncodingSelectionPolicyFactory{
+          std::move(readFactors), /*compressionOptions=*/std::nullopt}
+          .createPolicy(dataType);
+    };
+    writerOptions.flatMapColumns.emplace("shared", std::set<std::string>{});
+    writerOptions.experimentalSharedDictionaryEncoding =
+        SharedDictionaryEncodingConfig::builder()
+            .addFlatmapValueDictionary(
+                "shared",
+                /*key=*/10,
+                SharedDictionaryConfig{.scope = scope})
+            .build();
+
+    auto writer = std::make_unique<Writer>(
+        vector->type(),
+        std::make_unique<velox::InMemoryWriteFile>(&file),
+        *pool_,
+        std::move(writerOptions));
+    writer->write(vector);
+    writer->close();
+    return file;
+  }
+
+  uint32_t sharedDictionaryStreamId(const ReaderBase& reader) const {
+    const auto& flatMap =
+        reader.nimbleSchema()->asRow().childAt(0)->asFlatMap();
+    auto child = flatMap.findChild("10");
+    NIMBLE_CHECK(child.has_value());
+    return flatMap.childAt(child.value())
+        ->asScalar()
+        .scalarDescriptor()
+        .offset();
   }
 
   void ensureCache() {
@@ -227,7 +300,7 @@ TEST_P(ReaderBaseTest, equivalentAcrossModes) {
   auto inputCached =
       std::make_unique<velox::dwio::common::BufferedInput>(readFile, *pool_);
   auto fromCache =
-      ReaderBase::create(std::move(inputCached), std::move(cached), readerOpts);
+      ReaderBase::create(std::move(inputCached), cached, readerOpts);
 
   EXPECT_TRUE(direct->fileSchema()->equivalent(*fromCache->fileSchema()));
   EXPECT_EQ(
@@ -253,6 +326,7 @@ TEST_P(ReaderBaseTest, locateStreams) {
   };
 
   std::vector<uint32_t> allStreamIds;
+  allStreamIds.reserve(numStreams);
   for (uint32_t i = 0; i < numStreams; ++i) {
     allStreamIds.push_back(i);
   }
@@ -276,6 +350,75 @@ TEST_P(ReaderBaseTest, locateStreams) {
       }
     }
   }
+}
+
+TEST_P(ReaderBaseTest, fileDictionaryAlphabetLoader) {
+  const auto fileData = writeSharedDictionaryFile(SharedDictionaryScope::File);
+  auto reader = createReaderBase(fileData);
+  StripeStreams streams(reader);
+  streams.setStripe(0);
+
+  const auto& row = reader->nimbleSchema()->asRow();
+  const auto sharedStreamId = sharedDictionaryStreamId(*reader);
+  const auto plainStreamId =
+      row.childAt(1)->asScalar().scalarDescriptor().offset();
+
+  EXPECT_TRUE(reader->tablet().hasFileOrExternalDictionaries());
+  EXPECT_FALSE(
+      reader->tablet().stripeDictionaryStreamId(sharedStreamId).has_value());
+  const auto expectedAlphabet =
+      reader->tablet().resolveDictionaryAlphabet(sharedStreamId);
+  ASSERT_NE(expectedAlphabet, nullptr);
+  ASSERT_EQ(
+      reader->tablet().resolveDictionaryAlphabet(sharedStreamId).get(),
+      expectedAlphabet.get());
+
+  auto loader = streams.dictionaryAlphabetLoader(sharedStreamId);
+  ASSERT_TRUE(loader);
+  EXPECT_EQ(loader(), expectedAlphabet);
+  EXPECT_EQ(loader(), expectedAlphabet);
+
+  EXPECT_EQ(reader->tablet().resolveDictionaryAlphabet(plainStreamId), nullptr);
+  auto plainLoader = streams.dictionaryAlphabetLoader(plainStreamId);
+  EXPECT_FALSE(plainLoader);
+}
+
+TEST_P(ReaderBaseTest, stripeDictionaryAlphabetLoader) {
+  const auto fileData =
+      writeSharedDictionaryFile(SharedDictionaryScope::Stripe);
+  auto reader = createReaderBase(fileData);
+  StripeStreams streams(reader);
+  streams.setStripe(0);
+
+  const auto& row = reader->nimbleSchema()->asRow();
+  const auto sharedStreamId = sharedDictionaryStreamId(*reader);
+  const auto plainStreamId =
+      row.childAt(1)->asScalar().scalarDescriptor().offset();
+
+  EXPECT_TRUE(reader->tablet().hasStripeDictionaries());
+  const auto stripeDictionaryStreamId =
+      reader->tablet().stripeDictionaryStreamId(sharedStreamId);
+  ASSERT_TRUE(stripeDictionaryStreamId.has_value());
+  ASSERT_TRUE(streams.hasStream(
+      static_cast<int32_t>(stripeDictionaryStreamId.value())));
+
+  auto valueInput = streams.enqueue(sharedStreamId);
+  ASSERT_NE(valueInput, nullptr);
+  streams.load();
+
+  auto loader = streams.dictionaryAlphabetLoader(sharedStreamId);
+  ASSERT_TRUE(loader);
+  const auto alphabet = loader();
+  ASSERT_NE(alphabet, nullptr);
+  EXPECT_EQ(alphabet->entryCount(), 2);
+  EXPECT_EQ(alphabet->physicalValueAt<int32_t>(0), 0);
+  EXPECT_EQ(
+      alphabet->physicalValueAt<int32_t>(1),
+      std::numeric_limits<int32_t>::max());
+  EXPECT_FALSE(streams.dictionaryAlphabetLoader(sharedStreamId));
+
+  auto plainLoader = streams.dictionaryAlphabetLoader(plainStreamId);
+  EXPECT_FALSE(plainLoader);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/velox/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -18,6 +18,11 @@
 
 #include <algorithm>
 #include <array>
+#include <limits>
+#include <optional>
+#include <random>
+#include <set>
+#include <span>
 
 #include <fmt/format.h>
 
@@ -34,16 +39,21 @@
 #include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/TypeUtils.h"
+#include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/dwio/nimble/common/tests/TestUtils.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
 #include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
 #include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -53,6 +63,13 @@ namespace facebook::nimble {
 namespace {
 
 using namespace facebook::velox;
+
+using test::makeSharedDictionaryInput;
+using test::SharedDictionarySource;
+using test::SharedDictionaryTestResolver;
+using test::sharedDictionaryValueUniverse;
+using test::sharedDictionaryWriterOptions;
+using test::writeWithRandomStripes;
 
 struct NullableArrayData {
   std::optional<std::vector<std::optional<int64_t>>> value;
@@ -184,7 +201,9 @@ class SelectiveNimbleReaderTest
       const std::shared_ptr<common::ScanSpec>& scanSpec,
       bool stringDecoderZeroCopy,
       bool preserveFlatMapsInMemory = false,
-      bool lazyColumnIo = false) {
+      bool lazyColumnIo = false,
+      std::shared_ptr<const ExternalDictionaryResolver>
+          externalDictionaryResolver = nullptr) {
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
@@ -195,6 +214,12 @@ class SelectiveNimbleReaderTest
     options.setPinMetadata(GetParam().pinMetadata);
     options.setCacheMetadata(GetParam().enableCache);
     options.setFilePreloadThreshold(0);
+    if (externalDictionaryResolver != nullptr) {
+      auto nimbleOptions = std::make_shared<NimbleReaderOptions>();
+      nimbleOptions->externalDictionaryResolver =
+          std::move(externalDictionaryResolver);
+      options.setFormatSpecificOptions(std::move(nimbleOptions));
+    }
     std::unique_ptr<dwio::common::BufferedInput> input;
     auto& ids = fileIds();
     const auto readerId = readerIdCounter_++;
@@ -775,6 +800,162 @@ TEST_P(SelectiveNimbleReaderTest, denseWithNulls) {
   auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
   auto result = BaseVector::create(input->type(), 0, pool());
   validate(*input, *readers.rowReader, 7, [](auto) { return true; });
+}
+
+TEST_P(SelectiveNimbleReaderTest, sharedDictionary) {
+  const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
+  const auto valueUniverse = sharedDictionaryValueUniverse();
+
+  for (const bool nullableData : {false, true}) {
+    for (const auto scope :
+         {SharedDictionaryScope::Stripe,
+          SharedDictionaryScope::File,
+          SharedDictionaryScope::External}) {
+      const uint32_t dictionaryId =
+          scope == SharedDictionaryScope::Stripe ? 0 : 17;
+      std::shared_ptr<const ExternalDictionaryResolver> resolver;
+      if (scope == SharedDictionaryScope::External) {
+        resolver = std::make_shared<SharedDictionaryTestResolver>(
+            std::vector<std::pair<uint32_t, std::vector<int32_t>>>{
+                {dictionaryId, valueUniverse}},
+            pool());
+      }
+
+      const std::vector<SharedDictionarySource> sources{{
+          .columnName = "c0",
+          .dictionaryKey = 10,
+          .scope = scope,
+          .dictionaryId = dictionaryId,
+      }};
+      auto input = makeSharedDictionaryInput(
+          pool(),
+          /*rowCount=*/2'000,
+          sources,
+          valueUniverse,
+          nullableData);
+      auto scanSpec = std::make_shared<common::ScanSpec>("root");
+      scanSpec->addAllChildFields(*input->type());
+      const auto file = test::createNimbleFile(
+          *rootPool(),
+          input,
+          sharedDictionaryWriterOptions(
+              sources, {.externalDictionaryResolver = resolver}));
+
+      for (const bool lazyColumnIo : {false, true}) {
+        SCOPED_TRACE(
+            fmt::format(
+                "scope={}, nullableData={}, lazyColumnIo={}",
+                scope,
+                nullableData,
+                lazyColumnIo));
+        auto readers = makeReaders(
+            input,
+            file,
+            scanSpec,
+            stringDecoderZeroCopy,
+            /*preserveFlatMapsInMemory=*/false,
+            lazyColumnIo,
+            resolver);
+        if (!stringDecoderZeroCopy) {
+          NIMBLE_ASSERT_THROW(
+              validate(
+                  *input,
+                  *readers.rowReader,
+                  /*batchSize=*/127,
+                  [](auto /*row*/) { return true; }),
+              "Shared dictionary encoding requires non-legacy encoding "
+              "dispatch.");
+          continue;
+        }
+        validate(
+            *input,
+            *readers.rowReader,
+            /*batchSize=*/127,
+            [](auto /*row*/) { return true; });
+      }
+    }
+  }
+}
+
+TEST_P(SelectiveNimbleReaderTest, sharedDictionaryRandomizedSourcesAndStripes) {
+  const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
+  constexpr uint32_t kSeed{0x51A9D1C7};
+  SCOPED_TRACE(fmt::format("seed={}", kSeed));
+
+  const auto valueUniverse = sharedDictionaryValueUniverse();
+  const std::vector<SharedDictionarySource> sources{
+      {
+          .columnName = "stripe",
+          .dictionaryKey = 10,
+          .scope = SharedDictionaryScope::Stripe,
+          .dictionaryId = 0,
+      },
+      {
+          .columnName = "file",
+          .dictionaryKey = 20,
+          .scope = SharedDictionaryScope::File,
+          .dictionaryId = 7,
+      },
+      {
+          .columnName = "external",
+          .dictionaryKey = 30,
+          .scope = SharedDictionaryScope::External,
+          .dictionaryId = 17,
+      },
+  };
+  auto resolver = std::make_shared<SharedDictionaryTestResolver>(
+      std::vector<std::pair<uint32_t, std::vector<int32_t>>>{
+          {sources.back().dictionaryId, valueUniverse}},
+      pool());
+  auto input = makeSharedDictionaryInput(
+      pool(),
+      /*rowCount=*/1'024,
+      sources,
+      valueUniverse,
+      /*nullableData=*/true);
+  const auto file = writeWithRandomStripes(
+      rootPool(),
+      input,
+      sharedDictionaryWriterOptions(
+          sources, {.externalDictionaryResolver = resolver}),
+      kSeed);
+
+  {
+    auto readFile = std::make_shared<InMemoryReadFile>(file);
+    auto tabletOptions = test::makeTestTabletOptions(pool());
+    tabletOptions.externalDictionaryResolver = resolver;
+    auto tablet = TabletReader::create(readFile, pool(), tabletOptions);
+    EXPECT_GT(tablet->stripeCount(), 1);
+  }
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  for (const bool lazyColumnIo : {false, true}) {
+    SCOPED_TRACE(fmt::format("lazyColumnIo={}", lazyColumnIo));
+    auto readers = makeReaders(
+        input,
+        file,
+        scanSpec,
+        stringDecoderZeroCopy,
+        /*preserveFlatMapsInMemory=*/false,
+        lazyColumnIo,
+        resolver);
+    if (!stringDecoderZeroCopy) {
+      NIMBLE_ASSERT_THROW(
+          validate(
+              *input,
+              *readers.rowReader,
+              /*batchSize=*/89,
+              [](auto /*row*/) { return true; }),
+          "Shared dictionary encoding requires non-legacy encoding dispatch.");
+      continue;
+    }
+    validate(
+        *input,
+        *readers.rowReader,
+        /*batchSize=*/89,
+        [](auto /*row*/) { return true; });
+  }
 }
 
 TEST_P(SelectiveNimbleReaderTest, denseMostlyNulls) {

--- a/velox/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/tests/CMakeLists.txt
@@ -48,6 +48,23 @@ target_link_libraries(
   gtest_main
 )
 
+add_library(
+  nimble_shared_dictionary_test_utils
+  SharedDictionaryTestUtils.cpp
+  SharedDictionaryTestUtils.h
+)
+target_link_libraries(
+  nimble_shared_dictionary_test_utils
+  nimble_common
+  nimble_encodings
+  nimble_velox_shared_dictionary_config
+  nimble_writer
+  velox_file
+  velox_memory
+  velox_vector
+  velox_vector_test_lib
+)
+
 add_executable(
   nimble_velox_tests
   BufferGrowthPolicyTest.cpp
@@ -62,6 +79,7 @@ add_executable(
   SchemaTest.cpp
   SchemaUtilsTest.cpp
   SharedDictionaryConfigTest.cpp
+  SharedDictionaryE2ETest.cpp
   SharedDictionaryWriterTest.cpp
   StreamChunkerTest.cpp
   StreamDataTest.cpp
@@ -93,6 +111,7 @@ target_link_libraries(
   nimble_velox_tests
   nimble_velox_common
   nimble_velox_schema_utils
+  nimble_shared_dictionary_test_utils
   nimble_writer_test_utils
   nimble_velox_reader
   nimble_velox_shared_dictionary_config

--- a/velox/dwio/nimble/velox/tests/ChunkedStreamDecoderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/ChunkedStreamDecoderTest.cpp
@@ -223,10 +223,12 @@ void test(
           *memoryPool, std::move(streamLoader)),
       optimizeStringBufferHandling ? [](velox::memory::MemoryPool& pool,
          std::string_view data, std::function<void*(uint32_t)> stringBufferFactory) -> std::unique_ptr<nimble::Encoding> {
-        return nimble::EncodingFactory().create(pool, data, stringBufferFactory);
+        return nimble::EncodingFactory().create(
+            pool, data, std::move(stringBufferFactory), nimble::Encoding::Options{});
       } : [](velox::memory::MemoryPool& pool,
          std::string_view data, std::function<void*(uint32_t)> stringBufferFactory) -> std::unique_ptr<nimble::Encoding> {
-        return nimble::legacy::EncodingFactory().create(pool, data, stringBufferFactory);
+        return nimble::legacy::EncodingFactory().create(
+            pool, data, std::move(stringBufferFactory), nimble::Encoding::Options{});
       },
       optimizeStringBufferHandling,
       /* metricLogger */ {}};

--- a/velox/dwio/nimble/velox/tests/LayoutPlannerTest.cpp
+++ b/velox/dwio/nimble/velox/tests/LayoutPlannerTest.cpp
@@ -202,8 +202,7 @@ TEST(DefaultLayoutPlannerTests, reorderFlatMap) {
   auto namedTypes = getNamedTypes(*builder.root());
 
   nimble::DefaultLayoutPlanner planner{
-      [&]() { return builder.root(); },
-      {{{1, {3, 42, 9, 2, 21}}, {5, {3, 2, 42, 21}}}}};
+      &builder, {{{1, {3, 42, 9, 2, 21}}, {5, {3, 2, 42, 21}}}}};
 
   std::vector<nimble::Stream> streams;
   streams = planner.getLayout(std::move(streams));
@@ -286,8 +285,7 @@ TEST(DefaultLayoutPlannerTests, reorderFlatMapDynamicFeatures) {
 
   auto namedTypes = getNamedTypes(*builder.root());
 
-  nimble::DefaultLayoutPlanner planner{
-      [&]() { return builder.root(); }, {{{1, {3, 42, 9, 2, 21}}}}};
+  nimble::DefaultLayoutPlanner planner{&builder, {{{1, {3, 42, 9, 2, 21}}}}};
 
   std::vector<nimble::Stream> streams;
   streams.reserve(namedTypes.size());
@@ -385,8 +383,7 @@ TEST(DefaultLayoutPlannerTests, noFeatureReordering) {
 
   auto namedTypes = getNamedTypes(*builder.root());
 
-  nimble::DefaultLayoutPlanner planner{
-      [&]() { return builder.root(); }, std::nullopt};
+  nimble::DefaultLayoutPlanner planner{&builder, std::nullopt};
 
   std::vector<nimble::Stream> streams;
   streams.reserve(namedTypes.size());
@@ -416,6 +413,68 @@ TEST(DefaultLayoutPlannerTests, noFeatureReordering) {
   testStreamLayout(rng, planner, std::move(streams), std::move(expected));
 }
 
+TEST(DefaultLayoutPlannerTests, sharedDictionaryFollowsValueStream) {
+  nimble::SchemaBuilder builder;
+  nimble::test::FlatMapChildAdder flatMapChildAdder;
+  NIMBLE_SCHEMA(
+      builder,
+      NIMBLE_ROW({
+          {"c1", NIMBLE_TINYINT()},
+          {"c2", NIMBLE_FLATMAP(Int8, NIMBLE_TINYINT(), flatMapChildAdder)},
+          {"c3", NIMBLE_TINYINT()},
+      }));
+  flatMapChildAdder.addChild("feature");
+
+  const auto scalarValueStreamOffset =
+      builder.root()->asRow().childAt(0).asScalar().scalarDescriptor().offset();
+  const auto flatMapValueStreamOffset = builder.root()
+                                            ->asRow()
+                                            .childAt(1)
+                                            .asFlatMap()
+                                            .childAt(0)
+                                            .asScalar()
+                                            .scalarDescriptor()
+                                            .offset();
+  const auto scalarDictionaryOffset =
+      builder.createSharedDictionaryStream(scalarValueStreamOffset);
+  const auto flatMapDictionaryOffset =
+      builder.createSharedDictionaryStream(flatMapValueStreamOffset);
+  auto namedTypes = getNamedTypes(*builder.root());
+  std::vector<nimble::Stream> streams;
+  streams.reserve(namedTypes.size() + 2);
+  for (const auto& [offset, name] : namedTypes) {
+    streams.push_back(nimble::Stream{offset, {{.content = {name}}}});
+  }
+  streams.push_back(
+      nimble::Stream{
+          scalarDictionaryOffset,
+          {{.content = {"scalar dictionary for c1(0).s"}}}});
+  streams.push_back(
+      nimble::Stream{
+          flatMapDictionaryOffset,
+          {{.content = {"flat map dictionary for c2(1).f.feature(0).s"}}}});
+
+  nimble::DefaultLayoutPlanner planner{&builder, std::nullopt};
+  streams = planner.getLayout(std::move(streams));
+
+  std::vector<std::string> streamNames;
+  streamNames.reserve(streams.size());
+  for (const auto& stream : streams) {
+    streamNames.emplace_back(stream.chunks.front().content.front());
+  }
+  EXPECT_EQ(
+      streamNames,
+      (std::vector<std::string>{
+          "r",
+          "r.c1(0).s",
+          "scalar dictionary for c1(0).s",
+          "r.c2(1).f",
+          "r.c2(1).f.feature(0).im",
+          "r.c2(1).f.feature(0).s",
+          "flat map dictionary for c2(1).f.feature(0).s",
+          "r.c3(2).s"}));
+}
+
 TEST(DefaultLayoutPlannerTests, nonFlatMapOrdinalsAreIgnored) {
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
@@ -443,7 +502,7 @@ TEST(DefaultLayoutPlannerTests, nonFlatMapOrdinalsAreIgnored) {
   fm2.addChild("5");
 
   nimble::DefaultLayoutPlanner planner{
-      [&]() { return builder.root(); }, {{{0, {1, 2, 3}}, {1, {42, 5}}}}};
+      &builder, {{{0, {1, 2, 3}}, {1, {42, 5}}}}};
 
   auto namedTypes = getNamedTypes(*builder.root());
   std::vector<nimble::Stream> streams;
@@ -512,8 +571,7 @@ TEST(DefaultLayoutPlannerTests, ordinalOutOfRangeAreIgnored) {
   fm2.addChild("5");
 
   nimble::DefaultLayoutPlanner planner{
-      [&]() { return builder.root(); },
-      {{{6, {3, 42, 9, 2, 21}}, {3, {3, 2, 42, 21}}}}};
+      &builder, {{{6, {3, 42, 9, 2, 21}}, {3, {3, 2, 42, 21}}}}};
 
   auto namedTypes = getNamedTypes(*builder.root());
   std::vector<nimble::Stream> streams;
@@ -558,8 +616,7 @@ TEST(DefaultLayoutPlannerTests, incompatibleSchema) {
 
   NIMBLE_SCHEMA(builder, NIMBLE_MAP(NIMBLE_TINYINT(), NIMBLE_STRING()));
 
-  nimble::DefaultLayoutPlanner planner{
-      [&]() { return builder.root(); }, {{{3, {3, 2, 42, 21}}}}};
+  nimble::DefaultLayoutPlanner planner{&builder, {{{3, {3, 2, 42, 21}}}}};
   try {
     planner.getLayout({});
     FAIL() << "Factory should have failed.";
@@ -590,8 +647,7 @@ TEST(DefaultLayoutPlannerTests, timestampMicros) {
 
   auto namedTypes = getNamedTypes(*builder.root());
 
-  nimble::DefaultLayoutPlanner planner{
-      [&]() { return builder.root(); }, std::nullopt};
+  nimble::DefaultLayoutPlanner planner{&builder, std::nullopt};
 
   std::vector<nimble::Stream> streams;
   streams.reserve(namedTypes.size());

--- a/velox/dwio/nimble/velox/tests/SchemaSerializationTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SchemaSerializationTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
 #include "velox/dwio/nimble/velox/SchemaGenerated.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
+#include "velox/dwio/nimble/velox/SchemaTypes.h"
 #include "velox/dwio/nimble/velox/tests/SchemaUtils.h"
 
 using namespace facebook;
@@ -53,6 +54,34 @@ void expectSchemaNodesEqual(
 }
 
 } // namespace
+
+TEST(SchemaTypesTest, isIntegerScalarKind) {
+  struct TestCase {
+    ScalarKind scalarKind;
+    bool expected;
+  };
+  const std::vector<TestCase> testCases{
+      {ScalarKind::Int8, true},
+      {ScalarKind::UInt8, true},
+      {ScalarKind::Int16, true},
+      {ScalarKind::UInt16, true},
+      {ScalarKind::Int32, true},
+      {ScalarKind::UInt32, true},
+      {ScalarKind::Int64, true},
+      {ScalarKind::UInt64, true},
+      {ScalarKind::Float, false},
+      {ScalarKind::Double, false},
+      {ScalarKind::Bool, false},
+      {ScalarKind::String, false},
+      {ScalarKind::Binary, false},
+      {ScalarKind::Undefined, false},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(toString(testCase.scalarKind));
+    EXPECT_EQ(isIntegerScalarKind(testCase.scalarKind), testCase.expected);
+  }
+}
 
 TEST(SchemaSerializationTest, scalarInt8) {
   SchemaBuilder schemaBuilder;

--- a/velox/dwio/nimble/velox/tests/SchemaTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SchemaTest.cpp
@@ -508,6 +508,30 @@ TEST(SchemaTests, roundTrip) {
   nimble::test::compareSchema(nodes, result);
 }
 
+TEST(SchemaTests, sharedDictionaryStream) {
+  nimble::SchemaBuilder builder;
+  auto scalar = builder.createScalarTypeBuilder(nimble::ScalarKind::Int32);
+  const auto valueStreamOffset = scalar->scalarDescriptor().offset();
+
+  EXPECT_FALSE(
+      builder.sharedDictionaryStreamOffset(valueStreamOffset).has_value());
+  const auto dictionaryStreamOffset =
+      builder.createSharedDictionaryStream(valueStreamOffset);
+  EXPECT_EQ(
+      builder.sharedDictionaryStreamOffset(valueStreamOffset),
+      dictionaryStreamOffset);
+
+  NIMBLE_ASSERT_THROW(
+      builder.createSharedDictionaryStream(valueStreamOffset),
+      "already has a shared dictionary stream");
+  NIMBLE_ASSERT_THROW(
+      builder.createSharedDictionaryStream(dictionaryStreamOffset),
+      "already the shared dictionary stream for value stream");
+  NIMBLE_ASSERT_THROW(
+      builder.createSharedDictionaryStream(builder.nodeCount()),
+      "Shared dictionary value stream is not allocated");
+}
+
 // Custom context classes for testing checkedContext
 class TestStreamContext : public nimble::StreamContext {
  public:
@@ -666,6 +690,20 @@ TEST(SchemaTests, typeBuilderSetAttributesOverwrites) {
   scalar->setAttributes(kSecond);
 
   EXPECT_EQ(scalar->attributes(), kSecond);
+}
+
+TEST(SchemaTests, rowTypeBuilderFindChild) {
+  nimble::SchemaBuilder builder;
+  auto row = builder.createRowTypeBuilder(2);
+  auto alpha = builder.createScalarTypeBuilder(nimble::ScalarKind::Int32);
+  auto beta = builder.createScalarTypeBuilder(nimble::ScalarKind::Int64);
+  row->addChild("alpha", alpha);
+  row->addChild("beta", beta);
+
+  EXPECT_EQ(&row->findChild("alpha"), alpha.get());
+  EXPECT_EQ(&row->findChild("beta"), beta.get());
+  NIMBLE_ASSERT_USER_THROW(
+      row->findChild("gamma"), "Row child 'gamma' does not exist.");
 }
 
 TEST(SchemaTests, rowTypeFindChild) {

--- a/velox/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
@@ -19,6 +19,7 @@
 
 #include <folly/Random.h>
 
+#include <memory>
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
@@ -104,7 +105,7 @@ void expectSameType(const Type& a, const Type& b, const std::string& path) {
 
 // --- convertToVeloxType tests ---
 
-TEST(SchemaUtilsTest, ConvertScalarToVelox) {
+TEST(SchemaUtilsTest, convertScalarToVelox) {
   struct TestCase {
     ScalarKind scalarKind;
     velox::TypeKind expectedVeloxKind;
@@ -135,7 +136,7 @@ TEST(SchemaUtilsTest, ConvertScalarToVelox) {
   }
 }
 
-TEST(SchemaUtilsTest, ConvertUnsupportedScalarToVeloxThrows) {
+TEST(SchemaUtilsTest, convertUnsupportedScalarToVeloxThrows) {
   std::vector<ScalarKind> unsupported = {
       ScalarKind::UInt8,
       ScalarKind::UInt16,
@@ -156,7 +157,7 @@ TEST(SchemaUtilsTest, ConvertUnsupportedScalarToVeloxThrows) {
   }
 }
 
-TEST(SchemaUtilsTest, ConvertTimestampMicroNanoToVelox) {
+TEST(SchemaUtilsTest, convertTimestampMicroNanoToVelox) {
   SchemaBuilder schemaBuilder;
   NIMBLE_SCHEMA(
       schemaBuilder, NIMBLE_ROW({{"ts", NIMBLE_TIMESTAMPMICRONANO()}}));
@@ -166,7 +167,7 @@ TEST(SchemaUtilsTest, ConvertTimestampMicroNanoToVelox) {
   EXPECT_EQ(velox::TypeKind::TIMESTAMP, veloxType->kind());
 }
 
-TEST(SchemaUtilsTest, ConvertRowToVelox) {
+TEST(SchemaUtilsTest, convertRowToVelox) {
   SchemaBuilder schemaBuilder;
   NIMBLE_SCHEMA(
       schemaBuilder,
@@ -182,7 +183,7 @@ TEST(SchemaUtilsTest, ConvertRowToVelox) {
   EXPECT_EQ(velox::TypeKind::BIGINT, veloxRow.childAt(1)->kind());
 }
 
-TEST(SchemaUtilsTest, ConvertArrayToVelox) {
+TEST(SchemaUtilsTest, convertArrayToVelox) {
   SchemaBuilder schemaBuilder;
   NIMBLE_SCHEMA(
       schemaBuilder, NIMBLE_ROW({{"arr", NIMBLE_ARRAY(NIMBLE_BIGINT())}}));
@@ -194,7 +195,7 @@ TEST(SchemaUtilsTest, ConvertArrayToVelox) {
       velox::TypeKind::BIGINT, veloxType->asArray().elementType()->kind());
 }
 
-TEST(SchemaUtilsTest, ConvertArrayWithOffsetsToVelox) {
+TEST(SchemaUtilsTest, convertArrayWithOffsetsToVelox) {
   SchemaBuilder schemaBuilder;
   NIMBLE_SCHEMA(
       schemaBuilder, NIMBLE_ROW({{"oa", NIMBLE_OFFSETARRAY(NIMBLE_BIGINT())}}));
@@ -206,7 +207,7 @@ TEST(SchemaUtilsTest, ConvertArrayWithOffsetsToVelox) {
       velox::TypeKind::BIGINT, veloxType->asArray().elementType()->kind());
 }
 
-TEST(SchemaUtilsTest, ConvertMapToVelox) {
+TEST(SchemaUtilsTest, convertMapToVelox) {
   SchemaBuilder schemaBuilder;
   NIMBLE_SCHEMA(
       schemaBuilder,
@@ -219,7 +220,7 @@ TEST(SchemaUtilsTest, ConvertMapToVelox) {
   EXPECT_EQ(velox::TypeKind::INTEGER, veloxType->asMap().valueType()->kind());
 }
 
-TEST(SchemaUtilsTest, ConvertSlidingWindowMapToVelox) {
+TEST(SchemaUtilsTest, convertSlidingWindowMapToVelox) {
   SchemaBuilder schemaBuilder;
   NIMBLE_SCHEMA(
       schemaBuilder,
@@ -234,7 +235,7 @@ TEST(SchemaUtilsTest, ConvertSlidingWindowMapToVelox) {
   EXPECT_EQ(velox::TypeKind::INTEGER, veloxType->asMap().valueType()->kind());
 }
 
-TEST(SchemaUtilsTest, ConvertFlatMapToVelox) {
+TEST(SchemaUtilsTest, convertFlatMapToVelox) {
   SchemaBuilder schemaBuilder;
   test::FlatMapChildAdder adder;
   NIMBLE_SCHEMA(
@@ -251,7 +252,7 @@ TEST(SchemaUtilsTest, ConvertFlatMapToVelox) {
 
 // --- convertToNimbleType tests ---
 
-TEST(SchemaUtilsTest, ConvertVeloxScalarToNimble) {
+TEST(SchemaUtilsTest, convertVeloxScalarToNimble) {
   struct TestCase {
     velox::TypePtr veloxType;
     ScalarKind expectedScalarKind;
@@ -279,12 +280,12 @@ TEST(SchemaUtilsTest, ConvertVeloxScalarToNimble) {
   }
 }
 
-TEST(SchemaUtilsTest, ConvertVeloxTimestampToNimble) {
+TEST(SchemaUtilsTest, convertVeloxTimestampToNimble) {
   auto nimbleType = convertToNimbleType(*velox::TIMESTAMP());
   ASSERT_EQ(Kind::TimestampMicroNano, nimbleType->kind());
 }
 
-TEST(SchemaUtilsTest, ConvertVeloxArrayToNimble) {
+TEST(SchemaUtilsTest, convertVeloxArrayToNimble) {
   auto vType = velox::ARRAY(velox::BIGINT());
   auto nimbleType = convertToNimbleType(*vType);
   ASSERT_EQ(Kind::Array, nimbleType->kind());
@@ -295,7 +296,7 @@ TEST(SchemaUtilsTest, ConvertVeloxArrayToNimble) {
       arr.elements()->asScalar().scalarDescriptor().scalarKind());
 }
 
-TEST(SchemaUtilsTest, ConvertVeloxMapToNimble) {
+TEST(SchemaUtilsTest, convertVeloxMapToNimble) {
   auto vType = velox::MAP(velox::VARCHAR(), velox::INTEGER());
   auto nimbleType = convertToNimbleType(*vType);
   ASSERT_EQ(Kind::Map, nimbleType->kind());
@@ -308,7 +309,7 @@ TEST(SchemaUtilsTest, ConvertVeloxMapToNimble) {
       map.values()->asScalar().scalarDescriptor().scalarKind());
 }
 
-TEST(SchemaUtilsTest, ConvertVeloxRowToNimble) {
+TEST(SchemaUtilsTest, convertVeloxRowToNimble) {
   auto vType = velox::ROW({"x", "y"}, {velox::TINYINT(), velox::DOUBLE()});
   auto nimbleType = convertToNimbleType(*vType);
   ASSERT_EQ(Kind::Row, nimbleType->kind());
@@ -326,7 +327,7 @@ TEST(SchemaUtilsTest, ConvertVeloxRowToNimble) {
 
 // --- Round-trip tests ---
 
-TEST(SchemaUtilsTest, RoundTripScalarTypes) {
+TEST(SchemaUtilsTest, roundTripScalarTypes) {
   std::vector<velox::TypePtr> scalarTypes = {
       velox::BOOLEAN(),
       velox::TINYINT(),
@@ -348,28 +349,28 @@ TEST(SchemaUtilsTest, RoundTripScalarTypes) {
   }
 }
 
-TEST(SchemaUtilsTest, RoundTripTimestamp) {
+TEST(SchemaUtilsTest, roundTripTimestamp) {
   auto vType = velox::TIMESTAMP();
   auto nimbleType = convertToNimbleType(*vType);
   auto roundTripped = convertToVeloxType(*nimbleType);
   EXPECT_TRUE(vType->equivalent(*roundTripped));
 }
 
-TEST(SchemaUtilsTest, RoundTripArray) {
+TEST(SchemaUtilsTest, roundTripArray) {
   auto vType = velox::ARRAY(velox::INTEGER());
   auto nimbleType = convertToNimbleType(*vType);
   auto roundTripped = convertToVeloxType(*nimbleType);
   EXPECT_TRUE(vType->equivalent(*roundTripped)) << roundTripped->toString();
 }
 
-TEST(SchemaUtilsTest, RoundTripMap) {
+TEST(SchemaUtilsTest, roundTripMap) {
   auto vType = velox::MAP(velox::VARCHAR(), velox::BIGINT());
   auto nimbleType = convertToNimbleType(*vType);
   auto roundTripped = convertToVeloxType(*nimbleType);
   EXPECT_TRUE(vType->equivalent(*roundTripped)) << roundTripped->toString();
 }
 
-TEST(SchemaUtilsTest, RoundTripRow) {
+TEST(SchemaUtilsTest, roundTripRow) {
   auto vType = velox::ROW({"a", "b"}, {velox::TINYINT(), velox::DOUBLE()});
   auto nimbleType = convertToNimbleType(*vType);
   auto roundTripped = convertToVeloxType(*nimbleType);

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryConfigTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryConfigTest.cpp
@@ -37,7 +37,7 @@ TEST(SharedDictionaryConfigTest, defaultValues) {
   SharedDictionaryEncodingConfig config;
   EXPECT_TRUE(config.empty());
   EXPECT_TRUE(config.columns.empty());
-  EXPECT_TRUE(config.flatMapColumns.empty());
+  EXPECT_TRUE(config.flatMaps.empty());
   EXPECT_EQ(config.externalResolver, nullptr);
 }
 
@@ -65,11 +65,16 @@ TEST(SharedDictionaryConfigTest, config) {
                   .useExternalAlphabet = true,
                   .alphabetEncodings = {EncodingType::FixedBitWidth}},
               "items[*].score")
+          .addFlatmapValueDictionary(
+              "features",
+              /*key=*/43,
+              SharedDictionaryConfig{
+                  .scope = SharedDictionaryScope::File, .dictionaryId = 18})
           .build();
 
   EXPECT_FALSE(config.empty());
   ASSERT_EQ(config.columns.size(), 3);
-  ASSERT_EQ(config.flatMapColumns.size(), 1);
+  ASSERT_EQ(config.flatMaps.size(), 1);
   EXPECT_EQ(config.externalResolver, nullptr);
 
   EXPECT_EQ(config.columns[0].fieldPath, "value");
@@ -85,9 +90,9 @@ TEST(SharedDictionaryConfigTest, config) {
   EXPECT_EQ(config.columns[2].dictionary.scope, SharedDictionaryScope::File);
   EXPECT_EQ(config.columns[2].dictionary.dictionaryId, 11);
 
-  const auto& columnDictionary = config.flatMapColumns[0];
+  const auto& columnDictionary = config.flatMaps[0];
   EXPECT_EQ(columnDictionary.fieldPath, "features");
-  ASSERT_EQ(columnDictionary.keys.size(), 1);
+  ASSERT_EQ(columnDictionary.keys.size(), 2);
   const auto& keyDictionary = columnDictionary.keys[0];
   EXPECT_EQ(keyDictionary.key, 42);
   EXPECT_EQ(keyDictionary.valueSubfield, "items[*].score");
@@ -97,6 +102,12 @@ TEST(SharedDictionaryConfigTest, config) {
   EXPECT_EQ(
       keyDictionary.dictionary.alphabetEncodings,
       std::vector<EncodingType>{EncodingType::FixedBitWidth});
+
+  const auto& arrayKeyDictionary = columnDictionary.keys[1];
+  EXPECT_EQ(arrayKeyDictionary.key, 43);
+  EXPECT_EQ(arrayKeyDictionary.valueSubfield, "");
+  EXPECT_EQ(arrayKeyDictionary.dictionary.scope, SharedDictionaryScope::File);
+  EXPECT_EQ(arrayKeyDictionary.dictionary.dictionaryId, 18);
 }
 
 TEST(SharedDictionaryConfigTest, builderSeedsExistingConfig) {
@@ -119,7 +130,7 @@ TEST(SharedDictionaryConfigTest, builderSeedsExistingConfig) {
           .build();
 
   ASSERT_EQ(config.columns.size(), seedConfig.columns.size());
-  ASSERT_EQ(config.flatMapColumns.size(), 1);
+  ASSERT_EQ(config.flatMaps.size(), 1);
   EXPECT_EQ(config.columns[0].fieldPath, seedConfig.columns[0].fieldPath);
   EXPECT_EQ(
       config.columns[0].dictionary.scope,
@@ -127,10 +138,10 @@ TEST(SharedDictionaryConfigTest, builderSeedsExistingConfig) {
   EXPECT_EQ(
       config.columns[0].dictionary.dictionaryId,
       seedConfig.columns[0].dictionary.dictionaryId);
-  EXPECT_TRUE(seedConfig.flatMapColumns.empty());
-  EXPECT_EQ(config.flatMapColumns[0].fieldPath, "features");
-  ASSERT_EQ(config.flatMapColumns[0].keys.size(), 1);
-  EXPECT_EQ(config.flatMapColumns[0].keys[0].key, 10);
+  EXPECT_TRUE(seedConfig.flatMaps.empty());
+  EXPECT_EQ(config.flatMaps[0].fieldPath, "features");
+  ASSERT_EQ(config.flatMaps[0].keys.size(), 1);
+  EXPECT_EQ(config.flatMaps[0].keys[0].key, 10);
 }
 
 TEST(SharedDictionaryConfigTest, builderRejectsDuplicateTargets) {
@@ -176,7 +187,7 @@ TEST(SharedDictionaryConfigTest, builderRejectsInvalidPaths) {
           .name = "empty column path",
           .fieldPath = "",
           .flatMap = false,
-          .expectedMessage = "Shared dictionary column path must not be empty.",
+          .expectedMessage = "Shared dictionary path must not be empty.",
       },
       {
           .name = "column path with subscript",
@@ -190,8 +201,7 @@ TEST(SharedDictionaryConfigTest, builderRejectsInvalidPaths) {
           .name = "empty flat-map path",
           .fieldPath = "",
           .flatMap = true,
-          .expectedMessage =
-              "Shared dictionary flat-map column path must not be empty.",
+          .expectedMessage = "Shared dictionary path must not be empty.",
       },
       {
           .name = "nested flat-map path",
@@ -247,11 +257,17 @@ TEST(SharedDictionaryConfigTest, builderRejectsInvalidValueSubfields) {
               "elements.",
       },
       {
-          .name = "leading wildcard",
-          .valueSubfield = "[*].value",
+          .name = "leading key subscript",
+          .valueSubfield = "[10].value",
           .expectedMessage =
-              "Shared dictionary flat-map value subfield path '[*].value' "
-              "must start with a field name.",
+              "Shared dictionary path '[10].value' must start with a field "
+              "name.",
+      },
+      {
+          .name = "leading all subscript",
+          .valueSubfield = "[*]",
+          .expectedMessage =
+              "Shared dictionary path '[*]' must start with a field name.",
       },
   };
 

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
@@ -1,0 +1,1740 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <set>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include "velox/common/file/File.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
+#include "velox/dwio/nimble/tablet/SharedDictionaryReader.h"
+#include "velox/dwio/nimble/tablet/TabletReader.h"
+#include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "velox/dwio/nimble/velox/ChunkedStream.h"
+#include "velox/dwio/nimble/velox/SchemaReader.h"
+#include "velox/dwio/nimble/velox/SchemaSerialization.h"
+#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
+#include "velox/dwio/nimble/writer/Writer.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::nimble {
+namespace {
+
+std::vector<int32_t> toLogicalValues(const std::vector<uint32_t>& values) {
+  std::vector<int32_t> logicalValues;
+  logicalValues.reserve(values.size());
+  for (const auto value : values) {
+    logicalValues.push_back(
+        EncodingPhysicalType<int32_t>::asEncodingLogicalType(value));
+  }
+  return logicalValues;
+}
+
+int32_t directStripeValue(velox::vector_size_t row) {
+  return row % 2 == 0 ? 10'000 + row
+                      : std::numeric_limits<int32_t>::max() - row;
+}
+
+static const std::vector<int32_t> kDictionaryStripeAlphabetValues{
+    0,
+    std::numeric_limits<int32_t>::max()};
+
+std::vector<int32_t> externalDictionaryValues(
+    velox::vector_size_t directValueCount) {
+  auto values = kDictionaryStripeAlphabetValues;
+  values.reserve(values.size() + directValueCount);
+  for (velox::vector_size_t row{0}; row < directValueCount; ++row) {
+    values.push_back(directStripeValue(row));
+  }
+  return values;
+}
+
+std::vector<int32_t> externalDictionaryValues() {
+  return externalDictionaryValues(2'000);
+}
+
+enum class InputType {
+  FlatMapScalar,
+  NullableFlatMapScalar,
+  FlatMapArray,
+  FlatMapArrayArray,
+  FlatMapMap,
+  FlatMapRowValue,
+  NestedScalar,
+  NestedArray,
+  NestedMap,
+  NestedArrayRow,
+  NestedMapRow,
+};
+
+enum class StripeValueType {
+  Dictionary,
+  Direct,
+};
+
+enum class DictionaryTargetSet {
+  Default,
+  FlatMapRowValueOther,
+  FlatMapRowValueSubfields,
+};
+
+enum class InvalidDictionaryTarget {
+  FlatMapWholeRowValue,
+  RegularRowColumnValue,
+};
+
+enum class ExternalDictionaryFailure {
+  MissingResolver,
+  MissingValue,
+};
+
+enum class FileDictionaryAlphabetOrder {
+  Sorted,
+  Unsorted,
+};
+
+struct TabletReaderDictionaryApiTestCase {
+  SharedDictionaryScope scope;
+  bool hasStripeDictionaries;
+  bool hasFileOrExternalDictionaries;
+  bool hasStripeDictionaryStreamId;
+  bool resolvesDictionaryAlphabet;
+};
+
+std::string_view inputTypeName(InputType inputType) {
+  switch (inputType) {
+    case InputType::FlatMapScalar:
+      return "FlatMapScalar";
+    case InputType::NullableFlatMapScalar:
+      return "NullableFlatMapScalar";
+    case InputType::FlatMapArray:
+      return "FlatMapArray";
+    case InputType::FlatMapArrayArray:
+      return "FlatMapArrayArray";
+    case InputType::FlatMapMap:
+      return "FlatMapMap";
+    case InputType::FlatMapRowValue:
+      return "FlatMapRowValue";
+    case InputType::NestedScalar:
+      return "NestedScalar";
+    case InputType::NestedArray:
+      return "NestedArray";
+    case InputType::NestedMap:
+      return "NestedMap";
+    case InputType::NestedArrayRow:
+      return "NestedArrayRow";
+    case InputType::NestedMapRow:
+      return "NestedMapRow";
+  }
+  NIMBLE_UNREACHABLE("Unsupported input type.");
+}
+
+std::string_view invalidDictionaryTargetName(InvalidDictionaryTarget target) {
+  switch (target) {
+    case InvalidDictionaryTarget::FlatMapWholeRowValue:
+      return "FlatMapWholeRowValue";
+    case InvalidDictionaryTarget::RegularRowColumnValue:
+      return "RegularRowColumnValue";
+  }
+  NIMBLE_UNREACHABLE("Unsupported invalid dictionary target.");
+}
+
+std::string_view dictionaryTargetSetName(DictionaryTargetSet targetSet) {
+  switch (targetSet) {
+    case DictionaryTargetSet::Default:
+      return "Default";
+    case DictionaryTargetSet::FlatMapRowValueOther:
+      return "FlatMapRowValueOther";
+    case DictionaryTargetSet::FlatMapRowValueSubfields:
+      return "FlatMapRowValueSubfields";
+  }
+  NIMBLE_UNREACHABLE("Unsupported dictionary target set.");
+}
+
+std::string_view externalDictionaryFailureName(
+    ExternalDictionaryFailure failure) {
+  switch (failure) {
+    case ExternalDictionaryFailure::MissingResolver:
+      return "MissingResolver";
+    case ExternalDictionaryFailure::MissingValue:
+      return "MissingValue";
+  }
+  NIMBLE_UNREACHABLE("Unsupported external dictionary failure.");
+}
+
+std::string_view fileDictionaryAlphabetOrderName(
+    FileDictionaryAlphabetOrder order) {
+  switch (order) {
+    case FileDictionaryAlphabetOrder::Sorted:
+      return "Sorted";
+    case FileDictionaryAlphabetOrder::Unsorted:
+      return "Unsorted";
+  }
+  NIMBLE_UNREACHABLE("Unsupported file dictionary alphabet order.");
+}
+
+class FixedFileResolver final : public ExternalDictionaryResolver {
+ public:
+  FixedFileResolver(
+      std::vector<int32_t> values,
+      velox::memory::MemoryPool* pool,
+      std::span<const EncodingType> candidateEncodings = {})
+      : alphabet_{test::createSharedDictionaryAlphabet<int32_t>(
+            std::span<const int32_t>{values},
+            candidateEncodings,
+            pool)} {}
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      uint32_t dictionaryId,
+      DataType dataType) const final {
+    NIMBLE_CHECK_EQ(dictionaryId, 17);
+    NIMBLE_CHECK_EQ(dataType, DataType::Int32);
+    return alphabet_;
+  }
+
+ private:
+  std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
+};
+
+class SharedDictionaryE2ETest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::SharedArbitrator::registerFactory();
+    velox::memory::MemoryManager::Options options;
+    options.arbitratorKind = "SHARED";
+    velox::memory::MemoryManager::testingSetInstance(options);
+  }
+
+  static void TearDownTestCase() {
+    // Pair with SetUpTestCase so other suites in this binary can register the
+    // same process-global arbitrator factory.
+    velox::memory::SharedArbitrator::unregisterFactory();
+  }
+
+  void SetUp() final {
+    rootPool_ = velox::memory::memoryManager()->addRootPool("shared_dict_root");
+    leafPool_ = rootPool_->addLeafChild("shared_dict_leaf");
+  }
+
+  static void useSharedDictionarySelectionPolicy(WriterOptions& options) {
+    test::configureSharedDictionarySelectionPolicy(
+        options, {.forceDictionaryForInt32 = false});
+  }
+
+  std::shared_ptr<const ExternalDictionaryResolver> makeExternalResolver(
+      std::vector<int32_t> values) {
+    return makeExternalResolver(
+        std::vector<test::SharedDictionaryTestDictionary>{
+            {17, std::move(values)}});
+  }
+
+  std::shared_ptr<const ExternalDictionaryResolver> makeExternalResolver(
+      const std::vector<test::SharedDictionaryTestDictionary>& dictionaries) {
+    return std::make_shared<test::SharedDictionaryTestResolver>(
+        dictionaries, leafPool_.get());
+  }
+
+  static constexpr velox::vector_size_t kStripeRows{2'000};
+
+  static std::vector<velox::vector_size_t> makeOffsets(
+      velox::vector_size_t rowCount,
+      velox::vector_size_t rowWidth = 1) {
+    std::vector<velox::vector_size_t> offsets(rowCount);
+    for (velox::vector_size_t row{0}; row < rowCount; ++row) {
+      offsets[row] = row * rowWidth;
+    }
+    return offsets;
+  }
+
+  static int32_t dictionaryStripeValue(velox::vector_size_t position) {
+    return kDictionaryStripeAlphabetValues.at(
+        position % kDictionaryStripeAlphabetValues.size());
+  }
+
+  static velox::vector_size_t dictionaryValueCount(InputType inputType) {
+    switch (inputType) {
+      case InputType::FlatMapArray:
+      case InputType::FlatMapArrayArray:
+      case InputType::FlatMapMap:
+      case InputType::FlatMapRowValue:
+      case InputType::NestedArray:
+      case InputType::NestedArrayRow:
+        return kStripeRows * 2;
+      case InputType::FlatMapScalar:
+      case InputType::NullableFlatMapScalar:
+      case InputType::NestedScalar:
+      case InputType::NestedMap:
+      case InputType::NestedMapRow:
+        return kStripeRows;
+    }
+    NIMBLE_UNREACHABLE("Unsupported input type.");
+  }
+
+  static int32_t stripeValue(
+      StripeValueType stripeValueType,
+      velox::vector_size_t position) {
+    if (stripeValueType == StripeValueType::Direct) {
+      return directStripeValue(position);
+    }
+    return dictionaryStripeValue(position);
+  }
+
+  velox::RowVectorPtr makeStripe(
+      InputType type,
+      StripeValueType stripeValueType) {
+    velox::test::VectorMaker maker{leafPool_.get()};
+    switch (type) {
+      case InputType::FlatMapScalar:
+        return maker.rowVector(
+            {"features"},
+            {maker.mapVector<int64_t, int32_t>(
+                kStripeRows,
+                [](auto /* row */) { return 1; },
+                [](auto /* idx */) { return 10; },
+                [stripeValueType](auto row) {
+                  return stripeValue(stripeValueType, row);
+                })});
+      case InputType::NullableFlatMapScalar: {
+        auto offsets = makeOffsets(kStripeRows);
+        auto keys = maker.flatVector<int64_t>(
+            kStripeRows, [](auto /*row*/) { return 10; });
+        auto values = maker.flatVector<int32_t>(
+            kStripeRows,
+            [stripeValueType](auto row) {
+              return stripeValue(stripeValueType, row);
+            },
+            [](auto row) { return row % 5 == 0; });
+        return maker.rowVector(
+            {"features"}, {maker.mapVector(offsets, keys, values)});
+      }
+      case InputType::FlatMapArray: {
+        auto offsets = makeOffsets(kStripeRows);
+        auto keys = maker.flatVector<int64_t>(
+            kStripeRows, [](auto /*row*/) { return 10; });
+
+        std::vector<std::vector<int32_t>> valueArrays;
+        valueArrays.reserve(kStripeRows);
+        for (velox::vector_size_t row{0}; row < kStripeRows; ++row) {
+          valueArrays.push_back(
+              {stripeValue(stripeValueType, row * 2),
+               stripeValue(stripeValueType, row * 2 + 1)});
+        }
+
+        return maker.rowVector(
+            {"features"},
+            {maker.mapVector(
+                offsets, keys, maker.arrayVector<int32_t>(valueArrays))});
+      }
+      case InputType::FlatMapArrayArray: {
+        auto mapOffsets = makeOffsets(kStripeRows);
+        auto keys = maker.flatVector<int64_t>(
+            kStripeRows, [](auto /*row*/) { return 10; });
+        auto innerArrayOffsets = makeOffsets(kStripeRows, /*rowWidth=*/2);
+        auto innerArrays = maker.arrayVector(
+            innerArrayOffsets,
+            maker.flatVector<int32_t>(
+                kStripeRows * 2, [stripeValueType](auto position) {
+                  return stripeValue(stripeValueType, position);
+                }));
+        auto outerArrayOffsets = makeOffsets(kStripeRows);
+        return maker.rowVector(
+            {"features"},
+            {maker.mapVector(
+                mapOffsets,
+                keys,
+                maker.arrayVector(outerArrayOffsets, innerArrays))});
+      }
+      case InputType::FlatMapMap: {
+        auto mapOffsets = makeOffsets(kStripeRows);
+        auto keys = maker.flatVector<int64_t>(
+            kStripeRows, [](auto /*row*/) { return 10; });
+        auto valueMapOffsets = makeOffsets(kStripeRows, /*rowWidth=*/2);
+        auto valueMapKeys = maker.flatVector<int64_t>(
+            kStripeRows * 2, [](auto position) { return position % 2; });
+        auto valueMapValues = maker.flatVector<int32_t>(
+            kStripeRows * 2, [stripeValueType](auto position) {
+              return stripeValue(stripeValueType, position);
+            });
+        return maker.rowVector(
+            {"features"},
+            {maker.mapVector(
+                mapOffsets,
+                keys,
+                maker.mapVector(
+                    valueMapOffsets, valueMapKeys, valueMapValues))});
+      }
+      case InputType::FlatMapRowValue: {
+        auto mapOffsets = makeOffsets(kStripeRows);
+        auto keys = maker.flatVector<int64_t>(
+            kStripeRows, [](auto /*row*/) { return 10; });
+        auto arrayOffsets = makeOffsets(kStripeRows, /*rowWidth=*/2);
+        auto values = maker.rowVector(
+            {"items", "other"},
+            {
+                maker.arrayVector(
+                    arrayOffsets,
+                    maker.flatVector<int32_t>(
+                        kStripeRows * 2,
+                        [stripeValueType](auto position) {
+                          return stripeValue(stripeValueType, position);
+                        })),
+                maker.flatVector<int32_t>(
+                    kStripeRows,
+                    [stripeValueType](auto row) {
+                      return stripeValue(stripeValueType, row);
+                    }),
+            });
+        return maker.rowVector(
+            {"features"}, {maker.mapVector(mapOffsets, keys, values)});
+      }
+      case InputType::NestedScalar:
+        return maker.rowVector(
+            {"nested"},
+            {maker.rowVector(
+                {"value"},
+                {maker.flatVector<int32_t>(
+                    kStripeRows, [stripeValueType](auto row) {
+                      return stripeValue(stripeValueType, row);
+                    })})});
+      case InputType::NestedArray: {
+        std::vector<std::vector<int32_t>> valueArrays;
+        valueArrays.reserve(kStripeRows);
+        for (velox::vector_size_t row{0}; row < kStripeRows; ++row) {
+          valueArrays.push_back(
+              {stripeValue(stripeValueType, row * 2),
+               stripeValue(stripeValueType, row * 2 + 1)});
+        }
+        return maker.rowVector(
+            {"nested"},
+            {maker.rowVector(
+                {"items"}, {maker.arrayVector<int32_t>(valueArrays)})});
+      }
+      case InputType::NestedMap: {
+        auto offsets = makeOffsets(kStripeRows);
+        auto keys = maker.flatVector<int64_t>(
+            kStripeRows, [](auto row) { return row + 100; });
+        auto values =
+            maker.flatVector<int32_t>(kStripeRows, [stripeValueType](auto row) {
+              return stripeValue(stripeValueType, row);
+            });
+        return maker.rowVector(
+            {"nested"},
+            {maker.rowVector(
+                {"props"}, {maker.mapVector(offsets, keys, values)})});
+      }
+      case InputType::NestedArrayRow: {
+        auto offsets = makeOffsets(kStripeRows, /*rowWidth=*/2);
+        auto elements = maker.rowVector(
+            {"value", "other"},
+            {
+                maker.flatVector<int32_t>(
+                    kStripeRows * 2,
+                    [stripeValueType](auto position) {
+                      return stripeValue(stripeValueType, position);
+                    }),
+                maker.flatVector<int32_t>(
+                    kStripeRows * 2,
+                    [](auto position) { return directStripeValue(position); }),
+            });
+        return maker.rowVector(
+            {"nested"},
+            {maker.rowVector(
+                {"items"}, {maker.arrayVector(offsets, elements)})});
+      }
+      case InputType::NestedMapRow: {
+        auto offsets = makeOffsets(kStripeRows);
+        auto keys = maker.flatVector<int64_t>(
+            kStripeRows, [](auto row) { return row + 100; });
+        auto values = maker.rowVector(
+            {"value", "other"},
+            {
+                maker.flatVector<int32_t>(
+                    kStripeRows,
+                    [stripeValueType](auto row) {
+                      return stripeValue(stripeValueType, row);
+                    }),
+                maker.flatVector<int32_t>(
+                    kStripeRows,
+                    [](auto row) { return directStripeValue(row); }),
+            });
+        return maker.rowVector(
+            {"nested"},
+            {maker.rowVector(
+                {"props"}, {maker.mapVector(offsets, keys, values)})});
+      }
+    }
+    NIMBLE_UNREACHABLE("Unsupported stripe type.");
+  }
+
+  velox::RowVectorPtr makeDictionaryStripe(InputType type) {
+    return makeStripe(type, StripeValueType::Dictionary);
+  }
+
+  velox::RowVectorPtr makeFileDictionaryStripe(
+      FileDictionaryAlphabetOrder alphabetOrder) {
+    velox::test::VectorMaker maker{leafPool_.get()};
+    const auto values = fileDictionaryValues(alphabetOrder);
+    return maker.rowVector(
+        {"features"},
+        {maker.mapVector<int64_t, int32_t>(
+            2'000,
+            [](auto /* row */) { return 1; },
+            [](auto /* idx */) { return 10; },
+            [&](auto idx) { return values[idx % values.size()]; })});
+  }
+
+  static std::vector<int32_t> fileDictionaryValues(
+      FileDictionaryAlphabetOrder order) {
+    switch (order) {
+      case FileDictionaryAlphabetOrder::Sorted:
+        return {10, 20, 30, 40};
+      case FileDictionaryAlphabetOrder::Unsorted:
+        return {40, 10, 30, 20};
+    }
+    NIMBLE_UNREACHABLE("Unsupported file dictionary alphabet order.");
+  }
+
+  void addFlatmapDictionary(
+      WriterOptions& options,
+      SharedDictionaryConfig dictionary) {
+    options.experimentalSharedDictionaryEncoding =
+        SharedDictionaryEncodingConfig::builder(
+            std::move(options.experimentalSharedDictionaryEncoding))
+            .addFlatmapValueDictionary(
+                "features",
+                /*key=*/10,
+                std::move(dictionary))
+            .build();
+  }
+
+  void addFlatmapDictionary(
+      WriterOptions& options,
+      SharedDictionaryConfig dictionary,
+      std::string valueSubfield) {
+    options.experimentalSharedDictionaryEncoding =
+        SharedDictionaryEncodingConfig::builder(
+            std::move(options.experimentalSharedDictionaryEncoding))
+            .addFlatmapValueDictionary(
+                "features",
+                /*key=*/10,
+                std::move(dictionary),
+                std::move(valueSubfield))
+            .build();
+  }
+
+  void addColumnDictionary(
+      WriterOptions& options,
+      SharedDictionaryConfig dictionary,
+      std::string fieldPath) {
+    options.experimentalSharedDictionaryEncoding =
+        SharedDictionaryEncodingConfig::builder(
+            std::move(options.experimentalSharedDictionaryEncoding))
+            .addColumnDictionary(std::move(fieldPath), std::move(dictionary))
+            .build();
+  }
+
+  static SharedDictionaryConfig sharedDictionaryConfig(
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId) {
+    SharedDictionaryConfig dictionary{.scope = scope};
+    if (scope != SharedDictionaryScope::Stripe) {
+      dictionary.dictionaryId = dictionaryId;
+    }
+    return dictionary;
+  }
+
+  void addDictionary(
+      WriterOptions& options,
+      InputType inputType,
+      SharedDictionaryConfig dictionary) {
+    switch (inputType) {
+      case InputType::FlatMapScalar:
+      case InputType::NullableFlatMapScalar:
+      case InputType::FlatMapArray:
+      case InputType::FlatMapArrayArray:
+      case InputType::FlatMapMap:
+        options.flatMapColumns.emplace("features", std::set<std::string>{});
+        addFlatmapDictionary(options, std::move(dictionary));
+        return;
+      case InputType::FlatMapRowValue:
+        options.flatMapColumns.emplace("features", std::set<std::string>{});
+        addFlatmapDictionary(
+            options, std::move(dictionary), /*valueSubfield=*/"items[*]");
+        return;
+      case InputType::NestedScalar:
+        addColumnDictionary(options, std::move(dictionary), "nested.value");
+        return;
+      case InputType::NestedArray:
+        addColumnDictionary(options, std::move(dictionary), "nested.items");
+        return;
+      case InputType::NestedMap:
+        addColumnDictionary(options, std::move(dictionary), "nested.props");
+        return;
+      case InputType::NestedArrayRow:
+        addColumnDictionary(
+            options, std::move(dictionary), "nested.items[*].value");
+        return;
+      case InputType::NestedMapRow:
+        addColumnDictionary(
+            options, std::move(dictionary), "nested.props[*].value");
+        return;
+    }
+    NIMBLE_UNREACHABLE("Unsupported input type.");
+  }
+
+  void addFlatMapRowValueSubfieldDictionaries(
+      WriterOptions& options,
+      SharedDictionaryScope scope) {
+    options.flatMapColumns.emplace("features", std::set<std::string>{});
+    addFlatmapDictionary(
+        options,
+        sharedDictionaryConfig(scope, /*dictionaryId=*/17),
+        "items[*]");
+    addFlatmapDictionary(
+        options, sharedDictionaryConfig(scope, /*dictionaryId=*/18), "other");
+  }
+
+  void addFlatMapRowValueOtherDictionary(
+      WriterOptions& options,
+      SharedDictionaryScope scope) {
+    options.flatMapColumns.emplace("features", std::set<std::string>{});
+    addFlatmapDictionary(
+        options,
+        sharedDictionaryConfig(scope, /*dictionaryId=*/17),
+        /*valueSubfield=*/"other");
+  }
+
+  WriterOptions makeSharedDictionaryWriterOptions() {
+    WriterOptions options;
+    options.maxStreamChunkRawSize = 512;
+    options.minStreamChunkRawSize = 1;
+    useSharedDictionarySelectionPolicy(options);
+    return options;
+  }
+
+  std::string writeInput(
+      const std::vector<velox::RowVectorPtr>& stripeInputs,
+      WriterOptions options) {
+    NIMBLE_CHECK(!stripeInputs.empty(), "Must write at least one stripe.");
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    Writer writer{
+        stripeInputs.front()->type(),
+        std::move(writeFile),
+        *rootPool_,
+        std::move(options)};
+    for (size_t stripeIndex{0}; stripeIndex < stripeInputs.size();
+         ++stripeIndex) {
+      if (stripeIndex > 0) {
+        writer.flush();
+      }
+      writer.write(stripeInputs[stripeIndex]);
+    }
+    writer.close();
+    return file;
+  }
+
+  std::string write(
+      InputType inputType,
+      SharedDictionaryScope scope,
+      const std::vector<StripeValueType>& stripeValueTypes =
+          {StripeValueType::Dictionary, StripeValueType::Direct},
+      std::shared_ptr<const ExternalDictionaryResolver>
+          externalDictionaryResolver = nullptr,
+      DictionaryTargetSet dictionaryTargetSet = DictionaryTargetSet::Default) {
+    NIMBLE_CHECK(!stripeValueTypes.empty(), "Must write at least one stripe.");
+    auto options = makeSharedDictionaryWriterOptions();
+    if (dictionaryTargetSet == DictionaryTargetSet::FlatMapRowValueSubfields) {
+      NIMBLE_CHECK(
+          inputType == InputType::FlatMapRowValue,
+          "FlatMapRowValueSubfields only applies to FlatMapRowValue input.");
+      addFlatMapRowValueSubfieldDictionaries(options, scope);
+    } else if (
+        dictionaryTargetSet == DictionaryTargetSet::FlatMapRowValueOther) {
+      NIMBLE_CHECK(
+          inputType == InputType::FlatMapRowValue,
+          "FlatMapRowValueOther only applies to FlatMapRowValue input.");
+      addFlatMapRowValueOtherDictionary(options, scope);
+    } else {
+      addDictionary(
+          options,
+          inputType,
+          sharedDictionaryConfig(
+              scope, scope == SharedDictionaryScope::External ? 17 : 7));
+    }
+    options.experimentalSharedDictionaryEncoding.externalResolver =
+        std::move(externalDictionaryResolver);
+
+    std::vector<velox::RowVectorPtr> stripeInputs;
+    stripeInputs.reserve(stripeValueTypes.size());
+    for (const auto stripeValueType : stripeValueTypes) {
+      stripeInputs.push_back(makeStripe(inputType, stripeValueType));
+    }
+    return writeInput(stripeInputs, std::move(options));
+  }
+
+  std::shared_ptr<const ExternalDictionaryResolver> makeExternalResolver(
+      InputType inputType,
+      DictionaryTargetSet dictionaryTargetSet = DictionaryTargetSet::Default) {
+    switch (dictionaryTargetSet) {
+      case DictionaryTargetSet::Default:
+        return makeExternalResolver(
+            externalDictionaryValues(dictionaryValueCount(inputType)));
+      case DictionaryTargetSet::FlatMapRowValueOther:
+        NIMBLE_CHECK(
+            inputType == InputType::FlatMapRowValue,
+            "FlatMapRowValueOther only applies to FlatMapRowValue input.");
+        return makeExternalResolver(externalDictionaryValues(kStripeRows));
+      case DictionaryTargetSet::FlatMapRowValueSubfields:
+        NIMBLE_CHECK(
+            inputType == InputType::FlatMapRowValue,
+            "FlatMapRowValueSubfields only applies to FlatMapRowValue input.");
+        return makeExternalResolver(
+            std::vector<test::SharedDictionaryTestDictionary>{
+                {17, externalDictionaryValues(kStripeRows * 2)},
+                {18, externalDictionaryValues()}});
+    }
+    NIMBLE_UNREACHABLE("Unsupported dictionary target set.");
+  }
+
+  static DictionaryTargetSet randomDictionaryTargetSet(
+      InputType inputType,
+      std::mt19937& rng) {
+    if (inputType != InputType::FlatMapRowValue) {
+      return DictionaryTargetSet::Default;
+    }
+    const std::array<DictionaryTargetSet, 3> targetSets{
+        DictionaryTargetSet::Default,
+        DictionaryTargetSet::FlatMapRowValueOther,
+        DictionaryTargetSet::FlatMapRowValueSubfields};
+    return targetSets[std::uniform_int_distribution<size_t>{
+        0, targetSets.size() - 1}(rng)];
+  }
+
+  static size_t expectedSharedDictionaryValueStreamCount(
+      DictionaryTargetSet dictionaryTargetSet) {
+    return dictionaryTargetSet == DictionaryTargetSet::FlatMapRowValueSubfields
+        ? 2
+        : 1;
+  }
+
+  std::string writeWithCompressedFileDictionary(size_t stripeCount) {
+    auto input = makeDictionaryStripe(InputType::FlatMapScalar);
+    auto options = makeSharedDictionaryWriterOptions();
+    options.enableChunking = true;
+    options.metadataCompressionThreshold = std::numeric_limits<uint32_t>::max();
+    options.chunkCompression = {
+        .type = CompressionType::Zstd, .zstdLevel = 3, .acceptRatio = 1.0f};
+    addDictionary(
+        options,
+        InputType::FlatMapScalar,
+        SharedDictionaryConfig{
+            .scope = SharedDictionaryScope::File, .dictionaryId = 17});
+
+    return writeInput(
+        std::vector<velox::RowVectorPtr>(stripeCount, input),
+        std::move(options));
+  }
+
+  std::string writeWithFileDictionary(
+      size_t stripeCount,
+      FileDictionaryAlphabetOrder alphabetOrder) {
+    auto input = makeFileDictionaryStripe(alphabetOrder);
+    auto resolver = std::make_shared<FixedFileResolver>(
+        fileDictionaryValues(alphabetOrder),
+        leafPool_.get(),
+        std::array{EncodingType::FixedBitWidth});
+    auto options = makeSharedDictionaryWriterOptions();
+    options.experimentalSharedDictionaryEncoding.externalResolver =
+        std::move(resolver);
+    addDictionary(
+        options,
+        InputType::FlatMapScalar,
+        SharedDictionaryConfig{
+            .scope = SharedDictionaryScope::File,
+            .dictionaryId = 17,
+            .useExternalAlphabet = true,
+            // Ignored for prebuilt external alphabets; the resolver's
+            // FixedBitWidth encoding should be preserved instead.
+            .alphabetEncodings = {EncodingType::DeltaBlock}});
+
+    return writeInput(
+        std::vector<velox::RowVectorPtr>(stripeCount, input),
+        std::move(options));
+  }
+
+  std::shared_ptr<TabletReader> openTablet(
+      const std::string& file,
+      std::shared_ptr<const ExternalDictionaryResolver> externalResolver =
+          nullptr) {
+    auto options = test::makeTestTabletOptions(leafPool_.get());
+    options.externalDictionaryResolver = std::move(externalResolver);
+    return TabletReader::create(
+        std::make_shared<velox::InMemoryReadFile>(file),
+        leafPool_.get(),
+        options);
+  }
+
+  std::shared_ptr<const Type> readSchema(const TabletReader& tablet) {
+    auto schemaSection =
+        tablet.loadOptionalSection(std::string(kSchemaSection));
+    NIMBLE_CHECK(schemaSection.has_value());
+    return SchemaDeserializer::deserialize(schemaSection->content().data());
+  }
+
+  const Type& flatMapValueType(
+      const Type& schema,
+      std::string_view key = "10") {
+    const auto& flatMap = schema.asRow().childAt(0)->asFlatMap();
+    auto child = flatMap.findChild(key);
+    NIMBLE_CHECK(child.has_value());
+    return *flatMap.childAt(child.value());
+  }
+
+  uint32_t scalarStreamId(const Type& type) {
+    return type.asScalar().scalarDescriptor().offset();
+  }
+
+  std::vector<uint32_t> scalarStreamIds(const Type& type) {
+    if (type.isScalar()) {
+      return {scalarStreamId(type)};
+    }
+    if (type.isArray()) {
+      return scalarStreamIds(*type.asArray().elements());
+    }
+    if (type.isMap()) {
+      return scalarStreamIds(*type.asMap().values());
+    }
+    if (type.isRow()) {
+      const auto& rowType = type.asRow();
+      std::vector<uint32_t> streamIds;
+      for (size_t childIndex{0}; childIndex < rowType.childrenCount();
+           ++childIndex) {
+        const auto childStreamIds =
+            scalarStreamIds(*rowType.childAt(childIndex));
+        streamIds.insert(
+            streamIds.end(), childStreamIds.begin(), childStreamIds.end());
+      }
+      return streamIds;
+    }
+    NIMBLE_UNREACHABLE("Unsupported dictionary value type.");
+  }
+
+  std::vector<uint32_t> candidateDictionaryValueStreamIds(
+      const TabletReader& tablet,
+      InputType inputType) {
+    const auto schema = readSchema(tablet);
+    switch (inputType) {
+      case InputType::FlatMapScalar:
+      case InputType::NullableFlatMapScalar:
+      case InputType::FlatMapArray:
+      case InputType::FlatMapArrayArray:
+      case InputType::FlatMapMap:
+      case InputType::FlatMapRowValue:
+        return scalarStreamIds(flatMapValueType(*schema));
+      case InputType::NestedScalar:
+      case InputType::NestedArray:
+      case InputType::NestedMap:
+      case InputType::NestedArrayRow:
+      case InputType::NestedMapRow:
+        return scalarStreamIds(*schema->asRow().childAt(0));
+    }
+    NIMBLE_UNREACHABLE("Unsupported input type.");
+  }
+
+  bool hasSharedDictionary(const TabletReader& tablet, uint32_t valueStreamId) {
+    return tablet.stripeDictionaryStreamId(valueStreamId).has_value() ||
+        tablet.resolveDictionaryAlphabet(valueStreamId) != nullptr;
+  }
+
+  enum class EncodingTypeComparison {
+    Equal,
+    NotEqual,
+  };
+
+  using EncodingTypesByStripe = std::vector<std::vector<EncodingType>>;
+
+  std::vector<uint32_t> sharedDictionaryValueStreamIds(
+      const TabletReader& tablet,
+      InputType inputType) {
+    std::vector<uint32_t> streamIds;
+    for (const auto streamId :
+         candidateDictionaryValueStreamIds(tablet, inputType)) {
+      if (hasSharedDictionary(tablet, streamId)) {
+        streamIds.push_back(streamId);
+      }
+    }
+    NIMBLE_CHECK(
+        !streamIds.empty(),
+        "Expected at least one shared dictionary value stream.");
+    return streamIds;
+  }
+
+  EncodingType valueEncodingType(std::string_view chunk) {
+    const auto encodingType = EncodingPrefix::encodingType(chunk);
+    if (encodingType != EncodingType::Nullable) {
+      return encodingType;
+    }
+
+    const char* dataChild =
+        chunk.data() + EncodingPrefix::prefixSize(chunk, /*useVarint=*/false);
+    const auto dataChildSize = encoding::readUint32(dataChild);
+    return EncodingPrefix::encodingType({dataChild, dataChildSize});
+  }
+
+  template <typename EncodingTypeReader>
+  EncodingTypesByStripe collectStreamEncodingTypesByStripe(
+      const TabletReader& tablet,
+      uint32_t streamId,
+      EncodingTypeReader readEncodingType) {
+    EncodingTypesByStripe typesByStripe;
+    typesByStripe.reserve(tablet.stripeCount());
+    for (uint32_t stripeIndex{0}; stripeIndex < tablet.stripeCount();
+         ++stripeIndex) {
+      const std::array<uint32_t, 1> ids{streamId};
+      auto streams = tablet.load(tablet.stripeIdentifier(stripeIndex), ids);
+      NIMBLE_CHECK_EQ(streams.size(), 1);
+      NIMBLE_CHECK_NOT_NULL(streams.front().get());
+      InMemoryChunkedStream chunks{*leafPool_, std::move(streams.front())};
+      auto& stripeTypes = typesByStripe.emplace_back();
+      while (chunks.hasNext()) {
+        stripeTypes.push_back(readEncodingType(chunks.nextChunk()));
+      }
+      NIMBLE_CHECK(!stripeTypes.empty());
+    }
+    return typesByStripe;
+  }
+
+  EncodingTypesByStripe streamEncodingTypesByStripe(
+      const TabletReader& tablet,
+      uint32_t streamId) {
+    return collectStreamEncodingTypesByStripe(
+        tablet, streamId, [](std::string_view chunk) {
+          return EncodingPrefix::encodingType(chunk);
+        });
+  }
+
+  EncodingTypesByStripe streamDataEncodingTypesByStripe(
+      const TabletReader& tablet,
+      uint32_t streamId) {
+    return collectStreamEncodingTypesByStripe(
+        tablet, streamId, [this](std::string_view chunk) {
+          return valueEncodingType(chunk);
+        });
+  }
+
+  void expectStripeEncodingTypes(
+      const EncodingTypesByStripe& typesByStripe,
+      size_t stripeIndex,
+      EncodingType expected,
+      EncodingTypeComparison comparison = EncodingTypeComparison::Equal) {
+    ASSERT_LT(stripeIndex, typesByStripe.size());
+    ASSERT_FALSE(typesByStripe[stripeIndex].empty());
+    for (size_t chunkIndex{0}; chunkIndex < typesByStripe[stripeIndex].size();
+         ++chunkIndex) {
+      SCOPED_TRACE(
+          fmt::format(
+              "stripeIndex={}, chunkIndex={}", stripeIndex, chunkIndex));
+      if (comparison == EncodingTypeComparison::Equal) {
+        EXPECT_EQ(typesByStripe[stripeIndex][chunkIndex], expected);
+      } else {
+        EXPECT_NE(typesByStripe[stripeIndex][chunkIndex], expected);
+      }
+    }
+  }
+
+  void expectAllStripeEncodingTypes(
+      const EncodingTypesByStripe& typesByStripe,
+      EncodingType expected) {
+    ASSERT_FALSE(typesByStripe.empty());
+    for (size_t stripeIndex{0}; stripeIndex < typesByStripe.size();
+         ++stripeIndex) {
+      SCOPED_TRACE(fmt::format("stripeIndex={}", stripeIndex));
+      expectStripeEncodingTypes(typesByStripe, stripeIndex, expected);
+    }
+  }
+
+  void expectMultipleChunksPerStripe(
+      const EncodingTypesByStripe& typesByStripe) {
+    ASSERT_FALSE(typesByStripe.empty());
+    for (size_t stripeIndex{0}; stripeIndex < typesByStripe.size();
+         ++stripeIndex) {
+      SCOPED_TRACE(fmt::format("stripeIndex={}", stripeIndex));
+      EXPECT_GT(typesByStripe[stripeIndex].size(), 1);
+    }
+  }
+
+  void expectStripeDictionaryStreamPresence(
+      const TabletReader& tablet,
+      uint32_t valueStreamId,
+      std::span<const StripeValueType> stripeValueTypes) {
+    ASSERT_EQ(tablet.stripeCount(), stripeValueTypes.size());
+    const auto dictionaryStreamId =
+        tablet.stripeDictionaryStreamId(valueStreamId);
+    ASSERT_TRUE(dictionaryStreamId.has_value());
+    const std::array<uint32_t, 1> dictionaryStreamIds{
+        dictionaryStreamId.value()};
+    for (size_t stripeIndex{0}; stripeIndex < stripeValueTypes.size();
+         ++stripeIndex) {
+      SCOPED_TRACE(fmt::format("stripeIndex={}", stripeIndex));
+      auto dictionaryStreams = tablet.load(
+          tablet.stripeIdentifier(static_cast<uint32_t>(stripeIndex)),
+          dictionaryStreamIds);
+      ASSERT_EQ(dictionaryStreams.size(), 1);
+      if (stripeValueTypes[stripeIndex] == StripeValueType::Dictionary) {
+        EXPECT_NE(dictionaryStreams.front(), nullptr);
+      } else {
+        EXPECT_EQ(dictionaryStreams.front(), nullptr);
+      }
+    }
+  }
+
+  void expectDictionaryValueEncodingTypes(
+      const TabletReader& tablet,
+      uint32_t valueStreamId,
+      SharedDictionaryScope scope,
+      std::span<const StripeValueType> stripeValueTypes) {
+    const auto dataEncodingTypesByStripe =
+        streamDataEncodingTypesByStripe(tablet, valueStreamId);
+    ASSERT_EQ(dataEncodingTypesByStripe.size(), stripeValueTypes.size());
+    if (scope == SharedDictionaryScope::Stripe) {
+      expectMultipleChunksPerStripe(dataEncodingTypesByStripe);
+      for (size_t stripeIndex{0}; stripeIndex < stripeValueTypes.size();
+           ++stripeIndex) {
+        SCOPED_TRACE(fmt::format("stripeIndex={}", stripeIndex));
+        expectStripeEncodingTypes(
+            dataEncodingTypesByStripe,
+            stripeIndex,
+            EncodingType::SharedDictionary,
+            stripeValueTypes[stripeIndex] == StripeValueType::Dictionary
+                ? EncodingTypeComparison::Equal
+                : EncodingTypeComparison::NotEqual);
+      }
+      expectStripeDictionaryStreamPresence(
+          tablet, valueStreamId, stripeValueTypes);
+      return;
+    }
+    expectAllStripeEncodingTypes(
+        dataEncodingTypesByStripe, EncodingType::SharedDictionary);
+  }
+
+  CompressionType dictionaryValueChunkCompressionType(
+      const std::string& file,
+      InputType inputType,
+      uint32_t stripeIndex) {
+    auto tablet = openTablet(file);
+    const auto streamIds = sharedDictionaryValueStreamIds(*tablet, inputType);
+    NIMBLE_CHECK_EQ(streamIds.size(), 1);
+
+    const std::array<uint32_t, 1> ids{streamIds.front()};
+    auto streams = tablet->load(tablet->stripeIdentifier(stripeIndex), ids);
+    InMemoryChunkedStream chunks{*leafPool_, std::move(streams.front())};
+    NIMBLE_CHECK(chunks.hasNext());
+    return chunks.peekCompressionType();
+  }
+
+  EncodingType fileDictionaryAlphabetEncodingType(const std::string& file) {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    auto options = test::makeTestTabletOptions(leafPool_.get());
+    auto tablet = TabletReader::create(readFile, leafPool_.get(), options);
+    auto section = tablet->loadOptionalSection(std::string(kDictionarySection));
+    NIMBLE_CHECK(section.has_value());
+
+    const auto catalog =
+        SharedDictionaryCatalog::deserialize(section->content());
+    const auto& fileDictionaries = catalog.fileDictionaries();
+    NIMBLE_CHECK_EQ(fileDictionaries.size(), 1);
+    NIMBLE_CHECK_EQ(fileDictionaries[0].dictionaryId, 17);
+    NIMBLE_CHECK_EQ(fileDictionaries[0].dataType, DataType::Int32);
+    const auto encoded = std::string_view{file}.substr(
+        fileDictionaries[0].offset, fileDictionaries[0].length);
+    NIMBLE_CHECK_GT(encoded.size(), EncodingPrefix::kEncodingTypeOffset);
+    return static_cast<EncodingType>(
+        encoded[EncodingPrefix::kEncodingTypeOffset]);
+  }
+
+  std::vector<int32_t> fileDictionaryValues(const std::string& file) {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    auto options = test::makeTestTabletOptions(leafPool_.get());
+    auto tablet = TabletReader::create(readFile, leafPool_.get(), options);
+    auto section = tablet->loadOptionalSection(std::string(kDictionarySection));
+    NIMBLE_CHECK(section.has_value());
+    const auto catalog =
+        SharedDictionaryCatalog::deserialize(section->content());
+    NIMBLE_CHECK_EQ(catalog.fileDictionaries().size(), 1);
+    const auto& fileDictionary = catalog.fileDictionaries()[0];
+    auto encodedAlphabetOwner =
+        std::make_shared<const std::string>(std::string_view{file}.substr(
+            fileDictionary.offset, fileDictionary.length));
+    const std::string_view encodedAlphabet{*encodedAlphabetOwner};
+    auto alphabet = SharedDictionaryAlphabet::create(
+        encodedAlphabet, std::move(encodedAlphabetOwner), leafPool_.get());
+    NIMBLE_CHECK_NOT_NULL(alphabet);
+    NIMBLE_CHECK_EQ(alphabet->dataType(), fileDictionary.dataType);
+    std::vector<uint32_t> physicalValues(alphabet->entryCount());
+    std::vector<uint32_t> indices;
+    indices.reserve(alphabet->entryCount());
+    for (uint32_t i = 0; i < alphabet->entryCount(); ++i) {
+      indices.push_back(i);
+    }
+    alphabet->materialize<int32_t>(indices, physicalValues.data());
+    return toLogicalValues(physicalValues);
+  }
+
+  std::vector<int32_t> materializedAlphabetValues(
+      const SharedDictionaryAlphabet& alphabet) {
+    Vector<int32_t> values{leafPool_.get()};
+    alphabet.materializeAll<int32_t>(values);
+    return {values.begin(), values.end()};
+  }
+
+  std::vector<int32_t> expectedResolvedAlphabetValues(
+      const std::string& file,
+      SharedDictionaryScope scope) {
+    switch (scope) {
+      case SharedDictionaryScope::File:
+        return fileDictionaryValues(file);
+      case SharedDictionaryScope::External:
+        return externalDictionaryValues();
+      case SharedDictionaryScope::Stripe:
+        NIMBLE_UNREACHABLE("Stripe dictionaries do not resolve an alphabet.");
+    }
+    NIMBLE_UNREACHABLE("Unsupported shared dictionary scope.");
+  }
+
+  void verifyRoundTrip(
+      const std::string& file,
+      InputType inputType = InputType::FlatMapScalar,
+      const std::vector<StripeValueType>& stripeValueTypes =
+          {StripeValueType::Dictionary, StripeValueType::Direct},
+      std::shared_ptr<const ExternalDictionaryResolver> externalResolver =
+          nullptr) {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    VeloxReadParams params;
+    params.externalDictionaryResolver = std::move(externalResolver);
+    VeloxReader reader{readFile, *leafPool_, nullptr, params};
+    velox::VectorPtr output;
+    for (const auto stripeValueType : stripeValueTypes) {
+      ASSERT_TRUE(reader.next(kStripeRows, output));
+      auto expected = makeStripe(inputType, stripeValueType);
+      ASSERT_EQ(output->size(), expected->size());
+      for (velox::vector_size_t i = 0; i < output->size(); ++i) {
+        ASSERT_TRUE(output->equalValueAt(expected.get(), i, i));
+      }
+    }
+    EXPECT_FALSE(reader.next(kStripeRows, output));
+  }
+
+  void verifyFileDictionaryRoundTrip(
+      const std::string& file,
+      FileDictionaryAlphabetOrder alphabetOrder,
+      size_t stripeCount = 1) {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    VeloxReader reader{readFile, *leafPool_};
+    velox::VectorPtr output;
+    auto expected = makeFileDictionaryStripe(alphabetOrder);
+    for (size_t stripeIndex{0}; stripeIndex < stripeCount; ++stripeIndex) {
+      SCOPED_TRACE(fmt::format("stripeIndex={}", stripeIndex));
+      ASSERT_TRUE(reader.next(kStripeRows, output));
+      ASSERT_EQ(output->size(), expected->size());
+      for (velox::vector_size_t i = 0; i < output->size(); ++i) {
+        ASSERT_TRUE(output->equalValueAt(expected.get(), i, i));
+      }
+    }
+    EXPECT_FALSE(reader.next(kStripeRows, output));
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+};
+
+class SharedDictionaryE2EInputTypeTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<InputType> {};
+
+class SharedDictionaryE2EFlatMapRowValueSubfieldsTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<SharedDictionaryScope> {};
+
+class SharedDictionaryE2EFlatMapDefaultValueSubfieldTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<InputType> {};
+
+class SharedDictionaryE2ETabletReaderApiTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<TabletReaderDictionaryApiTestCase> {};
+
+TEST_P(SharedDictionaryE2EInputTypeTest, stripeScopeRoundTrip) {
+  const auto inputType = GetParam();
+  const std::vector<StripeValueType> stripeValueTypes{
+      StripeValueType::Dictionary, StripeValueType::Direct};
+  const auto file =
+      write(inputType, SharedDictionaryScope::Stripe, stripeValueTypes);
+  auto tablet = openTablet(file);
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, inputType);
+  ASSERT_FALSE(valueStreamIds.empty());
+  for (const auto valueStreamId : valueStreamIds) {
+    SCOPED_TRACE(fmt::format("valueStreamId={}", valueStreamId));
+    expectDictionaryValueEncodingTypes(
+        *tablet,
+        valueStreamId,
+        SharedDictionaryScope::Stripe,
+        stripeValueTypes);
+  }
+  verifyRoundTrip(file, inputType);
+}
+
+TEST_P(SharedDictionaryE2EInputTypeTest, fileScopeRoundTrip) {
+  const auto inputType = GetParam();
+  const std::vector<StripeValueType> stripeValueTypes{
+      StripeValueType::Dictionary, StripeValueType::Direct};
+  const auto file =
+      write(inputType, SharedDictionaryScope::File, stripeValueTypes);
+  auto tablet = openTablet(file);
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, inputType);
+  ASSERT_EQ(valueStreamIds.size(), 1);
+  for (const auto valueStreamId : valueStreamIds) {
+    SCOPED_TRACE(fmt::format("valueStreamId={}", valueStreamId));
+    expectDictionaryValueEncodingTypes(
+        *tablet, valueStreamId, SharedDictionaryScope::File, stripeValueTypes);
+    if (inputType == InputType::NullableFlatMapScalar) {
+      const auto encodingTypesByStripe =
+          streamEncodingTypesByStripe(*tablet, valueStreamId);
+      ASSERT_EQ(encodingTypesByStripe.size(), stripeValueTypes.size());
+      expectAllStripeEncodingTypes(
+          encodingTypesByStripe, EncodingType::Nullable);
+    }
+  }
+  verifyRoundTrip(file, inputType, stripeValueTypes);
+}
+
+TEST_P(SharedDictionaryE2EFlatMapRowValueSubfieldsTest, roundTrip) {
+  const auto scope = GetParam();
+  const std::vector<StripeValueType> stripeValueTypes{
+      StripeValueType::Dictionary, StripeValueType::Direct};
+  std::shared_ptr<const ExternalDictionaryResolver> resolver;
+  if (scope == SharedDictionaryScope::External) {
+    resolver = makeExternalResolver(
+        std::vector<test::SharedDictionaryTestDictionary>{
+            {17, externalDictionaryValues(kStripeRows * 2)},
+            {18, externalDictionaryValues()}});
+  }
+  const auto file = write(
+      InputType::FlatMapRowValue,
+      scope,
+      stripeValueTypes,
+      resolver,
+      DictionaryTargetSet::FlatMapRowValueSubfields);
+  auto tablet = openTablet(file, resolver);
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapRowValue);
+  ASSERT_EQ(valueStreamIds.size(), 2);
+  for (const auto valueStreamId : valueStreamIds) {
+    SCOPED_TRACE(fmt::format("valueStreamId={}", valueStreamId));
+    expectDictionaryValueEncodingTypes(
+        *tablet, valueStreamId, scope, stripeValueTypes);
+  }
+  verifyRoundTrip(file, InputType::FlatMapRowValue, stripeValueTypes, resolver);
+}
+
+TEST_P(
+    SharedDictionaryE2EFlatMapDefaultValueSubfieldTest,
+    selectsNestedValueStream) {
+  const auto inputType = GetParam();
+  const std::vector<StripeValueType> stripeValueTypes{
+      StripeValueType::Dictionary, StripeValueType::Direct};
+  const auto file =
+      write(inputType, SharedDictionaryScope::File, stripeValueTypes);
+  auto tablet = openTablet(file);
+  const auto expectedValueStreamIds =
+      candidateDictionaryValueStreamIds(*tablet, inputType);
+  ASSERT_EQ(expectedValueStreamIds.size(), 1);
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, inputType);
+  EXPECT_EQ(valueStreamIds, expectedValueStreamIds);
+  expectDictionaryValueEncodingTypes(
+      *tablet,
+      valueStreamIds.front(),
+      SharedDictionaryScope::File,
+      stripeValueTypes);
+  verifyRoundTrip(file, inputType, stripeValueTypes);
+}
+
+TEST_F(SharedDictionaryE2ETest, fuzzRoundTrip) {
+  constexpr uint32_t kSeed{0x5D1C710A};
+  constexpr size_t kIterationCount{50};
+  const std::array<InputType, 11> inputTypes{
+      InputType::FlatMapScalar,
+      InputType::NullableFlatMapScalar,
+      InputType::FlatMapArray,
+      InputType::FlatMapArrayArray,
+      InputType::FlatMapMap,
+      InputType::FlatMapRowValue,
+      InputType::NestedScalar,
+      InputType::NestedArray,
+      InputType::NestedMap,
+      InputType::NestedArrayRow,
+      InputType::NestedMapRow};
+  const std::array<SharedDictionaryScope, 3> scopes{
+      SharedDictionaryScope::Stripe,
+      SharedDictionaryScope::File,
+      SharedDictionaryScope::External};
+
+  std::mt19937 rng{kSeed};
+  for (size_t iteration{0}; iteration < kIterationCount; ++iteration) {
+    const auto inputType = inputTypes[std::uniform_int_distribution<size_t>{
+        0, inputTypes.size() - 1}(rng)];
+    const auto scope = scopes[std::uniform_int_distribution<size_t>{
+        0, scopes.size() - 1}(rng)];
+    const auto dictionaryTargetSet = randomDictionaryTargetSet(inputType, rng);
+    const auto stripeCount = std::uniform_int_distribution<size_t>{1, 4}(rng);
+    std::vector<StripeValueType> stripeValueTypes;
+    stripeValueTypes.reserve(stripeCount);
+    bool hasDictionaryStripe{false};
+    for (size_t stripeIndex{0}; stripeIndex < stripeCount; ++stripeIndex) {
+      const auto stripeValueType =
+          std::uniform_int_distribution<int>{0, 1}(rng) == 0
+          ? StripeValueType::Dictionary
+          : StripeValueType::Direct;
+      hasDictionaryStripe |= stripeValueType == StripeValueType::Dictionary;
+      stripeValueTypes.push_back(stripeValueType);
+    }
+    if (!hasDictionaryStripe) {
+      stripeValueTypes.front() = StripeValueType::Dictionary;
+    }
+
+    SCOPED_TRACE(
+        fmt::format(
+            "iteration={}, seed={}, inputType={}, scope={}, dictionaryTargetSet={}",
+            iteration,
+            kSeed,
+            inputTypeName(inputType),
+            SharedDictionaryScopeName::toName(scope),
+            dictionaryTargetSetName(dictionaryTargetSet)));
+    std::shared_ptr<const ExternalDictionaryResolver> resolver;
+    if (scope == SharedDictionaryScope::External) {
+      resolver = makeExternalResolver(inputType, dictionaryTargetSet);
+    }
+    const auto file = write(
+        inputType, scope, stripeValueTypes, resolver, dictionaryTargetSet);
+    auto tablet = openTablet(file, resolver);
+    const auto valueStreamIds =
+        sharedDictionaryValueStreamIds(*tablet, inputType);
+    ASSERT_EQ(
+        valueStreamIds.size(),
+        expectedSharedDictionaryValueStreamCount(dictionaryTargetSet));
+    for (const auto valueStreamId : valueStreamIds) {
+      SCOPED_TRACE(fmt::format("valueStreamId={}", valueStreamId));
+      expectDictionaryValueEncodingTypes(
+          *tablet, valueStreamId, scope, stripeValueTypes);
+    }
+    verifyRoundTrip(file, inputType, stripeValueTypes, resolver);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllInputTypes,
+    SharedDictionaryE2EInputTypeTest,
+    testing::Values(
+        InputType::FlatMapScalar,
+        InputType::NullableFlatMapScalar,
+        InputType::FlatMapArray,
+        InputType::FlatMapArrayArray,
+        InputType::FlatMapMap,
+        InputType::FlatMapRowValue,
+        InputType::NestedScalar,
+        InputType::NestedArray,
+        InputType::NestedMap,
+        InputType::NestedArrayRow,
+        InputType::NestedMapRow),
+    [](const testing::TestParamInfo<InputType>& testInfo) {
+      return std::string{inputTypeName(testInfo.param)};
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    InputTypes,
+    SharedDictionaryE2EFlatMapDefaultValueSubfieldTest,
+    testing::Values(
+        InputType::FlatMapArray,
+        InputType::FlatMapArrayArray,
+        InputType::FlatMapMap),
+    [](const testing::TestParamInfo<InputType>& testInfo) {
+      return std::string{inputTypeName(testInfo.param)};
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    Scopes,
+    SharedDictionaryE2EFlatMapRowValueSubfieldsTest,
+    testing::Values(
+        SharedDictionaryScope::Stripe,
+        SharedDictionaryScope::File,
+        SharedDictionaryScope::External),
+    [](const testing::TestParamInfo<SharedDictionaryScope>& testInfo) {
+      return std::string{SharedDictionaryScopeName::toName(testInfo.param)};
+    });
+
+TEST_F(SharedDictionaryE2ETest, stripeScopeRejectsConfiguredDictionaryId) {
+  auto input = makeDictionaryStripe(InputType::FlatMapScalar);
+  WriterOptions options;
+  addDictionary(
+      options,
+      InputType::FlatMapScalar,
+      SharedDictionaryConfig{
+          .scope = SharedDictionaryScope::Stripe, .dictionaryId = 7});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  Writer writer{
+      input->type(), std::move(writeFile), *rootPool_, std::move(options)};
+  NIMBLE_ASSERT_USER_THROW(
+      writer.write(input),
+      "Stripe shared dictionary config must leave dictionaryId unset.");
+}
+
+TEST_P(SharedDictionaryE2ETabletReaderApiTest, dictionaryApis) {
+  const auto testCase = GetParam();
+  std::shared_ptr<const ExternalDictionaryResolver> resolver;
+  if (testCase.scope == SharedDictionaryScope::External) {
+    resolver = makeExternalResolver(externalDictionaryValues());
+  }
+  const auto file = write(
+      InputType::FlatMapScalar,
+      testCase.scope,
+      {StripeValueType::Dictionary, StripeValueType::Direct},
+      resolver);
+  auto tablet = openTablet(file, resolver);
+  const auto sharedValueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapScalar);
+  ASSERT_EQ(sharedValueStreamIds.size(), 1);
+  const auto valueStreamId = sharedValueStreamIds.front();
+
+  EXPECT_EQ(tablet->hasStripeDictionaries(), testCase.hasStripeDictionaries);
+  EXPECT_EQ(
+      tablet->hasFileOrExternalDictionaries(),
+      testCase.hasFileOrExternalDictionaries);
+  const auto resolvedAlphabet =
+      tablet->resolveDictionaryAlphabet(valueStreamId);
+  EXPECT_EQ(resolvedAlphabet != nullptr, testCase.resolvesDictionaryAlphabet);
+  if (testCase.resolvesDictionaryAlphabet) {
+    ASSERT_NE(resolvedAlphabet, nullptr);
+    EXPECT_EQ(
+        materializedAlphabetValues(*resolvedAlphabet),
+        expectedResolvedAlphabetValues(file, testCase.scope));
+  } else {
+    EXPECT_EQ(resolvedAlphabet, nullptr);
+  }
+
+  const auto stripeDictionaryStreamId =
+      tablet->stripeDictionaryStreamId(valueStreamId);
+  EXPECT_EQ(
+      stripeDictionaryStreamId.has_value(),
+      testCase.hasStripeDictionaryStreamId);
+  if (!testCase.hasStripeDictionaryStreamId) {
+    const std::array valueStreamIds{valueStreamId};
+    EXPECT_TRUE(tablet->stripeDictionaryStreamIds(valueStreamIds).empty());
+    return;
+  }
+
+  ASSERT_TRUE(stripeDictionaryStreamId.has_value());
+  const std::array valueStreamIds{
+      valueStreamId, stripeDictionaryStreamId.value()};
+  const auto dictionaryStreamIds =
+      tablet->stripeDictionaryStreamIds(valueStreamIds);
+  ASSERT_EQ(dictionaryStreamIds.size(), 1);
+  EXPECT_EQ(dictionaryStreamIds.at(valueStreamId), stripeDictionaryStreamId);
+  EXPECT_FALSE(dictionaryStreamIds.contains(stripeDictionaryStreamId.value()));
+
+  const std::array dictionaryStreamIdsToLoad{stripeDictionaryStreamId.value()};
+  auto dictionaryStreams =
+      tablet->load(tablet->stripeIdentifier(0), dictionaryStreamIdsToLoad);
+  ASSERT_EQ(dictionaryStreams.size(), 1);
+  ASSERT_NE(dictionaryStreams.front(), nullptr);
+  std::shared_ptr<const StreamLoader> dictionaryStreamOwner{
+      std::move(dictionaryStreams.front())};
+  auto alphabet = SharedDictionaryAlphabet::create(
+      dictionaryStreamOwner->getStream(),
+      dictionaryStreamOwner,
+      leafPool_.get());
+  ASSERT_NE(alphabet, nullptr);
+  EXPECT_EQ(
+      materializedAlphabetValues(*alphabet), kDictionaryStripeAlphabetValues);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Scopes,
+    SharedDictionaryE2ETabletReaderApiTest,
+    testing::Values(
+        TabletReaderDictionaryApiTestCase{
+            .scope = SharedDictionaryScope::Stripe,
+            .hasStripeDictionaries = true,
+            .hasFileOrExternalDictionaries = false,
+            .hasStripeDictionaryStreamId = true,
+            .resolvesDictionaryAlphabet = false},
+        TabletReaderDictionaryApiTestCase{
+            .scope = SharedDictionaryScope::File,
+            .hasStripeDictionaries = false,
+            .hasFileOrExternalDictionaries = true,
+            .hasStripeDictionaryStreamId = false,
+            .resolvesDictionaryAlphabet = true},
+        TabletReaderDictionaryApiTestCase{
+            .scope = SharedDictionaryScope::External,
+            .hasStripeDictionaries = false,
+            .hasFileOrExternalDictionaries = true,
+            .hasStripeDictionaryStreamId = false,
+            .resolvesDictionaryAlphabet = true}),
+    [](const testing::TestParamInfo<TabletReaderDictionaryApiTestCase>&
+           testInfo) {
+      return std::string{
+          SharedDictionaryScopeName::toName(testInfo.param.scope)};
+    });
+
+TEST_F(SharedDictionaryE2ETest, dictionaryConfigRejected) {
+  for (const auto target :
+       {InvalidDictionaryTarget::FlatMapWholeRowValue,
+        InvalidDictionaryTarget::RegularRowColumnValue}) {
+    SCOPED_TRACE(fmt::format("target={}", invalidDictionaryTargetName(target)));
+    velox::test::VectorMaker maker{leafPool_.get()};
+    velox::RowVectorPtr input;
+    WriterOptions options;
+    switch (target) {
+      case InvalidDictionaryTarget::FlatMapWholeRowValue:
+        input = maker.rowVector(
+            {"features"},
+            {maker.mapVector(
+                std::vector<velox::vector_size_t>{0},
+                std::vector<velox::vector_size_t>{1},
+                maker.flatVector<int64_t>({10}),
+                maker.rowVector(
+                    {"a", "b"},
+                    {maker.flatVector<int64_t>({1}),
+                     maker.flatVector<int64_t>({2})}))});
+        options.flatMapColumns.emplace("features", std::set<std::string>{});
+        addFlatmapDictionary(
+            options,
+            sharedDictionaryConfig(
+                SharedDictionaryScope::File, /*dictionaryId=*/17));
+        break;
+      case InvalidDictionaryTarget::RegularRowColumnValue:
+        input = maker.rowVector(
+            {"nested"},
+            {maker.rowVector(
+                {"a", "b"},
+                {maker.flatVector<int32_t>({1}),
+                 maker.flatVector<int32_t>({2})})});
+        useSharedDictionarySelectionPolicy(options);
+        options.experimentalSharedDictionaryEncoding =
+            SharedDictionaryEncodingConfig::builder()
+                .addColumnDictionary(
+                    "nested",
+                    sharedDictionaryConfig(
+                        SharedDictionaryScope::File, /*dictionaryId=*/17))
+                .build();
+        break;
+    }
+    ASSERT_NE(input, nullptr);
+    auto writeInvalidTarget = [&]() {
+      std::string file;
+      auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+      Writer writer{
+          input->type(), std::move(writeFile), *rootPool_, std::move(options)};
+      writer.write(input);
+    };
+    NIMBLE_ASSERT_USER_THROW(
+        writeInvalidTarget(), "must resolve to an integer scalar");
+  }
+}
+
+TEST_F(
+    SharedDictionaryE2ETest,
+    fileScopeSharedDictionaryStreamUsesChunkCompression) {
+  constexpr size_t kStripeCount{2};
+  const auto file = writeWithCompressedFileDictionary(kStripeCount);
+  auto tablet = openTablet(file);
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapScalar);
+  ASSERT_EQ(valueStreamIds.size(), 1);
+  const auto valueStreamId = valueStreamIds.front();
+  const auto encodingTypes =
+      streamEncodingTypesByStripe(*tablet, valueStreamId);
+  ASSERT_EQ(encodingTypes.size(), kStripeCount);
+  expectAllStripeEncodingTypes(encodingTypes, EncodingType::SharedDictionary);
+  for (uint32_t stripeIndex{0}; stripeIndex < kStripeCount; ++stripeIndex) {
+    SCOPED_TRACE(fmt::format("stripeIndex={}", stripeIndex));
+    EXPECT_EQ(
+        dictionaryValueChunkCompressionType(
+            file, InputType::FlatMapScalar, stripeIndex),
+        CompressionType::Zstd);
+  }
+  verifyRoundTrip(
+      file,
+      InputType::FlatMapScalar,
+      std::vector<StripeValueType>(kStripeCount, StripeValueType::Dictionary));
+}
+
+TEST_F(SharedDictionaryE2ETest, fileScopePrebuiltAlphabetPreservesEncoding) {
+  constexpr size_t kStripeCount{2};
+  for (const auto alphabetOrder :
+       {FileDictionaryAlphabetOrder::Sorted,
+        FileDictionaryAlphabetOrder::Unsorted}) {
+    SCOPED_TRACE(
+        fmt::format(
+            "alphabetOrder={}",
+            fileDictionaryAlphabetOrderName(alphabetOrder)));
+    const auto file = writeWithFileDictionary(kStripeCount, alphabetOrder);
+    auto tablet = openTablet(file);
+    const auto valueStreamIds =
+        sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapScalar);
+    ASSERT_EQ(valueStreamIds.size(), 1);
+    const auto valueStreamId = valueStreamIds.front();
+    const auto encodingTypes =
+        streamEncodingTypesByStripe(*tablet, valueStreamId);
+    ASSERT_EQ(encodingTypes.size(), kStripeCount);
+    expectAllStripeEncodingTypes(encodingTypes, EncodingType::SharedDictionary);
+    EXPECT_EQ(fileDictionaryValues(file), fileDictionaryValues(alphabetOrder));
+    EXPECT_EQ(
+        fileDictionaryAlphabetEncodingType(file), EncodingType::FixedBitWidth);
+    verifyFileDictionaryRoundTrip(file, alphabetOrder, kStripeCount);
+  }
+}
+
+TEST_P(SharedDictionaryE2EInputTypeTest, externalScopeRoundTrip) {
+  const auto inputType = GetParam();
+  const std::vector<StripeValueType> stripeValueTypes{
+      StripeValueType::Dictionary, StripeValueType::Direct};
+  auto resolver = makeExternalResolver(
+      externalDictionaryValues(dictionaryValueCount(inputType)));
+  const auto file = write(
+      inputType, SharedDictionaryScope::External, stripeValueTypes, resolver);
+  auto tablet = openTablet(file, resolver);
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, inputType);
+  ASSERT_EQ(valueStreamIds.size(), 1);
+  for (const auto valueStreamId : valueStreamIds) {
+    SCOPED_TRACE(fmt::format("valueStreamId={}", valueStreamId));
+    expectDictionaryValueEncodingTypes(
+        *tablet,
+        valueStreamId,
+        SharedDictionaryScope::External,
+        stripeValueTypes);
+  }
+  verifyRoundTrip(file, inputType, stripeValueTypes, resolver);
+}
+
+TEST_F(SharedDictionaryE2ETest, externalDictionaryFailures) {
+  for (const auto failure :
+       {ExternalDictionaryFailure::MissingResolver,
+        ExternalDictionaryFailure::MissingValue}) {
+    SCOPED_TRACE(
+        fmt::format("failure={}", externalDictionaryFailureName(failure)));
+    switch (failure) {
+      case ExternalDictionaryFailure::MissingResolver: {
+        auto resolver = makeExternalResolver(externalDictionaryValues());
+        const auto file = write(
+            InputType::FlatMapScalar,
+            SharedDictionaryScope::External,
+            {StripeValueType::Dictionary, StripeValueType::Direct},
+            resolver);
+        auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+        VeloxReader reader{readFile, *leafPool_};
+        velox::VectorPtr output;
+        NIMBLE_ASSERT_USER_THROW(
+            reader.next(kStripeRows, output),
+            "External shared dictionary 17 requires an "
+            "ExternalDictionaryResolver.");
+        break;
+      }
+      case ExternalDictionaryFailure::MissingValue: {
+        auto resolver = makeExternalResolver(kDictionaryStripeAlphabetValues);
+        NIMBLE_ASSERT_USER_THROW(
+            write(
+                InputType::FlatMapScalar,
+                SharedDictionaryScope::External,
+                {StripeValueType::Dictionary, StripeValueType::Direct},
+                resolver),
+            "External shared dictionary 17 does not contain value 10000.");
+        break;
+      }
+    }
+  }
+}
+
+TEST_F(
+    SharedDictionaryE2ETest,
+    externalMissingValueAfterFirstChunkFailsStripe) {
+  auto resolver = makeExternalResolver(kDictionaryStripeAlphabetValues);
+  velox::test::VectorMaker maker{leafPool_.get()};
+  auto input = maker.rowVector(
+      {"features"},
+      {maker.mapVector<int64_t, int32_t>(
+          2'000,
+          [](auto /* row */) { return 1; },
+          [](auto /* idx */) { return 10; },
+          [](auto idx) {
+            if (idx < 128) {
+              return kDictionaryStripeAlphabetValues.at(
+                  idx % kDictionaryStripeAlphabetValues.size());
+            }
+            return 42;
+          })});
+  WriterOptions options;
+  options.maxStreamChunkRawSize = 512;
+  options.minStreamChunkRawSize = 1;
+  useSharedDictionarySelectionPolicy(options);
+  addDictionary(
+      options,
+      InputType::FlatMapScalar,
+      SharedDictionaryConfig{
+          .scope = SharedDictionaryScope::External, .dictionaryId = 17});
+  options.experimentalSharedDictionaryEncoding.externalResolver = resolver;
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  Writer writer{
+      input->type(), std::move(writeFile), *rootPool_, std::move(options)};
+  writer.write(input);
+  NIMBLE_ASSERT_USER_THROW(
+      writer.close(),
+      "External shared dictionary 17 does not contain value 42.");
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
+
+#include <algorithm>
+#include <limits>
+#include <optional>
+#include <random>
+#include <set>
+#include <string_view>
+
+#include "velox/common/file/File.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::nimble::test {
+namespace {
+
+std::unique_ptr<EncodingSelectionPolicyBase> sharedDictionarySelectionPolicy(
+    DataType dataType,
+    SharedDictionarySelectionPolicyOptions selectionOptions) {
+  std::vector<std::pair<EncodingType, float>> readFactors;
+  switch (dataType) {
+    case DataType::Int32:
+      if (selectionOptions.forceDictionaryForInt32) {
+        readFactors = {{EncodingType::Dictionary, 1.0}};
+      } else {
+        readFactors = {
+            {EncodingType::Trivial, 1.0}, {EncodingType::Dictionary, 1.0}};
+      }
+      break;
+    case DataType::Uint32:
+      readFactors = {{EncodingType::FixedBitWidth, 1.0}};
+      break;
+    case DataType::Undefined:
+    case DataType::Int8:
+    case DataType::Uint8:
+    case DataType::Int16:
+    case DataType::Uint16:
+    case DataType::Int64:
+    case DataType::Uint64:
+    case DataType::Float:
+    case DataType::Double:
+    case DataType::Bool:
+    case DataType::String:
+      readFactors = {{EncodingType::Trivial, 1.0}};
+      break;
+  }
+  return ManualEncodingSelectionPolicyFactory{
+      readFactors, /*compressionOptions=*/std::nullopt}
+      .createPolicy(dataType);
+}
+
+velox::MapVectorPtr makeSharedDictionaryMap(
+    velox::memory::MemoryPool* pool,
+    velox::vector_size_t rowCount,
+    const SharedDictionarySource& source,
+    std::span<const int32_t> valueUniverse,
+    bool nullableData,
+    uint32_t salt) {
+  velox::test::VectorMaker vectorMaker{pool};
+  std::vector<velox::vector_size_t> offsets;
+  std::vector<velox::vector_size_t> sizes;
+  std::vector<int64_t> keys;
+  std::vector<std::optional<int32_t>> values;
+  std::vector<velox::vector_size_t> nullRows;
+  offsets.reserve(rowCount);
+  sizes.reserve(rowCount);
+
+  for (velox::vector_size_t row{0}; row < rowCount; ++row) {
+    offsets.push_back(static_cast<velox::vector_size_t>(keys.size()));
+    if (nullableData && (row + salt) % 29 == 0) {
+      nullRows.push_back(row);
+      sizes.push_back(0);
+      continue;
+    }
+
+    if ((row + salt) % 5 == 0) {
+      sizes.push_back(0);
+      continue;
+    }
+
+    keys.push_back(source.dictionaryKey);
+    if (nullableData && (row + salt) % 7 == 0) {
+      values.emplace_back(std::nullopt);
+    } else {
+      const auto valueIndex =
+          (row * (salt + 3) + source.dictionaryKey) % valueUniverse.size();
+      values.emplace_back(valueUniverse[valueIndex]);
+    }
+    sizes.push_back(1);
+  }
+
+  return vectorMaker.mapVector(
+      offsets,
+      sizes,
+      vectorMaker.flatVector<int64_t>(keys),
+      vectorMaker.flatVectorNullable<int32_t>(values),
+      nullRows);
+}
+
+} // namespace
+
+std::vector<int32_t> sharedDictionaryValueUniverse() {
+  std::vector<int32_t> values{
+      std::numeric_limits<int32_t>::min(),
+      -1,
+      0,
+      std::numeric_limits<int32_t>::max()};
+  values.reserve(256);
+  for (int32_t i{0}; i < 252; ++i) {
+    values.push_back(i * 13 - 57);
+  }
+  return values;
+}
+
+SharedDictionaryTestResolver::SharedDictionaryTestResolver(
+    const std::vector<SharedDictionaryTestDictionary>& dictionaries,
+    velox::memory::MemoryPool* pool) {
+  alphabets_.reserve(dictionaries.size());
+  for (const auto& [dictionaryId, values] : dictionaries) {
+    Buffer buffer{*pool};
+    const auto encoded = SharedDictionaryAlphabet::encode<int32_t>(
+        values, std::span<const EncodingType>{}, buffer);
+    auto encodedOwner = std::make_shared<const std::string>(encoded);
+    const std::string_view encodedAlphabet{
+        encodedOwner->data(), encodedOwner->size()};
+    alphabets_.emplace_back(
+        dictionaryId,
+        SharedDictionaryAlphabet::create(
+            encodedAlphabet, std::move(encodedOwner), pool));
+  }
+}
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+SharedDictionaryTestResolver::resolve(uint32_t dictionaryId, DataType dataType)
+    const {
+  if (dataType != DataType::Int32) {
+    return nullptr;
+  }
+  for (const auto& [candidateId, alphabet] : alphabets_) {
+    if (candidateId == dictionaryId) {
+      return alphabet;
+    }
+  }
+  return nullptr;
+}
+
+void configureSharedDictionarySelectionPolicy(
+    WriterOptions& options,
+    SharedDictionarySelectionPolicyOptions selectionOptions) {
+  options.encodingSelectionPolicyCreator =
+      [selectionOptions](DataType dataType) {
+        return sharedDictionarySelectionPolicy(dataType, selectionOptions);
+      };
+}
+
+velox::RowVectorPtr makeSharedDictionaryInput(
+    velox::memory::MemoryPool* pool,
+    velox::vector_size_t rowCount,
+    const std::vector<SharedDictionarySource>& sources,
+    std::span<const int32_t> valueUniverse,
+    bool nullableData) {
+  std::vector<std::string> names;
+  std::vector<velox::VectorPtr> children;
+  names.reserve(sources.size());
+  children.reserve(sources.size());
+  for (size_t i{0}; i < sources.size(); ++i) {
+    names.push_back(sources[i].columnName);
+    children.push_back(makeSharedDictionaryMap(
+        pool,
+        rowCount,
+        sources[i],
+        valueUniverse,
+        nullableData,
+        static_cast<uint32_t>(i * 17 + 3)));
+  }
+  velox::test::VectorMaker vectorMaker{pool};
+  return vectorMaker.rowVector(names, children);
+}
+
+WriterOptions sharedDictionaryWriterOptions(
+    const std::vector<SharedDictionarySource>& sources,
+    const SharedDictionaryWriterOptions& writerOptions) {
+  WriterOptions options;
+  options.maxStreamChunkRawSize = 512;
+  options.minStreamChunkRawSize = 1;
+  options.skipConstantFlatMapInMapStreams =
+      writerOptions.skipConstantFlatMapInMapStreams;
+  configureSharedDictionarySelectionPolicy(
+      options, writerOptions.selectionPolicy);
+
+  auto builder = SharedDictionaryEncodingConfig::builder();
+  if (writerOptions.externalDictionaryResolver != nullptr) {
+    builder.setExternalResolver(writerOptions.externalDictionaryResolver);
+  }
+  for (const auto& source : sources) {
+    options.flatMapColumns.emplace(source.columnName, std::set<std::string>{});
+    builder.addFlatmapValueDictionary(
+        source.columnName,
+        source.dictionaryKey,
+        SharedDictionaryConfig{
+            .scope = source.scope,
+            .dictionaryId = source.scope == SharedDictionaryScope::Stripe
+                ? 0
+                : source.dictionaryId});
+  }
+  options.experimentalSharedDictionaryEncoding = builder.build();
+  return options;
+}
+
+std::string writeWithRandomStripes(
+    velox::memory::MemoryPool* pool,
+    const velox::RowVectorPtr& input,
+    WriterOptions options,
+    uint32_t seed) {
+  std::mt19937 rng{seed};
+  std::uniform_int_distribution<velox::vector_size_t> batchSizeDistribution{
+      1, 41};
+  std::uniform_int_distribution<velox::vector_size_t> stripeSizeDistribution{
+      71, 193};
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  Writer writer{input->type(), std::move(writeFile), *pool, std::move(options)};
+
+  velox::vector_size_t nextStripeBoundary = stripeSizeDistribution(rng);
+  for (velox::vector_size_t row{0}; row < input->size();) {
+    const auto batchSize =
+        std::min(batchSizeDistribution(rng), input->size() - row);
+    writer.write(input->slice(row, batchSize));
+    row += batchSize;
+    if (row < input->size() && row >= nextStripeBoundary) {
+      writer.flush();
+      nextStripeBoundary = row + stripeSizeDistribution(rng);
+    }
+  }
+  writer.close();
+  return file;
+}
+
+} // namespace facebook::nimble::test

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
+#include "velox/dwio/nimble/writer/Writer.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::nimble::test {
+
+using SharedDictionaryTestDictionary =
+    std::pair<uint32_t, std::vector<int32_t>>;
+
+/// Returns a deterministic int32 universe with edge values for tests.
+std::vector<int32_t> sharedDictionaryValueUniverse();
+
+/// Resolves one or more fixed int32 shared dictionaries by id.
+class SharedDictionaryTestResolver final : public ExternalDictionaryResolver {
+ public:
+  SharedDictionaryTestResolver(
+      const std::vector<SharedDictionaryTestDictionary>& dictionaries,
+      velox::memory::MemoryPool* pool);
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      uint32_t dictionaryId,
+      DataType dataType) const final;
+
+ private:
+  std::vector<
+      std::pair<uint32_t, std::shared_ptr<const SharedDictionaryAlphabet>>>
+      alphabets_;
+};
+
+struct SharedDictionarySelectionPolicyOptions {
+  // Force int32 streams toward Dictionary encoding before shared-dictionary
+  // wrapping. Integration tests disable this when they need a mixed direct and
+  // shared-dictionary stripe sequence.
+  bool forceDictionaryForInt32{true};
+};
+
+/// Installs the shared-dictionary selection policy on writer options.
+void configureSharedDictionarySelectionPolicy(
+    WriterOptions& options,
+    SharedDictionarySelectionPolicyOptions selectionOptions = {});
+
+struct SharedDictionarySource {
+  // Top-level map column configured as a flat map.
+  std::string columnName{};
+
+  // Flat-map key whose value stream uses shared dictionary encoding.
+  int64_t dictionaryKey{};
+
+  // Scope used for this key's shared dictionary.
+  SharedDictionaryScope scope{SharedDictionaryScope::Stripe};
+
+  // Dictionary id for file and external scopes. Stripe scope always uses zero.
+  uint32_t dictionaryId{};
+};
+
+struct SharedDictionaryWriterOptions {
+  // Mirrors WriterOptions::skipConstantFlatMapInMapStreams for reader tests
+  // that exercise both writer modes.
+  bool skipConstantFlatMapInMapStreams{false};
+
+  // Resolver used for external shared dictionaries, when configured.
+  std::shared_ptr<const ExternalDictionaryResolver> externalDictionaryResolver{
+      nullptr};
+
+  // Selection-policy tuning for the generated writer options.
+  SharedDictionarySelectionPolicyOptions selectionPolicy{};
+};
+
+/// Builds a deterministic row vector containing shared-dictionary flat maps.
+velox::RowVectorPtr makeSharedDictionaryInput(
+    velox::memory::MemoryPool* pool,
+    velox::vector_size_t rowCount,
+    const std::vector<SharedDictionarySource>& sources,
+    std::span<const int32_t> valueUniverse,
+    bool nullableData);
+
+/// Builds writer options for shared-dictionary flat-map sources.
+WriterOptions sharedDictionaryWriterOptions(
+    const std::vector<SharedDictionarySource>& sources,
+    const SharedDictionaryWriterOptions& writerOptions = {});
+
+/// Writes input in deterministic random-sized batches and stripes.
+std::string writeWithRandomStripes(
+    velox::memory::MemoryPool* pool,
+    const velox::RowVectorPtr& input,
+    WriterOptions options,
+    uint32_t seed);
+
+} // namespace facebook::nimble::test

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
@@ -37,6 +37,7 @@
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
@@ -47,16 +48,91 @@ namespace facebook::nimble {
 namespace {
 
 using TestSharedDictionaryWriter = TypedSharedDictionaryWriter<int32_t>;
+using EncodingReadFactors = std::vector<std::pair<EncodingType, float>>;
 
-EncodingSelectionPolicyCreator testEncodingSelectionPolicyCreator() {
-  return [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
-    const auto encodingType = dataType == DataType::Uint32
-        ? EncodingType::FixedBitWidth
-        : EncodingType::Trivial;
+EncodingReadFactors dictionaryValueEncoding() {
+  return {{EncodingType::Dictionary, 1.0}};
+}
+
+EncodingReadFactors trivialPreferredValueEncoding() {
+  return {{EncodingType::Trivial, 0.01}, {EncodingType::Dictionary, 1000.0}};
+}
+
+class StripeAbandonValueSelectionPolicy final
+    : public EncodingSelectionPolicy<int32_t> {
+ public:
+  using physicalType = TypeTraits<int32_t>::physicalType;
+
+  EncodingSelectionResult select(
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& /*statistics*/,
+      const Encoding::Options& /*options*/) final {
+    return {
+        .encodingType = values.size() <= 6 ? EncodingType::Trivial
+                                           : EncodingType::Dictionary};
+  }
+
+  EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /*values*/,
+      std::span<const bool> /*notNulls*/,
+      const Statistics<physicalType>& /*statistics*/,
+      const Encoding::Options& /*options*/) final {
+    return {.encodingType = EncodingType::Nullable};
+  }
+
+ private:
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType /*parentEncodingType*/,
+      NestedEncodingIdentifier /*nestedEncodingIdentifier*/,
+      DataType nestedDataType) final {
     ManualEncodingSelectionPolicyFactory factory{
-        {{encodingType, 1.0}}, std::nullopt};
+        {{EncodingType::Trivial, 1.0}}, std::nullopt};
+    return factory.createPolicy(nestedDataType);
+  }
+};
+
+EncodingSelectionPolicyCreator stripeAbandonEncodingSelectionPolicyCreator() {
+  return [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+    if (dataType == DataType::Int32) {
+      return std::make_unique<StripeAbandonValueSelectionPolicy>();
+    }
+    ManualEncodingSelectionPolicyFactory factory{
+        {{EncodingType::Trivial, 1.0}}, std::nullopt};
     return factory.createPolicy(dataType);
   };
+}
+
+EncodingSelectionPolicyCreator testEncodingSelectionPolicyCreator(
+    EncodingReadFactors valueEncodingReadFactors = dictionaryValueEncoding()) {
+  return
+      [valueEncodingReadFactors = std::move(valueEncodingReadFactors)](
+          DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        EncodingReadFactors encodingReadFactors;
+        switch (dataType) {
+          case DataType::Int32:
+            encodingReadFactors = valueEncodingReadFactors;
+            break;
+          case DataType::Uint32:
+            encodingReadFactors = {{EncodingType::FixedBitWidth, 1.0}};
+            break;
+          case DataType::Undefined:
+          case DataType::Int8:
+          case DataType::Uint8:
+          case DataType::Int16:
+          case DataType::Uint16:
+          case DataType::Int64:
+          case DataType::Uint64:
+          case DataType::Float:
+          case DataType::Double:
+          case DataType::Bool:
+          case DataType::String:
+            encodingReadFactors = {{EncodingType::Trivial, 1.0}};
+            break;
+        }
+        ManualEncodingSelectionPolicyFactory factory{
+            std::move(encodingReadFactors), std::nullopt};
+        return factory.createPolicy(dataType);
+      };
 }
 
 TestSharedDictionaryWriter::Options writerOptions(
@@ -64,14 +140,18 @@ TestSharedDictionaryWriter::Options writerOptions(
     uint32_t dictionaryId,
     std::shared_ptr<const ExternalDictionaryResolver> resolver = nullptr,
     std::vector<EncodingType> alphabetEncodings = {},
-    bool useExternalAlphabet = false) {
+    bool useExternalAlphabet = false,
+    bool useVarintRowCount = false,
+    EncodingReadFactors valueEncodingReadFactors = dictionaryValueEncoding()) {
   return TestSharedDictionaryWriter::Options{
       .scope = scope,
       .dictionaryId = dictionaryId,
       .useExternalAlphabet = useExternalAlphabet,
       .alphabetEncodings = std::move(alphabetEncodings),
-      .encodingSelectionPolicyCreator = testEncodingSelectionPolicyCreator(),
-      .encodingOptions = {},
+      .encodingSelectionPolicyCreator = testEncodingSelectionPolicyCreator(
+          std::move(valueEncodingReadFactors)),
+      .encodingOptions =
+          Encoding::Options{.useVarintRowCount = useVarintRowCount},
       .resolver = std::move(resolver)};
 }
 
@@ -86,11 +166,12 @@ class TestDictionaryResolver final : public ExternalDictionaryResolver {
   TestDictionaryResolver(
       uint32_t dictionaryId,
       std::span<const int32_t> values,
-      velox::memory::MemoryPool* pool)
+      velox::memory::MemoryPool* pool,
+      std::span<const EncodingType> candidateEncodings = {})
       : dictionaryId_{dictionaryId},
         alphabet_{test::createSharedDictionaryAlphabet<int32_t>(
             values,
-            /*candidateEncodings=*/{},
+            candidateEncodings,
             pool)} {}
 
   std::shared_ptr<const SharedDictionaryAlphabet> resolve(
@@ -209,7 +290,11 @@ struct ExpectedStripeDictionary {
 };
 
 ExpectedStripeDictionary expectedStripeDictionary(std::vector<int32_t> values) {
-  ExpectedStripeDictionary expected{.values = std::move(values)};
+  ExpectedStripeDictionary expected{
+      .values = std::move(values),
+      .indices = {},
+      .alphabet = {},
+  };
   expected.indices.reserve(expected.values.size());
   for (const auto value : expected.values) {
     const auto it =
@@ -249,18 +334,18 @@ ExpectedStripeDictionary generatedStripeDictionary(size_t stripeIndex) {
 std::vector<uint32_t> sharedDictionaryIndices(
     std::string_view encoded,
     uint32_t rowCount,
-    velox::memory::MemoryPool* pool) {
+    velox::memory::MemoryPool* pool,
+    bool useVarintRowCount = false) {
   const auto encodingType = EncodingPrefix::encodingType(encoded);
   EXPECT_EQ(encodingType, EncodingType::SharedDictionary);
   if (encodingType != EncodingType::SharedDictionary) {
     return {};
   }
   EXPECT_EQ(EncodingPrefix::dataType(encoded), DataType::Int32);
-  EXPECT_EQ(
-      EncodingPrefix::readRowCount(encoded, /*useVarint=*/false), rowCount);
+  EXPECT_EQ(EncodingPrefix::readRowCount(encoded, useVarintRowCount), rowCount);
 
   const char* pos =
-      encoded.data() + EncodingPrefix::prefixSize(encoded, /*useVarint=*/false);
+      encoded.data() + EncodingPrefix::prefixSize(encoded, useVarintRowCount);
   EXPECT_LE(pos, encoded.end());
   const std::string_view encodedIndices{
       pos, static_cast<size_t>(encoded.end() - pos)};
@@ -269,7 +354,7 @@ std::vector<uint32_t> sharedDictionaryIndices(
       *pool,
       encodedIndices,
       [](uint32_t /*size*/) -> void* { return nullptr; },
-      Encoding::Options{});
+      Encoding::Options{.useVarintRowCount = useVarintRowCount});
   EXPECT_EQ(indicesEncoding->dataType(), DataType::Uint32);
   EXPECT_EQ(indicesEncoding->rowCount(), rowCount);
 
@@ -286,6 +371,28 @@ std::unique_ptr<Encoding> createEncoding(
       *pool, encoded, [](uint32_t /*size*/) -> void* { return nullptr; });
 }
 
+std::string_view encodeValues(
+    TestSharedDictionaryWriter& writer,
+    size_t stripeIndex,
+    const StreamData& streamData,
+    Buffer& buffer,
+    const Encoding::Options& options = {}) {
+  NIMBLE_CHECK_EQ(
+      streamData.data().size() % sizeof(int32_t),
+      0,
+      "Test stream has incomplete int32 values.");
+  const std::span<const int32_t> values{
+      reinterpret_cast<const int32_t*>(streamData.data().data()),
+      streamData.data().size() / sizeof(int32_t)};
+  auto policy = writer.createEncodingPolicy(stripeIndex);
+  if (streamData.hasNulls()) {
+    return EncodingFactory::encodeNullable<int32_t>(
+        std::move(policy), values, streamData.nonNulls(), buffer, options);
+  }
+  return EncodingFactory::encode<int32_t>(
+      std::move(policy), values, buffer, options);
+}
+
 const Encoding* nullableValuesChild(const Encoding& encoding) {
   EXPECT_EQ(encoding.encodingType(), EncodingType::Nullable);
   const auto* nullableEncoding =
@@ -295,6 +402,49 @@ const Encoding* nullableValuesChild(const Encoding& encoding) {
     return nullptr;
   }
   return nullableEncoding->nonNulls();
+}
+
+std::vector<uint32_t> nullableSharedDictionaryIndices(
+    std::string_view encoded,
+    uint32_t rowCount,
+    std::span<const bool> expectedNonNulls,
+    uint32_t nonNullRowCount,
+    velox::memory::MemoryPool* pool,
+    bool useVarintRowCount) {
+  const auto encodingType = EncodingPrefix::encodingType(encoded);
+  EXPECT_EQ(encodingType, EncodingType::Nullable);
+  if (encodingType != EncodingType::Nullable) {
+    return {};
+  }
+  EXPECT_EQ(EncodingPrefix::dataType(encoded), DataType::Int32);
+  EXPECT_EQ(EncodingPrefix::readRowCount(encoded, useVarintRowCount), rowCount);
+
+  const char* pos =
+      encoded.data() + EncodingPrefix::prefixSize(encoded, useVarintRowCount);
+  const auto nonNullValuesBytes = encoding::readUint32(pos);
+  EXPECT_LE(pos + nonNullValuesBytes, encoded.end());
+  const std::string_view encodedNonNullValues{pos, nonNullValuesBytes};
+  pos += nonNullValuesBytes;
+  const std::string_view encodedNonNulls{
+      pos, static_cast<size_t>(encoded.end() - pos)};
+
+  auto nonNullsEncoding = EncodingFactory{}.create(
+      *pool,
+      encodedNonNulls,
+      [](uint32_t /*size*/) -> void* { return nullptr; },
+      Encoding::Options{.useVarintRowCount = useVarintRowCount});
+  EXPECT_EQ(nonNullsEncoding->dataType(), DataType::Bool);
+  EXPECT_EQ(nonNullsEncoding->rowCount(), rowCount);
+
+  Vector<bool> actualNonNulls{pool};
+  actualNonNulls.resize(rowCount);
+  nonNullsEncoding->materialize(rowCount, actualNonNulls.data());
+  for (size_t i = 0; i < expectedNonNulls.size(); ++i) {
+    EXPECT_EQ(actualNonNulls[i], expectedNonNulls[i]) << "row " << i;
+  }
+
+  return sharedDictionaryIndices(
+      encodedNonNullValues, nonNullRowCount, pool, useVarintRowCount);
 }
 
 void expectAlphabetEntries(
@@ -393,8 +543,11 @@ TEST_F(SharedDictionaryWriterTest, stripeScope) {
     for (size_t i = 0; i < testData.stripes.size(); ++i) {
       SCOPED_TRACE(fmt::format("stripe={}", i));
       const auto& stripe = testData.stripes[i];
-      const auto encoded = writer.encodeValues(
-          /*stripeIndex=*/i, streamView(descriptor_, stripe.values), buffer);
+      const auto encoded = encodeValues(
+          writer,
+          /*stripeIndex=*/i,
+          streamView(descriptor_, stripe.values),
+          buffer);
 
       EXPECT_FALSE(encoded.empty());
       EXPECT_EQ(
@@ -425,7 +578,8 @@ TEST_F(SharedDictionaryWriterTest, nullableStripeScope) {
       std::array<std::optional<int32_t>, 6>{
           10, std::nullopt, 20, 10, std::nullopt, 20},
       256);
-  const auto encoded = writer.encodeValues(
+  const auto encoded = encodeValues(
+      writer,
       /*stripeIndex=*/0,
       nullableStreamView(
           descriptor_, values.nonNullValues, values.notNullsSpan()),
@@ -458,14 +612,22 @@ TEST_F(SharedDictionaryWriterTest, nullableStripeScope) {
 TEST_F(SharedDictionaryWriterTest, nullableStripeScopeAbandon) {
   auto writer = createTestWriter(
       pool_.get(),
-      writerOptions(SharedDictionaryScope::Stripe, /*dictionaryId=*/7));
+      writerOptions(
+          SharedDictionaryScope::Stripe,
+          /*dictionaryId=*/7,
+          nullptr,
+          /*alphabetEncodings=*/{},
+          /*useExternalAlphabet=*/false,
+          /*useVarintRowCount=*/false,
+          trivialPreferredValueEncoding()));
   Buffer buffer{*pool_};
 
   const auto values = repeatedNullableValues(
       std::array<std::optional<int32_t>, 8>{
           1, std::nullopt, 2, 3, std::nullopt, 4, 5, 6},
       1);
-  const auto encoded = writer.encodeValues(
+  const auto encoded = encodeValues(
+      writer,
       /*stripeIndex=*/0,
       nullableStreamView(
           descriptor_, values.nonNullValues, values.notNullsSpan()),
@@ -475,11 +637,36 @@ TEST_F(SharedDictionaryWriterTest, nullableStripeScopeAbandon) {
   auto encoding = createEncoding(encoded, pool_.get());
   const auto* nonNullValuesEncoding = nullableValuesChild(*encoding);
   ASSERT_NE(nonNullValuesEncoding, nullptr);
-  EXPECT_EQ(nonNullValuesEncoding->encodingType(), EncodingType::Trivial);
+  EXPECT_NE(
+      nonNullValuesEncoding->encodingType(), EncodingType::SharedDictionary);
   std::vector<int32_t> materialized(encoding->rowCount());
   encoding->materialize(encoding->rowCount(), materialized.data());
   EXPECT_EQ(materialized, values.materializedValues);
   EXPECT_FALSE(writer.encodeAlphabet(buffer).has_value());
+}
+
+TEST_F(SharedDictionaryWriterTest, stripeScopeRequiresDictionaryCandidate) {
+  auto writer = createTestWriter(
+      pool_.get(),
+      writerOptions(
+          SharedDictionaryScope::Stripe,
+          /*dictionaryId=*/7,
+          nullptr,
+          /*alphabetEncodings=*/{},
+          /*useExternalAlphabet=*/false,
+          /*useVarintRowCount=*/false,
+          EncodingReadFactors{{EncodingType::Trivial, 1.0}}));
+  Buffer buffer{*pool_};
+
+  const std::vector<int32_t> values{1, 2, 3, 4, 5, 6};
+  NIMBLE_ASSERT_THROW(
+      encodeValues(
+          writer,
+          /*stripeIndex=*/0,
+          streamView(descriptor_, values),
+          buffer),
+      "Stripe shared dictionary selection requires regular Dictionary in the "
+      "non-shared value encoding candidates.");
 }
 
 TEST_F(
@@ -491,8 +678,11 @@ TEST_F(
   Buffer buffer{*pool_};
 
   const auto values = repeatedValues(std::array<int32_t, 2>{10, 20}, 512);
-  writer.encodeValues(
-      /*stripeIndex=*/0, streamView(descriptor_, values), buffer);
+  encodeValues(
+      writer,
+      /*stripeIndex=*/0,
+      streamView(descriptor_, values),
+      buffer);
 
   const auto alphabet = writer.encodeAlphabet(buffer);
   ASSERT_TRUE(alphabet.has_value());
@@ -503,14 +693,20 @@ TEST_F(
       "0.");
 
   NIMBLE_ASSERT_THROW(
-      writer.encodeValues(
-          /*stripeIndex=*/0, streamView(descriptor_, values), buffer),
+      encodeValues(
+          writer,
+          /*stripeIndex=*/0,
+          streamView(descriptor_, values),
+          buffer),
       "Stripe shared dictionary 7 cannot encode values after its alphabet was "
       "finalized for stripe 0.");
 
   const auto nextStripeValues = repeatedValues(std::array<int32_t, 1>{30}, 512);
-  const auto nextStripeEncoded = writer.encodeValues(
-      /*stripeIndex=*/1, streamView(descriptor_, nextStripeValues), buffer);
+  const auto nextStripeEncoded = encodeValues(
+      writer,
+      /*stripeIndex=*/1,
+      streamView(descriptor_, nextStripeValues),
+      buffer);
 
   EXPECT_EQ(
       sharedDictionaryIndices(
@@ -537,12 +733,18 @@ TEST_F(
     Buffer buffer{*pool_};
 
     const auto values = repeatedValues(std::array<int32_t, 2>{10, 20}, 512);
-    writer.encodeValues(
-        /*stripeIndex=*/0, streamView(descriptor_, values), buffer);
+    encodeValues(
+        writer,
+        /*stripeIndex=*/0,
+        streamView(descriptor_, values),
+        buffer);
 
     NIMBLE_ASSERT_THROW(
-        writer.encodeValues(
-            /*stripeIndex=*/1, streamView(descriptor_, values), buffer),
+        encodeValues(
+            writer,
+            /*stripeIndex=*/1,
+            streamView(descriptor_, values),
+            buffer),
         "Stripe shared dictionary 7 reached a stripe boundary before encoding "
         "its alphabet.");
   }
@@ -550,16 +752,29 @@ TEST_F(
   {
     auto writer = createTestWriter(
         pool_.get(),
-        writerOptions(SharedDictionaryScope::Stripe, /*dictionaryId=*/7));
+        writerOptions(
+            SharedDictionaryScope::Stripe,
+            /*dictionaryId=*/7,
+            nullptr,
+            /*alphabetEncodings=*/{},
+            /*useExternalAlphabet=*/false,
+            /*useVarintRowCount=*/false,
+            trivialPreferredValueEncoding()));
     Buffer buffer{*pool_};
 
     const std::vector<int32_t> values{1, 2, 3, 4, 5, 6};
-    writer.encodeValues(
-        /*stripeIndex=*/0, streamView(descriptor_, values), buffer);
+    encodeValues(
+        writer,
+        /*stripeIndex=*/0,
+        streamView(descriptor_, values),
+        buffer);
 
     NIMBLE_ASSERT_THROW(
-        writer.encodeValues(
-            /*stripeIndex=*/1, streamView(descriptor_, values), buffer),
+        encodeValues(
+            writer,
+            /*stripeIndex=*/1,
+            streamView(descriptor_, values),
+            buffer),
         "Stripe shared dictionary 7 reached a stripe boundary with an active "
         "encoding decision.");
   }
@@ -573,18 +788,25 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeRejectsBackwardStripeIndex) {
 
   const auto firstStripeValues =
       repeatedValues(std::array<int32_t, 2>{10, 20}, 512);
-  writer.encodeValues(
-      /*stripeIndex=*/0, streamView(descriptor_, firstStripeValues), buffer);
+  encodeValues(
+      writer,
+      /*stripeIndex=*/0,
+      streamView(descriptor_, firstStripeValues),
+      buffer);
   ASSERT_TRUE(writer.encodeAlphabet(buffer).has_value());
 
   const auto secondStripeValues =
       repeatedValues(std::array<int32_t, 1>{30}, 512);
-  writer.encodeValues(
-      /*stripeIndex=*/2, streamView(descriptor_, secondStripeValues), buffer);
+  encodeValues(
+      writer,
+      /*stripeIndex=*/2,
+      streamView(descriptor_, secondStripeValues),
+      buffer);
   ASSERT_TRUE(writer.encodeAlphabet(buffer).has_value());
 
   NIMBLE_ASSERT_THROW(
-      writer.encodeValues(
+      encodeValues(
+          writer,
           /*stripeIndex=*/1,
           streamView(descriptor_, firstStripeValues),
           buffer),
@@ -603,8 +825,11 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeUsesForcedAlphabetEncoding) {
 
   const std::array<int32_t, 2> pattern{10, 20};
   const auto values = repeatedValues(pattern, 512);
-  const auto encoded = writer.encodeValues(
-      /*stripeIndex=*/0, streamView(descriptor_, values), buffer);
+  const auto encoded = encodeValues(
+      writer,
+      /*stripeIndex=*/0,
+      streamView(descriptor_, values),
+      buffer);
 
   EXPECT_FALSE(encoded.empty());
   const auto alphabet = writer.encodeAlphabet(buffer);
@@ -647,8 +872,11 @@ TEST_F(SharedDictionaryWriterTest, stripeAlphabetRoundTripsThroughReader) {
     // dictionary assigns indices in.
     const std::array<int32_t, 3> pattern{30, 10, 20};
     const auto values = repeatedValues(pattern, 512);
-    writer.encodeValues(
-        /*stripeIndex=*/0, streamView(descriptor_, values), buffer);
+    encodeValues(
+        writer,
+        /*stripeIndex=*/0,
+        streamView(descriptor_, values),
+        buffer);
 
     const auto encodedAlphabet = writer.encodeAlphabet(buffer);
     ASSERT_TRUE(encodedAlphabet.has_value());
@@ -707,8 +935,11 @@ TEST_F(
       SCOPED_TRACE(fmt::format("stripe={}", stripeIndex));
       const auto expected = generatedStripeDictionary(stripeIndex);
 
-      const auto encoded = writer.encodeValues(
-          stripeIndex, streamView(descriptor_, expected.values), buffer);
+      const auto encoded = encodeValues(
+          writer,
+          stripeIndex,
+          streamView(descriptor_, expected.values),
+          buffer);
 
       EXPECT_EQ(
           sharedDictionaryIndices(encoded, expected.values.size(), pool_.get()),
@@ -733,9 +964,11 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeAbandon) {
     std::vector<int32_t> values;
   };
 
-  auto writer = createTestWriter(
-      pool_.get(),
-      writerOptions(SharedDictionaryScope::Stripe, /*dictionaryId=*/7));
+  auto options =
+      writerOptions(SharedDictionaryScope::Stripe, /*dictionaryId=*/7);
+  options.encodingSelectionPolicyCreator =
+      stripeAbandonEncodingSelectionPolicyCreator();
+  auto writer = createTestWriter(pool_.get(), options);
   Buffer buffer{*pool_};
   EXPECT_FALSE(writer.hasUsedDictionary());
 
@@ -757,9 +990,13 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeAbandon) {
 
   for (const auto& chunk : chunks) {
     SCOPED_TRACE(chunk.testName);
-    const auto encoded = writer.encodeValues(
-        /*stripeIndex=*/0, streamView(descriptor_, chunk.values), buffer);
-    EXPECT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Trivial);
+    const auto encoded = encodeValues(
+        writer,
+        /*stripeIndex=*/0,
+        streamView(descriptor_, chunk.values),
+        buffer);
+    EXPECT_NE(
+        EncodingPrefix::encodingType(encoded), EncodingType::SharedDictionary);
     EXPECT_FALSE(writer.hasUsedDictionary());
   }
   EXPECT_FALSE(writer.encodeAlphabet(buffer).has_value());
@@ -770,8 +1007,11 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeAbandon) {
       "0.");
 
   const auto repeated = repeatedValues(std::array<int32_t, 2>{10, 20}, 512);
-  const auto nextStripeEncoded = writer.encodeValues(
-      /*stripeIndex=*/1, streamView(descriptor_, repeated), buffer);
+  const auto nextStripeEncoded = encodeValues(
+      writer,
+      /*stripeIndex=*/1,
+      streamView(descriptor_, repeated),
+      buffer);
 
   const std::array<uint32_t, 2> expectedIndices{0, 1};
   EXPECT_EQ(
@@ -791,7 +1031,8 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeAbandon) {
         writerOptions(SharedDictionaryScope::File, /*dictionaryId=*/17));
     Buffer fileBuffer{*pool_};
 
-    const auto encoded = fileWriter.encodeValues(
+    const auto encoded = encodeValues(
+        fileWriter,
         /*stripeIndex=*/0,
         streamView(descriptor_, directFriendlyValues),
         fileBuffer);
@@ -821,7 +1062,8 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeAbandon) {
             /*useExternalAlphabet=*/true));
     Buffer externalAlphabetFileBuffer{*pool_};
 
-    const auto encoded = externalAlphabetFileWriter.encodeValues(
+    const auto encoded = encodeValues(
+        externalAlphabetFileWriter,
         /*stripeIndex=*/0,
         streamView(descriptor_, directFriendlyValues),
         externalAlphabetFileBuffer);
@@ -848,7 +1090,8 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeAbandon) {
             SharedDictionaryScope::External, /*dictionaryId=*/29, resolver));
     Buffer externalBuffer{*pool_};
 
-    const auto encoded = externalWriter.encodeValues(
+    const auto encoded = encodeValues(
+        externalWriter,
         /*stripeIndex=*/0,
         streamView(descriptor_, directFriendlyValues),
         externalBuffer);
@@ -858,7 +1101,10 @@ TEST_F(SharedDictionaryWriterTest, stripeScopeAbandon) {
             encoded, directFriendlyValues.size(), pool_.get()),
         directFriendlyIndices);
     EXPECT_TRUE(externalWriter.hasUsedDictionary());
-    EXPECT_FALSE(externalWriter.encodeAlphabet(externalBuffer).has_value());
+    NIMBLE_ASSERT_THROW(
+        externalWriter.encodeAlphabet(externalBuffer),
+        "External shared dictionary 29 cannot encode an alphabet; its "
+        "resolver owns the alphabet.");
     EXPECT_TRUE(externalWriter.hasUsedDictionary());
   }
 }
@@ -906,8 +1152,11 @@ TEST_F(SharedDictionaryWriterTest, encodeValuesRejectsEmptyValues) {
 
     const std::vector<int32_t> values;
     NIMBLE_ASSERT_THROW(
-        writer.encodeValues(
-            /*stripeIndex=*/0, streamView(descriptor_, values), buffer),
+        encodeValues(
+            writer,
+            /*stripeIndex=*/0,
+            streamView(descriptor_, values),
+            buffer),
         fmt::format(
             "{} shared dictionary {} cannot encode an empty value stream.",
             testData.scope,
@@ -915,13 +1164,21 @@ TEST_F(SharedDictionaryWriterTest, encodeValuesRejectsEmptyValues) {
 
     const auto validValues =
         repeatedValues(std::array<int32_t, 3>{10, 20, 10}, 512);
-    const auto encoded = writer.encodeValues(
-        /*stripeIndex=*/0, streamView(descriptor_, validValues), buffer);
+    const auto encoded = encodeValues(
+        writer,
+        /*stripeIndex=*/0,
+        streamView(descriptor_, validValues),
+        buffer);
     EXPECT_EQ(
         sharedDictionaryIndices(encoded, validValues.size(), pool_.get()),
         repeatedIndices(std::array<uint32_t, 3>{0, 1, 0}, 512));
     if (testData.scope == SharedDictionaryScope::External) {
-      EXPECT_FALSE(writer.encodeAlphabet(buffer).has_value());
+      NIMBLE_ASSERT_THROW(
+          writer.encodeAlphabet(buffer),
+          fmt::format(
+              "External shared dictionary {} cannot encode an alphabet; its "
+              "resolver owns the alphabet.",
+              testData.dictionaryId));
     } else {
       ASSERT_TRUE(writer.encodeAlphabet(buffer).has_value());
     }
@@ -962,8 +1219,11 @@ TEST_F(SharedDictionaryWriterTest, fileScope) {
 
   for (const auto& chunk : chunks) {
     SCOPED_TRACE(fmt::format("stripe={}", chunk.stripeIndex));
-    const auto encoded = writer.encodeValues(
-        chunk.stripeIndex, streamView(descriptor_, chunk.values), buffer);
+    const auto encoded = encodeValues(
+        writer,
+        chunk.stripeIndex,
+        streamView(descriptor_, chunk.values),
+        buffer);
 
     EXPECT_EQ(
         sharedDictionaryIndices(encoded, chunk.values.size(), pool_.get()),
@@ -978,12 +1238,103 @@ TEST_F(SharedDictionaryWriterTest, fileScope) {
       writer.encodeAlphabet(buffer),
       "File shared dictionary 17 already finalized its alphabet.");
   NIMBLE_ASSERT_THROW(
-      writer.encodeValues(
+      encodeValues(
+          writer,
           /*stripeIndex=*/1,
           streamView(descriptor_, chunks.front().values),
           buffer),
       "File shared dictionary 17 cannot encode values after its alphabet was "
       "finalized.");
+}
+
+TEST_F(SharedDictionaryWriterTest, nullableEncodingAcrossScopes) {
+  struct TestParam {
+    std::string testName;
+    SharedDictionaryScope scope;
+    uint32_t dictionaryId;
+    bool usesResolver;
+  };
+
+  const std::vector<TestParam> testSettings{
+      {"stripe", SharedDictionaryScope::Stripe, /*dictionaryId=*/7, false},
+      {"file", SharedDictionaryScope::File, /*dictionaryId=*/17, false},
+      {"external", SharedDictionaryScope::External, /*dictionaryId=*/29, true},
+  };
+
+  constexpr size_t repeatCount{512};
+  const auto nonNullValues =
+      repeatedValues(std::array<int32_t, 4>{10, 20, 10, 30}, repeatCount);
+  const auto expectedIndices =
+      repeatedIndices(std::array<uint32_t, 4>{0, 1, 0, 2}, repeatCount);
+  const std::array<bool, 6> nonNullPattern{
+      true, false, true, true, false, true};
+  const auto rowCount = nonNullPattern.size() * repeatCount;
+  const auto nullCount = 2 * repeatCount;
+
+  for (const auto& testData : testSettings) {
+    for (const bool useVarintRowCount : {false, true}) {
+      SCOPED_TRACE(
+          fmt::format(
+              "testName={}, useVarintRowCount={}",
+              testData.testName,
+              useVarintRowCount));
+      const std::array<int32_t, 3> externalAlphabet{10, 20, 30};
+      auto resolver = testData.usesResolver
+          ? std::make_shared<TestDictionaryResolver>(
+                testData.dictionaryId, externalAlphabet, pool_.get())
+          : nullptr;
+      auto writer = createTestWriter(
+          pool_.get(),
+          writerOptions(
+              testData.scope,
+              testData.dictionaryId,
+              resolver,
+              /*alphabetEncodings=*/{},
+              /*useExternalAlphabet=*/false,
+              useVarintRowCount));
+      Buffer buffer{*pool_};
+      Vector<bool> nonNulls{pool_.get()};
+      nonNulls.resize(rowCount);
+      for (size_t i = 0; i < rowCount; ++i) {
+        nonNulls[i] = nonNullPattern[i % nonNullPattern.size()];
+      }
+      const StreamDataView stream{
+          descriptor_,
+          bytesOf(nonNullValues),
+          static_cast<uint32_t>(rowCount),
+          std::span<const bool>{nonNulls.data(), nonNulls.size()},
+          static_cast<uint32_t>(nullCount)};
+
+      const auto encoded = encodeValues(
+          writer,
+          /*stripeIndex=*/0,
+          stream,
+          buffer,
+          Encoding::Options{.useVarintRowCount = useVarintRowCount});
+
+      EXPECT_EQ(
+          nullableSharedDictionaryIndices(
+              encoded,
+              rowCount,
+              std::span<const bool>{nonNulls.data(), nonNulls.size()},
+              nonNullValues.size(),
+              pool_.get(),
+              useVarintRowCount),
+          expectedIndices);
+
+      if (testData.scope == SharedDictionaryScope::External) {
+        NIMBLE_ASSERT_THROW(
+            writer.encodeAlphabet(buffer),
+            "External shared dictionary 29 cannot encode an alphabet; its "
+            "resolver owns the alphabet.");
+      } else {
+        const auto alphabet = writer.encodeAlphabet(buffer);
+        ASSERT_TRUE(alphabet.has_value());
+        expectAlphabetEntries(
+            *alphabet, std::array<int32_t, 3>{10, 20, 30}, pool_.get());
+      }
+    }
+  }
 }
 
 TEST_F(SharedDictionaryWriterTest, fileScopeWithExternalAlphabet) {
@@ -995,7 +1346,10 @@ TEST_F(SharedDictionaryWriterTest, fileScopeWithExternalAlphabet) {
 
   const std::vector<int32_t> externalAlphabet{7, 11, 13, 17};
   auto resolver = std::make_shared<TestDictionaryResolver>(
-      /*dictionaryId=*/23, externalAlphabet, pool_.get());
+      /*dictionaryId=*/23,
+      externalAlphabet,
+      pool_.get(),
+      std::array{EncodingType::Trivial});
   auto writer = createTestWriter(
       pool_.get(),
       writerOptions(
@@ -1029,8 +1383,11 @@ TEST_F(SharedDictionaryWriterTest, fileScopeWithExternalAlphabet) {
 
   for (const auto& chunk : chunks) {
     SCOPED_TRACE(fmt::format("stripe={}", chunk.stripeIndex));
-    const auto encoded = writer.encodeValues(
-        chunk.stripeIndex, streamView(descriptor_, chunk.values), buffer);
+    const auto encoded = encodeValues(
+        writer,
+        chunk.stripeIndex,
+        streamView(descriptor_, chunk.values),
+        buffer);
 
     EXPECT_EQ(
         sharedDictionaryIndices(encoded, chunk.values.size(), pool_.get()),
@@ -1042,13 +1399,14 @@ TEST_F(SharedDictionaryWriterTest, fileScopeWithExternalAlphabet) {
   ASSERT_EQ(alphabet->content.size(), 1);
   EXPECT_EQ(
       EncodingPrefix::encodingType(alphabet->content.front()),
-      EncodingType::FixedBitWidth);
+      EncodingType::Trivial);
   expectAlphabetEntries(*alphabet, externalAlphabet, pool_.get());
   NIMBLE_ASSERT_THROW(
       writer.encodeAlphabet(buffer),
       "File shared dictionary 23 already finalized its alphabet.");
   NIMBLE_ASSERT_THROW(
-      writer.encodeValues(
+      encodeValues(
+          writer,
           /*stripeIndex=*/3,
           streamView(descriptor_, chunks.front().values),
           buffer),
@@ -1090,8 +1448,11 @@ TEST_F(SharedDictionaryWriterTest, externalAlphabetRejectsUnknownValue) {
     // error rather than a new dictionary entry.
     const std::vector<int32_t> values{10, 99};
     NIMBLE_ASSERT_USER_THROW(
-        writer.encodeValues(
-            /*stripeIndex=*/0, streamView(descriptor_, values), buffer),
+        encodeValues(
+            writer,
+            /*stripeIndex=*/0,
+            streamView(descriptor_, values),
+            buffer),
         fmt::format(
             "{} shared dictionary 29 does not contain value 99.",
             testData.scope));
@@ -1136,14 +1497,20 @@ TEST_F(SharedDictionaryWriterTest, externalScope) {
 
   for (const auto& chunk : chunks) {
     SCOPED_TRACE(fmt::format("stripe={}", chunk.stripeIndex));
-    const auto encoded = writer.encodeValues(
-        chunk.stripeIndex, streamView(descriptor_, chunk.values), buffer);
+    const auto encoded = encodeValues(
+        writer,
+        chunk.stripeIndex,
+        streamView(descriptor_, chunk.values),
+        buffer);
 
     EXPECT_EQ(
         sharedDictionaryIndices(encoded, chunk.values.size(), pool_.get()),
         chunk.expectedIndices);
   }
-  EXPECT_FALSE(writer.encodeAlphabet(buffer).has_value());
+  NIMBLE_ASSERT_THROW(
+      writer.encodeAlphabet(buffer),
+      "External shared dictionary 29 cannot encode an alphabet; its resolver "
+      "owns the alphabet.");
 }
 
 TEST_F(SharedDictionaryWriterTest, externalAlphabetRequiresResolver) {
@@ -1174,12 +1541,22 @@ TEST_F(SharedDictionaryWriterTest, externalAlphabetRequiresResolver) {
             testData.useExternalAlphabet));
     Buffer buffer{*pool_};
 
-    EXPECT_FALSE(writer.encodeAlphabet(buffer).has_value());
+    if (testData.scope == SharedDictionaryScope::External) {
+      NIMBLE_ASSERT_THROW(
+          writer.encodeAlphabet(buffer),
+          "External shared dictionary 29 cannot encode an alphabet; its "
+          "resolver owns the alphabet.");
+    } else {
+      EXPECT_FALSE(writer.encodeAlphabet(buffer).has_value());
+    }
 
     const std::vector<int32_t> values{10};
     NIMBLE_ASSERT_USER_THROW(
-        writer.encodeValues(
-            /*stripeIndex=*/0, streamView(descriptor_, values), buffer),
+        encodeValues(
+            writer,
+            /*stripeIndex=*/0,
+            streamView(descriptor_, values),
+            buffer),
         fmt::format(
             "{} shared dictionary 29 requires a dictionary resolver.",
             testData.scope));

--- a/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -15,9 +15,16 @@
  */
 #include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
+#include <array>
 #include <cmath>
+#include <limits>
 #include <optional>
+#include <random>
+#include <set>
+#include <span>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include "folly/FileUtil.h"
 #include "folly/Random.h"
@@ -37,11 +44,15 @@
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/dwio/nimble/common/tests/TestUtils.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
 #include "velox/dwio/nimble/velox/SchemaUtils.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
 #include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 #include "velox/type/CppToType.h"
 #include "velox/type/Type.h"
@@ -66,6 +77,12 @@ DEFINE_uint32(
     "If provided, this seed will be used when executing tests. "
     "Otherwise, a random seed will be used.");
 
+using nimble::test::makeSharedDictionaryInput;
+using nimble::test::SharedDictionarySource;
+using nimble::test::SharedDictionaryTestResolver;
+using nimble::test::sharedDictionaryValueUniverse;
+using nimble::test::sharedDictionaryWriterOptions;
+using nimble::test::writeWithRandomStripes;
 using nimble::testing::TrackingReadFile;
 
 namespace {
@@ -550,10 +567,14 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
   // Creates a TabletReader with cache options applied.
   std::shared_ptr<nimble::TabletReader> createTablet(
       std::shared_ptr<velox::ReadFile> readFile,
-      velox::memory::MemoryPool* pool) {
+      velox::memory::MemoryPool* pool,
+      std::shared_ptr<const nimble::ExternalDictionaryResolver>
+          externalDictionaryResolver = nullptr) {
     nimble::TabletReader::Options tabletOptions;
     tabletOptions.pinMetadata = pinMetadata();
     tabletOptions.cacheMetadata = enableCache();
+    tabletOptions.externalDictionaryResolver =
+        std::move(externalDictionaryResolver);
     ioReaderOptions_ = std::make_unique<velox::io::ReaderOptions>(pool);
     ioReaderOptions_->setDataIoStats(dataIoStats_);
     ioReaderOptions_->setMetadataIoStats(metadataIoStats_);
@@ -581,7 +602,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       nimble::VeloxReadParams params = {}) {
     params = configureWithTestParam(std::move(params));
     if (enableCache() || pinMetadata()) {
-      auto tablet = createTablet(readFile, &pool);
+      auto tablet =
+          createTablet(readFile, &pool, params.externalDictionaryResolver);
       return std::make_unique<nimble::VeloxReader>(
           std::move(tablet), pool, std::move(selector), std::move(params));
     }
@@ -606,7 +628,10 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
              std::function<void*(uint32_t)> stringBufferFactory)
           -> std::unique_ptr<nimble::Encoding> {
         return nimble::EncodingFactory().create(
-            pool, data, std::move(stringBufferFactory));
+            pool,
+            data,
+            std::move(stringBufferFactory),
+            nimble::Encoding::Options{});
       };
     } else {
       params.encodingFactory =
@@ -615,7 +640,10 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
              std::function<void*(uint32_t)> stringBufferFactory)
           -> std::unique_ptr<nimble::Encoding> {
         return nimble::legacy::EncodingFactory().create(
-            pool, data, std::move(stringBufferFactory));
+            pool,
+            data,
+            std::move(stringBufferFactory),
+            nimble::Encoding::Options{});
       };
     }
     return params;
@@ -631,6 +659,56 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       const velox::VectorPtr& actual,
       velox::vector_size_t index) {
     return expected->equalValueAt(actual.get(), index, index);
+  }
+
+  void validateSharedDictionaryRead(
+      const velox::RowVectorPtr& expected,
+      const std::string& file,
+      std::shared_ptr<const nimble::ExternalDictionaryResolver>
+          externalDictionaryResolver,
+      std::span<const uint32_t> readSizes) {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
+        std::dynamic_pointer_cast<const velox::RowType>(expected->type()));
+    nimble::VeloxReadParams readParams;
+    readParams.externalDictionaryResolver =
+        std::move(externalDictionaryResolver);
+    auto reader = createVeloxReader(readFile, *leafPool_, selector, readParams);
+
+    velox::VectorPtr result;
+    velox::vector_size_t rowOffset{0};
+    size_t readIndex{0};
+    while (rowOffset < expected->size()) {
+      const auto readSize = std::min<velox::vector_size_t>(
+          static_cast<velox::vector_size_t>(
+              readSizes[readIndex++ % readSizes.size()]),
+          expected->size() - rowOffset);
+      ASSERT_TRUE(reader->next(readSize, result));
+      ASSERT_LE(result->size(), readSize);
+      for (auto row = 0; row < result->size(); ++row) {
+        const auto expectedRow = rowOffset + row;
+        ASSERT_TRUE(expected->equalValueAt(result.get(), expectedRow, row))
+            << "Content mismatch at row " << expectedRow
+            << "\nReference: " << expected->toString(expectedRow)
+            << "\nResult: " << result->toString(row);
+      }
+      rowOffset += result->size();
+    }
+    ASSERT_FALSE(reader->next(1, result));
+
+    auto skipReader =
+        createVeloxReader(readFile, *leafPool_, selector, readParams);
+    const auto skipOffset = expected->size() / 3;
+    ASSERT_EQ(skipReader->skipRows(skipOffset), skipOffset);
+    ASSERT_TRUE(skipReader->next(/*rowCount=*/32, result));
+    ASSERT_EQ(result->size(), 32);
+    for (auto row = 0; row < result->size(); ++row) {
+      const auto expectedRow = skipOffset + row;
+      ASSERT_TRUE(expected->equalValueAt(result.get(), expectedRow, row))
+          << "Content mismatch after skip at row " << expectedRow
+          << "\nReference: " << expected->toString(expectedRow)
+          << "\nResult: " << result->toString(row);
+    }
   }
 
   void verifyReadersEqual(
@@ -1612,6 +1690,116 @@ INSTANTIATE_TEST_SUITE_P(
       }
       return "Unknown";
     });
+
+TEST_P(VeloxReaderTest, sharedDictionary) {
+  const auto valueUniverse = sharedDictionaryValueUniverse();
+  const std::array<nimble::SharedDictionaryScope, 3> scopes{
+      nimble::SharedDictionaryScope::Stripe,
+      nimble::SharedDictionaryScope::File,
+      nimble::SharedDictionaryScope::External};
+  const std::array<uint32_t, 3> readSizes{127, 64, 251};
+
+  for (const bool nullableData : {false, true}) {
+    for (const auto scope : scopes) {
+      SCOPED_TRACE(
+          fmt::format("scope={}, nullableData={}", scope, nullableData));
+      const uint32_t dictionaryId =
+          scope == nimble::SharedDictionaryScope::Stripe ? 0 : 17;
+      std::shared_ptr<const nimble::ExternalDictionaryResolver> resolver;
+      if (scope == nimble::SharedDictionaryScope::External) {
+        resolver = std::make_shared<SharedDictionaryTestResolver>(
+            std::vector<std::pair<uint32_t, std::vector<int32_t>>>{
+                {dictionaryId, valueUniverse}},
+            leafPool_.get());
+      }
+
+      const std::vector<SharedDictionarySource> sources{{
+          .columnName = "shared",
+          .dictionaryKey = 10,
+          .scope = scope,
+          .dictionaryId = dictionaryId,
+      }};
+      auto input = makeSharedDictionaryInput(
+          leafPool_.get(),
+          /*rowCount=*/2'000,
+          sources,
+          valueUniverse,
+          nullableData);
+      const auto file = writeWithRandomStripes(
+          rootPool_.get(),
+          input,
+          sharedDictionaryWriterOptions(
+              sources,
+              {.skipConstantFlatMapInMapStreams =
+                   skipConstantFlatMapInMapStreams(),
+               .externalDictionaryResolver = resolver}),
+          /*seed=*/0xB1170000u + dictionaryId + nullableData);
+
+      if (!FLAGS_output_test_file_path.empty()) {
+        folly::writeFile(file, FLAGS_output_test_file_path.c_str());
+      }
+
+      validateSharedDictionaryRead(input, file, resolver, readSizes);
+    }
+  }
+}
+
+TEST_P(VeloxReaderTest, sharedDictionaryRandomizedSourcesAndStripes) {
+  constexpr uint32_t kSeed{0xB117D1C7};
+  SCOPED_TRACE(fmt::format("seed={}", kSeed));
+
+  const auto valueUniverse = sharedDictionaryValueUniverse();
+  const std::vector<SharedDictionarySource> sources{
+      {
+          .columnName = "stripe",
+          .dictionaryKey = 10,
+          .scope = nimble::SharedDictionaryScope::Stripe,
+          .dictionaryId = 0,
+      },
+      {
+          .columnName = "file",
+          .dictionaryKey = 20,
+          .scope = nimble::SharedDictionaryScope::File,
+          .dictionaryId = 7,
+      },
+      {
+          .columnName = "external",
+          .dictionaryKey = 30,
+          .scope = nimble::SharedDictionaryScope::External,
+          .dictionaryId = 17,
+      },
+  };
+  auto resolver = std::make_shared<SharedDictionaryTestResolver>(
+      std::vector<std::pair<uint32_t, std::vector<int32_t>>>{
+          {sources.back().dictionaryId, valueUniverse}},
+      leafPool_.get());
+  auto input = makeSharedDictionaryInput(
+      leafPool_.get(),
+      /*rowCount=*/1'024,
+      sources,
+      valueUniverse,
+      /*nullableData=*/true);
+  const auto file = writeWithRandomStripes(
+      rootPool_.get(),
+      input,
+      sharedDictionaryWriterOptions(
+          sources,
+          {.skipConstantFlatMapInMapStreams = skipConstantFlatMapInMapStreams(),
+           .externalDictionaryResolver = resolver}),
+      kSeed);
+
+  {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+    tabletOptions.externalDictionaryResolver = resolver;
+    auto tablet =
+        nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
+    EXPECT_GT(tablet->stripeCount(), 1);
+  }
+
+  const std::array<uint32_t, 4> readSizes{89, 17, 233, 5};
+  validateSharedDictionaryRead(input, file, resolver, readSizes);
+}
 
 TEST_P(VeloxReaderTest, readComplexData) {
   auto type = velox::ROW({
@@ -4908,7 +5096,7 @@ class TestNimbleReaderFactory {
             vectors[0]->type())},
         pool_{&leafPool} {}
 
-  nimble::VeloxReader createReader(nimble::VeloxReadParams params = {}) {
+  nimble::VeloxReader createReader(const nimble::VeloxReadParams& params = {}) {
     auto selector =
         std::make_shared<velox::dwio::common::ColumnSelector>(type_);
     return nimble::VeloxReader(

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -17,8 +17,12 @@
 #include <folly/system/HardwareConcurrency.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <limits>
 #include <map>
+#include <optional>
 #include <set>
+#include <unordered_map>
 
 #include "velox/common/testutil/TestValue.h"
 
@@ -35,9 +39,10 @@
 #include "velox/dwio/nimble/encodings/PrefixEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingUtils.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
-#include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 #include "velox/dwio/nimble/index/ChunkStatsGroup.h"
 #include "velox/dwio/nimble/index/ClusterIndexConfig.h"
 #include "velox/dwio/nimble/index/KeyEncoding.h"
@@ -49,6 +54,7 @@
 #include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SchemaUtils.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
 #include "velox/dwio/nimble/velox/StatsGenerated.h"
 #include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/stats/VectorizedStatistics.h"
@@ -163,6 +169,69 @@ class WriterTest : public ::testing::Test {
       }
     }
     return chunkLayouts;
+  }
+
+  std::vector<nimble::EncodingLayout> captureFlatMapKeyChunkLayouts(
+      const std::shared_ptr<velox::InMemoryReadFile>& readFile,
+      int columnIndex,
+      std::string_view key,
+      uint32_t expectedStripeCount) {
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+    auto section =
+        tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+    NIMBLE_CHECK(section.has_value(), "Schema not found.");
+    auto schema =
+        nimble::SchemaDeserializer::deserialize(section->content().data());
+    const auto& flatMap = schema->asRow().childAt(columnIndex)->asFlatMap();
+    auto child = flatMap.findChild(key);
+    NIMBLE_CHECK(child.has_value());
+    auto offset =
+        flatMap.childAt(child.value())->asScalar().scalarDescriptor().offset();
+
+    EXPECT_EQ(tablet->stripeCount(), expectedStripeCount);
+    std::vector<nimble::EncodingLayout> chunkLayouts;
+    for (uint32_t stripe = 0; stripe < tablet->stripeCount(); ++stripe) {
+      auto streams = tablet->load(
+          tablet->stripeIdentifier(stripe), std::vector<uint32_t>{offset});
+      nimble::InMemoryChunkedStream chunkedStream{
+          *leafPool_, std::move(streams[0])};
+      while (chunkedStream.hasNext()) {
+        chunkLayouts.push_back(
+            nimble::EncodingLayoutCapture::capture(
+                chunkedStream.nextChunk(), nimble::Encoding::Options{}));
+      }
+    }
+    return chunkLayouts;
+  }
+
+  static std::unique_ptr<nimble::EncodingSelectionPolicyBase>
+  sharedDictionaryFeatureSelectionPolicy(nimble::DataType dataType) {
+    std::vector<std::pair<nimble::EncodingType, float>> readFactors;
+    switch (dataType) {
+      case nimble::DataType::Int32:
+        readFactors = {{nimble::EncodingType::Dictionary, 1.0}};
+        break;
+      case nimble::DataType::Uint32:
+        readFactors = {{nimble::EncodingType::FixedBitWidth, 1.0}};
+        break;
+      case nimble::DataType::Undefined:
+      case nimble::DataType::Int8:
+      case nimble::DataType::Uint8:
+      case nimble::DataType::Int16:
+      case nimble::DataType::Uint16:
+      case nimble::DataType::Int64:
+      case nimble::DataType::Uint64:
+      case nimble::DataType::Float:
+      case nimble::DataType::Double:
+      case nimble::DataType::Bool:
+      case nimble::DataType::String:
+        readFactors = {{nimble::EncodingType::Trivial, 1.0}};
+        break;
+    }
+    nimble::ManualEncodingSelectionPolicyFactory factory{
+        readFactors, /*compressionOptions=*/std::nullopt};
+    return factory.createPolicy(dataType);
   }
 
   // Structurally compares two captured EncodingLayouts, recursing into every
@@ -1375,6 +1444,186 @@ TEST_F(WriterTest, featureReorderingStreamCollocation) {
   }
 }
 
+TEST_F(WriterTest, featureReorderingSharedDictionaryStreamCollocation) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+
+  const std::vector<int64_t> reorderedKeys = {4, 2, 0};
+  constexpr int kNumRows = 1'000;
+
+  for (bool enableIndex : {false, true}) {
+    SCOPED_TRACE(fmt::format("enableIndex={}", enableIndex));
+
+    auto keyAt = [](auto, auto mapIndex) {
+      return static_cast<int64_t>(mapIndex);
+    };
+    // Keep each configured feature's value stream physically distinct so
+    // stream deduplication does not mask the layout being checked below.
+    auto valueAt = [](auto row, auto mapIndex) {
+      const auto cardinality = static_cast<int32_t>(mapIndex + 2);
+      return static_cast<int32_t>(mapIndex * 100 + (row + 1) % cardinality);
+    };
+    auto vector = enableIndex
+        ? vectorMaker.rowVector(
+              {"key", "flatmap"},
+              {vectorMaker.flatVector<int64_t>(
+                   kNumRows,
+                   [](auto row) { return static_cast<int64_t>(row); }),
+               vectorMaker.mapVector<int64_t, int32_t>(
+                   kNumRows,
+                   [](auto) { return 5; },
+                   keyAt,
+                   valueAt,
+                   [](auto) { return false; })})
+        : vectorMaker.rowVector(
+              {"flatmap"},
+              {vectorMaker.mapVector<int64_t, int32_t>(
+                  kNumRows,
+                  [](auto) { return 5; },
+                  keyAt,
+                  valueAt,
+                  [](auto) { return false; })});
+
+    const size_t flatmapOrdinal = enableIndex ? 1 : 0;
+
+    std::string file;
+    {
+      auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+      nimble::WriterOptions options;
+      options.flatMapColumns = {{"flatmap", {}}};
+      options.featureReordering =
+          std::vector<std::tuple<size_t, std::vector<int64_t>>>{
+              {flatmapOrdinal, reorderedKeys}};
+      options.encodingSelectionPolicyCreator = [](nimble::DataType dataType) {
+        return sharedDictionaryFeatureSelectionPolicy(dataType);
+      };
+      options.experimentalSharedDictionaryEncoding =
+          nimble::SharedDictionaryEncodingConfig::builder(
+              std::move(options.experimentalSharedDictionaryEncoding))
+              .addFlatmapValueDictionary(
+                  "flatmap",
+                  4,
+                  nimble::SharedDictionaryConfig{
+                      .scope = nimble::SharedDictionaryScope::Stripe})
+              .addFlatmapValueDictionary(
+                  "flatmap",
+                  2,
+                  nimble::SharedDictionaryConfig{
+                      .scope = nimble::SharedDictionaryScope::Stripe})
+              .addFlatmapValueDictionary(
+                  "flatmap",
+                  0,
+                  nimble::SharedDictionaryConfig{
+                      .scope = nimble::SharedDictionaryScope::Stripe})
+              .build();
+
+      if (enableIndex) {
+        options.clusterIndexConfig =
+            nimble::index::ClusterIndexConfigBuilder{}
+                .withKeyColumns({"key"})
+                .withSortOrders({nimble::SortOrder{.ascending = true}})
+                .withEnforceKeyOrder(true)
+                .build();
+      }
+
+      nimble::Writer writer(
+          vector->type(), std::move(writeFile), *rootPool_, std::move(options));
+      writer.write(vector);
+      writer.close();
+    }
+
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    {
+      nimble::VeloxReader reader(readFile.get(), *leafPool_);
+      velox::VectorPtr result;
+      ASSERT_TRUE(reader.next(kNumRows, result));
+      ASSERT_EQ(result->size(), vector->size());
+      for (velox::vector_size_t row = 0; row < vector->size(); ++row) {
+        EXPECT_TRUE(vector->equalValueAt(result.get(), row, row))
+            << "Content mismatch at row " << row;
+      }
+      ASSERT_FALSE(reader.next(1, result));
+    }
+
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+    ASSERT_GE(tablet->stripeCount(), 1);
+    if (enableIndex) {
+      ASSERT_NE(tablet->clusterIndex(), nullptr) << "Cluster index must exist";
+    }
+
+    const auto stripeId = tablet->stripeIdentifier(0);
+    const auto streamCount = tablet->streamCount(stripeId);
+    std::vector<uint32_t> offsets(streamCount);
+    std::vector<uint32_t> sizes(streamCount);
+    tablet->streamOffsets(stripeId, offsets);
+    tablet->streamSizes(stripeId, sizes);
+
+    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    const auto& flatMap =
+        reader.schema()->asRow().childAt(flatmapOrdinal)->asFlatMap();
+
+    std::unordered_map<std::string, uint32_t> keyToValueStreamId;
+    for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+      keyToValueStreamId[flatMap.nameAt(i)] =
+          flatMap.childAt(i)->asScalar().scalarDescriptor().offset();
+    }
+
+    struct FeatureStreamSpan {
+      std::string key;
+      uint32_t begin;
+      uint32_t end;
+    };
+
+    std::vector<FeatureStreamSpan> featureStreamSpans;
+    featureStreamSpans.reserve(reorderedKeys.size());
+    for (const auto reorderedKey : reorderedKeys) {
+      const auto key = folly::to<std::string>(reorderedKey);
+      const auto valueStreamId = keyToValueStreamId.at(key);
+      const auto dictionaryStreamId =
+          tablet->stripeDictionaryStreamId(valueStreamId);
+      ASSERT_TRUE(dictionaryStreamId.has_value())
+          << "Missing shared dictionary stream for key " << key;
+
+      ASSERT_LT(valueStreamId, offsets.size());
+      ASSERT_LT(dictionaryStreamId.value(), offsets.size());
+      EXPECT_GT(sizes[valueStreamId], 0);
+      EXPECT_GT(sizes[dictionaryStreamId.value()], 0);
+
+      auto streams =
+          tablet->load(stripeId, std::vector<uint32_t>{valueStreamId});
+      nimble::InMemoryChunkedStream chunkedStream{
+          *leafPool_, std::move(streams[0])};
+      ASSERT_TRUE(chunkedStream.hasNext());
+      EXPECT_EQ(
+          nimble::EncodingPrefix::encodingType(chunkedStream.nextChunk()),
+          nimble::EncodingType::SharedDictionary)
+          << "Key " << key << " value stream should use SharedDictionary";
+
+      const auto valueBegin = offsets[valueStreamId];
+      const auto valueEnd = valueBegin + sizes[valueStreamId];
+      const auto dictionaryBegin = offsets[dictionaryStreamId.value()];
+      const auto dictionaryEnd =
+          dictionaryBegin + sizes[dictionaryStreamId.value()];
+      EXPECT_TRUE(valueEnd == dictionaryBegin || dictionaryEnd == valueBegin)
+          << "Key " << key
+          << " dictionary stream should be adjacent to its value stream";
+
+      featureStreamSpans.push_back({
+          key,
+          std::min(valueBegin, dictionaryBegin),
+          std::max(valueEnd, dictionaryEnd),
+      });
+    }
+
+    for (size_t i = 1; i < featureStreamSpans.size(); ++i) {
+      EXPECT_EQ(featureStreamSpans[i - 1].end, featureStreamSpans[i].begin)
+          << "Key " << featureStreamSpans[i - 1].key << " and key "
+          << featureStreamSpans[i].key
+          << " value/dictionary streams should be adjacent on disk";
+    }
+  }
+}
+
 TEST_F(
     WriterTest,
     featureReorderingUsesInputOrdinalWithOmittedClusterIndexKey) {
@@ -2539,7 +2788,7 @@ TEST_F(WriterTest, combineMultipleLayersOfDictionaries) {
   nimble::VeloxReadParams params;
   params.readFlatMapFieldAsStruct = {"c0"};
   params.flatMapFeatureSelector["c0"].features = {"c0"};
-  nimble::VeloxReader reader(&readFile, *leafPool_, nullptr, std::move(params));
+  nimble::VeloxReader reader(&readFile, *leafPool_, nullptr, params);
   VectorPtr result;
   ASSERT_TRUE(reader.next(4, result));
   ASSERT_EQ(result->size(), 4);
@@ -5617,6 +5866,87 @@ DEBUG_ONLY_TEST_F(WriterTest, cachedEncodingLayoutSelectionCount) {
   }
 }
 
+DEBUG_ONLY_TEST_F(WriterTest, cachedEncodingLayoutSkipsSharedDictionary) {
+  velox::common::testutil::TestValue::enable();
+
+  constexpr int kChunkCount = 4;
+  constexpr int kRowsPerChunk = 512;
+  const auto type =
+      velox::ROW({{"c0", velox::MAP(velox::BIGINT(), velox::INTEGER())}});
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  std::vector<velox::RowVectorPtr> batches;
+  batches.reserve(kChunkCount);
+  for (int chunk = 0; chunk < kChunkCount; ++chunk) {
+    batches.push_back(vectorMaker.rowVector(
+        {"c0"},
+        {vectorMaker.mapVector<int64_t, int32_t>(
+            kRowsPerChunk,
+            [](auto /*row*/) { return 1; },
+            [](auto /*idx*/) { return 10; },
+            [chunk](auto row) {
+              return static_cast<int32_t>((row + chunk) % 4);
+            })}));
+  }
+
+  int fullSelectionCount = 0;
+  int replayCount = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::encode",
+      std::function<void(const bool*)>([&](const bool* hasEncodingLayout) {
+        if (*hasEncodingLayout) {
+          ++replayCount;
+        } else {
+          ++fullSelectionCount;
+        }
+      }));
+
+  nimble::WriterOptions options;
+  options.enableEncodingSelectionCache = true;
+  options.enableChunking = true;
+  options.minStreamChunkRawSize = 0;
+  options.flushPolicyFactory = [] {
+    return std::make_unique<nimble::LambdaFlushPolicy>(
+        /*flushLambda=*/[](auto&) { return false; },
+        /*chunkLambda=*/[](auto&) { return true; });
+  };
+  options.flatMapColumns.emplace("c0", std::set<std::string>{});
+  options.experimentalSharedDictionaryEncoding =
+      nimble::SharedDictionaryEncodingConfig::builder()
+          .addFlatmapValueDictionary(
+              "c0",
+              /*key=*/10,
+              nimble::SharedDictionaryConfig{
+                  .scope = nimble::SharedDictionaryScope::File,
+                  .dictionaryId = 17})
+          .build();
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::Writer writer{
+      type, std::move(writeFile), *rootPool_, std::move(options)};
+  for (const auto& batch : batches) {
+    writer.write(batch);
+  }
+  writer.close();
+
+  // The shared-dictionary value stream still runs fresh selection for every
+  // chunk. The flat-map in-map bool stream is not dictionary-configured, so it
+  // captures once and replays for the remaining chunks.
+  EXPECT_EQ(fullSelectionCount, kChunkCount + 1);
+  EXPECT_EQ(replayCount, kChunkCount - 1);
+
+  auto layouts = captureFlatMapKeyChunkLayouts(
+      std::make_shared<velox::InMemoryReadFile>(file),
+      /*columnIndex=*/0,
+      /*key=*/"10",
+      /*expectedStripeCount=*/1);
+  ASSERT_EQ(layouts.size(), static_cast<size_t>(kChunkCount));
+  for (const auto& layout : layouts) {
+    EXPECT_EQ(layout.encodingType(), nimble::EncodingType::SharedDictionary);
+  }
+}
+
 // Parameterized test fixture for index tests.
 // When enableChunking is false, sets very high minChunkRawSize and
 // maxChunkRawSize to prevent chunking (one chunk per stream).
@@ -5889,12 +6219,15 @@ class WriterIndexTest : public WriterTest,
             const auto chunkData = chunkedStream.nextChunk();
             std::vector<velox::BufferPtr> stringBuffers;
             auto encoding = nimble::EncodingFactory().create(
-                *leafPool_, chunkData, [&](uint32_t totalLength) {
+                *leafPool_,
+                chunkData,
+                [&](uint32_t totalLength) {
                   auto& buffer = stringBuffers.emplace_back(
                       velox::AlignedBuffer::allocate<char>(
                           totalLength, leafPool_.get()));
                   return buffer->asMutable<void>();
-                });
+                },
+                nimble::Encoding::Options{});
             EXPECT_EQ(encoding->rowCount(), expectedChunkRowCounts[chunkIndex])
                 << "Stripe " << stripeIdx << " stream " << streamId << " chunk "
                 << chunkIndex << " row count mismatch (sequential)";
@@ -5932,12 +6265,15 @@ class WriterIndexTest : public WriterTest,
           auto encodingData = chunkDecoder.decode();
           std::vector<velox::BufferPtr> stringBuffers;
           auto encoding = nimble::EncodingFactory().create(
-              *leafPool_, encodingData, [&](uint32_t totalLength) {
+              *leafPool_,
+              encodingData,
+              [&](uint32_t totalLength) {
                 auto& buffer = stringBuffers.emplace_back(
                     velox::AlignedBuffer::allocate<char>(
                         totalLength, leafPool_.get()));
                 return buffer->asMutable<void>();
-              });
+              },
+              nimble::Encoding::Options{});
 
           EXPECT_EQ(encoding->rowCount(), expectedChunkRowCounts[i])
               << "Stripe " << stripeIdx << " stream " << streamId << " chunk "
@@ -7208,12 +7544,15 @@ TEST_F(WriterTest, customPrefixRestartInterval) {
     // Decode the key encoding
     std::vector<velox::BufferPtr> stringBuffers;
     auto keyEncoding = nimble::EncodingFactory().create(
-        *leafPool_, encodingData, [&](uint32_t totalLength) {
+        *leafPool_,
+        encodingData,
+        [&](uint32_t totalLength) {
           auto& buf = stringBuffers.emplace_back(
               velox::AlignedBuffer::allocate<char>(
                   totalLength, leafPool_.get()));
           return buf->asMutable<void>();
-        });
+        },
+        nimble::Encoding::Options{});
 
     // Verify the restart interval through debugString()
     const std::string debug = keyEncoding->debugString(0);
@@ -7391,7 +7730,10 @@ nimble::VeloxReadParams nonLegacyReadParams() {
          std::function<void*(uint32_t)> stringBufferFactory)
       -> std::unique_ptr<nimble::Encoding> {
     return nimble::EncodingFactory().create(
-        pool, data, std::move(stringBufferFactory));
+        pool,
+        data,
+        std::move(stringBufferFactory),
+        nimble::Encoding::Options{});
   };
   return params;
 }

--- a/velox/dwio/nimble/writer/CMakeLists.txt
+++ b/velox/dwio/nimble/writer/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   nimble_velox_field_writer
   nimble_velox_layout_planner
   nimble_velox_metadata_fb
+  nimble_velox_shared_dictionary_config
   nimble_velox_schema_serialization
   nimble_velox_stats_fb
   raw_size_utils
@@ -54,5 +55,6 @@ target_link_libraries(
   velox_dwio_common
   velox_exec
   velox_key_encoder
+  velox_type
   Folly::folly
 )

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -18,12 +18,17 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <span>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "folly/container/F14Map.h"
 #include "velox/common/base/Counters.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/common/memory/MemoryArbitrator.h"
@@ -33,6 +38,8 @@
 #include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/index/ClusterIndexConfig.h"
 #include "velox/dwio/nimble/index/ClusterIndexFactory.h"
@@ -52,11 +59,14 @@
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SchemaTypes.h"
+
+#include "velox/dwio/nimble/velox/SharedDictionaryWriter.h"
 #include "velox/dwio/nimble/velox/StatsGenerated.h"
 #include "velox/dwio/nimble/velox/stats/VectorizedStatistics.h"
 #include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
 #include "velox/dwio/nimble/writer/FlushPolicy.h"
 #include "velox/dwio/nimble/writer/StreamChunker.h"
+#include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
 
 namespace facebook::nimble {
@@ -70,6 +80,7 @@ class WriterContext : public FieldWriterContext {
   WriterContext(velox::memory::MemoryPool& memoryPool, WriterOptions options)
       : FieldWriterContext{memoryPool, options.reclaimerFactory(), options.vectorDecoderVisitor},
         options_{std::move(options)},
+        hasStripeDictionaryConfig_{hasStripeDictionaryConfig(options_)},
         logger_{
             this->options_.metricsLogger == nullptr
                 ? std::make_shared<MetricsLogger>()
@@ -90,6 +101,10 @@ class WriterContext : public FieldWriterContext {
 
   const WriterOptions& options() const {
     return options_;
+  }
+
+  bool hasStripeDictionaryConfig() const {
+    return hasStripeDictionaryConfig_;
   }
 
   velox::CpuWallTiming& encodingTiming() {
@@ -214,7 +229,26 @@ class WriterContext : public FieldWriterContext {
   }
 
  private:
+  static bool hasStripeDictionaryConfig(const WriterOptions& options) {
+    for (const auto& columnDictionary :
+         options.experimentalSharedDictionaryEncoding.columns) {
+      if (columnDictionary.dictionary.scope == SharedDictionaryScope::Stripe) {
+        return true;
+      }
+    }
+    for (const auto& flatMap :
+         options.experimentalSharedDictionaryEncoding.flatMaps) {
+      for (const auto& flatMapKey : flatMap.keys) {
+        if (flatMapKey.dictionary.scope == SharedDictionaryScope::Stripe) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   const WriterOptions options_;
+  const bool hasStripeDictionaryConfig_;
   velox::CpuWallTiming encodingTiming_;
   velox::CpuWallTiming writeTiming_;
   velox::CpuWallTiming ingestionTiming_;
@@ -442,14 +476,15 @@ WriterOptions storedWriterOptions(
         *options.encodingLayoutTree, storedInputColumnIndices));
   }
 
-  if (!options.featureReordering.has_value()) {
+  const bool hasFeatureReordering = options.featureReordering.has_value();
+  if (!hasFeatureReordering) {
     return options;
   }
 
   // Field writers and the layout planner are built from storedDataType().
   // When key columns are omitted, stored column ordinals can differ from input
-  // ordinals, so feature reordering must be translated to stored ordinals
-  // before it reaches the layout planner.
+  // ordinals, so ordinal-based feature reordering configs must be translated to
+  // stored ordinals before they reach the writer internals.
   folly::F14FastMap<velox::column_index_t, size_t> storedIndexByInputIndex;
   storedIndexByInputIndex.reserve(storedInputColumnIndices.size());
   for (auto storedIndex = 0; storedIndex < storedInputColumnIndices.size();
@@ -572,6 +607,10 @@ class WriterStreamContext : public StreamContext {
     isInMapStream_ = value;
   }
 
+  void setFlatMapValueStreamOffsets(std::vector<offset_size> offsets) {
+    flatMapValueStreamOffsets_ = std::move(offsets);
+  }
+
   // The layout to replay for this stream: overlaid from the EncodingLayoutTree
   // at setup, or captured from this stream's first encode when
   // encoding-selection caching is enabled. Empty until one of those populates
@@ -584,24 +623,400 @@ class WriterStreamContext : public StreamContext {
     encoding_.emplace(std::move(value));
   }
 
+  // Stores the shared dictionary configuration selected for this value stream.
+  void setSharedDictionaryConfig(const SharedDictionaryConfig& config) {
+    sharedDictionaryConfig_ = config;
+  }
+
+  // Returns the shared dictionary configuration, if this stream is configured
+  // to use one.
+  const std::optional<SharedDictionaryConfig>& sharedDictionaryConfig() const {
+    return sharedDictionaryConfig_;
+  }
+
+  SharedDictionaryWriter* sharedDictionaryWriter() const {
+    return sharedDictionaryWriter_.get();
+  }
+
+  void setSharedDictionaryWriter(
+      std::unique_ptr<SharedDictionaryWriter> writer) const {
+    NIMBLE_CHECK_NULL(
+        sharedDictionaryWriter_, "Shared dictionary writer already exists.");
+    sharedDictionaryWriter_ = std::move(writer);
+  }
+
  private:
   bool isNullStream_{false};
   bool isInMapStream_{false};
+  // Value stream descriptor offsets for this in-map stream's flat-map field.
+  // Empty for non in-map streams and flat-map values with no reader-visible
+  // value stream.
+  std::vector<offset_size> flatMapValueStreamOffsets_;
   std::optional<EncodingLayout> encoding_;
+  std::optional<SharedDictionaryConfig> sharedDictionaryConfig_;
+  mutable std::unique_ptr<SharedDictionaryWriter> sharedDictionaryWriter_;
 };
 
+// Context attached to one FlatMap TypeBuilder node. It carries the per-key
+// encoding layouts and value dictionary configs that are applied later when the
+// writer materializes children for specific flat-map keys.
 class FlatmapEncodingLayoutContext : public TypeBuilderContext {
  public:
-  explicit FlatmapEncodingLayoutContext(
-      folly::F14FastMap<std::string_view, const EncodingLayoutTree&>
-          keyEncodings)
-      : keyEncodings{std::move(keyEncodings)} {}
+  using KeyEncodingMap =
+      folly::F14FastMap<std::string_view, const EncodingLayoutTree*>;
 
-  const folly::F14FastMap<std::string_view, const EncodingLayoutTree&>
-      keyEncodings;
+  struct ValueDictionaryConfig {
+    // Relative subfield below the materialized flat-map key value. Empty
+    // selects the key value itself.
+    std::string valueSubfield;
+    SharedDictionaryConfig dictionary;
+  };
+
+  // Keyed by the materialized flat-map key name, e.g. "10" or "feature_a".
+  using ValueDictionaryMap =
+      folly::F14FastMap<std::string, std::vector<ValueDictionaryConfig>>;
+
+  explicit FlatmapEncodingLayoutContext(
+      KeyEncodingMap keyEncodings = {},
+      ValueDictionaryMap valueDictionaries = {})
+      : keyEncodings{std::move(keyEncodings)},
+        valueDictionaries{std::move(valueDictionaries)} {}
+
+  const KeyEncodingMap keyEncodings;
+  const ValueDictionaryMap valueDictionaries;
 };
 
 WriterStreamContext& streamContext(const StreamDescriptorBuilder& descriptor);
+
+Encoding::Options makeEncodingOptions(
+    const WriterOptions& writerOptions,
+    velox::BufferPool* encodingScratchBufferPool,
+    EncodingBufferPool* encodingBufferPool) {
+  // WriterOptions carries file-format and selection settings; the scratch
+  // pools are per encode call and must be threaded into nested encoders.
+  auto encodingOptions = writerOptions.buildEncodingOptions();
+  encodingOptions.bufferPool = encodingScratchBufferPool;
+  encodingOptions.encodingBufferPool = encodingBufferPool;
+  return encodingOptions;
+}
+
+bool hasDictionaryConfig(const StreamData& streamData) {
+  const auto* streamContext =
+      streamData.descriptor().context<WriterStreamContext>();
+  return streamContext != nullptr &&
+      streamContext->sharedDictionaryConfig().has_value();
+}
+
+bool isSharedDictionaryValueType(DataType dataType) {
+  switch (dataType) {
+    case DataType::Int8:
+    case DataType::Uint8:
+    case DataType::Int16:
+    case DataType::Uint16:
+    case DataType::Int32:
+    case DataType::Uint32:
+    case DataType::Int64:
+    case DataType::Uint64:
+      return true;
+    case DataType::Undefined:
+    case DataType::Float:
+    case DataType::Double:
+    case DataType::Bool:
+    case DataType::String:
+      return false;
+  }
+  NIMBLE_UNREACHABLE("Unsupported data type {}.", dataType);
+}
+
+template <typename T>
+// NOLINTNEXTLINE(facebook-hte-NullableReturn)
+TypedSharedDictionaryWriter<T>* sharedDictionaryWriter(
+    const StreamData& streamData,
+    detail::WriterContext& context,
+    Buffer& buffer,
+    velox::BufferPool* encodingScratchBufferPool,
+    EncodingBufferPool* encodingBufferPool) {
+  auto* streamContext = streamData.descriptor().context<WriterStreamContext>();
+  if (streamContext == nullptr) {
+    return nullptr;
+  }
+
+  // Chunked writes revisit the same value stream, so the writer is cached in
+  // the stream context. The type check guards against reusing that state with
+  // a different physical value type.
+  if (auto* dictionaryWriter = streamContext->sharedDictionaryWriter()) {
+    NIMBLE_CHECK_EQ(
+        dictionaryWriter->dataType(),
+        TypeTraits<T>::dataType,
+        "Shared dictionary writer has unexpected value type.");
+    return velox::checkedPointerCast<TypedSharedDictionaryWriter<T>>(
+        dictionaryWriter);
+  }
+
+  const auto& config = streamContext->sharedDictionaryConfig();
+  if (!config.has_value()) {
+    return nullptr;
+  }
+  const auto& writerOptions = context.options();
+  auto encodingOptions = makeEncodingOptions(
+      writerOptions, encodingScratchBufferPool, encodingBufferPool);
+  SharedDictionaryWriter::Options dictionaryOptions{
+      .scope = config->scope,
+      .dictionaryId = config->dictionaryId,
+      .useExternalAlphabet = config->useExternalAlphabet,
+      .alphabetEncodings = config->alphabetEncodings,
+      .encodingSelectionPolicyCreator =
+          writerOptions.encodingSelectionPolicyCreator,
+      .encodingOptions = std::move(encodingOptions),
+      .resolver =
+          writerOptions.experimentalSharedDictionaryEncoding.externalResolver,
+  };
+  auto writer = std::make_unique<TypedSharedDictionaryWriter<T>>(
+      &buffer.getMemoryPool(), dictionaryOptions);
+  auto* writerPtr = writer.get();
+  streamContext->setSharedDictionaryWriter(std::move(writer));
+  return writerPtr;
+}
+
+template <typename T>
+std::unique_ptr<EncodingSelectionPolicy<T>> makeEncodingPolicy(
+    bool hasEncodingLayout,
+    std::optional<EncodingLayout> encodingLayout,
+    detail::WriterContext& context,
+    Buffer& buffer,
+    velox::BufferPool* encodingScratchBufferPool,
+    EncodingBufferPool* encodingBufferPool,
+    const StreamData& streamData) {
+  if (hasDictionaryConfig(streamData)) {
+    NIMBLE_USER_CHECK(
+        isSharedDictionaryValueType(TypeTraits<T>::dataType),
+        "Shared dictionary encoding only supports non-bool integer streams, "
+        "got {}.",
+        TypeTraits<T>::dataType);
+    if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+      auto* dictionaryWriter = sharedDictionaryWriter<T>(
+          streamData,
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool);
+      NIMBLE_CHECK_NOT_NULL(dictionaryWriter);
+      return dictionaryWriter->createEncodingPolicy(context.getStripeIndex());
+    } else {
+      NIMBLE_UNREACHABLE(
+          "Shared dictionary type validation accepted unsupported {}.",
+          TypeTraits<T>::dataType);
+    }
+  }
+  if (hasEncodingLayout) {
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(encodingLayout.value()),
+        context.options().compressionOptions,
+        context.options().encodingSelectionPolicyCreator);
+  }
+  return std::unique_ptr<EncodingSelectionPolicy<T>>(
+      static_cast<EncodingSelectionPolicy<T>*>(
+          context.options()
+              .encodingSelectionPolicyCreator(TypeTraits<T>::dataType)
+              .release()));
+}
+
+void configureDictionary(
+    const TypeBuilder& typeBuilder,
+    SharedDictionaryConfig config,
+    SchemaBuilder& schemaBuilder) {
+  switch (typeBuilder.kind()) {
+    case Kind::Scalar: {
+      const auto& scalar = typeBuilder.asScalar();
+      NIMBLE_USER_CHECK(
+          isIntegerScalarKind(scalar.scalarDescriptor().scalarKind()),
+          "Shared dictionary value must be an integer scalar, got {}.",
+          scalar.scalarDescriptor().scalarKind());
+      if (config.scope == SharedDictionaryScope::Stripe) {
+        NIMBLE_USER_CHECK_EQ(
+            config.dictionaryId,
+            0,
+            "Stripe shared dictionary config must leave dictionaryId unset.");
+        config.dictionaryId = schemaBuilder.createSharedDictionaryStream(
+            scalar.scalarDescriptor().offset());
+      }
+      streamContext(scalar.scalarDescriptor())
+          .setSharedDictionaryConfig(config);
+      return;
+    }
+    case Kind::Array:
+      configureDictionary(
+          typeBuilder.asArray().elements(), std::move(config), schemaBuilder);
+      return;
+    case Kind::ArrayWithOffsets:
+      configureDictionary(
+          typeBuilder.asArrayWithOffsets().elements(),
+          std::move(config),
+          schemaBuilder);
+      return;
+    case Kind::Map:
+      configureDictionary(
+          typeBuilder.asMap().values(), std::move(config), schemaBuilder);
+      return;
+    case Kind::SlidingWindowMap:
+      configureDictionary(
+          typeBuilder.asSlidingWindowMap().values(),
+          std::move(config),
+          schemaBuilder);
+      return;
+    case Kind::TimestampMicroNano:
+    case Kind::Row:
+    case Kind::FlatMap:
+      NIMBLE_USER_FAIL(
+          "Shared dictionary value must resolve to an integer scalar, array "
+          "element, or map value, got {}.",
+          typeBuilder.kind());
+  }
+}
+
+// Resolves [*] to the selected array element or map value type.
+const TypeBuilder& allSubscriptValueType(
+    const TypeBuilder& typeBuilder,
+    std::string_view subfield) {
+  switch (typeBuilder.kind()) {
+    case Kind::Array:
+      return typeBuilder.asArray().elements();
+    case Kind::ArrayWithOffsets:
+      return typeBuilder.asArrayWithOffsets().elements();
+    case Kind::Map:
+      return typeBuilder.asMap().values();
+    case Kind::SlidingWindowMap:
+      return typeBuilder.asSlidingWindowMap().values();
+    case Kind::Scalar:
+    case Kind::TimestampMicroNano:
+    case Kind::Row:
+    case Kind::FlatMap:
+      NIMBLE_USER_FAIL(
+          "Shared dictionary value subfield '{}' cannot apply [*] to {}.",
+          subfield,
+          typeBuilder.kind());
+  }
+  NIMBLE_UNREACHABLE("Unknown schema kind: {}.", typeBuilder.kind());
+}
+
+const TypeBuilder& resolveFieldPath(
+    const TypeBuilder& root,
+    const std::string& fieldPath) {
+  if (fieldPath.empty()) {
+    return root;
+  }
+  const velox::common::Subfield subfield{fieldPath};
+  const auto& path = subfield.path();
+  const TypeBuilder* current = &root;
+  for (const auto& pathElement : path) {
+    if (pathElement->is(velox::common::SubfieldKind::kAllSubscripts)) {
+      current = &allSubscriptValueType(*current, fieldPath);
+      continue;
+    }
+    const auto& childName =
+        pathElement->asChecked<velox::common::Subfield::NestedField>()->name();
+    current = &current->asRow().findChild(childName);
+  }
+  return *current;
+}
+
+void maybeAddFileDictionaryId(
+    const SharedDictionaryConfig& config,
+    folly::F14FastSet<uint32_t>& fileDictionaryIds) {
+  if (config.scope != SharedDictionaryScope::File) {
+    return;
+  }
+  const bool inserted = fileDictionaryIds.insert(config.dictionaryId).second;
+  NIMBLE_USER_CHECK(
+      inserted,
+      "File shared dictionary ID {} is configured for multiple streams. "
+      "Cross-stream domains are not supported yet.",
+      config.dictionaryId);
+}
+
+// Resolves [*] to the selected array element or map value type.
+const TypeWithId& allSubscriptValueType(
+    const TypeWithId& type,
+    const std::string& fieldPath) {
+  switch (type.type()->kind()) {
+    case velox::TypeKind::ARRAY:
+      return *type.childAt(0);
+    case velox::TypeKind::MAP:
+      return *type.childAt(1);
+    case velox::TypeKind::BOOLEAN:
+    case velox::TypeKind::TINYINT:
+    case velox::TypeKind::SMALLINT:
+    case velox::TypeKind::INTEGER:
+    case velox::TypeKind::BIGINT:
+    case velox::TypeKind::REAL:
+    case velox::TypeKind::DOUBLE:
+    case velox::TypeKind::VARCHAR:
+    case velox::TypeKind::VARBINARY:
+    case velox::TypeKind::TIMESTAMP:
+    case velox::TypeKind::HUGEINT:
+    case velox::TypeKind::ROW:
+    case velox::TypeKind::UNKNOWN:
+    case velox::TypeKind::FUNCTION:
+    case velox::TypeKind::OPAQUE:
+    case velox::TypeKind::INVALID:
+      NIMBLE_USER_FAIL(
+          "Shared dictionary path '{}' cannot apply [*] to {}.",
+          fieldPath,
+          type.type()->toString());
+  }
+  VELOX_UNREACHABLE();
+}
+
+const TypeWithId& resolveFieldPath(
+    const TypeWithId& root,
+    const std::string& fieldPath) {
+  const velox::common::Subfield subfield{fieldPath};
+  const TypeWithId* current = &root;
+  for (const auto& pathElement : subfield.path()) {
+    if (pathElement->is(velox::common::SubfieldKind::kAllSubscripts)) {
+      current = &allSubscriptValueType(*current, fieldPath);
+      continue;
+    }
+    const auto& childName =
+        pathElement->asChecked<velox::common::Subfield::NestedField>()->name();
+    current = current->childByName(childName).get();
+  }
+  return *current;
+}
+
+const TypeWithId& resolveDictionaryValueType(
+    const TypeWithId& type,
+    const std::string& fieldPath) {
+  switch (type.type()->kind()) {
+    case velox::TypeKind::ARRAY:
+      return resolveDictionaryValueType(*type.childAt(0), fieldPath);
+    case velox::TypeKind::MAP:
+      return resolveDictionaryValueType(*type.childAt(1), fieldPath);
+    case velox::TypeKind::TINYINT:
+    case velox::TypeKind::SMALLINT:
+    case velox::TypeKind::INTEGER:
+    case velox::TypeKind::BIGINT:
+      return type;
+    case velox::TypeKind::BOOLEAN:
+    case velox::TypeKind::REAL:
+    case velox::TypeKind::DOUBLE:
+    case velox::TypeKind::VARCHAR:
+    case velox::TypeKind::VARBINARY:
+    case velox::TypeKind::TIMESTAMP:
+    case velox::TypeKind::HUGEINT:
+    case velox::TypeKind::ROW:
+    case velox::TypeKind::UNKNOWN:
+    case velox::TypeKind::FUNCTION:
+    case velox::TypeKind::OPAQUE:
+    case velox::TypeKind::INVALID:
+      NIMBLE_USER_FAIL(
+          "Shared dictionary column '{}' must resolve to an integer scalar, "
+          "array element, or map value, got {}.",
+          fieldPath,
+          type.type()->toString());
+  }
+  VELOX_UNREACHABLE();
+}
 
 template <typename T>
 std::string_view encode(
@@ -629,24 +1044,17 @@ std::string_view encode(
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::encode", const_cast<bool*>(&hasEncodingLayout));
 
-  std::unique_ptr<EncodingSelectionPolicy<T>> policy;
-  if (hasEncodingLayout) {
-    policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
-        std::move(encodingLayout.value()),
-        context.options().compressionOptions,
-        context.options().encodingSelectionPolicyCreator);
+  auto policy = makeEncodingPolicy<T>(
+      hasEncodingLayout,
+      std::move(encodingLayout),
+      context,
+      buffer,
+      encodingScratchBufferPool,
+      encodingBufferPool,
+      streamData);
 
-  } else {
-    policy = std::unique_ptr<EncodingSelectionPolicy<T>>(
-        static_cast<EncodingSelectionPolicy<T>*>(
-            context.options()
-                .encodingSelectionPolicyCreator(TypeTraits<T>::dataType)
-                .release()));
-  }
-
-  auto encodingOptions = context.options().buildEncodingOptions();
-  encodingOptions.bufferPool = encodingScratchBufferPool;
-  encodingOptions.encodingBufferPool = encodingBufferPool;
+  auto encodingOptions = makeEncodingOptions(
+      context.options(), encodingScratchBufferPool, encodingBufferPool);
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::Writer::encode", &encodingOptions);
 
@@ -687,8 +1095,8 @@ std::string_view encodeWithFallback(
         streamData);
   } catch (const std::exception&) {
     // A saved layout can fail to apply to this chunk's data in ways beyond a
-    // clean IncompatibleEncoding, so retry on any error rather than keying off
-    // a specific (unreliable) error code.
+    // clean IncompatibleEncoding, so retry on any error rather than keying
+    // off a specific (unreliable) error code.
     return encode<T>(
         std::nullopt,
         context,
@@ -708,12 +1116,14 @@ std::string_view encodeStreamTyped(
     const StreamData& streamData) {
   const auto* writerStreamContext =
       streamData.descriptor().context<WriterStreamContext>();
+  const bool hasDictionary = hasDictionaryConfig(streamData);
 
   // Replay an externally provided (EncodingLayoutTree) or previously captured
   // layout, falling back to a fresh selection if it no longer fits the data.
   // TODO: Replace the exception-based best-effort replay in encodeWithFallback
   // with a non-throwing compatibility check before the replay attempt.
-  if (writerStreamContext && writerStreamContext->encoding()) {
+  if (!hasDictionary && writerStreamContext &&
+      writerStreamContext->encoding()) {
     return encodeWithFallback<T>(
         writerStreamContext->encoding(),
         context,
@@ -737,7 +1147,7 @@ std::string_view encodeStreamTyped(
   // already strips any Nullable/Sentinel wrapper, so the cached layout is the
   // data encoding alone — Nimble re-applies per-chunk nullability at encode
   // time, so it stays valid regardless of a later chunk's nulls.
-  if (context.options().enableEncodingSelectionCache) {
+  if (!hasDictionary && context.options().enableEncodingSelectionCache) {
     streamContext(streamData.descriptor())
         .setEncoding(
             EncodingLayoutCapture::capture(
@@ -845,6 +1255,210 @@ void findNodeIds(
   }
 }
 
+void collectFlatMapValueStreamOffsets(
+    const TypeBuilder& type,
+    std::vector<offset_size>& offsets) {
+  switch (type.kind()) {
+    case Kind::Scalar:
+      offsets.push_back(type.asScalar().scalarDescriptor().offset());
+      return;
+    case Kind::TimestampMicroNano:
+      offsets.push_back(
+          type.asTimestampMicroNano().microsDescriptor().offset());
+      offsets.push_back(type.asTimestampMicroNano().nanosDescriptor().offset());
+      return;
+    case Kind::Array:
+      offsets.push_back(type.asArray().lengthsDescriptor().offset());
+      collectFlatMapValueStreamOffsets(type.asArray().elements(), offsets);
+      return;
+    case Kind::ArrayWithOffsets:
+      offsets.push_back(type.asArrayWithOffsets().offsetsDescriptor().offset());
+      offsets.push_back(type.asArrayWithOffsets().lengthsDescriptor().offset());
+      collectFlatMapValueStreamOffsets(
+          type.asArrayWithOffsets().elements(), offsets);
+      return;
+    case Kind::Map:
+      offsets.push_back(type.asMap().lengthsDescriptor().offset());
+      collectFlatMapValueStreamOffsets(type.asMap().keys(), offsets);
+      collectFlatMapValueStreamOffsets(type.asMap().values(), offsets);
+      return;
+    case Kind::SlidingWindowMap:
+      offsets.push_back(type.asSlidingWindowMap().offsetsDescriptor().offset());
+      offsets.push_back(type.asSlidingWindowMap().lengthsDescriptor().offset());
+      collectFlatMapValueStreamOffsets(
+          type.asSlidingWindowMap().keys(), offsets);
+      collectFlatMapValueStreamOffsets(
+          type.asSlidingWindowMap().values(), offsets);
+      return;
+    case Kind::Row: {
+      const auto& row = type.asRow();
+      offsets.push_back(row.nullsDescriptor().offset());
+      for (size_t i = 0; i < row.childrenCount(); ++i) {
+        collectFlatMapValueStreamOffsets(row.childAt(i), offsets);
+      }
+      return;
+    }
+    case Kind::FlatMap: {
+      const auto& flatMap = type.asFlatMap();
+      offsets.push_back(flatMap.nullsDescriptor().offset());
+      for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+        offsets.push_back(flatMap.inMapDescriptorAt(i).offset());
+        collectFlatMapValueStreamOffsets(flatMap.childAt(i), offsets);
+      }
+      return;
+    }
+    default:
+      NIMBLE_UNREACHABLE("Unsupported type kind {}", type.kind());
+  }
+}
+
+FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodingsForFlatMap(
+    const EncodingLayoutTree& encodingLayoutTree) {
+  FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodings;
+  keyEncodings.reserve(encodingLayoutTree.childrenCount());
+  for (auto i = 0; i < encodingLayoutTree.childrenCount(); ++i) {
+    const auto& child = encodingLayoutTree.child(i);
+    keyEncodings.emplace(child.name(), &child);
+  }
+  return keyEncodings;
+}
+
+folly::F14FastMap<uint32_t, FlatmapEncodingLayoutContext::KeyEncodingMap>
+collectFlatMapKeyEncodings(
+    const TypeWithId& type,
+    const detail::WriterContext& context) {
+  folly::F14FastMap<uint32_t, FlatmapEncodingLayoutContext::KeyEncodingMap>
+      flatMapKeyEncodings;
+  if (!context.options().encodingLayoutTree.has_value() ||
+      context.options().flatMapColumns.empty()) {
+    return flatMapKeyEncodings;
+  }
+
+  const auto& encodingLayoutTree = context.options().encodingLayoutTree.value();
+  NIMBLE_CHECK_EQ(
+      encodingLayoutTree.schemaKind(),
+      Kind::Row,
+      "Incompatible encoding layout node. Expecting row node.");
+  NIMBLE_CHECK_EQ(
+      type.type()->kind(),
+      velox::TypeKind::ROW,
+      "Flat-map encoding layout collection requires row root type, got {}.",
+      type.type()->toString());
+  const auto& rowType = type.type()->as<velox::TypeKind::ROW>();
+  for (const auto& [columnName, _] : context.options().flatMapColumns) {
+    const auto child = type.childByName(columnName);
+    for (uint32_t i = 0;
+         i < rowType.size() && i < encodingLayoutTree.childrenCount();
+         ++i) {
+      if (rowType.nameOf(i) != columnName) {
+        continue;
+      }
+      const auto& childLayout = encodingLayoutTree.child(i);
+      if (childLayout.schemaKind() == Kind::Map) {
+        // Schema evolution - If a map is converted to flatmap, we should not
+        // fail, but also not try to replay captured encodings.
+        break;
+      }
+      NIMBLE_CHECK_EQ(
+          childLayout.schemaKind(),
+          Kind::FlatMap,
+          "Incompatible encoding layout node. Expecting flatmap node.");
+      const auto nodeId = static_cast<uint32_t>(child->id());
+      flatMapKeyEncodings.emplace(nodeId, keyEncodingsForFlatMap(childLayout));
+      break;
+    }
+  }
+  return flatMapKeyEncodings;
+}
+
+struct DictionaryConfigs {
+  folly::F14FastMap<uint32_t, SharedDictionaryConfig> columns;
+  folly::F14FastMap<uint32_t, FlatmapEncodingLayoutContext::ValueDictionaryMap>
+      flatMaps;
+};
+
+// Resolves shared dictionary configs to writer schema targets. Flat-map value
+// stream assignment is deferred until each configured key is materialized.
+DictionaryConfigs collectDictionaryConfigs(
+    const TypeWithId& type,
+    const detail::WriterContext& context) {
+  DictionaryConfigs configs;
+  const auto& dictionaryEncodingConfig =
+      context.options().experimentalSharedDictionaryEncoding;
+  if (dictionaryEncodingConfig.empty()) {
+    return configs;
+  }
+
+  NIMBLE_USER_CHECK_EQ(
+      type.type()->kind(),
+      velox::TypeKind::ROW,
+      "Shared dictionary encoding requires a row root type, got {}.",
+      type.type()->toString());
+  folly::F14FastSet<uint32_t> fileDictionaryIds;
+  folly::F14FastSet<uint32_t> columnValueNodeIds;
+  configs.columns.reserve(dictionaryEncodingConfig.columns.size());
+  for (const auto& columnDictionary : dictionaryEncodingConfig.columns) {
+    const auto& fieldType = resolveFieldPath(type, columnDictionary.fieldPath);
+    const auto& valueType =
+        resolveDictionaryValueType(fieldType, columnDictionary.fieldPath);
+    const auto valueNodeId = static_cast<uint32_t>(valueType.id());
+    const auto insertedValueNode =
+        columnValueNodeIds.insert(valueNodeId).second;
+    NIMBLE_USER_CHECK(
+        insertedValueNode,
+        "Duplicate shared dictionary column configuration for schema value "
+        "node {}.",
+        valueNodeId);
+    NIMBLE_USER_CHECK(
+        valueType.type()->isInteger(),
+        "Shared dictionary column '{}' must resolve to an integer scalar, "
+        "array element, or map value, got {}.",
+        columnDictionary.fieldPath,
+        valueType.type()->toString());
+    maybeAddFileDictionaryId(columnDictionary.dictionary, fileDictionaryIds);
+    const auto nodeId = static_cast<uint32_t>(fieldType.id());
+    const auto inserted =
+        configs.columns.emplace(nodeId, columnDictionary.dictionary).second;
+    NIMBLE_USER_CHECK(
+        inserted,
+        "Duplicate shared dictionary column configuration for schema node {}.",
+        nodeId);
+  }
+
+  configs.flatMaps.reserve(dictionaryEncodingConfig.flatMaps.size());
+  for (const auto& flatMap : dictionaryEncodingConfig.flatMaps) {
+    const velox::common::Subfield subfield{flatMap.fieldPath};
+    NIMBLE_USER_CHECK_EQ(
+        subfield.path().size(),
+        1,
+        "Shared dictionary flat-map path '{}' must be a top-level writer input "
+        "column.",
+        flatMap.fieldPath);
+    const auto& fieldType = resolveFieldPath(type, flatMap.fieldPath);
+    NIMBLE_USER_CHECK_EQ(
+        fieldType.type()->kind(),
+        velox::TypeKind::MAP,
+        "Flat-map dictionary column '{}' must be a map, got {}.",
+        flatMap.fieldPath,
+        fieldType.type()->toString());
+    NIMBLE_USER_CHECK(
+        context.hasFlatMapNodeId(fieldType.id()),
+        "Flat-map dictionary column '{}' is not configured as a flat map.",
+        flatMap.fieldPath);
+
+    const auto nodeId = static_cast<uint32_t>(fieldType.id());
+    auto& flatMapKeys = configs.flatMaps[nodeId];
+    for (const auto& flatMapKey : flatMap.keys) {
+      const auto& config = flatMapKey.dictionary;
+      maybeAddFileDictionaryId(config, fileDictionaryIds);
+      flatMapKeys[std::to_string(flatMapKey.key)].push_back(
+          FlatmapEncodingLayoutContext::ValueDictionaryConfig{
+              .valueSubfield = flatMapKey.valueSubfield, .dictionary = config});
+    }
+  }
+  return configs;
+}
+
 WriterStreamContext& streamContext(const StreamDescriptorBuilder& descriptor) {
   auto* context = descriptor.context<WriterStreamContext>();
   if (context != nullptr) {
@@ -852,6 +1466,51 @@ WriterStreamContext& streamContext(const StreamDescriptorBuilder& descriptor) {
   }
   descriptor.setContext(std::make_unique<WriterStreamContext>());
   return *descriptor.context<WriterStreamContext>();
+}
+
+// Applies writer context that depends on the TypeBuilder node just created.
+// FlatMap value configs live on the parent FlatMap node so the key-add handler
+// can apply them when each keyed value stream is materialized.
+void configureAddedType(
+    detail::WriterContext& context,
+    TypeBuilder& type,
+    uint32_t nodeId,
+    const DictionaryConfigs& dictionaryConfigs,
+    const folly::
+        F14FastMap<uint32_t, FlatmapEncodingLayoutContext::KeyEncodingMap>&
+            flatMapKeyEncodingLayouts) {
+  if (type.kind() == Kind::Row) {
+    streamContext(type.asRow().nullsDescriptor()).setIsNullStream(true);
+  } else if (type.kind() == Kind::FlatMap) {
+    streamContext(type.asFlatMap().nullsDescriptor()).setIsNullStream(true);
+    FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodings;
+    auto keyEncodingIt = flatMapKeyEncodingLayouts.find(nodeId);
+    if (keyEncodingIt != flatMapKeyEncodingLayouts.end()) {
+      keyEncodings = keyEncodingIt->second;
+    }
+    FlatmapEncodingLayoutContext::ValueDictionaryMap valueDictionaries;
+    auto dictionaryIt = dictionaryConfigs.flatMaps.find(nodeId);
+    if (dictionaryIt != dictionaryConfigs.flatMaps.end()) {
+      valueDictionaries = dictionaryIt->second;
+    }
+    if (!keyEncodings.empty() || !valueDictionaries.empty()) {
+      type.setContext(
+          std::make_unique<FlatmapEncodingLayoutContext>(
+              std::move(keyEncodings), std::move(valueDictionaries)));
+    }
+  }
+
+  auto columnDictionaryIt = dictionaryConfigs.columns.find(nodeId);
+  if (columnDictionaryIt != dictionaryConfigs.columns.end()) {
+    configureDictionary(
+        type, columnDictionaryIt->second, context.schemaBuilder());
+  }
+
+  const auto& schemaAttributes = context.options().schemaAttributes;
+  auto attribute = schemaAttributes.find(nodeId);
+  if (attribute != schemaAttributes.end()) {
+    type.setAttributes(attribute->second);
+  }
 }
 
 std::unique_ptr<FieldWriter> createRootFieldWriter(
@@ -899,19 +1558,22 @@ std::unique_ptr<FieldWriter> createRootFieldWriter(
   // id. schemaAttributes uses the same TypeWithId::id() numbering the handler
   // receives, so the lookup is a direct O(1) hit as each TypeBuilder is
   // constructed. Ids with no matching node are simply never looked up.
+  auto flatMapKeyEncodingLayouts = collectFlatMapKeyEncodings(*type, context);
+  auto dictionaryConfigs = collectDictionaryConfigs(*type, context);
+
   return FieldWriter::create(
-      context, type, [&context](TypeBuilder& type, uint32_t nodeId) {
-        if (type.kind() == Kind::Row) {
-          streamContext(type.asRow().nullsDescriptor()).setIsNullStream(true);
-        } else if (type.kind() == Kind::FlatMap) {
-          streamContext(type.asFlatMap().nullsDescriptor())
-              .setIsNullStream(true);
-        }
-        const auto& schemaAttributes = context.options().schemaAttributes;
-        auto it = schemaAttributes.find(nodeId);
-        if (it != schemaAttributes.end()) {
-          type.setAttributes(it->second);
-        }
+      context,
+      type,
+      [&context,
+       _flatMapKeyEncodingLayouts = std::move(flatMapKeyEncodingLayouts),
+       _dictionaryConfigs = std::move(dictionaryConfigs)](
+          TypeBuilder& type, uint32_t nodeId) {
+        configureAddedType(
+            context,
+            type,
+            nodeId,
+            _dictionaryConfigs,
+            _flatMapKeyEncodingLayouts);
       });
 }
 
@@ -935,18 +1597,7 @@ void initializeEncodingLayouts(
           encodingLayoutTree.schemaKind(),
           Kind::FlatMap,
           "Incompatible encoding layout node. Expecting flatmap node.");
-      folly::F14FastMap<std::string_view, const EncodingLayoutTree&>
-          keyEncodings;
-      keyEncodings.reserve(encodingLayoutTree.childrenCount());
-      for (auto i = 0; i < encodingLayoutTree.childrenCount(); ++i) {
-        auto& child = encodingLayoutTree.child(i);
-        keyEncodings.emplace(child.name(), child);
-      }
       const auto& mapBuilder = typeBuilder.asFlatMap();
-      mapBuilder.setContext(
-          std::make_unique<FlatmapEncodingLayoutContext>(
-              std::move(keyEncodings)));
-
       SET_STREAM_CONTEXT(mapBuilder, nullsDescriptor, FlatMap::NullsStream);
       return;
     }
@@ -1084,6 +1735,43 @@ void initializeEncodingLayouts(
 #undef SET_STREAM_CONTEXT
   }
 }
+
+void configureAddedFlatMapField(
+    detail::WriterContext& context,
+    const TypeBuilder& flatmap,
+    std::string_view fieldKey,
+    const TypeBuilder& fieldType) {
+  auto& flatmapBuilder = flatmap.asFlatMap();
+  auto& inMapContext = streamContext(
+      flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1));
+  inMapContext.setIsInMapStream(true);
+  std::vector<offset_size> valueStreamOffsets;
+  collectFlatMapValueStreamOffsets(fieldType, valueStreamOffsets);
+  inMapContext.setFlatMapValueStreamOffsets(std::move(valueStreamOffsets));
+
+  auto* flatMapContext = flatmap.context<FlatmapEncodingLayoutContext>();
+  if (flatMapContext == nullptr) {
+    return;
+  }
+
+  if (context.options().encodingLayoutTree.has_value()) {
+    auto it = flatMapContext->keyEncodings.find(fieldKey);
+    if (it != flatMapContext->keyEncodings.end()) {
+      initializeEncodingLayouts(fieldType, *it->second);
+    }
+  }
+
+  auto it = flatMapContext->valueDictionaries.find(std::string{fieldKey});
+  if (it == flatMapContext->valueDictionaries.end()) {
+    return;
+  }
+  for (const auto& valueDictionary : it->second) {
+    configureDictionary(
+        resolveFieldPath(fieldType, valueDictionary.valueSubfield),
+        valueDictionary.dictionary,
+        context.schemaBuilder());
+  }
+}
 } // namespace
 
 std::unique_ptr<index::IndexWriter> Writer::createClusterIndexWriter(
@@ -1213,9 +1901,7 @@ Writer::Writer(
           file_.get(),
           *encodingMemoryPool_,
           {.layoutPlanner = std::make_unique<DefaultLayoutPlanner>(
-               [&schemaBuilder = context_->schemaBuilder()]() {
-                 return schemaBuilder.root();
-               },
+               &context_->schemaBuilder(),
                context_->options().featureReordering),
            .metadataCompressionThreshold =
                context_->options().metadataCompressionThreshold.value_or(
@@ -1250,6 +1936,7 @@ Writer::Writer(
                    const WriteDataFn& writeDataFn,
                    const CreateMetadataSectionFn& createMetadataFn,
                    const WriteOptionalSectionFn& writeMetadataFn) {
+                 writeDictionarySection(writeDataFn, writeMetadataFn);
                  writeProperties(writeMetadataFn);
                  writeIndexes(writeDataFn, createMetadataFn, writeMetadataFn);
                }})},
@@ -1265,22 +1952,7 @@ Writer::Writer(
                                                  const TypeBuilder& flatmap,
                                                  std::string_view fieldKey,
                                                  const TypeBuilder& fieldType) {
-    // Mark the newly added child's in-map stream descriptor.
-    auto& flatmapBuilder = flatmap.asFlatMap();
-    streamContext(
-        flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1))
-        .setIsInMapStream(true);
-
-    // Handle encoding layout if configured.
-    if (context_->options().encodingLayoutTree.has_value()) {
-      auto* ctx = flatmap.context<FlatmapEncodingLayoutContext>();
-      if (ctx != nullptr) {
-        auto it = ctx->keyEncodings.find(fieldKey);
-        if (it != ctx->keyEncodings.end()) {
-          initializeEncodingLayouts(fieldType, it->second);
-        }
-      }
-    }
+    configureAddedFlatMapField(*context_, flatmap, fieldKey, fieldType);
   });
 
   rootWriter_ = createRootFieldWriter(schema_, *context_);
@@ -1481,6 +2153,106 @@ void Writer::writeSchema() {
   tabletWriter_->writeOptionalSection(
       std::string(kSchemaSection),
       serializer.serialize(context_->schemaBuilder()));
+}
+
+void Writer::writeStripeDictionaryStreams() {
+  if (!context_->hasStripeDictionaryConfig()) {
+    return;
+  }
+  for (const auto& [_, streamData] : context_->streams()) {
+    const auto* streamContext =
+        streamData->descriptor().context<WriterStreamContext>();
+    if (streamContext == nullptr) {
+      continue;
+    }
+    auto* writer = streamContext->sharedDictionaryWriter();
+    if (writer == nullptr) {
+      continue;
+    }
+    if (writer->scope() != SharedDictionaryScope::Stripe) {
+      continue;
+    }
+    auto alphabetChunk = writer->encodeAlphabet(*encodingBuffer_);
+    if (!alphabetChunk.has_value()) {
+      continue;
+    }
+    const auto streamId = writer->dictionaryId();
+    NIMBLE_CHECK_LT(streamId, encodedStreams_.size());
+    auto& dictionaryStream = encodedStreams_[streamId];
+    NIMBLE_CHECK(dictionaryStream.chunks.empty());
+    dictionaryStream.offset = streamId;
+    dictionaryStream.chunks.push_back(std::move(alphabetChunk.value()));
+  }
+}
+
+void Writer::writeDictionarySection(
+    const WriteDataFn& writeDataFn,
+    const WriteOptionalSectionFn& writeMetadataFn) {
+  if (context_->options().experimentalSharedDictionaryEncoding.empty()) {
+    return;
+  }
+
+  std::vector<SharedDictionaryReference> stripeDictionaryReferences;
+  std::vector<SharedDictionaryReference> fileDictionaryReferences;
+  std::vector<SharedDictionaryReference> externalDictionaryReferences;
+  std::vector<FileDictionary> fileDictionaries;
+  for (const auto& [_, streamData] : context_->streams()) {
+    const auto* streamContext =
+        streamData->descriptor().context<WriterStreamContext>();
+    if (streamContext == nullptr) {
+      continue;
+    }
+    auto* writer = streamContext->sharedDictionaryWriter();
+    if (writer == nullptr) {
+      continue;
+    }
+    if (!writer->hasUsedDictionary()) {
+      continue;
+    }
+    if (writer->scope() == SharedDictionaryScope::File) {
+      auto alphabet = writer->encodeAlphabet(*encodingBuffer_);
+      NIMBLE_CHECK(
+          alphabet.has_value(),
+          "File shared dictionary {} used shared dictionary encoding but "
+          "produced no alphabet.",
+          writer->dictionaryId());
+      const auto [offset, length] = writeDataFn(alphabet->content);
+      fileDictionaries.push_back({
+          .dictionaryId = writer->dictionaryId(),
+          .dataType = writer->dataType(),
+          .offset = offset,
+          .length = length,
+      });
+    }
+    const SharedDictionaryReference reference{
+        .valueStreamId = streamData->descriptor().offset(),
+        .dictionaryId = writer->dictionaryId(),
+        .dataType = writer->dataType(),
+    };
+    switch (writer->scope()) {
+      case SharedDictionaryScope::Stripe:
+        stripeDictionaryReferences.push_back(reference);
+        break;
+      case SharedDictionaryScope::File:
+        fileDictionaryReferences.push_back(reference);
+        break;
+      case SharedDictionaryScope::External:
+        externalDictionaryReferences.push_back(reference);
+        break;
+    }
+  }
+  if (stripeDictionaryReferences.empty() && fileDictionaryReferences.empty() &&
+      externalDictionaryReferences.empty()) {
+    return;
+  }
+
+  writeMetadataFn(
+      std::string(kDictionarySection),
+      SharedDictionaryCatalog::serialize(
+          stripeDictionaryReferences,
+          fileDictionaryReferences,
+          externalDictionaryReferences,
+          fileDictionaries));
 }
 
 void Writer::addIndexKey(const velox::VectorPtr& input) {
@@ -2317,6 +3089,8 @@ bool Writer::writeStripe() {
   } else {
     writeStreams();
   }
+
+  writeStripeDictionaryStreams();
 
   uint64_t stripeSize{0};
   {

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -27,6 +27,7 @@
 #include "velox/dwio/nimble/index/IndexWriter.h"
 #include "velox/dwio/nimble/tablet/TabletWriter.h"
 #include "velox/dwio/nimble/velox/FieldWriter.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryWriter.h"
 #include "velox/dwio/nimble/writer/BufferPolicy.h"
 #include "velox/dwio/nimble/writer/NimbleFileMetadata.h"
 #include "velox/dwio/nimble/writer/WriterOptions.h"
@@ -286,9 +287,23 @@ class Writer : public velox::dwio::common::Writer {
   // them at close still sees consistent deltas.
   void updateIoStatistics();
 
+  // Writes caller-supplied key/value metadata into the optional metadata
+  // section.
   void writeMetadata();
+  // Writes the column statistics section, using the vectorized representation
+  // when enabled and the legacy raw-size section otherwise.
   void writeColumnStats();
+  // Writes the serialized Nimble schema section built from the writer context.
   void writeSchema();
+  // Writes the dictionary catalog and any file-scope alphabet payloads.
+  // File-scope alphabet bytes go through writeDataFn so the catalog can point
+  // at their final file offsets.
+  void writeDictionarySection(
+      const WriteDataFn& writeDataFn,
+      const WriteOptionalSectionFn& writeMetadataFn);
+  // Encodes stripe-scope alphabet chunks into their dedicated dictionary
+  // streams after value streams have chosen shared dictionary encoding.
+  void writeStripeDictionaryStreams();
   // Finalizes and writes all indexes. Called via TabletWriter close callback.
   void writeIndexes(
       const WriteDataFn& writeDataFn,

--- a/velox/dwio/nimble/writer/WriterOptions.h
+++ b/velox/dwio/nimble/writer/WriterOptions.h
@@ -20,16 +20,22 @@
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/MetricsLogger.h"
 #include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/index/IndexConfig.h"
 #include "velox/dwio/nimble/tablet/StripeGroup.h"
 #include "velox/dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "velox/dwio/nimble/velox/NimbleConfig.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
 #include "velox/dwio/nimble/writer/BufferPolicy.h"
 #include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
 #include "velox/dwio/nimble/writer/FlushPolicy.h"
 
+#include <memory>
+#include <optional>
 #include <set>
+#include <unordered_map>
+#include <vector>
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/type/Type.h"
@@ -58,6 +64,12 @@ struct WriterOptions {
   /// Property bag for storing user metadata in the file.
   std::unordered_map<std::string, std::string> metadata =
       detail::defaultMetadata();
+
+  /// Shared dictionary encoding settings.
+  /// EXPERIMENTAL: Shared dictionary encoding is not production-ready. Do not
+  /// enable for production tables without consulting the Nimble team (oncall:
+  /// dwios).
+  SharedDictionaryEncodingConfig experimentalSharedDictionaryEncoding{};
 
   /// Enable column statistics collection. When false, the writer skips
   /// collecting per-column statistics, reducing write CPU cost.


### PR DESCRIPTION
Summary:

Add shared dictionary encoding for integer Nimble value streams. Encoded chunks store the normal prefix plus dictionary indices, while the alphabet is resolved from a stripe stream, a file catalog, or an external resolver. This lets selected value streams share alphabets even when their physical stream ids vary by stripe, including FlatMap values.

Wire dictionary resolution through tablet readers and bind the resolved alphabet before regular, selective, and index-reader decoding. Writers configure eligible regular columns and flat-map values explicitly, compare shared dictionary encoding with direct encoding for stripe scope on the first chunk, and keep that choice for the rest of the stripe.

File and external dictionaries use prebuilt alphabets and avoid per-chunk scope or dictionary-id payload. Unsupported dictionary lifecycles remain rejected until they are implemented.

Reviewed By: tanjialiang

Differential Revision: D112768733
