### PR TITLE
feat(nimble): Verify schema roundtrip and stripe group consistency in writer fuzzer (#18671)

### DIFF
--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -991,10 +991,10 @@ std::string NimbleWriterFuzzer::writeFile(
   auto file = test::createNimbleFile(
       rootPool_, batches, std::move(writerOptions), /*flushAfterWrite=*/false);
   verifyChunkStatsMetadata(file, chunkStatsEnabled);
-  verifyColumnStatistics(
-      file,
-      std::dynamic_pointer_cast<const velox::RowType>(batches[0]->type()),
-      batches);
+  auto schema =
+      std::dynamic_pointer_cast<const velox::RowType>(batches[0]->type());
+  verifyColumnStatistics(file, schema, batches);
+  verifySchemaAndStripeGroupConsistency(file, schema);
   return file;
 }
 
@@ -1556,6 +1556,101 @@ void NimbleWriterFuzzer::verifyColumnStatistics(
           options_.seed);
     }
   }
+}
+
+void NimbleWriterFuzzer::verifySchemaAndStripeGroupConsistency(
+    const std::string& file,
+    const RowTypePtr& schema) {
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = TabletReader::create(
+      readFile, leafPool_.get(), test::makeTestTabletOptions(leafPool_.get()));
+
+  // Schema roundtrip: the Velox type reconstructed from the file must match
+  // the type that was written.
+  VeloxReader reader(
+      std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
+  NIMBLE_CHECK(
+      schema->equivalent(*reader.type()),
+      "Schema roundtrip mismatch (seed {}): written {} but read {}.",
+      options_.seed,
+      schema->toString(),
+      reader.type()->toString());
+
+  // StripeGroup consistency: per-stream byte ranges must not overlap and must
+  // end before the next stripe or the end of the file.
+  for (uint32_t stripe = 0; stripe < tablet->stripeCount(); ++stripe) {
+    const auto stripeIdentifier = tablet->stripeIdentifier(stripe);
+    const uint32_t streamCount = tablet->streamCount(stripeIdentifier);
+    if (streamCount == 0) {
+      continue;
+    }
+
+    std::vector<TabletReader::StreamLocation> locations(streamCount);
+    tablet->streamLocations(stripeIdentifier, locations);
+    const uint64_t stripeOffset = tablet->stripeOffset(stripe);
+    const uint64_t stripeEnd = stripe + 1 < tablet->stripeCount()
+        ? tablet->stripeOffset(stripe + 1)
+        : tablet->fileSize();
+    NIMBLE_CHECK_LE(
+        stripeOffset,
+        stripeEnd,
+        "Stripe {} has invalid bounds (seed {}).",
+        stripe,
+        options_.seed);
+
+    // Collect non-empty stream ranges and sort by offset.
+    struct StreamRange {
+      uint32_t streamId;
+      uint32_t offset;
+      uint32_t size;
+    };
+    std::vector<StreamRange> ranges;
+    for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+      const auto& location = locations[streamId];
+      if (location.size > 0) {
+        NIMBLE_CHECK_LE(
+            uint64_t{location.offset} + location.size,
+            stripeEnd - stripeOffset,
+            "Stream {} extends past stripe {} bounds (seed {}).",
+            streamId,
+            stripe,
+            options_.seed);
+        ranges.push_back({streamId, location.offset, location.size});
+      }
+    }
+    std::sort(
+        ranges.begin(), ranges.end(), [](const auto& lhs, const auto& rhs) {
+          return lhs.offset < rhs.offset;
+        });
+
+    // Verify no overlaps, allowing dedup aliases with identical ranges.
+    for (size_t i = 1; i < ranges.size(); ++i) {
+      const auto& prev = ranges[i - 1];
+      const auto& curr = ranges[i];
+      if (prev.offset == curr.offset && prev.size == curr.size) {
+        continue;
+      }
+      NIMBLE_CHECK_LE(
+          uint64_t{prev.offset} + prev.size,
+          curr.offset,
+          "Streams {} and {} overlap in stripe {} (seed {}).",
+          prev.streamId,
+          curr.streamId,
+          stripe,
+          options_.seed);
+    }
+  }
+
+  // Stripe row counts must sum to the tablet's total row count.
+  uint64_t totalRows = 0;
+  for (uint32_t stripe = 0; stripe < tablet->stripeCount(); ++stripe) {
+    totalRows += tablet->stripeRowCount(stripe);
+  }
+  NIMBLE_CHECK_EQ(
+      totalRows,
+      tablet->tabletRowCount(),
+      "Stripe row count sum mismatch (seed {}).",
+      options_.seed);
 }
 
 void NimbleWriterFuzzer::readAndVerify(

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
@@ -349,6 +349,12 @@ class NimbleWriterFuzzer {
       const velox::RowTypePtr& schema,
       const std::vector<velox::VectorPtr>& batches);
 
+  // Verifies the serialized schema round-trips back to the written Velox type,
+  // and that per-stream byte ranges within each stripe are non-overlapping.
+  void verifySchemaAndStripeGroupConsistency(
+      const std::string& file,
+      const velox::RowTypePtr& schema);
+
   // Reads 'file' through 'readerPath' and compares every row against
   // 'batches'. Throws on the first difference.
   void readAndVerify(


### PR DESCRIPTION
Summary:

CONTEXT: The writer fuzzer verifies chunk stats and column statistics but
does not check that the serialized schema round-trips correctly or that
per-stream byte ranges within stripes are consistent. Schema corruption
silently produces wrong reads; overlapping stream ranges corrupt file data.

WHAT: Add `verifySchemaAndStripeGroupConsistency()` to `NimbleWriterFuzzer`.
After every file write, it verifies:
- Schema roundtrip: the Velox type reconstructed from the file matches the
  type that was written (`schema->equivalent(*reader.type())`).
- StripeGroup consistency: per-stream byte ranges within each stripe are
  sorted, non-overlapping (allowing dedup aliases at the same offset+size),
  and fit within the stripe boundaries.
- Stripe row count sum equals the tablet total row count.

Reviewed By: HuamengJiang

Differential Revision: D117308769
