### PR TITLE
perf(nimble): Answer integral constancy from min/max instead of unique counts (#18676)

### DIFF
--- a/velox/dwio/nimble/encodings/ConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/ConstantEncoding.h
@@ -237,12 +237,33 @@ class ConstantEncodingBase
       const Encoding::Options& options) {
     NIMBLE_CHECK(
         !values.empty(), "ConstantEncoding requires non-empty values.");
-    if (values.size() == 1 || statistics.uniqueCounts().value().size() == 1) {
+    if (values.size() == 1) {
       return true;
     }
+
+    // For integral types a unique count of one is equivalent to min == max.
+    // Both are lazily populated, but populateMinMax() is a comparison scan
+    // while populateUniques() inserts one hash entry per value. Encoding
+    // selection evaluates ConstantEncoding on every stream, so going through
+    // uniqueCounts() here builds a full unique-value map on high-cardinality
+    // streams purely to discover that the count is not one.
+    //
+    // Only integral types qualify. Statistics has no min/max for booleans, and
+    // their unique counts are bounded at two entries anyway. String min/max are
+    // by length rather than lexicographic, so equal endpoints do not imply
+    // equal values.
+    if constexpr (isIntegralType<T>()) {
+      return statistics.min() == statistics.max();
+    }
+
+    if (statistics.uniqueCounts().value().size() == 1) {
+      return true;
+    }
+
     if constexpr (!isFloatingPointType<T>()) {
       return false;
     }
+
     // Logical-equality constancy collapses physically-distinct but logically
     // equal floats (only -0.0/+0.0; NaN is excluded since NaN != NaN) to a
     // single canonical value. That is only sound when ALP is enabled, since ALP

--- a/velox/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -464,3 +464,66 @@ TEST_F(ConstantEncodingStringTest, invalidSliceRange) {
         "");
   }
 }
+
+// estimateSize() answers constancy through Statistics. Integral types now take
+// that answer from min/max rather than from the unique-count map, so these
+// cases pin the observable behaviour of both the constant and the non-constant
+// path. The string case is included because string min/max are by length, not
+// lexicographic, which is why strings keep the unique-count path.
+TEST(ConstantEncodingEstimateSizeTest, integralConstancy) {
+  const nimble::Encoding::Options options{};
+
+  const std::vector<uint32_t> constantValues{7, 7, 7, 7};
+  EXPECT_TRUE(
+      nimble::ConstantEncoding<int32_t>::estimateSize(
+          constantValues,
+          nimble::Statistics<uint32_t>::create(constantValues),
+          options)
+          .has_value());
+
+  // Differs only in the final element, so a min/max check must still see it.
+  const std::vector<uint32_t> trailingOutlier{7, 7, 7, 8};
+  EXPECT_FALSE(
+      nimble::ConstantEncoding<int32_t>::estimateSize(
+          trailingOutlier,
+          nimble::Statistics<uint32_t>::create(trailingOutlier),
+          options)
+          .has_value());
+
+  // Differs only in the first element, which min/max also has to catch.
+  const std::vector<uint32_t> leadingOutlier{6, 7, 7, 7};
+  EXPECT_FALSE(
+      nimble::ConstantEncoding<int32_t>::estimateSize(
+          leadingOutlier,
+          nimble::Statistics<uint32_t>::create(leadingOutlier),
+          options)
+          .has_value());
+
+  const std::vector<uint32_t> singleValue{7};
+  EXPECT_TRUE(
+      nimble::ConstantEncoding<int32_t>::estimateSize(
+          singleValue,
+          nimble::Statistics<uint32_t>::create(singleValue),
+          options)
+          .has_value());
+}
+
+TEST(ConstantEncodingEstimateSizeTest, stringConstancy) {
+  const nimble::Encoding::Options options{};
+
+  const std::vector<std::string_view> constantValues{"abc", "abc", "abc"};
+  EXPECT_TRUE(
+      nimble::ConstantEncoding<std::string_view>::estimateSize(
+          constantValues,
+          nimble::Statistics<std::string_view>::create(constantValues),
+          options)
+          .has_value());
+
+  const std::vector<std::string_view> mixedValues{"abc", "abc", "abd"};
+  EXPECT_FALSE(
+      nimble::ConstantEncoding<std::string_view>::estimateSize(
+          mixedValues,
+          nimble::Statistics<std::string_view>::create(mixedValues),
+          options)
+          .has_value());
+}


### PR DESCRIPTION
Summary:

## Context

Encoding selection evaluates `ConstantEncoding` on every stream, and
`isConstant()` decided constancy by materialising `Statistics::uniqueCounts()`
and testing whether the map holds a single entry. `populateUniques()` inserts
one hash entry per value, so on a high-cardinality stream the writer builds a
full unique-value map and then discards it to answer "not constant".

A strobelight profile of a `common_pool` CTAS bottoms out in
`populateHashUniqueCounts` and
`absl::container_internal::raw_hash_set::find_or_prepare_insert_large`, reached
through `ManualEncodingSelectionPolicy::select` ->
`EncodingSizeEstimation::estimateSize` -> `ConstantEncodingBase::isConstant`.

## Details

For integral types a unique count of one is equivalent to `min == max`, and
`populateMinMax()` is a comparison scan rather than a hash insert per value.
Both are lazily populated, so the min/max route avoids triggering
`populateUniques()` at all when no other candidate encoding needs it.

Every other type keeps the existing path:
- booleans have no `min`/`max` in `Statistics`, and their unique counts are
  bounded at two entries anyway
- string `min`/`max` are by length rather than lexicographic, so equal endpoints
  do not imply equal values
- floats keep the bit-exact unique-count check that the ALP logical-equality
  branch relies on

## Test Plan

`buck test fbcode//velox/dwio/nimble/encodings/tests:tests` - 2517 pass, 0 fail.

New `ConstantEncodingEstimateSizeTest` covers constant, leading-outlier,
trailing-outlier and single-value integral cases, plus a string case that pins
why strings keep the unique-count path.

Reviewed By: xiaoxmeng

Differential Revision: D115396781


