### PR TITLE
feat(ucx-exchange): Bring the UCX exchange transport up to date

### DIFF
--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -54,6 +54,14 @@ struct CudfConfig {
   static constexpr const char* kCudfStreamingGroupbyCapacityMultiplier{
       "cudf.streaming_groupby_capacity_multiplier"};
   static constexpr const char* kCudfTimestampUnit{"cudf.timestamp_unit"};
+  static constexpr const char* kUcxExchange{"cudf.exchange"};
+  static constexpr const char* kUcxxErrorHandling{"ucxx.error_handling"};
+  static constexpr const char* kUcxIntraNodeExchange{
+      "cudf.intra_node_exchange"};
+  static constexpr const char* kUcxxBlockingPolling{"ucxx.blocking_polling"};
+  static constexpr const char* kUcxExchangeLogLevel{"cudf.exchange_log_level"};
+  static constexpr const char* kUcxPartitionedOutputBatchRows{
+      "cudf.partitioned_output_batch_rows"};
   /// Query session configs for the cuDF Operators.
   static constexpr const char* kCudfTopNBatchSize{"cudf.topk_batch_size"};
 
@@ -73,6 +81,27 @@ struct CudfConfig {
 
   /// Allow fallback to CPU operators if GPU operator replacement fails.
   bool allowCpuFallback{true};
+
+  /// Enable GPU exchange operators (UcxExchange / UcxPartitionedOutput).
+  bool exchange{false};
+
+  /// Whether to enable error handling in UCXX endpoints.
+  bool ucxxErrorHandling{true};
+
+  /// Whether intra-node exchange optimization is enabled.
+  bool intraNodeExchange{false};
+
+  /// Whether to use blocking polling in UCXX.
+  bool ucxxBlockingPolling{true};
+
+  /// VLOG level for ucx-exchange source files.
+  int32_t exchangeLogLevel{0};
+
+  /// Minimum number of rows to accumulate in UCX partitioned output before
+  /// flushing. Small inputs are buffered and concatenated when this threshold
+  /// is reached, avoiding pathologically small exchange chunks. Set to 0 to
+  /// disable accumulation.
+  int64_t partitionedOutputBatchRows{10'000};
 
   /// Memory resource for cuDF.
   /// Possible values are (cuda, pool, async, arena, managed, managed_pool).

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -82,7 +82,13 @@ struct CudfConfig {
   /// Allow fallback to CPU operators if GPU operator replacement fails.
   bool allowCpuFallback{true};
 
-  /// Enable GPU exchange operators (UcxExchange / UcxPartitionedOutput).
+  /// Enable GPU exchange operators (UcxExchange / UcxPartitionedOutput). This
+  /// is a capability, not a request: it is read once at registerCudf() to
+  /// decide whether the UCX transports are registered in this process at all.
+  /// Which transport a given edge uses is named per node in the plan, so
+  /// different edges of one plan may differ. Naming a transport nothing
+  /// registered -- kUcx while this is false, or on a worker built without the
+  /// UCX exchange -- is a user error from exec::Task, never a silent fallback.
   bool exchange{false};
 
   /// Whether to enable error handling in UCXX endpoints.

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -58,7 +58,7 @@ struct CudfConfig {
   static constexpr const char* kUcxxErrorHandling{"ucxx.error_handling"};
   static constexpr const char* kUcxIntraNodeExchange{
       "cudf.intra_node_exchange"};
-  static constexpr const char* kUcxxBlockingPolling{"ucxx.blocking_polling"};
+  static constexpr const char* kUcxxBlockingProgress{"ucxx.blocking_progress"};
   static constexpr const char* kUcxExchangeLogLevel{"cudf.exchange_log_level"};
   static constexpr const char* kUcxPartitionedOutputBatchRows{
       "cudf.partitioned_output_batch_rows"};
@@ -91,8 +91,17 @@ struct CudfConfig {
   /// Whether intra-node exchange optimization is enabled.
   bool intraNodeExchange{false};
 
-  /// Whether to use blocking polling in UCXX.
-  bool ucxxBlockingPolling{true};
+  /// Whether the UCX worker is set up for UCXX blocking progress mode: the
+  /// wakeup feature on the context plus an epoll file descriptor on the worker,
+  /// which is also what lets enqueueing work signal it. False creates a
+  /// tag/active-message-only worker that the progress loop polls.
+  ///
+  /// Requesting a feature the fabric cannot provide removes that transport from
+  /// UCX's selection instead of failing, so setting this on a fabric without
+  /// wakeup support silently costs RDMA. Tested with this and
+  /// kUcxxErrorHandling both true on InfiniBand / A100, and both false on AWS
+  /// SRD, which supports neither and otherwise stops using RDMA.
+  bool ucxxBlockingProgress{true};
 
   /// VLOG level for ucx-exchange source files.
   int32_t exchangeLogLevel{0};

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -415,6 +415,25 @@ void CudfConfig::initialize(
   if (config.find(kCudfAllowCpuFallback) != config.end()) {
     allowCpuFallback = folly::to<bool>(config[kCudfAllowCpuFallback]);
   }
+  if (config.find(kUcxExchange) != config.end()) {
+    exchange = folly::to<bool>(config[kUcxExchange]);
+  }
+  if (config.find(kUcxxErrorHandling) != config.end()) {
+    ucxxErrorHandling = folly::to<bool>(config[kUcxxErrorHandling]);
+  }
+  if (config.find(kUcxIntraNodeExchange) != config.end()) {
+    intraNodeExchange = folly::to<bool>(config[kUcxIntraNodeExchange]);
+  }
+  if (config.find(kUcxxBlockingPolling) != config.end()) {
+    ucxxBlockingPolling = folly::to<bool>(config[kUcxxBlockingPolling]);
+  }
+  if (config.find(kUcxExchangeLogLevel) != config.end()) {
+    exchangeLogLevel = folly::to<int32_t>(config[kUcxExchangeLogLevel]);
+  }
+  if (config.find(kUcxPartitionedOutputBatchRows) != config.end()) {
+    partitionedOutputBatchRows =
+        folly::to<int64_t>(config[kUcxPartitionedOutputBatchRows]);
+  }
   if (config.find(kCudfLogFallback) != config.end()) {
     logFallback = folly::to<bool>(config[kCudfLogFallback]);
   }

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -424,8 +424,8 @@ void CudfConfig::initialize(
   if (config.find(kUcxIntraNodeExchange) != config.end()) {
     intraNodeExchange = folly::to<bool>(config[kUcxIntraNodeExchange]);
   }
-  if (config.find(kUcxxBlockingPolling) != config.end()) {
-    ucxxBlockingPolling = folly::to<bool>(config[kUcxxBlockingPolling]);
+  if (config.find(kUcxxBlockingProgress) != config.end()) {
+    ucxxBlockingProgress = folly::to<bool>(config[kUcxxBlockingProgress]);
   }
   if (config.find(kUcxExchangeLogLevel) != config.end()) {
     exchangeLogLevel = folly::to<int32_t>(config[kUcxExchangeLogLevel]);

--- a/velox/experimental/ucx-exchange/CMakeLists.txt
+++ b/velox/experimental/ucx-exchange/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(ucx REQUIRED)
 
 target_link_libraries(
   velox_ucx_exchange
-  PUBLIC ucxx::ucxx ucx::ucp
+  PUBLIC ucxx::ucxx ucx::ucp nvtx3::nvtx3-cpp
   PRIVATE cudf::cudf CUDA::cudart CUDA::cuda_driver Folly::folly velox_core ucx::ucs
 )
 

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -42,7 +42,7 @@ std::shared_ptr<Communicator> Communicator::initAndGet(
     uint16_t port,
     std::string_view coordinatorURL,
     ContinueFuture* future) {
-  if (!FLAGS_velox_ucx_exchange) {
+  if (!CudfConfig::getInstance().exchange) {
     return nullptr;
   }
   std::call_once(onceFlag, [&] {

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -110,7 +110,7 @@ void Communicator::run() {
   VLOG(3) << "Using error handling mode: "
           << CudfConfig::getInstance().ucxxErrorHandling << std::endl;
   VLOG(3) << "Using blocking progress mode: "
-          << CudfConfig::getInstance().ucxxBlockingPolling << std::endl;
+          << CudfConfig::getInstance().ucxxBlockingProgress << std::endl;
 
   running_.store(true);
   // Force CUDA context creation.
@@ -121,7 +121,7 @@ void Communicator::run() {
       cudaGetErrorString(cudaStatus));
 
   // create the UCXX context, worker, listener-context etc.
-  if (CudfConfig::getInstance().ucxxBlockingPolling) {
+  if (CudfConfig::getInstance().ucxxBlockingProgress) {
     context_ = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
   } else {
     context_ = ucxx::createContext({}, UCP_FEATURE_TAG | UCP_FEATURE_AM);
@@ -129,7 +129,7 @@ void Communicator::run() {
 
   worker_ = context_->createWorker();
 
-  if (CudfConfig::getInstance().ucxxBlockingPolling) {
+  if (CudfConfig::getInstance().ucxxBlockingProgress) {
     // Communicator is using blocking progress mode.
     worker_->initBlockingProgressMode();
   }
@@ -145,7 +145,7 @@ void Communicator::run() {
   promise_.setValue();
 
   VLOG(3) << "Communicator running.";
-  const bool blockingMode = CudfConfig::getInstance().ucxxBlockingPolling;
+  const bool blockingMode = CudfConfig::getInstance().ucxxBlockingProgress;
   while (running_) {
     try {
       // Periodic heartbeat for diagnostic logging.
@@ -269,7 +269,7 @@ void Communicator::registerCommElement(std::shared_ptr<CommElement> comms) {
 }
 
 void Communicator::signalWorker() {
-  if (worker_ && CudfConfig::getInstance().ucxxBlockingPolling) {
+  if (worker_ && CudfConfig::getInstance().ucxxBlockingProgress) {
     worker_->signal();
   }
 }

--- a/velox/experimental/ucx-exchange/Communicator.h
+++ b/velox/experimental/ucx-exchange/Communicator.h
@@ -26,10 +26,6 @@
 #include "velox/experimental/ucx-exchange/CommElement.h"
 #include "velox/experimental/ucx-exchange/WorkQueue.h"
 
-#include <gflags/gflags.h>
-
-DECLARE_bool(velox_ucx_exchange);
-
 namespace facebook::velox::ucx_exchange {
 
 struct HostPort {

--- a/velox/experimental/ucx-exchange/Communicator.h
+++ b/velox/experimental/ucx-exchange/Communicator.h
@@ -38,10 +38,12 @@ struct HostPort {
 
   // Strict weak ordering for std::map
   bool operator<(HostPort const& other) const noexcept {
-    if (hostname < other.hostname)
+    if (hostname < other.hostname) {
       return true;
-    if (other.hostname < hostname)
+    }
+    if (other.hostname < hostname) {
       return false;
+    }
     return port < other.port;
   }
 };

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.cpp
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.cpp
@@ -32,6 +32,7 @@ IntraNodeTransferRegistry::getInstance() {
 std::future<void> IntraNodeTransferRegistry::publish(
     const IntraNodeTransferKey& key,
     std::shared_ptr<cudf::packed_columns> data,
+    vector_size_t numRows,
     bool atEnd) {
   std::shared_ptr<IntraNodeTransferEntry> entry;
   std::future<void> future;
@@ -74,6 +75,7 @@ std::future<void> IntraNodeTransferRegistry::publish(
   {
     std::lock_guard<std::mutex> entryLock(entry->entryMutex);
     entry->data = std::move(data);
+    entry->numRows = numRows;
     entry->atEnd = atEnd;
     entry->ready = true;
     // Get the future while holding the lock to avoid race with consumer
@@ -99,7 +101,8 @@ std::optional<IntraNodeTransferResult> IntraNodeTransferRegistry::poll(
     if (cancelledTasks_.count(key.taskId)) {
       VLOG(2) << "[INTRA-REG] poll cancelled: task=" << key.taskId
               << " dest=" << key.destination << " seq=" << key.sequenceNumber;
-      return IntraNodeTransferResult{nullptr, true};
+      return IntraNodeTransferResult{
+          .data = nullptr, .numRows = 0, .atEnd = true};
     }
 
     auto it = registry_.find(key);
@@ -128,6 +131,7 @@ std::optional<IntraNodeTransferResult> IntraNodeTransferRegistry::poll(
 
     // Data is ready, retrieve it while holding the lock
     result.data = std::move(entry->data);
+    result.numRows = entry->numRows;
     result.atEnd = entry->atEnd;
 
     // Fulfill the promise to notify the server while still holding entry lock

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
@@ -25,6 +25,8 @@
 #include <string_view>
 #include <unordered_set>
 
+#include "velox/vector/TypeAliases.h"
+
 namespace facebook::velox::ucx_exchange {
 
 /// @brief Key for identifying intra-node transfer entries in the registry.
@@ -46,6 +48,10 @@ struct IntraNodeTransferKey {
 /// @brief Result from intra-node transfer containing data and end marker.
 struct IntraNodeTransferResult {
   std::shared_ptr<cudf::packed_columns> data;
+  /// Logical rows in 'data'. Carried explicitly for the same reason the remote
+  /// path puts a row count on the wire: a packed table with no columns cannot
+  /// report its own row count.
+  vector_size_t numRows{0};
   bool atEnd{false}; // True if this is the end-of-stream marker
 };
 
@@ -55,6 +61,8 @@ struct IntraNodeTransferResult {
 /// promise on retrieval.
 struct IntraNodeTransferEntry {
   std::shared_ptr<cudf::packed_columns> data;
+  vector_size_t numRows{
+      0}; // Logical rows in 'data'; see IntraNodeTransferResult.
   bool atEnd{false}; // True if this is the end-of-stream marker
   std::promise<void> retrievedPromise; // Server waits on this after publishing
   std::mutex entryMutex;
@@ -85,11 +93,13 @@ class IntraNodeTransferRegistry {
   /// so that the GPU data is ready when the consumer reads it.
   /// @param key The unique key identifying this transfer (taskId, dest, seq)
   /// @param data The packed_columns data to share (nullptr for atEnd)
+  /// @param numRows Logical rows in 'data'; 0 for atEnd
   /// @param atEnd True if this is the end-of-stream marker
   /// @return A future that completes when source has retrieved the data
   [[nodiscard]] std::future<void> publish(
       const IntraNodeTransferKey& key,
       std::shared_ptr<cudf::packed_columns> data,
+      vector_size_t numRows,
       bool atEnd);
 
   /// @brief Non-blocking poll for intra-node transfer data.

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
@@ -37,10 +37,12 @@ struct IntraNodeTransferKey {
   uint32_t sequenceNumber;
 
   bool operator<(const IntraNodeTransferKey& other) const {
-    if (taskId != other.taskId)
+    if (taskId != other.taskId) {
       return taskId < other.taskId;
-    if (destination != other.destination)
+    }
+    if (destination != other.destination) {
       return destination < other.destination;
+    }
     return sequenceNumber < other.sequenceNumber;
   }
 };

--- a/velox/experimental/ucx-exchange/UcxExchange.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchange.cpp
@@ -44,24 +44,14 @@ UcxExchange::UcxExchange(
           fmt::format("[{}]", planNode->id())),
       preferredOutputBatchBytes_{
           driverCtx->queryConfig().preferredOutputBatchBytes()},
-      closeExchangeClientOnClose_{ucxExchangeClient == nullptr},
       processSplits_{driverCtx->driverId == 0},
       pipelineId_{driverCtx->pipelineId},
       driverId_{driverCtx->driverId} {
-  if (ucxExchangeClient) {
-    // UcxExchangeClient is provided externally when this is a "plain"
-    // UcxExchange.
-    exchangeClient_ = std::move(ucxExchangeClient);
-  } else {
-    // UcxExchangeClient is nullptr when this UcxExchange is used to
-    // implement a MergeExchange. Create a new UCX exchange client.
-    auto task = operatorCtx_->task();
-    exchangeClient_ = std::make_shared<UcxExchangeClient>(
-        task->taskId(),
-        task->destination(),
-        1 // number of consumers, is always 1.
-    );
-  }
+  VELOX_CHECK_NOT_NULL(
+      ucxExchangeClient,
+      "UCX exchange client is null, plan node: {}",
+      planNode->id());
+  exchangeClient_ = std::move(ucxExchangeClient);
 }
 
 UcxExchange::~UcxExchange() {
@@ -180,8 +170,26 @@ RowVectorPtr UcxExchange::getOutputFromPackedTable() {
 
   // Get the packed_table and stream from the PackedTableWithStream
   PackedTableWithStream& data = *currentData_;
-  auto numRows = data.packedTable->table.num_rows();
+  // The producer's count, not table.num_rows(): a packed table with no columns
+  // reports zero rows however many it holds, which is what an exchange
+  // fragment with an empty output layout sends.
+  const auto numRows = data.numRows;
+  const auto& tableView = data.packedTable->table;
+  VELOX_CHECK(
+      tableView.num_columns() == 0 || tableView.num_rows() == numRows,
+      "Row count from the exchange disagrees with the received table: {} vs. {}",
+      numRows,
+      tableView.num_rows());
   auto gpuDataSize = data.gpuDataSize();
+
+  if (numRows == 0) {
+    // An empty page carries no rows to hand on, and Operator::getOutput() must
+    // never return an empty vector. Drop it and let the next isBlocked() fetch
+    // the following page or reach the end of the stream. Producers do not
+    // enqueue empty pages, so this is a defence rather than a live path.
+    currentData_.reset();
+    return nullptr;
+  }
 
   // Use the stream that was allocated in UcxExchangeSource::onMetadata
   // and the packed_table constructor of CudfVector to avoid copying data.
@@ -218,10 +226,9 @@ void UcxExchange::close() {
   currentData_.reset();
   if (exchangeClient_) {
     recordExchangeClientStats();
-    if (closeExchangeClientOnClose_) {
-      exchangeClient_->close();
-    }
   }
+  // The client is shared by all consumers of this pipeline and owned by the
+  // Task, which closes it on termination. Only drop this operator's reference.
   exchangeClient_ = nullptr;
 }
 

--- a/velox/experimental/ucx-exchange/UcxExchange.h
+++ b/velox/experimental/ucx-exchange/UcxExchange.h
@@ -29,11 +29,15 @@ using exec::DriverCtx;
 using exec::SourceOperator;
 
 /// @brief The UCX exchange operator receives data from upstream tasks via
-/// UcxExchangeClient. It is used as a replacement for the Velox Exchange
-/// operator when the plan node's transport type is UCX. The operator receives
+/// UcxExchangeClient. exec::ExchangeTransportRegistry builds it for plan nodes
+/// whose transportKind is core::TransportKind::kUcx. The operator receives
 /// cudf::packed_columns from remote tasks and wraps them as CudfVectors.
 class UcxExchange : public SourceOperator, public cudf_velox::NvtxHelper {
  public:
+  /// @param ucxExchangeClient Client this operator reads from. Must not be
+  /// null: it is created by the same exec::ExchangeTransportEntry that builds
+  /// this operator and is shared by all consumers of the pipeline, so the Task
+  /// that owns it -- not this operator -- closes it.
   UcxExchange(
       int32_t operatorId,
       DriverCtx* driverCtx,
@@ -77,13 +81,10 @@ class UcxExchange : public SourceOperator, public cudf_velox::NvtxHelper {
   std::shared_ptr<UcxExchangeClient> exchangeClient_;
 
   const uint64_t preferredOutputBatchBytes_;
-  // True only when this operator created the client itself. An externally
-  // shared client is left for its owner or final shared_ptr release to close.
-  const bool closeExchangeClientOnClose_;
 
-  /// True if this operator is responsible for fetching splits from the Task
-  /// and passing these to ExchangeClient. When running with multile drivers,
-  /// this is done by the exchange running on driver 0.
+  // True if this operator is responsible for fetching splits from the Task
+  // and passing these to the exchange client. When running with multiple
+  // drivers, this is done by the exchange running on driver 0.
   const bool processSplits_;
   const int pipelineId_;
   const int driverId_;

--- a/velox/experimental/ucx-exchange/UcxExchangeProtocol.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeProtocol.cpp
@@ -66,6 +66,9 @@ std::pair<std::shared_ptr<uint8_t>, size_t> MetadataMsg::serialize() {
   std::memcpy(ptr, &dataSizeBytes, sizeof(dataSizeBytes));
   ptr += sizeof(dataSizeBytes);
 
+  std::memcpy(ptr, &numRows, sizeof(numRows));
+  ptr += sizeof(numRows);
+
   WireLengthType numRemaining = remainingBytes.size();
   std::memcpy(ptr, &numRemaining, sizeof(numRemaining));
   ptr += sizeof(numRemaining);
@@ -117,6 +120,11 @@ MetadataMsg MetadataMsg::deserializeMetadataMsg(const uint8_t* buffer) {
     throw std::runtime_error("Insufficient data for dataSizeBytes");
   std::memcpy(&record.dataSizeBytes, ptr, sizeof(record.dataSizeBytes));
   ptr += sizeof(record.dataSizeBytes);
+
+  if (ptr + sizeof(record.numRows) > endPtr)
+    throw std::runtime_error("Insufficient data for numRows");
+  std::memcpy(&record.numRows, ptr, sizeof(record.numRows));
+  ptr += sizeof(record.numRows);
 
   WireLengthType numRemaining = 0;
   if (ptr + sizeof(numRemaining) > endPtr)

--- a/velox/experimental/ucx-exchange/UcxExchangeProtocol.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeProtocol.cpp
@@ -103,40 +103,46 @@ MetadataMsg MetadataMsg::deserializeMetadataMsg(const uint8_t* buffer) {
   const uint8_t* endPtr = buffer + totalSize;
 
   WireLengthType metaSize = 0;
-  if (ptr + sizeof(metaSize) > endPtr)
+  if (ptr + sizeof(metaSize) > endPtr) {
     throw std::runtime_error("Insufficient data for cudfMetadata size");
+  }
   std::memcpy(&metaSize, ptr, sizeof(metaSize));
   ptr += sizeof(metaSize);
 
   record.cudfMetadata = std::make_unique<std::vector<uint8_t>>(metaSize);
   if (metaSize > 0) {
-    if (ptr + metaSize > endPtr)
+    if (ptr + metaSize > endPtr) {
       throw std::runtime_error("Insufficient data for cudfMetadata bytes");
+    }
     std::memcpy(record.cudfMetadata->data(), ptr, metaSize);
     ptr += metaSize;
   }
 
-  if (ptr + sizeof(record.dataSizeBytes) > endPtr)
+  if (ptr + sizeof(record.dataSizeBytes) > endPtr) {
     throw std::runtime_error("Insufficient data for dataSizeBytes");
+  }
   std::memcpy(&record.dataSizeBytes, ptr, sizeof(record.dataSizeBytes));
   ptr += sizeof(record.dataSizeBytes);
 
-  if (ptr + sizeof(record.numRows) > endPtr)
+  if (ptr + sizeof(record.numRows) > endPtr) {
     throw std::runtime_error("Insufficient data for numRows");
+  }
   std::memcpy(&record.numRows, ptr, sizeof(record.numRows));
   ptr += sizeof(record.numRows);
 
   WireLengthType numRemaining = 0;
-  if (ptr + sizeof(numRemaining) > endPtr)
+  if (ptr + sizeof(numRemaining) > endPtr) {
     throw std::runtime_error("Insufficient data for remainingBytes count");
+  }
   std::memcpy(&numRemaining, ptr, sizeof(numRemaining));
   ptr += sizeof(numRemaining);
 
   record.remainingBytes.resize(numRemaining);
   if (numRemaining > 0) {
     auto bytesSize = numRemaining * sizeof(record.remainingBytes[0]);
-    if (ptr + bytesSize > endPtr)
+    if (ptr + bytesSize > endPtr) {
       throw std::runtime_error("Insufficient data for remainingBytes values");
+    }
     std::memcpy(record.remainingBytes.data(), ptr, bytesSize);
     ptr += bytesSize;
   }

--- a/velox/experimental/ucx-exchange/UcxExchangeProtocol.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeProtocol.h
@@ -107,10 +107,21 @@ constexpr uint32_t kMetaHeaderSize = sizeof(kMagicNumber) + sizeof(uint32_t);
 using WireLengthType = uint64_t;
 using WireDataSizeType = int64_t;
 using WireRemainingElementType = int64_t;
+/// A cuDF table's row count is a cudf::size_type, so it cannot exceed
+/// 2^31 - 1 and needs no more than 32 bits on the wire.
+using WireRowCountType = int32_t;
 
 struct MetadataMsg {
   std::unique_ptr<std::vector<uint8_t>> cudfMetadata;
   WireDataSizeType dataSizeBytes;
+
+  /// Logical rows in the payload. Sent explicitly because cuDF derives a
+  /// table's row count from its columns, so a payload with no columns — an
+  /// exchange fragment whose output layout is empty — cannot report its own
+  /// row count once it has been packed. Bounded by cudf::size_type, which is
+  /// also what bounds the CudfVector the consumer rebuilds.
+  WireRowCountType numRows;
+
   std::vector<WireRemainingElementType> remainingBytes;
   bool atEnd;
 
@@ -123,6 +134,8 @@ struct MetadataMsg {
     totalSize += cudfSize;
     // dataSizeBytes
     totalSize += sizeof(dataSizeBytes);
+    // numRows
+    totalSize += sizeof(numRows);
     // remainingBytes: length and then the data.
     totalSize += sizeof(WireLengthType); // for numRemaining count
     totalSize += remainingBytes.size() * sizeof(remainingBytes[0]);

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.cpp
@@ -63,6 +63,7 @@ void UcxExchangeQueue::enqueueLocked(
   receivedBytes_ += dataSize;
 
   queue_.push_back(std::move(data));
+  publishSizeLocked();
 
   // High-water-mark alerts: log when queue size crosses thresholds.
   auto newSize = static_cast<int64_t>(queue_.size());
@@ -145,6 +146,7 @@ PackedTableWithStreamPtr UcxExchangeQueue::dequeueLocked(
 
   data = std::move(queue_.front());
   queue_.pop_front();
+  publishSizeLocked();
   totalBytes_ -= data->gpuDataSize();
 
   return data;
@@ -162,6 +164,7 @@ void UcxExchangeQueue::setError(std::string_view error) {
     // NOTE: clear the serialized page queue as we won't consume from an
     // errored queue.
     queue_.clear();
+    publishSizeLocked();
     promises = clearAllPromisesLocked();
   }
   clearPromises(promises);

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/future/VeloxPromise.h"
+#include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::ucx_exchange {
 
@@ -31,11 +32,19 @@ struct PackedTableWithStream {
   std::unique_ptr<cudf::packed_table> packedTable;
   rmm::cuda_stream_view stream;
 
+  /// Logical rows in 'packedTable', as reported by the producer. Authoritative:
+  /// cudf::table_view::num_rows() derives the count from the columns and so
+  /// returns 0 for a table with none, which is what an exchange fragment with
+  /// an empty output layout sends. 32-bit because a cuDF table cannot hold more
+  /// rows than a cudf::size_type can index.
+  vector_size_t numRows{0};
+
   PackedTableWithStream() = default;
   PackedTableWithStream(
       std::unique_ptr<cudf::packed_table>&& table,
-      rmm::cuda_stream_view s)
-      : packedTable(std::move(table)), stream(s) {}
+      rmm::cuda_stream_view s,
+      vector_size_t numRows)
+      : packedTable(std::move(table)), stream(s), numRows(numRows) {}
 
   /// Returns the size of the GPU data buffer, or 0 if packedTable is null.
   size_t gpuDataSize() const {

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.h
@@ -17,6 +17,7 @@
 
 #include <cudf/contiguous_split.hpp>
 #include <rmm/cuda_stream_view.hpp>
+#include <atomic>
 #include <cinttypes>
 #include <memory>
 #include "velox/common/base/Exceptions.h"
@@ -69,8 +70,10 @@ class UcxExchangeQueue {
     return mutex_;
   }
 
+  /// Returns true if no packed table is queued. Safe to call without
+  /// 'mutex_'.
   bool empty() const {
-    return queue_.empty();
+    return size_.load(std::memory_order_relaxed) == 0;
   }
 
   /// Enqueues 'data' to the queue. One random promise(top of promise queue)
@@ -105,8 +108,10 @@ class UcxExchangeQueue {
       ContinueFuture* future,
       ContinuePromise* stalePromise);
 
+  /// Returns the number of queued packed tables. Safe to call without
+  /// 'mutex_'.
   int32_t size() const {
-    return queue_.size();
+    return size_.load(std::memory_order_relaxed);
   }
 
   /// Returns the total bytes held by packed tables in 'this'.
@@ -140,8 +145,15 @@ class UcxExchangeQueue {
   void close();
 
  private:
+  // Publishes the depth of 'queue_' to 'size_'. Call with 'mutex_' held after
+  // every mutation of 'queue_'.
+  void publishSizeLocked() {
+    size_.store(static_cast<int32_t>(queue_.size()), std::memory_order_relaxed);
+  }
+
   std::vector<ContinuePromise> closeLocked() {
     queue_.clear();
+    publishSizeLocked();
     return clearAllPromisesLocked();
   }
 
@@ -194,6 +206,14 @@ class UcxExchangeQueue {
 
   std::mutex mutex_;
   std::deque<PackedTableWithStreamPtr> queue_;
+  // Depth of 'queue_', maintained under 'mutex_' so that size() and empty() can
+  // be read without it. The Communicator progress thread polls the depth on
+  // every UcxExchangeSource::process() call to decide backpressure, and taking
+  // 'mutex_' there would contend with dequeueLocked() on the driver threads.
+  // Reading queue_.size() unlocked is not an option: std::deque computes it by
+  // subtracting iterators over the node map, so a concurrent push_back or
+  // pop_front that crosses a node boundary can yield an arbitrary value.
+  std::atomic<int32_t> size_{0};
   // The map from consumer id to the waiting promise
   folly::F14FastMap<int, ContinuePromise> promises_;
 

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.h
@@ -73,7 +73,7 @@ class UcxExchangeQueue {
   /// Returns true if no packed table is queued. Safe to call without
   /// 'mutex_'.
   bool empty() const {
-    return size_.load(std::memory_order_relaxed) == 0;
+    return size() == 0;
   }
 
   /// Enqueues 'data' to the queue. One random promise(top of promise queue)

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -131,6 +131,7 @@ void UcxExchangeServer::process() {
           partitionKey_.destination,
           [weakQueue](
               std::shared_ptr<cudf::packed_columns> data,
+              vector_size_t numRows,
               std::vector<int64_t> remainingBytes) {
             auto self = weakQueue.lock();
             if (!self) {
@@ -153,6 +154,7 @@ void UcxExchangeServer::process() {
             VELOX_CHECK_NULL(
                 self->dataPtr_, "Data pointer exists: Illegal state!");
             self->dataPtr_ = std::move(data);
+            self->dataNumRows_ = numRows;
             self->setState(ServerState::DataReady);
             self->communicator_->addToWorkQueue(self);
           });
@@ -281,8 +283,9 @@ void UcxExchangeServer::sendData() {
       // dataPtr_ is already a shared_ptr, pass directly to share ownership.
       intraNodeRetrieveFuture_ =
           IntraNodeTransferRegistry::getInstance()->publish(
-              key, dataPtr_, /*atEnd=*/false);
+              key, dataPtr_, dataNumRows_, /*atEnd=*/false);
       dataPtr_.reset();
+      dataNumRows_ = 0;
       intraNodeAtEndPublished_ = false;
 
       // Transition to WaitingForIntraNodeRetrieve state
@@ -299,7 +302,7 @@ void UcxExchangeServer::sendData() {
           partitionKey_.taskId, partitionKey_.destination, sequenceNumber_};
       intraNodeRetrieveFuture_ =
           IntraNodeTransferRegistry::getInstance()->publish(
-              key, nullptr, /*atEnd=*/true);
+              key, nullptr, /*numRows=*/0, /*atEnd=*/true);
       intraNodeAtEndPublished_ = true;
 
       queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
@@ -319,6 +322,7 @@ void UcxExchangeServer::sendData() {
       metadataMsg->cudfMetadata =
           std::make_unique<std::vector<uint8_t>>(*dataPtr_->metadata);
       metadataMsg->dataSizeBytes = dataPtr_->gpu_data->size();
+      metadataMsg->numRows = dataNumRows_;
       metadataMsg->remainingBytes = {};
       metadataMsg->atEnd = false;
     } else {
@@ -326,6 +330,7 @@ void UcxExchangeServer::sendData() {
               << partitionKey_.toString();
       metadataMsg->cudfMetadata = nullptr;
       metadataMsg->dataSizeBytes = 0;
+      metadataMsg->numRows = 0;
       metadataMsg->remainingBytes = {};
       metadataMsg->atEnd = true;
     }
@@ -472,6 +477,7 @@ void UcxExchangeServer::sendComplete(
 
     this->sequenceNumber_++;
     dataPtr_.reset(); // release memory.
+    dataNumRows_ = 0;
     VLOG(3) << "@" << partitionKey_.taskId
             << " Releasing dataPtr_ in sendComplete.";
     setState(ServerState::ReadyToTransfer);

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -466,7 +466,7 @@ void UcxExchangeServer::sendComplete(
     auto duration = end - sendStart_;
     auto micros =
         std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
-    auto throughput = bytes_ / micros;
+    auto throughput = (micros > 0) ? (bytes_ / micros) : 0;
 
     VLOG(3) << "@" << partitionKey_.taskId << " duration: "
             << std::chrono::duration_cast<std::chrono::milliseconds>(duration)

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.h
@@ -25,7 +25,8 @@
 #include <future>
 #include <memory>
 #include <tuple>
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
+#include "velox/common/EnumDefine.h"
 #include "velox/experimental/ucx-exchange/CommElement.h"
 #include "velox/experimental/ucx-exchange/EndpointRef.h"
 #include "velox/experimental/ucx-exchange/PartitionKey.h"
@@ -117,6 +118,9 @@ class UcxExchangeServer
 
   std::atomic<ServerState> state_;
   std::shared_ptr<cudf::packed_columns> dataPtr_{nullptr};
+  /// Logical rows in 'dataPtr_', taken from the output queue rather than from
+  /// the packed table, which reports zero rows when it has no columns.
+  vector_size_t dataNumRows_{0};
   /// Protects dataPtr_. Must be recursive because sendData() holds the lock
   /// when calling tagSend(), and for small messages UCX completes inline via
   /// its fast-completion path, firing the sendComplete() callback on the same

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -615,8 +615,10 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
         cudf::packed_table{tableView, std::move(packedCols)});
 
     // Bundle the packed_table with the stream that was used for allocation
+    // and the producer's row count, which the packed table cannot report for
+    // itself when it has no columns.
     auto data = std::make_unique<PackedTableWithStream>(
-        std::move(packedTable), ptr->stream);
+        std::move(packedTable), ptr->stream, ptr->metadata.numRows);
 
     enqueue(std::move(data));
     setStateIf(ReceiverState::WaitingForData, ReceiverState::ReadyToReceive);
@@ -723,11 +725,12 @@ void UcxExchangeSource::waitForIntraNodeData() {
   }
 
   intraNodePollCount_ = 0;
-  onIntraNodeData(std::move(result->data), result->atEnd);
+  onIntraNodeData(std::move(result->data), result->numRows, result->atEnd);
 }
 
 void UcxExchangeSource::onIntraNodeData(
     std::shared_ptr<cudf::packed_columns> data,
+    vector_size_t numRows,
     bool atEnd) {
   // Check if close() was called
   if (closed_.load(std::memory_order_acquire)) {
@@ -785,8 +788,8 @@ void UcxExchangeSource::onIntraNodeData(
   // the inter-node (UCX) receive path which also allocates a pool stream.
   auto stream =
       facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
-  auto tableWithStream =
-      std::make_unique<PackedTableWithStream>(std::move(packedTable), stream);
+  auto tableWithStream = std::make_unique<PackedTableWithStream>(
+      std::move(packedTable), stream, numRows);
 
   enqueue(std::move(tableWithStream));
 

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -15,7 +15,8 @@
  */
 #pragma once
 
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
+#include "velox/common/EnumDefine.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/exec/Exchange.h"
 #include "velox/experimental/ucx-exchange/CommElement.h"
@@ -33,7 +34,6 @@
 #include <rmm/cuda_stream_pool.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 namespace facebook::velox::ucx_exchange {
@@ -212,8 +212,12 @@ class UcxExchangeSource
 
   /// @brief For intra-node transfer: handles data retrieved from registry.
   /// @param data The packed_columns from registry (nullptr if atEnd or error)
+  /// @param numRows Logical rows in 'data'
   /// @param atEnd True if this is end-of-stream
-  void onIntraNodeData(std::shared_ptr<cudf::packed_columns> data, bool atEnd);
+  void onIntraNodeData(
+      std::shared_ptr<cudf::packed_columns> data,
+      vector_size_t numRows,
+      bool atEnd);
 
   /// @brief Sets the new state of this exchange source using
   /// sequential consistency. Logs transitions at VLOG(2).

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -37,7 +37,8 @@ void UcxOutputQueueManager::initializeTask(
     std::shared_ptr<exec::Task> task,
     core::PartitionedOutputNode::Kind kind,
     int numDestinations,
-    int numDrivers) {
+    int numDrivers,
+    const std::string& /*transportOptions*/) {
   const auto& taskId = task->taskId();
   queues_.withLock([&](auto& queues) {
     auto it = queues.find(taskId);
@@ -60,18 +61,22 @@ void UcxOutputQueueManager::initializeTask(
   IntraNodeTransferRegistry::getInstance()->clearCancelledTask(taskId);
 }
 
-void UcxOutputQueueManager::updateOutputBuffers(
-    std::string_view taskId,
+bool UcxOutputQueueManager::updateOutputBuffers(
+    const std::string& taskId,
     int numBuffers,
     bool noMoreBuffers) {
-  getQueue(taskId)->updateOutputBuffers(numBuffers, noMoreBuffers);
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->updateOutputBuffers(numBuffers, noMoreBuffers);
+    return true;
+  }
+  return false;
 }
 
 void UcxOutputQueueManager::enqueue(
     std::string_view taskId,
     int destination,
     std::unique_ptr<cudf::packed_columns> txData,
-    int numRows) {
+    vector_size_t numRows) {
   getQueue(taskId)->enqueue(destination, std::move(txData), numRows);
 }
 
@@ -132,7 +137,7 @@ void UcxOutputQueueManager::getData(
   });
   if (taskRemoved) {
     // Fire callback immediately with nullptr to signal end-of-stream.
-    notify(nullptr, {});
+    notify(nullptr, /*numRows=*/0, {});
     return;
   }
   // outside of lock. Queue must exist.
@@ -146,7 +151,7 @@ bool UcxOutputQueueManager::canUseIntraNode(std::string_view taskId) {
       queue->kind() != core::PartitionedOutputNode::Kind::kBroadcast;
 }
 
-void UcxOutputQueueManager::removeTask(std::string_view taskId) {
+void UcxOutputQueueManager::removeTask(const std::string& taskId) {
   std::string taskIdStr{taskId};
   auto queue =
       queues_.withLock([&](auto& queues) -> std::shared_ptr<UcxOutputQueue> {
@@ -198,12 +203,48 @@ std::shared_ptr<UcxOutputQueue> UcxOutputQueueManager::getQueue(
 }
 
 std::optional<exec::OutputBuffer::Stats> UcxOutputQueueManager::stats(
-    std::string_view taskId) {
+    const std::string& taskId) {
   auto queue = getQueueIfExists(taskId);
   if (queue != nullptr) {
     return queue->stats();
   }
   return std::nullopt;
+}
+
+bool UcxOutputQueueManager::updateNumDrivers(
+    const std::string& taskId,
+    uint32_t newNumDrivers) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->updateNumDrivers(newNumDrivers);
+    return true;
+  }
+  return false;
+}
+
+std::optional<double> UcxOutputQueueManager::getUtilization(
+    const std::string& taskId) {
+  auto queue = getQueueIfExists(taskId);
+  if (queue == nullptr) {
+    return std::nullopt;
+  }
+  return queue->getUtilization();
+}
+
+std::optional<bool> UcxOutputQueueManager::isOverutilized(
+    const std::string& taskId) {
+  auto queue = getQueueIfExists(taskId);
+  if (queue == nullptr) {
+    return std::nullopt;
+  }
+  return queue->isOverutilized();
+}
+
+std::string UcxOutputQueueManager::toString(const std::string& taskId) {
+  auto queue = getQueueIfExists(taskId);
+  if (queue != nullptr) {
+    return "UcxOutputQueue[" + taskId + "]";
+  }
+  return "UcxOutputQueue[" + taskId + " not found]";
 }
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/contiguous_split.hpp>
+#include <velox/exec/OutputBufferManager.h>
 #include <velox/exec/Task.h>
 #include <functional>
 #include <string_view>
@@ -24,7 +25,7 @@
 
 namespace facebook::velox::ucx_exchange {
 
-class UcxOutputQueueManager {
+class UcxOutputQueueManager : public exec::OutputBufferManager {
  public:
   /// Factory method to retrieve a reference to the output queue manager.
   static std::shared_ptr<UcxOutputQueueManager> getInstanceRef();
@@ -44,31 +45,37 @@ class UcxOutputQueueManager {
   /// associated with this task.
   /// @param numDrivers The number of drivers that contribute data to these
   /// queues. Used to recognize when the queues are complete.
+  /// @param transportOptions Opaque per-node transport configuration carried on
+  /// the PartitionedOutputNode. Unused: UCX takes its settings from CudfConfig
+  /// and the communicator, so there is nothing node-scoped to apply yet.
   void initializeTask(
       std::shared_ptr<exec::Task> task,
       core::PartitionedOutputNode::Kind kind,
       int numDestinations,
-      int numDrivers);
+      int numDrivers,
+      const std::string& transportOptions = {}) override;
 
   /// @brief Updates the number of destination buffers for a task.
   /// For broadcast mode, new destinations are backfilled with previously
   /// broadcast data.
-  void updateOutputBuffers(
-      std::string_view taskId,
+  bool updateOutputBuffers(
+      const std::string& taskId,
       int numBuffers,
-      bool noMoreBuffers);
+      bool noMoreBuffers) override;
 
   /// @brief Enqueues a cudf packed column into the queue.
   /// @param taskId The unique task Id.
   /// @param destination The destination (partition, queue number) into which
   /// the data is queued.
   /// @param txData The data to enqueue.
-  /// @param numRows The number of rows in the data.
+  /// @param numRows The number of rows in the data. Supplied by the producer
+  /// rather than read back from 'txData', which cannot report a row count once
+  /// it has no columns.
   void enqueue(
       std::string_view taskId,
       int destination,
       std::unique_ptr<cudf::packed_columns> txData,
-      int32_t numRows);
+      vector_size_t numRows);
 
   /// @brief Checks if the queue for a task is over capacity.
   /// Should be called after enqueueing all partitions for a batch.
@@ -110,11 +117,21 @@ class UcxOutputQueueManager {
 
   /// @brief Removes the queue for the given task from the queue manager.
   /// Calls "terminate" on the queue to awake waiting producers.
-  void removeTask(std::string_view taskId);
+  void removeTask(const std::string& taskId) override;
 
   /// @brief Returns the queue statistics of the queue associated with the given
   /// task. Returns nullopt when the specified output queue doesn't exist.
-  std::optional<exec::OutputBuffer::Stats> stats(std::string_view taskId);
+  std::optional<exec::OutputBuffer::Stats> stats(
+      const std::string& taskId) override;
+
+  bool updateNumDrivers(const std::string& taskId, uint32_t newNumDrivers)
+      override;
+
+  std::optional<double> getUtilization(const std::string& taskId) override;
+
+  std::optional<bool> isOverutilized(const std::string& taskId) override;
+
+  std::string toString(const std::string& taskId) override;
 
  private:
   // Retrieves the queue for a task if it exists.

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -44,27 +44,29 @@ void UcxDestinationQueue::Stats::recordDequeue(
 }
 
 void UcxDestinationQueue::enqueueBack(
-    std::shared_ptr<cudf::packed_columns> data) {
+    std::shared_ptr<cudf::packed_columns> data,
+    vector_size_t numRows) {
   // drop duplicate end markers.
-  if (data == nullptr && !queue_.empty() && queue_.back() == nullptr) {
+  if (data == nullptr && !queue_.empty() && queue_.back().data == nullptr) {
     return;
   }
 
   if (data != nullptr) {
     stats_.recordEnqueue(data.get());
   }
-  queue_.push_back(std::move(data));
+  queue_.push_back(QueuedPage{std::move(data), numRows});
 }
 
 void UcxDestinationQueue::enqueueFront(
-    std::shared_ptr<cudf::packed_columns> data) {
+    std::shared_ptr<cudf::packed_columns> data,
+    vector_size_t numRows) {
   // ignore nullptr.
   if (data == nullptr) {
     return;
   }
 
   // insert at the front.
-  queue_.push_front(std::move(data));
+  queue_.push_front(QueuedPage{std::move(data), numRows});
 }
 
 UcxDestinationQueue::Data UcxDestinationQueue::getData(
@@ -76,26 +78,26 @@ UcxDestinationQueue::Data UcxDestinationQueue::getData(
   }
 
   // queue is not empty.
-  auto data = std::move(queue_.front());
+  auto page = std::move(queue_.front());
   queue_.pop_front();
-  stats_.recordDequeue(data.get());
+  stats_.recordDequeue(page.data.get());
 
   std::vector<int64_t> remainingBytes;
   remainingBytes.reserve(queue_.size());
   // fill in the remainingbytes vector.
   for (std::size_t i = 0; i < queue_.size(); ++i) {
-    if (queue_[i] == nullptr) {
+    if (queue_[i].data == nullptr) {
       VELOX_CHECK_EQ(i, queue_.size() - 1, "null marker found in the middle");
       break;
     }
-    remainingBytes.push_back(queue_[i]->gpu_data->size());
+    remainingBytes.push_back(queue_[i].data->gpu_data->size());
   }
-  return {std::move(data), std::move(remainingBytes), true};
+  return {std::move(page.data), page.numRows, std::move(remainingBytes), true};
 }
 
 void UcxDestinationQueue::deleteResults() {
   for (auto i = 0; i < queue_.size(); ++i) {
-    if (queue_[i] == nullptr) {
+    if (queue_[i].data == nullptr) {
       VELOX_CHECK_EQ(i, queue_.size() - 1, "null marker found in the middle");
       break;
     }
@@ -111,6 +113,7 @@ UcxDataAvailable UcxDestinationQueue::getAndClearNotify() {
   result.callback = notify_;
   auto data = getData(nullptr);
   result.data = std::move(data.data);
+  result.numRows = data.numRows;
   result.remainingBytes = std::move(data.remainingBytes);
   clearNotify();
   return result;
@@ -203,7 +206,7 @@ void UcxOutputQueue::updateNumDrivers(uint32_t newNumDrivers) {
 void UcxOutputQueue::enqueue(
     int destination,
     std::unique_ptr<cudf::packed_columns> data,
-    int32_t numRows) {
+    vector_size_t numRows) {
   VELOX_CHECK_NOT_NULL(data);
   VELOX_CHECK_NOT_NULL(task_);
   VELOX_CHECK(
@@ -218,7 +221,7 @@ void UcxOutputQueue::enqueue(
     if (kind_ == core::PartitionedOutputNode::Kind::kBroadcast) {
       VELOX_CHECK_EQ(destination, 0, "Broadcast uses destination 0");
       enqueueBroadcastOutputLocked(
-          std::move(sharedData), dataAvailableCallbacks);
+          std::move(sharedData), numRows, dataAvailableCallbacks);
       // For broadcast, count queuedBytes_ once per active destination so
       // that each destination's dequeue symmetrically decrements it. The
       // total sent stats count the logical data once.
@@ -238,7 +241,7 @@ void UcxOutputQueue::enqueue(
     } else {
       VELOX_CHECK_LT(destination, queues_.size());
       success = enqueuePartitionedOutputLocked(
-          destination, std::move(sharedData), dataAvailableCallbacks);
+          destination, std::move(sharedData), numRows, dataAvailableCallbacks);
       if (success) {
         updateStatsWithEnqueuedLocked(numBytes, numRows);
       }
@@ -287,10 +290,11 @@ void UcxOutputQueue::getData(int destination, UcxDataAvailableCallback notify) {
       std::weak_ptr<UcxOutputQueue> weakSelf = shared_from_this();
       data = queue->getData([notify, weakSelf](
                                 std::shared_ptr<cudf::packed_columns> data,
+                                vector_size_t numRows,
                                 std::vector<int64_t> remainingBytes) {
         std::vector<ContinuePromise> promises;
         int64_t bytes = data ? data->gpu_data->size() : -1L;
-        notify(std::move(data), std::move(remainingBytes));
+        notify(std::move(data), numRows, std::move(remainingBytes));
         if (bytes >= 0L) {
           auto self = weakSelf.lock();
           if (!self) {
@@ -312,12 +316,12 @@ void UcxOutputQueue::getData(int destination, UcxDataAvailableCallback notify) {
         updateStatsWithFreedLocked(data.data->gpu_data->size(), 1L, promises);
       }
     } else {
-      data = UcxDestinationQueue::Data{nullptr, {}, true};
+      data = UcxDestinationQueue::Data{nullptr, 0, {}, true};
     }
   }
   // outside lock: If we have data, then return it immediately.
   if (data.immediate) {
-    notify(std::move(data.data), std::move(data.remainingBytes));
+    notify(std::move(data.data), data.numRows, std::move(data.remainingBytes));
   } else {
     VLOG(2) << "[QUEUE] task=" << (task_ ? task_->taskId() : "n/a")
             << " dest=" << destination
@@ -366,7 +370,7 @@ void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
     }
     for (auto& queue : queues_) {
       if (queue != nullptr) {
-        queue->enqueueBack(nullptr);
+        queue->enqueueBack(nullptr, /*numRows=*/0);
         finished.push_back(queue->getAndClearNotify());
       }
     }
@@ -380,13 +384,14 @@ void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
 bool UcxOutputQueue::enqueuePartitionedOutputLocked(
     int destination,
     std::shared_ptr<cudf::packed_columns> data,
+    vector_size_t numRows,
     std::vector<UcxDataAvailable>& dataAvailableCbs) {
   VELOX_DCHECK(dataAvailableCbs.empty());
   VELOX_CHECK_LT(destination, queues_.size());
   bool success = false;
   auto* queue = queues_[destination].get();
   if (queue != nullptr) {
-    queue->enqueueBack(std::move(data));
+    queue->enqueueBack(std::move(data), numRows);
     dataAvailableCbs.emplace_back(queue->getAndClearNotify());
     success = true;
   }
@@ -395,19 +400,20 @@ bool UcxOutputQueue::enqueuePartitionedOutputLocked(
 
 void UcxOutputQueue::enqueueBroadcastOutputLocked(
     std::shared_ptr<cudf::packed_columns> data,
+    vector_size_t numRows,
     std::vector<UcxDataAvailable>& dataAvailableCbs) {
   VELOX_DCHECK(dataAvailableCbs.empty());
 
   for (auto& queue : queues_) {
     if (queue != nullptr) {
-      queue->enqueueBack(data);
+      queue->enqueueBack(data, numRows);
       dataAvailableCbs.emplace_back(queue->getAndClearNotify());
     }
   }
 
   // Store for late-arriving destinations (backfill).
   if (!noMoreQueues_) {
-    dataToBroadcast_.emplace_back(std::move(data));
+    dataToBroadcast_.emplace_back(std::move(data), numRows);
   }
 }
 
@@ -452,15 +458,15 @@ void UcxOutputQueue::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
       queues_.reserve(numBuffers);
       for (int32_t i = 0; i < numNewBuffers; ++i) {
         auto buffer = std::make_unique<UcxDestinationQueue>();
-        for (const auto& data : dataToBroadcast_) {
-          buffer->enqueueBack(data);
+        for (const auto& [data, numRows] : dataToBroadcast_) {
+          buffer->enqueueBack(data, numRows);
           // Account for backfilled data in queuedBytes_ so that dequeue
           // decrements don't drive it negative.
           queuedBytes_ += data->gpu_data->size();
           queuedPackedColumns_++;
         }
         if (atEnd_) {
-          buffer->enqueueBack(nullptr);
+          buffer->enqueueBack(nullptr, /*numRows=*/0);
         }
         queues_.emplace_back(std::move(buffer));
       }
@@ -534,7 +540,7 @@ void UcxOutputQueue::terminate() {
     // noMoreData() is called, preventing consumers from being orphaned.
     for (auto& queue : queues_) {
       if (queue != nullptr) {
-        queue->enqueueBack(nullptr);
+        queue->enqueueBack(nullptr, /*numRows=*/0);
         pendingCallbacks.push_back(queue->getAndClearNotify());
       }
     }
@@ -550,6 +556,22 @@ void UcxOutputQueue::terminate() {
   for (auto& promise : promises) {
     promise.setValue();
   }
+}
+
+std::optional<double> UcxOutputQueue::getUtilization() {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (maxSize_ == 0) {
+    return std::nullopt;
+  }
+  return queuedBytes_ / static_cast<double>(maxSize_);
+}
+
+std::optional<bool> UcxOutputQueue::isOverutilized() {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (maxSize_ == 0) {
+    return std::nullopt;
+  }
+  return (queuedBytes_ > (0.5 * static_cast<double>(maxSize_))) || atEnd_;
 }
 
 exec::OutputBuffer::Stats UcxOutputQueue::stats() {

--- a/velox/experimental/ucx-exchange/UcxQueues.h
+++ b/velox/experimental/ucx-exchange/UcxQueues.h
@@ -20,6 +20,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 #include "velox/core/PlanNode.h"
 #include "velox/exec/OutputBuffer.h" // for the Stats structure
@@ -29,22 +30,27 @@ namespace facebook::velox::ucx_exchange {
 
 /// @brief  Callback function for getting data from the queues.
 /// A nullptr indicates that there is no more data.
+/// 'numRows' is the logical row count of 'data', supplied by the producer
+/// because a packed table with no columns cannot report one: cuDF derives
+/// num_rows() from the columns. It is 0 for the end-of-stream marker.
 /// The remainingBytes vector contains the sizes for the
 /// packed_columns elements remaining in the queue.
 /// Uses shared_ptr to support broadcast mode where the same GPU data
 /// is shared across multiple destination queues without copying.
 using UcxDataAvailableCallback = std::function<void(
     std::shared_ptr<cudf::packed_columns> data,
+    vector_size_t numRows,
     std::vector<int64_t> remainingBytes)>;
 
 struct UcxDataAvailable {
   UcxDataAvailableCallback callback{nullptr};
   std::shared_ptr<cudf::packed_columns> data;
+  vector_size_t numRows{0};
   std::vector<int64_t> remainingBytes;
 
   void notify() {
     if (callback) {
-      callback(std::move(data), remainingBytes);
+      callback(std::move(data), numRows, remainingBytes);
     }
   }
 };
@@ -73,15 +79,22 @@ class UcxDestinationQueue {
 
   /// @brief Enqueues the data to the back of the queue.
   /// @param data Corresponds to a RowVector
-  void enqueueBack(std::shared_ptr<cudf::packed_columns> data);
+  /// @param numRows The logical row count of 'data'
+  void enqueueBack(
+      std::shared_ptr<cudf::packed_columns> data,
+      vector_size_t numRows);
 
   /// @brief Enqueues the data to the front of the queue. This is needed when
   /// a transfer fails.
   /// @param data
-  void enqueueFront(std::shared_ptr<cudf::packed_columns> data);
+  /// @param numRows The logical row count of 'data'
+  void enqueueFront(
+      std::shared_ptr<cudf::packed_columns> data,
+      vector_size_t numRows);
 
   struct Data {
     std::shared_ptr<cudf::packed_columns> data;
+    vector_size_t numRows{0};
     std::vector<int64_t> remainingBytes;
     /// Whether the result is returned immediately without invoking the `notify'
     /// callback.
@@ -112,7 +125,15 @@ class UcxDestinationQueue {
  private:
   void clearNotify();
 
-  std::deque<std::shared_ptr<cudf::packed_columns>> queue_;
+  // A queued page and the logical row count the producer gave it. Paired here
+  // rather than recovered from the page, which reports no rows when it has no
+  // columns.
+  struct QueuedPage {
+    std::shared_ptr<cudf::packed_columns> data;
+    vector_size_t numRows{0};
+  };
+
+  std::deque<QueuedPage> queue_;
   UcxDataAvailableCallback notify_{nullptr};
   Stats stats_;
 };
@@ -178,11 +199,13 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   /// in OutputQueue.
   /// @param destination The destination, must be < numDestinations.
   /// @param data The data.
-  /// @param numRows The number of rows in the data.
+  /// @param numRows The number of rows in the data. Supplied by the producer
+  /// rather than read back from 'data', which cannot report a row count once it
+  /// has no columns.
   void enqueue(
       int destination,
       std::unique_ptr<cudf::packed_columns> data,
-      int32_t numRows);
+      vector_size_t numRows);
 
   /// @brief Checks if the queue is over capacity and returns a future if so.
   /// This should be called after enqueueing all partitions for a batch.
@@ -228,6 +251,22 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   /// are never processed by Presto.
   exec::OutputBuffer::Stats stats();
 
+  /// @brief Queued bytes over this queue's byte capacity, the task's configured
+  /// maxOutputBufferSize. Producers are only blocked after adding data (see
+  /// checkBlocked), so the ratio can exceed 1.0. Returns nullopt while the
+  /// capacity is still unknown, which is the case for a placeholder queue
+  /// created by a getData() that arrived before initializeTask() supplied the
+  /// task's query config.
+  std::optional<double> getUtilization();
+
+  /// @brief Whether enough is queued to risk back-pressuring producers soon, or
+  /// the last data has been seen. Half the capacity is the threshold, matching
+  /// exec::OutputBuffer. Returns nullopt while the capacity is unknown, for the
+  /// same reason as getUtilization(): without a capacity there is no ratio to
+  /// compare against, and reporting `false` there would let a placeholder queue
+  /// masquerade as having spare room.
+  std::optional<bool> isOverutilized();
+
  private:
   // Percentage of maxSize below which a blocked producer should
   // be unblocked.
@@ -259,10 +298,12 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   bool enqueuePartitionedOutputLocked(
       int destination,
       std::shared_ptr<cudf::packed_columns> data,
+      vector_size_t numRows,
       std::vector<UcxDataAvailable>& dataAvailableCbs);
 
   void enqueueBroadcastOutputLocked(
       std::shared_ptr<cudf::packed_columns> data,
+      vector_size_t numRows,
       std::vector<UcxDataAvailable>& dataAvailableCbs);
 
   // Reference to the task that owns this UcxQueue.
@@ -279,7 +320,9 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
 
   // For broadcast: stores data for late-arriving destinations that need
   // backfill. Cleared once noMoreQueues_ is set.
-  std::vector<std::shared_ptr<cudf::packed_columns>> dataToBroadcast_;
+  // Paired with the row count for the same reason QueuedPage is.
+  std::vector<std::pair<std::shared_ptr<cudf::packed_columns>, vector_size_t>>
+      dataToBroadcast_;
 
   /// If 'queuedBytes_' > 'maxSize_', each producer is blocked after adding
   /// data.

--- a/velox/experimental/ucx-exchange/tests/Main.cpp
+++ b/velox/experimental/ucx-exchange/tests/Main.cpp
@@ -32,7 +32,10 @@ int main(int argc, char** argv) {
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
   folly::Init init(&argc, &argv, false);
-  facebook::velox::cudf_velox::CudfConfig::getInstance().exchangeLogLevel =
-      FLAGS_exchange_log_level;
+  auto& cudfConfig = facebook::velox::cudf_velox::CudfConfig::getInstance();
+  // Enable the UCX exchange so the Communicator initializes under test;
+  // production code enables it via the "cudf.exchange" session config.
+  cudfConfig.exchange = true;
+  cudfConfig.exchangeLogLevel = FLAGS_exchange_log_level;
   return RUN_ALL_TESTS();
 }

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -22,20 +22,34 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <folly/Executor.h>
+#include <folly/Synchronized.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/synchronization/EventCount.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 #include <rmm/device_buffer.hpp>
+#include <algorithm>
 #include <chrono>
+#include <functional>
 #include <future>
+#include <limits>
 #include <memory>
 #include <sstream>
+#include <utility>
 #include <vector>
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/exec/OutputTransportRegistry.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/PortUtil.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
@@ -44,6 +58,8 @@
 #include "velox/experimental/ucx-exchange/tests/UcxPartitionedOutputMock.h"
 #include "velox/experimental/ucx-exchange/tests/UcxTestData.h"
 #include "velox/experimental/ucx-exchange/tests/UcxTestHelpers.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/FlatVector.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -130,7 +146,18 @@ struct ExchangeTestParamsPrinter {
 
 class UcxExchangeTest : public testing::TestWithParam<ExchangeTestParams> {
  protected:
-  static constexpr uint16_t kCommunicatorPort = 21346;
+  // Chosen per process in SetUpTestCase() rather than hardcoded. The
+  // communicator opens a listener on this port without address reuse, so two
+  // runs of this binary in quick succession fail the second with
+  // "bind(0.0.0.0:21346) failed: Address already in use" while the first port
+  // is still in TIME_WAIT.
+  static uint16_t communicatorPort_;
+
+  // UcxExchangeSource computes the UCX port as the split URL's port + 3
+  // (UcxExchangeSource.cpp), so remoteSplit() advertises this much below the
+  // communicator's port for the round trip to land back on it.
+  static constexpr int kSplitUrlPortOffset = 3;
+
   static constexpr auto kUnusedCoordinatorUrl =
       std::string_view("http://localhost:12345/bla");
 
@@ -164,10 +191,18 @@ class UcxExchangeTest : public testing::TestWithParam<ExchangeTestParams> {
     VLOG(0) << "setup test case, creating queue manager, communicator, etc..";
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
 
+    // UcxExchangeSource derives the UCX port as the split URL's port + 3, and
+    // remoteSplit() advertises communicatorPort_ - 3 to match, so the offset
+    // must stay below the chosen port.
+    const auto freePort = exec::test::getFreePort();
+    ASSERT_GT(freePort, kSplitUrlPortOffset);
+    ASSERT_LE(freePort, std::numeric_limits<uint16_t>::max());
+    communicatorPort_ = static_cast<uint16_t>(freePort);
+
     queueManager_ = UcxOutputQueueManager::getInstanceRef();
     ContinueFuture future;
     communicator_ = facebook::velox::ucx_exchange::Communicator::initAndGet(
-        kCommunicatorPort, std::string(kUnusedCoordinatorUrl), &future);
+        communicatorPort_, std::string(kUnusedCoordinatorUrl), &future);
     if (communicator_) {
       communicatorThread_ = std::make_shared<std::thread>(
           &facebook::velox::ucx_exchange::Communicator::run,
@@ -194,7 +229,7 @@ class UcxExchangeTest : public testing::TestWithParam<ExchangeTestParams> {
   exec::Split remoteSplit(std::string_view taskId, int partitionId) {
     std::string remoteUrl = fmt::format(
         "http://127.0.0.1:{}/v1/task/{}/results/{}",
-        kCommunicatorPort - 3,
+        communicatorPort_ - kSplitUrlPortOffset,
         taskId,
         partitionId);
     return exec::Split(
@@ -1420,7 +1455,7 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
 
     // Pass custom threshold via QueryConfig.
     std::unordered_map<std::string, std::string> extraConfig{
-        {core::QueryConfig::kUcxPartitionedOutputBatchRows,
+        {cudf_velox::CudfConfig::kUcxPartitionedOutputBatchRows,
          std::to_string(customThreshold)}};
 
     auto srcTask = createPartitionedOutputTask(
@@ -1574,5 +1609,6 @@ std::shared_ptr<UcxOutputQueueManager> UcxExchangeTest::queueManager_;
 std::shared_ptr<std::thread> UcxExchangeTest::communicatorThread_;
 std::shared_ptr<Communicator> UcxExchangeTest::communicator_;
 std::atomic<uint32_t> UcxExchangeTest::testCounter_{0};
+uint16_t UcxExchangeTest::communicatorPort_{0};
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -246,6 +246,61 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(generateTestParams()),
     ExchangeTestParamsPrinter());
 
+// size() and empty() read a counter maintained under the queue's mutex rather
+// than the deque, so that the Communicator progress thread can poll the depth
+// lock-free. Covers that the counter stays in step with every mutation.
+TEST(UcxExchangeQueueTest, sizeTracksQueuedTables) {
+  UcxExchangeQueue queue{/*numberOfConsumers=*/1};
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(queue.mutex());
+    queue.addSourceLocked();
+    EXPECT_EQ(queue.size(), 0);
+    EXPECT_TRUE(queue.empty());
+
+    for (int32_t expected = 1; expected <= 3; ++expected) {
+      queue.enqueueLocked(std::make_unique<PackedTableWithStream>(), promises);
+      EXPECT_EQ(queue.size(), expected);
+    }
+    EXPECT_FALSE(queue.empty());
+
+    bool atEnd{false};
+    ContinueFuture future = ContinueFuture::makeEmpty();
+    ContinuePromise stalePromise = ContinuePromise::makeEmpty();
+    EXPECT_NE(queue.dequeueLocked(0, &atEnd, &future, &stalePromise), nullptr);
+    EXPECT_FALSE(atEnd);
+    EXPECT_EQ(queue.size(), 2);
+
+    // The end-of-stream marker counts a source as completed instead of being
+    // queued, so the depth must not move.
+    queue.enqueueLocked(nullptr, promises);
+    EXPECT_EQ(queue.size(), 2);
+  }
+
+  // setError() discards the queued tables, because an errored queue is never
+  // consumed from.
+  queue.setError("Producer failed");
+  EXPECT_EQ(queue.size(), 0);
+  EXPECT_TRUE(queue.empty());
+}
+
+TEST(UcxExchangeQueueTest, closeResetsSize) {
+  UcxExchangeQueue queue{/*numberOfConsumers=*/1};
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(queue.mutex());
+    queue.addSourceLocked();
+    queue.enqueueLocked(std::make_unique<PackedTableWithStream>(), promises);
+    queue.enqueueLocked(std::make_unique<PackedTableWithStream>(), promises);
+    EXPECT_EQ(queue.size(), 2);
+  }
+
+  // close() discards whatever is still queued.
+  queue.close();
+  EXPECT_EQ(queue.size(), 0);
+  EXPECT_TRUE(queue.empty());
+}
+
 TEST_P(UcxExchangeTest, basicTest) {
   VLOG(3) << "+ UcxExchangeTest::basicTest";
   ExchangeTestParams p = GetParam();

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -23,8 +23,11 @@
 #include <gtest/gtest.h>
 #include <rmm/device_buffer.hpp>
 #include <memory>
+#include <type_traits>
 #include <vector>
 #include "velox/common/memory/MemoryPool.h"
+#include "velox/core/PlanNode.h"
+#include "velox/exec/OutputTransportRegistry.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/experimental/ucx-exchange/tests/UcxTestHelpers.h"
 
@@ -47,17 +50,19 @@ class UcxOutputQueueManagerTest : public testing::Test {
   }
 
   std::shared_ptr<Task> initializeTask(
-      std::string_view taskId,
+      const std::string& taskId,
       int numDestinations,
       int numDrivers,
       bool cleanup = true,
       core::PartitionedOutputNode::Kind kind =
-          core::PartitionedOutputNode::Kind::kPartitioned) {
+          core::PartitionedOutputNode::Kind::kPartitioned,
+      uint64_t maxOutputBufferSize = FOUR_GBYTES) {
     if (cleanup) {
       queueManager_->removeTask(taskId);
     }
 
-    auto task = createSourceTask(taskId, pool_, UcxTestData::kTestRowType);
+    auto task = createSourceTask(
+        taskId, pool_, UcxTestData::kTestRowType, maxOutputBufferSize);
 
     queueManager_->initializeTask(task, kind, numDestinations, numDrivers);
     return task;
@@ -98,6 +103,7 @@ class UcxOutputQueueManagerTest : public testing::Test {
         destination,
         [destination, expectedEndMarker, &receivedData](
             std::shared_ptr<cudf::packed_columns> data,
+            vector_size_t /*numRows*/,
             std::vector<int64_t> remainingBytes) {
           ASSERT_EQ(expectedEndMarker, data == nullptr)
               << "for destination " << destination;
@@ -111,6 +117,7 @@ class UcxOutputQueueManagerTest : public testing::Test {
       bool& receivedEndMarker) {
     return [destination, &receivedEndMarker](
                std::shared_ptr<cudf::packed_columns> data,
+               vector_size_t /*numRows*/,
                std::vector<int64_t> remainingBytes) {
       EXPECT_FALSE(receivedEndMarker) << "for destination " << destination;
       EXPECT_TRUE(data == nullptr) << "for destination " << destination;
@@ -145,6 +152,7 @@ class UcxOutputQueueManagerTest : public testing::Test {
     receivedData = false;
     return [destination, &receivedData](
                std::shared_ptr<cudf::packed_columns> data,
+               vector_size_t /*numRows*/,
                std::vector<int64_t> /*remainingBytes*/) {
       EXPECT_FALSE(receivedData) << "for destination " << destination;
       EXPECT_TRUE(data != nullptr) << "for destination " << destination;
@@ -182,6 +190,7 @@ class UcxOutputQueueManagerTest : public testing::Test {
           taskId,
           destination,
           [&](std::shared_ptr<cudf::packed_columns> data,
+              vector_size_t /*numRows*/,
               std::vector<int64_t> /*remainingBytes*/) {
             if (data == nullptr) {
               atEnd = true;
@@ -209,6 +218,7 @@ class UcxOutputQueueManagerTest : public testing::Test {
           destination,
           [&promise](
               std::shared_ptr<cudf::packed_columns> data,
+              vector_size_t /*numRows*/,
               std::vector<int64_t> remainingBytes) {
             promise.setValue(
                 Response{std::move(data), std::move(remainingBytes)});
@@ -226,6 +236,92 @@ class UcxOutputQueueManagerTest : public testing::Test {
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
   std::shared_ptr<UcxOutputQueueManager> queueManager_;
 };
+
+// Drives all eight exec::OutputBufferManager virtuals through a base-class
+// pointer, which is the only surface exec::Task and the Presto stats layer see.
+// The utilization pair is pinned to the queue's own byte accounting rather than
+// to a loose bound, so a constant-returning implementation cannot satisfy it.
+TEST_F(UcxOutputQueueManagerTest, implementsOutputBufferManager) {
+  static_assert(
+      std::is_base_of_v<exec::OutputBufferManager, UcxOutputQueueManager>);
+
+  std::shared_ptr<exec::OutputBufferManager> mgr = queueManager_;
+  ASSERT_NE(mgr, nullptr);
+
+  // An unknown task is tolerated by every method, and the two observability
+  // methods report "no answer" rather than inventing one.
+  const std::string unknownTaskId = "outputBufferManagerIface.unknown";
+  EXPECT_NO_THROW(mgr->toString(unknownTaskId));
+  EXPECT_FALSE(mgr->updateNumDrivers(unknownTaskId, 1));
+  EXPECT_FALSE(mgr->updateOutputBuffers(unknownTaskId, 1, true));
+  EXPECT_EQ(mgr->stats(unknownTaskId), std::nullopt);
+  EXPECT_EQ(mgr->getUtilization(unknownTaskId), std::nullopt);
+  EXPECT_EQ(mgr->isOverutilized(unknownTaskId), std::nullopt);
+
+  // Use an id unique to this case: the manager is a process-wide singleton
+  // shared with every other case in the binary.
+  const std::string taskId = "outputBufferManagerIface";
+  const int numDestinations = 2;
+  // A capacity small enough that a handful of pages crosses the
+  // over-utilization threshold, so isOverutilized() is seen in both states.
+  const uint64_t maxOutputBufferSize = 4096;
+  auto task = initializeTask(
+      taskId,
+      numDestinations,
+      1 /*numDrivers*/,
+      true /*cleanup*/,
+      core::PartitionedOutputNode::Kind::kPartitioned,
+      maxOutputBufferSize);
+
+  // Empty but bounded: a real ratio of exactly zero, which is a different
+  // answer from the unbounded placeholder queue's nullopt (see
+  // lateTaskCreation).
+  auto stats = mgr->stats(taskId);
+  ASSERT_TRUE(stats.has_value());
+  ASSERT_EQ(stats->bufferedBytes, 0);
+  EXPECT_EQ(mgr->getUtilization(taskId), 0.0);
+  EXPECT_EQ(mgr->isOverutilized(taskId), false);
+
+  // One page: utilization is queued bytes over the configured capacity.
+  // Producers are only blocked *after* adding data (UcxOutputQueue::
+  // checkBlocked), so queuedBytes_ may exceed maxSize_ and the ratio is not
+  // bounded by 1.0.
+  enqueue(taskId, 0, /*size=*/10);
+  stats = mgr->stats(taskId);
+  ASSERT_TRUE(stats.has_value());
+  const int64_t bufferedBytes = stats->bufferedBytes;
+  ASSERT_GT(bufferedBytes, 0);
+
+  auto utilization = mgr->getUtilization(taskId);
+  ASSERT_TRUE(utilization.has_value());
+  EXPECT_GT(*utilization, 0.0);
+  EXPECT_DOUBLE_EQ(
+      *utilization, bufferedBytes / static_cast<double>(maxOutputBufferSize));
+
+  const auto halfCapacity = static_cast<int64_t>(maxOutputBufferSize / 2);
+  auto overutilized = mgr->isOverutilized(taskId);
+  ASSERT_TRUE(overutilized.has_value());
+  EXPECT_EQ(*overutilized, bufferedBytes > halfCapacity);
+
+  // Fill past half the capacity: the flag must follow the queued bytes. The
+  // iteration bound only stops a runaway loop if enqueue ever stops
+  // accumulating; the assertion after it is what the case actually checks.
+  for (int i = 0; i < 100 && mgr->stats(taskId)->bufferedBytes <= halfCapacity;
+       ++i) {
+    enqueue(taskId, 0, /*size=*/10);
+  }
+  ASSERT_GT(mgr->stats(taskId)->bufferedBytes, halfCapacity);
+  EXPECT_EQ(mgr->isOverutilized(taskId), true);
+  ASSERT_TRUE(mgr->getUtilization(taskId).has_value());
+  EXPECT_GT(*mgr->getUtilization(taskId), 0.5);
+
+  EXPECT_TRUE(mgr->updateNumDrivers(taskId, 2));
+  EXPECT_TRUE(mgr->updateOutputBuffers(taskId, numDestinations, true));
+  EXPECT_FALSE(mgr->toString(taskId).empty());
+
+  mgr->removeTask(taskId);
+  EXPECT_EQ(mgr->stats(taskId), std::nullopt);
+}
 
 TEST_F(UcxOutputQueueManagerTest, basicPartitioned) {
   vector_size_t size = 100;
@@ -356,9 +452,20 @@ TEST_F(UcxOutputQueueManagerTest, lateTaskCreation) {
       destination,
       [&promise](
           std::shared_ptr<cudf::packed_columns> data,
+          vector_size_t /*numRows*/,
           std::vector<int64_t> remainingBytes) {
         promise.setValue(Response{std::move(data), std::move(remainingBytes)});
       });
+
+  // getData() above created a placeholder queue with no known capacity yet:
+  // maxSize_ is only set from the task's query config, in initializeTask().
+  // Both observability methods must report that honestly as nullopt -- one so
+  // it does not divide by zero, the other so it does not call an
+  // unknown-capacity queue over-utilized the moment any byte is queued.
+  std::shared_ptr<exec::OutputBufferManager> mgr = queueManager_;
+  EXPECT_EQ(mgr->getUtilization(taskId), std::nullopt);
+  EXPECT_EQ(mgr->isOverutilized(taskId), std::nullopt);
+
   // initialize task.
   auto task = initializeTask(taskId, numPartitions, 1, false);
   // enqueue some data.
@@ -381,6 +488,7 @@ TEST_F(UcxOutputQueueManagerTest, lateTaskCreation) {
         destination,
         [&promise](
             std::shared_ptr<cudf::packed_columns> data,
+            vector_size_t /*numRows*/,
             std::vector<int64_t> remainingBytes) {
           promise.setValue(
               Response{std::move(data), std::move(remainingBytes)});
@@ -463,6 +571,7 @@ TEST_F(UcxOutputQueueManagerTest, callbackFiredOnTerminateBeforeInit) {
       0, // destination
       [&callbackFired, &receivedNullptr](
           std::shared_ptr<cudf::packed_columns> data,
+          vector_size_t /*numRows*/,
           std::vector<int64_t> remainingBytes) {
         callbackFired = true;
         receivedNullptr = (data == nullptr);
@@ -500,6 +609,7 @@ TEST_F(UcxOutputQueueManagerTest, callbackFiredOnTerminateAfterInit) {
       0,
       [&callback0Fired, &callback0Nullptr](
           std::shared_ptr<cudf::packed_columns> data,
+          vector_size_t /*numRows*/,
           std::vector<int64_t> remainingBytes) {
         callback0Fired = true;
         callback0Nullptr = (data == nullptr);
@@ -509,6 +619,7 @@ TEST_F(UcxOutputQueueManagerTest, callbackFiredOnTerminateAfterInit) {
       1,
       [&callback1Fired, &callback1Nullptr](
           std::shared_ptr<cudf::packed_columns> data,
+          vector_size_t /*numRows*/,
           std::vector<int64_t> remainingBytes) {
         callback1Fired = true;
         callback1Nullptr = (data == nullptr);

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -264,7 +264,7 @@ TEST_F(UcxOutputQueueManagerTest, implementsOutputBufferManager) {
   const int numDestinations = 2;
   // A capacity small enough that a handful of pages crosses the
   // over-utilization threshold, so isOverutilized() is seen in both states.
-  const uint64_t maxOutputBufferSize = 4096;
+  const uint64_t maxOutputBufferSize{4'096};
   auto task = initializeTask(
       taskId,
       numDestinations,

--- a/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
@@ -20,6 +20,7 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/structs/structs_column_view.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <functional>
@@ -53,7 +54,7 @@ std::unique_ptr<cudf::column> BaseTableGenerator::makeNumericColumn(
 
   // Allocate a device buffer of the correct size
   rmm::device_buffer data(
-      numRows * sizeof(T), stream, rmm::mr::get_current_device_resource());
+      numRows * sizeof(T), stream, cudf::get_current_device_resource_ref());
 
   // Copy host -> device
   cudaMemcpyAsync(
@@ -135,7 +136,7 @@ std::unique_ptr<cudf::column> BaseTableGenerator::makeStringsColumn(
   rmm::device_buffer charsBuffer(
       totalBytes,
       cudf::get_default_stream(),
-      rmm::mr::get_current_device_resource());
+      cudf::get_current_device_resource_ref());
 
   std::vector<char> hostConcat;
   hostConcat.reserve(totalBytes);

--- a/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
@@ -19,6 +19,8 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <rmm/device_buffer.hpp>
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -105,7 +107,8 @@ std::shared_ptr<Task> createPartitionedOutputTask(
     int numPartitions,
     const std::vector<std::string>& partitionKeys,
     uint64_t kMaxOutputBufferSize,
-    const std::unordered_map<std::string, std::string>& extraConfig) {
+    const std::unordered_map<std::string, std::string>& extraConfig,
+    bool replicateNullsAndAny) {
   VLOG(3) << "Creating PartitionedOutput task with " << numPartitions
           << " partitions";
 
@@ -123,10 +126,11 @@ std::shared_ptr<Task> createPartitionedOutputTask(
       pool.get(), rowType, BufferPtr(nullptr), vectorSize, vecPtrs);
 
   // Build the plan: Values -> PartitionedOutput
-  auto planFragment = exec::test::PlanBuilder()
-                          .values({rowVector})
-                          .partitionedOutput(partitionKeys, numPartitions)
-                          .planFragment();
+  auto planFragment =
+      exec::test::PlanBuilder()
+          .values({rowVector})
+          .partitionedOutput(partitionKeys, numPartitions, replicateNullsAndAny)
+          .planFragment();
 
   std::shared_ptr<folly::Executor> executor(
       std::make_shared<folly::CPUThreadPoolExecutor>(
@@ -180,8 +184,8 @@ template <typename T>
 std::unique_ptr<cudf::column> make_numeric_column_from_vector(
     const std::vector<T>& host_values,
     rmm::cuda_stream_view stream = cudf::get_default_stream(),
-    rmm::mr::device_memory_resource* mr =
-        rmm::mr::get_current_device_resource()) {
+    rmm::device_async_resource_ref mr =
+        cudf::get_current_device_resource_ref()) {
   size_t num_rows = host_values.size();
 
   // Allocate a device buffer of the correct size
@@ -208,8 +212,8 @@ std::unique_ptr<cudf::column> make_numeric_column_from_vector(
 rmm::device_buffer make_chars_buffer_from_host(
     const std::vector<std::string>& host_strings,
     rmm::cuda_stream_view stream = cudf::get_default_stream(),
-    rmm::mr::device_memory_resource* mr =
-        rmm::mr::get_current_device_resource()) {
+    rmm::device_async_resource_ref mr =
+        cudf::get_current_device_resource_ref()) {
   // Compute total bytes needed
   size_t total_bytes = 0;
   for (auto const& s : host_strings)

--- a/velox/experimental/ucx-exchange/tests/UcxTestHelpers.h
+++ b/velox/experimental/ucx-exchange/tests/UcxTestHelpers.h
@@ -86,6 +86,8 @@ std::shared_ptr<facebook::velox::exec::Task> createExchangeTask(
 /// round-robin)
 /// @param kMaxOutputBufferSize Maximum output buffer size
 /// @return Shared pointer to the created Task
+/// @param replicateNullsAndAny Whether rows with a null partition key, plus one
+/// arbitrary row, must reach every destination
 std::shared_ptr<facebook::velox::exec::Task> createPartitionedOutputTask(
     std::string_view taskId,
     std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
@@ -93,7 +95,8 @@ std::shared_ptr<facebook::velox::exec::Task> createPartitionedOutputTask(
     int numPartitions,
     const std::vector<std::string>& partitionKeys = {},
     uint64_t kMaxOutputBufferSize = FOUR_GBYTES,
-    const std::unordered_map<std::string, std::string>& extraConfig = {});
+    const std::unordered_map<std::string, std::string>& extraConfig = {},
+    bool replicateNullsAndAny = false);
 
 /// @brief Helper function to create a CudfVector for testing.
 /// Uses makeTable when tableGenerator is null, or tableGenerator->makeTable()


### PR DESCRIPTION
`velox/experimental/ucx-exchange/` appears in no `add_subdirectory()` upstream, so CI has never compiled it. Meanwhile cuDF and the surrounding tree advanced, and the module had no build to tell it so — this brings it back up to the current interfaces.

## Motivation

Four references no longer resolve, three of them because the code around them moved on:

- `rmm::mr::get_current_device_resource()` became `cudf::get_current_device_resource_ref()`
- `Enums.h` was split into `EnumDeclare.h` and `EnumDefine.h`
- `QueryConfig::ucxPartitionedOutputBatchRows()` has no definition anywhere in velox
- `FLAGS_velox_ucx_exchange` is never defined

The config half is a repair, not a relocation: there is no dead core config to delete, because the accessor those call sites named never existed.

## What changed

- Six `CudfConfig` knobs replace the dangling config reads, so the transport's tunables live with the rest of the cuDF configuration instead of in core.
- `UcxOutputQueueManager` implements `exec::OutputBufferManager`, a pure-virtual interface since b6040fcfc1, so this needs no core change; unknown-task calls now return false instead of asserting.
- A logical row count travels beside the packed GPU data through `MetadataMsg`. A cuDF table with no columns reports `num_rows() == 0`, so without it a zero-column payload arrives having lost its cardinality. This is the transport's wire format, not a cuDF operator fix.
- `UcxExchange` no longer creates or closes its own client; ownership moves to the Task, retiring the double-close hazard #17752 worked around.

## Caveat

This leaves MergeExchange-over-UCX with no source of a client until a later change supplies one. Nothing upstream runs that path today, so nothing regresses.

## Test plan

Extends `UcxExchangeTest` and `UcxOutputQueueManagerTest`.

The directory is still in no `add_subdirectory()`, so **CI will not compile this** — enabling the build is a later, deliberately separate change so that turning coverage on is revertible on its own.