### PR TITLE
fix(type): Support mergeWith() on HUGEINT filters

### DIFF
--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -7144,6 +7144,84 @@ TEST_F(TableScanTest, longDecimalFilter) {
   assertQuery(op, createSplit(), "SELECT b FROM tmp WHERE a is null");
 }
 
+// A long-decimal equi-join makes HashProbe push a HugeintValuesUsingHashTable
+// dynamic filter onto the probe scan, which TableScan::createDataSource() then
+// merges with the scan's static filters on the same column.
+TEST_F(TableScanTest, longDecimalDynamicFilter) {
+  std::vector<std::optional<int128_t>> longValues = {
+      HugeInt::parse("123456789123456789123456789" + std::string(9, '0')),
+      HugeInt::parse("987654321123456789" + std::string(9, '0')),
+      std::nullopt,
+      HugeInt::parse("2" + std::string(37, '0')),
+      HugeInt::parse("5" + std::string(37, '0')),
+      HugeInt::parse("987654321987654321987654321" + std::string(9, '0')),
+      HugeInt::parse("1" + std::string(26, '0')),
+      HugeInt::parse("123000000012345678" + std::string(10, '0')),
+      HugeInt::parse("120000000123456789" + std::string(9, '0')),
+      HugeInt::parse("9" + std::string(37, '0'))};
+
+  auto rowVector = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int64_t>(longValues.size(), folly::identity),
+          makeNullableFlatVector<int128_t>(longValues, DECIMAL(38, 18)),
+      });
+  createDuckDbTable("t", {rowVector});
+
+  // A subset of the non-null probe-side keys.
+  auto buildVector = makeRowVector(
+      {"u_b"},
+      {makeFlatVector<int128_t>(
+          {longValues[3].value(), longValues[4].value(), longValues[9].value()},
+          DECIMAL(38, 18))});
+  createDuckDbTable("u", {buildVector});
+
+  auto filePath = facebook::velox::test::getDataFilePath(
+      "velox/exec/tests", "data/decimal.orc");
+  auto createSplit = [&]() {
+    return exec::test::HiveConnectorSplitBuilder(filePath)
+        .start(0)
+        .length(fs::file_size(filePath))
+        .fileFormat(dwio::common::FileFormat::ORC)
+        .build();
+  };
+
+  auto outputType = ROW({"b"}, {DECIMAL(38, 18)});
+  auto dataColumns = ROW({"a", "b"}, {DECIMAL(18, 6), DECIMAL(38, 18)});
+
+  // Joins the scan, carrying 'subfieldFilter' as its static filter, against the
+  // build side so that the two filters have to be merged on column 'b'.
+  auto assertJoin = [&](const std::string& subfieldFilter,
+                        const std::string& duckDbPredicate) {
+    SCOPED_TRACE(subfieldFilter);
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto buildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
+                         .values({buildVector})
+                         .planNode();
+    core::PlanNodeId scanId;
+    auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                    .tableScan(outputType, {subfieldFilter}, "", dataColumns)
+                    .capturePlanNodeId(scanId)
+                    .hashJoin({"b"}, {"u_b"}, buildSide, "", {"b"})
+                    .planNode();
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .split(scanId, exec::Split(createSplit()))
+        .assertResults(
+            fmt::format(
+                "SELECT t.b FROM t, u WHERE t.b = u.u_b AND {}",
+                duckDbPredicate));
+  };
+
+  // IsNotNull is the static filter Spark adds for a join key. Merging it with
+  // the dynamic filter previously threw VELOX_UNSUPPORTED.
+  assertJoin("b is not null", "t.b IS NOT NULL");
+
+  // HugeintRange, which exercises intersecting the dynamic filter's values.
+  assertJoin(
+      "b < 60000000000000000000.0::DECIMAL(38, 18)",
+      "t.b < 60000000000000000000.0");
+}
+
 TEST_F(TableScanTest, fileFormatRuntimeStats) {
   auto vectors = makeVectors(3, 1'000);
 

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1909,6 +1909,66 @@ std::unique_ptr<Filter> TimestampRange::mergeWith(const Filter* other) const {
   }
 }
 
+std::unique_ptr<Filter> HugeintRange::mergeWith(const Filter* other) const {
+  switch (other->kind()) {
+    case FilterKind::kAlwaysTrue:
+    case FilterKind::kAlwaysFalse:
+    case FilterKind::kIsNull:
+      return other->mergeWith(this);
+    case FilterKind::kIsNotNull:
+      return this->clone(false);
+    case FilterKind::kHugeintRange: {
+      const bool bothNullAllowed = nullAllowed_ && other->testNull();
+      auto* otherRange = static_cast<const HugeintRange*>(other);
+
+      const auto lower = std::max(lower_, otherRange->lower_);
+      const auto upper = std::min(upper_, otherRange->upper_);
+
+      if (lower > upper) {
+        return nullOrFalse(bothNullAllowed);
+      }
+
+      return std::make_unique<HugeintRange>(lower, upper, bothNullAllowed);
+    }
+    case FilterKind::kHugeintValuesUsingHashTable:
+      return other->mergeWith(this);
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+std::unique_ptr<Filter> HugeintValuesUsingHashTable::mergeWith(
+    const Filter* other) const {
+  switch (other->kind()) {
+    case FilterKind::kAlwaysTrue:
+    case FilterKind::kAlwaysFalse:
+    case FilterKind::kIsNull:
+      return other->mergeWith(this);
+    case FilterKind::kIsNotNull:
+      return std::make_unique<HugeintValuesUsingHashTable>(*this, false);
+    case FilterKind::kHugeintRange:
+    case FilterKind::kHugeintValuesUsingHashTable: {
+      const bool bothNullAllowed = nullAllowed_ && other->testNull();
+
+      std::vector<int128_t> valuesToKeep;
+      valuesToKeep.reserve(values_.size());
+      for (const auto value : values_) {
+        if (other->testInt128(value)) {
+          valuesToKeep.push_back(value);
+        }
+      }
+
+      if (valuesToKeep.empty()) {
+        return nullOrFalse(bothNullAllowed);
+      }
+
+      return createHugeintValues(valuesToKeep, bothNullAllowed);
+    }
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
 std::unique_ptr<Filter> NegatedBigintRange::mergeWith(
     const Filter* other) const {
   switch (other->kind()) {

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -972,6 +972,8 @@ class HugeintRange final : public Filter {
     return upper_;
   }
 
+  std::unique_ptr<Filter> mergeWith(const Filter* other) const final;
+
   std::string toString() const override {
     return fmt::format(
         "HugeintRange: [{}, {}] {}",
@@ -1203,6 +1205,8 @@ class HugeintValuesUsingHashTable final : public Filter {
   bool testInt128(const int128_t& value) const final;
 
   bool testingEquals(const Filter& other) const final;
+
+  std::unique_ptr<Filter> mergeWith(const Filter* other) const final;
 
   int128_t min() const {
     return min_;

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1520,6 +1520,38 @@ void testMergeWithBigint(Filter* left, Filter* right) {
           right->testInt64(0xdeadbeefbadefeedL));
 }
 
+// Values straddling the boundaries of the HUGEINT filters used in
+// mergeWithHugeint, including both halves of the int128_t representation.
+std::vector<int128_t> hugeintTestValues() {
+  std::vector<int128_t> values;
+  for (int64_t upper = 0; upper <= 3; ++upper) {
+    for (int64_t lower = 0; lower <= 3; ++lower) {
+      values.push_back(HugeInt::build(upper, lower));
+      values.push_back(-HugeInt::build(upper, lower));
+    }
+  }
+  values.push_back(DecimalUtil::kLongDecimalMin);
+  values.push_back(DecimalUtil::kLongDecimalMax);
+  return values;
+}
+
+void testMergeWithHugeint(Filter* left, Filter* right) {
+  auto merged = left->mergeWith(right);
+
+  ASSERT_EQ(merged->testNull(), left->testNull() && right->testNull())
+      << "left: " << left->toString() << ", right: " << right->toString()
+      << ", merged: " << merged->toString();
+
+  for (const auto value : hugeintTestValues()) {
+    ASSERT_EQ(
+        merged->testInt128(value),
+        left->testInt128(value) && right->testInt128(value))
+        << "at " << fmt::format("{}", value) << ", left: " << left->toString()
+        << ", right: " << right->toString()
+        << ", merged: " << merged->toString();
+  }
+}
+
 void testMergeWithDouble(Filter* left, Filter* right) {
   auto merged = left->mergeWith(right);
   ASSERT_EQ(merged->testNull(), left->testNull() && right->testNull());
@@ -2151,6 +2183,41 @@ TEST(FilterTest, mergeWithBytesMultiRange) {
   for (const auto& left : filters) {
     for (const auto& right : filters) {
       testMergeWithBytes(left.get(), right.get());
+    }
+  }
+}
+
+TEST(FilterTest, mergeWithHugeint) {
+  const auto max = DecimalUtil::kLongDecimalMax;
+
+  std::vector<std::unique_ptr<Filter>> filters;
+  addUntypedFilters(filters);
+
+  // Equality.
+  filters.push_back(equalHugeint(HugeInt::build(1, 1)));
+  filters.push_back(equalHugeint(HugeInt::build(1, 1), true));
+
+  // Between.
+  filters.push_back(betweenHugeint(HugeInt::build(0, 1), HugeInt::build(2, 2)));
+  filters.push_back(
+      betweenHugeint(HugeInt::build(0, 1), HugeInt::build(2, 2), true));
+  filters.push_back(
+      betweenHugeint(-HugeInt::build(1, 0), HugeInt::build(1, 0)));
+  filters.push_back(betweenHugeint(HugeInt::build(3, 0), max));
+
+  // IN-list.
+  const std::vector<int128_t> values{
+      HugeInt::build(1, 1), HugeInt::build(1, 2), HugeInt::build(2, 0)};
+  filters.push_back(createHugeintValues(values, false));
+  filters.push_back(createHugeintValues(values, true));
+  filters.push_back(createHugeintValues({HugeInt::build(0, 3), max}, false));
+  filters.push_back(createHugeintValues(
+      {-HugeInt::build(2, 2), HugeInt::build(1, 1)}, false));
+  filters.push_back(createHugeintValues({HugeInt::build(1, 1)}, false));
+
+  for (const auto& left : filters) {
+    for (const auto& right : filters) {
+      testMergeWithHugeint(left.get(), right.get());
     }
   }
 }


### PR DESCRIPTION
Summary:
`HugeintValuesUsingHashTable` and `HugeintRange` were the only IN-list and
range filter classes without a `mergeWith()` override, so they fell through to
`Filter::mergeWith()` which throws `VELOX_UNSUPPORTED`.

This became reachable once `VectorHasher` gained HUGEINT support in its
distinct value-id path, because `HashProbe` can now build a
`HugeintValuesUsingHashTable` dynamic filter for a long-decimal join key.
`TableScan::createDataSource()` merges the scan's static filters into whatever
dynamic filter was already pushed onto that channel, so a long-decimal
equi-join against a column carrying an `isnotnull` static filter threw:

  Filter(HugeintValuesUsingHashTable, deterministic, no nulls): mergeWith() is
  not supported.

Implement `mergeWith()` for both classes, covering the untyped filters
(`AlwaysTrue`, `AlwaysFalse`, `IsNull`, `IsNotNull`) and the two HUGEINT kinds.
An empty intersection collapses to `IsNull`/`AlwaysFalse` via `nullOrFalse()`,
which also avoids constructing a `HugeintValuesUsingHashTable` with an empty
value set.

Differential Revision: D117265846


