### PR TITLE
fix(nimble): Make the shared dictionary export build and pass checks

### DIFF
--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   PrefixEncoding.cpp
   RLEEncoding.cpp
   SharedDictionaryCatalog.cpp
+  SharedDictionaryCatalog.h
   SharedDictionaryEncoding.cpp
   SparseBoolEncoding.cpp
   TrivialEncoding.cpp
@@ -134,10 +135,7 @@ target_include_directories(
   nimble_shared_dictionary_fb
   INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
 )
-add_dependencies(
-  nimble_shared_dictionary_fb
-  nimble_shared_dictionary_schema_fb
-)
+add_dependencies(nimble_shared_dictionary_fb nimble_shared_dictionary_schema_fb)
 
 target_link_libraries(
   nimble_encodings

--- a/velox/dwio/nimble/encodings/SharedDictionaryBuilder.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryBuilder.h
@@ -289,7 +289,8 @@ class ExternalSharedDictionaryBuilder final
 
   void resetImpl() final {
     NIMBLE_UNSUPPORTED(
-        "{} shared dictionary builder does not support reset().", this->kind());
+        "{} shared dictionary builder does not support reset().",
+        SharedDictionaryBuilder<T>::kindString(this->kind()));
   }
 
  private:

--- a/velox/dwio/nimble/encodings/common/Encoding.h
+++ b/velox/dwio/nimble/encodings/common/Encoding.h
@@ -162,7 +162,8 @@ class Encoding {
 
     /// Direct alphabet for SharedDictionary encodings when the read path has
     /// already resolved the dictionary bound to this value stream.
-    std::shared_ptr<const SharedDictionaryAlphabet> sharedDictionaryAlphabet;
+    std::shared_ptr<const SharedDictionaryAlphabet> sharedDictionaryAlphabet =
+        nullptr;
 
     velox::io::IoCounter* decompressCounter() const {
       return decodingStats != nullptr ? &decodingStats->decompressCPUTimeNanos

--- a/velox/dwio/nimble/tablet/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/CMakeLists.txt
@@ -186,6 +186,7 @@ add_library(
   nimble_tablet_reader
   FileLayout.cpp
   SharedDictionaryReader.cpp
+  SharedDictionaryReader.h
   StripeGroup.cpp
   TabletReader.cpp
   TabletReader.h

--- a/velox/dwio/nimble/tools/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/CMakeLists.txt
@@ -29,10 +29,7 @@ target_include_directories(
   nimble_external_dictionary_fb
   INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
 )
-add_dependencies(
-  nimble_external_dictionary_fb
-  nimble_external_dictionary_schema_fb
-)
+add_dependencies(nimble_external_dictionary_fb nimble_external_dictionary_schema_fb)
 
 add_library(nimble_dump_lib NimbleDumpLib.cpp NimbleDumpLib.h)
 target_link_libraries(
@@ -73,7 +70,11 @@ target_link_libraries(
   velox_memory
 )
 
-add_library(nimble_external_dictionary_builder ExternalDictionaryBuilder.cpp)
+add_library(
+  nimble_external_dictionary_builder
+  ExternalDictionaryBuilder.cpp
+  ExternalDictionaryBuilder.h
+)
 target_link_libraries(
   nimble_external_dictionary_builder
   nimble_external_dictionary_fb

--- a/velox/dwio/nimble/tools/ExternalDictionaryBuilder.h
+++ b/velox/dwio/nimble/tools/ExternalDictionaryBuilder.h
@@ -57,10 +57,10 @@ class ExternalDictionaryBuilder {
 
     /// Optional forced alphabet encoding. When unset, readFactors or default
     /// encoding selection picks the alphabet encoding.
-    std::optional<EncodingType> alphabetEncoding;
+    std::optional<EncodingType> alphabetEncoding{};
 
     /// Optional parsed manual read factors used by encoding selection.
-    std::vector<std::pair<EncodingType, float>> readFactors;
+    std::vector<std::pair<EncodingType, float>> readFactors{};
   };
 
   explicit ExternalDictionaryBuilder(velox::memory::MemoryPool* pool);

--- a/velox/dwio/nimble/tools/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/tests/CMakeLists.txt
@@ -24,10 +24,7 @@ target_link_libraries(
   gtest_main
 )
 
-add_executable(
-  external_dictionary_builder_tests
-  ExternalDictionaryBuilderTest.cpp
-)
+add_executable(external_dictionary_builder_tests ExternalDictionaryBuilderTest.cpp)
 add_test(external_dictionary_builder_tests external_dictionary_builder_tests)
 target_link_libraries(
   external_dictionary_builder_tests

--- a/velox/dwio/nimble/velox/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/CMakeLists.txt
@@ -14,7 +14,11 @@
 add_library(nimble_velox_common SchemaUtils.cpp SchemaUtils.h)
 target_link_libraries(nimble_velox_common nimble_common velox_type Folly::folly fmt::fmt)
 
-add_library(nimble_velox_shared_dictionary_config SharedDictionaryConfig.cpp)
+add_library(
+  nimble_velox_shared_dictionary_config
+  SharedDictionaryConfig.cpp
+  SharedDictionaryConfig.h
+)
 target_link_libraries(
   nimble_velox_shared_dictionary_config
   nimble_common

--- a/velox/dwio/nimble/velox/SharedDictionaryConfig.h
+++ b/velox/dwio/nimble/velox/SharedDictionaryConfig.h
@@ -37,7 +37,7 @@ struct SharedDictionaryConfig {
   /// Resolves a provided alphabet instead of building one from written values.
   bool useExternalAlphabet{false};
   /// Candidate encodings for alphabets stored in this file.
-  std::vector<EncodingType> alphabetEncodings;
+  std::vector<EncodingType> alphabetEncodings{};
 };
 
 /// Shared dictionary settings for one regular column value stream.


### PR DESCRIPTION
#18640 exported the shared dictionary work byte-identical to fbcode, which
leaves this tree not compiling and failing `pre-commit`. This fixes that.

- `Encoding::Options::sharedDictionaryAlphabet` and
  `SharedDictionaryConfig::alphabetEncodings` had no default initializer, so
  every brace-initialization of those structs failed under `-Wextra -Werror`.
  201 errors across six test files.
- `ExternalSharedDictionaryBuilder::resetImpl` passed a `Kind` enum to
  `NIMBLE_UNSUPPORTED`; fmt v11 will not format an enum. Uses the existing
  `kindString()` instead.
- Four headers had no CMake entry, breaking `check-header-ownership`. Each is
  now listed beside the `.cpp` already in its target.

Kept separate from #18640 so the export stays a clean mirror of fbcode.

See #18643 for why this keeps happening and how to stop it at source.
