### PR TITLE
build(ci): Cut macOS runner usage on pull requests

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,17 @@
 name: macOS Build
 
 on:
+  schedule:
+    # Nightly, so the release build keeps running without costing a macOS
+    # runner on every pull request.
+    - cron: 0 4 * * *
+
+  workflow_dispatch: {}
+
   push:
+    # Only main. A branch pushed to this repository and opened as a pull
+    # request otherwise triggers this workflow twice, once per event.
+    branches: [main]
     paths:
       - velox/**
       - '!velox/docs/**'
@@ -53,8 +63,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-15 = arm64 Mac and cmake 4.0 with 7GB RAM
-        type: [debug, release]
+        # macos-15 = arm64 Mac and cmake 4.0 with 7GB RAM.
+        # Pull requests build debug only; release is covered by the nightly
+        # schedule and by pushes to main. macOS runners are the most expensive
+        # in the fleet, and a release failure that a debug build does not also
+        # catch is rare.
+        type: ${{ (github.event_name == 'pull_request' && fromJSON('["debug"]')) || fromJSON('["debug", "release"]') }}
     runs-on: macos-15
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache


### PR DESCRIPTION
macOS runners are the most expensive in the fleet, and this workflow was using
up to four per pull request. This brings it to one.

- **Release builds move off pull requests.** The matrix is `debug` only for
  `pull_request`, and both types for pushes to `main` and for a new nightly
  schedule.
- **The `push` trigger is limited to `main`.** A branch pushed to this repo and
  opened as a PR matched both `push` and `pull_request`, running the whole
  matrix twice. Fork PRs were never affected, so this only removes duplicate
  work maintainers were paying for.
- **`workflow_dispatch` added**, so a release build can be run on demand.

Before, per maintainer PR: `macos-15-debug` ×2, `macos-15-release` ×2.
After: `macos-15-debug` ×1.

Worth noting these jobs only compile. The `Run Tests` step is gated on
`if: false`, so no macOS tests run today either way.

There is only one macOS version in the matrix (`macos-15`), so nothing was
needed there.
