### PR TITLE
fix(nimble): Satisfy gersemi and header-ownership pre-commit hooks

### DIFF
--- a/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -18,148 +18,152 @@
 # need the benchmark switch guarded explicitly rather than relying on the parent.
 if(VELOX_ENABLE_BENCHMARKS)
   add_executable(
-  nimble_fixed_bit_width_benchmark
-  FixedBitWidthBenchmark.cpp
-  BenchmarkUtils.h
-  DeltaBenchmarkData.h
-  FixedBitWidthBenchmarkData.h
-  NimbleEncodingRunner.h
-  SparseBoolBenchmarkData.h
-  VarintBenchmarkData.h
+    nimble_fixed_bit_width_benchmark
+    FixedBitWidthBenchmark.cpp
+    BenchmarkUtils.h
+    DeltaBenchmarkData.h
+    FixedBitWidthBenchmarkData.h
+    NimbleEncodingRunner.h
+    SparseBoolBenchmarkData.h
+    VarintBenchmarkData.h
   )
 
   target_link_libraries(
-  nimble_fixed_bit_width_benchmark
-  nimble_encodings_tests_utils
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_memory
+    nimble_fixed_bit_width_benchmark
+    nimble_encodings_tests_utils
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
   )
 
   add_executable(
-  nimble_block_bit_packing_encoding_benchmark
-  BlockBitPackingEncodingBenchmark.cpp
-  BlockBitPackingBenchmarkData.h
+    nimble_block_bit_packing_encoding_benchmark
+    BlockBitPackingEncodingBenchmark.cpp
+    BlockBitPackingBenchmarkData.h
   )
 
   target_link_libraries(
-  nimble_block_bit_packing_encoding_benchmark
-  nimble_encodings_tests_utils
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_memory
+    nimble_block_bit_packing_encoding_benchmark
+    nimble_encodings_tests_utils
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
   )
 
   add_executable(nimble_exact_bit_width_storage_benchmark ExactBitWidthStorageBenchmark.cpp)
 
   target_link_libraries(
-  nimble_exact_bit_width_storage_benchmark
-  nimble_encodings_tests_utils
-  nimble_encodings
-  nimble_common
-  velox_memory
+    nimble_exact_bit_width_storage_benchmark
+    nimble_encodings_tests_utils
+    nimble_encodings
+    nimble_common
+    velox_memory
   )
 
   add_executable(nimble_fsst_benchmark FsstBenchmark.cpp)
 
   target_link_libraries(
-  nimble_fsst_benchmark
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_memory
-  fsst
+    nimble_fsst_benchmark
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
+    fsst
   )
 
   add_executable(nimble_huffman_benchmark HuffmanBenchmark.cpp HuffmanBenchmarkData.h)
 
   target_link_libraries(
-  nimble_huffman_benchmark
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_memory
+    nimble_huffman_benchmark
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
   )
 
   add_executable(nimble_encoding_view_benchmark EncodingViewBenchmark.cpp)
 
   target_link_libraries(
-  nimble_encoding_view_benchmark
-  nimble_encodings_tests_utils
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_common_base
-  velox_memory
-  fmt::fmt
+    nimble_encoding_view_benchmark
+    nimble_encodings_tests_utils
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_common_base
+    velox_memory
+    fmt::fmt
   )
 
   add_executable(
-  nimble_simd_for_bitpack_benchmark
-  SimdForBitpackBenchmark.cpp
-  SimdForBitpackBenchmarkData.h
+    nimble_simd_for_bitpack_benchmark
+    SimdForBitpackBenchmark.cpp
+    SimdForBitpackBenchmarkData.h
   )
 
   target_link_libraries(
-  nimble_simd_for_bitpack_benchmark
-  nimble_encodings_tests_utils
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_common_base
-  velox_memory
-  )
-
-  add_executable(nimble_pfor_encoding_benchmark PFOREncodingBenchmark.cpp PFOREncodingBenchmarkData.h)
-
-  target_link_libraries(
-  nimble_pfor_encoding_benchmark
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_memory
+    nimble_simd_for_bitpack_benchmark
+    nimble_encodings_tests_utils
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_common_base
+    velox_memory
   )
 
   add_executable(
-  nimble_fsst_encoding_benchmark
-  FsstEncodingBenchmark.cpp
-  FsstBenchmarkData.h
-  StringBenchmarkCorpus.h
+    nimble_pfor_encoding_benchmark
+    PFOREncodingBenchmark.cpp
+    PFOREncodingBenchmarkData.h
   )
 
   target_link_libraries(
-  nimble_fsst_encoding_benchmark
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_memory
-  fsst
-  fmt::fmt
+    nimble_pfor_encoding_benchmark
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
   )
 
   add_executable(
-  nimble_prefix_encoding_benchmark
-  PrefixEncodingBenchmark.cpp
-  PrefixBenchmarkData.h
-  StringBenchmarkCorpus.h
+    nimble_fsst_encoding_benchmark
+    FsstEncodingBenchmark.cpp
+    FsstBenchmarkData.h
+    StringBenchmarkCorpus.h
   )
 
   target_link_libraries(
-  nimble_prefix_encoding_benchmark
-  nimble_encodings
-  nimble_common
-  Folly::follybenchmark
-  Folly::folly
-  velox_memory
+    nimble_fsst_encoding_benchmark
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
+    fsst
+    fmt::fmt
+  )
+
+  add_executable(
+    nimble_prefix_encoding_benchmark
+    PrefixEncodingBenchmark.cpp
+    PrefixBenchmarkData.h
+    StringBenchmarkCorpus.h
+  )
+
+  target_link_libraries(
+    nimble_prefix_encoding_benchmark
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
   )
 endif()
 

--- a/velox/dwio/nimble/encodings/benchmarks/ml_id_compression/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/benchmarks/ml_id_compression/CMakeLists.txt
@@ -34,10 +34,25 @@
 # ---------------------------------------------------------------------------
 add_library(nimble_ml_id_benchmark_common MlIdBenchmarkFlags.cpp)
 
-target_link_libraries(
+target_link_libraries(nimble_ml_id_benchmark_common PUBLIC gflags)
+
+# Header-only pieces of the suite, attached to the shared library so they are
+# tracked by a target.
+velox_add_test_headers(
   nimble_ml_id_benchmark_common
-  PUBLIC
-    gflags
+  AblationPolicy.h
+  Axes.h
+  CachePolicy.h
+  DriverSweep.h
+  ElemType.h
+  GatherTraceGen.h
+  MeasureLoop.h
+  OpenZLBenchTarget.h
+  PointTraceGen.h
+  ResultWriter.h
+  SelectiveTraceGen.h
+  SubstreamCompression.h
+  TimingStats.h
 )
 # ---------------------------------------------------------------------------
 # Every driver in this suite links the same set: the shared flag library, the
@@ -69,44 +84,54 @@ endfunction()
 # MlIdCompressionBenchmark: encodes a column of ML IDs under every candidate
 # encoding and reports compressed size + round-trip latency.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_compression_benchmark MlIdCompressionBenchmark.cpp OPENZL)
+  nimble_ml_id_compression_benchmark MlIdCompressionBenchmark.cpp OPENZL
+)
 
 # MlIdDecodeBulkBenchmark: full-materialization decode throughput.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_decode_bulk_benchmark MlIdDecodeBulkBenchmark.cpp OPENZL)
+  nimble_ml_id_decode_bulk_benchmark MlIdDecodeBulkBenchmark.cpp OPENZL
+)
 
 # MlIdDecodeRangeBenchmark: contiguous-range decode across (start, length).
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_decode_range_benchmark MlIdDecodeRangeBenchmark.cpp OPENZL)
+  nimble_ml_id_decode_range_benchmark MlIdDecodeRangeBenchmark.cpp OPENZL
+)
 
 # MlIdEncodeBenchmark: encode-side throughput and selection cost.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_encode_benchmark MlIdEncodeBenchmark.cpp OPENZL)
+  nimble_ml_id_encode_benchmark MlIdEncodeBenchmark.cpp OPENZL
+)
 
 # MlIdDecodePointBenchmark: single-row random access latency.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_decode_point_benchmark MlIdDecodePointBenchmark.cpp OPENZL)
+  nimble_ml_id_decode_point_benchmark MlIdDecodePointBenchmark.cpp OPENZL
+)
 
 # MlIdDecodeGatherBenchmark: scattered multi-range gather, the TableScan skip
 # pattern.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_decode_gather_benchmark MlIdDecodeGatherBenchmark.cpp OPENZL)
+  nimble_ml_id_decode_gather_benchmark MlIdDecodeGatherBenchmark.cpp OPENZL
+)
 
 # MlIdCostModelOracleBenchmark: validates SubIntSplit's DP cost model against an
 # oracle that actually encodes each candidate bit range.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_cost_model_oracle_benchmark MlIdCostModelOracleBenchmark.cpp)
+  nimble_ml_id_cost_model_oracle_benchmark MlIdCostModelOracleBenchmark.cpp
+)
 
 # MlIdIndexOracleBenchmark: sweeps FPE index types, Pareto frontier, scalarised
 # oracle.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_index_oracle_benchmark MlIdIndexOracleBenchmark.cpp)
+  nimble_ml_id_index_oracle_benchmark MlIdIndexOracleBenchmark.cpp
+)
 
 # MlIdAblationBenchmark: progressive encoding-set restriction for SIS sections.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_ablation_benchmark MlIdAblationBenchmark.cpp)
+  nimble_ml_id_ablation_benchmark MlIdAblationBenchmark.cpp
+)
 
 # MlIdSmokeBenchmark: encode + decode correctness check (no timing). Sweeps
 # every supported element type, so it is also the compile-coverage gate.
 nimble_add_ml_id_benchmark(
-  nimble_ml_id_smoke_benchmark MlIdSmokeBenchmark.cpp)
+  nimble_ml_id_smoke_benchmark MlIdSmokeBenchmark.cpp
+)


### PR DESCRIPTION
Main is red for `pre-commit`, and CI runs it with `--all-files` — so every open PR fails, not just ones touching nimble.

#18696 fixed the clang-format half. Two hooks are still failing, both under `velox/dwio/nimble/encodings/benchmarks/`:

- **gersemi** — both `CMakeLists.txt` in that tree.
- **check-header-ownership** — 13 headers belonged to no target; now attached to `nimble_ml_id_benchmark_common` via `velox_add_test_headers`.

Verified on a clean checkout of current main: both hooks red before, `pre-commit run --all-files` fully green after. CMake only, no behavior change.
