### PR TITLE
refactor(nimble): Extract encoding evaluation into common library (#18654)

### DIFF
--- a/velox/dwio/nimble/tools/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/CMakeLists.txt
@@ -90,6 +90,8 @@ target_link_libraries(
 # instrumentation include Meta-internal headers that are not part of the OSS
 # export, so they have no OSS build.
 
+add_subdirectory(encoding)
+
 if(NIMBLE_BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/velox/dwio/nimble/tools/encoding/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/encoding/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(nimble_encoding_evaluation EncodingEvaluation.cpp EncodingEvaluation.h)
+
+target_link_libraries(
+  nimble_encoding_evaluation
+  nimble_common
+  nimble_encodings
+  nimble_writer
+  nimble_serializer
+  nimble_deserializer
+  nimble_serializer_options
+  nimble_velox_schema_serialization
+  velox_memory
+  velox_time
+  velox_vector
+  Folly::folly
+  fmt::fmt
+)
+
+if(NIMBLE_BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/velox/dwio/nimble/tools/encoding/EncodingEvaluation.cpp
+++ b/velox/dwio/nimble/tools/encoding/EncodingEvaluation.cpp
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/tools/encoding/EncodingEvaluation.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include <fmt/core.h>
+#include <folly/futures/Future.h>
+
+#include "velox/common/time/CpuWallTimer.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/NimbleException.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/serializer/Deserializer.h"
+#include "velox/dwio/nimble/serializer/Serializer.h"
+#include "velox/dwio/nimble/velox/OrderedRanges.h"
+#include "velox/dwio/nimble/velox/SchemaSerialization.h"
+
+namespace facebook::nimble::selection {
+namespace {
+
+struct ChunkMeasurement {
+  uint64_t encodedBytes{};
+  uint64_t encodeNanos{};
+  uint64_t decodeNanos{};
+};
+
+uint8_t nestedChildrenCount(nimble::EncodingType encodingType) {
+  switch (encodingType) {
+    case nimble::EncodingType::Delta:
+    case nimble::EncodingType::BlockBitPacking:
+    case nimble::EncodingType::FOR:
+      return 3;
+    case nimble::EncodingType::RLE:
+    case nimble::EncodingType::Dictionary:
+    case nimble::EncodingType::MainlyConstant:
+    case nimble::EncodingType::PFOR:
+      return 2;
+    case nimble::EncodingType::SparseBool:
+    case nimble::EncodingType::Trivial:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+nimble::EncodingLayoutTree buildScalarOverrideTree(nimble::EncodingType type) {
+  using StreamIds = nimble::EncodingLayoutTree::StreamIdentifiers;
+  std::vector<std::optional<const nimble::EncodingLayout>> nestedChildren(
+      nestedChildrenCount(type), std::nullopt);
+  return nimble::EncodingLayoutTree(
+      nimble::Kind::Scalar,
+      {{StreamIds::Scalar::ScalarStream,
+        nimble::EncodingLayout(
+            type,
+            {},
+            nimble::CompressionType::Uncompressed,
+            std::move(nestedChildren))}},
+      "");
+}
+
+nimble::SerializerOptions buildSerializerOptions(
+    const CandidateEncoding& candidate,
+    const EvaluationOptions& opts) {
+  nimble::SerializerOptions options;
+  options.version = nimble::SerializationVersion::kSerialization;
+  options.encodingOptions.blockBitPackingBlockSize =
+      opts.blockBitPackingBlockSize;
+  options.encodingOptions.fixedBitWidthUseExactBits =
+      opts.fixedBitWidthUseExactBits;
+  options.compressionOptions = opts.compressionOptions;
+  options.flatMapColumns = opts.flatMapColumns;
+
+  auto readFactors = opts.readFactors;
+  if (readFactors.empty()) {
+    readFactors = nimble::ManualEncodingSelectionPolicyFactory::
+        defaultEncodingReadFactors();
+  }
+  nimble::ManualEncodingSelectionPolicyFactory factory{
+      std::move(readFactors), opts.compressionOptions, opts.nestedReadFactors};
+  options.encodingSelectionPolicyCreator =
+      [factory = std::move(factory)](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return factory.createPolicy(dataType);
+  };
+
+  options.encodingLayoutTree.emplace(candidate.tree);
+  return options;
+}
+
+ChunkMeasurement evaluateCandidateEncodingOnce(
+    const CandidateEncoding& candidate,
+    const std::vector<velox::VectorPtr>& vectors,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool) {
+  auto serializerOptions = buildSerializerOptions(candidate, opts);
+  nimble::Serializer serializer{
+      serializerOptions, vectors.front()->type(), pool};
+
+  velox::CpuWallTiming encodeTiming;
+  std::vector<std::string> serializedBuffers;
+  serializedBuffers.reserve(vectors.size());
+  uint64_t chunkBytes{0};
+
+  for (const auto& vector : vectors) {
+    nimble::OrderedRanges ranges;
+    ranges.add(0, vector->size());
+    std::string_view serialized;
+    {
+      velox::CpuWallTimer timer(encodeTiming);
+      serialized = serializer.serialize(vector, ranges);
+    }
+    serializedBuffers.emplace_back(serialized);
+    chunkBytes += serialized.size();
+  }
+
+  nimble::SchemaSerializer schemaSerializer;
+  const auto serializedSchema =
+      schemaSerializer.serialize(serializer.schemaBuilder());
+  auto schema = nimble::SchemaDeserializer::deserialize(serializedSchema);
+  nimble::DeserializerOptions deserializerOptions{.hasHeader = true};
+  nimble::Deserializer deserializer(schema, pool, deserializerOptions);
+
+  velox::CpuWallTiming decodeTiming;
+  for (const auto& buffer : serializedBuffers) {
+    velox::CpuWallTimer timer(decodeTiming);
+    velox::VectorPtr deserialized;
+    deserializer.deserialize(buffer, deserialized);
+  }
+
+  return {chunkBytes, encodeTiming.wallNanos, decodeTiming.wallNanos};
+}
+
+ChunkMeasurement evaluateCandidateEncodingParallel(
+    const CandidateEncoding& candidate,
+    const std::vector<velox::VectorPtr>& vectors,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  const auto parallelism =
+      std::min<size_t>(vectors.size(), std::max<size_t>(opts.parallelism, 1));
+  const auto chunkSize = (vectors.size() + parallelism - 1) / parallelism;
+  std::vector<folly::Future<ChunkMeasurement>> futures;
+  for (size_t t = 0; t < parallelism; ++t) {
+    const auto start = t * chunkSize;
+    const auto end = std::min(start + chunkSize, vectors.size());
+    if (start >= end) {
+      break;
+    }
+    std::vector<velox::VectorPtr> chunkVectors(
+        vectors.begin() + start, vectors.begin() + end);
+    auto chunkPool = pool->addLeafChild(fmt::format("chunk_{}", t));
+    futures.emplace_back(
+        folly::via(
+            executor,
+            [&candidate,
+             &opts,
+             chunkVectors = std::move(chunkVectors),
+             chunkPool = std::move(chunkPool)]() {
+              return evaluateCandidateEncodingOnce(
+                  candidate, chunkVectors, opts, chunkPool.get());
+            }));
+  }
+  auto perChunk = folly::collectAll(std::move(futures)).get();
+  ChunkMeasurement total;
+  for (auto& chunkResult : perChunk) {
+    const auto& measurement = chunkResult.value();
+    total.encodedBytes += measurement.encodedBytes;
+    total.encodeNanos += measurement.encodeNanos;
+    total.decodeNanos += measurement.decodeNanos;
+  }
+  return total;
+}
+
+std::optional<EvaluationResult> evaluateCandidateEncoding(
+    const CandidateEncoding& candidate,
+    const std::vector<velox::VectorPtr>& vectors,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  uint64_t encodeNanos{std::numeric_limits<uint64_t>::max()};
+  uint64_t decodeNanos{std::numeric_limits<uint64_t>::max()};
+  uint64_t encodedBytes{0};
+
+  for (int32_t iter = 0; iter < opts.iterations; ++iter) {
+    try {
+      const auto chunk =
+          (executor != nullptr && opts.parallelism > 1 && vectors.size() > 1)
+          ? evaluateCandidateEncodingParallel(
+                candidate, vectors, opts, pool, executor)
+          : evaluateCandidateEncodingOnce(candidate, vectors, opts, pool);
+      encodeNanos = std::min(encodeNanos, chunk.encodeNanos);
+      decodeNanos = std::min(decodeNanos, chunk.decodeNanos);
+      encodedBytes = chunk.encodedBytes;
+    } catch (const nimble::NimbleUserError& error) {
+      if (error.errorCode() != nimble::error_code::IncompatibleEncoding) {
+        throw;
+      }
+      return std::nullopt;
+    }
+  }
+
+  return EvaluationResult{
+      .type = candidate.type,
+      .encodedBytes = encodedBytes,
+      .encodeNanos = encodeNanos,
+      .decodeNanos = decodeNanos,
+  };
+}
+
+const EvaluationResult& findTrivialEncodingResult(
+    const std::vector<std::optional<EvaluationResult>>& results) {
+  for (const auto& result : results) {
+    if (result.has_value() && result->type == nimble::EncodingType::Trivial) {
+      return *result;
+    }
+  }
+  NIMBLE_USER_CHECK(
+      false, "Trivial encoding required for result normalization.");
+}
+
+} // namespace
+
+std::vector<std::optional<EvaluationResult>> evaluateCandidates(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  NIMBLE_USER_CHECK(
+      !vectors.empty(), "No data provided for encoding evaluation.");
+  NIMBLE_USER_CHECK(
+      opts.iterations > 0, "EvaluationOptions.iterations must be positive.");
+  NIMBLE_USER_CHECK(
+      std::any_of(
+          candidates.begin(),
+          candidates.end(),
+          [](const auto& c) {
+            return c.type == nimble::EncodingType::Trivial;
+          }),
+      "Trivial encoding required for result normalization.");
+
+  std::vector<std::optional<EvaluationResult>> results;
+  results.reserve(candidates.size());
+  for (const auto& candidate : candidates) {
+    results.emplace_back(
+        evaluateCandidateEncoding(candidate, vectors, opts, pool, executor));
+  }
+  return results;
+}
+
+std::vector<EvaluationResult> rankResults(
+    const std::vector<std::optional<EvaluationResult>>& results,
+    const ScoreWeights& weights) {
+  const auto& baseline = findTrivialEncodingResult(results);
+  NIMBLE_CHECK(
+      baseline.encodedBytes > 0,
+      "Trivial baseline encodedBytes must be positive.");
+  NIMBLE_CHECK(
+      baseline.encodeNanos > 0,
+      "Trivial baseline encodeNanos must be positive.");
+  NIMBLE_CHECK(
+      baseline.decodeNanos > 0,
+      "Trivial baseline decodeNanos must be positive.");
+
+  std::vector<EvaluationResult> ranked;
+  ranked.reserve(results.size());
+  for (const auto& result : results) {
+    if (!result.has_value()) {
+      continue;
+    }
+    EvaluationResult copy = *result;
+    copy.sizeRatio =
+        static_cast<double>(copy.encodedBytes) / baseline.encodedBytes;
+    copy.encodeRatio =
+        static_cast<double>(copy.encodeNanos) / baseline.encodeNanos;
+    copy.decodeRatio =
+        static_cast<double>(copy.decodeNanos) / baseline.decodeNanos;
+    copy.score = weights.encodeSize * copy.sizeRatio +
+        weights.encodeTime * copy.encodeRatio +
+        weights.decodeTime * copy.decodeRatio;
+    ranked.emplace_back(std::move(copy));
+  }
+
+  std::sort(ranked.begin(), ranked.end(), [](const auto& lhs, const auto& rhs) {
+    return lhs.score < rhs.score;
+  });
+  return ranked;
+}
+
+nimble::EncodingLayoutTree getOptimalEncoding(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  auto rawResults =
+      evaluateCandidates(vectors, candidates, opts, pool, executor);
+  auto ranked = rankResults(rawResults, opts.weights);
+  NIMBLE_USER_CHECK(!ranked.empty());
+  const auto best = ranked.front().type;
+  for (const auto& candidate : candidates) {
+    if (candidate.type == best) {
+      return candidate.tree;
+    }
+  }
+  NIMBLE_UNREACHABLE();
+}
+
+std::vector<CandidateEncoding> buildEncodingCandidates(
+    const std::vector<nimble::EncodingType>& encodings) {
+  std::vector<CandidateEncoding> candidates;
+  candidates.reserve(encodings.size());
+  for (const auto encoding : encodings) {
+    candidates.push_back({encoding, buildScalarOverrideTree(encoding)});
+  }
+  return candidates;
+}
+
+} // namespace facebook::nimble::selection

--- a/velox/dwio/nimble/tools/encoding/EncodingEvaluation.h
+++ b/velox/dwio/nimble/tools/encoding/EncodingEvaluation.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <folly/Executor.h>
+#include <folly/container/F14Map.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Constants.h"
+#include "velox/dwio/nimble/compression/CompressionPolicy.h"
+#include "velox/dwio/nimble/encodings/common/EncodingType.h"
+#include "velox/dwio/nimble/serializer/Options.h"
+#include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::nimble::selection {
+
+/// Weights applied to normalized encoding metrics during candidate ranking.
+struct ScoreWeights {
+  double encodeSize{1.0};
+  double encodeTime{0.0};
+  double decodeTime{0.0};
+};
+
+/// Configuration for an encoding evaluation.
+struct EvaluationOptions {
+  int32_t iterations{3};
+  ScoreWeights weights;
+  std::optional<nimble::CompressionOptions> compressionOptions;
+  uint16_t blockBitPackingBlockSize{nimble::kBlockBitPackingBlockSize};
+  bool fixedBitWidthUseExactBits{true};
+  std::vector<std::pair<nimble::EncodingType, float>> readFactors;
+  std::optional<std::vector<std::pair<nimble::EncodingType, float>>>
+      nestedReadFactors;
+  folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns;
+  size_t parallelism{1};
+};
+
+/// One candidate encoding to evaluate.
+struct CandidateEncoding {
+  nimble::EncodingType type{};
+  nimble::EncodingLayoutTree tree;
+};
+
+/// Measurement plus normalized ranking metrics for one candidate.
+struct EvaluationResult {
+  nimble::EncodingType type{};
+  uint64_t encodedBytes{};
+  uint64_t encodeNanos{};
+  uint64_t decodeNanos{};
+  double sizeRatio{};
+  double encodeRatio{};
+  double decodeRatio{};
+  double score{};
+};
+
+/// Measures each candidate against the given vectors. Nullopt slot means the
+/// encoding was incompatible with the data. When executor is set and vectors
+/// has more than one element, per-candidate measurement fans out across
+/// vector chunks on the executor.
+std::vector<std::optional<EvaluationResult>> evaluateCandidates(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor = nullptr);
+
+/// Normalizes results against the Trivial baseline, applies weights, and
+/// returns them sorted best-first.
+std::vector<EvaluationResult> rankResults(
+    const std::vector<std::optional<EvaluationResult>>& results,
+    const ScoreWeights& weights);
+
+/// Evaluates the candidates and returns the winning EncodingLayoutTree.
+nimble::EncodingLayoutTree getOptimalEncoding(
+    const std::vector<velox::VectorPtr>& vectors,
+    const std::vector<CandidateEncoding>& candidates,
+    const EvaluationOptions& opts,
+    velox::memory::MemoryPool* pool,
+    folly::Executor* executor = nullptr);
+
+/// Builds one CandidateEncoding per encoding type.
+std::vector<CandidateEncoding> buildEncodingCandidates(
+    const std::vector<nimble::EncodingType>& encodings);
+
+} // namespace facebook::nimble::selection

--- a/velox/dwio/nimble/tools/encoding/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/encoding/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(nimble_encoding_evaluation_tests EncodingEvaluationTest.cpp)
+add_test(nimble_encoding_evaluation_tests nimble_encoding_evaluation_tests)
+target_link_libraries(
+  nimble_encoding_evaluation_tests
+  nimble_encoding_evaluation
+  nimble_common
+  nimble_writer
+  velox_memory
+  velox_vector_test_lib
+  gtest
+  gtest_main
+)

--- a/velox/dwio/nimble/tools/encoding/tests/EncodingEvaluationTest.cpp
+++ b/velox/dwio/nimble/tools/encoding/tests/EncodingEvaluationTest.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/tools/encoding/EncodingEvaluation.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/NimbleException.h"
+#include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::nimble::selection {
+namespace {
+
+class EncodingEvaluationTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool("encoding_eval_test");
+    vectorMaker_ = std::make_unique<velox::test::VectorMaker>(pool_.get());
+  }
+
+  velox::VectorPtr makeConstantColumn(int64_t value, int32_t size) {
+    return vectorMaker_->flatVector<int64_t>(
+        size, [value](velox::vector_size_t) { return value; });
+  }
+
+  velox::VectorPtr makeVariedColumn(int32_t size) {
+    return vectorMaker_->flatVector<int64_t>(
+        size, [](velox::vector_size_t i) { return i * 17 + 3; });
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<velox::test::VectorMaker> vectorMaker_;
+};
+
+TEST_F(EncodingEvaluationTest, evaluateCandidatesReturnsResultsForCompatible) {
+  const std::vector<velox::VectorPtr> vectors{makeConstantColumn(42, 1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::FixedBitWidth,
+  });
+
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto results =
+      evaluateCandidates(vectors, candidates, opts, pool_.get());
+
+  ASSERT_EQ(results.size(), 2u);
+  ASSERT_TRUE(results[0].has_value());
+  ASSERT_TRUE(results[1].has_value());
+  EXPECT_EQ(results[0]->type, nimble::EncodingType::Trivial);
+  EXPECT_EQ(results[1]->type, nimble::EncodingType::FixedBitWidth);
+  EXPECT_GT(results[0]->encodedBytes, 0u);
+  EXPECT_GT(results[1]->encodedBytes, 0u);
+}
+
+TEST_F(EncodingEvaluationTest, evaluateCandidatesReturnsNulloptOnIncompatible) {
+  const std::vector<velox::VectorPtr> vectors{makeVariedColumn(1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::Constant,
+  });
+
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto results =
+      evaluateCandidates(vectors, candidates, opts, pool_.get());
+
+  ASSERT_EQ(results.size(), 2u);
+  EXPECT_TRUE(results[0].has_value());
+  EXPECT_FALSE(results[1].has_value());
+}
+
+TEST_F(EncodingEvaluationTest, evaluateCandidatesThrowsOnEmptyVectors) {
+  const std::vector<velox::VectorPtr> vectors;
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+  });
+  EvaluationOptions opts;
+
+  EXPECT_THROW(
+      evaluateCandidates(vectors, candidates, opts, pool_.get()),
+      nimble::NimbleUserError);
+}
+
+TEST_F(EncodingEvaluationTest, rankResultsThrowsWithoutTrivialBaseline) {
+  std::vector<std::optional<EvaluationResult>> results;
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::FixedBitWidth,
+          .encodedBytes = 100,
+          .encodeNanos = 100,
+          .decodeNanos = 100,
+      });
+
+  ScoreWeights weights;
+  EXPECT_THROW(rankResults(results, weights), nimble::NimbleUserError);
+}
+
+TEST_F(EncodingEvaluationTest, rankResultsSortsAscendingByScore) {
+  std::vector<std::optional<EvaluationResult>> results;
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::Trivial,
+          .encodedBytes = 1'000,
+          .encodeNanos = 1'000,
+          .decodeNanos = 1'000,
+      });
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::FixedBitWidth,
+          .encodedBytes = 500,
+          .encodeNanos = 2'000,
+          .decodeNanos = 2'000,
+      });
+  results.emplace_back(std::nullopt);
+  results.emplace_back(
+      EvaluationResult{
+          .type = nimble::EncodingType::Constant,
+          .encodedBytes = 10,
+          .encodeNanos = 10'000,
+          .decodeNanos = 10'000,
+      });
+
+  ScoreWeights sizeOnly;
+  const auto rankedBySize = rankResults(results, sizeOnly);
+  ASSERT_EQ(rankedBySize.size(), 3u);
+  EXPECT_EQ(rankedBySize[0].type, nimble::EncodingType::Constant);
+  EXPECT_EQ(rankedBySize[1].type, nimble::EncodingType::FixedBitWidth);
+  EXPECT_EQ(rankedBySize[2].type, nimble::EncodingType::Trivial);
+
+  ScoreWeights decodeOnly{.encodeSize = 0.0, .decodeTime = 1.0};
+  const auto rankedByDecode = rankResults(results, decodeOnly);
+  ASSERT_EQ(rankedByDecode.size(), 3u);
+  EXPECT_EQ(rankedByDecode[0].type, nimble::EncodingType::Trivial);
+}
+
+TEST_F(EncodingEvaluationTest, getOptimalEncodingPicksConstantForConstantData) {
+  const std::vector<velox::VectorPtr> vectors{makeConstantColumn(7, 1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::FixedBitWidth,
+      nimble::EncodingType::Constant,
+  });
+
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto winningTree =
+      getOptimalEncoding(vectors, candidates, opts, pool_.get());
+
+  ASSERT_EQ(winningTree.schemaKind(), nimble::Kind::Scalar);
+  const auto* layout = winningTree.encodingLayout(
+      nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream);
+  ASSERT_NE(layout, nullptr);
+  EXPECT_EQ(layout->encodingType(), nimble::EncodingType::Constant);
+}
+
+TEST_F(EncodingEvaluationTest, getOptimalEncodingSkipsIncompatibleCandidates) {
+  const std::vector<velox::VectorPtr> vectors{makeVariedColumn(1'024)};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::Constant,
+  });
+  EvaluationOptions opts;
+  opts.iterations = 1;
+
+  const auto winningTree =
+      getOptimalEncoding(vectors, candidates, opts, pool_.get());
+  ASSERT_EQ(winningTree.schemaKind(), nimble::Kind::Scalar);
+  const auto* layout = winningTree.encodingLayout(
+      nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream);
+  ASSERT_NE(layout, nullptr);
+  EXPECT_EQ(layout->encodingType(), nimble::EncodingType::Trivial);
+}
+
+} // namespace
+} // namespace facebook::nimble::selection


### PR DESCRIPTION
Summary:

Move offline encoding evaluation from NimbleEncodingEval into a shared library at velox/dwio/nimble/tools/encoding/. Public API: evaluateCandidates, rankResults, getOptimalEncoding, buildEncodingCandidates. EvaluationOptions carries weights, iterations, read factors, and parallelism.

Library takes an optional folly::Executor* for per-vector-chunk fan-out; benchmark passes a per-feature CPUThreadPoolExecutor to preserve the pre-refactor within-iter chunk-sum + across-iter best-of-N semantics. OSS-exported via CMakeLists.txt.

Reviewed By: xiaoxmeng

Differential Revision: D116675355


