### PR TITLE
feat(exec): Add storage parameters to TableWriterBuilder (#18693)

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -457,7 +457,11 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
         compressionKind_,
         serdeParameters_,
         options_,
-        ensureFiles_);
+        ensureFiles_,
+        // Repeats the constructor's default so that storageParameters, which
+        // follows it positionally, can be passed.
+        std::make_shared<const connector::hive::HiveInsertFileNameGenerator>(),
+        storageParameters_);
 
     insertHandle_ =
         std::make_shared<core::InsertTableHandle>(connectorId_, hiveHandle);
@@ -806,7 +810,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     const RowTypePtr& schema,
     const bool ensureFiles,
     const connector::CommitStrategy commitStrategy,
-    std::shared_ptr<core::InsertTableHandle> insertTableHandle) {
+    std::shared_ptr<core::InsertTableHandle> insertTableHandle,
+    const std::unordered_map<std::string, std::string>& storageParameters) {
   return TableWriterBuilder(*this)
       .outputDirectoryPath(outputDirectoryPath)
       .outputFileName(outputFileName)
@@ -819,6 +824,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       .aggregates(aggregates)
       .connectorId(connectorId)
       .serdeParameters(serdeParameters)
+      .storageParameters(storageParameters)
       .options(options)
       .compressionKind(compressionKind)
       .ensureFiles(ensureFiles)

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -594,6 +594,15 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param storageParameters Physical storage properties of the written
+    /// objects, as opposed to the byte layout inside them. Consumed by the
+    /// file sink rather than the format writer.
+    TableWriterBuilder& storageParameters(
+        std::unordered_map<std::string, std::string> storageParameters) {
+      storageParameters_ = std::move(storageParameters);
+      return *this;
+    }
+
     /// @param Option objects passed to the writer.
     TableWriterBuilder& options(
         std::shared_ptr<dwio::common::WriterOptions> options) {
@@ -656,6 +665,7 @@ class PlanBuilder {
         sortBy_;
 
     std::unordered_map<std::string, std::string> serdeParameters_;
+    std::unordered_map<std::string, std::string> storageParameters_;
     std::shared_ptr<dwio::common::WriterOptions> options_;
 
     dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
@@ -895,6 +905,9 @@ class PlanBuilder {
   /// to a table through a connector. If not specified, tableWrite will build
   /// a HiveInsertTableHandle with columnHandles, bucketProperty and
   /// locationHandle.
+  /// @param storageParameters Physical storage properties of the written
+  /// objects, as opposed to the byte layout inside them. Consumed by the file
+  /// sink rather than the format writer.
   PlanBuilder& tableWrite(
       const std::string& outputDirectoryPath,
       const std::vector<std::string>& partitionBy,
@@ -914,7 +927,9 @@ class PlanBuilder {
       const bool ensureFiles = false,
       const connector::CommitStrategy commitStrategy =
           connector::CommitStrategy::kNoCommit,
-      std::shared_ptr<core::InsertTableHandle> insertTableHandle = nullptr);
+      std::shared_ptr<core::InsertTableHandle> insertTableHandle = nullptr,
+      const std::unordered_map<std::string, std::string>& storageParameters =
+          {});
 
   /// Add a TableWriteMergeNode. Derives the ColumnStatsSpec from the
   /// TableWriteNode in the plan tree and applies the given step.


### PR DESCRIPTION
Summary:

Hive storage parameters never reached the Velox file sink from PySpark, so `SALLY_CHECKSUM` on an NCI table was inert and written files carried no `user.sally.checksum` xattr — which ZippyDB bulk load needs to resolve a file's IDS object id.

This diff threads storage parameters metastore -> plan -> sink: `TableStorageInfo` gains `storageParameters` (from `sd.parameters`, plus a lift of `SALLY_CHECKSUM` out of TBLPROPERTIES mirroring Prism's `ONLINE_FLASH_TTL` exception), `VeloxPlanBuilder` passes them through, and `PlanBuilder::TableWriterBuilder` sets them on `HiveInsertTableHandle`.

#### Flow
```
traits_to_nci_rows.py  .tableWrite(outputTableName=...)
        │                          no new argument -- storage parameters are read
        ▼                          from the metastore, not passed by the caller
  pysparkvelox_plan_builder.cpp:295          (pybind, unchanged)
        │
        ▼
  VeloxPlanBuilder::tableWrite               VeloxPlanBuilder.cpp:586
        │
        ├─ fetchTableStorageInfoFromMetastore()    CatalogUtils.cpp:517
        │     ├─ info.storageParameters = sd.parameters()          :555-557  (wholesale)
        │     └─ lift TBLPROPERTIES["SALLY_CHECKSUM"]              :562-565  (allowlisted)
        │        └─ TableStorageInfo::storageParameters            CatalogUtils.h:180
        │
        └─ planBuilder_.tableWrite(..., storageParameters)   VeloxPlanBuilder.cpp:636-638, 679
                  │
                  ▼
  PlanBuilder::tableWrite                    PlanBuilder.cpp:811, 824
        └─ TableWriterBuilder::storageParameters()   PlanBuilder.h:587
                  │
                  ▼
  TableWriterBuilder::build()                PlanBuilder.cpp:449-461
        └─ HiveInsertTableHandle ctor arg 10
           (arg 9 fileNameGenerator spelled out at its existing default)
  ═══════════════════════════════════════════════════════════════════════════
        │                          unchanged below this line
        ▼
  HiveInsertTableHandle serialize / deserialize   HiveDataSink.cpp:899-902, 935-938
        ▼
  HiveDataSink::createWriterForIndex              HiveDataSink.cpp:686
     └─ createHiveFileSink(..., insertTableHandle_->storageParameters())
          └─ FileSink::Options{.storageParameters}    HiveDataSink.cpp:81
               └─ dwio::utils::createFileSink          FileSink.cpp:134
                    └─ sallyChecksumEnabled()          FileSink.cpp:228
                         └─ SallyChecksumWriteFile wraps the WriteFile, outermost
                              └─ close() stamps  user.sally.checksum
                                                 user.sally.checksum_func_name
```

Differential Revision: D117152800


