### PR TITLE
refactor(reader): Move the reader factory out of fb/ (#18677)

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -15,16 +15,16 @@
  */
 
 // This end-to-end test exercises the batch NimbleReader/NimbleWriter factories,
-// both now under velox/dwio/nimble/. The reader factory is still internal-only
-// and keeps its fb/ segment; the writer factory is OSS-exportable and dropped
-// it. Guard the whole test so the OSS build (VELOX_ENABLE_NIMBLE off) does not
-// try to include the fb/ headers. Mirrors WriterOptionsAdapterTest.cpp.
+// both now under velox/dwio/nimble/ and neither behind an fb/ segment: both are
+// OSS-exportable. Guard the whole test so the OSS build (VELOX_ENABLE_NIMBLE
+// off) does not try to build the batch reader, which stays internal-only.
+// Mirrors WriterOptionsAdapterTest.cpp.
 #ifdef VELOX_ENABLE_NIMBLE
 
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
-#include "velox/dwio/nimble/velox/reader/fb/NimbleReader.h"
+#include "velox/dwio/nimble/velox/reader/NimbleReaderFactory.h"
 #include "velox/dwio/nimble/writer/WriterFactory.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"

--- a/velox/dwio/nimble/velox/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/CMakeLists.txt
@@ -185,6 +185,9 @@ target_link_libraries(raw_size_utils nimble_common velox_vector velox_dwio_commo
 
 add_subdirectory(index)
 add_subdirectory(selective)
+# Must follow selective: nimble_velox_reader_factory links
+# nimble_velox_selective.
+add_subdirectory(reader)
 add_subdirectory(stats)
 if(NIMBLE_BUILD_TESTING)
   add_subdirectory(tests)

--- a/velox/dwio/nimble/velox/reader/BatchReaderOSS.cpp
+++ b/velox/dwio/nimble/velox/reader/BatchReaderOSS.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/dwio/nimble/velox/reader/NimbleReaderFactory.h"
+
+namespace facebook::velox::nimble::detail {
+
+// The batch reader reaches into internal-only code, so it is not part of the
+// open-source build. Returning nullptr makes the factory report a clear error
+// rather than fail to link.
+std::unique_ptr<dwio::common::Reader> createBatchReader(
+    const dwio::common::ReaderOptions& /*options*/,
+    const std::shared_ptr<ReadFile>& /*readFile*/) {
+  return nullptr;
+}
+
+} // namespace facebook::velox::nimble::detail

--- a/velox/dwio/nimble/velox/reader/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/reader/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# BatchReaderOSS.cpp stands in for fb/NimbleReader.cpp, which the Buck build
+# compiles instead: the batch reader depends on internal-only code.
+add_library(
+  nimble_velox_reader_factory
+  NimbleReaderFactory.cpp
+  BatchReaderOSS.cpp
+  NimbleReaderFactory.h
+)
+target_link_libraries(nimble_velox_reader_factory nimble_velox_selective velox_dwio_common)

--- a/velox/dwio/nimble/velox/reader/NimbleReaderFactory.cpp
+++ b/velox/dwio/nimble/velox/reader/NimbleReaderFactory.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/dwio/nimble/velox/reader/NimbleReaderFactory.h"
+
+#include "velox/common/base/RuntimeMetrics.h"
+
+namespace facebook::velox::nimble {
+
+std::unique_ptr<dwio::common::Reader> NimbleReaderFactory::createReader(
+    std::unique_ptr<dwio::common::BufferedInput> input,
+    const dwio::common::ReaderOptions& options) {
+  // Missing metadata IO stats are defaulted by
+  // `TabletReader::configureOptions`, which both branches below funnel
+  // through, so no fixup is needed here.
+  if (options.selectiveNimbleReaderEnabled()) {
+    addThreadLocalRuntimeStat("selectiveNimbleReader", RuntimeCounter(1));
+    return selectiveFactory_.createReader(std::move(input), options);
+  }
+
+  addThreadLocalRuntimeStat("batchNimbleReader", RuntimeCounter(1));
+  auto reader = detail::createBatchReader(options, input->getReadFile());
+  VELOX_CHECK_NOT_NULL(
+      reader,
+      "The batch NIMBLE reader is not available in this build. Leave "
+      "selective_nimble_reader_enabled at its default to use the selective "
+      "reader.");
+  return reader;
+}
+
+void registerNimbleReaderFactory() {
+  dwio::common::registerReaderFactory(std::make_shared<NimbleReaderFactory>());
+}
+
+void unregisterNimbleReaderFactory() {
+  dwio::common::unregisterReaderFactory(dwio::common::FileFormat::NIMBLE);
+}
+
+} // namespace facebook::velox::nimble

--- a/velox/dwio/nimble/velox/reader/NimbleReaderFactory.h
+++ b/velox/dwio/nimble/velox/reader/NimbleReaderFactory.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/dwio/common/ReaderFactory.h"
+#include "velox/dwio/nimble/velox/selective/SelectiveNimbleReader.h"
+
+namespace facebook::velox::nimble {
+
+namespace detail {
+
+/// Creates the batch (non-selective) NIMBLE reader, or nullptr when that
+/// reader is not part of the build. Defined once per build flavour: the batch
+/// reader depends on internal-only code, so only the internal build can supply
+/// it.
+std::unique_ptr<dwio::common::Reader> createBatchReader(
+    const dwio::common::ReaderOptions& options,
+    const std::shared_ptr<ReadFile>& readFile);
+
+} // namespace detail
+
+/// Registered against FileFormat::NIMBLE. Chooses between the selective reader
+/// and the batch reader per read, based on
+/// `ReaderOptions::selectiveNimbleReaderEnabled()`.
+class NimbleReaderFactory : public dwio::common::ReaderFactory {
+ public:
+  NimbleReaderFactory() : ReaderFactory(dwio::common::FileFormat::NIMBLE) {}
+
+  std::unique_ptr<dwio::common::Reader> createReader(
+      std::unique_ptr<dwio::common::BufferedInput>,
+      const dwio::common::ReaderOptions&) override;
+
+ private:
+  facebook::nimble::SelectiveNimbleReaderFactory selectiveFactory_;
+};
+
+void registerNimbleReaderFactory();
+
+void unregisterNimbleReaderFactory();
+
+} // namespace facebook::velox::nimble


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/1069

Gets the NIMBLE reader's registration surface out of `fb/`, so that internal and open-source builds register the same factory instead of each having their own entry point.

Before this, `NimbleReaderFactory` -- and with it `registerNimbleReaderFactory()`, which is what Prism, Gluten, Axel, Axiom, and a long tail of tools call -- lived in `dwio/nimble/velox/reader/fb/NimbleReader.h`. Nothing about the factory is internal: it holds a `SelectiveNimbleReaderFactory`, reads one flag, and picks a reader. It was stuck in `fb/` by a single edge, namely that it constructs the batch reader, which does depend on internal-only code (`//dwio/api:velox-util`).

So the edge is inverted rather than the factory being kept hostage to it:

- `dwio/nimble/velox/reader/NimbleReaderFactory.{h,cpp}` is new, OSS-clean, and holds the factory, the dispatch, and the register/unregister pair.
- The batch branch now goes through `detail::createBatchReader()`, declared in that header and defined once per build flavour: `fb/NimbleReader.cpp` for Buck, `BatchReaderOSS.cpp` for CMake. This is the same ODR-based split already used for `detail::defaultMetadata()` (`VeloxWriterDefaultMetadataOSS.cpp`) and `detail::initHook()` (`SelectiveNimbleReaderInitHookOSS.cpp`).
- `fb/NimbleReader.h` is deleted. With the factory gone it declared nothing, since the batch `NimbleReader` and `NimbleRowReader` live in an anonymous namespace in the `.cpp`.
- `fb/` keeps what is genuinely internal: the batch reader, the Iceberg field-id projection helpers, and `FieldIdResolver`.

In the open-source build the hook returns nullptr and the factory raises a clear error naming the session property, rather than failing to link. That path is unreachable in practice: `FileConfig::kSelectiveNimbleReaderEnabledSession` and `QueryConfig::kSelectiveNimbleReaderEnabled` both default to true, so every engine-driven read already takes the selective branch.

The 28 `#include` sites move to the new header. They have to change in this commit rather than a follow-up, because deleting the old header breaks them immediately.

On the CMake side, `nimble_velox_reader_factory` is a new library and `add_subdirectory(reader)` is ordered after `selective`, which it links. The new `NimbleReaderFactory.h` is listed in the `add_library()` source list because velox's `check-header-ownership` pre-commit hook requires every OSS-exported `.h` to be named by some `CMakeLists.txt` target.

Behavior of the reader path is unchanged on both branches; this is placement and linkage only.

Note for reviewers -- one unrelated build fix is folded in, at #ranklake's target. `mrs/ranklake/table_service/src/storage/table:nimble_index_tablet` is one of the consumers of the moved header, and it did not build on trunk. The cause is unrelated to this refactor: `829e31d97d31` ("[velox]refactor: Add IO stats setters to ReaderOptions and use pool-only constructor", May 9 2026) removed the multi-argument `ReaderOptions` constructor, and `d78602ee9fb1` ("[velox] Refactor ReaderOptions IoStatistics from raw pointers to shared_ptr", May 15 2026) moved the stats to `shared_ptr`, but this call site was never ported and has been broken for roughly three months. Verified pre-existing: the failing statement is byte-identical on master. It went unnoticed because the target is orphaned -- `tablet_factory` wires up `json_tablet`, `sst_tablet` and `base_tablet` but not `nimble_index_tablet`, and `buck2 uquery "rdeps(fbcode//mrs/..., ...)"` returns nothing, so nothing depends on it and it has no tests.

The port is mechanical:

```
-  facebook::velox::io::IoStatistics dataIoStats;
-  facebook::velox::io::IoStatistics metadataIoStats;
-  facebook::velox::dwio::common::ReaderOptions readerOpts{
-      pool.get(), &dataIoStats, &metadataIoStats};
+  auto dataIoStats = std::make_shared<facebook::velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<facebook::velox::io::IoStatistics>();
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool.get()};
+  readerOpts.setDataIoStats(dataIoStats).setMetadataIoStats(metadataIoStats);
```

This also closes a latent dangling-pointer bug: the old form handed raw pointers to two stack locals into `readerOpts`, which feeds `nimbleReader_`, a member that outlives the function. The `shared_ptr` form keeps them alive, which is what the velox change was for.

Once the file compiled, CLANGTIDY could run on it for the first time and flagged a pre-existing `unused parameter 'blobData'` in the `mergeTabletBlobData` stub; that parameter name is now commented out. Verification there is compile-only, since the target has no tests and no dependents.

Reviewed By: xiaoxmeng

Differential Revision: D114807828


