### PR TITLE
fix(torchwave): Three unrelated crash and corruption bugs

### DIFF
--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -1783,6 +1783,19 @@ std::string cudaAttrType(const nativert::Constant& c) {
 
 namespace {
 
+// A C++ type spelling reduced to something usable inside an identifier, so a
+// shared declaration's variable can be made unique per type. Anything that is
+// not alphanumeric becomes an underscore, which keeps distinct types distinct
+// without needing to understand the spelling.
+std::string identifierSuffix(std::string_view type) {
+  std::string out;
+  out.reserve(type.size());
+  for (char c : type) {
+    out += std::isalnum(static_cast<unsigned char>(c)) ? c : '_';
+  }
+  return out;
+}
+
 void declareAttributesImpl(
     NodeCP node,
     const KernelOperation& op,
@@ -2047,16 +2060,30 @@ std::string CompileCtx::makeCall(
     }
   }
 
-  // Shared declarations: declare in the kernel and pass as arguments.
+  // Shared declarations: declare in the kernel and pass as arguments. The name
+  // is suffixed by the type, as the dynamic form below already does, because
+  // two ops fused into one kernel can ask for the same name at different
+  // types: masked_select_jagged wants a uint32_t 'counter' and
+  // group_length_guard_head an int64_t one. Emitting both unsuffixed put two
+  // conflicting declarations of 'counter' in one scope. nvcc calls that a
+  // redeclaration; NVRTC segfaults inside nvrtcCompileProgram, before the
+  // program log is readable, so it surfaces as a broken promise for the
+  // compiled module rather than as a compile error.
+  //
+  // Deduplication cannot fix this on its own: addSharedDeclaration matches on
+  // the whole declaration string, and even matching on the name would be wrong,
+  // since the two ops need storage of different types rather than one shared
+  // variable.
   for (const auto& [type, name] : meta->sharedDecls) {
+    auto varName = name + "_" + identifierSuffix(type);
     std::string decl = "  __shared__ ";
     decl += type;
     decl += " ";
-    decl += name;
+    decl += varName;
     decl += ";\n";
     op.addSharedDeclaration(decl);
     comma();
-    ss << name;
+    ss << varName;
   }
 
   // Dynamic shared declarations: type from input dtype, name suffixed by type.

--- a/velox/experimental/torchwave/Elementwise.cpp
+++ b/velox/experimental/torchwave/Elementwise.cpp
@@ -682,11 +682,17 @@ void CompileCtx::generateElementwise(
         auto id = it - allInputs.begin();
         if (resultSpecs[s].value->type().kind() ==
             nativert::Type::Kind::Tensor) {
-          auto bitIdx = fastPathBitIndex_[id];
-          code_ << "        " << storageRef(id) << "[complexIdx(isFastPath"
-                << bitIdx / kBitsPerWord << " & (1 << " << bitIdx % kBitsPerWord
-                << "), " << param(resultSpecs[s].value, op)
-                << ", idx)] = " << resultVar << ";\n";
+          // The output's own contiguity, read from its descriptor, not a
+          // bit of isFastPath. That bitmask is indexed by position in
+          // leafInputs, and an output sits past the end of it in allInputs --
+          // so the bit taken here belonged to some unrelated input, or to no
+          // tensor at all. A contiguous input then made a strided output be
+          // written linearly, which fills the first numEl slots of a pitched
+          // band and leaves the rest of it untouched.
+          code_ << "        " << storageRef(id) << "[complexIdx("
+                << param(resultSpecs[s].value, op) << "->contiguous, "
+                << param(resultSpecs[s].value, op) << ", idx)] = " << resultVar
+                << ";\n";
         } else {
           code_ << "        " << storageRef(id) << "[0] = " << resultVar
                 << ";\n";
@@ -723,11 +729,12 @@ void CompileCtx::generateElementwise(
         auto id = it - allInputs.begin();
         if (resultSpecs[s].value->type().kind() ==
             nativert::Type::Kind::Tensor) {
-          auto bitIdx = fastPathBitIndex_[id];
-          code_ << "      " << storageRef(id) << "[complexIdx(isFastPath"
-                << bitIdx / kBitsPerWord << " & (1 << " << bitIdx % kBitsPerWord
-                << "), " << param(resultSpecs[s].value, op)
-                << ", idx)] = " << resultVar << ";\n";
+          // See the store above: the output is not a leaf input, so it has
+          // no bit in isFastPath. Its own descriptor carries its contiguity.
+          code_ << "      " << storageRef(id) << "[complexIdx("
+                << param(resultSpecs[s].value, op) << "->contiguous, "
+                << param(resultSpecs[s].value, op) << ", idx)] = " << resultVar
+                << ";\n";
         } else {
           code_ << "      " << storageRef(id) << "[0] = " << resultVar << ";\n";
         }

--- a/velox/experimental/wave/common/GpuArena.cpp
+++ b/velox/experimental/wave/common/GpuArena.cpp
@@ -396,8 +396,11 @@ void GpuArena::free(Buffer* buffer) {
   if (iter == arenas_.end() || iter->first != addressU64) {
     VELOX_CHECK(iter != arenas_.begin());
     --iter;
+    // A request larger than singleArenaCapacity_ gets a slab sized to it, and
+    // that slab then serves later allocations too, so the bound is the slab's
+    // own size, not the nominal one.
     VELOX_CHECK_GE(
-        iter->first + singleArenaCapacity_, addressU64 + buffer->size_);
+        iter->first + iter->second->byteSize(), addressU64 + buffer->size_);
   }
   iter->second->free(buffer->ptr_, buffer->size_);
   if (iter->second->empty() && iter->second != currentArena_ &&

--- a/velox/experimental/wave/common/tests/GpuArenaTest.cpp
+++ b/velox/experimental/wave/common/tests/GpuArenaTest.cpp
@@ -156,6 +156,26 @@ TEST_F(GpuArenaTest, buffers) {
   EXPECT_EQ(1, arena->slabs().size());
 }
 
+// A request larger than the nominal slab size gets a slab sized to it. That
+// slab stays the current one after its buffer goes, so later allocations are
+// served from it, and the ones past the nominal size have to be freeable.
+TEST_F(GpuArenaTest, oversizedSlabServesLaterAllocations) {
+  constexpr uint64_t kNominal = 1 << 20;
+  auto arena = std::make_unique<GpuArena>(kNominal, allocator_.get());
+
+  auto oversized = arena->allocate<char>(4 * kNominal);
+  EXPECT_EQ(2, arena->slabs().size());
+  oversized = nullptr;
+
+  // Both land in the oversized slab; only the second starts past kNominal.
+  auto first = arena->allocate<char>(kNominal);
+  auto second = arena->allocate<char>(kNominal);
+  EXPECT_EQ(2, arena->slabs().size());
+
+  second = nullptr;
+  first = nullptr;
+}
+
 TEST_F(GpuArenaTest, views) {
   auto arena = std::make_unique<GpuArena>(1 << 20, allocator_.get());
   WaveBufferPtr buffer = arena->allocate<char>(1024);


### PR DESCRIPTION
Summary:
Three independent fixes, folded together because each is small, self-contained, and touches a different layer: an arena free that aborts, an elementwise output that reads its contiguity flag out of bounds, and a shared-variable name collision that segfaults the compiler.

`GpuArena::free` bounded a buffer against the arena's nominal slab size rather than the slab's own `byteSize()`. An allocation larger than `singleArenaCapacity_` gets a slab sized to the request and becomes the current slab, and an empty current slab is never released, so it goes on serving later allocations -- some of which sit past the nominal size. Freeing one of those failed a check that was simply too small for that slab:

    Expression: iter->first + singleArenaCapacity_ >= addressU64 + buffer->size_

The abort lands at teardown, in whatever frees last, so it reads as memory corruption in some unrelated feature rather than as an allocation-size problem.

An elementwise expression already supports a non-contiguous output -- the stores go through `complexIdx(flag, t, idx)`, which falls back to `t->indexToOffset(idx)` when `flag` is false -- but the flag was read from the wrong place. Both output stores indexed `fastPathBitIndex_` by the output's position in `allInputs`, which holds inputs then outputs, while the bitmap is sized to `leafInputs` alone; every output lookup therefore read past the end of the vector. When the garbage bit came out set, the store wrote `storage[idx]` linearly into a pitched band, filling the first `numEl` slots and leaving the rest of the band untouched. The flag now comes off the output's own descriptor, which is correct by construction and avoids the indexing mismatch entirely.

Two ops fused into one kernel can ask for the same shared variable name at different types: the `masked_select_jagged` family declares a `uint32_t counter`, `group_length_guard_head` an `int64_t` one, and codegen emitted both. `nvcc` calls that a redeclaration; NVRTC instead segfaults inside `nvrtcCompileProgram` before the program log can be read, so it surfaces as `Broken promise for type name std::shared_ptr<CompiledModule>` with a stack pointing at the compiler rather than at the generated source -- a long way from "two declarations of `counter`". Suffixing the name by its type, as the `dynamicSharedDecls` form immediately below it already does, keeps the two distinct; deduplicating by name would be wrong, since the ops need storage of different types rather than one shared variable. This changes the text of every kernel carrying a shared declaration, so it invalidates cached cubins once.

Differential Revision: D117230309


