### PR TITLE
refactor(nimble): Generalize dictionary index dispatch

### DIFF
--- a/velox/dwio/nimble/encodings/NullableEncoding.h
+++ b/velox/dwio/nimble/encodings/NullableEncoding.h
@@ -374,7 +374,7 @@ void NullableEncoding<T>::readIndicesWithVisitor(
   NIMBLE_CHECK(
       !V::kHasHook, "readIndicesWithVisitor does not support value hooks");
   materializeNullsForVisitor(visitor, params);
-  callReadIndicesWithVisitor(*nonNullValues_, visitor, params);
+  callReadIndicesWithVisitor<physicalType>(*nonNullValues_, visitor, params);
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/velox/dwio/nimble/encodings/common/EncodingUtils.h
@@ -232,38 +232,50 @@ struct DefaultEncodingTrait {
 };
 
 /// Dispatches readIndicesWithVisitor to the correct encoding type.
-/// Supports DictionaryEncoding, NullableEncoding, and MainlyConstantEncoding
-/// wrapping DictionaryEncoding. Currently only supports string
-/// (std::string_view) dictionary encodings. Non-legacy encodings only.
-template <typename V>
+/// Supports DictionaryEncoding and dictionary-enabled NullableEncoding,
+/// MainlyConstantEncoding, RLEEncoding, and ConstantEncoding wrappers.
+/// Non-legacy encodings only.
+///
+/// T is the encoding's logical value type, which cannot be deduced from the
+/// visitor: the visitor reads dictionary indices, so its DataType is the index
+/// type rather than the alphabet's value type.
+template <typename T, typename V>
 void callReadIndicesWithVisitor(
     Encoding& encoding,
     V& visitor,
     ReadWithVisitorParams& params) {
+  static_assert(
+      !std::is_same_v<T, std::string>,
+      "String encodings use std::string_view as their logical value type");
+  NIMBLE_CHECK_EQ(
+      encoding.dataType(),
+      TypeTraits<T>::dataType,
+      "Unexpected encoding data type: {}",
+      encoding.dataType());
   switch (encoding.encodingType()) {
     case EncodingType::Dictionary: {
-      static_cast<DictionaryEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<DictionaryEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::Nullable: {
-      static_cast<NullableEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<NullableEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::MainlyConstant: {
-      static_cast<MainlyConstantEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<MainlyConstantEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::RLE: {
-      static_cast<RLEEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<RLEEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::Constant: {
-      static_cast<ConstantEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<ConstantEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     default:

--- a/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -3198,7 +3198,11 @@ TEST_P(ReadWithVisitorNonLegacyTest, readIndicesWithVisitorInteger) {
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-    encoding->readIndicesWithVisitor(visitor, params);
+    if constexpr (std::is_same_v<T, int64_t>) {
+      ASSERT_ANY_THROW(
+          callReadIndicesWithVisitor<double>(*encoding, visitor, params));
+    }
+    callReadIndicesWithVisitor<T>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), kRows);
     const auto* indices = reader->rawIndices();
@@ -3298,7 +3302,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, fuzzReadIndicesWithVisitorInteger) {
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
 
-    encoding->readIndicesWithVisitor(visitor, params);
+    callReadIndicesWithVisitor<T>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), numRows);
     const auto* indices = reader->rawIndices();
@@ -3420,7 +3424,9 @@ TEST_P(ReadWithVisitorNonLegacyTest, readIndicesWithVisitorNullable) {
       visitor(filter, reader, rows, extractValues);
   auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-  callReadIndicesWithVisitor(*encoding, visitor, params);
+  ASSERT_ANY_THROW(
+      callReadIndicesWithVisitor<int64_t>(*encoding, visitor, params));
+  callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
   ASSERT_EQ(reader->numValues(), kRows);
   const auto* indices = reader->rawIndices();
@@ -3547,7 +3553,7 @@ TEST_P(
       visitor(filter, reader, rows, extractValues);
   auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-  callReadIndicesWithVisitor(*encoding, visitor, params);
+  callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
   ASSERT_EQ(reader->numValues(), kRows);
   const auto* indices = reader->rawIndices();
@@ -3688,7 +3694,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, fuzzReadIndicesWithVisitorNullable) {
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
 
-    callReadIndicesWithVisitor(*encoding, visitor, params);
+    callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), numRows);
     const auto* indices = reader->rawIndices();
@@ -3995,7 +4001,7 @@ TEST_P(
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-    callReadIndicesWithVisitor(*encoding, visitor, params);
+    callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), numRows);
     const auto* indices = reader->rawIndices();
@@ -4065,7 +4071,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, numValuesAfterMainlyConstantReadIndices) {
   auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
   ASSERT_EQ(reader->numValues(), 0);
-  callReadIndicesWithVisitor(*encoding, visitor, params);
+  callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
   // numValues must equal kRows (all rows), not just numNonCommon
   // (what the inner Dict encoding's bulkScan wrote via addNumValues).

--- a/velox/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/velox/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -326,7 +326,9 @@ class ChunkedDecoder {
   // reading stopped early at a chunk boundary (the callback returned false);
   // in that case it advances the reader's readOffset_ to the boundary so the
   // flat encoding fallback resumes the decode there.
-  template <typename DictionaryVisitor>
+  // T is the encoding's logical value type, needed to cast the encoding to its
+  // concrete type. It cannot be deduced from the visitor, which reads indices.
+  template <typename T, typename DictionaryVisitor>
   bool readDictionaryIndices(
       DictionaryVisitor& visitor,
       const ChunkBoundaryCallback& onChunkBoundary) {
@@ -380,7 +382,7 @@ class ChunkedDecoder {
           return nulls->template asMutable<uint64_t>();
         };
       }
-      return readDictionaryIndicesImpl<true>(
+      return readDictionaryIndicesImpl<T, true>(
           visitor, nulls->template as<uint64_t>(), onChunkBoundary, params);
     } else {
       const auto numRows = visitor.numRows();
@@ -399,7 +401,7 @@ class ChunkedDecoder {
             .nullsInReadRange()
             ->template asMutable<uint64_t>();
       };
-      return readDictionaryIndicesImpl<false>(
+      return readDictionaryIndicesImpl<T, false>(
           visitor, /*nulls=*/nullptr, onChunkBoundary, params);
     }
   }
@@ -415,7 +417,7 @@ class ChunkedDecoder {
   // readWithVisitorImpl, this handles chunk transitions explicitly at the
   // top of the loop (for both kHasNulls and !kHasNulls paths) instead of
   // relying on testNulls which counts non-nulls across chunk boundaries.
-  template <bool kHasNulls, typename V>
+  template <typename T, bool kHasNulls, typename V>
   bool readDictionaryIndicesImpl(
       V& visitor,
       const uint64_t* nulls,
@@ -516,7 +518,7 @@ class ChunkedDecoder {
       if (visitor.rowIndex() < endRowIndex) {
         visitor.setRows(velox::RowSet(visitor.rows(), endRowIndex));
         if (numNonNulls > 0) {
-          callReadIndicesWithVisitor(*encoding_, visitor, params);
+          callReadIndicesWithVisitor<T>(*encoding_, visitor, params);
         } else if (!visitor.allowNulls()) {
           visitor.setRowIndex(endRowIndex);
         } else {

--- a/velox/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/velox/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -479,8 +479,8 @@ bool StringColumnReader::readWithDictionary(
     // readDictionaryIndices returns false when the onChunkBoundary callback
     // returns false (new chunk is not dict-compatible), meaning the
     // dictionary path must be abandoned for the remaining rows.
-    abandonDictionary =
-        !decoder_.readDictionaryIndices(dictVisitor, onChunkBoundary);
+    abandonDictionary = !decoder_.readDictionaryIndices<std::string_view>(
+        dictVisitor, onChunkBoundary);
 
     // Offset the final chunk's indices into the merged alphabet.
     updateDictionaryIndices(alphabetOffset, valueOffset);


### PR DESCRIPTION
Summary:
`callReadIndicesWithVisitor` cast every encoding to `DictionaryEncoding<std::string_view>`, so the bulk dictionary-index read path was reachable only from string columns. The alphabet's value type is now an explicit template parameter, threaded through `ChunkedDecoder::readDictionaryIndices`. It cannot be deduced from the visitor: the visitor reads dictionary indices, so its `DataType` is the index type rather than the value type.

No behavior change. The only production caller is `StringColumnReader`, which passes `std::string_view` and gets the same dispatch as before. This unblocks a dictionary-index read path for integer columns, which does not exist yet.

Differential Revision: D116478694


