### PR TITLE
fix: Point iceberg Nimble tests at the migrated writer factory header

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -15,16 +15,17 @@
  */
 
 // This end-to-end test exercises the batch NimbleReader/NimbleWriter factories,
-// which live under dwio/nimble/.../fb/ and are internal-only (not shipped to
-// OSS). Guard the whole test so the OSS build (VELOX_ENABLE_NIMBLE off) does
-// not try to include the fb/ headers. Mirrors WriterOptionsAdapterTest.cpp.
+// both now under velox/dwio/nimble/. The reader factory is still internal-only
+// and keeps its fb/ segment; the writer factory is OSS-exportable and dropped
+// it. Guard the whole test so the OSS build (VELOX_ENABLE_NIMBLE off) does not
+// try to include the fb/ headers. Mirrors WriterOptionsAdapterTest.cpp.
 #ifdef VELOX_ENABLE_NIMBLE
 
-#include "dwio/nimble/velox/reader/fb/NimbleReader.h"
-#include "dwio/nimble/writer/fb/NimbleWriter.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/dwio/nimble/velox/reader/fb/NimbleReader.h"
+#include "velox/dwio/nimble/writer/WriterFactory.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 #ifdef VELOX_ENABLE_NIMBLE
-#include "dwio/nimble/writer/fb/NimbleWriter.h"
+#include "velox/dwio/nimble/writer/WriterFactory.h"
 #endif
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"


### PR DESCRIPTION
Summary:
`writer_options_adapter_test` and `iceberg_nimble_insert_test` have been broken on trunk for 16-26 consecutive runs, failing at compile:

```
fatal error: 'dwio/nimble/writer/fb/NimbleWriter.h' file not found
```

The Nimble-to-Velox-OSS migration renamed that header to `velox/dwio/nimble/writer/WriterFactory.h`, dropping the `fb/` segment because the writer-factory registration is now OSS-exportable.  A compatibility shim was left at the old NON-`fb/` path (`dwio/nimble/writer/WriterFactory.h`), which is why the ~24 consumers that include that path -- among them the sibling `iceberg/fb/NimbleWriterOptionsAdapter.cpp` -- still compile.  No shim exists at `writer/fb/NimbleWriter.h`, because the writer had no same-named counterpart to forward to, so these two tests are the ones left behind.

The reader in the same file is the contrast that proves it: the reader factory is still internal-only, so it kept its `fb/` segment (`velox/dwio/nimble/velox/reader/fb/NimbleReader.h`) and a one-line shim at the old path does exist -- which is why `#include "dwio/nimble/velox/reader/fb/NimbleReader.h"` still resolved while the writer include next to it did not.

Point both tests at the new headers directly rather than at the shims, which are documented as slated for deletion once consumers migrate, and swap their deps from the shim targets to the real ones:

- `//dwio/nimble/writer:writer_factory` -> `//velox/dwio/nimble/writer:writer_factory`
- `//dwio/nimble/velox/reader:reader` -> `//velox/dwio/nimble/velox/reader:reader`

The reader move is not needed to fix the build; it is included so the file is not left half-migrated, with one include on a doomed shim two lines from one that was just moved off it.  No namespace change is needed: the symbols are in `facebook::velox::nimble` and the tests already qualify them as `nimble::`.

Also corrects the file comment that claimed both factories live under `dwio/nimble/.../fb/`.

Not included: `velox/connectors/hive/iceberg/BUCK:64-65` and `velox/connectors/hive/iceberg/tests/BUCK:379` still depend on `//dwio/nimble/writer:*` shims.  They are not failing, so they are left for the migration owner rather than folded into an outage fix.

Differential Revision: D117137725


