### PR TITLE
feat: Add runtime stat `toIntermediateFastPathCalls` in HashAggregation

### DIFF
--- a/velox/docs/develop/aggregations.rst
+++ b/velox/docs/develop/aggregations.rst
@@ -367,3 +367,7 @@ Many aggregate functions implement toIntermediate() fast path. Some examples inc
 Runtime statistic `abandonedPartialAggregationRows` counts rows that bypassed
 partial aggregation after it was abandoned. A value greater than 0 indicates
 that partial aggregation was abandoned.
+
+Runtime statistic `toIntermediateFastPathCalls` counts calls to aggregate
+functions that use the `toIntermediate()` fast path after partial aggregation
+is abandoned.

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1625,9 +1625,8 @@ void GroupingSet::toIntermediate(
     if (function->supportsToIntermediate()) {
       populateTempVectors(i, input);
       VELOX_DCHECK(aggregateVector);
-      TestValue::adjust(
-          "facebook::velox::exec::Aggregate::toIntermediate", function.get());
       function->toIntermediate(rows, tempVectors_, aggregateVector);
+      ++numToIntermediateFastPathCalls_;
       continue;
     }
 

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -119,6 +119,10 @@ class GroupingSet {
     return numInputRows_;
   }
 
+  uint64_t numToIntermediateFastPathCalls() const {
+    return numToIntermediateFastPathCalls_;
+  }
+
   /// Returns the number of global grouping sets.
   vector_size_t numGlobalGroupingSets() const {
     return static_cast<vector_size_t>(globalGroupingSets_.size());
@@ -374,6 +378,8 @@ class GroupingSet {
   bool hasCompactableAggregates_{false};
 
   uint64_t numInputRows_ = 0;
+
+  uint64_t numToIntermediateFastPathCalls_ = 0;
 
   // Column for groupId for a GROUPING SET.
   std::optional<column_index_t> groupIdChannel_;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -627,6 +627,15 @@ void HashAggregation::reclaim(
 }
 
 void HashAggregation::close() {
+  if (groupingSet_) {
+    const auto numToIntermediateFastPathCalls =
+        groupingSet_->numToIntermediateFastPathCalls();
+    if (numToIntermediateFastPathCalls > 0) {
+      addRuntimeStat(
+          std::string(kToIntermediateFastPathCalls),
+          RuntimeCounter(numToIntermediateFastPathCalls));
+    }
+  }
   Operator::close();
 
   output_ = nullptr;

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -35,6 +35,9 @@ class HashAggregation : public Operator {
   /// Number of rows emitted after partial aggregation was abandoned.
   static constexpr std::string_view kAbandonedPartialAggregationRows =
       "abandonedPartialAggregationRows";
+  /// Number of calls to the Aggregate::toIntermediate() fast path.
+  static constexpr std::string_view kToIntermediateFastPathCalls =
+      "toIntermediateFastPathCalls";
 
   HashAggregation(
       int32_t operatorId,

--- a/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
@@ -305,9 +305,7 @@ TEST_F(MinMaxAggregationTest, failOnUnorderableType) {
   }
 }
 
-DEBUG_ONLY_TEST_F(
-    MinMaxAggregationTest,
-    partialCompanionAbandonPartialAggregation) {
+TEST_F(MinMaxAggregationTest, partialCompanionAbandonPartialAggregation) {
   constexpr vector_size_t kBatchSize = 100;
   std::vector<RowVectorPtr> data;
   for (auto batch = 0; batch < 3; ++batch) {
@@ -326,11 +324,6 @@ DEBUG_ONLY_TEST_F(
                   .capturePlanNodeId(partialNodeId)
                   .finalAggregation()
                   .planNode();
-  std::atomic_bool usedToIntermediateFastPath{false};
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Aggregate::toIntermediate",
-      std::function<void(void*)>(
-          [&](void*) { usedToIntermediateFastPath = true; }));
   auto task =
       AssertQueryBuilder(plan, duckDbQueryRunner_)
           .maxDrivers(1)
@@ -344,7 +337,9 @@ DEBUG_ONLY_TEST_F(
       stats.at(partialNodeId)
           .customStats.at("abandonedPartialAggregationRows")
           .sum);
-  EXPECT_TRUE(usedToIntermediateFastPath);
+  EXPECT_GT(
+      stats.at(partialNodeId).customStats.at("toIntermediateFastPathCalls").sum,
+      0);
 }
 
 } // namespace


### PR DESCRIPTION
The patch adds a new runtime stat HashAggregation::kToIntermediateFastPathCalls to replace a previous debug hook.

 Addresses the [review comment](https://github.com/facebookincubator/velox/pull/18565#discussion_r3825045895) in PR https://github.com/facebookincubator/velox/pull/18565.