### PR TITLE
perf(nimble): Reuse encoding slice scratch buffers (#18660)

### DIFF
--- a/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -372,17 +372,20 @@ class BlockBitPackingEncoding final
       uint32_t blockCount,
       uint32_t packedDataSize,
       Vector<uint32_t>& output,
-      velox::memory::MemoryPool* pool,
+      Buffer& scratchBuffer,
       const Encoding::Options& options) {
     // Each block size is derived from its start offset and the next block's
     // start offset. For the final source block, the next offset is the packed
     // data size because there is no stored successor offset.
-    NIMBLE_CHECK_NOT_NULL(pool);
     const auto numReadBlocks =
         blockCount + (blockOffset + blockCount < header.numBlocks ? 1 : 0);
-    detail::createTypedEncodingView<uint32_t>(
-        header.encodedBlockOffsets, pool, options)
-        ->read(blockOffset, numReadBlocks, output.data());
+    readMetadataRange(
+        header.encodedBlockOffsets,
+        blockOffset,
+        numReadBlocks,
+        output,
+        scratchBuffer,
+        options);
     if (numReadBlocks == blockCount) {
       output[blockCount] = packedDataSize;
     }
@@ -507,6 +510,15 @@ class BlockBitPackingEncoding final
       velox::memory::MemoryPool& pool,
       const std::function<void*(uint32_t)>& stringBufferFactory,
       const Encoding::Options& options) const;
+
+  template <typename OutputVector>
+  static void readMetadataRange(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t count,
+      OutputVector& output,
+      Buffer& scratchBuffer,
+      const Encoding::Options& options);
 
   uint16_t blockSize_;
   uint16_t numBlocks_;
@@ -707,6 +719,25 @@ void BlockBitPackingEncoding<T>::readMetadataStream(
   EncodingFactory()
       .create(pool, encoded, stringBufferFactory, options)
       ->materialize(numBlocks_, output.data());
+}
+
+template <typename T>
+template <typename OutputVector>
+void BlockBitPackingEncoding<T>::readMetadataRange(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t count,
+    OutputVector& output,
+    Buffer& scratchBuffer,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK_GE(output.size(), count, "Metadata output buffer is too small.");
+  auto* const pool = &scratchBuffer.getMemoryPool();
+  auto encoding = EncodingFactory{options}.create(
+      *pool, encoded, [&scratchBuffer](uint32_t size) -> void* {
+        return scratchBuffer.reserve(size);
+      });
+  encoding->skip(offset);
+  encoding->materialize(count, output.data());
 }
 
 template <typename T>
@@ -1259,23 +1290,30 @@ std::string_view BlockBitPackingEncoding<T>::slice(
 
   ScopedVector<uint32_t> blockOffsets{
       static_cast<uint64_t>(numBlocks) + 1, pool, options.bufferPool};
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   readBlockOffsets(
       source,
       firstBlock,
       numBlocks,
       static_cast<uint32_t>(packedData.size()),
       blockOffsets,
-      pool,
+      scopedBuffer.get(),
       options);
 
   const auto getPackedSize = [&](uint32_t blockIndex) {
     const auto blockOffset = blockIndex - firstBlock;
     return blockOffsets[blockOffset + 1] - blockOffsets[blockOffset];
   };
-  const auto bitWidthView = detail::createTypedEncodingView<uint8_t>(
-      source.encodedBitWidths, pool, options);
+  ScopedVector<uint8_t> bitWidths{numBlocks, pool, options.bufferPool};
+  readMetadataRange(
+      source.encodedBitWidths,
+      firstBlock,
+      numBlocks,
+      bitWidths,
+      scopedBuffer.get(),
+      options);
   const auto getBlockBitWidth = [&](uint32_t blockIndex) {
-    return bitWidthView->readAt(blockIndex);
+    return bitWidths[blockIndex - firstBlock];
   };
 
   ScopedVector<BlockSliceInfo> blockSlices{numBlocks, pool, options.bufferPool};
@@ -1315,7 +1353,6 @@ std::string_view BlockBitPackingEncoding<T>::slice(
   sliceOffsets[numBlocks] = totalPackedSize;
   NIMBLE_CHECK_EQ(curRow, endRow);
 
-  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   const auto encodedBaselines = EncodingFactory::slice(
       source.encodedBaselines,
       firstBlock,

--- a/velox/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/DictionaryEncoding.h
@@ -167,7 +167,7 @@ class DictionaryEncoding
  private:
   static std::string_view encodeAlphabet(
       EncodingSelection<physicalType>& selection,
-      const Vector<physicalType>& alphabet,
+      std::span<const physicalType> alphabet,
       Buffer& buffer,
       const Encoding::Options& options);
 
@@ -358,12 +358,12 @@ void DictionaryEncoding<T>::readIndicesWithVisitor(
 template <typename T>
 std::string_view DictionaryEncoding<T>::encodeAlphabet(
     EncodingSelection<physicalType>& selection,
-    const Vector<physicalType>& alphabet,
+    std::span<const physicalType> alphabet,
     Buffer& buffer,
     const Encoding::Options& options) {
   if constexpr (isFloatingPointType<T>()) {
-    Vector<T> logicalAlphabet{&buffer.getMemoryPool()};
-    logicalAlphabet.resize(alphabet.size());
+    ScopedVector<T> logicalAlphabet{
+        alphabet.size(), &buffer.getMemoryPool(), options.bufferPool};
     for (uint32_t i = 0; i < alphabet.size(); ++i) {
       logicalAlphabet[i] =
           EncodingPhysicalType<T>::asEncodingLogicalType(alphabet[i]);
@@ -397,13 +397,12 @@ std::string_view DictionaryEncoding<T>::encode(
   const uint32_t valueCount = values.size();
   const uint32_t alphabetCount =
       selection.statistics().uniqueCounts().value().size();
+  auto* pool = &buffer.getMemoryPool();
 
   folly::F14FastMap<physicalType, uint32_t> alphabetMapping;
   alphabetMapping.reserve(alphabetCount);
-  Vector<physicalType> alphabet{&buffer.getMemoryPool()};
-  alphabet.resize(alphabetCount);
-  Vector<uint32_t> indices{&buffer.getMemoryPool()};
-  indices.resize(valueCount);
+  ScopedVector<physicalType> alphabet{alphabetCount, pool, options.bufferPool};
+  ScopedVector<uint32_t> indices{valueCount, pool, options.bufferPool};
 
   uint32_t alphabetIndex{0};
   uint32_t indiciesIndex{0};
@@ -460,8 +459,11 @@ std::string_view DictionaryEncoding<T>::encode(
 
   ScopedEncodingBuffer scopedBuffer{
       &buffer.getMemoryPool(), options.encodingBufferPool};
-  std::string_view serializedAlphabet =
-      encodeAlphabet(selection, alphabet, scopedBuffer.get(), options);
+  std::string_view serializedAlphabet = encodeAlphabet(
+      selection,
+      {alphabet.data(), alphabet.size()},
+      scopedBuffer.get(),
+      options);
   std::string_view serializedIndices =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::Dictionary::Indices,

--- a/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -74,19 +74,19 @@ std::string_view sliceByMaterializing(
   using physicalType = typename TypeTraits<T>::physicalType;
   auto* pool = &buffer.getMemoryPool();
   ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
-  Vector<physicalType> physicalValues{pool, length};
+  ScopedVector<physicalType> physicalValues{length, pool, options.bufferPool};
 
   auto encoding = EncodingFactory{options}.create(
       *pool, encoded, [&scopedBuffer](uint32_t size) -> void* {
         return scopedBuffer.get().reserve(size);
       });
   encoding->skip(offset);
-  encoding->materialize(length, physicalValues.data());
+  encoding->materialize(length, physicalValues->data());
 
   return encodeValuesWithLayout<T>(
       EncodingLayoutCapture::capture(encoded, options),
-      {reinterpret_cast<const T*>(physicalValues.data()),
-       physicalValues.size()},
+      {reinterpret_cast<const T*>(physicalValues->data()),
+       physicalValues->size()},
       buffer,
       options);
 }

--- a/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -661,7 +661,7 @@ class MainlyConstantEncodingBase
     auto encoding = EncodingFactory{options}.create(
         *pool, encoded, [](uint32_t /*size*/) -> void* { return nullptr; });
 
-    Vector<bool> values{pool, rowEnd};
+    ScopedVector<bool> values{rowEnd, pool, options.bufferPool};
     encoding->materialize(rowEnd, values.data());
     const auto sliceBegin = values.begin() + offset;
     return {

--- a/velox/dwio/nimble/encodings/NullableEncoding.h
+++ b/velox/dwio/nimble/encodings/NullableEncoding.h
@@ -468,7 +468,7 @@ std::pair<uint32_t, uint32_t> NullableEncoding<T>::countNonNullsForSlice(
   auto encoding = EncodingFactory{options}.create(
       *pool, encoded, [](uint32_t /*size*/) -> void* { return nullptr; });
 
-  Vector<bool> values{pool, rowEnd};
+  ScopedVector<bool> values{rowEnd, pool, options.bufferPool};
   encoding->materialize(rowEnd, values.data());
   const auto sliceBegin = values.begin() + offset;
   return {

--- a/velox/dwio/nimble/serializer/StreamSlicer.cpp
+++ b/velox/dwio/nimble/serializer/StreamSlicer.cpp
@@ -70,8 +70,21 @@ std::unique_ptr<Encoding> createEncoding(
 }
 
 Encoding::Options streamEncodingOptions(
+    bool useVarintRowCount,
+    velox::BufferPool* bufferPool,
+    EncodingBufferPool* encodingBufferPool) {
+  Encoding::Options options;
+  options.useVarintRowCount = useVarintRowCount;
+  options.bufferPool = bufferPool;
+  options.encodingBufferPool = encodingBufferPool;
+  return options;
+}
+
+Encoding::Options streamEncodingOptions(
     SerializationVersion version,
-    bool streamsUseVarintRowCount) {
+    bool streamsUseVarintRowCount,
+    velox::BufferPool* bufferPool,
+    EncodingBufferPool* encodingBufferPool) {
   NIMBLE_CHECK(
       version == SerializationVersion::kSerialization ||
           version == SerializationVersion::kProjection ||
@@ -82,11 +95,8 @@ Encoding::Options streamEncodingOptions(
   NIMBLE_CHECK(
       isTabletVersion(version) || streamsUseVarintRowCount,
       "Non-tablet streams must use varint row counts");
-  return {.useVarintRowCount = streamsUseVarintRowCount};
-}
-
-Encoding::Options streamEncodingOptions(bool useVarintRowCount) {
-  return {.useVarintRowCount = useVarintRowCount};
+  return streamEncodingOptions(
+      streamsUseVarintRowCount, bufferPool, encodingBufferPool);
 }
 
 std::string_view nullableNullsStream(
@@ -262,6 +272,8 @@ StreamSlicer::StreamSlicer(
       pool_{pool},
       options_{std::move(options)},
       streamCount_{streamCount(schema_)},
+      bufferPool_{velox::BufferPool::kDefaultCapacity},
+      encodingBufferPool_{pool_},
       strippedStreamBufferPool_{pool_, /*maxCachedBuffers=*/1},
       headerBuffer_{pool_},
       trailerBuffer_{pool_} {
@@ -299,7 +311,10 @@ folly::IOBuf StreamSlicer::slice(
       inputStreams_,
       {.offset = offset, .length = length},
       outputBuffer,
-      streamEncodingOptions(parser.streamEncodingUsesVarintRowCount()));
+      streamEncodingOptions(
+          parser.streamEncodingUsesVarintRowCount(),
+          &bufferPool_,
+          &encodingBufferPool_));
 
   streamSizes_.assign(slicedStreams.streams.size(), 0);
   for (uint32_t i = 0; i < slicedStreams.streams.size(); ++i) {
@@ -346,7 +361,10 @@ StreamSlicer::SlicedStreams StreamSlicer::slice(
         {.offset = offset, .length = length},
         outputBuffer,
         streamEncodingOptions(
-            options_.streamVersion, options_.streamsUseVarintRowCount));
+            options_.streamVersion,
+            options_.streamsUseVarintRowCount,
+            &bufferPool_,
+            &encodingBufferPool_));
   }
 
   ScopedEncodingBuffer strippedStreamBuffer{pool_, &strippedStreamBufferPool_};
@@ -365,7 +383,10 @@ StreamSlicer::SlicedStreams StreamSlicer::slice(
       {.offset = offset, .length = length},
       outputBuffer,
       streamEncodingOptions(
-          options_.streamVersion, options_.streamsUseVarintRowCount));
+          options_.streamVersion,
+          options_.streamsUseVarintRowCount,
+          &bufferPool_,
+          &encodingBufferPool_));
 }
 
 StreamSlicer::SlicedStreams StreamSlicer::sliceStreams(

--- a/velox/dwio/nimble/serializer/StreamSlicer.h
+++ b/velox/dwio/nimble/serializer/StreamSlicer.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "folly/io/IOBuf.h"
+#include "velox/buffer/BufferPool.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Vector.h"
@@ -161,6 +162,10 @@ class StreamSlicer {
   velox::memory::MemoryPool* const pool_;
   const Options options_;
   const uint32_t streamCount_;
+  // Scratch Velox buffers reused by temporary Vector materialization.
+  mutable velox::BufferPool bufferPool_;
+  // Scratch arenas reused by nested EncodingFactory::slice() calls.
+  mutable EncodingBufferPool encodingBufferPool_;
   mutable EncodingBufferPool strippedStreamBufferPool_;
   mutable std::vector<std::string_view> inputStreams_;
   mutable std::vector<uint32_t> streamSizes_;


### PR DESCRIPTION
Summary:

Reuse pooled scratch vectors and encoding buffers inside encoding slice helpers so stream slicing can avoid repeated temporary allocations.

This diff isolates the encoding-level part of the optimization. It does not move StreamSlicer or NimbleIndexProjector to pass reusable buffers yet; that happens in the next diff.

Reviewed By: tanjialiang

Differential Revision: D117242038


