### PR TITLE
perf(nimble): Add selected stream location lookup (#18673)

### DIFF
--- a/velox/dwio/nimble/tablet/FileLayout.cpp
+++ b/velox/dwio/nimble/tablet/FileLayout.cpp
@@ -71,13 +71,16 @@ FileLayout FileLayout::create(
   // Per-stripe info
   const auto stripeCount = tablet->stripeCount();
   layout.stripesInfo.reserve(stripeCount);
-  std::vector<uint32_t> sizesScratch;
+  std::vector<TabletReader::StreamLocation> locationsScratch;
   for (uint32_t i = 0; i < stripeCount; ++i) {
     auto stripeIdentifier = tablet->stripeIdentifier(i);
-    sizesScratch.resize(tablet->streamCount(stripeIdentifier));
-    tablet->streamSizes(stripeIdentifier, sizesScratch);
-    auto stripeSize =
-        std::accumulate(sizesScratch.begin(), sizesScratch.end(), 0UL);
+    locationsScratch.resize(tablet->streamCount(stripeIdentifier));
+    tablet->streamLocations(stripeIdentifier, locationsScratch);
+    auto stripeSize = std::accumulate(
+        locationsScratch.begin(),
+        locationsScratch.end(),
+        0UL,
+        [](auto size, const auto& location) { return size + location.size; });
     layout.stripesInfo.push_back({
         .offset = tablet->stripeOffset(i),
         .size = stripeSize,

--- a/velox/dwio/nimble/tablet/StripeGroup.cpp
+++ b/velox/dwio/nimble/tablet/StripeGroup.cpp
@@ -15,8 +15,6 @@
  */
 #include "velox/dwio/nimble/tablet/StripeGroup.h"
 
-#include <algorithm>
-
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/encodings/views/EncodingViewFactory.h"
 #include "velox/dwio/nimble/tablet/FooterGenerated.h"
@@ -219,23 +217,35 @@ uint32_t StripeGroup::streamSize(uint32_t stripeIndex, uint32_t streamId)
       fmt::format("Unknown StripeGroup encoding layout: {}", encodingLayout_));
 }
 
-void StripeGroup::streamOffsets(uint32_t stripeIndex, std::span<uint32_t> out)
-    const {
+void StripeGroup::streamLocations(
+    uint32_t stripeIndex,
+    std::span<StreamLocation> locations) const {
   NIMBLE_CHECK_EQ(
-      out.size(), streamCount_, "output size must equal streamCount.");
-  const uint32_t stripeOffset = this->stripeOffset(stripeIndex);
+      locations.size(), streamCount_, "locations size must equal streamCount.");
+  const auto localStripe = stripeOffset(stripeIndex);
+
   switch (encodingLayout_) {
     case EncodingLayout::kRaw: {
-      const auto* base =
-          raw_.offsets + static_cast<size_t>(stripeOffset) * streamCount_;
-      std::copy(base, base + streamCount_, out.begin());
+      const auto base = static_cast<size_t>(localStripe) * streamCount_;
+      for (uint32_t streamId{0}; streamId < streamCount_; ++streamId) {
+        const auto size = raw_.sizes[base + streamId];
+        locations[streamId] = size == 0
+            ? StreamLocation{}
+            : StreamLocation{raw_.offsets[base + streamId], size};
+      }
       return;
     }
     case EncodingLayout::kStreamMajor:
-      // TODO: add a range-read API to EncodingView and decode the stripe's full
-      // offsets array in one call instead of per-stream readAt.
-      for (uint32_t i = 0; i < streamCount_; ++i) {
-        streamMajor_.offsets[i]->readAt(stripeOffset, &out[i]);
+      for (uint32_t streamId{0}; streamId < streamCount_; ++streamId) {
+        uint32_t size;
+        streamMajor_.sizes[streamId]->readAt(localStripe, &size);
+        if (size == 0) {
+          locations[streamId] = StreamLocation{};
+          continue;
+        }
+        uint32_t offset;
+        streamMajor_.offsets[streamId]->readAt(localStripe, &offset);
+        locations[streamId] = StreamLocation{offset, size};
       }
       return;
   }
@@ -243,23 +253,48 @@ void StripeGroup::streamOffsets(uint32_t stripeIndex, std::span<uint32_t> out)
       fmt::format("Unknown StripeGroup encoding layout: {}", encodingLayout_));
 }
 
-void StripeGroup::streamSizes(uint32_t stripeIndex, std::span<uint32_t> out)
-    const {
+void StripeGroup::streamLocations(
+    uint32_t stripeIndex,
+    std::span<const uint32_t> streamIds,
+    std::span<StreamLocation> locations) const {
   NIMBLE_CHECK_EQ(
-      out.size(), streamCount_, "output size must equal streamCount.");
-  const uint32_t stripeOffset = this->stripeOffset(stripeIndex);
+      streamIds.size(),
+      locations.size(),
+      "streamIds and locations sizes must match.");
+  const auto localStripe = stripeOffset(stripeIndex);
+
   switch (encodingLayout_) {
     case EncodingLayout::kRaw: {
-      const auto* base =
-          raw_.sizes + static_cast<size_t>(stripeOffset) * streamCount_;
-      std::copy(base, base + streamCount_, out.begin());
+      const auto base = static_cast<size_t>(localStripe) * streamCount_;
+      for (size_t i = 0; i < streamIds.size(); ++i) {
+        const auto streamId = streamIds[i];
+        if (streamId >= streamCount_) {
+          locations[i] = StreamLocation{};
+          continue;
+        }
+        const auto size = raw_.sizes[base + streamId];
+        locations[i] = size == 0
+            ? StreamLocation{}
+            : StreamLocation{raw_.offsets[base + streamId], size};
+      }
       return;
     }
     case EncodingLayout::kStreamMajor:
-      // TODO: add a range-read API to EncodingView and decode the stripe's full
-      // sizes array in one call instead of per-stream readAt.
-      for (uint32_t i = 0; i < streamCount_; ++i) {
-        streamMajor_.sizes[i]->readAt(stripeOffset, &out[i]);
+      for (size_t i = 0; i < streamIds.size(); ++i) {
+        const auto streamId = streamIds[i];
+        if (streamId >= streamCount_) {
+          locations[i] = StreamLocation{};
+          continue;
+        }
+        uint32_t size;
+        streamMajor_.sizes[streamId]->readAt(localStripe, &size);
+        if (size == 0) {
+          locations[i] = StreamLocation{};
+          continue;
+        }
+        uint32_t offset;
+        streamMajor_.offsets[streamId]->readAt(localStripe, &offset);
+        locations[i] = StreamLocation{offset, size};
       }
       return;
   }

--- a/velox/dwio/nimble/tablet/StripeGroup.h
+++ b/velox/dwio/nimble/tablet/StripeGroup.h
@@ -109,13 +109,26 @@ class StripeGroup {
   /// `stripeIndex`. Stateless. `streamId` must be less than streamCount().
   uint32_t streamSize(uint32_t stripeIndex, uint32_t streamId) const;
 
-  /// Bulk decode of all `streamCount` byte offsets for `stripeIndex` into the
-  /// caller-provided output buffer. `out.size()` must equal `streamCount`.
-  /// Intended for callers that scan the whole array (file-layout dump tools).
-  void streamOffsets(uint32_t stripeIndex, std::span<uint32_t> out) const;
+  /// Relative byte location of one stream within a stripe. A zero size means
+  /// the stream is absent.
+  struct StreamLocation {
+    uint32_t offset{0};
+    uint32_t size{0};
+  };
 
-  /// Bulk decode of all `streamCount` byte sizes for `stripeIndex`.
-  void streamSizes(uint32_t stripeIndex, std::span<uint32_t> out) const;
+  /// Reads locations for all streams in one stripe. `locations.size()` must
+  /// equal streamCount().
+  void streamLocations(
+      uint32_t stripeIndex,
+      std::span<StreamLocation> locations) const;
+
+  /// Reads locations for selected streams in one stripe. Stream IDs beyond
+  /// this group's stream count and streams with zero size produce absent
+  /// locations. `streamIds` and `locations` must have equal sizes.
+  void streamLocations(
+      uint32_t stripeIndex,
+      std::span<const uint32_t> streamIds,
+      std::span<StreamLocation> locations) const;
 
  private:
   // Maps an absolute stripe index to this group's local [0, stripeCount_)

--- a/velox/dwio/nimble/tablet/TabletReader.cpp
+++ b/velox/dwio/nimble/tablet/TabletReader.cpp
@@ -955,18 +955,20 @@ uint32_t TabletReader::streamSize(
   return stripe.stripeGroup()->streamSize(stripe.stripeId(), streamId);
 }
 
-void TabletReader::streamOffsets(
+void TabletReader::streamLocations(
     const StripeIdentifier& stripe,
-    std::span<uint32_t> out) const {
+    std::span<StreamLocation> locations) const {
   NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
-  stripe.stripeGroup()->streamOffsets(stripe.stripeId(), out);
+  stripe.stripeGroup()->streamLocations(stripe.stripeId(), locations);
 }
 
-void TabletReader::streamSizes(
+void TabletReader::streamLocations(
     const StripeIdentifier& stripe,
-    std::span<uint32_t> out) const {
+    std::span<const uint32_t> streamIds,
+    std::span<StreamLocation> locations) const {
   NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
-  stripe.stripeGroup()->streamSizes(stripe.stripeId(), out);
+  stripe.stripeGroup()->streamLocations(
+      stripe.stripeId(), streamIds, locations);
 }
 
 uint32_t TabletReader::streamCount(const StripeIdentifier& stripe) const {

--- a/velox/dwio/nimble/tablet/TabletReader.h
+++ b/velox/dwio/nimble/tablet/TabletReader.h
@@ -388,15 +388,22 @@ class TabletReader {
   /// stream does not exist in this stripe. O(1) point read.
   uint32_t streamSize(const StripeIdentifier& stripe, uint32_t streamId) const;
 
-  /// Bulk decode of all `streamCount(stripe)` byte offsets for `stripe` into
-  /// the caller-provided buffer. Intended for cold-path callers (file layout
-  /// dump tools) that need to scan every stream.
-  void streamOffsets(const StripeIdentifier& stripe, std::span<uint32_t> out)
-      const;
+  /// Relative byte location of one stream within a stripe. A zero size means
+  /// the stream is absent.
+  using StreamLocation = StripeGroup::StreamLocation;
 
-  /// Bulk decode of all `streamCount(stripe)` byte sizes for `stripe`.
-  void streamSizes(const StripeIdentifier& stripe, std::span<uint32_t> out)
-      const;
+  /// Reads locations for all `streamCount(stripe)` streams into the caller-
+  /// provided buffer.
+  void streamLocations(
+      const StripeIdentifier& stripe,
+      std::span<StreamLocation> locations) const;
+
+  /// Reads locations for selected streams. Stream IDs beyond
+  /// `streamCount(stripe)` and streams with zero size produce absent locations.
+  void streamLocations(
+      const StripeIdentifier& stripe,
+      std::span<const uint32_t> streamIds,
+      std::span<StreamLocation> locations) const;
 
   /// Returns the schema's leaf-stream count at the time `stripe`'s stripe
   /// group was written. May be less than the final schema's node count.

--- a/velox/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -16,6 +16,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <filesystem>
@@ -1466,6 +1467,74 @@ TEST_P(TabletTest, stripeGroupEncodingLayouts) {
     EXPECT_ANY_THROW(tablet->streamSize(stripe, streamCount));
   }
 
+  auto expectAllLocations = [](const std::shared_ptr<nimble::TabletReader>&
+                                   tablet,
+                               uint32_t stripeIndex) {
+    const auto stripe = tablet->stripeIdentifier(stripeIndex);
+    const auto streamCount = tablet->streamCount(stripe);
+    std::vector<nimble::TabletReader::StreamLocation> locations(streamCount);
+    tablet->streamLocations(stripe, locations);
+
+    for (uint32_t streamId{0}; streamId < streamCount; ++streamId) {
+      SCOPED_TRACE(fmt::format("stripe={} streamId={}", stripeIndex, streamId));
+      const auto expectedSize = tablet->streamSize(stripe, streamId);
+      if (expectedSize == 0) {
+        EXPECT_EQ(locations[streamId].offset, 0);
+        EXPECT_EQ(locations[streamId].size, 0);
+        continue;
+      }
+      EXPECT_EQ(
+          locations[streamId].offset, tablet->streamOffset(stripe, streamId));
+      EXPECT_EQ(locations[streamId].size, expectedSize);
+    }
+
+    ASSERT_GT(streamCount, 0);
+    std::vector<nimble::TabletReader::StreamLocation> tooFewLocations(
+        streamCount - 1);
+    NIMBLE_ASSERT_THROW(
+        tablet->streamLocations(stripe, tooFewLocations),
+        "locations size must equal streamCount.");
+  };
+
+  auto expectSelectedLocations = [](const std::shared_ptr<nimble::TabletReader>&
+                                        tablet,
+                                    uint32_t stripeIndex) {
+    const auto stripe = tablet->stripeIdentifier(stripeIndex);
+    constexpr size_t kNumStreamIds{5};
+    const std::array<uint32_t, kNumStreamIds> streamIds{2, 1, 999, 0, 3};
+    std::array<nimble::TabletReader::StreamLocation, kNumStreamIds> locations;
+
+    tablet->streamLocations(stripe, streamIds, locations);
+
+    for (size_t i{0}; i < streamIds.size(); ++i) {
+      SCOPED_TRACE(
+          fmt::format("stripe={} streamId={}", stripeIndex, streamIds[i]));
+      if (streamIds[i] >= tablet->streamCount(stripe) ||
+          tablet->streamSize(stripe, streamIds[i]) == 0) {
+        EXPECT_EQ(locations[i].offset, 0);
+        EXPECT_EQ(locations[i].size, 0);
+        continue;
+      }
+      EXPECT_EQ(
+          locations[i].offset, tablet->streamOffset(stripe, streamIds[i]));
+      EXPECT_EQ(locations[i].size, tablet->streamSize(stripe, streamIds[i]));
+    }
+
+    const std::array<uint32_t, 2> mismatchedStreamIds{0, 1};
+    std::array<nimble::TabletReader::StreamLocation, 1> mismatchedLocations;
+    NIMBLE_ASSERT_THROW(
+        tablet->streamLocations(
+            stripe, mismatchedStreamIds, mismatchedLocations),
+        "streamIds and locations sizes must match.");
+  };
+
+  for (const auto& tablet : {rawTablet, streamMajorTablet}) {
+    expectAllLocations(tablet, 0);
+    expectAllLocations(tablet, 1);
+    expectSelectedLocations(tablet, 0);
+    expectSelectedLocations(tablet, 1);
+  }
+
   // The encoded representation must agree with raw on every stripe/stream,
   // via point access and bulk materialize.
   for (const auto& encodedTablet : {streamMajorTablet}) {
@@ -1486,16 +1555,16 @@ TEST_P(TabletTest, stripeGroupEncodingLayouts) {
             encodedTablet->streamSize(encStripe, streamId));
       }
 
-      std::vector<uint32_t> rawOffsets(streamCount);
-      std::vector<uint32_t> encOffsets(streamCount);
-      std::vector<uint32_t> rawSizes(streamCount);
-      std::vector<uint32_t> encSizes(streamCount);
-      rawTablet->streamOffsets(rawStripe, rawOffsets);
-      encodedTablet->streamOffsets(encStripe, encOffsets);
-      rawTablet->streamSizes(rawStripe, rawSizes);
-      encodedTablet->streamSizes(encStripe, encSizes);
-      EXPECT_EQ(rawOffsets, encOffsets);
-      EXPECT_EQ(rawSizes, encSizes);
+      std::vector<nimble::TabletReader::StreamLocation> rawLocations(
+          streamCount);
+      std::vector<nimble::TabletReader::StreamLocation> encLocations(
+          streamCount);
+      rawTablet->streamLocations(rawStripe, rawLocations);
+      encodedTablet->streamLocations(encStripe, encLocations);
+      for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+        EXPECT_EQ(rawLocations[streamId].offset, encLocations[streamId].offset);
+        EXPECT_EQ(rawLocations[streamId].size, encLocations[streamId].size);
+      }
     }
   }
 }
@@ -1611,16 +1680,16 @@ TEST_P(TabletTest, stripeGroupEncodingLayoutsMultipleGroups) {
             encodedTablet->streamSize(encStripe, streamId));
       }
 
-      std::vector<uint32_t> rawOffsets(streamCount);
-      std::vector<uint32_t> encOffsets(streamCount);
-      std::vector<uint32_t> rawSizes(streamCount);
-      std::vector<uint32_t> encSizes(streamCount);
-      rawTablet->streamOffsets(rawStripe, rawOffsets);
-      encodedTablet->streamOffsets(encStripe, encOffsets);
-      rawTablet->streamSizes(rawStripe, rawSizes);
-      encodedTablet->streamSizes(encStripe, encSizes);
-      EXPECT_EQ(rawOffsets, encOffsets);
-      EXPECT_EQ(rawSizes, encSizes);
+      std::vector<nimble::TabletReader::StreamLocation> rawLocations(
+          streamCount);
+      std::vector<nimble::TabletReader::StreamLocation> encLocations(
+          streamCount);
+      rawTablet->streamLocations(rawStripe, rawLocations);
+      encodedTablet->streamLocations(encStripe, encLocations);
+      for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+        EXPECT_EQ(rawLocations[streamId].offset, encLocations[streamId].offset);
+        EXPECT_EQ(rawLocations[streamId].size, encLocations[streamId].size);
+      }
     }
   }
 }

--- a/velox/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/velox/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -654,13 +654,17 @@ void NimbleDumpLib::emitStripes(bool noHeader) {
   // stripe groups. We must hold on to it across loop iterations in order to
   // maintain the items in the cache.
   std::optional<StripeIdentifier> stripeIdentifier;
-  std::vector<uint32_t> sizesScratch;
+  std::vector<TabletReader::StreamLocation> locationsScratch;
   for (auto i = 0; i < tabletReader->stripeCount(); ++i) {
     stripeIdentifier = tabletReader->stripeIdentifier(i);
-    sizesScratch.resize(tabletReader->streamCount(stripeIdentifier.value()));
-    tabletReader->streamSizes(stripeIdentifier.value(), sizesScratch);
-    auto stripeSize =
-        std::accumulate(sizesScratch.begin(), sizesScratch.end(), 0UL);
+    locationsScratch.resize(
+        tabletReader->streamCount(stripeIdentifier.value()));
+    tabletReader->streamLocations(stripeIdentifier.value(), locationsScratch);
+    auto stripeSize = std::accumulate(
+        locationsScratch.begin(),
+        locationsScratch.end(),
+        0UL,
+        [](auto size, const auto& location) { return size + location.size; });
     formatter.writeRow({
         folly::to<std::string>(i),
         commaSeparated(tabletReader->stripeOffset(i)),

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -520,24 +520,22 @@ void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
   stripePlan.numRows = stripeRowCount(stripePlan.stripeIndex);
 
   const auto stripeId = tablet_->stripeIdentifier(stripePlan.stripeIndex);
-  const auto streamCount = tablet_->streamCount(stripeId);
   const auto stripeOffset = tablet_->stripeOffset(stripePlan.stripeIndex);
 
+  std::vector<TabletReader::StreamLocation> streamLocations(
+      projection_->streamOffsets.size());
+  tablet_->streamLocations(
+      stripeId, projection_->streamOffsets, streamLocations);
   stripePlan.projectedStreams.resize(projection_->streamOffsets.size());
-  for (size_t i = 0; i < projection_->streamOffsets.size(); ++i) {
-    const auto streamId = projection_->streamOffsets[i];
-    if (streamId >= streamCount) {
+  for (size_t i = 0; i < streamLocations.size(); ++i) {
+    const auto& streamLocation = streamLocations[i];
+    if (streamLocation.size == 0) {
       continue;
     }
-    const auto streamSize = tablet_->streamSize(stripeId, streamId);
-    if (streamSize == 0) {
-      continue;
-    }
-    const auto streamOffset = tablet_->streamOffset(stripeId, streamId);
-    stripePlan.projectedStreams[i] =
-        velox::common::Region{stripeOffset + streamOffset, streamSize};
+    stripePlan.projectedStreams[i] = velox::common::Region{
+        stripeOffset + streamLocation.offset, streamLocation.size};
     ++stripePlan.numStreams;
-    stripePlan.projectedBytes += streamSize;
+    stripePlan.projectedBytes += streamLocation.size;
     if (projection_->rowOrFlatMapNullStreams[i]) {
       // A present Row/FlatMap null stream means the slice may carry nulls.
       stripePlan.requiresNullBarrier = true;

--- a/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -3161,10 +3161,8 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
 
     auto stripeId = tablet->stripeIdentifier(0);
     const auto streamCount = tablet->streamCount(stripeId);
-    std::vector<uint32_t> offsets(streamCount);
-    std::vector<uint32_t> sizes(streamCount);
-    tablet->streamOffsets(stripeId, offsets);
-    tablet->streamSizes(stripeId, sizes);
+    std::vector<TabletReader::StreamLocation> streamLocations(streamCount);
+    tablet->streamLocations(stripeId, streamLocations);
 
     VeloxReader reader(readFile.get(), *leafPool_);
     const auto& flatMap = reader.schema()->asRow().childAt(1)->asFlatMap();
@@ -3176,7 +3174,8 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     }
 
     auto diskPosition = [&](int64_t key) -> uint32_t {
-      return offsets[keyToValueStreamId.at(folly::to<std::string>(key))];
+      return streamLocations[keyToValueStreamId.at(folly::to<std::string>(key))]
+          .offset;
     };
 
     // Verify projected keys appear in reordering order on disk.
@@ -3194,7 +3193,9 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
       auto currStreamId =
           keyToValueStreamId.at(folly::to<std::string>(projectedKeys[i]));
       EXPECT_EQ(
-          offsets[prevStreamId] + sizes[prevStreamId], offsets[currStreamId])
+          streamLocations[prevStreamId].offset +
+              streamLocations[prevStreamId].size,
+          streamLocations[currStreamId].offset)
           << "Key " << projectedKeys[i - 1]
           << " value stream should be adjacent to key " << projectedKeys[i];
     }

--- a/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -411,13 +411,14 @@ size_t streamsReadCount(
       makeTestTabletOptions(&pool));
   NIMBLE_CHECK_GE(tablet->stripeCount(), 1);
   auto stripeIdentifier = tablet->stripeIdentifier(0);
-  std::vector<uint32_t> offsets(tablet->streamCount(stripeIdentifier));
-  tablet->streamOffsets(stripeIdentifier, offsets);
+  std::vector<nimble::TabletReader::StreamLocation> locations(
+      tablet->streamCount(stripeIdentifier));
+  tablet->streamLocations(stripeIdentifier, locations);
   std::unordered_set<uint32_t> streamOffsets;
-  LOG(INFO) << "Number of streams: " << offsets.size();
-  for (auto offset : offsets) {
-    LOG(INFO) << "Stream offset: " << offset;
-    streamOffsets.insert(offset);
+  LOG(INFO) << "Number of streams: " << locations.size();
+  for (const auto& location : locations) {
+    LOG(INFO) << "Stream offset: " << location.offset;
+    streamOffsets.insert(location.offset);
   }
   size_t readCount = 0;
   auto fileSize = readFile->size();
@@ -446,11 +447,12 @@ std::unordered_set<nimble::offset_size> existingStreamOffsets(
   NIMBLE_CHECK_LT(stripeIndex, tablet->stripeCount(), "Stripe out of range");
   auto stripeId = tablet->stripeIdentifier(stripeIndex);
   const auto streamCount = tablet->streamCount(stripeId);
-  std::vector<uint32_t> streamSizes(streamCount);
-  tablet->streamSizes(stripeId, streamSizes);
+  std::vector<nimble::TabletReader::StreamLocation> streamLocations(
+      streamCount);
+  tablet->streamLocations(stripeId, streamLocations);
   std::unordered_set<nimble::offset_size> result;
   for (nimble::offset_size i = 0; i < streamCount; ++i) {
-    if (streamSizes[i] > 0) {
+    if (streamLocations[i].size > 0) {
       result.insert(i);
     }
   }

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -1390,10 +1390,9 @@ TEST_F(WriterTest, featureReorderingStreamCollocation) {
 
     auto stripeId = tablet->stripeIdentifier(0);
     const auto streamCount = tablet->streamCount(stripeId);
-    std::vector<uint32_t> offsets(streamCount);
-    std::vector<uint32_t> sizes(streamCount);
-    tablet->streamOffsets(stripeId, offsets);
-    tablet->streamSizes(stripeId, sizes);
+    std::vector<nimble::TabletReader::StreamLocation> streamLocations(
+        streamCount);
+    tablet->streamLocations(stripeId, streamLocations);
 
     nimble::VeloxReader reader(readFile.get(), *leafPool_);
     const auto& flatMap =
@@ -1409,7 +1408,7 @@ TEST_F(WriterTest, featureReorderingStreamCollocation) {
     // constant-encoded and deduplicated when all keys are present in every
     // row.
     auto diskPosition = [&](const std::string& key) -> uint32_t {
-      return offsets[keyToValueStreamId.at(key)];
+      return streamLocations[keyToValueStreamId.at(key)].offset;
     };
 
     // Verify reordered keys appear in the specified order on disk.
@@ -1428,7 +1427,9 @@ TEST_F(WriterTest, featureReorderingStreamCollocation) {
       auto prevStreamId = keyToValueStreamId.at(prevKey);
       auto currStreamId = keyToValueStreamId.at(currKey);
       EXPECT_EQ(
-          offsets[prevStreamId] + sizes[prevStreamId], offsets[currStreamId])
+          streamLocations[prevStreamId].offset +
+              streamLocations[prevStreamId].size,
+          streamLocations[currStreamId].offset)
           << "Key " << prevKey << " value stream should be adjacent to key "
           << currKey;
     }
@@ -1553,10 +1554,9 @@ TEST_F(WriterTest, featureReorderingSharedDictionaryStreamCollocation) {
 
     const auto stripeId = tablet->stripeIdentifier(0);
     const auto streamCount = tablet->streamCount(stripeId);
-    std::vector<uint32_t> offsets(streamCount);
-    std::vector<uint32_t> sizes(streamCount);
-    tablet->streamOffsets(stripeId, offsets);
-    tablet->streamSizes(stripeId, sizes);
+    std::vector<nimble::TabletReader::StreamLocation> streamLocations(
+        streamCount);
+    tablet->streamLocations(stripeId, streamLocations);
 
     nimble::VeloxReader reader(readFile.get(), *leafPool_);
     const auto& flatMap =
@@ -1584,10 +1584,10 @@ TEST_F(WriterTest, featureReorderingSharedDictionaryStreamCollocation) {
       ASSERT_TRUE(dictionaryStreamId.has_value())
           << "Missing shared dictionary stream for key " << key;
 
-      ASSERT_LT(valueStreamId, offsets.size());
-      ASSERT_LT(dictionaryStreamId.value(), offsets.size());
-      EXPECT_GT(sizes[valueStreamId], 0);
-      EXPECT_GT(sizes[dictionaryStreamId.value()], 0);
+      ASSERT_LT(valueStreamId, streamLocations.size());
+      ASSERT_LT(dictionaryStreamId.value(), streamLocations.size());
+      EXPECT_GT(streamLocations[valueStreamId].size, 0);
+      EXPECT_GT(streamLocations[dictionaryStreamId.value()].size, 0);
 
       auto streams =
           tablet->load(stripeId, std::vector<uint32_t>{valueStreamId});
@@ -1599,11 +1599,12 @@ TEST_F(WriterTest, featureReorderingSharedDictionaryStreamCollocation) {
           nimble::EncodingType::SharedDictionary)
           << "Key " << key << " value stream should use SharedDictionary";
 
-      const auto valueBegin = offsets[valueStreamId];
-      const auto valueEnd = valueBegin + sizes[valueStreamId];
-      const auto dictionaryBegin = offsets[dictionaryStreamId.value()];
+      const auto valueBegin = streamLocations[valueStreamId].offset;
+      const auto valueEnd = valueBegin + streamLocations[valueStreamId].size;
+      const auto dictionaryBegin =
+          streamLocations[dictionaryStreamId.value()].offset;
       const auto dictionaryEnd =
-          dictionaryBegin + sizes[dictionaryStreamId.value()];
+          dictionaryBegin + streamLocations[dictionaryStreamId.value()].size;
       EXPECT_TRUE(valueEnd == dictionaryBegin || dictionaryEnd == valueBegin)
           << "Key " << key
           << " dictionary stream should be adjacent to its value stream";
@@ -1677,10 +1678,9 @@ TEST_F(
 
   auto stripeId = tablet->stripeIdentifier(0);
   const auto streamCount = tablet->streamCount(stripeId);
-  std::vector<uint32_t> offsets(streamCount);
-  std::vector<uint32_t> sizes(streamCount);
-  tablet->streamOffsets(stripeId, offsets);
-  tablet->streamSizes(stripeId, sizes);
+  std::vector<nimble::TabletReader::StreamLocation> streamLocations(
+      streamCount);
+  tablet->streamLocations(stripeId, streamLocations);
 
   nimble::VeloxReader reader(readFile.get(), *leafPool_);
   const auto& rowSchema = reader.schema()->asRow();
@@ -1700,7 +1700,9 @@ TEST_F(
     const auto prevStreamId = keyToValueStreamId.at(prevKey);
     const auto currStreamId = keyToValueStreamId.at(currKey);
     EXPECT_EQ(
-        offsets[prevStreamId] + sizes[prevStreamId], offsets[currStreamId])
+        streamLocations[prevStreamId].offset +
+            streamLocations[prevStreamId].size,
+        streamLocations[currStreamId].offset)
         << "Key " << prevKey << " value stream should be adjacent to key "
         << currKey;
   }
@@ -6290,17 +6292,16 @@ class WriterIndexTest : public WriterTest,
          ++stripeIndex) {
       const auto stripeIdentifier = tablet.stripeIdentifier(stripeIndex);
       const auto streamCount = tablet.streamCount(stripeIdentifier);
-      std::vector<uint32_t> offsets(streamCount);
-      std::vector<uint32_t> sizes(streamCount);
-      tablet.streamOffsets(stripeIdentifier, offsets);
-      tablet.streamSizes(stripeIdentifier, sizes);
+      std::vector<nimble::TabletReader::StreamLocation> streamLocations(
+          streamCount);
+      tablet.streamLocations(stripeIdentifier, streamLocations);
 
       std::map<std::pair<uint32_t, uint32_t>, uint64_t> duplicateGroups;
-      for (size_t streamIndex = 0; streamIndex < sizes.size(); ++streamIndex) {
-        if (sizes[streamIndex] == 0) {
+      for (const auto& streamLocation : streamLocations) {
+        if (streamLocation.size == 0) {
           continue;
         }
-        ++duplicateGroups[{offsets[streamIndex], sizes[streamIndex]}];
+        ++duplicateGroups[{streamLocation.offset, streamLocation.size}];
       }
 
       for (const auto& [offsetAndSize, count] : duplicateGroups) {


### PR DESCRIPTION
Summary:

Add a selected-stream location API on `StripeGroup` and use it in `NimbleIndexProjector` to fetch projected stream offsets and sizes in one pass. Keep `TabletReader` full-array offset and size APIs as compatibility wrappers for dump and test callers.

Benchmarking this change alone did not show a measurable improvement; it is mainly a small API cleanup and prerequisite for the larger slice-buffer optimization.

Differential Revision: D117303255


