### PR TITLE
refactor(exec)!: Make ExchangeClient the abstract exchange-client interface

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -56,6 +56,7 @@ std::unique_ptr<folly::IOBuf> mergePages(
   }
   return mergedBufs;
 }
+
 } // namespace
 
 Exchange::Exchange(

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -56,7 +56,6 @@ std::unique_ptr<folly::IOBuf> mergePages(
   }
   return mergedBufs;
 }
-
 } // namespace
 
 Exchange::Exchange(

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -17,10 +17,6 @@
 
 #include <random>
 
-// Empty unless VELOX_ENABLE_BACKWARD_COMPATIBILITY is defined, in which case it
-// supplies the legacy ExchangeClient alias. Included here because pre-migration
-// callers reach that name through this header, as they did before the rename.
-#include "velox/exec/ExchangeClient.h"
 #include "velox/exec/InMemoryExchangeClient.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/OperatorType.h"
@@ -50,6 +46,10 @@ struct RemoteConnectorSplit : public connector::ConnectorSplit {
 
 class Exchange : public SourceOperator {
  public:
+  /// 'exchangeClient' is the concrete in-memory client rather than the abstract
+  /// ExchangeClient, because this operator reads pages off the in-memory
+  /// exchange queue, which belongs to that client's data plane and not to the
+  /// abstract control plane.
   Exchange(
       int32_t operatorId,
       DriverCtx* driverCtx,
@@ -89,8 +89,8 @@ class Exchange : public SourceOperator {
   // exchangeClient_.
   void getSplits(ContinueFuture* future);
 
-  // Fetches runtime stats from InMemoryExchangeClient and replaces these in
-  // this operator's stats.
+  // Fetches runtime stats from ExchangeClient and replaces these in this
+  // operator's stats.
   void recordExchangeClientStats();
 
   void recordInputStats(uint64_t rawInputBytes);
@@ -106,7 +106,7 @@ class Exchange : public SourceOperator {
   const std::unique_ptr<VectorSerde::Options> serdeOptions_;
 
   /// True if this operator is responsible for fetching splits from the Task
-  /// and passing these to InMemoryExchangeClient.
+  /// and passing these to ExchangeClient.
   const bool processSplits_;
 
   const int driverId_;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -105,8 +105,8 @@ class Exchange : public SourceOperator {
 
   const std::unique_ptr<VectorSerde::Options> serdeOptions_;
 
-  /// True if this operator is responsible for fetching splits from the Task
-  /// and passing these to ExchangeClient.
+  // True if this operator is responsible for fetching splits from the Task
+  // and passing these to ExchangeClient.
   const bool processSplits_;
 
   const int driverId_;

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -15,29 +15,52 @@
  */
 #pragma once
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+#include <string>
 
-#include "velox/exec/InMemoryExchangeClient.h"
+#include <folly/container/F14Map.h>
+#include <folly/dynamic.h>
+
+#include "velox/common/base/RuntimeMetrics.h"
 
 namespace facebook::velox::exec {
 
-/// Legacy name for InMemoryExchangeClient. Prefer InMemoryExchangeClient and
-/// the header that declares it.
+/// Control plane of a task's receive side for one exchange transport. Owns the
+/// set of producers a pipeline reads from and is what Task holds and drives.
 ///
-/// A type alias rather than a subclass, so a pre-migration
-/// std::shared_ptr<ExchangeClient> parameter still overrides the
-/// Operator::PlanNodeTranslator::toOperator virtual that now names
-/// InMemoryExchangeClient. Retained, together with this header, so the
-/// read-only-synced Prestissimo build keeps compiling. Its Buck targets define
-/// VELOX_ENABLE_BACKWARD_COMPATIBILITY, while velox and open-source builds
-/// never do.
+/// The data plane is deliberately absent: page payloads are transport specific
+/// (in-memory serialized pages, GPU buffers, ...), so there is nothing shared
+/// to abstract. The operator that consumes a transport's pages is built
+/// together with that transport's client, so it always knows the concrete
+/// client type and can reach the transport's own data plane directly.
 ///
-/// velox/exec/Exchange.h includes this header, which is what puts the alias on
-/// the include path those callers already take; declaring it here alone would
-/// leave it unreachable. Remove that include together with this file once every
-/// caller uses InMemoryExchangeClient.
-using ExchangeClient = InMemoryExchangeClient;
+/// Implementations must be safe to call from multiple threads: Task adds remote
+/// tasks from the split path while drivers consume data.
+class ExchangeClient {
+ public:
+  virtual ~ExchangeClient() = default;
+
+  /// Starts fetching data from the upstream task identified by 'remoteTaskId'.
+  /// If close() has been called already, notifies the upstream task that its
+  /// data is no longer needed. Repeated calls with the same 'remoteTaskId' are
+  /// ignored.
+  virtual void addRemoteTaskId(const std::string& remoteTaskId) = 0;
+
+  /// Signals that no more calls to addRemoteTaskId() will follow.
+  virtual void noMoreRemoteTasks() = 0;
+
+  /// Releases the producers and unblocks consumers. Idempotent.
+  virtual void close() = 0;
+
+  /// Returns runtime statistics aggregated across all producers.
+  /// Implementations are expected to report background CPU time as a metric
+  /// named Operator::kBackgroundCpuTimeNanos.
+  virtual folly::F14FastMap<std::string, RuntimeMetric> stats() = 0;
+
+  /// Returns a human-readable description of the producers, for logging.
+  virtual std::string toString() const = 0;
+
+  /// Returns the client state as JSON, for the task's /v1/task endpoint.
+  virtual folly::dynamic toJson() const = 0;
+};
 
 } // namespace facebook::velox::exec
-
-#endif // VELOX_ENABLE_BACKWARD_COMPATIBILITY

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include <folly/container/F14Map.h>
 #include <folly/dynamic.h>
@@ -24,8 +25,9 @@
 
 namespace facebook::velox::exec {
 
-/// Control plane of a task's receive side for one exchange transport. Owns the
-/// set of producers a pipeline reads from and is what Task holds and drives.
+/// Control-plane interface for a task's receive side over one exchange
+/// transport. Implementations own the set of producers a pipeline reads from
+/// and provide the operations by which Task drives them.
 ///
 /// The data plane is deliberately absent: page payloads are transport specific
 /// (in-memory serialized pages, GPU buffers, ...), so there is nothing shared
@@ -43,7 +45,7 @@ class ExchangeClient {
   /// If close() has been called already, notifies the upstream task that its
   /// data is no longer needed. Repeated calls with the same 'remoteTaskId' are
   /// ignored.
-  virtual void addRemoteTaskId(const std::string& remoteTaskId) = 0;
+  virtual void addRemoteTaskId(std::string_view remoteTaskId) = 0;
 
   /// Signals that no more calls to addRemoteTaskId() will follow.
   virtual void noMoreRemoteTasks() = 0;
@@ -54,7 +56,7 @@ class ExchangeClient {
   /// Returns runtime statistics aggregated across all producers.
   /// Implementations are expected to report background CPU time as a metric
   /// named Operator::kBackgroundCpuTimeNanos.
-  virtual folly::F14FastMap<std::string, RuntimeMetric> stats() = 0;
+  virtual folly::F14FastMap<std::string, RuntimeMetric> stats() const = 0;
 
   /// Returns a human-readable description of the producers, for logging.
   virtual std::string toString() const = 0;

--- a/velox/exec/InMemoryExchangeClient.cpp
+++ b/velox/exec/InMemoryExchangeClient.cpp
@@ -20,6 +20,51 @@
 
 namespace facebook::velox::exec {
 
+InMemoryExchangeClient::InMemoryExchangeClient(
+    std::string taskId,
+    int destination,
+    int64_t maxQueuedBytes,
+    int32_t numberOfConsumers,
+    uint64_t minOutputBatchBytes,
+    memory::MemoryPool* pool,
+    folly::Executor* executor,
+    int32_t requestDataSizesMaxWaitSec,
+    bool skipRequestDataSizeWithSingleSource,
+    bool lazyFetching)
+    : taskId_{std::move(taskId)},
+      destination_(destination),
+      maxQueuedBytes_{maxQueuedBytes},
+      requestDataSizesMaxWaitSec_{requestDataSizesMaxWaitSec},
+      pool_(pool),
+      executor_(executor),
+      queue_(
+          std::make_shared<ExchangeQueue>(
+              numberOfConsumers,
+              minOutputBatchBytes)),
+      // See comment in 'pickSourcesToRequestLocked' for why this is needed
+      // for 'minOutputBatchBytes_'. Note: ExchangeQueue does not need max(1,
+      // minOutputBatchBytes) because for 'MergeExchangeSource', we want
+      // ExchangeQueue 'minOutputBatchBytes' to be 0 so that it always
+      // unblocks. In short, 0 has a special meaning for ExchangeQueue
+      minOutputBatchBytes_(
+          std::max(static_cast<uint64_t>(1), minOutputBatchBytes)),
+      skipRequestDataSizeWithSingleSource_(skipRequestDataSizeWithSingleSource),
+      lazyFetching_(lazyFetching) {
+  VELOX_CHECK_NOT_NULL(pool_);
+  VELOX_CHECK_NOT_NULL(executor_);
+  // NOTE: the executor is used to run async response callback from the
+  // exchange source. The provided executor must not be
+  // folly::InlineLikeExecutor, otherwise it might cause potential deadlock as
+  // the response callback in exchange client might call back into the
+  // exchange source under uncertain execution context. For instance, the
+  // exchange client might inline close the exchange source from a background
+  // thread of the exchange source, and the close needs to wait for this
+  // background thread to complete first.
+  VELOX_CHECK_NULL(dynamic_cast<const folly::InlineLikeExecutor*>(executor_));
+  VELOX_CHECK_GE(
+      destination, 0, "Exchange client destination must not be negative");
+}
+
 void InMemoryExchangeClient::addRemoteTaskId(const std::string& remoteTaskId) {
   std::vector<RequestSpec> requestSpecs;
   std::shared_ptr<ExchangeSource> toClose;

--- a/velox/exec/InMemoryExchangeClient.cpp
+++ b/velox/exec/InMemoryExchangeClient.cpp
@@ -65,23 +65,25 @@ InMemoryExchangeClient::InMemoryExchangeClient(
       destination, 0, "Exchange client destination must not be negative");
 }
 
-void InMemoryExchangeClient::addRemoteTaskId(const std::string& remoteTaskId) {
+void InMemoryExchangeClient::addRemoteTaskId(std::string_view remoteTaskId) {
   std::vector<RequestSpec> requestSpecs;
   std::shared_ptr<ExchangeSource> toClose;
   {
     std::lock_guard<std::mutex> l(queue_->mutex());
 
-    bool duplicate = !remoteTaskIds_.insert(remoteTaskId).second;
-    if (duplicate) {
+    auto [remoteTaskIdIt, inserted] =
+        remoteTaskIds_.insert(std::string{remoteTaskId});
+    if (!inserted) {
       // Do not add sources twice. Presto protocol may add duplicate sources
       // and the task updates have no guarantees of arriving in order.
       return;
     }
+    const auto& ownedRemoteTaskId = *remoteTaskIdIt;
 
     std::shared_ptr<ExchangeSource> source;
     try {
-      source =
-          ExchangeSource::create(remoteTaskId, destination_, queue_, pool_);
+      source = ExchangeSource::create(
+          ownedRemoteTaskId, destination_, queue_, pool_);
     } catch (const VeloxException&) {
       throw;
     } catch (const std::exception& e) {
@@ -89,7 +91,7 @@ void InMemoryExchangeClient::addRemoteTaskId(const std::string& remoteTaskId) {
       VELOX_FAIL(
           "Failed to create ExchangeSource: {}. Task ID: {}.",
           e.what(),
-          remoteTaskId.substr(0, 128));
+          ownedRemoteTaskId.substr(0, 128));
     }
 
     if (closed_) {
@@ -124,6 +126,10 @@ void InMemoryExchangeClient::noMoreRemoteTasks() {
 }
 
 void InMemoryExchangeClient::close() {
+  closeImpl();
+}
+
+void InMemoryExchangeClient::closeImpl() {
   std::vector<std::shared_ptr<ExchangeSource>> sources;
   std::queue<ProducingSource> producingSources;
   std::queue<std::shared_ptr<ExchangeSource>> emptySources;
@@ -150,7 +156,8 @@ void InMemoryExchangeClient::close() {
   queue_->close();
 }
 
-folly::F14FastMap<std::string, RuntimeMetric> InMemoryExchangeClient::stats() {
+folly::F14FastMap<std::string, RuntimeMetric> InMemoryExchangeClient::stats()
+    const {
   std::lock_guard<std::mutex> l(queue_->mutex());
   if (stats_.empty()) {
     stats_ = collectStatsLocked();
@@ -394,7 +401,7 @@ InMemoryExchangeClient::pickupSingleSourceToRequestLocked() {
 }
 
 InMemoryExchangeClient::~InMemoryExchangeClient() {
-  close();
+  closeImpl();
 }
 
 std::string InMemoryExchangeClient::toString() const {

--- a/velox/exec/InMemoryExchangeClient.h
+++ b/velox/exec/InMemoryExchangeClient.h
@@ -15,23 +15,41 @@
  */
 #pragma once
 
+#include "velox/exec/ExchangeClient.h"
 #include "velox/exec/ExchangeQueue.h"
 #include "velox/exec/ExchangeSource.h"
 
 namespace facebook::velox::exec {
 
-// Handle for a set of producers. This may be shared by multiple Exchanges, one
-// per consumer thread.
-//
-// Renamed from ExchangeClient, which velox/exec/ExchangeClient.h keeps as an
-// alias of this class for the read-only-synced Prestissimo build. That alias
-// and its header go away once every caller uses this name.
+/// Handle for a set of producers reached through ExchangeSource, buffering
+/// their pages in an in-memory ExchangeQueue. This may be shared by multiple
+/// Exchange operators, one per consumer thread.
+///
+/// This is the client of the built-in in-memory transport. Its data plane --
+/// next() and queue() -- is deliberately not part of the ExchangeClient
+/// interface: page payloads are transport specific, so the operator that reads
+/// them reaches this class directly.
 class InMemoryExchangeClient
-    : public std::enable_shared_from_this<InMemoryExchangeClient> {
+    : public ExchangeClient,
+      public std::enable_shared_from_this<InMemoryExchangeClient> {
  public:
   static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
   static constexpr std::chrono::milliseconds kRequestDataMaxWait{100};
 
+  /// @param taskId Id of the consuming task, for logging.
+  /// @param destination Index of the output buffer to fetch from producers.
+  /// @param maxQueuedBytes Soft limit on bytes buffered in the queue.
+  /// @param numberOfConsumers Number of Exchange operators sharing this client.
+  /// @param minOutputBatchBytes Minimum bytes to accumulate in the queue before
+  /// unblocking a consumer. 0 unblocks as soon as any page arrives.
+  /// @param pool Memory pool the received pages are allocated from.
+  /// @param executor Executor running the exchange sources' response callbacks.
+  /// Must not be a folly::InlineLikeExecutor.
+  /// @param requestDataSizesMaxWaitSec Max wait for a data-size request.
+  /// @param skipRequestDataSizeWithSingleSource If true, skips the data-size
+  /// round trip when there is exactly one source.
+  /// @param lazyFetching If true, defers fetching until next() is called
+  /// instead of starting when a remote task is added.
   InMemoryExchangeClient(
       std::string taskId,
       int destination,
@@ -42,64 +60,29 @@ class InMemoryExchangeClient
       folly::Executor* executor,
       int32_t requestDataSizesMaxWaitSec = 10,
       bool skipRequestDataSizeWithSingleSource = false,
-      bool lazyFetching = false)
-      : taskId_{std::move(taskId)},
-        destination_(destination),
-        maxQueuedBytes_{maxQueuedBytes},
-        requestDataSizesMaxWaitSec_{requestDataSizesMaxWaitSec},
-        pool_(pool),
-        executor_(executor),
-        queue_(
-            std::make_shared<ExchangeQueue>(
-                numberOfConsumers,
-                minOutputBatchBytes)),
-        // See comment in 'pickSourcesToRequestLocked' for why this is needed
-        // for 'minOutputBatchBytes_'. Note: ExchangeQueue does not need max(1,
-        // minOutputBatchBytes) because for 'MergeExchangeSource', we want
-        // ExchangeQueue 'minOutputBatchBytes' to be 0 so that it always
-        // unblocks. In short, 0 has a special meaning for ExchangeQueue
-        minOutputBatchBytes_(
-            std::max(static_cast<uint64_t>(1), minOutputBatchBytes)),
-        skipRequestDataSizeWithSingleSource_(
-            skipRequestDataSizeWithSingleSource),
-        lazyFetching_(lazyFetching) {
-    VELOX_CHECK_NOT_NULL(pool_);
-    VELOX_CHECK_NOT_NULL(executor_);
-    // NOTE: the executor is used to run async response callback from the
-    // exchange source. The provided executor must not be
-    // folly::InlineLikeExecutor, otherwise it might cause potential deadlock as
-    // the response callback in exchange client might call back into the
-    // exchange source under uncertain execution context. For instance, the
-    // exchange client might inline close the exchange source from a background
-    // thread of the exchange source, and the close needs to wait for this
-    // background thread to complete first.
-    VELOX_CHECK_NULL(dynamic_cast<const folly::InlineLikeExecutor*>(executor_));
-    VELOX_CHECK_GE(
-        destination, 0, "Exchange client destination must not be negative");
-  }
+      bool lazyFetching = false);
 
-  ~InMemoryExchangeClient();
+  ~InMemoryExchangeClient() override;
 
+  /// Memory pool the received pages are allocated from.
   memory::MemoryPool* pool() const {
     return pool_;
   }
 
-  // Creates an exchange source and starts fetching data from the specified
-  // upstream task. If 'close' has been called already, creates an exchange
-  // source and immediately closes it to notify the upstream task that data is
-  // no longer needed. Repeated calls with the same 'taskId' are ignored.
-  void addRemoteTaskId(const std::string& remoteTaskId);
+  void addRemoteTaskId(const std::string& remoteTaskId) override;
 
-  void noMoreRemoteTasks();
+  void noMoreRemoteTasks() override;
 
-  // Closes exchange sources.
-  void close();
+  void close() override;
 
-  // Returns runtime statistics aggregated across all of the exchange sources.
-  // InMemoryExchangeClient is expected to report background CPU time by
-  // including a runtime metric named Operator::kBackgroundCpuTimeNanos.
-  folly::F14FastMap<std::string, RuntimeMetric> stats();
+  folly::F14FastMap<std::string, RuntimeMetric> stats() override;
 
+  std::string toString() const override;
+
+  folly::dynamic toJson() const override;
+
+  /// Queue the received pages are buffered in. Part of the in-memory data
+  /// plane, used by the Exchange operator and by MergeExchangeSource.
   const std::shared_ptr<ExchangeQueue>& queue() const {
     return queue_;
   }
@@ -115,14 +98,12 @@ class InMemoryExchangeClient
   std::vector<std::unique_ptr<SerializedPageBase>>
   next(int consumerId, uint32_t maxBytes, bool* atEnd, ContinueFuture* future);
 
-  std::string toString() const;
-
-  folly::dynamic toJson() const;
-
+  /// Max wait for a data-size request to a producer.
   std::chrono::seconds requestDataSizesMaxWaitSec() const {
     return requestDataSizesMaxWaitSec_;
   }
 
+  /// Ids of the upstream tasks added so far.
   const std::unordered_set<std::string>& getRemoteTaskIdList() const {
     return remoteTaskIds_;
   }
@@ -163,8 +144,8 @@ class InMemoryExchangeClient
   std::vector<RequestSpec> pickupSingleSourceToRequestLocked();
   void request(std::vector<RequestSpec>&& requestSpecs);
 
-  /// Returns true if skip request data size optimization is enabled for single
-  /// source exchanges.
+  // Returns true if skip request data size optimization is enabled for single
+  // source exchanges.
   bool skipRequestDataSizeWithSingleSource() const {
     return skipRequestDataSizeWithSingleSource_ && queue_->hasNoMoreSources() &&
         sources_.size() == 1;

--- a/velox/exec/InMemoryExchangeClient.h
+++ b/velox/exec/InMemoryExchangeClient.h
@@ -69,13 +69,13 @@ class InMemoryExchangeClient
     return pool_;
   }
 
-  void addRemoteTaskId(const std::string& remoteTaskId) override;
+  void addRemoteTaskId(std::string_view remoteTaskId) override;
 
   void noMoreRemoteTasks() override;
 
   void close() override;
 
-  folly::F14FastMap<std::string, RuntimeMetric> stats() override;
+  folly::F14FastMap<std::string, RuntimeMetric> stats() const override;
 
   std::string toString() const override;
 
@@ -144,12 +144,14 @@ class InMemoryExchangeClient
   std::vector<RequestSpec> pickupSingleSourceToRequestLocked();
   void request(std::vector<RequestSpec>&& requestSpecs);
 
-  // Returns true if skip request data size optimization is enabled for single
-  // source exchanges.
+  /// Returns true if skip request data size optimization is enabled for single
+  /// source exchanges.
   bool skipRequestDataSizeWithSingleSource() const {
     return skipRequestDataSizeWithSingleSource_ && queue_->hasNoMoreSources() &&
         sources_.size() == 1;
   }
+
+  void closeImpl();
 
   folly::F14FastMap<std::string, RuntimeMetric> collectStatsLocked() const;
 
@@ -167,7 +169,7 @@ class InMemoryExchangeClient
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
   bool closed_{false};
 
-  folly::F14FastMap<std::string, RuntimeMetric> stats_;
+  mutable folly::F14FastMap<std::string, RuntimeMetric> stats_;
 
   // The minimum byte size the consumer is expected to consume from
   // the exchange queue.


### PR DESCRIPTION
Turns `ExchangeClient` into the abstract exchange-client interface, and removes the alias that
was holding its name.

## Motivation

#18110 renamed the concrete class to `InMemoryExchangeClient` and left
`velox/exec/ExchangeClient.h` behind as a `using ExchangeClient = InMemoryExchangeClient` alias
guarded by `VELOX_ENABLE_BACKWARD_COMPATIBILITY`, described there as step one of an
expand/migrate/contract sequence whose last step removes the alias so the abstract interface can
reclaim the name. **This is that step.**

## What changed

- `ExchangeClient` now declares the control plane a task's receive side needs whatever transport
  carries the data: `addRemoteTaskId`, `noMoreRemoteTasks`, `close`, `stats`, `toString`,
  `toJson`.
- The data plane is deliberately absent — page payloads are transport specific, in-memory
  serialized pages in one case and GPU buffers in another — so there is nothing shared to
  abstract. Implementations must be safe to call from several threads, because Task adds remote
  tasks from the split path while drivers consume.
- `InMemoryExchangeClient` implements it, unchanged in behaviour. Its constructor moves out of
  line into the `.cpp`, since a class that now overrides an interface keeps only declarations in
  the header.
- `Exchange.h` drops the legacy include, and its comments go back to naming the role rather than
  the implementation.

## Downstream

`BREAKING CHANGE`: `velox/exec/ExchangeClient.h` no longer defines an alias for
`InMemoryExchangeClient`. Downstream code naming `ExchangeClient` and meaning the concrete
in-memory client must name `InMemoryExchangeClient` instead.

For the OSS build this is already done: `prestodb/presto` master pins a velox containing #18110,
and its `ShuffleRead.h` / `MaterializedExchange.h` already take
`std::shared_ptr<InMemoryExchangeClient>`. Only builds that define
`VELOX_ENABLE_BACKWARD_COMPATIBILITY` — internal Buck targets — still reach the alias and need
the same rename.

## Test plan

Pure interface extraction with no behaviour change; `InMemoryExchangeClientTest` covers the
concrete client unchanged.
