### PR TITLE
fix(abfs): Guard AbfsFileSystemTest::TearDown() against a failed SetUp()

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -167,7 +167,13 @@ class AbfsFileSystemTest : public testing::Test {
   }
 
   void TearDown() override {
-    azuriteServer_->stop();
+    // azuriteServer_ is left null if SetUp() threw before it could be
+    // constructed (e.g. the azurite-blob executable wasn't found).
+    // TearDown() runs unconditionally after SetUp(), even on failure, so
+    // it must not assume construction succeeded.
+    if (azuriteServer_ != nullptr) {
+      azuriteServer_->stop();
+    }
   }
 
   static std::string generateRandomData(int size) {


### PR DESCRIPTION
Split out of #18618 at review request.

`AbfsFileSystemTest::SetUp()` constructs an `AzuriteServer`. That constructor throws when `azurite-blob` isn't on `PATH`:

```
Failed to find azurite executable azurite-blob'
```

gtest still runs the fixture's `TearDown()` after a throwing `SetUp()`, and `TearDown()` dereferenced `azuriteServer_` unconditionally. So instead of reporting the error above, the whole `velox_abfs_test` binary died with SIGSEGV.

`azuriteServer_` stays null until `AzuriteServer`'s constructor returns successfully, so `TearDown()` now guards on it. The test still fails when azurite is missing — it just fails cleanly, with the original error visible, instead of taking the binary down with it.

Found while validating aarch64 support (#18587).

## Test plan

Reproduced by running `velox_abfs_test` with no `azurite-blob` on `PATH`: SIGSEGV before the change, a clean gtest failure naming the real cause after it.
