### PR TITLE
perf(Nimble): Add bulk translate fast path to Nimble DictionaryEncoding::readWithVisitor

### DIFF
--- a/velox/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/DictionaryEncoding.h
@@ -301,6 +301,32 @@ void DictionaryEncoding<T>::readWithVisitor(
           &indicesHook));
   indicesVisitor.setRowIndex(startRowIndex);
   callReadWithVisitor(*indicesEncoding_, indicesVisitor, params);
+
+  // Once the indices are materialised, a dense read that inspects no filter,
+  // hook or null per row is a straight alphabet gather, so translate the whole
+  // run in one pass instead of paying a visitor callback per value.
+  // `kFilterOnly` visitors are excluded: they have no values buffer to write.
+  if constexpr (V::dense && !V::kHasFilter && !V::kHasHook && !V::kFilterOnly) {
+    if (visitor.reader().rawNullsInReadRange() == nullptr) {
+      using DataType = typename V::DataType;
+
+      // Mirrors readWithVisitorSlow: the extract-to-reader path allocates
+      // result nulls even when this range has none, or a reused buffer leaks
+      // stale null bits from a previous chunk into the output.
+      params.prepareResultNulls();
+      auto* values = detail::mutableValues<detail::ValueType<DataType>>(
+          visitor, numIndices);
+      for (vector_size_t i = 0; i < numIndices; ++i) {
+        values[i] = detail::dataToValue(
+            visitor,
+            detail::castFromPhysicalType<DataType>(alphabet_[rawIndices[i]]));
+      }
+      visitor.addNumValues(numIndices);
+      visitor.setRowIndex(visitor.numRows());
+      return;
+    }
+  }
+
   detail::readWithVisitorSlow(visitor, params, nullptr, [&] {
     return alphabet_[rawIndices[visitor.rowIndex() - startRowIndex]];
   });

--- a/velox/dwio/nimble/encodings/legacy/DictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/DictionaryEncoding.h
@@ -198,6 +198,34 @@ void DictionaryEncoding<T>::readWithVisitor(
           &indicesHook));
   indicesVisitor.setRowIndex(startRowIndex);
   legacy::callReadWithVisitor(*indicesEncoding_, indicesVisitor, params);
+
+  // Once the indices are materialised, a dense read that inspects no filter,
+  // hook or null per row is a straight alphabet gather, so translate the whole
+  // run in one pass instead of paying a visitor callback per value.
+  // `kFilterOnly` visitors are excluded: they have no values buffer to write.
+  if constexpr (V::dense && !V::kHasFilter && !V::kHasHook && !V::kFilterOnly) {
+    if (visitor.reader().rawNullsInReadRange() == nullptr) {
+      using DataType = typename V::DataType;
+      const auto numIndices = visitor.numRows() - startRowIndex;
+
+      // Mirrors readWithVisitorSlow: the extract-to-reader path allocates
+      // result nulls even when this range has none, or a reused buffer leaks
+      // stale null bits from a previous chunk into the output.
+      params.prepareResultNulls();
+      auto* values = detail::mutableValues<detail::ValueType<DataType>>(
+          visitor, numIndices);
+      for (vector_size_t i = 0; i < numIndices; ++i) {
+        values[i] = detail::dataToValue(
+            visitor,
+            detail::castFromPhysicalType<DataType>(
+                alphabet_[indicesBuffer_[i]]));
+      }
+      visitor.addNumValues(numIndices);
+      visitor.setRowIndex(visitor.numRows());
+      return;
+    }
+  }
+
   detail::readWithVisitorSlow(visitor, params, nullptr, [&] {
     const auto index = indicesBuffer_[visitor.rowIndex() - startRowIndex];
     return alphabet_[index];


### PR DESCRIPTION
Summary:
DictionaryEncoding is the only hot encoding in velox/dwio/nimble/encodings
without a bulkScan path, so a dense no-filter read fell through to
readWithVisitorSlow and paid a per-row visitor callback per value, even
though materialize() in this same class already does the bulk translate.

When the visitor is dense with no filter, no hook and not filter-only, and the
reader has no nulls in the read range, translate every index in one loop into
the visitor's value buffer and account for the whole run at once. Filters,
hooks, scatter and nulls are untouched and keep the existing slow path.

Applied to both the current and the legacy DictionaryEncoding. A CPU profile of
a production-shaped Nimble scan on a test cluster showed the hot decode is
legacy::DictionaryEncoding::readWithVisitor (25.7% of scan CPU, and all of the
readWithVisitorSlow time), so patching only the non-legacy copy leaves the
real read path untouched.

Differential Revision: D115976529


