### PR TITLE
refactor(nimble): Share writer randomization across fuzzers (#18678)

### DIFF
--- a/velox/dwio/nimble/fuzzer/encoding_selection/CMakeLists.txt
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/CMakeLists.txt
@@ -37,9 +37,22 @@ if(NOT TARGET gflags::gflags)
   endforeach()
 endif()
 
-# Built but deliberately not registered with add_test. These targets exist so the
-# fuzzer sources stay compiling; deciding what to run in CI, and with which
-# iteration counts, is a separate call.
+# The fuzzing targets below are built but deliberately not registered with
+# add_test. They keep the fuzzer sources compiling; deciding what to run in CI,
+# and with which iteration counts, is a separate call.
+add_library(
+  nimble_writer_config_randomizer
+  WriterConfigRandomizer.cpp
+  WriterConfigRandomizer.h
+)
+
+target_link_libraries(
+  nimble_writer_config_randomizer
+  nimble_writer
+  fmt::fmt
+  Folly::folly
+)
+
 add_library(
   nimble_writer_fuzzer_runner
   NimbleWriterFuzzer.cpp
@@ -60,12 +73,25 @@ target_link_libraries(
   nimble_velox_reader
   nimble_velox_selective
   nimble_writer
+  nimble_writer_config_randomizer
   velox_memory
   velox_vector_fuzzer
   gflags::gflags
   glog::glog
   Folly::folly
 )
+
+add_executable(writer_config_randomizer_test WriterConfigRandomizerTest.cpp)
+
+target_link_libraries(
+  writer_config_randomizer_test
+  nimble_random_encoding_selection_policy
+  nimble_writer_config_randomizer
+  nimble_writer
+  gtest_main
+  Folly::folly
+)
+add_test(writer_config_randomizer_test writer_config_randomizer_test)
 
 # Each of these defines its own main() through folly::Init, so they link gtest
 # without gtest_main.

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -51,6 +51,7 @@
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizer.h"
 #include "velox/dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
@@ -241,97 +242,6 @@ EncodingSelectionPolicyCreator gateFloatingPointStreams(
             compressionOptions}
             .createPolicy(dataType);
       };
-}
-
-CompressionType randomCompressionType(FuzzerGenerator& rng) {
-  static constexpr std::array<CompressionType, 5> kCompressionTypes = {
-      CompressionType::Uncompressed,
-      CompressionType::Zstd,
-      CompressionType::MetaInternal,
-      CompressionType::Lz4,
-      CompressionType::OpenZL,
-  };
-  return kCompressionTypes[folly::Random::rand32(
-      kCompressionTypes.size(), rng)];
-}
-
-// Applies the layout and experimental knobs the fuzzer is meant to cover. Kept
-// separate from encoding selection so a failure can be attributed to either the
-// requested encoding or the surrounding configuration.
-void randomizeWriterOptions(WriterOptions& options, FuzzerGenerator& rng) {
-  options.compressionOptions.compressionType = randomCompressionType(rng);
-  // Accept ratio in [0.5, 1.0]. A low floor keeps compression from being
-  // rejected so often that the compressed paths go unexercised.
-  options.compressionOptions.compressionAcceptRatio =
-      0.5f + 0.5f * static_cast<float>(folly::Random::randDouble01(rng));
-  options.compressionOptions.zstdCompressionLevel =
-      1 + folly::Random::rand32(9, rng);
-  options.compressionOptions.internalCompressionLevel =
-      1 + folly::Random::rand32(9, rng);
-  // Compress even tiny streams; the production minimums would skip nearly
-  // everything the fuzzer writes.
-  options.compressionOptions.zstdMinCompressionSize = 0;
-  options.compressionOptions.lz4MinCompressionSize = 0;
-  options.compressionOptions.internalMinCompressionSize = 0;
-  options.compressionOptions.openzlMinCompressionSize = 0;
-
-  options.enableChunking = !folly::Random::oneIn(4, rng);
-  options.minStreamChunkRawSize = folly::Random::oneIn(2, rng)
-      ? 0
-      : (uint64_t{1} << folly::Random::rand32(14, rng));
-  options.maxStreamChunkRawSize = uint64_t{1}
-      << (10 + folly::Random::rand32(12, rng));
-  options.enableChunkIndex =
-      options.enableChunking && folly::Random::oneIn(2, rng);
-  options.enableStreamDeduplication = folly::Random::oneIn(2, rng);
-  options.fixedBitWidthUseExactBits = folly::Random::oneIn(2, rng);
-  options.allowNestedAlpSelection = folly::Random::oneIn(2, rng);
-  // Ratios above 1.0 keep FSST even when it does not shrink the data, so the
-  // encoding is actually exercised instead of rejected on size.
-  options.fsstCompressionTargetRatio =
-      0.2 + 1.0 * folly::Random::randDouble01(rng);
-  options.blockBitPackingBlockSize =
-      static_cast<uint16_t>(1 << (5 + folly::Random::rand32(6, rng)));
-
-  // Three flush regimes: a small size-based threshold, a chunk on every batch,
-  // and seeded probabilistic chunking plus stripe cutting. These only take
-  // effect because writeFile passes flushAfterWrite=false; with the helper's
-  // default the writer would cut a stripe per batch and shouldFlush would
-  // never be consulted. The lambda policies need an rng that outlives them,
-  // because VeloxWriter rebuilds the policy on every write().
-  switch (folly::Random::rand32(3, rng)) {
-    case 1:
-      options.flushPolicyFactory = []() {
-        return std::make_unique<LambdaFlushPolicy>(
-            [](const StripeProgress&) { return false; },
-            [](const StripeProgress&) { return true; });
-      };
-      break;
-    case 2: {
-      auto policyRng =
-          std::make_shared<std::mt19937_64>(folly::Random::rand64(rng));
-      options.flushPolicyFactory = [policyRng]() {
-        return std::make_unique<LambdaFlushPolicy>(
-            [policyRng](const StripeProgress&) {
-              return folly::Random::oneIn(20, *policyRng);
-            },
-            [policyRng](const StripeProgress&) {
-              return folly::Random::oneIn(3, *policyRng);
-            });
-      };
-      break;
-    }
-    default: {
-      // A threshold small enough that the fuzzer's modest batches actually
-      // cross it, so this regime produces multi-stripe files.
-      const uint64_t stripeRawSize = uint64_t{1}
-          << (12 + folly::Random::rand32(8, rng));
-      options.flushPolicyFactory = [stripeRawSize]() {
-        return std::make_unique<StripeRawSizeFlushPolicy>(stripeRawSize);
-      };
-      break;
-    }
-  }
 }
 
 uint64_t totalRows(const std::vector<VectorPtr>& batches) {
@@ -951,10 +861,13 @@ std::string NimbleWriterFuzzer::writeFile(
     const std::vector<VectorPtr>& batches,
     std::optional<EncodingType> encodingType,
     uint64_t iterationSeed) {
-  FuzzerGenerator rng(iterationSeed);
   WriterOptions writerOptions;
+  std::optional<RandomizedWriterConfig> randomizedConfig;
   if (options_.randomizeWriterConfig) {
-    randomizeWriterOptions(writerOptions, rng);
+    randomizedConfig = randomizeWriterConfig(iterationSeed);
+    randomizedConfig->applyTo(writerOptions);
+    randomizedConfig->applyEncodingSelectionTo(writerOptions, encodingType);
+    VLOG(1) << "Writer config: " << randomizedConfig->debugString();
   }
 
   // Build the policy through the config-string parser rather than constructing
@@ -962,19 +875,24 @@ std::string NimbleWriterFuzzer::writeFile(
   // covered too. Every candidate encoding is accepted by that parser, which
   // validates against
   // ManualEncodingSelectionPolicyFactory::possibleEncodings().
-  const auto selectionConfig = encodingType.has_value()
-      ? fmt::format(
-            "type:random,seed:{},encodings:{}",
-            iterationSeed,
-            toString(*encodingType))
-      : fmt::format("type:random,seed:{}", iterationSeed);
-  auto parsedCreator = createEncodingSelectionPolicyFactory(
-      selectionConfig, writerOptions.compressionOptions);
-  NIMBLE_CHECK(
-      parsedCreator.has_value(),
-      "Encoding selection config produced no policy creator for '{}'.",
-      selectionConfig);
-  EncodingSelectionPolicyCreator policyCreator = std::move(*parsedCreator);
+  EncodingSelectionPolicyCreator policyCreator;
+  if (randomizedConfig.has_value()) {
+    policyCreator = std::move(writerOptions.encodingSelectionPolicyCreator);
+  } else {
+    const auto selectionConfig = encodingType.has_value()
+        ? fmt::format(
+              "type:random,seed:{},encodings:{}",
+              iterationSeed,
+              toString(*encodingType))
+        : fmt::format("type:random,seed:{}", iterationSeed);
+    auto parsedCreator = createEncodingSelectionPolicyFactory(
+        selectionConfig, writerOptions.compressionOptions);
+    NIMBLE_CHECK(
+        parsedCreator.has_value(),
+        "Encoding selection config produced no policy creator for '{}'.",
+        selectionConfig);
+    policyCreator = std::move(*parsedCreator);
+  }
 
   // The write-side gate admits floating point directly for SimdForBitpack and
   // Huffman. A Nullable float's nested policy can also admit DeltaBlock after

--- a/velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizer.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizer.h"
+
+#include <algorithm>
+#include <random>
+#include <string_view>
+
+#include <fmt/format.h>
+#include <folly/Random.h>
+#include <folly/hash/Hash.h>
+
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/velox/NimbleConfig.h"
+#include "velox/dwio/nimble/writer/EncodingSelectionPolicyFactory.h"
+#include "velox/dwio/nimble/writer/FlushPolicy.h"
+#include "velox/dwio/nimble/writer/FlushPolicyFactory.h"
+#include "velox/dwio/nimble/writer/WriterOptions.h"
+
+namespace facebook::nimble::fuzzer {
+namespace {
+
+std::mt19937_64 makeGenerator(uint64_t seed, std::string_view domain) {
+  return std::mt19937_64{folly::hash::hash_combine(seed, domain)};
+}
+
+std::string boolString(bool value) {
+  return value ? "true" : "false";
+}
+
+std::string flushModeName(FuzzedFlushMode mode) {
+  switch (mode) {
+    case FuzzedFlushMode::kRawSize:
+      return "raw_size";
+    case FuzzedFlushMode::kPerBatch:
+      return "per_batch";
+    case FuzzedFlushMode::kRandom:
+      return "random";
+  }
+  NIMBLE_UNREACHABLE("Unknown fuzzed flush mode.");
+}
+
+} // namespace
+
+void RandomizedWriterConfig::applyTo(WriterOptions& options) const {
+  options.compressionOptions.compressionAcceptRatio = compressionAcceptRatio;
+  options.compressionOptions.zstdMinCompressionSize = zstdMinCompressionSize;
+  options.compressionOptions.internalMinCompressionSize =
+      internalMinCompressionSize;
+  options.compressionOptions.internalCompressionLevel =
+      internalCompressionLevel;
+
+  options.enableChunking = enableChunking;
+  options.minStreamChunkRawSize = minStreamChunkRawSize;
+  options.maxStreamChunkRawSize = maxStreamChunkRawSize;
+  options.wideSchemaMaxStreamChunkRawSize = wideSchemaMaxStreamChunkRawSize;
+  options.enableChunkIndex = enableChunkIndex;
+  options.enableStreamDeduplication = enableStreamDeduplication;
+
+  options.blockBitPackingBlockSize = blockBitPackingBlockSize;
+
+  switch (flushMode) {
+    case FuzzedFlushMode::kRawSize:
+      options.flushPolicyFactory = [rawSize = stripeRawSize]() {
+        return std::make_unique<StripeRawSizeFlushPolicy>(rawSize);
+      };
+      break;
+    case FuzzedFlushMode::kPerBatch: {
+      TestFlushPolicy::Options flushOptions;
+      flushOptions.seed = flushSeed;
+      flushOptions.flushChunkProbability = 1.0;
+      flushOptions.flushStripeProbability = 0.0;
+      options.flushPolicyFactory = TestFlushPolicyFactory{flushOptions};
+    } break;
+    case FuzzedFlushMode::kRandom:
+      options.flushPolicyFactory =
+          TestFlushPolicyFactory{TestFlushPolicy::Options{.seed = flushSeed}};
+      break;
+  }
+}
+
+void RandomizedWriterConfig::applyEncodingSelectionTo(
+    WriterOptions& options,
+    std::optional<EncodingType> forcedEncoding) const {
+  if (!encodingSelectionSeed.has_value()) {
+    return;
+  }
+  auto creator = createEncodingSelectionPolicyFactory(
+      encodingSelectionConfig(forcedEncoding), options.compressionOptions);
+  NIMBLE_CHECK(
+      creator.has_value(),
+      "Encoding selection config produced no policy creator for writer config seed {}.",
+      seed);
+  options.encodingSelectionPolicyCreator = std::move(*creator);
+}
+
+std::unordered_map<std::string, std::string>
+RandomizedWriterConfig::toSerdeParams() const {
+  std::unordered_map<std::string, std::string> params{
+      {std::string(Config::ENCODING_SELECTION_COMPRESSION_ACCEPT_RATIO.key),
+       fmt::format("{:.9g}", compressionAcceptRatio)},
+      {std::string(Config::ZSTD_COMPRESSION_MIN_SIZE.key),
+       fmt::format("{}", zstdMinCompressionSize)},
+      {std::string(Config::ZSTRONG_COMPRESSION_MIN_SIZE.key),
+       fmt::format("{}", internalMinCompressionSize)},
+      {std::string(Config::ZSTRONG_COMPRESSION_LEVEL.key),
+       fmt::format("{}", internalCompressionLevel)},
+      {std::string(Config::ENABLE_CHUNKING.key), boolString(enableChunking)},
+      {std::string(Config::CHUNKING_WRITER_MIN_CHUNK_SIZE.key),
+       fmt::format("{}", minStreamChunkRawSize)},
+      {std::string(Config::CHUNKING_WRITER_MAX_CHUNK_SIZE.key),
+       fmt::format("{}", maxStreamChunkRawSize)},
+      {std::string(Config::CHUNKING_WRITER_WIDE_SCHEMA_MAX_CHUNK_SIZE.key),
+       fmt::format("{}", wideSchemaMaxStreamChunkRawSize)},
+      {std::string(Config::ENABLE_CHUNK_INDEX.key),
+       boolString(enableChunkIndex)},
+      {std::string(Config::ENABLE_STREAM_DEDUPLICATION.key),
+       boolString(enableStreamDeduplication)},
+      {std::string(Config::BLOCK_BIT_PACKING_BLOCK_SIZE.key),
+       fmt::format("{}", blockBitPackingBlockSize)},
+  };
+
+  switch (flushMode) {
+    case FuzzedFlushMode::kRawSize:
+      params.emplace(
+          std::string(Config::RAW_STRIPE_SIZE.key),
+          fmt::format("{}", stripeRawSize));
+      break;
+    case FuzzedFlushMode::kPerBatch:
+      params.emplace(
+          std::string(Config::FLUSH_POLICY_CONFIG.key),
+          fmt::format(
+              "type:test_per_batch,seed:{},flush_stripe_probability:0",
+              flushSeed));
+      break;
+    case FuzzedFlushMode::kRandom:
+      params.emplace(
+          std::string(Config::FLUSH_POLICY_CONFIG.key),
+          fmt::format("type:test_random,seed:{}", flushSeed));
+      break;
+  }
+
+  if (encodingSelectionSeed.has_value()) {
+    params.emplace(
+        std::string(Config::ENCODING_SELECTION_CONFIG.key),
+        encodingSelectionConfig());
+  }
+  return params;
+}
+
+std::string RandomizedWriterConfig::encodingSelectionConfig(
+    std::optional<EncodingType> forcedEncoding) const {
+  NIMBLE_CHECK(
+      encodingSelectionSeed.has_value(),
+      "Random encoding selection is disabled for writer config seed {}.",
+      seed);
+  if (forcedEncoding.has_value()) {
+    return fmt::format(
+        "type:random,seed:{},encodings:{}",
+        *encodingSelectionSeed,
+        toString(*forcedEncoding));
+  }
+  return fmt::format("type:random,seed:{}", *encodingSelectionSeed);
+}
+
+std::string RandomizedWriterConfig::debugString() const {
+  return fmt::format(
+      "version={},seed={},compression={{acceptRatio:{:.9g},internalLevel:{}}},chunking={{enabled:{},min:{},max:{},wideMax:{},index:{},dedup:{}}},encoding={{blockSize:{},selectionSeed:{}}},flush={{mode:{},rawSize:{},seed:{}}}",
+      version,
+      seed,
+      compressionAcceptRatio,
+      internalCompressionLevel,
+      enableChunking,
+      minStreamChunkRawSize,
+      maxStreamChunkRawSize,
+      wideSchemaMaxStreamChunkRawSize,
+      enableChunkIndex,
+      enableStreamDeduplication,
+      blockBitPackingBlockSize,
+      encodingSelectionSeed.has_value()
+          ? fmt::format("{}", *encodingSelectionSeed)
+          : "manual",
+      flushModeName(flushMode),
+      stripeRawSize,
+      flushSeed);
+}
+
+RandomizedWriterConfig randomizeWriterConfig(
+    uint64_t seed,
+    WriterConfigRandomizationOptions options) {
+  RandomizedWriterConfig config;
+  config.seed = seed;
+
+  auto compressionGenerator = makeGenerator(seed, "compression");
+  config.compressionAcceptRatio = 0.5f +
+      0.5f *
+          static_cast<float>(folly::Random::randDouble01(compressionGenerator));
+  config.internalCompressionLevel =
+      1 + folly::Random::rand32(9, compressionGenerator);
+
+  auto chunkingGenerator = makeGenerator(seed, "chunking");
+  config.flushMode =
+      static_cast<FuzzedFlushMode>(folly::Random::rand32(3, chunkingGenerator));
+  if (config.flushMode == FuzzedFlushMode::kRawSize) {
+    config.enableChunking = false;
+  } else if (config.flushMode == FuzzedFlushMode::kPerBatch) {
+    config.enableChunking = true;
+  } else {
+    config.enableChunking = !folly::Random::oneIn(4, chunkingGenerator);
+  }
+  const uint32_t maxChunkExponent =
+      10 + folly::Random::rand32(12, chunkingGenerator);
+  config.maxStreamChunkRawSize = uint64_t{1} << maxChunkExponent;
+  config.wideSchemaMaxStreamChunkRawSize = config.maxStreamChunkRawSize;
+  config.minStreamChunkRawSize = folly::Random::oneIn(2, chunkingGenerator)
+      ? 0
+      : uint64_t{1} << folly::Random::rand32(
+            std::min<uint32_t>(14, maxChunkExponent), chunkingGenerator);
+  config.enableChunkIndex = folly::Random::oneIn(2, chunkingGenerator);
+  if (!config.enableChunking) {
+    config.enableChunkIndex = false;
+  }
+  config.enableStreamDeduplication = folly::Random::oneIn(2, chunkingGenerator);
+
+  auto encodingGenerator = makeGenerator(seed, "encoding");
+  config.blockBitPackingBlockSize = static_cast<uint16_t>(
+      uint16_t{1} << (5 + folly::Random::rand32(6, encodingGenerator)));
+  if (options.randomEncodingSelectionOneIn != 0 &&
+      (options.randomEncodingSelectionOneIn == 1 ||
+       folly::Random::oneIn(
+           options.randomEncodingSelectionOneIn, encodingGenerator))) {
+    config.encodingSelectionSeed = folly::Random::rand64(encodingGenerator);
+  }
+
+  auto flushGenerator = makeGenerator(seed, "flush");
+  config.flushSeed = folly::Random::rand64(flushGenerator);
+  if (config.flushMode == FuzzedFlushMode::kRawSize) {
+    config.stripeRawSize = uint64_t{1}
+        << (12 + folly::Random::rand32(8, flushGenerator));
+  }
+
+  return config;
+}
+
+} // namespace facebook::nimble::fuzzer

--- a/velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizer.h
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizer.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "velox/dwio/nimble/common/Types.h"
+
+namespace facebook::nimble {
+struct WriterOptions;
+}
+
+namespace facebook::nimble::fuzzer {
+
+/// Flush regimes exercised by the shared writer configuration randomizer.
+enum class FuzzedFlushMode {
+  kRawSize,
+  kPerBatch,
+  kRandom,
+};
+
+/// Controls random encoding-selection frequency for each fuzzer user.
+struct WriterConfigRandomizationOptions {
+  /// One-in-N probability of installing random encoding selection. Zero
+  /// disables it; one always installs it.
+  uint32_t randomEncodingSelectionOneIn{1};
+};
+
+/// Reproducible, serializable writer settings shared by Nimble fuzzers.
+struct RandomizedWriterConfig {
+  /// Distribution version. Increment when a seed maps to different settings.
+  uint32_t version{2};
+
+  /// Root seed from which domain-separated draws are derived.
+  uint64_t seed{0};
+
+  /// Maximum accepted compressed-to-uncompressed size ratio.
+  float compressionAcceptRatio{1.0};
+
+  /// Minimum sizes at which shared compression codecs are attempted.
+  uint64_t zstdMinCompressionSize{0};
+  uint64_t internalMinCompressionSize{0};
+
+  /// MetaInternal compression level.
+  uint32_t internalCompressionLevel{1};
+
+  /// Chunking enablement and raw-size thresholds.
+  bool enableChunking{true};
+  uint64_t minStreamChunkRawSize{0};
+  uint64_t maxStreamChunkRawSize{1'024};
+  uint64_t wideSchemaMaxStreamChunkRawSize{1'024};
+
+  /// Optional file-layout features.
+  bool enableChunkIndex{false};
+  bool enableStreamDeduplication{false};
+
+  /// Encoding-selection tuning exposed through serde.
+  uint16_t blockBitPackingBlockSize{32};
+
+  /// Flush regime and its reproducible parameters.
+  FuzzedFlushMode flushMode{FuzzedFlushMode::kRawSize};
+  uint64_t stripeRawSize{4'096};
+  uint64_t flushSeed{0};
+
+  /// Seed for random encoding selection; absent keeps manual selection.
+  std::optional<uint64_t> encodingSelectionSeed;
+
+  bool operator==(const RandomizedWriterConfig&) const = default;
+
+  /// Applies scalar and flush settings directly to the low-level writer
+  /// options. Apply encoding selection after any direct-only compression
+  /// overrides so the policy captures the final compression options.
+  void applyTo(WriterOptions& options) const;
+
+  /// Applies random encoding selection to the low-level writer options when
+  /// enabled, optionally restricting the policy to one encoding.
+  void applyEncodingSelectionTo(
+      WriterOptions& options,
+      std::optional<EncodingType> forcedEncoding = std::nullopt) const;
+
+  /// Serializes this configuration for TableEvolution's serde parameter hook.
+  std::unordered_map<std::string, std::string> toSerdeParams() const;
+
+  /// Returns the random-policy string, optionally restricted to one encoding.
+  std::string encodingSelectionConfig(
+      std::optional<EncodingType> forcedEncoding = std::nullopt) const;
+
+  /// Returns a stable, ordered representation suitable for failure logs.
+  std::string debugString() const;
+};
+
+/// Generates a writer configuration solely from 'seed' and 'options'.
+RandomizedWriterConfig randomizeWriterConfig(
+    uint64_t seed,
+    WriterConfigRandomizationOptions options = {});
+
+} // namespace facebook::nimble::fuzzer

--- a/velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizerTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizerTest.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/fuzzer/encoding_selection/WriterConfigRandomizer.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/velox/NimbleConfig.h"
+#include "velox/dwio/nimble/writer/FlushPolicy.h"
+#include "velox/dwio/nimble/writer/WriterOptions.h"
+
+namespace facebook::nimble::fuzzer {
+namespace {
+
+bool isPowerOfTwo(uint64_t value) {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+TEST(WriterConfigRandomizerTest, deterministicAndValid) {
+  EXPECT_EQ(randomizeWriterConfig(123), randomizeWriterConfig(123));
+
+  for (uint64_t seed = 0; seed < 1'000; ++seed) {
+    const auto config = randomizeWriterConfig(seed);
+    EXPECT_GE(config.compressionAcceptRatio, 0.5);
+    EXPECT_LT(config.compressionAcceptRatio, 1.0);
+    EXPECT_GE(config.internalCompressionLevel, 1);
+    EXPECT_LE(config.internalCompressionLevel, 9);
+    EXPECT_TRUE(
+        config.minStreamChunkRawSize == 0 ||
+        isPowerOfTwo(config.minStreamChunkRawSize));
+    EXPECT_LT(config.minStreamChunkRawSize, config.maxStreamChunkRawSize);
+    EXPECT_TRUE(isPowerOfTwo(config.maxStreamChunkRawSize));
+    EXPECT_GE(config.maxStreamChunkRawSize, uint64_t{1} << 10);
+    EXPECT_LE(config.maxStreamChunkRawSize, uint64_t{1} << 21);
+    EXPECT_EQ(
+        config.maxStreamChunkRawSize, config.wideSchemaMaxStreamChunkRawSize);
+    EXPECT_FALSE(
+        config.flushMode == FuzzedFlushMode::kRawSize && config.enableChunking);
+    EXPECT_FALSE(config.enableChunkIndex && !config.enableChunking);
+    if (config.flushMode == FuzzedFlushMode::kPerBatch) {
+      EXPECT_TRUE(config.enableChunking);
+    }
+    EXPECT_TRUE(isPowerOfTwo(config.blockBitPackingBlockSize));
+    EXPECT_GE(config.blockBitPackingBlockSize, 32);
+    EXPECT_LE(config.blockBitPackingBlockSize, 1024);
+    EXPECT_TRUE(config.encodingSelectionSeed.has_value());
+  }
+}
+
+TEST(WriterConfigRandomizerTest, encodingSelectionFrequency) {
+  bool observedRandomSelection = false;
+  bool observedManualSelection = false;
+  for (uint64_t seed = 0; seed < 100; ++seed) {
+    const auto config =
+        randomizeWriterConfig(seed, {.randomEncodingSelectionOneIn = 2});
+    observedRandomSelection |= config.encodingSelectionSeed.has_value();
+    observedManualSelection |= !config.encodingSelectionSeed.has_value();
+  }
+  EXPECT_TRUE(observedRandomSelection);
+  EXPECT_TRUE(observedManualSelection);
+
+  const auto withoutRandomSelection =
+      randomizeWriterConfig(123, {.randomEncodingSelectionOneIn = 0});
+  EXPECT_FALSE(withoutRandomSelection.encodingSelectionSeed.has_value());
+}
+
+TEST(WriterConfigRandomizerTest, fixedSeedIsStable) {
+  const auto config =
+      randomizeWriterConfig(123, {.randomEncodingSelectionOneIn = 2});
+  EXPECT_EQ(config.version, 2);
+  EXPECT_EQ(
+      config.debugString(),
+      "version=2,seed=123,compression={acceptRatio:0.80707252,internalLevel:3},chunking={enabled:true,min:2048,max:4096,wideMax:4096,index:true,dedup:false},encoding={blockSize:256,selectionSeed:manual},flush={mode:per_batch,rawSize:4096,seed:2122292633536747636}");
+}
+
+TEST(WriterConfigRandomizerTest, appliesScalarOptions) {
+  const auto config = randomizeWriterConfig(456);
+  WriterOptions options;
+  config.applyTo(options);
+  config.applyEncodingSelectionTo(options);
+
+  EXPECT_FLOAT_EQ(
+      options.compressionOptions.compressionAcceptRatio,
+      config.compressionAcceptRatio);
+  EXPECT_EQ(options.enableChunking, config.enableChunking);
+  EXPECT_EQ(options.minStreamChunkRawSize, config.minStreamChunkRawSize);
+  EXPECT_EQ(options.maxStreamChunkRawSize, config.maxStreamChunkRawSize);
+  EXPECT_EQ(
+      options.wideSchemaMaxStreamChunkRawSize,
+      config.wideSchemaMaxStreamChunkRawSize);
+  EXPECT_EQ(options.enableChunkIndex, config.enableChunkIndex);
+  EXPECT_EQ(
+      options.enableStreamDeduplication, config.enableStreamDeduplication);
+  EXPECT_EQ(options.blockBitPackingBlockSize, config.blockBitPackingBlockSize);
+  auto policy =
+      options.encodingSelectionPolicyCreator(TypeTraits<int32_t>::dataType);
+  EXPECT_NE(
+      dynamic_cast<testing::RandomEncodingSelectionPolicy<int32_t>*>(
+          policy.get()),
+      nullptr);
+}
+
+TEST(WriterConfigRandomizerTest, serializesEveryOption) {
+  const auto config = randomizeWriterConfig(789);
+  const auto params = config.toSerdeParams();
+
+  EXPECT_TRUE(params.contains(std::string(Config::ENABLE_CHUNKING.key)));
+  EXPECT_TRUE(params.contains(std::string(Config::ENABLE_CHUNK_INDEX.key)));
+  EXPECT_TRUE(
+      params.contains(std::string(Config::ENABLE_STREAM_DEDUPLICATION.key)));
+  EXPECT_TRUE(
+      params.contains(std::string(Config::FLUSH_POLICY_CONFIG.key)) ||
+      params.contains(std::string(Config::RAW_STRIPE_SIZE.key)));
+  EXPECT_EQ(
+      params.at(std::string(Config::ENCODING_SELECTION_CONFIG.key)),
+      config.encodingSelectionConfig());
+}
+
+TEST(WriterConfigRandomizerTest, installsEveryFlushMode) {
+  auto config = randomizeWriterConfig(999);
+  WriterOptions options;
+
+  config.flushMode = FuzzedFlushMode::kRawSize;
+  config.stripeRawSize = 4'096;
+  config.applyTo(options);
+  auto policy = options.flushPolicyFactory();
+  if (policy == nullptr) {
+    FAIL() << "Raw-size flush factory returned null";
+  }
+  EXPECT_NE(dynamic_cast<StripeRawSizeFlushPolicy*>(policy.get()), nullptr);
+  EXPECT_FALSE(policy->shouldFlush({4'095, 0, 0}));
+  EXPECT_TRUE(policy->shouldFlush({4'096, 0, 0}));
+
+  config.flushMode = FuzzedFlushMode::kPerBatch;
+  config.applyTo(options);
+  policy = options.flushPolicyFactory();
+  if (policy == nullptr) {
+    FAIL() << "Per-batch flush factory returned null";
+  }
+  EXPECT_NE(dynamic_cast<TestFlushPolicy*>(policy.get()), nullptr);
+  EXPECT_TRUE(policy->shouldChunk({0, 0, 0}));
+
+  config.flushMode = FuzzedFlushMode::kRandom;
+  config.applyTo(options);
+  policy = options.flushPolicyFactory();
+  if (policy == nullptr) {
+    FAIL() << "Random flush factory returned null";
+  }
+  EXPECT_NE(dynamic_cast<TestFlushPolicy*>(policy.get()), nullptr);
+}
+
+} // namespace
+} // namespace facebook::nimble::fuzzer


### PR DESCRIPTION
Summary:

NimbleWriterFuzzer and TableEvolutionFuzzer currently maintain separate writer-option randomization. This makes their physical file coverage drift and makes failures harder to reproduce consistently.

Introduce one seed-based writer configuration for the serde-exposed writer settings, with adapters for direct WriterOptions and serde parameters. Both fuzzers now use the same reproducible distribution for this shared configuration surface; writer options without serde equivalents remain at their defaults.

Reviewed By: HuamengJiang

Differential Revision: D116913256


