### PR TITLE
feat(parquet): Add parquet writer compression codec config

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1136,7 +1136,7 @@ Parquet Options (prefix ``hive.parquet.``)
        Session: ``hive.parquet.writer.enable_page_index``.
    * - ``writer.compression-codec``
      - string
-     -
+     - none
      - Compression codec used when writing into Parquet. Supported values are ``none``, ``snappy``,
        ``zstd``, ``lz4``, ``gzip``, and ``lz4_hadoop``. Applied as a fallback when the compression is
        not already set on the insert table handle.

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1134,6 +1134,13 @@ Parquet Options (prefix ``hive.parquet.``)
        Parquet through the Arrow bridge. When enabled, per-page statistics are stored in the page
        index instead of the data page headers, letting readers skip pages that cannot match a filter.
        Session: ``hive.parquet.writer.enable_page_index``.
+   * - ``writer.compression-codec``
+     - string
+     -
+     - Compression codec used when writing into Parquet. Supported values are ``none``, ``snappy``,
+       ``zstd``, ``lz4``, ``gzip``, and ``lz4_hadoop``. Applied as a fallback when the compression is
+       not already set on the insert table handle.
+       Session: ``hive.parquet.writer.compression_codec``.
 
 Nimble Options (prefix ``hive.nimble.``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/parquet/common/ParquetConfig.h
+++ b/velox/dwio/parquet/common/ParquetConfig.h
@@ -133,6 +133,16 @@ class ParquetConfig {
       "Write the Parquet page index (column index and offset index) in the "
       "Parquet writer. When enabled, per-page statistics are stored in the "
       "page index instead of the data page headers.")
+  VELOX_FORMAT_CONFIG_PROPERTY(
+      kWriterCompressionCodecSession,
+      kWriterCompressionCodec,
+      "writer_compression_codec",
+      "writer.compression-codec",
+      std::string_view,
+      "",
+      "Compression codec used by the Parquet writer. Supported values are "
+      "none, snappy, zstd, lz4, gzip, and lz4_hadoop. Shared between the "
+      "Hive and Iceberg connectors.")
   static constexpr std::string_view kWriterCreatedBy = "writer.created-by";
 
   // Writer config accessors expect format-scoped configs. Connector prefixes
@@ -205,6 +215,15 @@ class ParquetConfig {
     return connectorConfig.get<std::string>(std::string(kWriterCreatedBy));
   }
 
+  static std::optional<std::string> writerCompressionCodec(
+      const config::ConfigBase& connectorConfig,
+      const config::ConfigBase& session) {
+    return session.getLegacyWithFallback<std::string>(
+        kWriterCompressionCodecSession,
+        connectorConfig,
+        kWriterCompressionCodec);
+  }
+
   /// Serde parameter key for overriding the Parquet writer timestamp unit.
   /// Accepts numeric values 3 (milliseconds), 6 (microseconds), and 9
   /// (nanoseconds).
@@ -245,6 +264,8 @@ class ParquetConfig {
         properties, sessionPrefix);
     dwio::common::registerFormatConfigProperty<
         kWriterEnablePageIndexSessionProperty>(properties, sessionPrefix);
+    dwio::common::registerFormatConfigProperty<
+        kWriterCompressionCodecSessionProperty>(properties, sessionPrefix);
   }
 };
 

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -601,6 +601,72 @@ TEST_F(ParquetWriterTest, compressionRoundTripAcrossPages) {
   }
 }
 
+TEST_F(ParquetWriterTest, writerCompressionCodecConfig) {
+  constexpr int64_t kRows = 1'000;
+  const auto data = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row; }),
+  });
+
+  // Writes 'data' with 'codec' set via the connector (useSession == false) or
+  // session (useSession == true) Parquet writer config, then returns the
+  // compression kind and total compressed size recorded in the first column
+  // chunk.
+  const auto writeWithCodec = [&](const std::string& codec, bool useSession) {
+    std::unordered_map<std::string, std::string> configFromFile;
+    std::unordered_map<std::string, std::string> sessionProperties;
+    if (useSession) {
+      sessionProperties[std::string(
+          ParquetConfig::kWriterCompressionCodecSession)] = codec;
+    } else {
+      configFromFile[std::string(ParquetConfig::kWriterCompressionCodec)] =
+          codec;
+    }
+    // Disable dictionary so the values take the PLAIN path and the codec's
+    // effect shows up in the column chunk size.
+    configFromFile[std::string(ParquetConfig::kWriterEnableDictionary)] =
+        "false";
+    auto* sinkPtr = write(data, configFromFile, sessionProperties);
+    auto reader = createReaderInMemory(*sinkPtr);
+    EXPECT_EQ(reader->numberOfRows(), kRows);
+    const auto columnChunk = reader->fileMetaData().rowGroup(0).columnChunk(0);
+    return std::make_pair(
+        columnChunk.compression(), columnChunk.totalCompressedSize());
+  };
+
+  const auto [noneKind, uncompressedSize] = writeWithCodec("none", false);
+  EXPECT_EQ(noneKind, CompressionKind_NONE);
+
+  const auto [zstdKind, zstdSize] = writeWithCodec("zstd", false);
+  EXPECT_EQ(zstdKind, CompressionKind_ZSTD);
+  EXPECT_LT(zstdSize, uncompressedSize);
+
+  // Session-level config takes effect the same way as connector-level config.
+  const auto [snappyKind, snappySize] = writeWithCodec("snappy", true);
+  EXPECT_EQ(snappyKind, CompressionKind_SNAPPY);
+  EXPECT_LT(snappySize, uncompressedSize);
+
+  // An unknown codec is rejected.
+  VELOX_ASSERT_THROW(
+      writeWithCodec("invalid_codec", false),
+      "Not support compression kind invalid_codec");
+
+  // The base WriterOptions compression (set from the insert table handle) wins
+  // over the Parquet writer config, which is only a fallback.
+  {
+    dwio::common::WriterOptions options;
+    options.memoryPool = rootPool_.get();
+    options.compressionKind = CompressionKind_ZSTD;
+    ParquetWriterOptions writerOptions;
+    writerOptions.enableDictionary = false;
+    writerOptions.compressionKind = CompressionKind_SNAPPY;
+    auto* sinkPtr = write(data, options, writerOptions);
+    auto reader = createReaderInMemory(*sinkPtr);
+    EXPECT_EQ(
+        reader->fileMetaData().rowGroup(0).columnChunk(0).compression(),
+        CompressionKind_ZSTD);
+  }
+}
+
 TEST_F(ParquetWriterTest, testPageSizeAndBatchSizeConfiguration) {
   constexpr int64_t kRows = 10'000;
   const auto data = makeSmallintTestData(kRows);

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -134,6 +134,7 @@ void ParquetWriterOptions::merge(
   mergeIfSet(dataPageSize, parquetOverrides->dataPageSize);
   mergeIfSet(batchSize, parquetOverrides->batchSize);
   mergeIfSet(createdBy, parquetOverrides->createdBy);
+  mergeIfSet(compressionKind, parquetOverrides->compressionKind);
 }
 
 struct ArrowContext {
@@ -207,8 +208,11 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   } else {
     properties = properties->disableDictionary();
   }
+  // The base WriterOptions::compressionKind (set from the insert table handle)
+  // takes precedence; the Parquet writer config is only a fallback.
   properties = properties->compression(getArrowParquetCompression(
-      options.compressionKind.value_or(common::CompressionKind_NONE)));
+      options.compressionKind.value_or(parquetOptions.compressionKind.value_or(
+          common::CompressionKind_NONE))));
   for (const auto& columnCompressionValues :
        parquetOptions.columnCompressionsMap) {
     properties->compression(
@@ -402,6 +406,14 @@ std::optional<int64_t> toParquetBatchSize(
   } catch (const std::exception& e) {
     VELOX_USER_FAIL("Invalid parquet writer batch size: {}", e.what());
   }
+}
+
+std::optional<common::CompressionKind> toCompressionKind(
+    std::optional<std::string> codec) {
+  if (!codec || codec->empty()) {
+    return std::nullopt;
+  }
+  return common::stringToCompressionKind(*codec);
 }
 
 } // namespace
@@ -843,6 +855,8 @@ ParquetWriterFactory::createFormatOptions(
   parquetOptions->batchSize = toParquetBatchSize(
       ParquetConfig::writerBatchSize(connectorConfig, session));
   parquetOptions->createdBy = ParquetConfig::writerCreatedBy(connectorConfig);
+  parquetOptions->compressionKind = toCompressionKind(
+      ParquetConfig::writerCompressionCodec(connectorConfig, session));
   return parquetOptions;
 }
 

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -130,6 +130,10 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::shared_ptr<CodecOptions> codecOptions;
   std::unordered_map<std::string, common::CompressionKind>
       columnCompressionsMap;
+  /// Compression codec derived from the Parquet writer config. Used as a
+  /// fallback when the base WriterOptions::compressionKind (set from the
+  /// insert table handle) is not specified.
+  std::optional<common::CompressionKind> compressionKind;
 
   /// Timestamp unit for Parquet write through Arrow bridge.
   /// Default if not specified: TimestampPrecision::kNanoseconds (9).


### PR DESCRIPTION
Continue of https://github.com/facebookincubator/velox/pull/16608.

Support setting the Parquet writer compression codec through a connector or session config:

  hive.parquet.writer.compression-codec  (connector)
  hive.parquet.writer.compression_codec  (session)

The codec is parsed into ParquetWriterOptions::compressionKind in ParquetWriterFactory::createFormatOptions and applied as a fallback: the base WriterOptions::compressionKind, set from the insert table handle, still takes precedence when specified.