### PR TITLE
fix(nimble): Reject enableChunkIndex without enableChunking (#18664)

### DIFF
--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -3444,6 +3444,19 @@ TEST_F(WriterTest, chunkStatsAbsentWhenChunkIndexDisabled) {
       << "no chunk stats section should be written when the index is disabled";
 }
 
+TEST_F(WriterTest, chunkIndexRequiresChunking) {
+  auto type = velox::ROW({{"c1", velox::INTEGER()}});
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  NIMBLE_ASSERT_USER_THROW(
+      nimble::Writer(
+          type,
+          std::move(writeFile),
+          *rootPool_,
+          {.enableChunkIndex = true, .enableChunking = false}),
+      "Chunk stats require chunking to be enabled.");
+}
+
 TEST_F(WriterTest, chunkedStreamsRowNoNullsNoChunks) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -1945,6 +1945,10 @@ Writer::Writer(
               ? context_->options().bufferPolicyFactory()
               : nullptr} {
   NIMBLE_CHECK_NOT_NULL(file_);
+  NIMBLE_USER_CHECK(
+      !context_->options().enableChunkIndex ||
+          context_->options().enableChunking,
+      "Chunk stats require chunking to be enabled.");
 
   // Register handler for dynamically discovered FlatMap keys before creating
   // the writer tree, so that predefined keys also trigger the handler.


### PR DESCRIPTION
Summary:

CONTEXT: `enableChunkIndex` and `enableChunking` are independent
`WriterOptions` fields. Enabling chunk stats without chunking produces
single-chunk streams whose metadata is meaningless and can record
wrong null counts for struct null-only streams (T285998584).

WHAT: Add a `NIMBLE_USER_CHECK` in the `Writer` constructor that
rejects `enableChunkIndex = true` when `enableChunking = false`.
Also fix `IndexBenchmarkUtils` which unconditionally set
`enableChunkIndex = true` regardless of the `enableChunking` parameter.

Differential Revision: D117248249


