### PR TITLE
feat(cudf): Let a kept operator be followed by GPU operators

### DIFF
--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -20,6 +20,8 @@
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
+#include "velox/core/PlanNode.h"
+
 #include <cudf/sorting.hpp>
 
 namespace facebook::velox::cudf_velox {
@@ -37,19 +39,41 @@ CudfOrderBy::CudfOrderBy(
           nvtx3::rgb{64, 224, 208}, // Turquoise
           NvtxMethodFlag::kAll,
           std::nullopt,
-          orderByNode),
-      orderByNode_(orderByNode) {
-  sortKeys_.reserve(orderByNode->sortingKeys().size());
-  columnOrder_.reserve(orderByNode->sortingKeys().size());
-  nullOrder_.reserve(orderByNode->sortingKeys().size());
-  for (int i = 0; i < orderByNode->sortingKeys().size(); ++i) {
-    const auto channel =
-        exec::exprToChannel(orderByNode->sortingKeys()[i].get(), outputType_);
+          orderByNode) {
+  initializeSortKeys(orderByNode->sortingKeys(), orderByNode->sortingOrders());
+}
+
+CudfOrderBy::CudfOrderBy(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const core::MergeExchangeNode>& mergeExchangeNode)
+    : CudfOperatorBase(
+          operatorId,
+          driverCtx,
+          mergeExchangeNode->outputType(),
+          mergeExchangeNode->id(),
+          "CudfOrderBy",
+          nvtx3::rgb{64, 224, 208}, // Turquoise
+          NvtxMethodFlag::kAll,
+          std::nullopt,
+          mergeExchangeNode) {
+  initializeSortKeys(
+      mergeExchangeNode->sortingKeys(), mergeExchangeNode->sortingOrders());
+}
+
+void CudfOrderBy::initializeSortKeys(
+    const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
+    const std::vector<core::SortOrder>& sortingOrders) {
+  sortKeys_.reserve(sortingKeys.size());
+  columnOrder_.reserve(sortingKeys.size());
+  nullOrder_.reserve(sortingKeys.size());
+  for (size_t i = 0; i < sortingKeys.size(); ++i) {
+    const auto channel = exec::exprToChannel(sortingKeys[i].get(), outputType_);
     VELOX_CHECK(
         channel != kConstantChannel,
         "OrderBy doesn't allow constant sorting keys");
     sortKeys_.push_back(channel);
-    auto const& sortingOrder = orderByNode->sortingOrders()[i];
+    const auto& sortingOrder = sortingOrders[i];
     columnOrder_.push_back(
         sortingOrder.isAscending() ? cudf::order::ASCENDING
                                    : cudf::order::DESCENDING);

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -33,6 +33,15 @@ class CudfOrderBy : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       const std::shared_ptr<const core::OrderByNode>& orderByNode);
 
+  /// Constructs from a MergeExchangeNode, which supplies the same sorting keys
+  /// and orders an OrderByNode would. The UCX exchange transport builds its
+  /// merge exchange as UcxExchange followed by this operator, since the sort
+  /// that MergeExchange does on the CPU happens on the GPU here.
+  CudfOrderBy(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::MergeExchangeNode>& mergeExchangeNode);
+
   bool needsInput() const override {
     return !finished_;
   }
@@ -52,8 +61,13 @@ class CudfOrderBy : public CudfOperatorBase {
   void doClose() override;
 
  private:
+  // Translates 'sortingKeys' and 'sortingOrders' into the cuDF sort-key
+  // channels and orders used by doNoMoreInput(), resolved against outputType_.
+  void initializeSortKeys(
+      const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
+      const std::vector<core::SortOrder>& sortingOrders);
+
   CudfVectorPtr outputTable_;
-  std::shared_ptr<const core::OrderByNode> orderByNode_;
   std::vector<CudfVectorPtr> inputs_;
   std::vector<cudf::size_type> sortKeys_;
   std::vector<cudf::order> columnOrder_;

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -33,10 +33,8 @@ class CudfOrderBy : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       const std::shared_ptr<const core::OrderByNode>& orderByNode);
 
-  /// Constructs from a MergeExchangeNode, which supplies the same sorting keys
-  /// and orders an OrderByNode would. The UCX exchange transport builds its
-  /// merge exchange as UcxExchange followed by this operator, since the sort
-  /// that MergeExchange does on the CPU happens on the GPU here.
+  /// Builds the GPU sort appended after a kept UcxExchange operator. Together,
+  /// the two operators implement MergeExchange on the GPU.
   CudfOrderBy(
       int32_t operatorId,
       exec::DriverCtx* driverCtx,
@@ -61,8 +59,7 @@ class CudfOrderBy : public CudfOperatorBase {
   void doClose() override;
 
  private:
-  // Translates 'sortingKeys' and 'sortingOrders' into the cuDF sort-key
-  // channels and orders used by doNoMoreInput(), resolved against outputType_.
+  // Initializes cuDF sort keys from the plan node's ordering.
   void initializeSortKeys(
       const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
       const std::vector<core::SortOrder>& sortingOrders);

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -80,6 +80,11 @@ void OperatorAdapterRegistry::registerAdapter(
   adapters_.push_back(std::move(adapter));
 }
 
+void OperatorAdapterRegistry::registerAdapterFront(
+    std::unique_ptr<OperatorAdapter> adapter) {
+  adapters_.insert(adapters_.begin(), std::move(adapter));
+}
+
 const OperatorAdapter* OperatorAdapterRegistry::findAdapter(
     const exec::Operator* op) const {
   for (const auto& adapter : adapters_) {

--- a/velox/experimental/cudf/exec/OperatorAdapters.h
+++ b/velox/experimental/cudf/exec/OperatorAdapters.h
@@ -78,8 +78,13 @@ class OperatorAdapter {
     return props;
   }
 
-  /// Create replacement GPU operator(s). Returns a vector of replacement
-  /// operators (empty if operator should be kept).
+  /// Create the GPU operator(s) this adapter contributes to the driver.
+  /// When keepOperator() is false they replace 'op', and returning none means
+  /// the operator could not be replaced. When keepOperator() is true they are
+  /// inserted after 'op', which is how a plan node that expands into several
+  /// operators is described; returning none then simply keeps 'op' alone.
+  /// Either way the caller renumbers the driver's operator ids afterwards, so
+  /// 'operatorId' need not be unique across the returned operators.
   virtual std::vector<std::unique_ptr<exec::Operator>> createReplacements(
       const exec::Operator* op,
       const core::PlanNodePtr& planNode,
@@ -87,7 +92,11 @@ class OperatorAdapter {
       int32_t operatorId) const = 0;
 
   /// Check if the original operator should be kept (not replaced). Returns
-  /// true if the original operator should be kept, false otherwise.
+  /// true if the original operator should be kept, in which case anything
+  /// createReplacements() returns runs after it rather than instead of it. The
+  /// decision is a property of the adapter and the plan, not of per-query
+  /// state: the transport an exchange uses is resolved from the plan node
+  /// through the transport registries before this runs.
   virtual bool keepOperator() const {
     return false;
   }

--- a/velox/experimental/cudf/exec/OperatorAdapters.h
+++ b/velox/experimental/cudf/exec/OperatorAdapters.h
@@ -44,7 +44,10 @@ class OperatorAdapter {
   virtual bool canHandle(const exec::Operator* op) const = 0;
 
   /// Check if the operator is supported for GPU execution. Returns true if
-  /// the operator can be executed on GPU.
+  /// the operator can be executed on GPU. Returning false is how an adapter
+  /// declines an operator it cannot implement, which leaves the operator in
+  /// place for CPU execution; createReplacements() must not be used for that,
+  /// see below.
   virtual bool canRunOnGPU(
       const exec::Operator* op,
       const core::PlanNodePtr& planNode,
@@ -79,10 +82,20 @@ class OperatorAdapter {
   }
 
   /// Create the GPU operator(s) this adapter contributes to the driver.
-  /// When keepOperator() is false they replace 'op', and returning none means
-  /// the operator could not be replaced. When keepOperator() is true they are
-  /// inserted after 'op', which is how a plan node that expands into several
-  /// operators is described; returning none then simply keeps 'op' alone.
+  ///
+  /// When keepOperator() is false the returned operators replace 'op', and at
+  /// least one operator must be returned. Combining keepOperator() == false
+  /// with canRunOnGPU() == true and an empty result is not supported: with CPU
+  /// fallback disabled the driver is rejected, and with fallback enabled a
+  /// conversion operator appended behind the failed replacement takes the place
+  /// of 'op', which drops the plan node from the pipeline. An adapter that
+  /// cannot implement a particular operator returns false from canRunOnGPU()
+  /// instead, which keeps 'op' in place.
+  ///
+  /// When keepOperator() is true the returned operators are inserted after
+  /// 'op', which is how a plan node that expands into several operators is
+  /// described; returning none then simply keeps 'op' alone.
+  ///
   /// Either way the caller renumbers the driver's operator ids afterwards, so
   /// 'operatorId' need not be unique across the returned operators.
   virtual std::vector<std::unique_ptr<exec::Operator>> createReplacements(
@@ -121,6 +134,12 @@ class OperatorAdapterRegistry {
 
   /// Register an adapter with the registry.
   void registerAdapter(std::unique_ptr<OperatorAdapter> adapter);
+
+  /// Registers 'adapter' ahead of everything already registered, so it wins
+  /// findAdapter() for an operator a built-in adapter also handles. For
+  /// substituting an adapter in a test; production registration appends with
+  /// registerAdapter(). Relies on findAdapter() returning the first match.
+  void registerAdapterFront(std::unique_ptr<OperatorAdapter> adapter);
 
   /// Find an adapter that can handle the given operator. Returns a pointer
   /// to the adapter, or nullptr if none found.

--- a/velox/experimental/cudf/exec/OperatorAdapters.h
+++ b/velox/experimental/cudf/exec/OperatorAdapters.h
@@ -84,13 +84,11 @@ class OperatorAdapter {
   /// Create the GPU operator(s) this adapter contributes to the driver.
   ///
   /// When keepOperator() is false the returned operators replace 'op', and at
-  /// least one operator must be returned. Combining keepOperator() == false
-  /// with canRunOnGPU() == true and an empty result is not supported: with CPU
-  /// fallback disabled the driver is rejected, and with fallback enabled a
-  /// conversion operator appended behind the failed replacement takes the place
-  /// of 'op', which drops the plan node from the pipeline. An adapter that
-  /// cannot implement a particular operator returns false from canRunOnGPU()
-  /// instead, which keeps 'op' in place.
+  /// least one operator must be returned. Returning none is a defect in the
+  /// adapter rather than a plan that cannot run on GPU, so CompileState fails
+  /// the query whatever allowCpuFallback says. An adapter that cannot implement
+  /// a particular operator returns false from canRunOnGPU() instead, which
+  /// keeps 'op' in place for CPU execution.
   ///
   /// When keepOperator() is true the returned operators are inserted after
   /// 'op', which is how a plan node that expands into several operators is

--- a/velox/experimental/cudf/exec/OperatorAdapters.h
+++ b/velox/experimental/cudf/exec/OperatorAdapters.h
@@ -43,11 +43,9 @@ class OperatorAdapter {
   /// if this adapter handles this operator type.
   virtual bool canHandle(const exec::Operator* op) const = 0;
 
-  /// Check if the operator is supported for GPU execution. Returns true if
-  /// the operator can be executed on GPU. Returning false is how an adapter
-  /// declines an operator it cannot implement, which leaves the operator in
-  /// place for CPU execution; createReplacements() must not be used for that,
-  /// see below.
+  /// Returns whether the operator can use this adapter's GPU path.
+  /// createReplacements() is called only when this returns true.
+  /// keepOperator() independently determines whether the original remains.
   virtual bool canRunOnGPU(
       const exec::Operator* op,
       const core::PlanNodePtr& planNode,
@@ -81,33 +79,18 @@ class OperatorAdapter {
     return props;
   }
 
-  /// Create the GPU operator(s) this adapter contributes to the driver.
-  ///
-  /// When keepOperator() is false the returned operators replace 'op', and at
-  /// least one operator must be returned. Returning none is a defect in the
-  /// adapter rather than a plan that cannot run on GPU, so CompileState fails
-  /// the query whatever allowCpuFallback says. An adapter that cannot implement
-  /// a particular operator returns false from canRunOnGPU() instead, which
-  /// keeps 'op' in place for CPU execution.
-  ///
-  /// When keepOperator() is true the returned operators are inserted after
-  /// 'op', which is how a plan node that expands into several operators is
-  /// described; returning none then simply keeps 'op' alone.
-  ///
-  /// Either way the caller renumbers the driver's operator ids afterwards, so
-  /// 'operatorId' need not be unique across the returned operators.
+  /// Creates operators for a GPU-capable input. If keepOperator() is false,
+  /// returns one or more operators that replace 'op'; returning none is an
+  /// adapter error. Otherwise, returns operators to append after 'op'. The
+  /// caller renumbers operator IDs, so 'operatorId' need not be unique.
   virtual std::vector<std::unique_ptr<exec::Operator>> createReplacements(
       const exec::Operator* op,
       const core::PlanNodePtr& planNode,
       exec::DriverCtx* ctx,
       int32_t operatorId) const = 0;
 
-  /// Check if the original operator should be kept (not replaced). Returns
-  /// true if the original operator should be kept, in which case anything
-  /// createReplacements() returns runs after it rather than instead of it. The
-  /// decision is a property of the adapter and the plan, not of per-query
-  /// state: the transport an exchange uses is resolved from the plan node
-  /// through the transport registries before this runs.
+  /// Whether to keep 'op'. Operators returned by createReplacements() follow
+  /// it when true and replace it when false.
   virtual bool keepOperator() const {
     return false;
   }
@@ -133,10 +116,8 @@ class OperatorAdapterRegistry {
   /// Register an adapter with the registry.
   void registerAdapter(std::unique_ptr<OperatorAdapter> adapter);
 
-  /// Registers 'adapter' ahead of everything already registered, so it wins
-  /// findAdapter() for an operator a built-in adapter also handles. For
-  /// substituting an adapter in a test; production registration appends with
-  /// registerAdapter(). Relies on findAdapter() returning the first match.
+  /// Inserts an adapter at highest lookup priority. Intended for tests that
+  /// override a built-in adapter.
   void registerAdapterFront(std::unique_ptr<OperatorAdapter> adapter);
 
   /// Find an adapter that can handle the given operator. Returns a pointer

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -182,20 +182,25 @@ bool CompileState::compile(bool allowCpuFallback) {
         auto replacements =
             adapter->createReplacements(oper, planNode, ctx, id);
         adapterReturnedOperators = !replacements.empty();
+        // An adapter that does not keep its operator has to return something
+        // to put in its place. Returning nothing is a defect in the adapter,
+        // not a plan that cannot run on GPU, so it fails the query whatever
+        // allowCpuFallback says. Checking here, before the conversion operator
+        // below can join replaceOp, keeps the driver unmodified.
+        VELOX_CHECK(
+            keepOperator != 0 || adapterReturnedOperators,
+            "Adapter replaced an operator with nothing: {}",
+            adapter->name());
         for (auto& r : replacements) {
           replaceOp.push_back(std::move(r));
         }
       }
 
       if (keepOperator == 0) {
-        // An adapter that replaces its operator but returns nothing has not
-        // replaced it, so the operator is still a CPU operator. That is the
-        // same outcome as the adapter having declined the operator through
-        // canRunOnGPU(), which is why both fold into one condition here. The
-        // decision has to come from what createReplacements() returned rather
-        // than from replaceOp, because replaceOp can still gain a conversion
-        // operator further down and an empty replacement would then be
-        // indistinguishable from a successful one.
+        // No GPU operators were produced for this operator, so it stays a CPU
+        // operator. After the check above the only way to reach this with
+        // adapterReturnedOperators false is canRunOnGPU() having declined the
+        // operator, which is the ordinary CPU fallback case.
         isPureCpuOperator = !adapterReturnedOperators;
       } else {
         // A kept operator is GPU compatible, so it is allowed even when

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -174,10 +174,16 @@ bool CompileState::compile(bool allowCpuFallback) {
         if (planNode && thisOpProps.canRunOnGPU) {
           auto replacements =
               adapter->createReplacements(oper, planNode, ctx, id);
+          // An adapter that replaces its operator but returns nothing has not
+          // replaced it, so the operator is still a CPU operator. Decide that
+          // from what createReplacements() returned rather than from having
+          // called it, because replaceOp can still gain a conversion operator
+          // further down and an empty replacement would then be
+          // indistinguishable from a successful one.
+          isPureCpuOperator = replacements.empty();
           for (auto& r : replacements) {
             replaceOp.push_back(std::move(r));
           }
-          isPureCpuOperator = false;
         } else {
           // This is the CPU fallback case.
           isPureCpuOperator = true;

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -171,7 +171,6 @@ bool CompileState::compile(bool allowCpuFallback) {
     if (adapter) {
       keepOperator = adapter->keepOperator();
       const bool canUseGpuPath = planNode && thisOpProps.canRunOnGPU;
-      bool adapterReturnedOperators = false;
       if (canUseGpuPath) {
         // Whether these run instead of 'oper' or after it is keepOperator()'s
         // decision, not this call's. A kept operator describing operators that
@@ -181,14 +180,13 @@ bool CompileState::compile(bool allowCpuFallback) {
         // no operator ids of its own.
         auto replacements =
             adapter->createReplacements(oper, planNode, ctx, id);
-        adapterReturnedOperators = !replacements.empty();
         // An adapter that does not keep its operator has to return something
         // to put in its place. Returning nothing is a defect in the adapter,
         // not a plan that cannot run on GPU, so it fails the query whatever
         // allowCpuFallback says. Checking here, before the conversion operator
         // below can join replaceOp, keeps the driver unmodified.
         VELOX_CHECK(
-            keepOperator != 0 || adapterReturnedOperators,
+            keepOperator != 0 || !replacements.empty(),
             "Adapter replaced an operator with nothing: {}",
             adapter->name());
         for (auto& r : replacements) {
@@ -197,11 +195,11 @@ bool CompileState::compile(bool allowCpuFallback) {
       }
 
       if (keepOperator == 0) {
-        // No GPU operators were produced for this operator, so it stays a CPU
-        // operator. After the check above the only way to reach this with
-        // adapterReturnedOperators false is canRunOnGPU() having declined the
-        // operator, which is the ordinary CPU fallback case.
-        isPureCpuOperator = !adapterReturnedOperators;
+        // The check above already rejected an adapter that reached the GPU path
+        // and returned nothing, so the only way this operator is still a CPU
+        // operator is canRunOnGPU() having declined it. That is the ordinary
+        // CPU fallback case, which allowCpuFallback below decides on.
+        isPureCpuOperator = !canUseGpuPath;
       } else {
         // A kept operator is GPU compatible, so it is allowed even when
         // fallback is disabled, whether or not the adapter described any

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -357,6 +357,10 @@ void registerCudf() {
 void unregisterCudf() {
   output_mr_.reset();
   mr_.reset();
+  // registerCudf() populated this through registerAllOperatorAdapters(), so
+  // undo it here as well. Nothing can read it once the driver adapter below is
+  // gone, since CompileState is the only production reader.
+  OperatorAdapterRegistry::getInstance().clear();
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -170,41 +170,38 @@ bool CompileState::compile(bool allowCpuFallback) {
 
     if (adapter) {
       keepOperator = adapter->keepOperator();
+      const bool canUseGpuPath = planNode && thisOpProps.canRunOnGPU;
+      bool adapterReturnedOperators = false;
+      if (canUseGpuPath) {
+        // Whether these run instead of 'oper' or after it is keepOperator()'s
+        // decision, not this call's. A kept operator describing operators that
+        // run after it is how one plan node expanding into several operators is
+        // expressed: the replaceOperators() call below inserts them behind the
+        // kept operator and renumbers the whole driver, so the expansion needs
+        // no operator ids of its own.
+        auto replacements =
+            adapter->createReplacements(oper, planNode, ctx, id);
+        adapterReturnedOperators = !replacements.empty();
+        for (auto& r : replacements) {
+          replaceOp.push_back(std::move(r));
+        }
+      }
+
       if (keepOperator == 0) {
-        if (planNode && thisOpProps.canRunOnGPU) {
-          auto replacements =
-              adapter->createReplacements(oper, planNode, ctx, id);
-          // An adapter that replaces its operator but returns nothing has not
-          // replaced it, so the operator is still a CPU operator. Decide that
-          // from what createReplacements() returned rather than from having
-          // called it, because replaceOp can still gain a conversion operator
-          // further down and an empty replacement would then be
-          // indistinguishable from a successful one.
-          isPureCpuOperator = replacements.empty();
-          for (auto& r : replacements) {
-            replaceOp.push_back(std::move(r));
-          }
-        } else {
-          // This is the CPU fallback case.
-          isPureCpuOperator = true;
-        }
+        // An adapter that replaces its operator but returns nothing has not
+        // replaced it, so the operator is still a CPU operator. That is the
+        // same outcome as the adapter having declined the operator through
+        // canRunOnGPU(), which is why both fold into one condition here. The
+        // decision has to come from what createReplacements() returned rather
+        // than from replaceOp, because replaceOp can still gain a conversion
+        // operator further down and an empty replacement would then be
+        // indistinguishable from a successful one.
+        isPureCpuOperator = !adapterReturnedOperators;
       } else {
-        // adapter is present and keepOperator is 1, so this is GPU compatible
-        // operator. so this CPU operators is allowed even if fallback is
-        // disabled.
+        // A kept operator is GPU compatible, so it is allowed even when
+        // fallback is disabled, whether or not the adapter described any
+        // operators to run after it.
         isPureCpuOperator = false;
-        if (planNode && thisOpProps.canRunOnGPU) {
-          // A kept operator may still describe operators that have to run
-          // after it. That is how one plan node expanding into several
-          // operators is expressed: the replaceOperators() call below inserts
-          // them behind the kept operator and renumbers the whole driver, so
-          // the expansion needs no operator ids of its own.
-          auto replacements =
-              adapter->createReplacements(oper, planNode, ctx, id);
-          for (auto& r : replacements) {
-            replaceOp.push_back(std::move(r));
-          }
-        }
       }
     } else {
       // special case for CudfOperator

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -172,19 +172,13 @@ bool CompileState::compile(bool allowCpuFallback) {
       keepOperator = adapter->keepOperator();
       const bool canUseGpuPath = planNode && thisOpProps.canRunOnGPU;
       if (canUseGpuPath) {
-        // Whether these run instead of 'oper' or after it is keepOperator()'s
-        // decision, not this call's. A kept operator describing operators that
-        // run after it is how one plan node expanding into several operators is
-        // expressed: the replaceOperators() call below inserts them behind the
-        // kept operator and renumbers the whole driver, so the expansion needs
-        // no operator ids of its own.
+        // canRunOnGPU() controls whether createReplacements() is called;
+        // keepOperator() determines whether returned operators replace or
+        // follow the original.
         auto replacements =
             adapter->createReplacements(oper, planNode, ctx, id);
-        // An adapter that does not keep its operator has to return something
-        // to put in its place. Returning nothing is a defect in the adapter,
-        // not a plan that cannot run on GPU, so it fails the query whatever
-        // allowCpuFallback says. Checking here, before the conversion operator
-        // below can join replaceOp, keeps the driver unmodified.
+        // A replacing adapter must produce an operator. Check before appending
+        // an output conversion, which could make the result appear non-empty.
         VELOX_CHECK(
             keepOperator != 0 || !replacements.empty(),
             "Adapter replaced an operator with nothing: {}",
@@ -195,15 +189,10 @@ bool CompileState::compile(bool allowCpuFallback) {
       }
 
       if (keepOperator == 0) {
-        // The check above already rejected an adapter that reached the GPU path
-        // and returned nothing, so the only way this operator is still a CPU
-        // operator is canRunOnGPU() having declined it. That is the ordinary
-        // CPU fallback case, which allowCpuFallback below decides on.
+        // Only a declined GPU path requires CPU fallback.
         isPureCpuOperator = !canUseGpuPath;
       } else {
-        // A kept operator is GPU compatible, so it is allowed even when
-        // fallback is disabled, whether or not the adapter described any
-        // operators to run after it.
+        // A kept operator is valid with or without appended operators.
         isPureCpuOperator = false;
       }
     } else {
@@ -363,9 +352,7 @@ void registerCudf() {
 void unregisterCudf() {
   output_mr_.reset();
   mr_.reset();
-  // registerCudf() populated this through registerAllOperatorAdapters(), so
-  // undo it here as well. Nothing can read it once the driver adapter below is
-  // gone, since CompileState is the only production reader.
+  // Undo registerCudf()'s operator adapter registration.
   OperatorAdapterRegistry::getInstance().clear();
   exec::DriverFactory::adapters.erase(
       std::remove_if(

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -187,6 +187,18 @@ bool CompileState::compile(bool allowCpuFallback) {
         // operator. so this CPU operators is allowed even if fallback is
         // disabled.
         isPureCpuOperator = false;
+        if (planNode && thisOpProps.canRunOnGPU) {
+          // A kept operator may still describe operators that have to run
+          // after it. That is how one plan node expanding into several
+          // operators is expressed: the replaceOperators() call below inserts
+          // them behind the kept operator and renumbers the whole driver, so
+          // the expansion needs no operator ids of its own.
+          auto replacements =
+              adapter->createReplacements(oper, planNode, ctx, id);
+          for (auto& r : replacements) {
+            replaceOp.push_back(std::move(r));
+          }
+        }
       }
     } else {
       // special case for CudfOperator

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfConversion.h"
+#include "velox/experimental/cudf/exec/OperatorAdapters.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/tests/CudfFunctionBaseTest.h"
 
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/FilterProject.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
@@ -31,15 +35,141 @@ class AdapterOperatorTest : public OperatorTestBase {
  protected:
   void SetUp() override {
     OperatorTestBase::SetUp();
+    savedCpuFallback_ = cudf_velox::CudfConfig::getInstance().allowCpuFallback;
     cudf_velox::CudfConfig::getInstance().allowCpuFallback = false;
     cudf_velox::registerCudf();
   }
 
   void TearDown() override {
     cudf_velox::unregisterCudf();
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback = savedCpuFallback_;
     OperatorTestBase::TearDown();
   }
+
+  // Puts 'adapter' ahead of every built-in adapter, because
+  // OperatorAdapterRegistry::findAdapter() returns the first match and
+  // registerAdapter() appends. The built-ins are restored behind it so every
+  // other operator in the plan still resolves; clearing them instead would make
+  // those operators pure-CPU and trip the allowCpuFallback check for a reason
+  // that has nothing to do with the case under test.
+  void registerAdapterFirst(
+      std::unique_ptr<cudf_velox::OperatorAdapter> adapter) {
+    // registerCudf() in SetUp() already installed the built-ins. Put the test
+    // adapter ahead of them; calling registerAllOperatorAdapters() here would
+    // clear the registry and discard it.
+    cudf_velox::OperatorAdapterRegistry::getInstance().registerAdapterFront(
+        std::move(adapter));
+  }
+
+  bool savedCpuFallback_{true};
 };
+
+namespace {
+// Claims FilterProject and reports it as GPU-capable, but contributes no
+// operators. Whether that is a failure depends on keepOperator(): a replacing
+// adapter has produced nothing to replace 'op' with, while a keeping adapter
+// has simply nothing to append.
+class EmptyReplacementAdapter : public cudf_velox::OperatorAdapter {
+ public:
+  EmptyReplacementAdapter(bool keepOperator, bool producesGpuOutput = false)
+      : cudf_velox::OperatorAdapter("EmptyReplacement"),
+        keepOperator_{keepOperator},
+        producesGpuOutput_{producesGpuOutput} {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::FilterProject*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/) const override {
+    return true;
+  }
+
+  bool acceptsGpuInput() const override {
+    return false;
+  }
+
+  bool producesGpuOutput() const override {
+    return producesGpuOutput_;
+  }
+
+  bool keepOperator() const override {
+    return keepOperator_;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/,
+      int32_t /*operatorId*/) const override {
+    return {};
+  }
+
+ private:
+  const bool keepOperator_;
+  const bool producesGpuOutput_;
+};
+
+// Keeps its operator and describes two operators that must run after it. The
+// pair converts to GPU and back so the appended span is type-balanced whatever
+// the neighbours are, which keeps the case about insertion and renumbering
+// rather than about conversion placement.
+//
+// The plan node ids carry the "-from-velox" and "-to-velox" suffixes because
+// CudfFromVelox and CudfToVelox recover the plan node they belong to by
+// stripping exactly those strings, so any other suffix files their stats under
+// a plan node of its own instead of the one being expanded.
+class AppendingAdapter : public cudf_velox::OperatorAdapter {
+ public:
+  AppendingAdapter() : cudf_velox::OperatorAdapter("Appending") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::FilterProject*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/) const override {
+    return true;
+  }
+
+  bool acceptsGpuInput() const override {
+    return false;
+  }
+
+  bool producesGpuOutput() const override {
+    return false;
+  }
+
+  bool keepOperator() const override {
+    return true;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    std::vector<std::unique_ptr<exec::Operator>> appended;
+    appended.push_back(
+        std::make_unique<cudf_velox::CudfFromVelox>(
+            operatorId,
+            planNode->outputType(),
+            ctx,
+            planNode->id() + "-from-velox"));
+    appended.push_back(
+        std::make_unique<cudf_velox::CudfToVelox>(
+            operatorId,
+            planNode->outputType(),
+            ctx,
+            planNode->id() + "-to-velox"));
+    return appended;
+  }
+};
+} // namespace
 
 TEST_F(AdapterOperatorTest, adapterStatsMergedIntoPlanNode) {
   auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
@@ -59,4 +189,95 @@ TEST_F(AdapterOperatorTest, adapterStatsMergedIntoPlanNode) {
 
   EXPECT_TRUE(projStats.isMultiOperatorTypeNode());
   EXPECT_TRUE(projStats.operatorStats.count("CudfToVelox"));
+}
+
+// A replacing adapter that contributes nothing has not replaced the operator,
+// so with fallback disabled the pipeline must be rejected rather than run with
+// the CPU operator still in place. The decision has to come from what
+// createReplacements() returned, not from having called it.
+TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithoutFallback) {
+  registerAdapterFirst(
+      std::make_unique<EmptyReplacementAdapter>(/*keepOperator=*/false));
+
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+  auto plan = PlanBuilder().values({data}).project({"c0 * 2 as x"}).planNode();
+
+  std::shared_ptr<exec::Task> task;
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool(), task),
+      "Replacement with cuDF operator failed");
+}
+
+// The mirror case, so that rejecting an empty replacement cannot be implemented
+// by rejecting every empty result: a keeping adapter that appends nothing
+// leaves the operator running on its own, which is what lets one plan node
+// expand into several operators.
+TEST_F(AdapterOperatorTest, keptOperatorNeedsNoAppendedOperators) {
+  registerAdapterFirst(
+      std::make_unique<EmptyReplacementAdapter>(/*keepOperator=*/true));
+
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+  auto plan = PlanBuilder().values({data}).project({"c0 * 2 as x"}).planNode();
+
+  std::shared_ptr<exec::Task> task;
+  auto results = AssertQueryBuilder(plan).copyResults(pool(), task);
+  EXPECT_EQ(results->size(), 5);
+}
+
+// The same failure, but with the adapter claiming GPU output so that
+// CompileState appends a CudfToVelox conversion behind it. Deciding the failure
+// from the accumulated replacement list rather than from what the adapter
+// returned would see that conversion operator and conclude the replacement
+// succeeded, so this case is what pins the decision to the adapter's own
+// result. Left undetected the conversion replaces the operator outright, which
+// drops the plan node from the pipeline.
+TEST_F(
+    AdapterOperatorTest,
+    emptyReplacementIsRejectedDespiteConversionOperator) {
+  registerAdapterFirst(
+      std::make_unique<EmptyReplacementAdapter>(
+          /*keepOperator=*/false, /*producesGpuOutput=*/true));
+
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+  auto plan = PlanBuilder().values({data}).project({"c0 * 2 as x"}).planNode();
+
+  std::shared_ptr<exec::Task> task;
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool(), task),
+      "Replacement with cuDF operator failed");
+}
+
+// The capability this contract change exists for: a kept operator describing
+// operators that run after it, which is how one plan node expands into several.
+// No built-in adapter both keeps its operator and returns any, so nothing else
+// exercises the insert-behind path or the operator-id renumbering it relies on.
+TEST_F(AdapterOperatorTest, keptOperatorGetsAppendedOperators) {
+  registerAdapterFirst(std::make_unique<AppendingAdapter>());
+
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+  core::PlanNodeId projNodeId;
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .project({"c0 * 2 as x"})
+                  .capturePlanNodeId(projNodeId)
+                  .planNode();
+
+  std::shared_ptr<exec::Task> task;
+  auto results = AssertQueryBuilder(plan).copyResults(pool(), task);
+
+  facebook::velox::test::assertEqualVectors(
+      makeRowVector({"x"}, {makeFlatVector<int64_t>({2, 4, 6, 8, 10})}),
+      results);
+
+  // The kept operator and both appended operators report under the one plan
+  // node, which is the expansion of a single plan node into several operators
+  // that keepOperator() together with a non-empty createReplacements() exists
+  // to express. FilterProject still being there is what distinguishes the
+  // append from a replacement.
+  auto stats = toPlanStats(task->taskStats());
+  auto& projStats = stats.at(projNodeId);
+  EXPECT_TRUE(projStats.isMultiOperatorTypeNode());
+  EXPECT_EQ(projStats.operatorStats.count("FilterProject"), 1);
+  EXPECT_EQ(projStats.operatorStats.count("CudfFromVelox"), 1);
+  EXPECT_EQ(projStats.operatorStats.count("CudfToVelox"), 1);
 }

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -179,6 +179,46 @@ class AppendingAdapter : public cudf_velox::OperatorAdapter {
     return appended;
   }
 };
+// Claims FilterProject but declines it, which is how an adapter reports that it
+// cannot implement a particular operator. createReplacements() is never called
+// on this path, so the operator stays on the CPU and allowCpuFallback alone
+// decides whether that is acceptable.
+class DecliningAdapter : public cudf_velox::OperatorAdapter {
+ public:
+  DecliningAdapter() : cudf_velox::OperatorAdapter("Declining") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::FilterProject*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/) const override {
+    return false;
+  }
+
+  bool acceptsGpuInput() const override {
+    return false;
+  }
+
+  bool producesGpuOutput() const override {
+    return false;
+  }
+
+  bool keepOperator() const override {
+    return false;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/,
+      int32_t /*operatorId*/) const override {
+    VELOX_FAIL(
+        "createReplacements() must not be called for a declined operator");
+  }
+};
 } // namespace
 
 TEST_F(AdapterOperatorTest, adapterStatsMergedIntoPlanNode) {
@@ -234,13 +274,12 @@ TEST_F(AdapterOperatorTest, keptOperatorNeedsNoAppendedOperators) {
   EXPECT_EQ(results->size(), 5);
 }
 
-// The same failure, but with the adapter claiming GPU output so that
-// CompileState appends a CudfToVelox conversion behind it. Deciding the failure
-// from the accumulated replacement list rather than from what the adapter
-// returned would see that conversion operator and conclude the replacement
-// succeeded, so this case is what pins the decision to the adapter's own
-// result. Left undetected the conversion replaces the operator outright, which
-// drops the plan node from the pipeline.
+// The same failure with the adapter also claiming GPU output, which is the
+// shape that used to be destructive: the CudfToVelox appended behind the empty
+// replacement took the operator's place and the plan node dropped out of the
+// pipeline. The rejection has to name the adapter rather than surface later as
+// a conversion operator receiving the wrong vector type, so this case pins the
+// error to the contract check.
 TEST_F(
     AdapterOperatorTest,
     emptyReplacementIsRejectedDespiteConversionOperator) {
@@ -276,6 +315,50 @@ TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithCpuFallbackEnabled) {
   VELOX_ASSERT_THROW(
       AssertQueryBuilder(plan).copyResults(pool(), task),
       "Adapter replaced an operator with nothing");
+}
+
+// An adapter declining its operator is the other reason the operator stays on
+// the CPU, and it is a different failure from returning nothing: the plan
+// cannot run on GPU rather than the adapter being broken, so allowCpuFallback
+// decides it and the error names the fallback rather than the adapter.
+TEST_F(AdapterOperatorTest, declinedOperatorIsRejectedWithoutFallback) {
+  registerAdapterFirst(std::make_unique<DecliningAdapter>());
+
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+  auto plan = PlanBuilder().values({data}).project({"c0 * 2 as x"}).planNode();
+
+  std::shared_ptr<exec::Task> task;
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool(), task),
+      "Replacement with cuDF operator failed");
+}
+
+// The same declined operator with fallback enabled has to run, on the CPU
+// operator that was left in place. Checking the plan node reports FilterProject
+// and no cuDF operator is what distinguishes running on the CPU from having
+// been replaced after all.
+TEST_F(AdapterOperatorTest, declinedOperatorRunsOnCpuWithFallback) {
+  enableCpuFallback();
+  registerAdapterFirst(std::make_unique<DecliningAdapter>());
+
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+  core::PlanNodeId projNodeId;
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .project({"c0 * 2 as x"})
+                  .capturePlanNodeId(projNodeId)
+                  .planNode();
+
+  std::shared_ptr<exec::Task> task;
+  auto results = AssertQueryBuilder(plan).copyResults(pool(), task);
+  facebook::velox::test::assertEqualVectors(
+      makeRowVector({"x"}, {makeFlatVector<int64_t>({2, 4, 6, 8, 10})}),
+      results);
+
+  auto stats = toPlanStats(task->taskStats());
+  auto& projStats = stats.at(projNodeId);
+  EXPECT_EQ(projStats.operatorStats.count("FilterProject"), 1);
+  EXPECT_EQ(projStats.operatorStats.count("CudfFilterProject"), 0);
 }
 
 // The capability this contract change exists for: a kept operator describing

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -61,6 +61,16 @@ class AdapterOperatorTest : public OperatorTestBase {
         std::move(adapter));
   }
 
+  // Rebuilds the cuDF registration with CPU fallback enabled, because
+  // CudfDriverAdapter captures allowCpuFallback when registerCudf() runs, so
+  // setting the config afterwards has no effect on the driver adapter already
+  // installed by SetUp().
+  void enableCpuFallback() {
+    cudf_velox::unregisterCudf();
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback = true;
+    cudf_velox::registerCudf();
+  }
+
   bool savedCpuFallback_{true};
 };
 
@@ -205,7 +215,7 @@ TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithoutFallback) {
   std::shared_ptr<exec::Task> task;
   VELOX_ASSERT_THROW(
       AssertQueryBuilder(plan).copyResults(pool(), task),
-      "Replacement with cuDF operator failed");
+      "Adapter replaced an operator with nothing");
 }
 
 // The mirror case, so that rejecting an empty replacement cannot be implemented
@@ -244,7 +254,28 @@ TEST_F(
   std::shared_ptr<exec::Task> task;
   VELOX_ASSERT_THROW(
       AssertQueryBuilder(plan).copyResults(pool(), task),
-      "Replacement with cuDF operator failed");
+      "Adapter replaced an operator with nothing");
+}
+
+// The same defect with CPU fallback enabled, which is the configuration that
+// used to lose the operator silently: the conversion operator appended behind
+// the empty replacement took its place and the plan node dropped out of the
+// pipeline. An adapter returning nothing while not keeping its operator is a
+// defect in the adapter rather than a plan that cannot run on GPU, so it is
+// rejected whatever allowCpuFallback says.
+TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithCpuFallbackEnabled) {
+  enableCpuFallback();
+  registerAdapterFirst(
+      std::make_unique<EmptyReplacementAdapter>(
+          /*keepOperator=*/false, /*producesGpuOutput=*/true));
+
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+  auto plan = PlanBuilder().values({data}).project({"c0 * 2 as x"}).planNode();
+
+  std::shared_ptr<exec::Task> task;
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool(), task),
+      "Adapter replaced an operator with nothing");
 }
 
 // The capability this contract change exists for: a kept operator describing

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -46,25 +46,16 @@ class AdapterOperatorTest : public OperatorTestBase {
     OperatorTestBase::TearDown();
   }
 
-  // Puts 'adapter' ahead of every built-in adapter, because
-  // OperatorAdapterRegistry::findAdapter() returns the first match and
-  // registerAdapter() appends. The built-ins are restored behind it so every
-  // other operator in the plan still resolves; clearing them instead would make
-  // those operators pure-CPU and trip the allowCpuFallback check for a reason
-  // that has nothing to do with the case under test.
+  // Gives the test adapter priority while preserving built-ins for other
+  // operators.
   void registerAdapterFirst(
       std::unique_ptr<cudf_velox::OperatorAdapter> adapter) {
-    // registerCudf() in SetUp() already installed the built-ins. Put the test
-    // adapter ahead of them; calling registerAllOperatorAdapters() here would
-    // clear the registry and discard it.
     cudf_velox::OperatorAdapterRegistry::getInstance().registerAdapterFront(
         std::move(adapter));
   }
 
-  // Rebuilds the cuDF registration with CPU fallback enabled, because
-  // CudfDriverAdapter captures allowCpuFallback when registerCudf() runs, so
-  // setting the config afterwards has no effect on the driver adapter already
-  // installed by SetUp().
+  // Re-registers the driver adapter to capture the updated CPU fallback
+  // setting.
   void enableCpuFallback() {
     cudf_velox::unregisterCudf();
     cudf_velox::CudfConfig::getInstance().allowCpuFallback = true;
@@ -75,10 +66,7 @@ class AdapterOperatorTest : public OperatorTestBase {
 };
 
 namespace {
-// Claims FilterProject and reports it as GPU-capable, but contributes no
-// operators. Whether that is a failure depends on keepOperator(): a replacing
-// adapter has produced nothing to replace 'op' with, while a keeping adapter
-// has simply nothing to append.
+// Returns no replacements to exercise both keep and replace contracts.
 class EmptyReplacementAdapter : public cudf_velox::OperatorAdapter {
  public:
   EmptyReplacementAdapter(bool keepOperator, bool producesGpuOutput = false)
@@ -122,15 +110,8 @@ class EmptyReplacementAdapter : public cudf_velox::OperatorAdapter {
   const bool producesGpuOutput_;
 };
 
-// Keeps its operator and describes two operators that must run after it. The
-// pair converts to GPU and back so the appended span is type-balanced whatever
-// the neighbours are, which keeps the case about insertion and renumbering
-// rather than about conversion placement.
-//
-// The plan node ids carry the "-from-velox" and "-to-velox" suffixes because
-// CudfFromVelox and CudfToVelox recover the plan node they belong to by
-// stripping exactly those strings, so any other suffix files their stats under
-// a plan node of its own instead of the one being expanded.
+// Keeps FilterProject and appends a GPU round trip. The standard conversion
+// suffixes preserve plan-node stat attribution.
 class AppendingAdapter : public cudf_velox::OperatorAdapter {
  public:
   AppendingAdapter() : cudf_velox::OperatorAdapter("Appending") {}
@@ -179,10 +160,7 @@ class AppendingAdapter : public cudf_velox::OperatorAdapter {
     return appended;
   }
 };
-// Claims FilterProject but declines it, which is how an adapter reports that it
-// cannot implement a particular operator. createReplacements() is never called
-// on this path, so the operator stays on the CPU and allowCpuFallback alone
-// decides whether that is acceptable.
+// Declines FilterProject; createReplacements() must not be called.
 class DecliningAdapter : public cudf_velox::OperatorAdapter {
  public:
   DecliningAdapter() : cudf_velox::OperatorAdapter("Declining") {}
@@ -241,10 +219,7 @@ TEST_F(AdapterOperatorTest, adapterStatsMergedIntoPlanNode) {
   EXPECT_TRUE(projStats.operatorStats.count("CudfToVelox"));
 }
 
-// A replacing adapter that contributes nothing has not replaced the operator,
-// so with fallback disabled the pipeline must be rejected rather than run with
-// the CPU operator still in place. The decision has to come from what
-// createReplacements() returned, not from having called it.
+// An empty replacement is an adapter error, not CPU fallback.
 TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithoutFallback) {
   registerAdapterFirst(
       std::make_unique<EmptyReplacementAdapter>(/*keepOperator=*/false));
@@ -258,10 +233,7 @@ TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithoutFallback) {
       "Adapter replaced an operator with nothing");
 }
 
-// The mirror case, so that rejecting an empty replacement cannot be implemented
-// by rejecting every empty result: a keeping adapter that appends nothing
-// leaves the operator running on its own, which is what lets one plan node
-// expand into several operators.
+// Empty additions are valid when the original operator is kept.
 TEST_F(AdapterOperatorTest, keptOperatorNeedsNoAppendedOperators) {
   registerAdapterFirst(
       std::make_unique<EmptyReplacementAdapter>(/*keepOperator=*/true));
@@ -274,12 +246,7 @@ TEST_F(AdapterOperatorTest, keptOperatorNeedsNoAppendedOperators) {
   EXPECT_EQ(results->size(), 5);
 }
 
-// The same failure with the adapter also claiming GPU output, which is the
-// shape that used to be destructive: the CudfToVelox appended behind the empty
-// replacement took the operator's place and the plan node dropped out of the
-// pipeline. The rejection has to name the adapter rather than surface later as
-// a conversion operator receiving the wrong vector type, so this case pins the
-// error to the contract check.
+// Reject before CudfToVelox can make an empty replacement appear non-empty.
 TEST_F(
     AdapterOperatorTest,
     emptyReplacementIsRejectedDespiteConversionOperator) {
@@ -296,12 +263,7 @@ TEST_F(
       "Adapter replaced an operator with nothing");
 }
 
-// The same defect with CPU fallback enabled, which is the configuration that
-// used to lose the operator silently: the conversion operator appended behind
-// the empty replacement took its place and the plan node dropped out of the
-// pipeline. An adapter returning nothing while not keeping its operator is a
-// defect in the adapter rather than a plan that cannot run on GPU, so it is
-// rejected whatever allowCpuFallback says.
+// Adapter errors are rejected even when CPU fallback is enabled.
 TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithCpuFallbackEnabled) {
   enableCpuFallback();
   registerAdapterFirst(
@@ -317,10 +279,7 @@ TEST_F(AdapterOperatorTest, emptyReplacementIsRejectedWithCpuFallbackEnabled) {
       "Adapter replaced an operator with nothing");
 }
 
-// An adapter declining its operator is the other reason the operator stays on
-// the CPU, and it is a different failure from returning nothing: the plan
-// cannot run on GPU rather than the adapter being broken, so allowCpuFallback
-// decides it and the error names the fallback rather than the adapter.
+// A declined GPU path requires CPU fallback.
 TEST_F(AdapterOperatorTest, declinedOperatorIsRejectedWithoutFallback) {
   registerAdapterFirst(std::make_unique<DecliningAdapter>());
 
@@ -333,10 +292,7 @@ TEST_F(AdapterOperatorTest, declinedOperatorIsRejectedWithoutFallback) {
       "Replacement with cuDF operator failed");
 }
 
-// The same declined operator with fallback enabled has to run, on the CPU
-// operator that was left in place. Checking the plan node reports FilterProject
-// and no cuDF operator is what distinguishes running on the CPU from having
-// been replaced after all.
+// Verify that fallback keeps FilterProject on CPU.
 TEST_F(AdapterOperatorTest, declinedOperatorRunsOnCpuWithFallback) {
   enableCpuFallback();
   registerAdapterFirst(std::make_unique<DecliningAdapter>());
@@ -361,10 +317,7 @@ TEST_F(AdapterOperatorTest, declinedOperatorRunsOnCpuWithFallback) {
   EXPECT_EQ(projStats.operatorStats.count("CudfFilterProject"), 0);
 }
 
-// The capability this contract change exists for: a kept operator describing
-// operators that run after it, which is how one plan node expands into several.
-// No built-in adapter both keeps its operator and returns any, so nothing else
-// exercises the insert-behind path or the operator-id renumbering it relies on.
+// Exercises appending after a kept operator and operator-ID renumbering.
 TEST_F(AdapterOperatorTest, keptOperatorGetsAppendedOperators) {
   registerAdapterFirst(std::make_unique<AppendingAdapter>());
 
@@ -383,11 +336,7 @@ TEST_F(AdapterOperatorTest, keptOperatorGetsAppendedOperators) {
       makeRowVector({"x"}, {makeFlatVector<int64_t>({2, 4, 6, 8, 10})}),
       results);
 
-  // The kept operator and both appended operators report under the one plan
-  // node, which is the expansion of a single plan node into several operators
-  // that keepOperator() together with a non-empty createReplacements() exists
-  // to express. FilterProject still being there is what distinguishes the
-  // append from a replacement.
+  // All three operators must report under the original plan node.
   auto stats = toPlanStats(task->taskStats());
   auto& projStats = stats.at(projNodeId);
   EXPECT_TRUE(projStats.isMultiOperatorTypeNode());


### PR DESCRIPTION
Two gaps that together stop one plan node from expanding into several operators on the GPU.

## Motivation

`CompileState::compile()` only asked an adapter for replacements when it was *replacing* the
operator. An adapter that returns `keepOperator() == true` — meaning the existing operator
stays because it already runs on the GPU — could therefore never describe operators that must
follow it. Separately, a merging exchange carries its ordering on the plan node rather than on
a separate sort node, so a GPU sort spliced after such an exchange has nowhere to read its
keys from.

## What changed

- `compile()` now calls `createReplacements()` for a kept operator too and appends the result
  behind it. `DriverFactory::replaceOperators()` renumbers the driver afterwards, so the
  expansion needs no operator ids of its own. `OperatorAdapters.h` documents the
  one-node-to-many-operators case this opens up.
- `CudfOrderBy` gains a constructor taking a `core::MergeExchangeNode`, sharing sort-key setup
  with the existing one through `initializeSortKeys()`.

## Test plan

No new tests: both halves are dormant until an adapter uses them — nothing in tree returns a
keep with replacements yet, and nothing constructs `CudfOrderBy` from a merge exchange. The
contract gap stands on its own either way, and the first consumer arrives in a later change in
this series. Existing cuDF tests cover the unchanged paths.
