### PR TITLE
feat: Add Nimble stripe-level column statistics section (#18656)

### DIFF
--- a/velox/dwio/nimble/common/FeatureGate.h
+++ b/velox/dwio/nimble/common/FeatureGate.h
@@ -37,6 +37,11 @@ class FeatureGate {
         "stream_deduplication";
     static constexpr std::string_view kDisableSharedStringBuffers =
         "disable_shared_string_buffers";
+    /// Writer-side: gates emitting the stripe-stats section (and the per-stripe
+    /// stats snapshot + file-stats-from-stripes merge that produces it). When
+    /// off, the writer accumulates stats across the whole file and emits no
+    /// stripe-stats section, matching pre-feature behavior.
+    static constexpr std::string_view kStripeStatsWrite = "stripe_stats_write";
   };
 
   virtual ~FeatureGate() = default;

--- a/velox/dwio/nimble/common/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/common/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
   TestUtils.h
   NimbleCompare.h
   GTestUtils.h
+  ScopedFeatureGate.h
 )
 
 add_test(nimble_common_tests nimble_common_tests)

--- a/velox/dwio/nimble/common/tests/ScopedFeatureGate.h
+++ b/velox/dwio/nimble/common/tests/ScopedFeatureGate.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+#include "velox/dwio/nimble/common/FeatureGate.h"
+
+namespace facebook::nimble::test {
+
+/// Force-enables one runtime-gated writer feature for the lifetime of this
+/// object, restoring the default no-op gate on destruction. Features that
+/// default to off are otherwise unreachable in tests, which register no gate.
+/// A writer resolves its gates once at construction, so this must be created
+/// before the writer under test.
+class ScopedFeatureGate {
+ public:
+  explicit ScopedFeatureGate(std::string_view feature) {
+    registerFeatureGate(std::make_shared<EnablingGate>(feature));
+  }
+
+  ScopedFeatureGate(const ScopedFeatureGate&) = delete;
+  ScopedFeatureGate& operator=(const ScopedFeatureGate&) = delete;
+
+  ~ScopedFeatureGate() {
+    registerFeatureGate(nullptr);
+  }
+
+ private:
+  // Forces one feature on and leaves every other feature at the value its
+  // caller requested, so enabling one does not perturb the rest.
+  class EnablingGate : public FeatureGate {
+   public:
+    explicit EnablingGate(std::string_view feature) : feature_{feature} {}
+
+    bool enabled(std::string_view feature, bool defaultValue) const override {
+      return feature == feature_ || defaultValue;
+    }
+
+   private:
+    const std::string_view feature_;
+  };
+};
+
+} // namespace facebook::nimble::test

--- a/velox/dwio/nimble/tablet/Constants.h
+++ b/velox/dwio/nimble/tablet/Constants.h
@@ -36,6 +36,7 @@ constexpr std::string_view kMetadataSection = "columnar.metadata";
 constexpr std::string_view kStatsSection = "columnar.stats";
 constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
+constexpr std::string_view kStripeStatsSection = "columnar.stripe_stats";
 constexpr std::string_view kIndexSection = "columnar.indexes";
 constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
 constexpr std::string_view kPropertiesSection = "columnar.properties";

--- a/velox/dwio/nimble/velox/FieldWriter.h
+++ b/velox/dwio/nimble/velox/FieldWriter.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <set>
 
 #include "folly/container/F14Map.h"
@@ -274,20 +275,17 @@ class FieldWriterContext {
   }
 
   inline std::vector<ColumnStatistics*> columnStats() {
-    if (!statsFinalized_) {
-      return {};
-    }
-    // TODO: add a build method for this pattern.
     std::vector<ColumnStatistics*> statsViews;
-    statsViews.reserve(statsCollectors_.size());
-    for (auto& collector : statsCollectors_) {
-      // FIXME: don't need this branching.
-      statsViews.push_back(
-          collector->shared()
-              ? collector->as<SharedStatisticsCollector>()->getBaseStatistics()
-              : collector->getStatsView());
+    statsViews.reserve(fileStats_.size());
+    for (auto& stat : fileStats_) {
+      statsViews.push_back(stat.get());
     }
     return statsViews;
+  }
+
+  inline const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+  stripeStats() const {
+    return stripeStats_;
   }
 
   void handleFlatmapFieldAddEvent(
@@ -454,10 +452,45 @@ class FieldWriterContext {
   // 1. roll up logical and physical sizes
   // 2. wrap all ancestors of deduplicated types
   // 3. backfill both known and newly wrapped deduplicated stats
-  void finalizeStatsCollectors() {
+  /// Finalizes the current stripe's collectors, snapshots their statistics
+  /// into stripeStats_, and resets the collectors for the next stripe.
+  void finalizeStripeStatsCollectors() {
     NIMBLE_CHECK(!statsFinalized_);
     finalizeStatsCollector(schemaWithId_);
     statsFinalized_ = true;
+    snapshotStripeStats();
+    resetStatsCollectors();
+  }
+
+  /// Rebuilds file-level column statistics by merging every per-stripe
+  /// snapshot in stripeStats_. Falls back to finalizing the live collectors
+  /// directly when no stripe snapshots were taken (single-stripe file).
+  void finalizeFileStatsFromStripes() {
+    fileStats_.clear();
+    if (stripeStats_.empty()) {
+      if (!statsFinalized_) {
+        finalizeStatsCollector(schemaWithId_);
+        statsFinalized_ = true;
+      }
+      fileStats_.reserve(statsCollectors_.size());
+      for (auto& collector : statsCollectors_) {
+        auto* stats = collector->shared()
+            ? collector->as<SharedStatisticsCollector>()->getBaseStatistics()
+            : collector->getStatsView();
+        fileStats_.push_back(stats->clone());
+      }
+      return;
+    }
+    fileStats_.reserve(stripeStats_.front().size());
+    for (const auto& stat : stripeStats_.front()) {
+      fileStats_.push_back(stat->clone());
+    }
+    for (size_t stripe = 1; stripe < stripeStats_.size(); ++stripe) {
+      NIMBLE_CHECK_EQ(stripeStats_[stripe].size(), fileStats_.size());
+      for (size_t column = 0; column < fileStats_.size(); ++column) {
+        mergeColumnStats(*fileStats_[column], *stripeStats_[stripe][column]);
+      }
+    }
   }
 
  protected:
@@ -484,6 +517,168 @@ class FieldWriterContext {
       [](TypeBuilder&, uint32_t) {}};
 
  private:
+  // Merges min/max from source into target for a scalar statistics subclass
+  // (Integral/FloatingPoint/String). Keeps the widest range across stripes.
+  template <typename StatsT>
+  static void mergeMinMax(
+      ColumnStatistics& target,
+      const ColumnStatistics& source) {
+    auto* targetStats = target.as<StatsT>();
+    const auto* sourceStats = source.as<StatsT>();
+    if (sourceStats->getMin().has_value() &&
+        (!targetStats->getMin().has_value() ||
+         *sourceStats->getMin() < *targetStats->getMin())) {
+      targetStats->min_ = sourceStats->getMin();
+    }
+    if (sourceStats->getMax().has_value() &&
+        (!targetStats->getMax().has_value() ||
+         *sourceStats->getMax() > *targetStats->getMax())) {
+      targetStats->max_ = sourceStats->getMax();
+    }
+  }
+
+  // NaN-aware min selection: returns true when source's min should replace
+  // target's. A present value always beats a missing one, and a real value
+  // beats NaN so NaN never wins as the minimum; otherwise the smaller value
+  // wins. NaN is handled explicitly because IEEE comparisons against NaN are
+  // always false.
+  static bool shouldUseSourceFloatingPointMin(
+      const FloatingPointStatistics& target,
+      const FloatingPointStatistics& source) {
+    if (!source.getMin().has_value()) {
+      return false;
+    }
+    if (!target.getMin().has_value()) {
+      return true;
+    }
+    if (std::isnan(*target.getMin())) {
+      return false;
+    }
+    if (std::isnan(*source.getMin())) {
+      return true;
+    }
+    return *source.getMin() < *target.getMin();
+  }
+
+  // Mirror of shouldUseSourceFloatingPointMin for the maximum: a real value
+  // beats NaN so NaN never wins as the maximum; otherwise the larger value
+  // wins.
+  static bool shouldUseSourceFloatingPointMax(
+      const FloatingPointStatistics& target,
+      const FloatingPointStatistics& source) {
+    if (!source.getMax().has_value()) {
+      return false;
+    }
+    if (!target.getMax().has_value()) {
+      return true;
+    }
+    if (std::isnan(*target.getMax())) {
+      return false;
+    }
+    if (std::isnan(*source.getMax())) {
+      return true;
+    }
+    return *source.getMax() > *target.getMax();
+  }
+
+  static void mergeFloatingPointMinMax(
+      ColumnStatistics& target,
+      const ColumnStatistics& source) {
+    auto* targetStats = target.as<FloatingPointStatistics>();
+    const auto* sourceStats = source.as<FloatingPointStatistics>();
+    if (shouldUseSourceFloatingPointMin(*targetStats, *sourceStats)) {
+      targetStats->min_ = sourceStats->getMin();
+    }
+    if (shouldUseSourceFloatingPointMax(*targetStats, *sourceStats)) {
+      targetStats->max_ = sourceStats->getMax();
+    }
+  }
+
+  static void mergeColumnStats(
+      ColumnStatistics& target,
+      const ColumnStatistics& source) {
+    NIMBLE_CHECK(
+        target.getType() == source.getType(),
+        "Merging stats with mismatched types: {} vs {}.",
+        static_cast<uint8_t>(target.getType()),
+        static_cast<uint8_t>(source.getType()));
+    // Deduplicated stats delegate their base metrics (value/null count, sizes)
+    // to the wrapped base statistics, so merge into that base rather than
+    // target's own (unused) member fields, and accumulate the dedup-specific
+    // counters separately.
+    if (target.getType() == StatType::DEDUPLICATED) {
+      auto* targetStats = target.as<DeduplicatedColumnStatistics>();
+      const auto* sourceStats = source.as<DeduplicatedColumnStatistics>();
+      targetStats->dedupedCount_ += sourceStats->getDedupedCount();
+      targetStats->dedupedLogicalSize_ += sourceStats->getDedupedLogicalSize();
+      auto* targetBase = targetStats->getBaseStatistics();
+      const auto* sourceBase = sourceStats->getBaseStatistics();
+      NIMBLE_CHECK(
+          (targetBase == nullptr) == (sourceBase == nullptr),
+          "Mismatched deduplicated stats structure during merge.");
+      if (targetBase != nullptr && sourceBase != nullptr) {
+        mergeColumnStats(*targetBase, *sourceBase);
+      }
+      return;
+    }
+
+    target.valueCount_ += source.getValueCount();
+    target.nullCount_ += source.getNullCount();
+    target.logicalSize_ += source.getLogicalSize();
+    target.physicalSize_ += source.getPhysicalSize();
+    switch (target.getType()) {
+      case StatType::INTEGRAL:
+        mergeMinMax<IntegralStatistics>(target, source);
+        break;
+      case StatType::FLOATING_POINT:
+        mergeFloatingPointMinMax(target, source);
+        break;
+      case StatType::STRING:
+        mergeMinMax<StringStatistics>(target, source);
+        break;
+      case StatType::DEFAULT:
+        break;
+      case StatType::DEDUPLICATED:
+        NIMBLE_UNREACHABLE("Deduplicated stats are handled above.");
+    }
+  }
+
+  // Clones the current per-column statistics into a new per-stripe snapshot
+  // appended to stripeStats_. Uses the deduplicated base statistics for shared
+  // collectors so each snapshot mirrors the file-level column layout.
+  void snapshotStripeStats() {
+    auto& stripe = stripeStats_.emplace_back();
+    stripe.reserve(statsCollectors_.size());
+    for (auto& collector : statsCollectors_) {
+      auto* stats = collector->shared()
+          ? collector->as<SharedStatisticsCollector>()->getBaseStatistics()
+          : collector->getStatsView();
+      stripe.push_back(stats->clone());
+    }
+  }
+
+  void resetStatsCollectors() {
+    // finalizeStatsCollector() wraps ancestors of deduplicated nodes into a
+    // DeduplicatedStatisticsCollector in place. That wrapping must be undone
+    // between stripes; otherwise the next stripe's finalization would take the
+    // "already deduplicated" branch and skip rolling child logical/physical
+    // sizes up into the ancestor, corrupting the file-level stats
+    // reconstruction. Genuine deduplicated nodes (configured at init via
+    // dictionary array / deduplicated map ids) must remain wrapped.
+    for (uint32_t id = 0; id < statsCollectors_.size(); ++id) {
+      auto& collector = statsCollectors_[id];
+      if (collector->getType() == StatType::DEDUPLICATED &&
+          !hasDictionaryArrayNodeId(id) && !hasDeduplicatedMapNodeId(id)) {
+        collector = collector->asChecked<DeduplicatedStatisticsCollector>()
+                        ->releaseBaseCollector();
+      }
+    }
+    for (auto& collector : statsCollectors_) {
+      collector->reset();
+    }
+    statsFinalized_ = false;
+  }
+
   void finalizeStatsCollector(
       const std::shared_ptr<const velox::dwio::common::TypeWithId>& type) {
     auto statsCollector = statsCollectors_[type->id()].get();
@@ -598,6 +793,8 @@ class FieldWriterContext {
   std::vector<std::pair<uint32_t, std::unique_ptr<StreamData>>> streams_;
   std::shared_ptr<const velox::dwio::common::TypeWithId> schemaWithId_;
   std::vector<std::unique_ptr<StatisticsCollector>> statsCollectors_;
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>> stripeStats_;
+  std::vector<std::unique_ptr<ColumnStatistics>> fileStats_;
   bool statsFinalized_{false};
 };
 

--- a/velox/dwio/nimble/velox/stats/ColumnStatistics.cpp
+++ b/velox/dwio/nimble/velox/stats/ColumnStatistics.cpp
@@ -76,6 +76,11 @@ StatType ColumnStatistics::getType() const {
   return StatType::DEFAULT;
 }
 
+std::unique_ptr<ColumnStatistics> ColumnStatistics::clone() const {
+  return std::make_unique<ColumnStatistics>(
+      getValueCount(), getNullCount(), getLogicalSize(), getPhysicalSize());
+}
+
 std::unique_ptr<velox::dwio::common::ColumnStatistics>
 ColumnStatistics::toCommonStatistics() const {
   const auto valueCount = std::make_optional<uint64_t>(getValueCount());
@@ -154,6 +159,16 @@ StatType StringStatistics::getType() const {
   return StatType::STRING;
 }
 
+std::unique_ptr<ColumnStatistics> StringStatistics::clone() const {
+  return std::make_unique<StringStatistics>(
+      getValueCount(),
+      getNullCount(),
+      getLogicalSize(),
+      getPhysicalSize(),
+      getMin(),
+      getMax());
+}
+
 IntegralStatistics::IntegralStatistics(
     uint64_t valueCount,
     uint64_t nullCount,
@@ -175,6 +190,16 @@ std::optional<int64_t> IntegralStatistics::getMax() const {
 
 StatType IntegralStatistics::getType() const {
   return StatType::INTEGRAL;
+}
+
+std::unique_ptr<ColumnStatistics> IntegralStatistics::clone() const {
+  return std::make_unique<IntegralStatistics>(
+      getValueCount(),
+      getNullCount(),
+      getLogicalSize(),
+      getPhysicalSize(),
+      getMin(),
+      getMax());
 }
 
 FloatingPointStatistics::FloatingPointStatistics(
@@ -200,11 +225,30 @@ StatType FloatingPointStatistics::getType() const {
   return StatType::FLOATING_POINT;
 }
 
+std::unique_ptr<ColumnStatistics> FloatingPointStatistics::clone() const {
+  return std::make_unique<FloatingPointStatistics>(
+      getValueCount(),
+      getNullCount(),
+      getLogicalSize(),
+      getPhysicalSize(),
+      getMin(),
+      getMax());
+}
+
 DeduplicatedColumnStatistics::DeduplicatedColumnStatistics(
     ColumnStatistics* baseStatistics,
     uint64_t dedupedCount,
     uint64_t dedupedLogicalSize)
     : baseStatistics_{baseStatistics},
+      dedupedCount_{dedupedCount},
+      dedupedLogicalSize_{dedupedLogicalSize} {}
+
+DeduplicatedColumnStatistics::DeduplicatedColumnStatistics(
+    std::unique_ptr<ColumnStatistics> baseStatistics,
+    uint64_t dedupedCount,
+    uint64_t dedupedLogicalSize)
+    : ownedBaseStatistics_{std::move(baseStatistics)},
+      baseStatistics_{ownedBaseStatistics_.get()},
       dedupedCount_{dedupedCount},
       dedupedLogicalSize_{dedupedLogicalSize} {}
 
@@ -234,6 +278,14 @@ uint64_t DeduplicatedColumnStatistics::getDedupedLogicalSize() const {
 
 StatType DeduplicatedColumnStatistics::getType() const {
   return StatType::DEDUPLICATED;
+}
+
+std::unique_ptr<ColumnStatistics> DeduplicatedColumnStatistics::clone() const {
+  return std::make_unique<DeduplicatedColumnStatistics>(
+      baseStatistics_ == nullptr ? std::make_unique<ColumnStatistics>()
+                                 : baseStatistics_->clone(),
+      getDedupedCount(),
+      getDedupedLogicalSize());
 }
 
 ColumnStatistics* DeduplicatedColumnStatistics::getBaseStatistics() {
@@ -301,6 +353,10 @@ void StatisticsCollector::merge(const StatisticsCollector& other) {
   stats_->physicalSize_ += otherStats->getPhysicalSize();
 }
 
+void StatisticsCollector::reset() {
+  stats_ = std::make_unique<ColumnStatistics>();
+}
+
 /* static */ std::unique_ptr<StatisticsCollector> StatisticsCollector::create(
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& type) {
   switch (type->type()->kind()) {
@@ -355,6 +411,10 @@ void IntegralStatisticsCollector::addValues(std::span<T> values) {
   if (!stats->max_.has_value() || max > *stats->max_) {
     stats->max_ = max;
   }
+}
+
+void IntegralStatisticsCollector::reset() {
+  stats_ = std::make_unique<IntegralStatistics>();
 }
 
 void IntegralStatisticsCollector::merge(const StatisticsCollector& other) {
@@ -423,6 +483,10 @@ void FloatingPointStatisticsCollector::addValues(std::span<T> values) {
   if (!stats->max_.has_value() || max > *stats->max_) {
     stats->max_ = max;
   }
+}
+
+void FloatingPointStatisticsCollector::reset() {
+  stats_ = std::make_unique<FloatingPointStatistics>();
 }
 
 void FloatingPointStatisticsCollector::merge(const StatisticsCollector& other) {
@@ -495,6 +559,10 @@ void StringStatisticsCollector::addValues(std::span<std::string_view> values) {
   }
 }
 
+void StringStatisticsCollector::reset() {
+  stats_ = std::make_unique<StringStatistics>();
+}
+
 void StringStatisticsCollector::merge(const StatisticsCollector& other) {
   auto* otherStats = other.getStatsView();
   NIMBLE_CHECK(
@@ -538,21 +606,34 @@ DeduplicatedStatisticsCollector::wrap(
 }
 
 ColumnStatistics* DeduplicatedStatisticsCollector::getStatsView() {
-  // Return this as DeduplicatedColumnStatistics to resolve diamond ambiguity
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
+  // Return this as DeduplicatedColumnStatistics to resolve diamond ambiguity.
   return stats_.get();
 }
 
 const ColumnStatistics* DeduplicatedStatisticsCollector::getStatsView() const {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   return stats_.get();
 }
 
 StatisticsCollector* DeduplicatedStatisticsCollector::getBaseCollector() const {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   return baseCollector_.get();
+}
+
+std::unique_ptr<StatisticsCollector>
+DeduplicatedStatisticsCollector::releaseBaseCollector() {
+  auto released = std::move(baseCollector_);
+  dedupedStats_ = nullptr;
+  stats_.reset();
+  return released;
 }
 
 void DeduplicatedStatisticsCollector::recordDeduplicatedStats(
     uint64_t count,
     uint64_t deduplicatedSize) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
+  NIMBLE_DCHECK_NOT_NULL(dedupedStats_);
   dedupedStats_->dedupedCount_ += count;
   dedupedStats_->dedupedLogicalSize_ += deduplicatedSize;
 }
@@ -560,14 +641,17 @@ void DeduplicatedStatisticsCollector::recordDeduplicatedStats(
 void DeduplicatedStatisticsCollector::addCounts(
     uint64_t totalCount,
     uint64_t nullCount) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   baseCollector_->addCounts(totalCount, nullCount);
 }
 
 void DeduplicatedStatisticsCollector::addLogicalSize(uint64_t logicalSize) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   baseCollector_->addLogicalSize(logicalSize);
 }
 
 void DeduplicatedStatisticsCollector::addPhysicalSize(uint64_t physicalSize) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   baseCollector_->addPhysicalSize(physicalSize);
 }
 
@@ -583,6 +667,13 @@ void DeduplicatedStatisticsCollector::merge(const StatisticsCollector& other) {
   const auto& otherDedup =
       dynamic_cast<const DeduplicatedStatisticsCollector&>(other);
   baseCollector_->merge(*otherDedup.baseCollector_);
+}
+
+void DeduplicatedStatisticsCollector::reset() {
+  baseCollector_->reset();
+  stats_ = std::make_unique<DeduplicatedColumnStatistics>(
+      baseCollector_->getStatsView(), 0, 0);
+  dedupedStats_ = stats_->as<DeduplicatedColumnStatistics>();
 }
 
 SharedStatisticsCollector::SharedStatisticsCollector(
@@ -663,6 +754,11 @@ void SharedStatisticsCollector::updateBaseCollector(
 void SharedStatisticsCollector::merge(const StatisticsCollector& other) {
   std::lock_guard<std::mutex> l{mutex_};
   baseCollector_->merge(other);
+}
+
+void SharedStatisticsCollector::reset() {
+  std::lock_guard<std::mutex> l{mutex_};
+  baseCollector_->reset();
 }
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/stats/ColumnStatistics.h
+++ b/velox/dwio/nimble/velox/stats/ColumnStatistics.h
@@ -73,6 +73,8 @@ class ColumnStatistics {
 
   virtual StatType getType() const;
 
+  virtual std::unique_ptr<ColumnStatistics> clone() const;
+
   /// Converts this nimble ColumnStatistics to dwio::common::ColumnStatistics
   /// for use in file-level filter pushdown.
   std::unique_ptr<velox::dwio::common::ColumnStatistics> toCommonStatistics()
@@ -92,6 +94,7 @@ class ColumnStatistics {
 
  protected:
   friend class StatisticsCollector;
+  friend class FieldWriterContext;
 
   uint64_t valueCount_{0};
   uint64_t nullCount_{0};
@@ -115,8 +118,11 @@ class StringStatistics : public ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
  protected:
   friend class StringStatisticsCollector;
+  friend class FieldWriterContext;
 
   std::optional<std::string> min_;
   std::optional<std::string> max_;
@@ -138,8 +144,11 @@ class IntegralStatistics : public ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
  protected:
   friend class IntegralStatisticsCollector;
+  friend class FieldWriterContext;
 
   std::optional<int64_t> min_;
   std::optional<int64_t> max_;
@@ -161,8 +170,11 @@ class FloatingPointStatistics : public ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
  protected:
   friend class FloatingPointStatisticsCollector;
+  friend class FieldWriterContext;
 
   std::optional<double> min_;
   std::optional<double> max_;
@@ -181,6 +193,10 @@ class DeduplicatedColumnStatistics : public virtual ColumnStatistics {
       ColumnStatistics* baseStatistics,
       uint64_t dedupedCount,
       uint64_t dedupedLogicalSize);
+  DeduplicatedColumnStatistics(
+      std::unique_ptr<ColumnStatistics> baseStatistics,
+      uint64_t dedupedCount,
+      uint64_t dedupedLogicalSize);
 
   // Getters delegate to baseStatistics_ for base metrics
   uint64_t getValueCount() const override;
@@ -193,13 +209,19 @@ class DeduplicatedColumnStatistics : public virtual ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
   // Access the wrapped base statistics (e.g., to get min/max for
   // IntegralStatistics)
   ColumnStatistics* getBaseStatistics();
   const ColumnStatistics* getBaseStatistics() const;
 
+ private:
+  std::unique_ptr<ColumnStatistics> ownedBaseStatistics_;
+
  protected:
   friend class DeduplicatedStatisticsCollector;
+  friend class FieldWriterContext;
 
   ColumnStatistics* baseStatistics_;
   uint64_t dedupedCount_{0};
@@ -264,6 +286,7 @@ class StatisticsCollector {
   virtual void addPhysicalSize(uint64_t physicalSize);
 
   virtual void merge(const StatisticsCollector& other);
+  virtual void reset();
 
  protected:
   std::unique_ptr<ColumnStatistics> stats_;
@@ -277,6 +300,7 @@ class IntegralStatisticsCollector : public StatisticsCollector {
   void addValues(std::span<T> values);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   // Helper to access stats_ as IntegralStatistics
@@ -291,6 +315,7 @@ class FloatingPointStatisticsCollector : public StatisticsCollector {
   void addValues(std::span<T> values);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   // Helper to access stats_ as FloatingPointStatistics
@@ -303,6 +328,7 @@ class StringStatisticsCollector : public StatisticsCollector {
 
   void addValues(std::span<std::string_view> values);
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   // Helper to access stats_ as StringStatistics
@@ -327,9 +353,15 @@ class DeduplicatedStatisticsCollector : public StatisticsCollector {
   void addPhysicalSize(uint64_t physicalSize) override;
 
   StatisticsCollector* getBaseCollector() const;
+  // Releases ownership of the wrapped base collector. Used to undo an ancestor
+  // deduplicated wrapping that was applied during finalization so per-stripe
+  // finalization can start from an identical collector structure. After this
+  // call the deduplicated wrapper must be discarded.
+  std::unique_ptr<StatisticsCollector> releaseBaseCollector();
   void recordDeduplicatedStats(uint64_t count, uint64_t deduplicatedSize);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   std::unique_ptr<StatisticsCollector> baseCollector_;
@@ -369,6 +401,7 @@ class SharedStatisticsCollector : public StatisticsCollector {
       std::function<void(StatisticsCollector*)> updateFunc);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   mutable std::mutex mutex_;

--- a/velox/dwio/nimble/velox/stats/VectorizedStatistics.cpp
+++ b/velox/dwio/nimble/velox/stats/VectorizedStatistics.cpp
@@ -24,7 +24,8 @@ namespace facebook::nimble {
 
 namespace {
 constexpr static uint16_t kVectorizedStatsVersion = 0;
-}
+constexpr static uint16_t kVectorizedStripeStatsVersion = 0;
+} // namespace
 
 template <typename T>
 void TypedVectorizedStatistic<T>::append(std::optional<T> value) {
@@ -844,6 +845,128 @@ VectorizedFileStats::toColumnStatistics(
   auto schemaInfo = getSchemaInfo(schema, nimbleType);
   traverseSchema(schema, schemaInfo, statStreams_, statTypeCounts, columnStats);
   return columnStats;
+}
+
+VectorizedStripeStats::VectorizedStripeStats(
+    const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+        stripeStats,
+    velox::memory::MemoryPool* pool)
+    : numStripes_{static_cast<uint32_t>(stripeStats.size())},
+      numColumns_{
+          numStripes_ == 0
+              ? 0
+              : static_cast<uint32_t>(stripeStats.front().size())} {
+  stripeFileStats_.reserve(numStripes_);
+  for (const auto& stripe : stripeStats) {
+    NIMBLE_CHECK_EQ(stripe.size(), numColumns_);
+    std::vector<ColumnStatistics*> columnStats;
+    columnStats.reserve(stripe.size());
+    for (const auto& stat : stripe) {
+      columnStats.push_back(stat.get());
+    }
+    stripeFileStats_.push_back(
+        std::make_unique<VectorizedFileStats>(columnStats, pool));
+  }
+}
+
+VectorizedStripeStats::VectorizedStripeStats(
+    uint32_t numStripes,
+    uint32_t numColumns,
+    std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats)
+    : numStripes_{numStripes},
+      numColumns_{numColumns},
+      stripeFileStats_{std::move(stripeFileStats)} {}
+
+std::string_view VectorizedStripeStats::serialize(nimble::Buffer& buffer) {
+  Buffer statsBuffer{buffer.getMemoryPool()};
+  std::vector<std::string_view> stripePayloads;
+  stripePayloads.reserve(stripeFileStats_.size());
+  uint64_t totalLength = sizeof(uint16_t) + (2 * sizeof(uint32_t)) +
+      (stripeFileStats_.size() * sizeof(uint64_t));
+  for (auto& stripeFileStats : stripeFileStats_) {
+    auto payload = stripeFileStats->serialize(statsBuffer);
+    stripePayloads.push_back(payload);
+    totalLength += payload.size();
+  }
+
+  auto writeBuffer = buffer.reserve(totalLength);
+  auto pos = writeBuffer;
+  encoding::write<uint16_t>(kVectorizedStripeStatsVersion, pos);
+  encoding::write<uint32_t>(numStripes_, pos);
+  encoding::write<uint32_t>(numColumns_, pos);
+  for (const auto payload : stripePayloads) {
+    encoding::writeUint64(payload.size(), pos);
+  }
+  for (const auto payload : stripePayloads) {
+    std::memcpy(pos, payload.data(), payload.size());
+    pos += payload.size();
+  }
+  NIMBLE_CHECK_EQ(pos - writeBuffer, totalLength);
+  return {writeBuffer, totalLength};
+}
+
+std::unique_ptr<VectorizedStripeStats> VectorizedStripeStats::deserialize(
+    std::string_view payload,
+    velox::memory::MemoryPool& pool) {
+  const auto* pos = payload.data();
+  const auto* const end = pos + payload.size();
+
+  constexpr size_t kHeaderSize = sizeof(uint16_t) + (2 * sizeof(uint32_t));
+  NIMBLE_CHECK(
+      payload.size() >= kHeaderSize,
+      "Stripe stats payload too small for header");
+  const auto version = encoding::read<uint16_t>(pos);
+  NIMBLE_CHECK_EQ(version, kVectorizedStripeStatsVersion);
+  const auto numStripes = encoding::read<uint32_t>(pos);
+  const auto numColumns = encoding::read<uint32_t>(pos);
+
+  const size_t lengthsSize = static_cast<size_t>(numStripes) * sizeof(uint64_t);
+  NIMBLE_CHECK(
+      static_cast<size_t>(end - pos) >= lengthsSize,
+      "Stripe stats payload too small for stripe lengths");
+  std::vector<uint64_t> stripePayloadLengths;
+  stripePayloadLengths.reserve(numStripes);
+  for (uint32_t stripe = 0; stripe < numStripes; ++stripe) {
+    stripePayloadLengths.push_back(encoding::readUint64(pos));
+  }
+  std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats;
+  stripeFileStats.reserve(numStripes);
+  for (const auto payloadLength : stripePayloadLengths) {
+    NIMBLE_CHECK(
+        static_cast<size_t>(end - pos) >= payloadLength,
+        "Stripe stats payload too small for stripe content");
+    stripeFileStats.push_back(
+        VectorizedFileStats::deserialize(
+            {pos, static_cast<size_t>(payloadLength)}, pool));
+    pos += payloadLength;
+  }
+  return std::unique_ptr<VectorizedStripeStats>(new VectorizedStripeStats(
+      numStripes, numColumns, std::move(stripeFileStats)));
+}
+
+const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+VectorizedStripeStats::toStripeColumnStatistics(
+    const velox::TypePtr& schema,
+    const std::shared_ptr<const nimble::Type>& nimbleType) {
+  if (!stripeStats_.empty()) {
+    return stripeStats_;
+  }
+  NIMBLE_CHECK_EQ(stripeFileStats_.size(), numStripes_);
+  stripeStats_.reserve(numStripes_);
+  for (auto& stripeFileStats : stripeFileStats_) {
+    auto columnStats = stripeFileStats->toColumnStatistics(schema, nimbleType);
+    NIMBLE_CHECK_EQ(columnStats.size(), numColumns_);
+    stripeStats_.push_back(std::move(columnStats));
+  }
+  return stripeStats_;
+}
+
+std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>
+VectorizedStripeStats::takeStripeColumnStatistics(
+    const velox::TypePtr& schema,
+    const std::shared_ptr<const nimble::Type>& nimbleType) {
+  toStripeColumnStatistics(schema, nimbleType);
+  return std::move(stripeStats_);
 }
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/stats/VectorizedStatistics.h
+++ b/velox/dwio/nimble/velox/stats/VectorizedStatistics.h
@@ -135,6 +135,8 @@ class VectorizedFileStats {
       const std::shared_ptr<const nimble::Type>& nimbleType);
 
  private:
+  friend class VectorizedStripeStats;
+
   VectorizedFileStats(
       const std::vector<StatStreamType>& streamTypes,
       const std::vector<uint64_t>& streamLengths,
@@ -161,6 +163,50 @@ class VectorizedFileStats {
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
     return encodingFactory.createPolicy(dataType);
   };
+};
+
+// Not thread-safe. toStripeColumnStatistics() lazily populates stripeStats_ as
+// a memoization cache on first call, so a single VectorizedStripeStats instance
+// must not be shared across threads. Readers construct one transiently and copy
+// the result out on a single thread (see ReaderBase).
+class VectorizedStripeStats {
+ public:
+  VectorizedStripeStats(
+      const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+          stripeStats,
+      velox::memory::MemoryPool* pool);
+
+  std::string_view serialize(nimble::Buffer& buffer);
+
+  static std::unique_ptr<VectorizedStripeStats> deserialize(
+      std::string_view payload,
+      velox::memory::MemoryPool& pool);
+
+  // Lazily materializes and caches the per-stripe column statistics. Mutates
+  // stripeStats_ on first call; see the thread-safety note above.
+  const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+  toStripeColumnStatistics(
+      const velox::TypePtr& schema,
+      const std::shared_ptr<const nimble::Type>& nimbleType);
+
+  // Materializes if needed, then transfers ownership of the cached stats to the
+  // caller. Use this for single-use extraction when the VectorizedStripeStats
+  // instance will be discarded afterward.
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>
+  takeStripeColumnStatistics(
+      const velox::TypePtr& schema,
+      const std::shared_ptr<const nimble::Type>& nimbleType);
+
+ private:
+  VectorizedStripeStats(
+      uint32_t numStripes,
+      uint32_t numColumns,
+      std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats);
+
+  uint32_t numStripes_{0};
+  uint32_t numColumns_{0};
+  std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats_;
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>> stripeStats_;
 };
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
+++ b/velox/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
@@ -279,6 +279,34 @@ TEST_F(ColumnStatisticsTests, stringStatisticsDefaultConstructor) {
   }
 }
 
+TEST_F(ColumnStatisticsTests, clonePreservesScalarStatistics) {
+  IntegralStatistics integralStat(100, 10, 1000, 500, -50, 150);
+  auto integralClone = integralStat.clone();
+  auto* clonedIntegralStat = integralClone->as<IntegralStatistics>();
+  ASSERT_NE(clonedIntegralStat, nullptr);
+  EXPECT_EQ(clonedIntegralStat->getValueCount(), 100);
+  EXPECT_EQ(clonedIntegralStat->getNullCount(), 10);
+  EXPECT_EQ(clonedIntegralStat->getLogicalSize(), 1000);
+  EXPECT_EQ(clonedIntegralStat->getPhysicalSize(), 500);
+  EXPECT_EQ(clonedIntegralStat->getMin(), -50);
+  EXPECT_EQ(clonedIntegralStat->getMax(), 150);
+
+  FloatingPointStatistics floatingPointStat(20, 2, 200, 80, -1.5, 9.5);
+  auto floatingPointClone = floatingPointStat.clone();
+  auto* clonedFloatingPointStat =
+      floatingPointClone->as<FloatingPointStatistics>();
+  ASSERT_NE(clonedFloatingPointStat, nullptr);
+  EXPECT_EQ(clonedFloatingPointStat->getMin(), -1.5);
+  EXPECT_EQ(clonedFloatingPointStat->getMax(), 9.5);
+
+  StringStatistics stringStat(3, 0, 12, 8, "apple", "pear");
+  auto stringClone = stringStat.clone();
+  auto* clonedStringStat = stringClone->as<StringStatistics>();
+  ASSERT_NE(clonedStringStat, nullptr);
+  EXPECT_EQ(clonedStringStat->getMin(), "apple");
+  EXPECT_EQ(clonedStringStat->getMax(), "pear");
+}
+
 TEST_F(ColumnStatisticsTests, deduplicatedColumnStatistics) {
   {
     DeduplicatedColumnStatistics stat;
@@ -539,6 +567,27 @@ TEST_F(StatisticsCollectorTests, mergeDefaultStatisticsCollectors) {
   EXPECT_EQ(collector1.getNullCount(), 30);
   EXPECT_EQ(collector1.getLogicalSize(), 3000);
   EXPECT_EQ(collector1.getPhysicalSize(), 1500);
+}
+
+TEST_F(StatisticsCollectorTests, resetClearsScalarStatistics) {
+  IntegralStatisticsCollector collector;
+  collector.addCounts(4, 1);
+  std::vector<int64_t> values = {3, 7, -1};
+  collector.addValues(std::span<int64_t>(values));
+  ASSERT_NE(
+      collector.getStatsView()->as<IntegralStatistics>()->getMin(),
+      std::nullopt);
+
+  collector.reset();
+
+  auto* stats = collector.getStatsView()->as<IntegralStatistics>();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->getValueCount(), 0);
+  EXPECT_EQ(stats->getNullCount(), 0);
+  EXPECT_EQ(stats->getLogicalSize(), 0);
+  EXPECT_EQ(stats->getPhysicalSize(), 0);
+  EXPECT_EQ(stats->getMin(), std::nullopt);
+  EXPECT_EQ(stats->getMax(), std::nullopt);
 }
 
 TEST_F(StatisticsCollectorTests, integralStatisticsCollectorCtor) {

--- a/velox/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
+++ b/velox/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
@@ -508,6 +508,44 @@ TEST_F(VectorizedFileStatsTests, schemaBasedRoundTripFlatRow) {
   expectStringStatisticsEqual(stringStat, *actualStringStat);
 }
 
+TEST_F(VectorizedFileStatsTests, stripeStatsRoundTripFlatRow) {
+  auto schema = velox::ROW({{"id", velox::BIGINT()}});
+  auto nimbleType = convertToNimbleType(*schema);
+
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>> stripeStats;
+  auto& firstStripe = stripeStats.emplace_back();
+  firstStripe.push_back(std::make_unique<ColumnStatistics>(4, 0, 32, 16));
+  firstStripe.push_back(
+      std::make_unique<IntegralStatistics>(4, 0, 32, 16, 0, 3));
+  auto& secondStripe = stripeStats.emplace_back();
+  secondStripe.push_back(std::make_unique<ColumnStatistics>(4, 0, 32, 16));
+  secondStripe.push_back(
+      std::make_unique<IntegralStatistics>(4, 0, 32, 16, 100, 103));
+
+  VectorizedStripeStats vectorizedStripeStats(stripeStats, leafPool_.get());
+  nimble::Buffer buffer(*leafPool_);
+  const auto serialized = vectorizedStripeStats.serialize(buffer);
+  ASSERT_FALSE(serialized.empty());
+
+  auto deserialized =
+      VectorizedStripeStats::deserialize(serialized, *leafPool_);
+  const auto& roundTrippedStats =
+      deserialized->toStripeColumnStatistics(schema, nimbleType);
+  ASSERT_EQ(roundTrippedStats.size(), 2);
+  ASSERT_EQ(roundTrippedStats[0].size(), 2);
+  ASSERT_EQ(roundTrippedStats[1].size(), 2);
+
+  auto* firstStripeIdStats = roundTrippedStats[0][1]->as<IntegralStatistics>();
+  ASSERT_NE(firstStripeIdStats, nullptr);
+  EXPECT_EQ(firstStripeIdStats->getMin(), 0);
+  EXPECT_EQ(firstStripeIdStats->getMax(), 3);
+
+  auto* secondStripeIdStats = roundTrippedStats[1][1]->as<IntegralStatistics>();
+  ASSERT_NE(secondStripeIdStats, nullptr);
+  EXPECT_EQ(secondStripeIdStats->getMin(), 100);
+  EXPECT_EQ(secondStripeIdStats->getMax(), 103);
+}
+
 TEST_F(VectorizedFileStatsTests, schemaBasedRoundTripNestedRow) {
   // Create a nested row schema
   auto schema = velox::ROW(

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
@@ -36,6 +36,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/SharedArbitrator.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/common/tests/ScopedFeatureGate.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
@@ -749,6 +750,55 @@ class SharedDictionaryE2ETest : public testing::Test {
     return options;
   }
 
+  // Writes one stripe carrying a stripe-scoped shared dictionary and checks
+  // that the root column's rolled-up physical size covers every byte the
+  // tablet wrote. Callers install a FeatureGate first to exercise the
+  // stripe-stats write path, which reconstructs file stats from per-stripe
+  // snapshots rather than reading the live collectors.
+  void verifyStripeDictionaryPhysicalStatsCovered() {
+    auto options = makeSharedDictionaryWriterOptions();
+    addDictionary(
+        options,
+        InputType::FlatMapScalar,
+        sharedDictionaryConfig(
+            SharedDictionaryScope::Stripe, /*dictionaryId=*/0));
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    auto input =
+        makeStripe(InputType::FlatMapScalar, StripeValueType::Dictionary);
+    Writer writer{input->type(), std::move(writeFile), *rootPool_, options};
+    writer.write(input);
+    writer.close();
+
+    uint64_t reportedPhysicalSize{0};
+    for (const auto* stat : writer.columnStats()) {
+      reportedPhysicalSize =
+          std::max(reportedPhysicalSize, stat->getPhysicalSize());
+    }
+    ASSERT_GT(reportedPhysicalSize, 0);
+
+    // Total bytes actually written across every stream of every stripe.
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    auto tabletOptions = test::makeTestTabletOptions(leafPool_.get());
+    auto tablet =
+        TabletReader::create(readFile, leafPool_.get(), tabletOptions);
+    uint64_t writtenStreamBytes{0};
+    for (uint32_t stripe{0}; stripe < tablet->stripeCount(); ++stripe) {
+      const auto identifier = tablet->stripeIdentifier(stripe);
+      const auto streamCount = tablet->streamCount(identifier);
+      for (uint32_t streamId{0}; streamId < streamCount; ++streamId) {
+        writtenStreamBytes += tablet->streamSize(identifier, streamId);
+      }
+    }
+    ASSERT_GT(writtenStreamBytes, 0);
+
+    EXPECT_GE(reportedPhysicalSize, writtenStreamBytes)
+        << "root physical size " << reportedPhysicalSize
+        << " does not cover the " << writtenStreamBytes
+        << " bytes written; the shared dictionary alphabet is likely unaccounted";
+  }
+
   std::string writeInput(
       const std::vector<velox::RowVectorPtr>& stripeInputs,
       WriterOptions options) {
@@ -1387,46 +1437,19 @@ TEST_P(SharedDictionaryE2EInputTypeTest, fileScopeRoundTrip) {
 // the omission understated the column badly. Pin the invariant that the root
 // column's rolled-up physical size covers every byte the stripe wrote.
 TEST_F(SharedDictionaryE2ETest, sharedStripeDictionaryColumnPhysicalStats) {
-  auto options = makeSharedDictionaryWriterOptions();
-  addDictionary(
-      options,
-      InputType::FlatMapScalar,
-      sharedDictionaryConfig(
-          SharedDictionaryScope::Stripe, /*dictionaryId=*/0));
+  verifyStripeDictionaryPhysicalStatsCovered();
+}
 
-  std::string file;
-  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
-  auto input =
-      makeStripe(InputType::FlatMapScalar, StripeValueType::Dictionary);
-  Writer writer{input->type(), std::move(writeFile), *rootPool_, options};
-  writer.write(input);
-  writer.close();
-
-  uint64_t reportedPhysicalSize{0};
-  for (const auto* stat : writer.columnStats()) {
-    reportedPhysicalSize =
-        std::max(reportedPhysicalSize, stat->getPhysicalSize());
-  }
-  ASSERT_GT(reportedPhysicalSize, 0);
-
-  // Total bytes actually written across every stream of every stripe.
-  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-  auto tabletOptions = test::makeTestTabletOptions(leafPool_.get());
-  auto tablet = TabletReader::create(readFile, leafPool_.get(), tabletOptions);
-  uint64_t writtenStreamBytes{0};
-  for (uint32_t stripe{0}; stripe < tablet->stripeCount(); ++stripe) {
-    const auto identifier = tablet->stripeIdentifier(stripe);
-    const auto streamCount = tablet->streamCount(identifier);
-    for (uint32_t streamId{0}; streamId < streamCount; ++streamId) {
-      writtenStreamBytes += tablet->streamSize(identifier, streamId);
-    }
-  }
-  ASSERT_GT(writtenStreamBytes, 0);
-
-  EXPECT_GE(reportedPhysicalSize, writtenStreamBytes)
-      << "root physical size " << reportedPhysicalSize << " does not cover the "
-      << writtenStreamBytes
-      << " bytes written; the shared dictionary alphabet is likely unaccounted";
+// Same invariant with the stripe-stats write path on. File statistics are then
+// rebuilt by merging per-stripe snapshots, so the snapshot must be taken after
+// the stripe dictionary streams are written: snapshotting earlier shifts the
+// alphabet bytes into the next stripe and loses them outright for the last one.
+TEST_F(
+    SharedDictionaryE2ETest,
+    sharedStripeDictionaryColumnPhysicalStatsWithStripeStats) {
+  test::ScopedFeatureGate stripeStatsGate{
+      FeatureGate::FeatureSet::kStripeStatsWrite};
+  verifyStripeDictionaryPhysicalStatsCovered();
 }
 
 TEST_F(SharedDictionaryE2ETest, fileScopeCompactRowCountRoundTrip) {

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -38,6 +38,7 @@
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/FeatureGate.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
@@ -83,6 +84,9 @@ class WriterContext : public FieldWriterContext {
       : FieldWriterContext{memoryPool, options.reclaimerFactory(), options.vectorDecoderVisitor},
         options_{std::move(options)},
         hasStripeDictionaryConfig_{hasStripeDictionaryConfig(options_)},
+        stripeStatsWriteEnabled_{featureGate()->enabled(
+            FeatureGate::FeatureSet::kStripeStatsWrite,
+            /*defaultValue=*/false)},
         logger_{
             this->options_.metricsLogger == nullptr
                 ? std::make_shared<MetricsLogger>()
@@ -96,6 +100,12 @@ class WriterContext : public FieldWriterContext {
 
   const WriterOptions& options() const {
     return options_;
+  }
+
+  // Whether the stripe-stats write path (per-stripe snapshot + merge + section)
+  // is enabled. Resolved once at construction so it cannot flip mid-file.
+  bool stripeStatsWriteEnabled() const {
+    return stripeStatsWriteEnabled_;
   }
 
   bool hasStripeDictionaryConfig() const {
@@ -244,6 +254,7 @@ class WriterContext : public FieldWriterContext {
 
   const WriterOptions options_;
   const bool hasStripeDictionaryConfig_;
+  const bool stripeStatsWriteEnabled_;
   velox::CpuWallTiming encodingTiming_;
   velox::CpuWallTiming writeTiming_;
   velox::CpuWallTiming ingestionTiming_;
@@ -2162,6 +2173,7 @@ void Writer::writeMetadata() {
 }
 
 void Writer::writeColumnStats() {
+  context_->finalizeFileStatsFromStripes();
   // When enableStatsConsistencyCheck is true, verify that fileRawSize
   // (accumulated via RawSizeUtils) matches the root column statistics.
   if (context_->options().enableStatsConsistencyCheck) {
@@ -2177,6 +2189,14 @@ void Writer::writeColumnStats() {
     Buffer buffer{*encodingMemoryPool_};
     tabletWriter_->writeOptionalSection(
         std::string(kVectorizedStatsSection), fileStats.serialize(buffer));
+    if (context_->stripeStatsWriteEnabled()) {
+      VectorizedStripeStats stripeStats{
+          context_->stripeStats(), encodingMemoryPool_.get()};
+      Buffer stripeStatsBuffer{*encodingMemoryPool_};
+      tabletWriter_->writeOptionalSection(
+          std::string(kStripeStatsSection),
+          stripeStats.serialize(stripeStatsBuffer));
+    }
   } else {
     flatbuffers::FlatBufferBuilder builder;
     builder.Finish(
@@ -2420,9 +2440,6 @@ std::unique_ptr<velox::dwio::common::FileMetadata> Writer::close() {
     }
     writeStripe();
     rootWriter_->close();
-    if (context_->options().enableStatsCollection) {
-      context_->finalizeStatsCollectors();
-    }
 
     writeMetadata();
     if (context_->options().enableStatsCollection) {
@@ -3198,8 +3215,15 @@ bool Writer::writeStripe() {
   } else {
     writeStreams();
   }
-
   writeStripeDictionaryStreams();
+
+  // Must run after writeStripeDictionaryStreams(), which still charges the
+  // stripe's alphabet bytes to the stats collectors: snapshotting first would
+  // shift those bytes into the next stripe and drop them for the last one.
+  if (context_->options().enableStatsCollection &&
+      context_->stripeStatsWriteEnabled()) {
+    context_->finalizeStripeStatsCollectors();
+  }
 
   uint64_t stripeSize{0};
   {


### PR DESCRIPTION
Summary:

Add a stripe-level vectorized column-statistics optional section to Nimble files. This is the producer half of stripe-stats pruning: it writes per-stripe min/max/count statistics that a later reader change consumes to skip non-matching stripes. The new write path is gated behind an OSS-neutral FeatureGate that defaults to off and the section is additive, so this change is behavior-neutral on its own: with the gate off the writer keeps its prior whole-file stats finalization and emits no stripe-stats section, and readers that do not understand the new optional section fall back to a normal full scan.

The writer snapshots per-stripe column stats after each stripe and reconstructs file-level stats by merging those snapshots at close time, preserving a fallback path for files that do not emit stripe snapshots. ColumnStatistics and StatisticsCollector gain clone()/reset() so a collector can be snapshotted per stripe and reused across stripes.

VectorizedStripeStats provides a versioned binary format for serializing and deserializing the per-stripe column statistics that round-trips correctly, stored under the new optional tablet section.

Deduplicated columns are handled correctly across stripes. mergeColumnStats merges into the wrapped base statistics (which back the delegating getters) and accumulates the dedup counters, instead of writing to unused fields. The per-stripe ancestor deduplication wrapping applied during finalization is undone between stripes (releasing the base collector) so every stripe finalizes from an identical collector structure; without this, stripe 1+ skipped the child logical-size rollup and the reconstructed file-level stats were wrong (tripping the raw-size consistency check). Genuine deduplicated nodes configured at init stay wrapped.

Gating: the per-stripe snapshot, the file-stats-from-stripes merge, and the stripe-stats section write are gated behind an OSS-neutral nimble::FeatureGate defaulting to off, resolved once per writer so it cannot flip mid-file. Internal builds map it to a runtime killswitch, so the new write path can be ramped gradually and disabled instantly without a code change. With the gate off, stats collectors accumulate across the whole file and are finalized directly at close (the pre-existing path) and no stripe-stats section is written; a knob-evaluation failure fails safe to off.

Reviewed By: srsuryadev

Differential Revision: D112143149


