### PR TITLE
feat(file_format): Add Nimble file dictionary conversion

### DIFF
--- a/velox/dwio/nimble/velox/VeloxReader.cpp
+++ b/velox/dwio/nimble/velox/VeloxReader.cpp
@@ -67,6 +67,13 @@ std::map<std::string, std::string> loadMetadata(
   return result;
 }
 
+Encoding::Options encodingOptions(const TabletReader& tabletReader) {
+  Encoding::Options options;
+  options.useVarintRowCount =
+      tabletReader.properties().compactRowCountEncoding();
+  return options;
+}
+
 class NimbleUnit : public velox::dwio::common::LoadUnit {
  public:
   NimbleUnit(
@@ -375,11 +382,11 @@ VeloxReadParams::StreamEncodingFactory VeloxReader::createStreamEncodingFactory(
   // written consistently as shared-dictionary streams.
   return [dictionaryStreamOwner =
               std::shared_ptr<const StreamLoader>{std::move(dictionaryStream)},
-          _dictionaryAlphabet = std::move(dictionaryAlphabet)](
+          _dictionaryAlphabet = std::move(dictionaryAlphabet),
+          options = encodingOptions(*tabletReader_)](
              velox::memory::MemoryPool& pool,
              std::string_view data,
              std::function<void*(uint32_t)> stringBufferFactory) mutable {
-    Encoding::Options options;
     if (_dictionaryAlphabet == nullptr) {
       NIMBLE_CHECK_NOT_NULL(
           dictionaryStreamOwner,

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
@@ -1247,6 +1247,55 @@ TEST_P(SharedDictionaryE2EInputTypeTest, fileScopeRoundTrip) {
   verifyRoundTrip(file, inputType, stripeValueTypes);
 }
 
+TEST_F(SharedDictionaryE2ETest, fileScopeCompactRowCountRoundTrip) {
+  const std::vector<StripeValueType> stripeValueTypes{
+      StripeValueType::Dictionary, StripeValueType::Direct};
+  auto options = makeSharedDictionaryWriterOptions();
+  options.experimentalCompactRowCountEncoding = true;
+  addDictionary(
+      options,
+      InputType::FlatMapScalar,
+      sharedDictionaryConfig(SharedDictionaryScope::File, /*dictionaryId=*/7));
+
+  std::vector<velox::RowVectorPtr> stripeInputs;
+  stripeInputs.reserve(stripeValueTypes.size());
+  for (const auto stripeValueType : stripeValueTypes) {
+    stripeInputs.push_back(
+        makeStripe(InputType::FlatMapScalar, stripeValueType));
+  }
+  const auto file = writeInput(stripeInputs, std::move(options));
+
+  auto tablet = openTablet(file);
+  EXPECT_TRUE(tablet->properties().compactRowCountEncoding());
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapScalar);
+  ASSERT_EQ(valueStreamIds.size(), 1);
+
+  VeloxReadParams params;
+  const Encoding::Options encodingOptions{.useVarintRowCount = true};
+  params.encodingFactory =
+      [encodingOptions](
+          velox::memory::MemoryPool& pool,
+          std::string_view data,
+          std::function<void*(uint32_t)> stringBufferFactory)
+      -> std::unique_ptr<Encoding> {
+    return EncodingFactory{encodingOptions}.create(
+        pool, data, std::move(stringBufferFactory));
+  };
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  VeloxReader reader{readFile, *leafPool_, nullptr, std::move(params)};
+  velox::VectorPtr output;
+  for (const auto stripeValueType : stripeValueTypes) {
+    ASSERT_TRUE(reader.next(kStripeRows, output));
+    auto expected = makeStripe(InputType::FlatMapScalar, stripeValueType);
+    ASSERT_EQ(output->size(), expected->size());
+    for (velox::vector_size_t i = 0; i < output->size(); ++i) {
+      ASSERT_TRUE(output->equalValueAt(expected.get(), i, i));
+    }
+  }
+  EXPECT_FALSE(reader.next(kStripeRows, output));
+}
+
 TEST_P(SharedDictionaryE2EFlatMapRowValueSubfieldsTest, roundTrip) {
   const auto scope = GetParam();
   const std::vector<StripeValueType> stripeValueTypes{


### PR DESCRIPTION
Summary:
Add benchmark conversion support for writing Nimble files with configured file-scope shared dictionaries. The conversion path can precompute alphabets for selected int and long traits, choose an alphabet encoding override, and write the corresponding shared dictionary config into Nimble writer options.

This stays outside the core Nimble encoding diff so D112 only contains the shared dictionary format and writer/reader support. The follow-up wires the new format into the RexDB sequence conversion benchmark.

Benchmark result on local one-flow input

Input: `/data/users/xiaoxmeng/rexdb/sources/one_flow_fb_public_compaction/00000.rio`, sorted without `--max_input_rows`. The local source has `6,462` RecordIO records and expands to `43,958` Nimble rows with the 10 selected traits.

| Mode | Encoded size | Size delta | Dict payload | Long 10/11 scan | Long 10/11 decode | All 10 traits scan | All 10 traits decode |
|---|---:|---:|---:|---:|---:|---:|---:|
| No shared dictionary | `1,305,684,326` bytes | baseline | `0` bytes | `1.90GB/s` | `39us` | `5.56GB/s` | `147us` |
| Streaming file dictionary | `1,199,356,467` bytes | `-8.14%` | `273,997,758` bytes | `1.26GB/s` | `365us` | `4.23GB/s` | `512us` |
| Sorted/prebuilt auto alphabet | `1,207,818,706` bytes | `-7.50%` | `273,997,758` bytes | `1.25GB/s` | `411us` | `4.16GB/s` | `476us` |
| Sorted/prebuilt `DeltaBlock` alphabet | `1,061,469,270` bytes | `-18.70%` | `127,648,322` bytes | `268.86MB/s` | `4.56ms` | `952.67MB/s` | `4.52ms` |
| Sorted/prebuilt `BlockBitPacking` alphabet | `1,091,128,388` bytes | `-16.43%` | `157,307,440` bytes | `985.00MB/s` | `726us` | `3.54GB/s` | `655us` |

Dictionary payload is the sum of the two file-scope alphabet lengths recorded in the shared-dictionary catalog: dictionary `1` is long trait `10`, dictionary `2` is long trait `11`. The `columnar.dictionaries` catalog section itself is `192` bytes. The full unlisted on-file dictionary region is payload plus `601,326` bytes in these generated files.

`DeltaBlock` gives the best size. `BlockBitPacking` is the better size/read tradeoff among the sorted prebuilt modes. Baseline remains fastest to decode.

Reviewed By: duxiao1212

Differential Revision: D116428359


