### PR TITLE
feat(nimble): Make FOR read-only while keeping PFOR writable (#18657)

### DIFF
--- a/velox/dwio/nimble/common/Types.cpp
+++ b/velox/dwio/nimble/common/Types.cpp
@@ -50,8 +50,9 @@ constexpr auto kEncodingTypes =
         {EncodingType::SharedDictionary, "SharedDictionary"},
     });
 
-constexpr auto kReadOnlyEncodingTypes =
-    std::to_array<EncodingType>({EncodingType::PFOR});
+constexpr auto kReadOnlyEncodingTypes = std::to_array<EncodingType>({
+    EncodingType::FOR,
+});
 
 constexpr auto kCompressionTypes =
     std::to_array<std::pair<CompressionType, std::string_view>>({

--- a/velox/dwio/nimble/common/tests/TypesTest.cpp
+++ b/velox/dwio/nimble/common/tests/TypesTest.cpp
@@ -69,8 +69,10 @@ TEST(TypesTest, toEncodingTypeUnknown) {
 }
 
 TEST(TypesTest, readOnlyEncoding) {
-  EXPECT_TRUE(isReadOnlyEncoding(EncodingType::PFOR));
-  EXPECT_TRUE(isReadOnlyEncoding("PFOR"));
+  EXPECT_FALSE(isReadOnlyEncoding(EncodingType::PFOR));
+  EXPECT_FALSE(isReadOnlyEncoding("PFOR"));
+  EXPECT_TRUE(isReadOnlyEncoding(EncodingType::FOR));
+  EXPECT_TRUE(isReadOnlyEncoding("FOR"));
   EXPECT_FALSE(isReadOnlyEncoding(EncodingType::Trivial));
   EXPECT_FALSE(isReadOnlyEncoding("Trivial"));
   EXPECT_FALSE(isReadOnlyEncoding("unknown"));

--- a/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -163,6 +163,7 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       // enable for production tables without consulting the Nimble team
       // (oncall: dwios).
       EncodingType::ALP,
+      EncodingType::PFOR,
       EncodingType::SimdForBitpack,
       EncodingType::SubIntSplit,
       EncodingType::BlockBitPacking,

--- a/velox/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1878,8 +1878,14 @@ TEST(ManualEncodingSelectionPolicyFactoryTest, fsstRequiresExplicitOptIn) {
 TEST(ManualEncodingSelectionPolicyFactoryTest, rejectsReadOnlyEncodings) {
   NIMBLE_ASSERT_THROW(
       nimble::ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
+          "FOR=1.0"),
+      "Encoding is read-only and cannot be used for new writes: FOR");
+
+  EXPECT_EQ(
+      nimble::ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
           "PFOR=1.0"),
-      "Encoding is read-only and cannot be used for new writes: PFOR");
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::PFOR, 1.0}}));
 }
 
 TEST(

--- a/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
@@ -289,11 +289,9 @@ TEST_F(
   options.randomizeWriterConfig = false;
   NimbleWriterFuzzer fuzzer(options, *rootPool_);
 
-  // PFOR is integral-only but is also read-only, so it is rejected by the
-  // writer config parser before dispatch is reached.
-  // `TypesTest.ReadOnlyEncoding` covers that property.
   for (const auto encodingType :
        {EncodingType::DeltaBlock,
+        EncodingType::PFOR,
         EncodingType::SimdForBitpack,
         EncodingType::Huffman}) {
     SCOPED_TRACE(toString(encodingType));

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -151,6 +151,7 @@ bool isNumericCompatible(EncodingType encodingType) {
       return true;
     // Gated on isIntegralType<physicalType>(), which holds for float and
     // double as well since their physical types are uint32_t and uint64_t.
+    case EncodingType::PFOR:
     case EncodingType::SimdForBitpack:
     case EncodingType::Huffman:
       return true;
@@ -919,6 +920,7 @@ bool isTypeCompatible(EncodingType encodingType, DataType dataType) {
 
 bool isIntegralOnlyEncoding(EncodingType encodingType) {
   return encodingType == EncodingType::DeltaBlock ||
+      encodingType == EncodingType::PFOR ||
       encodingType == EncodingType::SimdForBitpack ||
       encodingType == EncodingType::Huffman;
 }

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -2428,22 +2428,28 @@ TEST_F(WriterTest, openZLCompressionNumericRoundTrip) {
 }
 
 TEST_F(WriterTest, rejectsReadOnlyEncodingLayout) {
-  nimble::WriterOptions options;
-  options.encodingLayoutTree.emplace(
-      nimble::Kind::Row,
-      std::unordered_map<
-          nimble::EncodingLayoutTree::StreamIdentifier,
-          nimble::EncodingLayout>{},
-      "",
-      std::vector<nimble::EncodingLayoutTree>{nimble::EncodingLayoutTree{
-          nimble::Kind::Scalar,
-          {{nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
-            nimble::EncodingLayout{
-                nimble::EncodingType::PFOR,
-                {},
-                nimble::CompressionType::Uncompressed,
-                {std::nullopt, std::nullopt}}}},
-          "c0"}});
+  const auto makeOptions = [](nimble::EncodingType encodingType,
+                              uint32_t numChildren) {
+    nimble::WriterOptions options;
+    options.encodingLayoutTree.emplace(
+        nimble::Kind::Row,
+        std::unordered_map<
+            nimble::EncodingLayoutTree::StreamIdentifier,
+            nimble::EncodingLayout>{},
+        "",
+        std::vector<nimble::EncodingLayoutTree>{nimble::EncodingLayoutTree{
+            nimble::Kind::Scalar,
+            {{nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::
+                  ScalarStream,
+              nimble::EncodingLayout{
+                  encodingType,
+                  {},
+                  nimble::CompressionType::Uncompressed,
+                  std::vector<std::optional<const nimble::EncodingLayout>>(
+                      numChildren)}}},
+            "c0"}});
+    return options;
+  };
 
   std::string file;
   NIMBLE_ASSERT_THROW(
@@ -2451,8 +2457,16 @@ TEST_F(WriterTest, rejectsReadOnlyEncodingLayout) {
           velox::ROW({{"c0", velox::BIGINT()}}),
           std::make_unique<velox::InMemoryWriteFile>(&file),
           *rootPool_,
-          std::move(options)),
-      "Encoding is read-only and cannot be used for new writes: PFOR");
+          makeOptions(nimble::EncodingType::FOR, 3)),
+      "Encoding is read-only and cannot be used for new writes: FOR");
+
+  std::string pforFile;
+  EXPECT_NO_THROW(
+      nimble::Writer(
+          velox::ROW({{"c0", velox::BIGINT()}}),
+          std::make_unique<velox::InMemoryWriteFile>(&pforFile),
+          *rootPool_,
+          makeOptions(nimble::EncodingType::PFOR, 2)));
 }
 
 TEST_F(WriterTest, encodingLayoutSchemaMismatch) {


### PR DESCRIPTION
Summary:

`FOR` is now treated as a legacy/read-only Nimble encoding: old files remain readable, but new writer configs cannot select it.

`PFOR` stays writable/configurable. It is appended to the existing integer compatibility catalog so the current compatibility workflow continues to exercise PFOR without adding a separate writer profile or changing the Skycastle case matrix. `FOR` remains in the stable catalog slot for historical artifact coverage, but read-only encodings are filtered before generating new read-factor configs or explicit layout overrides.

FOR benchmark data from the rexdb fixture supports making only `FOR` read-only:
| Trait | Rows | BlockBitPacking bytes | BlockBitPacking decode | FOR bytes | FOR decode |
| --- | ---: | ---: | ---: | ---: | ---: |
| 2 full shard | 27,474 | 2,495,295 | 136.8 ms | 2,576,650 | 160.2 ms |
| 2 sample | 1,006 | 91,614 | 5.9 ms | 94,935 | 6.9 ms |
| 102 sample | 1,003 | 117,312 | 5.8 ms | 149,478 | 6.6 ms |
| 93 sample | 1,003 | 99,673 | 6.1 ms | 109,530 | 6.7 ms |
| 92 sample | 1,004 | 96,207 | 5.6 ms | 104,297 | 6.6 ms |

Reviewed By: xiaoxmeng

Differential Revision: D117225964
