### PR TITLE
fix: Avoid null dereference in Parquet StructColumnReader

### DIFF
--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -516,6 +516,13 @@ int64_t ColumnChunkMetaDataPtr::totalUncompressedSize() const {
            ->total_uncompressed_size());
 }
 
+uint64_t ColumnChunkMetaDataPtr::readSize() const {
+  return static_cast<uint64_t>(
+      compression() == common::CompressionKind::CompressionKind_NONE
+          ? totalUncompressedSize()
+          : totalCompressedSize());
+}
+
 FOLLY_ALWAYS_INLINE const thrift::RowGroup* thriftRowGroupPtr(
     const void* metadata) {
   return reinterpret_cast<const thrift::RowGroup*>(metadata);

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -95,6 +95,10 @@ class ColumnChunkMetaDataPtr {
   /// This information is optional and may be 0 if omitted.
   int64_t totalUncompressedSize() const;
 
+  /// Number of bytes read for this chunk. Uncompressed chunks use their
+  /// uncompressed size; compressed chunks use their compressed size.
+  uint64_t readSize() const;
+
   /// Returns the estimated total bytes held by this column's thrift
   /// representation: sizeof(thrift::ColumnChunk) plus every dynamically
   /// allocated vector and string reachable through it. The estimate

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -123,13 +123,8 @@ void ParquetData::enqueueRowGroup(
     chunkReadOffset = chunk.dictionaryPageOffset();
   }
 
-  uint64_t readSize =
-      (chunk.compression() == common::CompressionKind::CompressionKind_NONE)
-      ? chunk.totalUncompressedSize()
-      : chunk.totalCompressedSize();
-
   auto id = dwio::common::StreamIdentifier(type_->column());
-  streams_[index] = input.enqueue({chunkReadOffset, readSize}, &id);
+  streams_[index] = input.enqueue({chunkReadOffset, chunk.readSize()}, &id);
 }
 
 dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -50,6 +50,10 @@ class ParquetParams : public dwio::common::FormatParams {
     return timestampPrecision_;
   }
 
+  const FileMetaDataPtr& fileMetaData() const {
+    return metaData_;
+  }
+
  private:
   const FileMetaDataPtr metaData_;
   const tz::TimeZone* sessionTimezone_;

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -27,75 +27,91 @@ PageReader* readLeafRepDefs(
     dwio::common::SelectiveColumnReader* reader,
     int32_t numTop,
     bool mustRead) {
-  auto children = reader->children();
+  const auto& children = reader->children();
+  const auto kind = reader->fileType().type()->kind();
+  PageReader* pageReader = nullptr;
+  if (kind == TypeKind::ROW) {
+    auto* structReader = static_cast<StructColumnReader*>(reader);
+    // A struct can have no logical children and use a separate physical leaf
+    // solely as its rep/def source.
+    auto* repDefSourceReader = structReader->repDefSourceReader();
+    pageReader = readLeafRepDefs(repDefSourceReader, numTop, true);
+    structReader->setNullsFromRepDefs(*pageReader);
+    for (auto* child : children) {
+      if (child != repDefSourceReader) {
+        readLeafRepDefs(child, numTop, false);
+      }
+    }
+    return pageReader;
+  }
   if (children.empty()) {
     if (!mustRead) {
       return nullptr;
     }
-    auto pageReader = reader->formatData().as<ParquetData>().reader();
-    pageReader->decodeRepDefs(numTop);
-    return pageReader;
+    auto* leafPageReader = reader->formatData().as<ParquetData>().reader();
+    leafPageReader->decodeRepDefs(numTop);
+    return leafPageReader;
   }
-  PageReader* pageReader = nullptr;
-  auto& type = *reinterpret_cast<const ParquetTypeWithId*>(&reader->fileType());
-  if (type.type()->kind() == TypeKind::ARRAY) {
+  if (kind == TypeKind::ARRAY) {
     pageReader = readLeafRepDefs(children[0], numTop, true);
-    auto list = dynamic_cast<ListColumnReader*>(reader);
-    assert(list);
+    auto* list = static_cast<ListColumnReader*>(reader);
     list->setLengthsFromRepDefs(*pageReader);
     return pageReader;
   }
-  if (type.type()->kind() == TypeKind::MAP) {
+  if (kind == TypeKind::MAP) {
     pageReader = readLeafRepDefs(children[0], numTop, true);
     readLeafRepDefs(children[1], numTop, false);
-    auto map = dynamic_cast<MapColumnReader*>(reader);
-    assert(map);
+    auto* map = static_cast<MapColumnReader*>(reader);
     map->setLengthsFromRepDefs(*pageReader);
     return pageReader;
-  }
-  if (auto structReader = dynamic_cast<StructColumnReader*>(reader)) {
-    pageReader = readLeafRepDefs(structReader->childForRepDefs(), numTop, true);
-    assert(pageReader);
-    structReader->setNullsFromRepDefs(*pageReader);
-    for (auto i = 0; i < children.size(); ++i) {
-      auto child = children[i];
-      if (child != structReader->childForRepDefs()) {
-        readLeafRepDefs(child, numTop, false);
-      }
-    }
   }
   return pageReader;
 }
 
 void skipUnreadLengthsAndNulls(dwio::common::SelectiveColumnReader& reader) {
-  auto children = reader.children();
+  // A struct can have no logical children but still hold preset nulls decoded
+  // from its synthetic rep/def source. Advance these nulls before the empty-
+  // children check below.
+  const auto kind = reader.fileType().type()->kind();
+  if (kind == TypeKind::ROW) {
+    static_cast<StructColumnReader*>(&reader)->seekToEndOfPresetNulls();
+    return;
+  }
+  const auto& children = reader.children();
   if (children.empty()) {
     return;
   }
-  if (reader.fileType().type()->kind() == TypeKind::ARRAY) {
-    reinterpret_cast<ListColumnReader*>(&reader)->skipUnreadLengths();
-  } else if (reader.fileType().type()->kind() == TypeKind::ROW) {
-    reinterpret_cast<StructColumnReader*>(&reader)->seekToEndOfPresetNulls();
-  } else if (reader.fileType().type()->kind() == TypeKind::MAP) {
-    reinterpret_cast<MapColumnReader*>(&reader)->skipUnreadLengths();
+  if (kind == TypeKind::ARRAY) {
+    static_cast<ListColumnReader*>(&reader)->skipUnreadLengths();
+  } else if (kind == TypeKind::MAP) {
+    static_cast<MapColumnReader*>(&reader)->skipUnreadLengths();
   } else {
     VELOX_UNREACHABLE();
   }
 }
 
-void enqueueChildren(
-    dwio::common::SelectiveColumnReader* reader,
+} // namespace
+
+void enqueueRowGroupRecursive(
+    dwio::common::SelectiveColumnReader& reader,
     uint32_t index,
     dwio::common::BufferedInput& input) {
-  auto children = reader->children();
+  const auto& children = reader.children();
   if (children.empty()) {
-    return reader->formatData().as<ParquetData>().enqueueRowGroup(index, input);
+    if (reader.fileType().type()->kind() == TypeKind::ROW) {
+      auto* structReader = static_cast<StructColumnReader*>(&reader);
+      // Only the root struct has no rep/def source.
+      if (auto* repDefSourceReader = structReader->repDefSourceReader()) {
+        enqueueRowGroupRecursive(*repDefSourceReader, index, input);
+      }
+      return;
+    }
+    return reader.formatData().as<ParquetData>().enqueueRowGroup(index, input);
   }
   for (auto* child : children) {
-    enqueueChildren(child, index, input);
+    enqueueRowGroupRecursive(*child, index, input);
   }
 }
-} // namespace
 
 void prepareRepDefsAndOffset(
     dwio::common::SelectiveColumnReader& reader,
@@ -156,7 +172,7 @@ MapColumnReader::MapColumnReader(
 void MapColumnReader::enqueueRowGroup(
     uint32_t index,
     dwio::common::BufferedInput& input) {
-  enqueueChildren(this, index, input);
+  enqueueRowGroupRecursive(*this, index, input);
 }
 
 void MapColumnReader::seekToRowGroup(int64_t index) {
@@ -256,7 +272,7 @@ ListColumnReader::ListColumnReader(
 void ListColumnReader::enqueueRowGroup(
     uint32_t index,
     dwio::common::BufferedInput& input) {
-  enqueueChildren(this, index, input);
+  enqueueRowGroupRecursive(*this, index, input);
 }
 
 void ListColumnReader::seekToRowGroup(int64_t index) {

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -22,6 +22,13 @@
 
 namespace facebook::velox::parquet {
 
+/// Enqueues row-group streams for a reader's logical descendants. For a struct
+/// without logical children, follows its synthetic rep/def source instead.
+void enqueueRowGroupRecursive(
+    dwio::common::SelectiveColumnReader& reader,
+    uint32_t index,
+    dwio::common::BufferedInput& input);
+
 /// Comtainer for the lengths of a repeated reader where the lengths are
 /// pre-filled from repdefs.
 class RepeatedLengths {

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -16,8 +16,12 @@
 
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
 
+#include <optional>
+#include <tuple>
+
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/parquet/reader/ParquetColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetData.h"
 #include "velox/dwio/parquet/reader/RepeatedColumnReader.h"
 
 namespace facebook::velox::common {
@@ -25,6 +29,140 @@ class ScanSpec;
 }
 
 namespace facebook::velox::parquet {
+namespace {
+
+struct PhysicalLeafCost {
+  const ParquetTypeWithId* type;
+  bool hasCompleteMetadata{true};
+  uint64_t readBytes{0};
+  uint64_t uncompressedBytes{0};
+  uint64_t numValues{0};
+
+  bool operator<(const PhysicalLeafCost& other) const {
+    if (hasCompleteMetadata != other.hasCompleteMetadata) {
+      // Prefer a leaf with metadata for every non-empty row group. Partial
+      // metadata can underestimate its cost and may make the leaf unreadable.
+      return hasCompleteMetadata;
+    }
+    if (!hasCompleteMetadata) {
+      // Neither cost is reliable. Use schema order as a deterministic fallback.
+      return type->column() < other.type->column();
+    }
+    // Minimize bytes fetched first, then bytes decompressed and levels decoded.
+    // Use schema order to make costs deterministic.
+    return std::tuple{readBytes, uncompressedBytes, numValues, type->column()} <
+        std::tuple{
+            other.readBytes,
+            other.uncompressedBytes,
+            other.numValues,
+            other.type->column()};
+  }
+};
+
+PhysicalLeafCost physicalLeafCost(
+    const ParquetTypeWithId& type,
+    const FileMetaDataPtr& fileMetaData) {
+  PhysicalLeafCost cost{.type = &type};
+  // The source reader is fixed before row-group filtering. Use all non-empty
+  // row groups as a whole-file cost estimate; an individual split may have a
+  // different cheapest leaf for its subset of row groups.
+  for (auto i = 0; i < fileMetaData.numRowGroups(); ++i) {
+    auto rowGroup = fileMetaData.rowGroup(i);
+    if (rowGroup.numRows() == 0) {
+      continue;
+    }
+    if (type.column() >= static_cast<uint32_t>(rowGroup.numColumns())) {
+      cost.hasCompleteMetadata = false;
+      return cost;
+    }
+    auto chunk = rowGroup.columnChunk(type.column());
+    if (!chunk.hasMetadata()) {
+      cost.hasCompleteMetadata = false;
+      return cost;
+    }
+    const auto readSize = chunk.readSize();
+    if (readSize == 0) {
+      // Size metadata is optional. A non-empty row group cannot have a
+      // zero-byte column chunk, so zero means the read cost is unknown.
+      cost.hasCompleteMetadata = false;
+      return cost;
+    }
+    cost.readBytes += readSize;
+    cost.uncompressedBytes +=
+        static_cast<uint64_t>(chunk.totalUncompressedSize());
+    cost.numValues += static_cast<uint64_t>(chunk.numValues());
+  }
+  return cost;
+}
+
+std::optional<PhysicalLeafCost> findCheapestPhysicalLeafImpl(
+    const ParquetTypeWithId& type,
+    const FileMetaDataPtr& fileMetaData) {
+  if (type.getChildren().empty()) {
+    if (type.isLeaf()) {
+      return physicalLeafCost(type, fileMetaData);
+    }
+    return std::nullopt;
+  }
+
+  std::optional<PhysicalLeafCost> best;
+  for (auto i = 0; i < type.getChildren().size(); ++i) {
+    auto candidate =
+        findCheapestPhysicalLeafImpl(type.parquetChildAt(i), fileMetaData);
+    if (candidate && (!best || *candidate < *best)) {
+      best = std::move(candidate);
+    }
+  }
+  return best;
+}
+
+const ParquetTypeWithId& findCheapestPhysicalLeaf(
+    const ParquetTypeWithId& type,
+    const FileMetaDataPtr& fileMetaData) {
+  auto best = findCheapestPhysicalLeafImpl(type, fileMetaData);
+  VELOX_CHECK(
+      best.has_value(),
+      "Cannot source repetition/definition levels for nested struct: {}",
+      type.fullName());
+  return *best->type;
+}
+
+LevelMode repDefSourceLevelMode(
+    const ParquetTypeWithId& structType,
+    const ParquetTypeWithId& sourceType) {
+  const auto* node = &sourceType;
+  while (node != &structType) {
+    if (node->type()->kind() == TypeKind::ARRAY ||
+        node->type()->kind() == TypeKind::MAP) {
+      return LevelMode::kStructOverLists;
+    }
+    node = node->parquetParent();
+  }
+  return LevelMode::kNulls;
+}
+
+const ParquetTypeWithId& repDefSourceType(
+    const dwio::common::SelectiveColumnReader& reader) {
+  const auto* source = &reader;
+  while (source->fileType().type()->kind() == TypeKind::ROW) {
+    source =
+        static_cast<const StructColumnReader*>(source)->repDefSourceReader();
+  }
+  return *reinterpret_cast<const ParquetTypeWithId*>(&source->fileType());
+}
+
+} // namespace
+
+struct StructColumnReader::SyntheticRepDefSource {
+  // Members are destroyed in reverse declaration order. Keep the ScanSpec
+  // alive until after the reader that references it is destroyed.
+  std::unique_ptr<common::ScanSpec> scanSpec;
+
+  // Reads repetition and definition levels without producing values.
+  std::unique_ptr<dwio::common::SelectiveColumnReader> reader;
+};
+
+StructColumnReader::~StructColumnReader() = default;
 
 StructColumnReader::StructColumnReader(
     const dwio::common::ColumnReaderOptions& columnReaderOptions,
@@ -61,33 +199,50 @@ StructColumnReader::StructColumnReader(
 
     childSpecs[i]->setSubscript(children_.size() - 1);
   }
+  ensureSyntheticRepDefSource(columnReaderOptions, params);
   auto type = reinterpret_cast<const ParquetTypeWithId*>(fileType_.get());
   if (type->parent()) {
-    levelMode_ = reinterpret_cast<const ParquetTypeWithId*>(fileType_.get())
-                     ->makeLevelInfo(levelInfo_);
-    childForRepDefs_ = findBestLeaf();
-    // Set mode to struct over lists if the child for repdefs has a list between
-    // this and the child.
-    auto child = childForRepDefs_;
-    for (;;) {
-      assert(child);
-      if (child->fileType().type()->kind() == TypeKind::ARRAY ||
-          child->fileType().type()->kind() == TypeKind::MAP) {
-        levelMode_ = LevelMode::kStructOverLists;
-        break;
-      }
-      if (child->fileType().type()->kind() == TypeKind::ROW) {
-        child = reinterpret_cast<StructColumnReader*>(child)->childForRepDefs();
-        continue;
-      }
-      levelMode_ = LevelMode::kNulls;
-      break;
-    }
+    type->makeLevelInfo(levelInfo_);
+    repDefSourceReader_ = findBestLeaf();
+    levelMode_ =
+        repDefSourceLevelMode(*type, repDefSourceType(*repDefSourceReader_));
   }
+  VELOX_DCHECK_EQ(type->parent() == nullptr, repDefSourceReader_ == nullptr);
+}
+
+void StructColumnReader::ensureSyntheticRepDefSource(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
+    ParquetParams& params) {
+  auto type = reinterpret_cast<const ParquetTypeWithId*>(fileType_.get());
+  if (!type->parent() || !children_.empty()) {
+    return;
+  }
+
+  const auto* leafType =
+      &findCheapestPhysicalLeaf(*type, params.fileMetaData());
+  std::shared_ptr<const dwio::common::TypeWithId> leafFileType(
+      fileType_, leafType);
+
+  // Struct nullness can be derived from any leaf under the struct. Keep the
+  // least expensive physical leaf solely as the repetition/definition source.
+  auto repDefSource = std::make_unique<SyntheticRepDefSource>();
+  repDefSource->scanSpec = std::make_unique<common::ScanSpec>(leafType->name_);
+  repDefSource->scanSpec->setProjectOut(false);
+  repDefSource->reader = ParquetColumnReader::build(
+      columnReaderOptions,
+      leafFileType->type(),
+      leafFileType,
+      params,
+      *repDefSource->scanSpec);
+  syntheticRepDefSource_ = std::move(repDefSource);
 }
 
 dwio::common::SelectiveColumnReader* FOLLY_NONNULL
 StructColumnReader::findBestLeaf() {
+  if (children_.empty()) {
+    return syntheticRepDefSource_->reader.get();
+  }
+
   SelectiveColumnReader* best = nullptr;
   for (auto i = 0; i < children_.size(); ++i) {
     auto child = children_[i];
@@ -107,7 +262,6 @@ StructColumnReader::findBestLeaf() {
       best = child;
     }
   }
-  assert(best);
   return best;
 }
 
@@ -143,17 +297,7 @@ bool StructColumnReader::isRowGroupBuffered(
 void StructColumnReader::enqueueRowGroup(
     uint32_t index,
     dwio::common::BufferedInput& input) {
-  for (auto& child : children_) {
-    if (auto structChild = dynamic_cast<StructColumnReader*>(child)) {
-      structChild->enqueueRowGroup(index, input);
-    } else if (auto listChild = dynamic_cast<ListColumnReader*>(child)) {
-      listChild->enqueueRowGroup(index, input);
-    } else if (auto mapChild = dynamic_cast<MapColumnReader*>(child)) {
-      mapChild->enqueueRowGroup(index, input);
-    } else {
-      child->formatData().as<ParquetData>().enqueueRowGroup(index, input);
-    }
-  }
+  enqueueRowGroupRecursive(*this, index, input);
 }
 
 void StructColumnReader::seekToRowGroup(int64_t index) {
@@ -163,6 +307,10 @@ void StructColumnReader::seekToRowGroup(int64_t index) {
   readOffset_ = 0;
   for (auto& child : children_) {
     child->seekToRowGroup(index);
+  }
+  // Keep the rep/def source in sync when switching row groups.
+  if (syntheticRepDefSource_) {
+    syntheticRepDefSource_->reader->seekToRowGroup(index);
   }
 }
 

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/dwio/parquet/common/LevelConversion.h"
@@ -39,6 +41,8 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
       ParquetParams& params,
       common::ScanSpec& scanSpec);
 
+  ~StructColumnReader() override;
+
   void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
       override;
 
@@ -59,8 +63,12 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
 
   void setNullsFromRepDefs(PageReader& pageReader);
 
-  dwio::common::SelectiveColumnReader* childForRepDefs() const {
-    return childForRepDefs_;
+  /// Returns the reader that supplies repetition and definition levels for
+  /// this struct. This is null exactly for the root struct. For a nested
+  /// struct, the reader may be a logical child or a synthetic physical leaf
+  /// and must not be advanced using the enclosing struct's row count.
+  dwio::common::SelectiveColumnReader* repDefSourceReader() const {
+    return repDefSourceReader_;
   }
 
   /// Nested struct readers all get null flags and lengths for
@@ -78,23 +86,33 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
       dwio::common::FormatData::FilterRowGroupsResult&) const override;
 
  private:
-  dwio::common::SelectiveColumnReader* findBestLeaf();
+  struct SyntheticRepDefSource;
+
+  // Creates a non-projected physical leaf reader to source repetition and
+  // definition levels when no logical child reader is available.
+  void ensureSyntheticRepDefSource(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
+      ParquetParams& params);
+
+  dwio::common::SelectiveColumnReader* FOLLY_NONNULL findBestLeaf();
 
   void enqueueRowGroup(uint32_t index, dwio::common::BufferedInput& input);
 
   bool isRowGroupBuffered(uint32_t index, dwio::common::BufferedInput& input);
 
-  // Leaf column reader used for getting nullability information for
-  // 'this'. This is nullptr for the root of a table.
-  dwio::common::SelectiveColumnReader* childForRepDefs_{nullptr};
+  // Reader subtree used for getting nullability information for 'this'.
+  dwio::common::SelectiveColumnReader* repDefSourceReader_{nullptr};
 
-  // Mode for getting nulls from repdefs. kStructOverLists if 'this'
-  // only has list children.
+  // Mode for getting nulls from repdefs. kStructOverLists if the source is
+  // below an ARRAY or MAP.
   LevelMode levelMode_;
 
   // The level information for extracting nulls for 'this' from the
   // repdefs in a leaf PageReader.
   LevelInfo levelInfo_;
+
+  // Owns the synthetic non-projected reader and its ScanSpec.
+  std::unique_ptr<SyntheticRepDefSource> syntheticRepDefSource_;
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -18,8 +18,11 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/Mutation.h"
 #include "velox/dwio/parquet/common/ParquetRuntimeStats.h"
+#include "velox/dwio/parquet/reader/ParquetColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetData.h"
 #include "velox/dwio/parquet/reader/ParquetStatsContext.h"
 #include "velox/dwio/parquet/reader/SemanticVersion.h"
+#include "velox/dwio/parquet/reader/StructColumnReader.h"
 #include "velox/dwio/parquet/tests/ParquetTestBase.h"
 #include "velox/dwio/parquet/thrift/ParquetThrift.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
@@ -32,6 +35,41 @@ using namespace facebook::velox::parquet;
 
 class ParquetReaderTest : public ParquetTestBase {
  public:
+  struct RepDefSourceInfo {
+    uint32_t column;
+    TypeKind kind;
+  };
+
+  RepDefSourceInfo syntheticRepDefSourceInfo(
+      ParquetReader& reader,
+      const dwio::common::ReaderOptions& readerOptions,
+      common::ScanSpec& scanSpec) {
+    dwio::common::SplitStats splitStats{FileFormat::PARQUET};
+    ParquetParams params(
+        *leafPool_,
+        splitStats,
+        reader.fileMetaData(),
+        readerOptions.sessionTimezone(),
+        TimestampPrecision::kMilliseconds);
+    auto rootReader = ParquetColumnReader::build(
+        makeColumnReaderOptions(readerOptions),
+        reader.rowType(),
+        reader.typeWithId(),
+        params,
+        scanSpec);
+    auto* rootStruct = dynamic_cast<StructColumnReader*>(rootReader.get());
+    VELOX_CHECK_NOT_NULL(rootStruct);
+    VELOX_CHECK_EQ(rootStruct->children().size(), 1);
+    auto* nestedStruct =
+        dynamic_cast<StructColumnReader*>(rootStruct->children().front());
+    VELOX_CHECK_NOT_NULL(nestedStruct);
+    auto* sourceReader = nestedStruct->repDefSourceReader();
+    VELOX_CHECK_NOT_NULL(sourceReader);
+    return {
+        sourceReader->fileType().column(),
+        sourceReader->fileType().type()->kind()};
+  }
+
   void assertReadWithExpected(
       const std::string& fileName,
       const RowTypePtr& rowType,
@@ -1821,6 +1859,77 @@ TEST_F(ParquetReaderTest, structOfArrayOfArray) {
   constexpr int kBatchSize = 1000;
   while (readerBundle.rowReader->next(kBatchSize, result)) {
   }
+}
+
+TEST_F(ParquetReaderTest, cheapestRepDefSource) {
+  constexpr vector_size_t kNumRows = 100;
+  constexpr vector_size_t kElementsPerRow = 10;
+  std::vector<vector_size_t> detailOffsets(kNumRows);
+  for (auto row = 0; row < kNumRows; ++row) {
+    detailOffsets[row] = row * kElementsPerRow;
+  }
+  const auto details = makeArrayVector(
+      detailOffsets,
+      makeRowVector(
+          {"value"},
+          {makeFlatVector<std::string>(
+              kNumRows * kElementsPerRow, [](auto row) {
+                return std::string(256, 'x') + std::to_string(row);
+              })}));
+  const auto vector = makeRowVector(
+      {"target"},
+      {makeRowVector(
+          {"details", "suffix"},
+          {details, makeFlatVector<std::string>(kNumRows, [](auto row) {
+             return "s" + std::to_string(row);
+           })})});
+  const auto* sink = write(vector, ParquetWriterOptions{});
+
+  auto readerOptions = makeDefaultReaderOptions();
+  auto reader = createReaderInMemory(*sink, readerOptions);
+  const auto fileMetaData = reader->fileMetaData();
+  ASSERT_EQ(fileMetaData.numRowGroups(), 1);
+  const auto rowGroup = fileMetaData.rowGroup(0);
+  ASSERT_LT(
+      rowGroup.columnChunk(1).readSize(), rowGroup.columnChunk(0).readSize());
+
+  auto scanSpec = std::make_shared<ScanSpec>("");
+  auto* targetSpec = scanSpec->getOrCreateChild(Subfield("target"));
+  targetSpec->setFilter(exec::isNotNull());
+  targetSpec->setProjectOut(false);
+  const auto source =
+      syntheticRepDefSourceInfo(*reader, readerOptions, *scanSpec);
+  EXPECT_EQ(source.column, 1);
+  EXPECT_EQ(source.kind, TypeKind::VARCHAR);
+}
+
+// The first physical branch ends in a legacy repeated VARCHAR. Reading the
+// enclosing struct with no logical children must use the cheaper INTEGER leaf.
+TEST_F(ParquetReaderTest, legacyRepDefSource) {
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kName);
+  auto reader = createReader("struct_of_array_of_array.parquet", readerOptions);
+  auto scanSpec = std::make_shared<ScanSpec>("");
+  auto* structSpec = scanSpec->getOrCreateChild(Subfield("test"));
+  structSpec->setFilter(exec::isNotNull());
+  structSpec->setProjectOut(false);
+
+  const auto fileMetaData = reader->fileMetaData();
+  ASSERT_EQ(fileMetaData.numRowGroups(), 1);
+  const auto rowGroup = fileMetaData.rowGroup(0);
+  ASSERT_LT(
+      rowGroup.columnChunk(1).readSize(), rowGroup.columnChunk(0).readSize());
+  const auto source =
+      syntheticRepDefSourceInfo(*reader, readerOptions, *scanSpec);
+  EXPECT_EQ(source.column, 1);
+  EXPECT_EQ(source.kind, TypeKind::INTEGER);
+
+  RowReaderOptions options;
+  options.setScanSpec(scanSpec);
+  auto rowReader = reader->createRowReader(options);
+  auto result = BaseVector::create(ROW({}, {}), 0, leafPool_.get());
+  EXPECT_EQ(rowReader->next(20'000, result), 13'520);
+  EXPECT_EQ(result->size(), 13'520);
 }
 
 TEST_F(ParquetReaderTest, testLzoDataPage) {

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1397,6 +1397,184 @@ TEST_F(ParquetTableScanTest, testColumnNotExists) {
       "SELECT a, b, NULL, NULL, NULL FROM tmp");
 }
 
+// The filters reference whole structs without projecting or filtering their
+// children. The first struct has a repeated branch before a scalar sibling;
+// the second has scalar children only.
+TEST_F(ParquetTableScanTest, structFilterByIndex) {
+  const auto id = makeFlatVector<int64_t>({1, 2, 3});
+  const auto detailElements = makeRowVector(
+      {"first", "last"},
+      {
+          makeFlatVector<std::string>({"Janet", "John", "Susan"}),
+          makeFlatVector<std::string>({"Jones", "Smith", "Lee"}),
+      });
+  const auto details =
+      makeArrayVector(std::vector<vector_size_t>{0, 2, 2}, detailElements);
+  const auto name = makeRowVector(
+      {"details", "suffix"},
+      {
+          // A repeated branch appears first in schema order, but a scalar
+          // sibling can provide the struct's levels with less added I/O.
+          details,
+          makeFlatVector<std::string>({"Jr.", "Sr.", "III"}),
+      },
+      [](auto row) { return row == 1; });
+  const auto nickname = makeRowVector(
+      {"value", "suffix"},
+      {
+          makeFlatVector<std::string>({"Jan", "Johnny", "Sue"}),
+          makeFlatVector<std::string>({"J.", "S.", "L."}),
+      },
+      [](auto row) { return row == 2; });
+  const auto address = makeFlatVector<std::string>(
+      {"123 Main Street", "567 Maple Drive", "789 Oak Avenue"});
+  const auto vector = makeRowVector(
+      {"id", "name", "nickname", "address"}, {id, name, nickname, address});
+  dwio::common::WriterOptions writerOptions;
+  writerOptions.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/2, DefaultFlushPolicy::kDefaultBytesInRowGroup);
+  };
+  ParquetWriterOptions options;
+  const auto file = TempFilePath::create();
+  // Split the three rows across two row groups to verify that the hidden leaf
+  // reader is enqueued and repositioned when the row group changes.
+  writeToParquetFile(
+      file->getPath(), {vector}, std::move(writerOptions), options);
+
+  const auto dataColumns = vector->rowType();
+  const auto outputType = ROW("id", BIGINT());
+  const auto plan = PlanBuilder()
+                        .tableScan(
+                            outputType,
+                            {},
+                            "not(is_null(name)) AND not(is_null(nickname))",
+                            dataColumns)
+                        .planNode();
+  const auto expected = makeRowVector({"id"}, {makeFlatVector<int64_t>({1})});
+  AssertQueryBuilder(plan)
+      .split(makeSplit(file->getPath()))
+      .assertResults(expected);
+}
+
+// A MAP is the only physical child of a struct with no projected fields. Two
+// entries in the first row must not shift the following null struct, and an
+// empty map must still leave its enclosing struct non-null.
+TEST_F(ParquetTableScanTest, mapStructFilterByIndex) {
+  const auto id = makeFlatVector<int64_t>({1, 2, 3, 4});
+  const auto name = makeRowVector(
+      {"lookup"},
+      {
+          // The MAP supplies repetition and definition levels for the
+          // enclosing struct.
+          makeMapVector(
+              {0, 2, 2, 2},
+              makeFlatVector<int64_t>({10, 20, 30}),
+              makeFlatVector<bool>({true, false, true})),
+      },
+      [](auto row) { return row == 1; });
+  const auto vector = makeRowVector({"id", "name"}, {id, name});
+  dwio::common::WriterOptions writerOptions;
+  writerOptions.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/2, DefaultFlushPolicy::kDefaultBytesInRowGroup);
+  };
+  const auto file = TempFilePath::create();
+  writeToParquetFile(file->getPath(), {vector}, std::move(writerOptions), {});
+
+  const auto outputType = ROW("id", BIGINT());
+  const auto plan =
+      PlanBuilder()
+          .tableScan(outputType, {}, "not(is_null(name))", vector->rowType())
+          .planNode();
+  const auto expected =
+      makeRowVector({"id"}, {makeFlatVector<int64_t>({1, 3, 4})});
+  AssertQueryBuilder(plan)
+      .split(makeSplit(file->getPath()))
+      .assertResults(expected);
+}
+
+// ARRAY elements and MAP values are structs with no projected fields. Recursive
+// row-group setup must follow each struct's synthetic rep/def source through
+// the repeated reader to preserve element and value nullness.
+TEST_F(ParquetTableScanTest, structElementsByName) {
+  const auto id = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  const auto names = makeRowVector(
+      {"first", "last"},
+      {
+          makeFlatVector<std::string>({
+              "Janet",
+              "John",
+              "Susan",
+              "Martha",
+              "Alex",
+          }),
+          makeFlatVector<std::string>({
+              "Jones",
+              "Smith",
+              "Lee",
+              "Taylor",
+              "Wong",
+          }),
+      },
+      [](auto row) { return row == 1 || row == 4; });
+  // Rows cover multiple elements, empty collections, a null collection, and
+  // null struct elements or values. The final row is in its own row group.
+  const std::vector<vector_size_t> offsets = {0, 2, 2, 2, 2};
+  const auto vector = makeRowVector(
+      {"id", "names", "lookup"},
+      {
+          id,
+          makeArrayVector(offsets, names, {3}),
+          vectorMaker_.mapVector(
+              offsets, makeFlatVector<int64_t>({1, 2, 3, 4, 5}), names, {3}),
+      });
+
+  dwio::common::WriterOptions writerOptions;
+  writerOptions.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/2, DefaultFlushPolicy::kDefaultBytesInRowGroup);
+  };
+  ParquetWriterOptions options;
+  const auto file = TempFilePath::create();
+  writeToParquetFile(
+      file->getPath(), {vector}, std::move(writerOptions), options);
+
+  const auto emptyRowType = ROW({}, {});
+  const auto outputType =
+      ROW({"id", "names", "lookup"},
+          {BIGINT(), ARRAY(emptyRowType), MAP(BIGINT(), emptyRowType)});
+  const auto plan = PlanBuilder()
+                        .startTableScan()
+                        .outputType(outputType)
+                        .dataColumns(outputType)
+                        .endTableScan()
+                        .planNode();
+
+  const auto emptyRows = makeRowVector(emptyRowType, 5);
+  setNulls(emptyRows, [](auto row) { return row == 1 || row == 4; });
+  const auto expected = makeRowVector(
+      {"id", "names", "lookup"},
+      {
+          id,
+          makeArrayVector(offsets, emptyRows, {3}),
+          vectorMaker_.mapVector(
+              offsets,
+              makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+              emptyRows,
+              {3}),
+      });
+  AssertQueryBuilder(plan)
+      // Force multiple reads within each row group so preset nulls and lengths
+      // are consumed and refreshed without a row-group transition.
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "1")
+      .config(core::QueryConfig::kMaxOutputBatchRows, "1")
+      .connectorSessionProperty(
+          kHiveConnectorId, FileConfig::kUseColumnNamesSession, "true")
+      .split(makeSplit(file->getPath()))
+      .assertResults(expected);
+}
+
 TEST_F(ParquetTableScanTest, schemaMatchWithComplexTypes) {
   vector_size_t kSize = 100;
   auto valuesVector = makeRowVector(


### PR DESCRIPTION
#### Background
`StructColumnReader::findBestLeaf()` can return nullptr when a nested struct 
has no selected child readers. The previous code only guarded this with assert, 
which is compiled out in release builds and could lead to a null dereference.

#### Changes
This PR adds a non-projected physical child reader to provide repetition and 
definition levels, replaces the release-disabled assertion in `findBestLeaf()` 
with a checked error for structs with no physical children.