### PR TITLE
fix(cudf): Compare TIMESTAMP WITH TIME ZONE operator keys by instant

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(
   DecimalAggregationHostOps.cpp
   DecimalAggregationState.cpp
   GpuResources.cpp
+  KeyNormalization.cpp
   OperatorAdapters.cpp
   PrestoAggregateFunctions.cpp
   SparkAggregateFunctions.cpp

--- a/velox/experimental/cudf/exec/CudfDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfDistinct.cpp
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfDistinct.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashAggregation.h"
 
+#include <cudf/copying.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/stream_compaction.hpp>
@@ -56,6 +61,12 @@ void CudfDistinct::initialize() {
   inputType_ = aggregationNode_->sources()[0]->outputType();
   setupGroupingKeyChannelProjections(
       *aggregationNode_, groupingKeyInputChannels_, groupingKeyOutputChannels_);
+
+  groupingKeyIsTswtz_.reserve(groupingKeyInputChannels_.size());
+  for (const auto channel : groupingKeyInputChannels_) {
+    groupingKeyIsTswtz_.push_back(
+        isTimestampWithTimeZoneType(inputType_->asRow().childAt(channel)));
+  }
 
   aggregationNode_.reset();
 }
@@ -123,14 +134,50 @@ CudfVectorPtr CudfDistinct::getDistinctKeys(
     cudf::table_view tableView,
     std::vector<column_index_t> const& groupByKeys,
     rmm::cuda_stream_view stream) {
-  auto result = cudf::distinct(
-      tableView.select(groupByKeys.begin(), groupByKeys.end()),
-      {groupingKeyOutputChannels_.begin(), groupingKeyOutputChannels_.end()},
-      cudf::duplicate_keep_option::KEEP_FIRST,
-      cudf::null_equality::EQUAL,
-      cudf::nan_equality::ALL_EQUAL,
-      stream,
-      get_output_mr());
+  auto keysView = tableView.select(groupByKeys.begin(), groupByKeys.end());
+
+  // A TIMESTAMP WITH TIME ZONE key must deduplicate on its instant alone: it is
+  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
+  // read unpackMillisUtc only, so deduplicating on the raw value keeps one row per
+  // zone instead of one per moment.
+  //
+  // It cannot be done by normalizing in place, because the table cudf::distinct
+  // returns IS this operator's output -- the call passes only the key columns as
+  // its input, so emitting the normalized values would rewrite every zone key to
+  // UTC downstream. Instead take the indices of the distinct rows from the
+  // normalized keys and gather the ORIGINAL columns by them, so each surviving row
+  // keeps its own real zone key. Which row of a tied set survives is
+  // KEEP_FIRST either way, and unspecified in SQL.
+  //
+  // This is the idiom CudfMarkDistinct already uses (distinct_indices + gather).
+  auto normalizedKeys = normalizeKeyColumns(
+      keysView, groupingKeyIsTswtz_, stream, get_temp_mr());
+
+  std::unique_ptr<cudf::table> result;
+  if (normalizedKeys.normalizedAny()) {
+    auto distinctIndices = cudf::distinct_indices(
+        normalizedKeys.view,
+        cudf::duplicate_keep_option::KEEP_FIRST,
+        cudf::null_equality::EQUAL,
+        cudf::nan_equality::ALL_EQUAL,
+        stream,
+        get_temp_mr());
+    result = cudf::gather(
+        keysView,
+        distinctIndices->view(),
+        cudf::out_of_bounds_policy::DONT_CHECK,
+        stream,
+        get_output_mr());
+  } else {
+    result = cudf::distinct(
+        keysView,
+        {groupingKeyOutputChannels_.begin(), groupingKeyOutputChannels_.end()},
+        cudf::duplicate_keep_option::KEEP_FIRST,
+        cudf::null_equality::EQUAL,
+        cudf::nan_equality::ALL_EQUAL,
+        stream,
+        get_output_mr());
+  }
 
   auto numRows = result->num_rows();
 

--- a/velox/experimental/cudf/exec/CudfDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfDistinct.cpp
@@ -20,13 +20,12 @@
 #include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
-
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashAggregation.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
-#include <cudf/copying.hpp>
 #include <cudf/concatenate.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/stream_compaction.hpp>
 
@@ -137,21 +136,22 @@ CudfVectorPtr CudfDistinct::getDistinctKeys(
   auto keysView = tableView.select(groupByKeys.begin(), groupByKeys.end());
 
   // A TIMESTAMP WITH TIME ZONE key must deduplicate on its instant alone: it is
-  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
-  // read unpackMillisUtc only, so deduplicating on the raw value keeps one row per
-  // zone instead of one per moment.
+  // physically (millis << 12) | zone_key and Velox's hash and compare for the
+  // type read unpackMillisUtc only, so deduplicating on the raw value keeps one
+  // row per zone instead of one per moment.
   //
   // It cannot be done by normalizing in place, because the table cudf::distinct
-  // returns IS this operator's output -- the call passes only the key columns as
-  // its input, so emitting the normalized values would rewrite every zone key to
-  // UTC downstream. Instead take the indices of the distinct rows from the
-  // normalized keys and gather the ORIGINAL columns by them, so each surviving row
-  // keeps its own real zone key. Which row of a tied set survives is
-  // KEEP_FIRST either way, and unspecified in SQL.
+  // returns IS this operator's output -- the call passes only the key columns
+  // as its input, so emitting the normalized values would rewrite every zone
+  // key to UTC downstream. Instead take the indices of the distinct rows from
+  // the normalized keys and gather the ORIGINAL columns by them, so each
+  // surviving row keeps its own real zone key. Which row of a tied set survives
+  // is KEEP_FIRST either way, and unspecified in SQL.
   //
-  // This is the idiom CudfMarkDistinct already uses (distinct_indices + gather).
-  auto normalizedKeys = normalizeKeyColumns(
-      keysView, groupingKeyIsTswtz_, stream, get_temp_mr());
+  // This is the idiom CudfMarkDistinct already uses (distinct_indices +
+  // gather).
+  auto normalizedKeys =
+      normalizeKeyColumns(keysView, groupingKeyIsTswtz_, stream, get_temp_mr());
 
   std::unique_ptr<cudf::table> result;
   if (normalizedKeys.normalizedAny()) {

--- a/velox/experimental/cudf/exec/CudfDistinct.h
+++ b/velox/experimental/cudf/exec/CudfDistinct.h
@@ -61,9 +61,9 @@ class CudfDistinct : public CudfOperatorBase {
   std::vector<column_index_t> groupingKeyInputChannels_;
   std::vector<column_index_t> groupingKeyOutputChannels_;
 
-  // Which grouping keys are TIMESTAMP WITH TIME ZONE, by KEY POSITION rather than
-  // channel, so the one vector serves getDistinctKeys whichever channel vector it
-  // is called with -- both list the same keys in the same order.
+  // Which grouping keys are TIMESTAMP WITH TIME ZONE, by KEY POSITION rather
+  // than channel, so the one vector serves getDistinctKeys whichever channel
+  // vector it is called with -- both list the same keys in the same order.
   std::vector<bool> groupingKeyIsTswtz_;
 
   std::shared_ptr<const core::AggregationNode> aggregationNode_;

--- a/velox/experimental/cudf/exec/CudfDistinct.h
+++ b/velox/experimental/cudf/exec/CudfDistinct.h
@@ -61,6 +61,11 @@ class CudfDistinct : public CudfOperatorBase {
   std::vector<column_index_t> groupingKeyInputChannels_;
   std::vector<column_index_t> groupingKeyOutputChannels_;
 
+  // Which grouping keys are TIMESTAMP WITH TIME ZONE, by KEY POSITION rather than
+  // channel, so the one vector serves getDistinctKeys whichever channel vector it
+  // is called with -- both list the same keys in the same order.
+  std::vector<bool> groupingKeyIsTswtz_;
+
   std::shared_ptr<const core::AggregationNode> aggregationNode_;
 
   const bool isPartialOutput_;

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -17,12 +17,10 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfGroupby.h"
-#include "velox/experimental/cudf/exec/KeyNormalization.h"
-
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationState.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
@@ -32,6 +30,7 @@
 #include "velox/exec/HashAggregation.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
@@ -1472,10 +1471,10 @@ void CudfGroupby::initialize() {
   setupGroupingKeyChannelProjections(
       *aggregationNode_, groupingKeyInputChannels_, groupingKeyOutputChannels_);
 
-  // Recorded by key POSITION, not channel, because doGroupByAggregation is called
-  // with groupingKeyInputChannels_ on the input pass and
-  // groupingKeyOutputChannels_ on the compaction passes; both list the same keys
-  // in the same order, so one vector serves every caller.
+  // Recorded by key POSITION, not channel, because doGroupByAggregation is
+  // called with groupingKeyInputChannels_ on the input pass and
+  // groupingKeyOutputChannels_ on the compaction passes; both list the same
+  // keys in the same order, so one vector serves every caller.
   groupingKeyIsTswtz_.reserve(groupingKeyInputChannels_.size());
   for (const auto channel : groupingKeyInputChannels_) {
     groupingKeyIsTswtz_.push_back(
@@ -1727,10 +1726,10 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
   auto groupbyKeyView =
       tableView.select(groupByKeys.begin(), groupByKeys.end());
 
-  // A TIMESTAMP WITH TIME ZONE grouping key must group on its instant alone: it is
-  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
-  // read unpackMillisUtc only, so grouping on the raw value splits every set of
-  // rows that share a moment across zones into one group per zone.
+  // A TIMESTAMP WITH TIME ZONE grouping key must group on its instant alone: it
+  // is physically (millis << 12) | zone_key and Velox's hash and compare for
+  // the type read unpackMillisUtc only, so grouping on the raw value splits
+  // every set of rows that share a moment across zones into one group per zone.
   //
   // The normalized keys can only drive the GROUPING. cudf::groupby::aggregate
   // RETURNS the unique key rows, and those become this operator's output, so
@@ -1773,9 +1772,10 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
       aggregation.push_back(
           cudf::make_min_aggregation<cudf::groupby_aggregation>());
       keyRecoveryRequest[i] = requests.size();
-      requests.push_back(cudf::groupby::aggregation_request{
-          tableView.column(static_cast<cudf::size_type>(groupByKeys[i])),
-          std::move(aggregation)});
+      requests.push_back(
+          cudf::groupby::aggregation_request{
+              tableView.column(static_cast<cudf::size_type>(groupByKeys[i])),
+              std::move(aggregation)});
     }
   }
 
@@ -1796,7 +1796,9 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
       }
       auto& recovered = results[keyRecoveryRequest[i]].results;
       VELOX_CHECK_EQ(
-          recovered.size(), 1, "Key recovery expects exactly one result column");
+          recovered.size(),
+          1,
+          "Key recovery expects exactly one result column");
       groupKeysColumns[i] = std::move(recovered[0]);
     }
   }

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -17,6 +17,9 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfGroupby.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationState.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
@@ -1469,6 +1472,20 @@ void CudfGroupby::initialize() {
   setupGroupingKeyChannelProjections(
       *aggregationNode_, groupingKeyInputChannels_, groupingKeyOutputChannels_);
 
+  // Recorded by key POSITION, not channel, because doGroupByAggregation is called
+  // with groupingKeyInputChannels_ on the input pass and
+  // groupingKeyOutputChannels_ on the compaction passes; both list the same keys
+  // in the same order, so one vector serves every caller.
+  groupingKeyIsTswtz_.reserve(groupingKeyInputChannels_.size());
+  for (const auto channel : groupingKeyInputChannels_) {
+    groupingKeyIsTswtz_.push_back(
+        isTimestampWithTimeZoneType(inputType_->asRow().childAt(channel)));
+  }
+  groupingKeysNeedNormalization_ = std::any_of(
+      groupingKeyIsTswtz_.begin(), groupingKeyIsTswtz_.end(), [](bool b) {
+        return b;
+      });
+
   // Velox CPU does optimizations related to pre-grouped keys. This can be
   // done in cudf by passing sort information to cudf::groupby() constructor.
   // We're postponing this for now.
@@ -1710,10 +1727,22 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
   auto groupbyKeyView =
       tableView.select(groupByKeys.begin(), groupByKeys.end());
 
+  // A TIMESTAMP WITH TIME ZONE grouping key must group on its instant alone: it is
+  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
+  // read unpackMillisUtc only, so grouping on the raw value splits every set of
+  // rows that share a moment across zones into one group per zone.
+  //
+  // The normalized keys can only drive the GROUPING. cudf::groupby::aggregate
+  // RETURNS the unique key rows, and those become this operator's output, so
+  // emitting them would rewrite every zone key to UTC downstream. The original
+  // packed value is recovered per group below.
+  auto normalizedKeys = normalizeKeyColumns(
+      groupbyKeyView, groupingKeyIsTswtz_, stream, get_temp_mr());
+
   // TODO: All other args to groupby are related to sort groupby. We don't
   // support optimizations related to it yet.
   cudf::groupby::groupby groupByOwner(
-      groupbyKeyView,
+      normalizedKeys.view,
       ignoreNullKeys_ ? cudf::null_policy::EXCLUDE
                       : cudf::null_policy::INCLUDE);
 
@@ -1722,12 +1751,55 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
     aggregator->addGroupbyRequest(tableView, requests, stream, get_temp_mr());
   }
 
+  // Key-recovery requests are appended AFTER every aggregator's, so the result
+  // indices the aggregators recorded stay valid.
+  //
+  // MIN over the original packed column, not NTH_ELEMENT: cuDF's
+  // is_hash_aggregation (src/groupby/common/utils.hpp) admits SUM, MIN, MAX,
+  // COUNT, ARGMIN, ARGMAX, MEAN, M2, STD and VARIANCE and nothing else, so an
+  // NTH_ELEMENT request would make can_use_hash_groupby false and push every
+  // TSWTZ group-by onto the sort path. MIN yields the group's numerically
+  // smallest packed value, which is a real zone key from one of its own rows --
+  // matching CPU, where RowContainer keeps the packed value of whichever row
+  // created the group. Which of the tied zone keys survives is unspecified on
+  // both engines.
+  std::vector<size_t> keyRecoveryRequest(groupByKeys.size(), 0);
+  if (normalizedKeys.normalizedAny()) {
+    for (size_t i = 0; i < groupByKeys.size(); ++i) {
+      if (!groupingKeyIsTswtz_[i]) {
+        continue;
+      }
+      std::vector<std::unique_ptr<cudf::groupby_aggregation>> aggregation;
+      aggregation.push_back(
+          cudf::make_min_aggregation<cudf::groupby_aggregation>());
+      keyRecoveryRequest[i] = requests.size();
+      requests.push_back(cudf::groupby::aggregation_request{
+          tableView.column(static_cast<cudf::size_type>(groupByKeys[i])),
+          std::move(aggregation)});
+    }
+  }
+
   auto [groupKeys, results] = groupByOwner.aggregate(requests, stream, mr);
   // flatten the results
   std::vector<std::unique_ptr<cudf::column>> resultColumns;
 
   // first fill the grouping keys
   auto groupKeysColumns = groupKeys->release();
+
+  // Replace each normalized key with the original packed value recovered above,
+  // so the emitted TIMESTAMP WITH TIME ZONE carries a real zone key rather than
+  // the UTC the normalization would have left.
+  if (normalizedKeys.normalizedAny()) {
+    for (size_t i = 0; i < groupByKeys.size(); ++i) {
+      if (!groupingKeyIsTswtz_[i]) {
+        continue;
+      }
+      auto& recovered = results[keyRecoveryRequest[i]].results;
+      VELOX_CHECK_EQ(
+          recovered.size(), 1, "Key recovery expects exactly one result column");
+      groupKeysColumns[i] = std::move(recovered[0]);
+    }
+  }
   resultColumns.insert(
       resultColumns.begin(),
       std::make_move_iterator(groupKeysColumns.begin()),

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -1757,11 +1757,38 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
   // is_hash_aggregation (src/groupby/common/utils.hpp) admits SUM, MIN, MAX,
   // COUNT, ARGMIN, ARGMAX, MEAN, M2, STD and VARIANCE and nothing else, so an
   // NTH_ELEMENT request would make can_use_hash_groupby false and push every
-  // TSWTZ group-by onto the sort path. MIN yields the group's numerically
-  // smallest packed value, which is a real zone key from one of its own rows --
-  // matching CPU, where RowContainer keeps the packed value of whichever row
-  // created the group. Which of the tied zone keys survives is unspecified on
-  // both engines.
+  // TSWTZ group-by onto the sort path.
+  //
+  // What this guarantees, and what it does not:
+  //
+  // GUARANTEED -- the emitted key carries the group's correct INSTANT. Grouping
+  // runs on the normalized keys, so every row of a group has identical high
+  // bits and the packed values differ only in the low kTimezoneMask bits. A MIN
+  // over them therefore returns a value belonging to one of the group's own
+  // rows: never a fabricated value, never another group's instant, and never
+  // the bare UTC that normalization alone would leave.
+  //
+  // NOT GUARANTEED -- WHICH of the tied zone keys is emitted. All rows of a
+  // group are equal values, because this type's comparator is defined on the
+  // instant alone, so any of them is a valid representative and SQL does not
+  // define which one a GROUP BY returns.
+  //
+  // An earlier version of this comment claimed MIN "matches CPU, where
+  // RowContainer keeps the packed value of whichever row created the group".
+  // That is wrong and was never measured. On a live cluster, grouping one
+  // instant keyed to Pacific/Kiritimati and Pacific/Midway, the surviving zone
+  // differs between the engines AND is unstable on each of them: CPU returned
+  // -11:00 on three consecutive runs and +14:00 at task_concurrency=2, while
+  // this path returned +14:00 then -11:00 on otherwise identical runs. MIN is
+  // deterministic within a single aggregation, but the plan has partial and
+  // final stages behind a hash exchange, and which representative survives that
+  // merge follows scheduling.
+  //
+  // So do not rely on the emitted zone key, and do not "fix" a difference in it
+  // by chasing CPU -- CPU is not stable either. Any query that renders the
+  // group key with its offset (to_iso8601, cast to varchar, timezone_hour,
+  // format_datetime) can therefore differ run to run on both engines. The
+  // instant is the part that is contractual.
   std::vector<size_t> keyRecoveryRequest(groupByKeys.size(), 0);
   if (normalizedKeys.normalizedAny()) {
     for (size_t i = 0; i < groupByKeys.size(); ++i) {

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -212,8 +212,8 @@ class CudfGroupby : public CudfOperatorBase {
 
   std::vector<column_index_t> groupingKeyInputChannels_;
 
-  // Which grouping keys are TIMESTAMP WITH TIME ZONE, by KEY POSITION rather than
-  // by channel, so the one vector serves both the input pass (which passes
+  // Which grouping keys are TIMESTAMP WITH TIME ZONE, by KEY POSITION rather
+  // than by channel, so the one vector serves both the input pass (which passes
   // groupingKeyInputChannels_) and the compaction passes (which pass
   // groupingKeyOutputChannels_) -- both list the same keys in the same order.
   std::vector<bool> groupingKeyIsTswtz_;

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -211,6 +211,13 @@ class CudfGroupby : public CudfOperatorBase {
   void computeSingleGroupbyIncrementally(CudfVectorPtr tbl);
 
   std::vector<column_index_t> groupingKeyInputChannels_;
+
+  // Which grouping keys are TIMESTAMP WITH TIME ZONE, by KEY POSITION rather than
+  // by channel, so the one vector serves both the input pass (which passes
+  // groupingKeyInputChannels_) and the compaction passes (which pass
+  // groupingKeyOutputChannels_) -- both list the same keys in the same order.
+  std::vector<bool> groupingKeyIsTswtz_;
+  bool groupingKeysNeedNormalization_{false};
   std::vector<column_index_t> groupingKeyOutputChannels_;
   std::vector<column_index_t> aggregationInputChannels_;
 

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -17,6 +17,9 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
@@ -391,11 +394,43 @@ void CudfHashJoinBuild::doNoMoreInput() {
        joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
        joinNode_->isLeftSemiProjectJoin());
 
+  // A TIMESTAMP WITH TIME ZONE join key must match on its instant alone: it is
+  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
+  // read unpackMillisUtc only, so hashing the raw value means no two values
+  // carrying different zones ever match and the join silently returns nothing.
+  //
+  // Both sides must be normalized or neither. A one-sided fix would compare
+  // normalized keys against packed ones and make EVERY TSWTZ join empty for every
+  // zone, including the ones that work today -- worse than the bug. The probe side
+  // is normalized in probeKeys() below; this is the build side.
+  std::vector<bool> buildKeyIsTswtz;
+  buildKeyIsTswtz.reserve(buildKeyIndices.size());
+  for (size_t i = 0; i < buildKeyIndices.size(); i++) {
+    buildKeyIsTswtz.push_back(isTimestampWithTimeZoneType(
+        buildType->childAt(static_cast<uint32_t>(buildKeyIndices[i]))));
+  }
+
+  std::vector<std::shared_ptr<cudf::table>> normalizedBuildKeys;
   std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
   for (auto i = 0; i < tbls.size(); i++) {
+    // The hash object views the key table it is built from and outlives this
+    // function, so a normalized key table has to be owned by the bridge alongside
+    // it rather than by a local.
+    auto buildKeyView = tbls[i]->view().select(buildKeyIndices);
+    auto normalized =
+        normalizeKeyColumns(buildKeyView, buildKeyIsTswtz, stream, get_temp_mr());
+    if (normalized.normalizedAny()) {
+      auto owned = std::make_shared<cudf::table>(std::move(normalized.owned));
+      // Rebuild the view over the owned copy: normalized.view referenced the
+      // vector we just moved out of.
+      normalizedBuildKeys.push_back(owned);
+      buildKeyView = owned->view();
+    } else {
+      normalizedBuildKeys.push_back(nullptr);
+    }
     hashObjects.push_back(
         (buildHashJoin) ? std::make_shared<cudf::hash_join>(
-                              tbls[i]->view().select(buildKeyIndices),
+                              buildKeyView,
                               cudf::null_equality::UNEQUAL,
                               stream,
                               get_temp_mr())
@@ -429,8 +464,10 @@ void CudfHashJoinBuild::doNoMoreInput() {
   cudfHashJoinBridge->setBuildStream(stream);
   cudfHashJoinBridge->setBuildReadyEvent(std::move(buildReadyEvent));
   cudfHashJoinBridge->setHashTable(
-      std::make_optional(
-          std::make_pair(std::move(shared_tbls), std::move(hashObjects))));
+      std::make_optional(CudfHashJoinBridge::BuildState{
+          std::move(shared_tbls),
+          std::move(hashObjects),
+          std::move(normalizedBuildKeys)}));
 }
 
 exec::BlockingReason CudfHashJoinBuild::isBlocked(ContinueFuture* future) {
@@ -499,6 +536,19 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     rightKeyIndices_[i] = static_cast<cudf::size_type>(
         buildType_->getChildIdx(rightKeys[i]->name()));
     VELOX_CHECK_LT(rightKeyIndices_[i], buildTableNumColumns);
+  }
+
+  // Recorded once: which key columns are TIMESTAMP WITH TIME ZONE and so must be
+  // matched on their instant rather than their packed value.
+  leftKeyIsTswtz_.reserve(leftKeyIndices_.size());
+  for (const auto idx : leftKeyIndices_) {
+    leftKeyIsTswtz_.push_back(isTimestampWithTimeZoneType(
+        probeType_->childAt(static_cast<uint32_t>(idx))));
+  }
+  rightKeyIsTswtz_.reserve(rightKeyIndices_.size());
+  for (const auto idx : rightKeyIndices_) {
+    rightKeyIsTswtz_.push_back(isTimestampWithTimeZoneType(
+        buildType_->childAt(static_cast<uint32_t>(idx))));
   }
 
   auto outputType = joinNode_->outputType();
@@ -826,6 +876,26 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::unfilteredOutput(
   return {std::make_unique<cudf::table>(std::move(joinedCols)), numRows};
 }
 
+NormalizedKeys CudfHashJoinProbe::probeKeys(
+    cudf::table_view probeTableView,
+    rmm::cuda_stream_view stream) const {
+  return normalizeKeyColumns(
+      probeTableView.select(leftKeyIndices_),
+      leftKeyIsTswtz_,
+      stream,
+      get_temp_mr());
+}
+
+NormalizedKeys CudfHashJoinProbe::buildKeys(
+    cudf::table_view buildTableView,
+    rmm::cuda_stream_view stream) const {
+  return normalizeKeyColumns(
+      buildTableView.select(rightKeyIndices_),
+      rightKeyIsTswtz_,
+      stream,
+      get_temp_mr());
+}
+
 CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::filteredOutput(
     cudf::table_view leftTableView,
     cudf::column_view leftIndicesCol,
@@ -930,8 +1000,8 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
     rmm::cuda_stream_view stream) {
   std::vector<JoinOutput> cudfOutputs;
 
-  auto& rightTables = hashObject_.value().first;
-  auto& hbs = hashObject_.value().second;
+  auto& rightTables = hashObject_.value().tables;
+  auto& hbs = hashObject_.value().joins;
 
   // Precompute left (probe) table columns if needed (once, outside loop)
   std::vector<ColumnOrView> leftPrecomputed;
@@ -961,8 +1031,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
 
     // left = probe, right = build
     VELOX_CHECK_NOT_NULL(hb);
+    // Probe keys normalized to match the build side, which was normalized when hb
+    // was constructed. Kept in a named local so it outlives the call.
+    auto probeKeyTable = probeKeys(leftTableView, stream);
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        leftTableView.select(leftKeyIndices_),
+        probeKeyTable.view,
         std::nullopt,
         stream,
         get_temp_mr());
@@ -1022,8 +1095,8 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
     rmm::cuda_stream_view stream) {
   std::vector<JoinOutput> cudfOutputs;
 
-  auto& rightTables = hashObject_.value().first;
-  auto& hbs = hashObject_.value().second;
+  auto& rightTables = hashObject_.value().tables;
+  auto& hbs = hashObject_.value().joins;
   auto numProbeRows = leftTableView.num_rows();
 
   // Track which probe rows matched in any build batch so that unmatched probe
@@ -1142,8 +1215,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
     // Use inner_join to get only real matched pairs. Unmatched probe rows are
     // emitted separately after the loop.
     VELOX_CHECK_NOT_NULL(hb);
+    // Probe keys normalized to match the build side, which was normalized when hb
+    // was constructed. Kept in a named local so it outlives the call.
+    auto probeKeyTable = probeKeys(leftTableView, stream);
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        leftTableView.select(leftKeyIndices_),
+        probeKeyTable.view,
         std::nullopt,
         stream,
         get_temp_mr());
@@ -1201,16 +1277,19 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
     rmm::cuda_stream_view stream) {
   std::vector<JoinOutput> cudfOutputs;
 
-  auto& rightTables = hashObject_.value().first;
-  auto& hbs = hashObject_.value().second;
+  auto& rightTables = hashObject_.value().tables;
+  auto& hbs = hashObject_.value().joins;
 
   for (auto i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
     auto& hb = hbs[i];
 
     VELOX_CHECK_NOT_NULL(hb);
+    // Probe keys normalized to match the build side, which was normalized when hb
+    // was constructed. Kept in a named local so it outlives the call.
+    auto probeKeyTable = probeKeys(leftTableView, stream);
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        leftTableView.select(leftKeyIndices_),
+        probeKeyTable.view,
         std::nullopt,
         stream,
         get_temp_mr());
@@ -1337,8 +1416,8 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
     rmm::cuda_stream_view stream) {
   std::vector<JoinOutput> cudfOutputs;
 
-  auto& rightTables = hashObject_.value().first;
-  auto& hbs = hashObject_.value().second;
+  auto& rightTables = hashObject_.value().tables;
+  auto& hbs = hashObject_.value().joins;
   auto numProbeRows = leftTableView.num_rows();
 
   // For now, AST support is necessary to filter join output
@@ -1381,8 +1460,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
     // emitted separately after the loop. Unmatched build rows are emitted in
     // doGetOutput via rightMatchedFlags_.
     VELOX_CHECK_NOT_NULL(hb);
+    // Probe keys normalized to match the build side, which was normalized when hb
+    // was constructed. Kept in a named local so it outlives the call.
+    auto probeKeyTable = probeKeys(leftTableView, stream);
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        leftTableView.select(leftKeyIndices_),
+        probeKeyTable.view,
         std::nullopt,
         stream,
         get_temp_mr());
@@ -1475,7 +1557,7 @@ CudfHashJoinProbe::leftSemiFilterJoin(
     rmm::cuda_stream_view stream) {
   std::vector<JoinOutput> cudfOutputs;
 
-  auto& rightTables = hashObject_.value().first;
+  auto& rightTables = hashObject_.value().tables;
   auto numProbeRows = leftTableView.num_rows();
 
   // Track which probe rows matched across all build chunks so that each
@@ -1645,8 +1727,8 @@ CudfHashJoinProbe::leftSemiProjectJoin(
     VELOX_NYI("Left semi project join requires AST support for filtering");
   }
 
-  auto& rightTables = hashObject_.value().first;
-  auto& hbs = hashObject_.value().second;
+  auto& rightTables = hashObject_.value().tables;
+  auto& hbs = hashObject_.value().joins;
   auto numProbeRows = leftTableView.num_rows();
 
   const bool isNullAware = joinNode_->isNullAware();
@@ -1698,8 +1780,11 @@ CudfHashJoinProbe::leftSemiProjectJoin(
     // Step 1: Inner join to get (probe_idx, build_idx) pairs where keys match.
     // Unlike left_join, inner_join only returns valid pairs (no JoinNoMatch).
     VELOX_CHECK_NOT_NULL(hb);
+    // Probe keys normalized to match the build side, which was normalized when hb
+    // was constructed. Kept in a named local so it outlives the call.
+    auto probeKeyTable = probeKeys(leftTableView, stream);
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        leftTableView.select(leftKeyIndices_),
+        probeKeyTable.view,
         std::nullopt,
         stream,
         get_temp_mr());
@@ -2044,7 +2129,7 @@ CudfHashJoinProbe::rightSemiFilterJoin(
     rmm::cuda_stream_view stream) {
   std::vector<JoinOutput> cudfOutputs;
 
-  auto& rightTables = hashObject_.value().first;
+  auto& rightTables = hashObject_.value().tables;
   auto rightTableView = rightTables[0]->view();
 
   VELOX_CHECK_EQ(
@@ -2090,7 +2175,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::antiJoin(
     cudf::table_view leftTableViewParam,
     rmm::cuda_stream_view stream) {
   std::vector<JoinOutput> cudfOutputs;
-  auto& rightTables = hashObject_.value().first;
+  auto& rightTables = hashObject_.value().tables;
 
   VELOX_CHECK_EQ(
       rightTables.size(),
@@ -2170,7 +2255,7 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     // If no more input, emit unmatched-right rows if needed.
     if ((joinNode_->isRightJoin() || joinNode_->isFullJoin()) && noMoreInput_ &&
         !finished_ && isLastDriver_) {
-      auto& rightTables = hashObject_.value().first;
+      auto& rightTables = hashObject_.value().tables;
       auto stream = cudfGlobalStreamPool().get_stream();
       std::vector<std::unique_ptr<cudf::table>> toConcat;
       vector_size_t unmatchedRows = 0;
@@ -2260,8 +2345,8 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     VLOG(1) << "Probe table number of rows: " << leftTableView.num_rows();
   }
 
-  auto& rightTables = hashObject_.value().first;
-  auto& hbs = hashObject_.value().second;
+  auto& rightTables = hashObject_.value().tables;
+  auto& hbs = hashObject_.value().joins;
   for (auto i = 0; i < rightTables.size(); i++) {
     auto& rightTable = rightTables[i];
     auto& hb = hbs[i];
@@ -2385,7 +2470,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
 
   // Lazy initialize matched flags only when build side is done
   if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
-    auto& rightTablesInit = hashObject_.value().first;
+    auto& rightTablesInit = hashObject_.value().tables;
     rightMatchedFlags_.clear();
     rightMatchedFlags_.reserve(rightTablesInit.size());
     auto initStream = cudfGlobalStreamPool().get_stream();
@@ -2403,7 +2488,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
 
   // Precompute right table columns if filter exists (once when build is done)
   if (joinNode_->filter() && !rightPrecomputeInstructions_.empty()) {
-    auto& rightTablesInit = hashObject_.value().first;
+    auto& rightTablesInit = hashObject_.value().tables;
     cachedRightPrecomputed_.clear();
     cachedExtendedRightViews_.clear();
     cachedRightPrecomputed_.reserve(rightTablesInit.size());
@@ -2431,7 +2516,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   // Check if build side has any null keys (needed for null-aware left semi
   // project)
   if (joinNode_->isLeftSemiProjectJoin() && joinNode_->isNullAware()) {
-    auto& rightTablesInit = hashObject_.value().first;
+    auto& rightTablesInit = hashObject_.value().tables;
     buildSideHasNullKeys_ = false;
     for (auto& rt : rightTablesInit) {
       auto keyView = rt->view().select(rightKeyIndices_);
@@ -2447,7 +2532,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
     }
   }
 
-  auto& rightTables = hashObject_.value().first;
+  auto& rightTables = hashObject_.value().tables;
   // should be rightTable->numDistinct() but it needs compute,
   // so we use num_rows()
   if (rightTables[0]->num_rows() == 0) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -17,10 +17,8 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
-#include "velox/experimental/cudf/exec/KeyNormalization.h"
-
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstExpression.h"
@@ -31,6 +29,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h" // NOLINT(misc-unused-headers)
 #include "velox/expression/ExprOptimizer.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/TypeUtil.h"
 
 #include <cudf/aggregation.hpp>
@@ -395,14 +394,15 @@ void CudfHashJoinBuild::doNoMoreInput() {
        joinNode_->isLeftSemiProjectJoin());
 
   // A TIMESTAMP WITH TIME ZONE join key must match on its instant alone: it is
-  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
-  // read unpackMillisUtc only, so hashing the raw value means no two values
-  // carrying different zones ever match and the join silently returns nothing.
+  // physically (millis << 12) | zone_key and Velox's hash and compare for the
+  // type read unpackMillisUtc only, so hashing the raw value means no two
+  // values carrying different zones ever match and the join silently returns
+  // nothing.
   //
   // Both sides must be normalized or neither. A one-sided fix would compare
-  // normalized keys against packed ones and make EVERY TSWTZ join empty for every
-  // zone, including the ones that work today -- worse than the bug. The probe side
-  // is normalized in probeKeys() below; this is the build side.
+  // normalized keys against packed ones and make EVERY TSWTZ join empty for
+  // every zone, including the ones that work today -- worse than the bug. The
+  // probe side is normalized in probeKeys() below; this is the build side.
   std::vector<bool> buildKeyIsTswtz;
   buildKeyIsTswtz.reserve(buildKeyIndices.size());
   for (size_t i = 0; i < buildKeyIndices.size(); i++) {
@@ -414,11 +414,11 @@ void CudfHashJoinBuild::doNoMoreInput() {
   std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
   for (auto i = 0; i < tbls.size(); i++) {
     // The hash object views the key table it is built from and outlives this
-    // function, so a normalized key table has to be owned by the bridge alongside
-    // it rather than by a local.
+    // function, so a normalized key table has to be owned by the bridge
+    // alongside it rather than by a local.
     auto buildKeyView = tbls[i]->view().select(buildKeyIndices);
-    auto normalized =
-        normalizeKeyColumns(buildKeyView, buildKeyIsTswtz, stream, get_temp_mr());
+    auto normalized = normalizeKeyColumns(
+        buildKeyView, buildKeyIsTswtz, stream, get_temp_mr());
     if (normalized.normalizedAny()) {
       auto owned = std::make_shared<cudf::table>(std::move(normalized.owned));
       // Rebuild the view over the owned copy: normalized.view referenced the
@@ -464,10 +464,11 @@ void CudfHashJoinBuild::doNoMoreInput() {
   cudfHashJoinBridge->setBuildStream(stream);
   cudfHashJoinBridge->setBuildReadyEvent(std::move(buildReadyEvent));
   cudfHashJoinBridge->setHashTable(
-      std::make_optional(CudfHashJoinBridge::BuildState{
-          std::move(shared_tbls),
-          std::move(hashObjects),
-          std::move(normalizedBuildKeys)}));
+      std::make_optional(
+          CudfHashJoinBridge::BuildState{
+              std::move(shared_tbls),
+              std::move(hashObjects),
+              std::move(normalizedBuildKeys)}));
 }
 
 exec::BlockingReason CudfHashJoinBuild::isBlocked(ContinueFuture* future) {
@@ -538,8 +539,8 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     VELOX_CHECK_LT(rightKeyIndices_[i], buildTableNumColumns);
   }
 
-  // Recorded once: which key columns are TIMESTAMP WITH TIME ZONE and so must be
-  // matched on their instant rather than their packed value.
+  // Recorded once: which key columns are TIMESTAMP WITH TIME ZONE and so must
+  // be matched on their instant rather than their packed value.
   leftKeyIsTswtz_.reserve(leftKeyIndices_.size());
   for (const auto idx : leftKeyIndices_) {
     leftKeyIsTswtz_.push_back(isTimestampWithTimeZoneType(
@@ -1031,14 +1032,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
 
     // left = probe, right = build
     VELOX_CHECK_NOT_NULL(hb);
-    // Probe keys normalized to match the build side, which was normalized when hb
-    // was constructed. Kept in a named local so it outlives the call.
+    // Probe keys normalized to match the build side, which was normalized when
+    // hb was constructed. Kept in a named local so it outlives the call.
     auto probeKeyTable = probeKeys(leftTableView, stream);
-    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        probeKeyTable.view,
-        std::nullopt,
-        stream,
-        get_temp_mr());
+    auto [leftJoinIndices, rightJoinIndices] =
+        hb->inner_join(probeKeyTable.view, std::nullopt, stream, get_temp_mr());
 
     auto leftIndicesSpan =
         cudf::device_span<cudf::size_type const>{*leftJoinIndices};
@@ -1215,14 +1213,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
     // Use inner_join to get only real matched pairs. Unmatched probe rows are
     // emitted separately after the loop.
     VELOX_CHECK_NOT_NULL(hb);
-    // Probe keys normalized to match the build side, which was normalized when hb
-    // was constructed. Kept in a named local so it outlives the call.
+    // Probe keys normalized to match the build side, which was normalized when
+    // hb was constructed. Kept in a named local so it outlives the call.
     auto probeKeyTable = probeKeys(leftTableView, stream);
-    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        probeKeyTable.view,
-        std::nullopt,
-        stream,
-        get_temp_mr());
+    auto [leftJoinIndices, rightJoinIndices] =
+        hb->inner_join(probeKeyTable.view, std::nullopt, stream, get_temp_mr());
 
     if (leftJoinIndices->size() == 0) {
       continue;
@@ -1285,14 +1280,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
     auto& hb = hbs[i];
 
     VELOX_CHECK_NOT_NULL(hb);
-    // Probe keys normalized to match the build side, which was normalized when hb
-    // was constructed. Kept in a named local so it outlives the call.
+    // Probe keys normalized to match the build side, which was normalized when
+    // hb was constructed. Kept in a named local so it outlives the call.
     auto probeKeyTable = probeKeys(leftTableView, stream);
-    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        probeKeyTable.view,
-        std::nullopt,
-        stream,
-        get_temp_mr());
+    auto [leftJoinIndices, rightJoinIndices] =
+        hb->inner_join(probeKeyTable.view, std::nullopt, stream, get_temp_mr());
     if (!joinNode_->filter()) {
       // Mark matched build rows by checking which row indices appear in
       // rightJoinIndices. Use contains to avoid scatter with duplicate indices.
@@ -1460,14 +1452,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
     // emitted separately after the loop. Unmatched build rows are emitted in
     // doGetOutput via rightMatchedFlags_.
     VELOX_CHECK_NOT_NULL(hb);
-    // Probe keys normalized to match the build side, which was normalized when hb
-    // was constructed. Kept in a named local so it outlives the call.
+    // Probe keys normalized to match the build side, which was normalized when
+    // hb was constructed. Kept in a named local so it outlives the call.
     auto probeKeyTable = probeKeys(leftTableView, stream);
-    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        probeKeyTable.view,
-        std::nullopt,
-        stream,
-        get_temp_mr());
+    auto [leftJoinIndices, rightJoinIndices] =
+        hb->inner_join(probeKeyTable.view, std::nullopt, stream, get_temp_mr());
 
     if (leftJoinIndices->size() == 0) {
       continue;
@@ -1780,14 +1769,11 @@ CudfHashJoinProbe::leftSemiProjectJoin(
     // Step 1: Inner join to get (probe_idx, build_idx) pairs where keys match.
     // Unlike left_join, inner_join only returns valid pairs (no JoinNoMatch).
     VELOX_CHECK_NOT_NULL(hb);
-    // Probe keys normalized to match the build side, which was normalized when hb
-    // was constructed. Kept in a named local so it outlives the call.
+    // Probe keys normalized to match the build side, which was normalized when
+    // hb was constructed. Kept in a named local so it outlives the call.
     auto probeKeyTable = probeKeys(leftTableView, stream);
-    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        probeKeyTable.view,
-        std::nullopt,
-        stream,
-        get_temp_mr());
+    auto [leftJoinIndices, rightJoinIndices] =
+        hb->inner_join(probeKeyTable.view, std::nullopt, stream, get_temp_mr());
 
     if (leftJoinIndices->size() == 0) {
       continue; // No matches from this build table

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/experimental/cudf/exec/CudfOperator.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/expression/AstExpression.h"
 #include "velox/experimental/cudf/expression/AstExpressionUtils.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
@@ -59,9 +60,26 @@ class CudfHashJoinBridge : public exec::JoinBridge {
   // constructed from them to the probe operator
   /** @brief Hash tables paired with their corresponding join objects for
    * batched processing */
-  using hash_type = std::pair<
-      std::vector<std::shared_ptr<cudf::table>>,
-      std::vector<std::shared_ptr<cudf::hash_join>>>;
+  /// Build-side state handed to the probe operators.
+  ///
+  /// normalizedBuildKeys carries the key columns of each build table with any
+  /// TIMESTAMP WITH TIME ZONE zone key cleared, and exists purely for LIFETIME:
+  /// cudf::hash_join views the key table it was built from and must not outlive
+  /// it (hash_join.hpp), so the normalized columns have to live as long as the
+  /// join object. It is empty when no build key needed normalization, in which
+  /// case the join objects view the build tables directly as before.
+  ///
+  /// The columns are kept HERE rather than appended to the build tables, which
+  /// would have been a smaller change but is not safe: the probe's AST filter is
+  /// evaluated against the joined column layout, and cachedExtendedRightViews_
+  /// appends the filter's precompute columns after the build table's own, so extra
+  /// build columns would shift the precompute indices the filter references.
+  struct BuildState {
+    std::vector<std::shared_ptr<cudf::table>> tables;
+    std::vector<std::shared_ptr<cudf::hash_join>> joins;
+    std::vector<std::shared_ptr<cudf::table>> normalizedBuildKeys;
+  };
+  using hash_type = BuildState;
 
   void setHashTable(std::optional<hash_type> hashObject);
 
@@ -209,6 +227,23 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 
   /** @brief Column indices for join keys in left (probe) table */
+  // Selects the probe (or build) key columns and clears any TIMESTAMP WITH TIME
+  // ZONE zone key, so a join matches on the instant. Returns the owning value: the
+  // caller must keep it alive for as long as the returned view is read.
+  //
+  // Both sides go through normalization or neither -- a one-sided fix compares
+  // normalized keys against packed ones and empties every TSWTZ join, including
+  // the single-zone ones that work today.
+  NormalizedKeys probeKeys(
+      cudf::table_view probeTableView,
+      rmm::cuda_stream_view stream) const;
+  NormalizedKeys buildKeys(
+      cudf::table_view buildTableView,
+      rmm::cuda_stream_view stream) const;
+
+  std::vector<bool> leftKeyIsTswtz_;
+  std::vector<bool> rightKeyIsTswtz_;
+
   std::vector<cudf::size_type> leftKeyIndices_;
   /** @brief Column indices for join keys in right (build) table */
   std::vector<cudf::size_type> rightKeyIndices_;

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -70,10 +70,11 @@ class CudfHashJoinBridge : public exec::JoinBridge {
   /// case the join objects view the build tables directly as before.
   ///
   /// The columns are kept HERE rather than appended to the build tables, which
-  /// would have been a smaller change but is not safe: the probe's AST filter is
-  /// evaluated against the joined column layout, and cachedExtendedRightViews_
-  /// appends the filter's precompute columns after the build table's own, so extra
-  /// build columns would shift the precompute indices the filter references.
+  /// would have been a smaller change but is not safe: the probe's AST filter
+  /// is evaluated against the joined column layout, and
+  /// cachedExtendedRightViews_ appends the filter's precompute columns after
+  /// the build table's own, so extra build columns would shift the precompute
+  /// indices the filter references.
   struct BuildState {
     std::vector<std::shared_ptr<cudf::table>> tables;
     std::vector<std::shared_ptr<cudf::hash_join>> joins;
@@ -228,8 +229,8 @@ class CudfHashJoinProbe : public CudfOperatorBase {
 
   /** @brief Column indices for join keys in left (probe) table */
   // Selects the probe (or build) key columns and clears any TIMESTAMP WITH TIME
-  // ZONE zone key, so a join matches on the instant. Returns the owning value: the
-  // caller must keep it alive for as long as the returned view is read.
+  // ZONE zone key, so a join matches on the instant. Returns the owning value:
+  // the caller must keep it alive for as long as the returned view is read.
   //
   // Both sides go through normalization or neither -- a one-sided fix compares
   // normalized keys against packed ones and empties every TSWTZ join, including

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfLocalPartition.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
@@ -144,6 +147,14 @@ CudfLocalPartition::CudfLocalPartition(
       partitionFunctionType_ == PartitionFunctionType::kRoundRobin ||
       partitionFunctionType_ == PartitionFunctionType::kRoundRobinRow);
 
+  partitionKeyIsTswtz_.reserve(partitionKeyIndices_.size());
+  for (const auto channel : partitionKeyIndices_) {
+    partitionKeyIsTswtz_.push_back(
+        isTimestampWithTimeZoneType(planNode->outputType()->childAt(channel)));
+  }
+  partitionKeysNeedNormalization_ =
+      anyKeyNeedsNormalization(planNode->outputType(), partitionKeyIndices_);
+
   // Since we're replacing the LocalPartition with CudfLocalPartition, the
   // number of producers is already set. Adding producer only adds to a counter
   // which we don't have to do again.
@@ -204,6 +215,9 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
       enqueuePartition(partition, cudfVector);
       return;
     }
+    // Declared outside the lambda so the columns it owns outlive the
+    // hash_partition call that reads them; see the comment at its use below.
+    NormalizedKeys normalizedKeys;
     auto [partitionedTable, partitionOffsets] = [&]() {
       auto tableView = cudfVector->getTableView();
       // Use cudf hash partitioning
@@ -213,9 +227,37 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
           partitionKeyIndices.push_back(static_cast<cudf::size_type>(idx));
         }
 
+        if (!partitionKeysNeedNormalization_) {
+          return cudf::hash_partition(
+              tableView,
+              partitionKeyIndices,
+              numPartitions_,
+              cudf::hash_id::HASH_MURMUR3,
+              cudf::DEFAULT_HASH_SEED,
+              stream,
+              get_temp_mr());
+        }
+
+        // A TIMESTAMP WITH TIME ZONE partition key must be hashed on its instant
+        // alone: it is physically (millis << 12) | zone_key, Velox's hash for the
+        // type reads unpackMillisUtc only, and murmur3 over the raw int64 sends
+        // two values for the same moment in different zones to DIFFERENT
+        // partitions. A partitioned aggregation or join then never brings them
+        // together, so the rows are silently lost to each other -- with
+        // numPartitions_ counting consumer drivers, this happens on a single
+        // worker.
+        //
+        // The keys-table overload is what keeps this a pure key change: `input`
+        // stays the untouched payload, so every emitted row keeps its real zone
+        // key, and there is no shadow column to strip or index to remap.
+        normalizedKeys = normalizeKeyColumns(
+            tableView.select(partitionKeyIndices),
+            partitionKeyIsTswtz_,
+            stream,
+            get_temp_mr());
         return cudf::hash_partition(
             tableView,
-            partitionKeyIndices,
+            normalizedKeys.view,
             numPartitions_,
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -16,16 +16,15 @@
 
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfLocalPartition.h"
-#include "velox/experimental/cudf/exec/KeyNormalization.h"
-
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include "velox/core/PlanNode.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"
 #include "velox/exec/Task.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 #include <cudf/copying.hpp>
 #include <cudf/partitioning.hpp>
@@ -238,14 +237,14 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
               get_temp_mr());
         }
 
-        // A TIMESTAMP WITH TIME ZONE partition key must be hashed on its instant
-        // alone: it is physically (millis << 12) | zone_key, Velox's hash for the
-        // type reads unpackMillisUtc only, and murmur3 over the raw int64 sends
-        // two values for the same moment in different zones to DIFFERENT
-        // partitions. A partitioned aggregation or join then never brings them
-        // together, so the rows are silently lost to each other -- with
-        // numPartitions_ counting consumer drivers, this happens on a single
-        // worker.
+        // A TIMESTAMP WITH TIME ZONE partition key must be hashed on its
+        // instant alone: it is physically (millis << 12) | zone_key, Velox's
+        // hash for the type reads unpackMillisUtc only, and murmur3 over the
+        // raw int64 sends two values for the same moment in different zones to
+        // DIFFERENT partitions. A partitioned aggregation or join then never
+        // brings them together, so the rows are silently lost to each other --
+        // with numPartitions_ counting consumer drivers, this happens on a
+        // single worker.
         //
         // The keys-table overload is what keeps this a pure key change: `input`
         // stays the untouched payload, so every emitted row keeps its real zone

--- a/velox/experimental/cudf/exec/CudfLocalPartition.h
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.h
@@ -78,6 +78,13 @@ class CudfLocalPartition : public CudfOperatorBase {
   std::vector<ContinueFuture> futures_;
 
   std::vector<column_index_t> partitionKeyIndices_;
+
+  // Which partition keys are TIMESTAMP WITH TIME ZONE, in key order, computed
+  // once at construction. Such a key must be hashed on its instant alone. The
+  // bool lets the common case of no TSWTZ key skip the work without a type scan
+  // per batch.
+  std::vector<bool> partitionKeyIsTswtz_;
+  bool partitionKeysNeedNormalization_{false};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
@@ -16,8 +16,11 @@
 
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfMarkDistinct.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
@@ -50,6 +53,8 @@ CudfMarkDistinct::CudfMarkDistinct(
   for (const auto& key : planNode->distinctKeys()) {
     auto idx = inputType->getChildIdx(key->name());
     distinctKeyIndices_.push_back(static_cast<cudf::size_type>(idx));
+    distinctKeyIsTswtz_.push_back(
+        isTimestampWithTimeZoneType(inputType->childAt(idx)));
   }
 }
 
@@ -88,7 +93,30 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
   }
 
   // Extract key columns from the input batch.
-  auto batchKeys = tableView.select(distinctKeyIndices_);
+  //
+  // A TIMESTAMP WITH TIME ZONE key is compared on its INSTANT alone: it is
+  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
+  // read unpackMillisUtc only, so comparing the raw value marks one row distinct
+  // per zone instead of one per moment.
+  //
+  // Normalizing here covers all four uses at once, and that is deliberate rather
+  // than incidental. batchKeys feeds the within-batch distinct_indices, the
+  // first-batch seenKeys_, the per-batch uniqueBatchKeys, and through those the
+  // persistent filter -- and normalizing only some of them would compare
+  // normalized keys against unnormalized ones, making EVERY row look new and every
+  // row distinct, for every key type. That is a far worse regression than the bug,
+  // so the normalization has to happen at the single point where the keys are
+  // taken.
+  //
+  // Safe to store normalized: seenKeys_ and seenFilter_ are internal state. The
+  // output is the original input columns plus the marker column (see the end of
+  // this function), so no normalized value can reach a consumer.
+  auto normalizedKeys = normalizeKeyColumns(
+      tableView.select(distinctKeyIndices_),
+      distinctKeyIsTswtz_,
+      stream,
+      tempMr);
+  auto batchKeys = normalizedKeys.view;
 
   // Create marker column (all false initially).
   cudf::numeric_scalar<bool> falseScalar(false, true, stream, tempMr);

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
@@ -16,8 +16,8 @@
 
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfMarkDistinct.h"
-#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -95,18 +95,18 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
   // Extract key columns from the input batch.
   //
   // A TIMESTAMP WITH TIME ZONE key is compared on its INSTANT alone: it is
-  // physically (millis << 12) | zone_key and Velox's hash and compare for the type
-  // read unpackMillisUtc only, so comparing the raw value marks one row distinct
-  // per zone instead of one per moment.
+  // physically (millis << 12) | zone_key and Velox's hash and compare for the
+  // type read unpackMillisUtc only, so comparing the raw value marks one row
+  // distinct per zone instead of one per moment.
   //
-  // Normalizing here covers all four uses at once, and that is deliberate rather
-  // than incidental. batchKeys feeds the within-batch distinct_indices, the
-  // first-batch seenKeys_, the per-batch uniqueBatchKeys, and through those the
-  // persistent filter -- and normalizing only some of them would compare
-  // normalized keys against unnormalized ones, making EVERY row look new and every
-  // row distinct, for every key type. That is a far worse regression than the bug,
-  // so the normalization has to happen at the single point where the keys are
-  // taken.
+  // Normalizing here covers all four uses at once, and that is deliberate
+  // rather than incidental. batchKeys feeds the within-batch distinct_indices,
+  // the first-batch seenKeys_, the per-batch uniqueBatchKeys, and through those
+  // the persistent filter -- and normalizing only some of them would compare
+  // normalized keys against unnormalized ones, making EVERY row look new and
+  // every row distinct, for every key type. That is a far worse regression than
+  // the bug, so the normalization has to happen at the single point where the
+  // keys are taken.
   //
   // Safe to store normalized: seenKeys_ and seenFilter_ are internal state. The
   // output is the original input columns plus the marker column (see the end of

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.h
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.h
@@ -75,6 +75,10 @@ class CudfMarkDistinct : public CudfOperatorBase {
   /// Column indices in the input schema that form the distinct key.
   std::vector<cudf::size_type> distinctKeyIndices_;
 
+  // Which distinct keys are TIMESTAMP WITH TIME ZONE, in key order. Such a key
+  // must be compared on its instant alone.
+  std::vector<bool> distinctKeyIsTswtz_;
+
   /// Accumulated distinct keys seen across all batches processed so far.
   std::unique_ptr<cudf::table> seenKeys_;
 

--- a/velox/experimental/cudf/exec/KeyNormalization.cpp
+++ b/velox/experimental/cudf/exec/KeyNormalization.cpp
@@ -34,8 +34,8 @@ cudf::data_type int64Type() {
 // extract the zone; this ANDs with its complement to drop it.
 //
 // binary_operation propagates the input's null mask, so a null row stays null
-// rather than masking to a value -- which matters because a null key must remain
-// distinct from a real one under cudf::null_equality::UNEQUAL.
+// rather than masking to a value -- which matters because a null key must
+// remain distinct from a real one under cudf::null_equality::UNEQUAL.
 std::unique_ptr<cudf::column> clearZoneKey(
     const cudf::column_view& packed,
     rmm::cuda_stream_view stream,
@@ -43,7 +43,12 @@ std::unique_ptr<cudf::column> clearZoneKey(
   const cudf::numeric_scalar<int64_t> mask(
       ~static_cast<int64_t>(kTimezoneMask), true, stream);
   return cudf::binary_operation(
-      packed, mask, cudf::binary_operator::BITWISE_AND, int64Type(), stream, mr);
+      packed,
+      mask,
+      cudf::binary_operator::BITWISE_AND,
+      int64Type(),
+      stream,
+      mr);
 }
 
 } // namespace
@@ -103,8 +108,7 @@ NormalizedKeys normalizeKeyColumns(
   std::vector<bool> isTswtz;
   isTswtz.reserve(keyChannels.size());
   for (const auto channel : keyChannels) {
-    isTswtz.push_back(
-        isTimestampWithTimeZoneType(rowType->childAt(channel)));
+    isTswtz.push_back(isTimestampWithTimeZoneType(rowType->childAt(channel)));
   }
   return normalizeKeyColumns(keys, isTswtz, stream, mr);
 }

--- a/velox/experimental/cudf/exec/KeyNormalization.cpp
+++ b/velox/experimental/cudf/exec/KeyNormalization.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+#include <cudf/binaryop.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+cudf::data_type int64Type() {
+  return cudf::data_type{cudf::type_id::INT64};
+}
+
+// Clears the zone key of one packed column. Mirrors tswtzZoneKey in
+// expression/TimestampWithTimeZoneColumn.cpp, which ANDs with kTimezoneMask to
+// extract the zone; this ANDs with its complement to drop it.
+//
+// binary_operation propagates the input's null mask, so a null row stays null
+// rather than masking to a value -- which matters because a null key must remain
+// distinct from a real one under cudf::null_equality::UNEQUAL.
+std::unique_ptr<cudf::column> clearZoneKey(
+    const cudf::column_view& packed,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  const cudf::numeric_scalar<int64_t> mask(
+      ~static_cast<int64_t>(kTimezoneMask), true, stream);
+  return cudf::binary_operation(
+      packed, mask, cudf::binary_operator::BITWISE_AND, int64Type(), stream, mr);
+}
+
+} // namespace
+
+NormalizedKeys normalizeKeyColumns(
+    cudf::table_view keys,
+    const std::vector<bool>& isTswtz,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_EQ(
+      static_cast<size_t>(keys.num_columns()),
+      isTswtz.size(),
+      "One normalization flag is required per key column");
+
+  NormalizedKeys result;
+  // Nothing to do is the common case, so return the caller's view untouched
+  // rather than rebuilding an identical one.
+  if (std::none_of(isTswtz.begin(), isTswtz.end(), [](bool b) { return b; })) {
+    result.view = keys;
+    return result;
+  }
+
+  std::vector<cudf::column_view> columns;
+  columns.reserve(keys.num_columns());
+  // Reserve so the owned columns never reallocate: `columns` holds views into
+  // them, and a reallocation would leave those views dangling.
+  result.owned.reserve(keys.num_columns());
+
+  for (auto i = 0; i < keys.num_columns(); ++i) {
+    if (!isTswtz[i]) {
+      columns.push_back(keys.column(i));
+      continue;
+    }
+    VELOX_CHECK_EQ(
+        static_cast<int>(keys.column(i).type().id()),
+        static_cast<int>(cudf::type_id::INT64),
+        "A TIMESTAMP WITH TIME ZONE key column must be physically INT64");
+    result.owned.push_back(clearZoneKey(keys.column(i), stream, mr));
+    columns.push_back(result.owned.back()->view());
+  }
+
+  result.view = cudf::table_view{columns};
+  return result;
+}
+
+NormalizedKeys normalizeKeyColumns(
+    cudf::table_view keys,
+    const RowTypePtr& rowType,
+    const std::vector<column_index_t>& keyChannels,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_EQ(
+      static_cast<size_t>(keys.num_columns()),
+      keyChannels.size(),
+      "One key channel is required per key column");
+
+  std::vector<bool> isTswtz;
+  isTswtz.reserve(keyChannels.size());
+  for (const auto channel : keyChannels) {
+    isTswtz.push_back(
+        isTimestampWithTimeZoneType(rowType->childAt(channel)));
+  }
+  return normalizeKeyColumns(keys, isTswtz, stream, mr);
+}
+
+bool anyKeyNeedsNormalization(
+    const RowTypePtr& rowType,
+    const std::vector<column_index_t>& keyChannels) {
+  for (const auto channel : keyChannels) {
+    if (isTimestampWithTimeZoneType(rowType->childAt(channel))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/KeyNormalization.h
+++ b/velox/experimental/cudf/exec/KeyNormalization.h
@@ -20,6 +20,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/table/table_view.hpp>
+
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -31,9 +32,9 @@ namespace facebook::velox::cudf_velox {
 /// A key table whose TIMESTAMP WITH TIME ZONE columns have had their zone key
 /// cleared, plus the columns backing the rewritten ones.
 ///
-/// `owned` holds only the columns this normalization created; every other column
-/// in `view` still refers to the caller's input. So `owned` must outlive `view`,
-/// and `view` must not outlive the table it was built from.
+/// `owned` holds only the columns this normalization created; every other
+/// column in `view` still refers to the caller's input. So `owned` must outlive
+/// `view`, and `view` must not outlive the table it was built from.
 struct NormalizedKeys {
   cudf::table_view view;
   std::vector<std::unique_ptr<cudf::column>> owned;
@@ -45,18 +46,19 @@ struct NormalizedKeys {
   }
 };
 
-/// Rewrites the TIMESTAMP WITH TIME ZONE columns of a key table so that hashing,
-/// equality and ordering over the result match Velox's semantics for the type.
+/// Rewrites the TIMESTAMP WITH TIME ZONE columns of a key table so that
+/// hashing, equality and ordering over the result match Velox's semantics for
+/// the type.
 ///
 /// Why this is needed. A TIMESTAMP WITH TIME ZONE is physically one int64,
 /// (millis << kMillisShift) | zone_key, and Velox compares it on the INSTANT
 /// alone -- TimestampWithTimeZoneType::compare and ::hash both read
-/// unpackMillisUtc, reached through the type's ProvideCustomComparison hook. Two
-/// values for the same moment in different zones are therefore EQUAL, and must
-/// group together, deduplicate to one, join to each other and hash to the same
-/// partition. cuDF has no type-level hook: veloxToCudfDataType maps the type to
-/// INT64, so every cuDF primitive that hashes or compares the column uses all 64
-/// bits and the zone key decides.
+/// unpackMillisUtc, reached through the type's ProvideCustomComparison hook.
+/// Two values for the same moment in different zones are therefore EQUAL, and
+/// must group together, deduplicate to one, join to each other and hash to the
+/// same partition. cuDF has no type-level hook: veloxToCudfDataType maps the
+/// type to INT64, so every cuDF primitive that hashes or compares the column
+/// uses all 64 bits and the zone key decides.
 ///
 /// What it does. Clears the low kMillisShift bits, which computes
 /// (v >> kMillisShift) << kMillisShift. That is monotone and collapses exactly
@@ -73,16 +75,17 @@ struct NormalizedKeys {
 ///
 /// WHAT THIS IS NOT FOR. A normalized value is equivalent for EQUALITY and
 /// ORDERING ONLY. It must never be emitted as an operator's output: the packed
-/// value is what a projection has to carry and what to_iso8601 and timezone_hour
-/// have to read, so a normalized value flowing downstream would silently rewrite
-/// every zone key to UTC. Callers whose primitive RETURNS its key columns
-/// (cudf::groupby, and cudf::distinct as it is called in CudfDistinct) must
-/// therefore not hand the result of this function on as output -- they need to
-/// recover the original packed value separately.
+/// value is what a projection has to carry and what to_iso8601 and
+/// timezone_hour have to read, so a normalized value flowing downstream would
+/// silently rewrite every zone key to UTC. Callers whose primitive RETURNS its
+/// key columns (cudf::groupby, and cudf::distinct as it is called in
+/// CudfDistinct) must therefore not hand the result of this function on as
+/// output -- they need to recover the original packed value separately.
 ///
 /// @param keys       the key columns, already selected in key order
 /// @param rowType    the Velox row type the key columns came from
-/// @param keyChannels index into `rowType` for each column of `keys`, in the same
+/// @param keyChannels index into `rowType` for each column of `keys`, in the
+/// same
 ///                   order; must be the same length as `keys`
 /// @param stream, mr  the stream and resource any rewritten column is built on
 NormalizedKeys normalizeKeyColumns(

--- a/velox/experimental/cudf/exec/KeyNormalization.h
+++ b/velox/experimental/cudf/exec/KeyNormalization.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+#include <cudf/column/column.hpp>
+#include <cudf/table/table_view.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace facebook::velox::cudf_velox {
+
+/// A key table whose TIMESTAMP WITH TIME ZONE columns have had their zone key
+/// cleared, plus the columns backing the rewritten ones.
+///
+/// `owned` holds only the columns this normalization created; every other column
+/// in `view` still refers to the caller's input. So `owned` must outlive `view`,
+/// and `view` must not outlive the table it was built from.
+struct NormalizedKeys {
+  cudf::table_view view;
+  std::vector<std::unique_ptr<cudf::column>> owned;
+
+  /// True when at least one column was rewritten. Lets a caller skip any
+  /// bookkeeping it only needs on the normalized path.
+  bool normalizedAny() const {
+    return !owned.empty();
+  }
+};
+
+/// Rewrites the TIMESTAMP WITH TIME ZONE columns of a key table so that hashing,
+/// equality and ordering over the result match Velox's semantics for the type.
+///
+/// Why this is needed. A TIMESTAMP WITH TIME ZONE is physically one int64,
+/// (millis << kMillisShift) | zone_key, and Velox compares it on the INSTANT
+/// alone -- TimestampWithTimeZoneType::compare and ::hash both read
+/// unpackMillisUtc, reached through the type's ProvideCustomComparison hook. Two
+/// values for the same moment in different zones are therefore EQUAL, and must
+/// group together, deduplicate to one, join to each other and hash to the same
+/// partition. cuDF has no type-level hook: veloxToCudfDataType maps the type to
+/// INT64, so every cuDF primitive that hashes or compares the column uses all 64
+/// bits and the zone key decides.
+///
+/// What it does. Clears the low kMillisShift bits, which computes
+/// (v >> kMillisShift) << kMillisShift. That is monotone and collapses exactly
+/// the values sharing an instant, so it preserves both equality and ordering --
+/// everything a hash, a comparison and a sort need. It is also correct for
+/// pre-epoch instants: two's-complement AND floors toward negative infinity,
+/// matching unpackMillisUtc's arithmetic shift, where a divide by 4096 would
+/// truncate toward zero and land a millisecond late.
+///
+/// Masking rather than shifting is deliberate. cudf::ast::ast_operator has
+/// BITWISE_AND but no shift operator, so the expression-level fix in
+/// AstExpressionUtils.h had to mask; this uses the same operation so the two
+/// halves of the fix cannot drift.
+///
+/// WHAT THIS IS NOT FOR. A normalized value is equivalent for EQUALITY and
+/// ORDERING ONLY. It must never be emitted as an operator's output: the packed
+/// value is what a projection has to carry and what to_iso8601 and timezone_hour
+/// have to read, so a normalized value flowing downstream would silently rewrite
+/// every zone key to UTC. Callers whose primitive RETURNS its key columns
+/// (cudf::groupby, and cudf::distinct as it is called in CudfDistinct) must
+/// therefore not hand the result of this function on as output -- they need to
+/// recover the original packed value separately.
+///
+/// @param keys       the key columns, already selected in key order
+/// @param rowType    the Velox row type the key columns came from
+/// @param keyChannels index into `rowType` for each column of `keys`, in the same
+///                   order; must be the same length as `keys`
+/// @param stream, mr  the stream and resource any rewritten column is built on
+NormalizedKeys normalizeKeyColumns(
+    cudf::table_view keys,
+    const RowTypePtr& rowType,
+    const std::vector<column_index_t>& keyChannels,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
+/// Overload for callers that already know which columns are TIMESTAMP WITH TIME
+/// ZONE, e.g. because they cached the flags at operator construction. `isTswtz`
+/// must be the same length as `keys`.
+NormalizedKeys normalizeKeyColumns(
+    cudf::table_view keys,
+    const std::vector<bool>& isTswtz,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
+/// Whether any column of `rowType` named by `keyChannels` is a TIMESTAMP WITH
+/// TIME ZONE. Lets an operator decide at construction time whether it will ever
+/// need to normalize, so the common case costs one bool rather than a scan per
+/// batch.
+bool anyKeyNeedsNormalization(
+    const RowTypePtr& rowType,
+    const std::vector<column_index_t>& keyChannels);
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -2389,15 +2389,15 @@ TEST_F(AggregationTest, zeroColumnThroughCudfFromVelox) {
       .assertResults("SELECT count(*) FROM tmp WHERE c0 > 0");
 }
 
-
 // ---------------------------------------------------------------------------
 // Grouping on a TIMESTAMP WITH TIME ZONE key.
 //
 // The type is physically (millis << 12) | zone_key and Velox groups it on the
 // INSTANT alone -- TimestampWithTimeZoneType::hash and ::compare read
-// unpackMillisUtc, via the type's ProvideCustomComparison hook. Two values for the
-// same moment in different zones are therefore ONE group. cuDF sees a bare INT64,
-// so before the key-normalization fix it produced one group per zone key.
+// unpackMillisUtc, via the type's ProvideCustomComparison hook. Two values for
+// the same moment in different zones are therefore ONE group. cuDF sees a bare
+// INT64, so before the key-normalization fix it produced one group per zone
+// key.
 //
 // These assert on the unpacked result rather than through assertQuery, because
 // DuckDB has no TIMESTAMP WITH TIME ZONE to compare against.
@@ -2435,9 +2435,9 @@ TEST_F(AggregationTest, groupByTimestampWithTimeZoneCollapsesZoneKeys) {
   std::map<int64_t, int64_t> countByInstant;
   for (auto i = 0; i < result->size(); ++i) {
     // The surviving zone key is unspecified, but it must be a REAL one from the
-    // group's own rows -- never 0 from a normalized key leaking into the output.
-    // Both groups here are all-non-UTC except the second, so assert membership
-    // rather than a fixed value.
+    // group's own rows -- never 0 from a normalized key leaking into the
+    // output. Both groups here are all-non-UTC except the second, so assert
+    // membership rather than a fixed value.
     countByInstant[unpackMillisUtc(keys->valueAt(i))] = counts->valueAt(i);
   }
   EXPECT_EQ(countByInstant[millis], 3);
@@ -2467,7 +2467,8 @@ TEST_F(AggregationTest, groupByTimestampWithTimeZoneEmitsARealZoneKey) {
   EXPECT_EQ(unpackMillisUtc(key), millis);
   const auto zone = unpackZoneKeyId(key);
   EXPECT_TRUE(zone == kolkata || zone == kathmandu)
-      << "the group key must keep a zone key from one of its rows, got " << zone;
+      << "the group key must keep a zone key from one of its rows, got "
+      << zone;
   EXPECT_NE(zone, 0) << "zone 0 would mean a normalized key reached the output";
 }
 
@@ -2501,11 +2502,12 @@ TEST_F(AggregationTest, groupByTimestampWithTimeZoneKeepsNullsSeparate) {
   }
 }
 
-// SELECT DISTINCT on a TIMESTAMP WITH TIME ZONE key. A distinct aggregation (grouping
-// keys, no aggregates) routes to CudfDistinct rather than CudfGroupby, and that
-// operator returns its KEY columns as its output -- so the fix there had to take the
-// indices of the distinct rows from normalized keys and gather the ORIGINAL columns,
-// rather than deduplicate normalized values and emit them.
+// SELECT DISTINCT on a TIMESTAMP WITH TIME ZONE key. A distinct aggregation
+// (grouping keys, no aggregates) routes to CudfDistinct rather than
+// CudfGroupby, and that operator returns its KEY columns as its output -- so
+// the fix there had to take the indices of the distinct rows from normalized
+// keys and gather the ORIGINAL columns, rather than deduplicate normalized
+// values and emit them.
 TEST_F(AggregationTest, distinctTimestampWithTimeZoneCollapsesZoneKeys) {
   const int64_t millis = 1'623'758'400'000;
   const int64_t other = -14'182'940'000;
@@ -2553,21 +2555,22 @@ TEST_F(AggregationTest, distinctTimestampWithTimeZoneEmitsARealZoneKey) {
   EXPECT_NE(zone, 0) << "zone 0 would mean a normalized key reached the output";
 }
 
-// count(DISTINCT ts) is deliberately NOT asserted here. That plan shape is DECLINED
-// by cuDF, and this fixture sets allowCpuFallback = false, so the test would fail on
-// "Replacement with cuDF operator failed" rather than on the deduplication. Allowing
-// fallback instead would assert CPU's answer and prove nothing about the GPU. It is the
-// reason the parity suite's n_tswtz_count_distinct_across_zones case sets
-// gpu_claimed: false and is measured on the PERMISSIVE cluster, where the shape runs
-// partly on GPU and the wrong count is observable -- a strict-mode raise alone does not
-// establish that a shape is safely declined.
+// count(DISTINCT ts) is deliberately NOT asserted here. That plan shape is
+// DECLINED by cuDF, and this fixture sets allowCpuFallback = false, so the test
+// would fail on "Replacement with cuDF operator failed" rather than on the
+// deduplication. Allowing fallback instead would assert CPU's answer and prove
+// nothing about the GPU. It is the reason the parity suite's
+// n_tswtz_count_distinct_across_zones case sets gpu_claimed: false and is
+// measured on the PERMISSIVE cluster, where the shape runs partly on GPU and
+// the wrong count is observable -- a strict-mode raise alone does not establish
+// that a shape is safely declined.
 
-// The same grouping across a hash-partitioned local exchange, which is the shape
-// a real plan takes and the reason this needed two fixes rather than one:
-// CudfLocalPartition murmur3-hashed the packed value, so same-instant rows went to
-// different drivers and the final aggregation could not merge them even once the
-// group-by itself compared instants. maxDrivers > 1 is what makes numPartitions_
-// exceed 1 and put CudfLocalPartition in the plan at all.
+// The same grouping across a hash-partitioned local exchange, which is the
+// shape a real plan takes and the reason this needed two fixes rather than one:
+// CudfLocalPartition murmur3-hashed the packed value, so same-instant rows went
+// to different drivers and the final aggregation could not merge them even once
+// the group-by itself compared instants. maxDrivers > 1 is what makes
+// numPartitions_ exceed 1 and put CudfLocalPartition in the plan at all.
 TEST_F(AggregationTest, groupByTimestampWithTimeZoneAcrossPartitionedExchange) {
   const int64_t millis = 1'623'758'400'000;
   auto rows = [&](const char* zone) {
@@ -2583,17 +2586,18 @@ TEST_F(AggregationTest, groupByTimestampWithTimeZoneAcrossPartitionedExchange) {
         .partialAggregation({"c0"}, {"count(1)"})
         .planNode();
   };
-  auto plan = PlanBuilder(idGenerator)
-                  .localPartition(
-                      {"c0"},
-                      {source("Pacific/Kiritimati"), source("Pacific/Midway")})
-                  .finalAggregation()
-                  .planNode();
+  auto plan =
+      PlanBuilder(idGenerator)
+          .localPartition(
+              {"c0"}, {source("Pacific/Kiritimati"), source("Pacific/Midway")})
+          .finalAggregation()
+          .planNode();
 
-  auto result = AssertQueryBuilder(plan)
-                    .maxDrivers(2)
-                    .config(core::QueryConfig::kMaxLocalExchangePartitionCount, "2")
-                    .copyResults(pool());
+  auto result =
+      AssertQueryBuilder(plan)
+          .maxDrivers(2)
+          .config(core::QueryConfig::kMaxLocalExchangePartitionCount, "2")
+          .copyResults(pool());
 
   // Two instants, each present under both zones: two groups of two.
   ASSERT_EQ(result->size(), 2);
@@ -2606,6 +2610,5 @@ TEST_F(AggregationTest, groupByTimestampWithTimeZoneAcrossPartitionedExchange) {
   EXPECT_EQ(countByInstant[millis], 2);
   EXPECT_EQ(countByInstant[millis + 1], 2);
 }
-
 
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -2501,6 +2501,67 @@ TEST_F(AggregationTest, groupByTimestampWithTimeZoneKeepsNullsSeparate) {
   }
 }
 
+// SELECT DISTINCT on a TIMESTAMP WITH TIME ZONE key. A distinct aggregation (grouping
+// keys, no aggregates) routes to CudfDistinct rather than CudfGroupby, and that
+// operator returns its KEY columns as its output -- so the fix there had to take the
+// indices of the distinct rows from normalized keys and gather the ORIGINAL columns,
+// rather than deduplicate normalized values and emit them.
+TEST_F(AggregationTest, distinctTimestampWithTimeZoneCollapsesZoneKeys) {
+  const int64_t millis = 1'623'758'400'000;
+  const int64_t other = -14'182'940'000;
+  auto data = makeRowVector({makeFlatVector<int64_t>(
+      {packAt(millis, "Pacific/Kiritimati"),
+       packAt(millis, "Pacific/Midway"),
+       packAt(other, "Asia/Kolkata"),
+       packAt(millis, "UTC")},
+      TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan =
+      PlanBuilder().values({data}).singleAggregation({"c0"}, {}).planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 2) << "two instants, not four packed values";
+  auto keys = result->childAt(0)->as<SimpleVector<int64_t>>();
+  std::set<int64_t> instants;
+  for (auto i = 0; i < result->size(); ++i) {
+    instants.insert(unpackMillisUtc(keys->valueAt(i)));
+  }
+  EXPECT_EQ(instants, (std::set<int64_t>{millis, other}));
+}
+
+// The surviving row must keep its own zone key. Every row is non-UTC, so a
+// normalized key reaching the output shows up as zone 0 -- which the test above
+// cannot detect, because there UTC is one of the legitimate answers.
+TEST_F(AggregationTest, distinctTimestampWithTimeZoneEmitsARealZoneKey) {
+  const int64_t millis = 1'623'758'400'000;
+  const auto kolkata = tz::getTimeZoneID("Asia/Kolkata");
+  const auto kathmandu = tz::getTimeZoneID("Asia/Kathmandu");
+  auto data = makeRowVector({makeFlatVector<int64_t>(
+      {pack(millis, kolkata), pack(millis, kathmandu)},
+      TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan =
+      PlanBuilder().values({data}).singleAggregation({"c0"}, {}).planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 1);
+  const auto key = result->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+  EXPECT_EQ(unpackMillisUtc(key), millis);
+  const auto zone = unpackZoneKeyId(key);
+  EXPECT_TRUE(zone == kolkata || zone == kathmandu)
+      << "the surviving row must keep a zone key from the input, got " << zone;
+  EXPECT_NE(zone, 0) << "zone 0 would mean a normalized key reached the output";
+}
+
+// count(DISTINCT ts) is deliberately NOT asserted here. That plan shape is DECLINED
+// by cuDF, and this fixture sets allowCpuFallback = false, so the test would fail on
+// "Replacement with cuDF operator failed" rather than on the deduplication. Allowing
+// fallback instead would assert CPU's answer and prove nothing about the GPU. It is the
+// reason the parity suite's n_tswtz_count_distinct_across_zones case sets
+// gpu_claimed: false and is measured on the PERMISSIVE cluster, where the shape runs
+// partly on GPU and the wrong count is observable -- a strict-mode raise alone does not
+// establish that a shape is safely declined.
+
 // The same grouping across a hash-partitioned local exchange, which is the shape
 // a real plan takes and the reason this needed two fixes rather than one:
 // CudfLocalPartition murmur3-hashed the packed value, so same-instant rows went to

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -26,7 +26,9 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Timestamp.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 #include <cmath>
 
@@ -2386,5 +2388,163 @@ TEST_F(AggregationTest, zeroColumnThroughCudfFromVelox) {
       .plan(plan)
       .assertResults("SELECT count(*) FROM tmp WHERE c0 > 0");
 }
+
+
+// ---------------------------------------------------------------------------
+// Grouping on a TIMESTAMP WITH TIME ZONE key.
+//
+// The type is physically (millis << 12) | zone_key and Velox groups it on the
+// INSTANT alone -- TimestampWithTimeZoneType::hash and ::compare read
+// unpackMillisUtc, via the type's ProvideCustomComparison hook. Two values for the
+// same moment in different zones are therefore ONE group. cuDF sees a bare INT64,
+// so before the key-normalization fix it produced one group per zone key.
+//
+// These assert on the unpacked result rather than through assertQuery, because
+// DuckDB has no TIMESTAMP WITH TIME ZONE to compare against.
+// ---------------------------------------------------------------------------
+namespace {
+// Kiritimati (+14) and Midway (-11) are the extremes of the offset range, so
+// their zone keys are as far apart as their offsets.
+int64_t packAt(int64_t millis, const char* zone) {
+  return pack(millis, tz::getTimeZoneID(zone));
+}
+} // namespace
+
+TEST_F(AggregationTest, groupByTimestampWithTimeZoneCollapsesZoneKeys) {
+  const int64_t millis = 1'623'758'400'000;
+  const int64_t other = -14'182'940'000;
+  auto data = makeRowVector({makeFlatVector<int64_t>(
+      {packAt(millis, "Pacific/Kiritimati"),
+       packAt(millis, "Pacific/Midway"),
+       packAt(millis, "Asia/Kolkata"),
+       packAt(other, "Pacific/Midway"),
+       packAt(other, "UTC")},
+      TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({"c0"}, {"count(1)"})
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  // Two instants, so two groups -- not the five the packed values would give.
+  ASSERT_EQ(result->size(), 2);
+  auto keys = result->childAt(0)->as<SimpleVector<int64_t>>();
+  auto counts = result->childAt(1)->as<SimpleVector<int64_t>>();
+
+  std::map<int64_t, int64_t> countByInstant;
+  for (auto i = 0; i < result->size(); ++i) {
+    // The surviving zone key is unspecified, but it must be a REAL one from the
+    // group's own rows -- never 0 from a normalized key leaking into the output.
+    // Both groups here are all-non-UTC except the second, so assert membership
+    // rather than a fixed value.
+    countByInstant[unpackMillisUtc(keys->valueAt(i))] = counts->valueAt(i);
+  }
+  EXPECT_EQ(countByInstant[millis], 3);
+  EXPECT_EQ(countByInstant[other], 2);
+}
+
+// The emitted group key must carry a zone key from one of the group's own rows.
+// Every row here is non-UTC, so a normalized key leaking into the output would
+// show up as zone 0 -- which is what this catches and the test above cannot,
+// since there UTC is a legitimate answer.
+TEST_F(AggregationTest, groupByTimestampWithTimeZoneEmitsARealZoneKey) {
+  const int64_t millis = 1'623'758'400'000;
+  const auto kolkata = tz::getTimeZoneID("Asia/Kolkata");
+  const auto kathmandu = tz::getTimeZoneID("Asia/Kathmandu");
+  auto data = makeRowVector({makeFlatVector<int64_t>(
+      {pack(millis, kolkata), pack(millis, kathmandu)},
+      TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({"c0"}, {"count(1)"})
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 1);
+  const auto key = result->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
+  EXPECT_EQ(unpackMillisUtc(key), millis);
+  const auto zone = unpackZoneKeyId(key);
+  EXPECT_TRUE(zone == kolkata || zone == kathmandu)
+      << "the group key must keep a zone key from one of its rows, got " << zone;
+  EXPECT_NE(zone, 0) << "zone 0 would mean a normalized key reached the output";
+}
+
+// Nulls still form their own group, and normalization must not turn a null key
+// into a value: under Velox's semantics a null key is distinct from the epoch.
+TEST_F(AggregationTest, groupByTimestampWithTimeZoneKeepsNullsSeparate) {
+  const int64_t millis = 1'623'758'400'000;
+  auto data = makeRowVector({makeNullableFlatVector<int64_t>(
+      {packAt(millis, "Pacific/Kiritimati"),
+       packAt(millis, "Pacific/Midway"),
+       std::nullopt,
+       std::nullopt},
+      TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({"c0"}, {"count(1)"})
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 2);
+  auto keys = result->childAt(0)->as<SimpleVector<int64_t>>();
+  auto counts = result->childAt(1)->as<SimpleVector<int64_t>>();
+  for (auto i = 0; i < result->size(); ++i) {
+    if (keys->isNullAt(i)) {
+      EXPECT_EQ(counts->valueAt(i), 2) << "the two nulls form one group";
+    } else {
+      EXPECT_EQ(unpackMillisUtc(keys->valueAt(i)), millis);
+      EXPECT_EQ(counts->valueAt(i), 2) << "the two zones collapse to one group";
+    }
+  }
+}
+
+// The same grouping across a hash-partitioned local exchange, which is the shape
+// a real plan takes and the reason this needed two fixes rather than one:
+// CudfLocalPartition murmur3-hashed the packed value, so same-instant rows went to
+// different drivers and the final aggregation could not merge them even once the
+// group-by itself compared instants. maxDrivers > 1 is what makes numPartitions_
+// exceed 1 and put CudfLocalPartition in the plan at all.
+TEST_F(AggregationTest, groupByTimestampWithTimeZoneAcrossPartitionedExchange) {
+  const int64_t millis = 1'623'758'400'000;
+  auto rows = [&](const char* zone) {
+    return makeRowVector({makeFlatVector<int64_t>(
+        {packAt(millis, zone), packAt(millis + 1, zone)},
+        TIMESTAMP_WITH_TIME_ZONE())});
+  };
+
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto source = [&](const char* zone) {
+    return PlanBuilder(idGenerator)
+        .values({rows(zone)})
+        .partialAggregation({"c0"}, {"count(1)"})
+        .planNode();
+  };
+  auto plan = PlanBuilder(idGenerator)
+                  .localPartition(
+                      {"c0"},
+                      {source("Pacific/Kiritimati"), source("Pacific/Midway")})
+                  .finalAggregation()
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan)
+                    .maxDrivers(2)
+                    .config(core::QueryConfig::kMaxLocalExchangePartitionCount, "2")
+                    .copyResults(pool());
+
+  // Two instants, each present under both zones: two groups of two.
+  ASSERT_EQ(result->size(), 2);
+  auto keys = result->childAt(0)->as<SimpleVector<int64_t>>();
+  auto counts = result->childAt(1)->as<SimpleVector<int64_t>>();
+  std::map<int64_t, int64_t> countByInstant;
+  for (auto i = 0; i < result->size(); ++i) {
+    countByInstant[unpackMillisUtc(keys->valueAt(i))] = counts->valueAt(i);
+  }
+  EXPECT_EQ(countByInstant[millis], 2);
+  EXPECT_EQ(countByInstant[millis + 1], 2);
+}
+
 
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -213,6 +213,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_key_normalization_test
+  SOURCES Main.cpp KeyNormalizationTest.cpp
+  LIBS velox_cudf_exec cudf::cudf
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_null_mask_test
   SOURCES Main.cpp NullMaskTest.cpp
   LIBS velox_cudf_expression cudf::cudf

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -21,6 +21,8 @@
 
 #include "folly/synchronization/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
@@ -9691,6 +9693,113 @@ TEST_F(HashJoinTest, mixedGroupedExecution) {
           .numConcurrentSplitGroups(1)
           .countResults(),
       0);
+}
+
+// ---------------------------------------------------------------------------
+// TIMESTAMP WITH TIME ZONE join keys.
+//
+// The type is physically (millis << 12) | zone_key and Velox matches it on the
+// INSTANT alone, so two values for the same moment in different zones are the SAME
+// key and must join. Before the key-normalization fix cuDF hashed all 64 bits, so
+// no two values carrying different zones ever matched and such a join returned
+// nothing at all -- silently, with no error.
+//
+// Only the join types that build a cudf::hash_join are covered here: inner, left,
+// right, full and left-semi-project. The semi/anti FILTER variants build their own
+// hash tables from raw views through mixed_left_semi_join / filtered_join and are a
+// separate mechanism, still to be fixed.
+// ---------------------------------------------------------------------------
+namespace {
+// Kiritimati (+14) and Midway (-11) are the extremes of the offset range.
+int64_t packJoinKey(int64_t millis, const char* zone) {
+  return pack(millis, tz::getTimeZoneID(zone));
+}
+} // namespace
+
+TEST_F(HashJoinTest, innerJoinTimestampWithTimeZoneMatchesOnInstant) {
+  const int64_t a = 1'623'758'400'000;
+  const int64_t b = -14'182'940'000;
+  // Same instants on both sides, but every probe row carries a different zone key
+  // from its build counterpart, so nothing matches on the packed value.
+  auto probe = makeRowVector(
+      {"k"},
+      {makeFlatVector<int64_t>(
+          {packJoinKey(a, "Pacific/Kiritimati"),
+           packJoinKey(b, "Pacific/Kiritimati")},
+          TIMESTAMP_WITH_TIME_ZONE())});
+  auto build = makeRowVector(
+      {"u_k"},
+      {makeFlatVector<int64_t>(
+          {packJoinKey(a, "Pacific/Midway"), packJoinKey(b, "Asia/Kolkata")},
+          TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan =
+      countStarOverZeroColumnHashJoinPlan(probe, build, core::JoinType::kInner);
+  auto expected = makeRowVector({makeFlatVector<int64_t>({2})});
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// A left join is the shape where the defect is quietest: instead of an empty
+// result it produces the right ROW COUNT with every build column null, which looks
+// like "no matches" rather than a bug.
+TEST_F(HashJoinTest, leftJoinTimestampWithTimeZoneMatchesOnInstant) {
+  const int64_t a = 1'623'758'400'000;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto probe = makeRowVector(
+      {"k"},
+      {makeFlatVector<int64_t>(
+          {packJoinKey(a, "Pacific/Kiritimati"),
+           packJoinKey(a + 1, "Pacific/Kiritimati")},
+          TIMESTAMP_WITH_TIME_ZONE())});
+  // Only the first instant is present on the build side.
+  auto build = makeRowVector(
+      {"u_k"},
+      {makeFlatVector<int64_t>(
+          {packJoinKey(a, "Pacific/Midway")}, TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values({probe})
+                  .hashJoin(
+                      {"k"},
+                      {"u_k"},
+                      PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+                      "",
+                      {"k", "u_k"},
+                      core::JoinType::kLeft)
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 2);
+  auto buildSide = result->childAt(1)->as<SimpleVector<int64_t>>();
+  int matched = 0;
+  for (auto i = 0; i < result->size(); ++i) {
+    if (!buildSide->isNullAt(i)) {
+      ++matched;
+      EXPECT_EQ(unpackMillisUtc(buildSide->valueAt(i)), a);
+    }
+  }
+  EXPECT_EQ(matched, 1) << "the shared instant must match across zone keys";
+}
+
+// Instants one millisecond apart must NOT join, which is what fails if the
+// normalization ever clears more than the zone-key bits.
+TEST_F(HashJoinTest, innerJoinTimestampWithTimeZoneSeparatesAdjacentMillis) {
+  const int64_t a = 1'623'758'400'000;
+  auto probe = makeRowVector(
+      {"k"},
+      {makeFlatVector<int64_t>(
+          {packJoinKey(a, "Pacific/Kiritimati")}, TIMESTAMP_WITH_TIME_ZONE())});
+  auto build = makeRowVector(
+      {"u_k"},
+      {makeFlatVector<int64_t>(
+          {packJoinKey(a + 1, "Pacific/Midway"),
+           packJoinKey(a - 1, "Pacific/Midway")},
+          TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan =
+      countStarOverZeroColumnHashJoinPlan(probe, build, core::JoinType::kInner);
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0})});
+  AssertQueryBuilder(plan).assertResults(expected);
 }
 
 } // namespace

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -21,8 +21,6 @@
 
 #include "folly/synchronization/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
-#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
@@ -37,6 +35,8 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/VectorTestUtil.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/VectorPrinter.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -9699,15 +9699,15 @@ TEST_F(HashJoinTest, mixedGroupedExecution) {
 // TIMESTAMP WITH TIME ZONE join keys.
 //
 // The type is physically (millis << 12) | zone_key and Velox matches it on the
-// INSTANT alone, so two values for the same moment in different zones are the SAME
-// key and must join. Before the key-normalization fix cuDF hashed all 64 bits, so
-// no two values carrying different zones ever matched and such a join returned
-// nothing at all -- silently, with no error.
+// INSTANT alone, so two values for the same moment in different zones are the
+// SAME key and must join. Before the key-normalization fix cuDF hashed all 64
+// bits, so no two values carrying different zones ever matched and such a join
+// returned nothing at all -- silently, with no error.
 //
-// Only the join types that build a cudf::hash_join are covered here: inner, left,
-// right, full and left-semi-project. The semi/anti FILTER variants build their own
-// hash tables from raw views through mixed_left_semi_join / filtered_join and are a
-// separate mechanism, still to be fixed.
+// Only the join types that build a cudf::hash_join are covered here: inner,
+// left, right, full and left-semi-project. The semi/anti FILTER variants build
+// their own hash tables from raw views through mixed_left_semi_join /
+// filtered_join and are a separate mechanism, still to be fixed.
 // ---------------------------------------------------------------------------
 namespace {
 // Kiritimati (+14) and Midway (-11) are the extremes of the offset range.
@@ -9719,8 +9719,8 @@ int64_t packJoinKey(int64_t millis, const char* zone) {
 TEST_F(HashJoinTest, innerJoinTimestampWithTimeZoneMatchesOnInstant) {
   const int64_t a = 1'623'758'400'000;
   const int64_t b = -14'182'940'000;
-  // Same instants on both sides, but every probe row carries a different zone key
-  // from its build counterpart, so nothing matches on the packed value.
+  // Same instants on both sides, but every probe row carries a different zone
+  // key from its build counterpart, so nothing matches on the packed value.
   auto probe = makeRowVector(
       {"k"},
       {makeFlatVector<int64_t>(
@@ -9740,8 +9740,8 @@ TEST_F(HashJoinTest, innerJoinTimestampWithTimeZoneMatchesOnInstant) {
 }
 
 // A left join is the shape where the defect is quietest: instead of an empty
-// result it produces the right ROW COUNT with every build column null, which looks
-// like "no matches" rather than a bug.
+// result it produces the right ROW COUNT with every build column null, which
+// looks like "no matches" rather than a bug.
 TEST_F(HashJoinTest, leftJoinTimestampWithTimeZoneMatchesOnInstant) {
   const int64_t a = 1'623'758'400'000;
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -9757,16 +9757,17 @@ TEST_F(HashJoinTest, leftJoinTimestampWithTimeZoneMatchesOnInstant) {
       {makeFlatVector<int64_t>(
           {packJoinKey(a, "Pacific/Midway")}, TIMESTAMP_WITH_TIME_ZONE())});
 
-  auto plan = PlanBuilder(planNodeIdGenerator)
-                  .values({probe})
-                  .hashJoin(
-                      {"k"},
-                      {"u_k"},
-                      PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
-                      "",
-                      {"k", "u_k"},
-                      core::JoinType::kLeft)
-                  .planNode();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probe})
+          .hashJoin(
+              {"k"},
+              {"u_k"},
+              PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+              "",
+              {"k", "u_k"},
+              core::JoinType::kLeft)
+          .planNode();
   auto result = AssertQueryBuilder(plan).copyResults(pool());
 
   ASSERT_EQ(result->size(), 2);

--- a/velox/experimental/cudf/tests/KeyNormalizationTest.cpp
+++ b/velox/experimental/cudf/tests/KeyNormalizationTest.cpp
@@ -22,8 +22,8 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/device_buffer.hpp>
@@ -40,8 +40,8 @@ using namespace facebook::velox::cudf_velox;
 
 namespace {
 
-// The two zones used throughout: the extremes of the offset range, so their zone
-// keys differ as widely as their offsets (Kiritimati 2137, Midway 2142).
+// The two zones used throughout: the extremes of the offset range, so their
+// zone keys differ as widely as their offsets (Kiritimati 2137, Midway 2142).
 constexpr const char* kKiritimati = "Pacific/Kiritimati";
 constexpr const char* kMidway = "Pacific/Midway";
 
@@ -84,8 +84,7 @@ class KeyNormalizationTest : public testing::Test {
     }
     // Built by hand rather than with cudf::detail::valid_if, which lives in a
     // .cuh and so is unavailable to a .cpp translation unit.
-    const auto maskBytes =
-        cudf::bitmask_allocation_size_bytes(values.size());
+    const auto maskBytes = cudf::bitmask_allocation_size_bytes(values.size());
     std::vector<cudf::bitmask_type> hostMask(
         maskBytes / sizeof(cudf::bitmask_type), 0);
     cudf::size_type nullCount = 0;
@@ -96,8 +95,7 @@ class KeyNormalizationTest : public testing::Test {
         ++nullCount;
       }
     }
-    rmm::device_buffer maskBuffer(
-        hostMask.data(), maskBytes, stream(), mr());
+    rmm::device_buffer maskBuffer(hostMask.data(), maskBytes, stream(), mr());
     column->set_null_mask(std::move(maskBuffer), nullCount);
     return column;
   }
@@ -116,8 +114,8 @@ class KeyNormalizationTest : public testing::Test {
   }
 
   // "UTC" resolves to zone key 0 (see TimeZoneMap.cpp:60), which is the
-  // interesting boundary: a UTC-keyed value has no low bits to clear, so it must
-  // come out of normalization unchanged.
+  // interesting boundary: a UTC-keyed value has no low bits to clear, so it
+  // must come out of normalization unchanged.
   int64_t packed(int64_t millis, const char* zone) {
     return pack(millis, tz::getTimeZoneID(zone));
   }
@@ -130,9 +128,12 @@ class KeyNormalizationTest : public testing::Test {
 TEST_F(KeyNormalizationTest, sameInstantDifferentZonesBecomeIdentical) {
   const int64_t millis = 1'623'758'400'000;
   auto column = int64Column(
-      {packed(millis, kKiritimati), packed(millis, kMidway), packed(millis, "UTC")});
+      {packed(millis, kKiritimati),
+       packed(millis, kMidway),
+       packed(millis, "UTC")});
   auto raw = toHost(column->view());
-  // Precondition: the inputs really do differ, so the test cannot pass trivially.
+  // Precondition: the inputs really do differ, so the test cannot pass
+  // trivially.
   EXPECT_NE(raw[0], raw[1]);
   EXPECT_NE(raw[1], raw[2]);
 
@@ -184,8 +185,8 @@ TEST_F(KeyNormalizationTest, adjacentMillisStayDistinct) {
   EXPECT_NE(out[2], out[3]);
 }
 
-// Ordering is preserved, which is what makes the same helper usable for sort and
-// TopN keys and not only for hashing.
+// Ordering is preserved, which is what makes the same helper usable for sort
+// and TopN keys and not only for hashing.
 TEST_F(KeyNormalizationTest, orderingIsPreserved) {
   auto column = int64Column(
       {packed(-14'182'940'000, kMidway),
@@ -227,7 +228,8 @@ TEST_F(KeyNormalizationTest, nonTswtzColumnsArePassedThroughUnchanged) {
   ASSERT_EQ(normalized.view.num_columns(), 2);
   // Exactly one column was rewritten, so exactly one is owned.
   EXPECT_EQ(normalized.owned.size(), 1);
-  EXPECT_EQ(normalized.view.column(1).data<int64_t>(), plain->view().data<int64_t>())
+  EXPECT_EQ(
+      normalized.view.column(1).data<int64_t>(), plain->view().data<int64_t>())
       << "a non-TSWTZ key column must be referenced, not copied";
   EXPECT_EQ(toHost(normalized.view.column(1))[0], 1'623'758'400'123);
 }
@@ -242,19 +244,23 @@ TEST_F(KeyNormalizationTest, noTswtzKeyIsANoOp) {
   auto normalized = normalizeKeyColumns(keys, {false, false}, stream(), mr());
   EXPECT_FALSE(normalized.normalizedAny());
   EXPECT_TRUE(normalized.owned.empty());
-  EXPECT_EQ(normalized.view.column(0).data<int64_t>(), a->view().data<int64_t>());
-  EXPECT_EQ(normalized.view.column(1).data<int64_t>(), b->view().data<int64_t>());
+  EXPECT_EQ(
+      normalized.view.column(0).data<int64_t>(), a->view().data<int64_t>());
+  EXPECT_EQ(
+      normalized.view.column(1).data<int64_t>(), b->view().data<int64_t>());
 }
 
-// The row-type overload must derive the same flags the explicit one takes, so an
-// operator can pass its channels rather than precomputing.
+// The row-type overload must derive the same flags the explicit one takes, so
+// an operator can pass its channels rather than precomputing.
 TEST_F(KeyNormalizationTest, rowTypeOverloadDerivesTheFlags) {
   const int64_t millis = 1'623'758'400'000;
-  auto tswtz = int64Column({packed(millis, kKiritimati), packed(millis, kMidway)});
+  auto tswtz =
+      int64Column({packed(millis, kKiritimati), packed(millis, kMidway)});
   auto plain = int64Column({7, 8});
   auto keys = cudf::table_view{{tswtz->view(), plain->view()}};
 
-  auto rowType = ROW({"a", "t", "b"}, {BIGINT(), TIMESTAMP_WITH_TIME_ZONE(), BIGINT()});
+  auto rowType =
+      ROW({"a", "t", "b"}, {BIGINT(), TIMESTAMP_WITH_TIME_ZONE(), BIGINT()});
   // Key channels deliberately out of order and not starting at 0, so a fix that
   // assumed channel == column position would fail here.
   const std::vector<column_index_t> keyChannels{1, 2};

--- a/velox/experimental/cudf/tests/KeyNormalizationTest.cpp
+++ b/velox/experimental/cudf/tests/KeyNormalizationTest.cpp
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/KeyNormalization.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <vector>
+
+using namespace facebook::velox;
+using namespace facebook::velox::cudf_velox;
+
+namespace {
+
+// The two zones used throughout: the extremes of the offset range, so their zone
+// keys differ as widely as their offsets (Kiritimati 2137, Midway 2142).
+constexpr const char* kKiritimati = "Pacific/Kiritimati";
+constexpr const char* kMidway = "Pacific/Midway";
+
+class KeyNormalizationTest : public testing::Test {
+ protected:
+  rmm::cuda_stream_view stream() const {
+    return cudf::get_default_stream();
+  }
+
+  rmm::device_async_resource_ref mr() const {
+    return cudf::get_current_device_resource_ref();
+  }
+
+  // Builds an INT64 column from host values, with an optional validity mask.
+  std::unique_ptr<cudf::column> int64Column(
+      const std::vector<std::optional<int64_t>>& values) {
+    std::vector<int64_t> data;
+    data.reserve(values.size());
+    for (const auto& v : values) {
+      data.push_back(v.value_or(0));
+    }
+    auto column = cudf::make_numeric_column(
+        cudf::data_type{cudf::type_id::INT64},
+        static_cast<cudf::size_type>(values.size()),
+        cudf::mask_state::UNALLOCATED,
+        stream(),
+        mr());
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        column->mutable_view().data<int64_t>(),
+        data.data(),
+        data.size() * sizeof(int64_t),
+        cudaMemcpyHostToDevice,
+        stream().value()));
+    stream().synchronize();
+
+    const bool hasNulls = std::any_of(
+        values.begin(), values.end(), [](const auto& v) { return !v; });
+    if (!hasNulls) {
+      return column;
+    }
+    // Built by hand rather than with cudf::detail::valid_if, which lives in a
+    // .cuh and so is unavailable to a .cpp translation unit.
+    const auto maskBytes =
+        cudf::bitmask_allocation_size_bytes(values.size());
+    std::vector<cudf::bitmask_type> hostMask(
+        maskBytes / sizeof(cudf::bitmask_type), 0);
+    cudf::size_type nullCount = 0;
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (values[i].has_value()) {
+        cudf::set_bit_unsafe(hostMask.data(), static_cast<cudf::size_type>(i));
+      } else {
+        ++nullCount;
+      }
+    }
+    rmm::device_buffer maskBuffer(
+        hostMask.data(), maskBytes, stream(), mr());
+    column->set_null_mask(std::move(maskBuffer), nullCount);
+    return column;
+  }
+
+  // Reads a column back to host, so a test can assert on exact bit patterns.
+  std::vector<int64_t> toHost(const cudf::column_view& view) {
+    std::vector<int64_t> out(view.size());
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        out.data(),
+        view.data<int64_t>(),
+        out.size() * sizeof(int64_t),
+        cudaMemcpyDeviceToHost,
+        stream().value()));
+    stream().synchronize();
+    return out;
+  }
+
+  // "UTC" resolves to zone key 0 (see TimeZoneMap.cpp:60), which is the
+  // interesting boundary: a UTC-keyed value has no low bits to clear, so it must
+  // come out of normalization unchanged.
+  int64_t packed(int64_t millis, const char* zone) {
+    return pack(millis, tz::getTimeZoneID(zone));
+  }
+};
+
+// The property the whole fix rests on: two values for the same instant under
+// different zone keys are DIFFERENT packed values and become IDENTICAL after
+// normalization, which is what makes every downstream hash, equality and sort
+// agree with Velox.
+TEST_F(KeyNormalizationTest, sameInstantDifferentZonesBecomeIdentical) {
+  const int64_t millis = 1'623'758'400'000;
+  auto column = int64Column(
+      {packed(millis, kKiritimati), packed(millis, kMidway), packed(millis, "UTC")});
+  auto raw = toHost(column->view());
+  // Precondition: the inputs really do differ, so the test cannot pass trivially.
+  EXPECT_NE(raw[0], raw[1]);
+  EXPECT_NE(raw[1], raw[2]);
+
+  auto keys = cudf::table_view{{column->view()}};
+  auto normalized = normalizeKeyColumns(keys, {true}, stream(), mr());
+  ASSERT_TRUE(normalized.normalizedAny());
+  auto out = toHost(normalized.view.column(0));
+  EXPECT_EQ(out[0], out[1]);
+  EXPECT_EQ(out[1], out[2]);
+  // And the surviving value is the instant, shifted back into place.
+  EXPECT_EQ(out[0], millis << kMillisShift);
+}
+
+// Pre-epoch instants are the case a divide by 4096 gets wrong: it truncates
+// toward zero and lands a millisecond late, where the AND floors. Asserted
+// against unpackMillisUtc rather than a hand-computed constant, so the test
+// tracks the definition rather than restating it.
+TEST_F(KeyNormalizationTest, preEpochInstantsFloorRatherThanTruncate) {
+  const int64_t millis = -14'182'940'000;
+  auto column = int64Column(
+      {packed(millis, kKiritimati),
+       packed(millis, kMidway),
+       packed(millis, "UTC"),
+       // Maximum zone key: the largest possible low-bit contamination.
+       (millis << kMillisShift) | kTimezoneMask});
+  auto keys = cudf::table_view{{column->view()}};
+  auto normalized = normalizeKeyColumns(keys, {true}, stream(), mr());
+  auto out = toHost(normalized.view.column(0));
+  for (const auto value : out) {
+    EXPECT_EQ(unpackMillisUtc(value), millis)
+        << "normalization must floor to the instant for a pre-epoch value";
+    EXPECT_EQ(value, out[0]) << "every zone key must collapse to one value";
+  }
+}
+
+// Normalization must not over-collapse: instants one millisecond apart stay
+// distinct. This is what fails if the mask ever clears more than kMillisShift
+// bits.
+TEST_F(KeyNormalizationTest, adjacentMillisStayDistinct) {
+  auto column = int64Column(
+      {packed(1'623'758'400'000, kKiritimati),
+       packed(1'623'758'400'001, "UTC"),
+       packed(-14'182'940'001, kMidway),
+       packed(-14'182'940'000, "UTC")});
+  auto keys = cudf::table_view{{column->view()}};
+  auto normalized = normalizeKeyColumns(keys, {true}, stream(), mr());
+  auto out = toHost(normalized.view.column(0));
+  EXPECT_NE(out[0], out[1]);
+  EXPECT_NE(out[2], out[3]);
+}
+
+// Ordering is preserved, which is what makes the same helper usable for sort and
+// TopN keys and not only for hashing.
+TEST_F(KeyNormalizationTest, orderingIsPreserved) {
+  auto column = int64Column(
+      {packed(-14'182'940'000, kMidway),
+       packed(0, kKiritimati),
+       packed(1'623'758'400'000, "UTC")});
+  auto keys = cudf::table_view{{column->view()}};
+  auto normalized = normalizeKeyColumns(keys, {true}, stream(), mr());
+  auto out = toHost(normalized.view.column(0));
+  EXPECT_LT(out[0], out[1]);
+  EXPECT_LT(out[1], out[2]);
+}
+
+// A null key must stay null rather than masking to a value: under
+// cudf::null_equality::UNEQUAL a null key is distinct from every real one, and
+// turning it into 0 would silently make it equal to the epoch in UTC.
+TEST_F(KeyNormalizationTest, nullsArePreserved) {
+  const int64_t millis = 1'623'758'400'000;
+  auto column = int64Column(
+      {packed(millis, kKiritimati), std::nullopt, packed(millis, kMidway)});
+  ASSERT_EQ(column->null_count(), 1);
+
+  auto keys = cudf::table_view{{column->view()}};
+  auto normalized = normalizeKeyColumns(keys, {true}, stream(), mr());
+  const auto view = normalized.view.column(0);
+  EXPECT_EQ(view.null_count(), 1);
+  EXPECT_TRUE(view.nullable());
+  auto out = toHost(view);
+  EXPECT_EQ(out[0], out[2]) << "the two non-null rows still collapse";
+}
+
+// Columns not flagged as TIMESTAMP WITH TIME ZONE must be passed through
+// untouched, and by reference rather than copied.
+TEST_F(KeyNormalizationTest, nonTswtzColumnsArePassedThroughUnchanged) {
+  auto tswtz = int64Column({packed(1'623'758'400'000, kKiritimati)});
+  auto plain = int64Column({1'623'758'400'123});
+  auto keys = cudf::table_view{{tswtz->view(), plain->view()}};
+
+  auto normalized = normalizeKeyColumns(keys, {true, false}, stream(), mr());
+  ASSERT_EQ(normalized.view.num_columns(), 2);
+  // Exactly one column was rewritten, so exactly one is owned.
+  EXPECT_EQ(normalized.owned.size(), 1);
+  EXPECT_EQ(normalized.view.column(1).data<int64_t>(), plain->view().data<int64_t>())
+      << "a non-TSWTZ key column must be referenced, not copied";
+  EXPECT_EQ(toHost(normalized.view.column(1))[0], 1'623'758'400'123);
+}
+
+// With no TSWTZ key at all the helper is a no-op and must not allocate: this is
+// the common case for every operator, so it has to stay free.
+TEST_F(KeyNormalizationTest, noTswtzKeyIsANoOp) {
+  auto a = int64Column({1, 2, 3});
+  auto b = int64Column({4, 5, 6});
+  auto keys = cudf::table_view{{a->view(), b->view()}};
+
+  auto normalized = normalizeKeyColumns(keys, {false, false}, stream(), mr());
+  EXPECT_FALSE(normalized.normalizedAny());
+  EXPECT_TRUE(normalized.owned.empty());
+  EXPECT_EQ(normalized.view.column(0).data<int64_t>(), a->view().data<int64_t>());
+  EXPECT_EQ(normalized.view.column(1).data<int64_t>(), b->view().data<int64_t>());
+}
+
+// The row-type overload must derive the same flags the explicit one takes, so an
+// operator can pass its channels rather than precomputing.
+TEST_F(KeyNormalizationTest, rowTypeOverloadDerivesTheFlags) {
+  const int64_t millis = 1'623'758'400'000;
+  auto tswtz = int64Column({packed(millis, kKiritimati), packed(millis, kMidway)});
+  auto plain = int64Column({7, 8});
+  auto keys = cudf::table_view{{tswtz->view(), plain->view()}};
+
+  auto rowType = ROW({"a", "t", "b"}, {BIGINT(), TIMESTAMP_WITH_TIME_ZONE(), BIGINT()});
+  // Key channels deliberately out of order and not starting at 0, so a fix that
+  // assumed channel == column position would fail here.
+  const std::vector<column_index_t> keyChannels{1, 2};
+
+  EXPECT_TRUE(anyKeyNeedsNormalization(rowType, keyChannels));
+  auto normalized =
+      normalizeKeyColumns(keys, rowType, keyChannels, stream(), mr());
+  ASSERT_EQ(normalized.owned.size(), 1);
+  auto out = toHost(normalized.view.column(0));
+  EXPECT_EQ(out[0], out[1]);
+  EXPECT_EQ(toHost(normalized.view.column(1))[0], 7);
+}
+
+TEST_F(KeyNormalizationTest, anyKeyNeedsNormalizationIsFalseWithoutTswtz) {
+  auto rowType = ROW({"a", "b"}, {BIGINT(), VARCHAR()});
+  EXPECT_FALSE(anyKeyNeedsNormalization(rowType, {0, 1}));
+}
+
+TEST_F(KeyNormalizationTest, flagCountMustMatchColumnCount) {
+  auto column = int64Column({1});
+  auto keys = cudf::table_view{{column->view()}};
+  VELOX_ASSERT_THROW(
+      normalizeKeyColumns(keys, {true, false}, stream(), mr()),
+      "One normalization flag is required per key column");
+}
+
+} // namespace

--- a/velox/experimental/cudf/tests/MarkDistinctTest.cpp
+++ b/velox/experimental/cudf/tests/MarkDistinctTest.cpp
@@ -323,17 +323,17 @@ TEST_F(CudfMarkDistinctTest, persistentStateAcrossInputStreams) {
 // TIMESTAMP WITH TIME ZONE distinct keys.
 //
 // The type is physically (millis << 12) | zone_key and Velox compares it on the
-// INSTANT alone, so two values for the same moment in different zones are the SAME
-// key: the second is a duplicate. Before the key-normalization fix cuDF compared
-// all 64 bits and marked both distinct.
+// INSTANT alone, so two values for the same moment in different zones are the
+// SAME key: the second is a duplicate. Before the key-normalization fix cuDF
+// compared all 64 bits and marked both distinct.
 //
 // The single-batch and multi-batch cases are both needed. MarkDistinct is a
 // streaming operator: the first batch seeds seenKeys_ and the persistent
 // filtered_join, and later batches probe it. Normalizing only the within-batch
 // distinct_indices and not the stored keys would compare normalized against
-// unnormalized and mark EVERY row distinct, for every key type -- worse than the
-// bug -- so the multi-batch case is what proves the normalization is applied
-// consistently across the operator's state.
+// unnormalized and mark EVERY row distinct, for every key type -- worse than
+// the bug -- so the multi-batch case is what proves the normalization is
+// applied consistently across the operator's state.
 // ---------------------------------------------------------------------------
 namespace {
 int64_t packAtZone(int64_t millis, const char* zone) {
@@ -350,17 +350,16 @@ TEST_F(CudfMarkDistinctTest, timestampWithTimeZoneSameInstantIsADuplicate) {
        packAtZone(millis, "Asia/Kolkata")},
       TIMESTAMP_WITH_TIME_ZONE())});
 
-  auto plan = PlanBuilder()
-                  .values({batch})
-                  .markDistinct("m", {"c0"})
-                  .planNode();
+  auto plan =
+      PlanBuilder().values({batch}).markDistinct("m", {"c0"}).planNode();
   auto result = AssertQueryBuilder(plan).copyResults(pool());
 
   ASSERT_EQ(4, result->size());
   auto markers = result->childAt(1)->asFlatVector<bool>();
   ASSERT_NE(nullptr, markers);
   EXPECT_TRUE(markers->valueAt(0)) << "first occurrence of the instant";
-  EXPECT_FALSE(markers->valueAt(1)) << "same instant, different zone: duplicate";
+  EXPECT_FALSE(markers->valueAt(1))
+      << "same instant, different zone: duplicate";
   EXPECT_TRUE(markers->valueAt(2)) << "one millisecond later: a new instant";
   EXPECT_FALSE(markers->valueAt(3)) << "same instant, third zone: duplicate";
 }
@@ -391,20 +390,20 @@ TEST_F(CudfMarkDistinctTest, timestampWithTimeZoneAcrossBatches) {
   ASSERT_NE(nullptr, markers);
   EXPECT_TRUE(markers->valueAt(0)) << "batch1: first instant";
   EXPECT_TRUE(markers->valueAt(1)) << "batch1: second instant";
-  EXPECT_FALSE(markers->valueAt(2)) << "batch2: instant 1 seen under another zone";
+  EXPECT_FALSE(markers->valueAt(2))
+      << "batch2: instant 1 seen under another zone";
   EXPECT_TRUE(markers->valueAt(3)) << "batch2: a genuinely new instant";
-  EXPECT_FALSE(markers->valueAt(4)) << "batch2: instant 2 seen under another zone";
+  EXPECT_FALSE(markers->valueAt(4))
+      << "batch2: instant 2 seen under another zone";
 }
 
-// A non-TSWTZ key must be unaffected. This is the guard against the normalization
-// being applied where it should not be, which for a plain BIGINT would collapse
-// values 4096 apart.
+// A non-TSWTZ key must be unaffected. This is the guard against the
+// normalization being applied where it should not be, which for a plain BIGINT
+// would collapse values 4096 apart.
 TEST_F(CudfMarkDistinctTest, bigintKeyIsUnaffectedByNormalization) {
   auto batch = makeRowVector({makeFlatVector<int64_t>({1, 4096, 1, 8192})});
-  auto plan = PlanBuilder()
-                  .values({batch})
-                  .markDistinct("m", {"c0"})
-                  .planNode();
+  auto plan =
+      PlanBuilder().values({batch}).markDistinct("m", {"c0"}).planNode();
   auto result = AssertQueryBuilder(plan).copyResults(pool());
 
   ASSERT_EQ(4, result->size());

--- a/velox/experimental/cudf/tests/MarkDistinctTest.cpp
+++ b/velox/experimental/cudf/tests/MarkDistinctTest.cpp
@@ -21,6 +21,8 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -315,4 +317,100 @@ TEST_F(CudfMarkDistinctTest, persistentStateAcrossInputStreams) {
   EXPECT_EQ(
       kExpectedDistinct,
       result->childAt(0)->asFlatVector<int64_t>()->valueAt(0));
+}
+
+// ---------------------------------------------------------------------------
+// TIMESTAMP WITH TIME ZONE distinct keys.
+//
+// The type is physically (millis << 12) | zone_key and Velox compares it on the
+// INSTANT alone, so two values for the same moment in different zones are the SAME
+// key: the second is a duplicate. Before the key-normalization fix cuDF compared
+// all 64 bits and marked both distinct.
+//
+// The single-batch and multi-batch cases are both needed. MarkDistinct is a
+// streaming operator: the first batch seeds seenKeys_ and the persistent
+// filtered_join, and later batches probe it. Normalizing only the within-batch
+// distinct_indices and not the stored keys would compare normalized against
+// unnormalized and mark EVERY row distinct, for every key type -- worse than the
+// bug -- so the multi-batch case is what proves the normalization is applied
+// consistently across the operator's state.
+// ---------------------------------------------------------------------------
+namespace {
+int64_t packAtZone(int64_t millis, const char* zone) {
+  return pack(millis, tz::getTimeZoneID(zone));
+}
+} // namespace
+
+TEST_F(CudfMarkDistinctTest, timestampWithTimeZoneSameInstantIsADuplicate) {
+  const int64_t millis = 1'623'758'400'000;
+  auto batch = makeRowVector({makeFlatVector<int64_t>(
+      {packAtZone(millis, "Pacific/Kiritimati"),
+       packAtZone(millis, "Pacific/Midway"),
+       packAtZone(millis + 1, "Pacific/Midway"),
+       packAtZone(millis, "Asia/Kolkata")},
+      TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan = PlanBuilder()
+                  .values({batch})
+                  .markDistinct("m", {"c0"})
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(4, result->size());
+  auto markers = result->childAt(1)->asFlatVector<bool>();
+  ASSERT_NE(nullptr, markers);
+  EXPECT_TRUE(markers->valueAt(0)) << "first occurrence of the instant";
+  EXPECT_FALSE(markers->valueAt(1)) << "same instant, different zone: duplicate";
+  EXPECT_TRUE(markers->valueAt(2)) << "one millisecond later: a new instant";
+  EXPECT_FALSE(markers->valueAt(3)) << "same instant, third zone: duplicate";
+}
+
+// Across batches, which is what exercises seenKeys_ and the persistent filter
+// rather than only the within-batch distinct_indices.
+TEST_F(CudfMarkDistinctTest, timestampWithTimeZoneAcrossBatches) {
+  const int64_t millis = 1'623'758'400'000;
+  auto batch1 = makeRowVector({makeFlatVector<int64_t>(
+      {packAtZone(millis, "Pacific/Kiritimati"),
+       packAtZone(millis + 1, "Pacific/Kiritimati")},
+      TIMESTAMP_WITH_TIME_ZONE())});
+  // Both instants already seen, but under a different zone key.
+  auto batch2 = makeRowVector({makeFlatVector<int64_t>(
+      {packAtZone(millis, "Pacific/Midway"),
+       packAtZone(millis + 2, "Pacific/Midway"),
+       packAtZone(millis + 1, "Asia/Kolkata")},
+      TIMESTAMP_WITH_TIME_ZONE())});
+
+  auto plan = PlanBuilder()
+                  .values({batch1, batch2})
+                  .markDistinct("m", {"c0"})
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(5, result->size());
+  auto markers = result->childAt(1)->asFlatVector<bool>();
+  ASSERT_NE(nullptr, markers);
+  EXPECT_TRUE(markers->valueAt(0)) << "batch1: first instant";
+  EXPECT_TRUE(markers->valueAt(1)) << "batch1: second instant";
+  EXPECT_FALSE(markers->valueAt(2)) << "batch2: instant 1 seen under another zone";
+  EXPECT_TRUE(markers->valueAt(3)) << "batch2: a genuinely new instant";
+  EXPECT_FALSE(markers->valueAt(4)) << "batch2: instant 2 seen under another zone";
+}
+
+// A non-TSWTZ key must be unaffected. This is the guard against the normalization
+// being applied where it should not be, which for a plain BIGINT would collapse
+// values 4096 apart.
+TEST_F(CudfMarkDistinctTest, bigintKeyIsUnaffectedByNormalization) {
+  auto batch = makeRowVector({makeFlatVector<int64_t>({1, 4096, 1, 8192})});
+  auto plan = PlanBuilder()
+                  .values({batch})
+                  .markDistinct("m", {"c0"})
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(4, result->size());
+  auto markers = result->childAt(1)->asFlatVector<bool>();
+  EXPECT_TRUE(markers->valueAt(0));
+  EXPECT_TRUE(markers->valueAt(1)) << "4096 is not a duplicate of 1";
+  EXPECT_FALSE(markers->valueAt(2));
+  EXPECT_TRUE(markers->valueAt(3)) << "8192 is not a duplicate either";
 }


### PR DESCRIPTION
## Summary

`TIMESTAMP WITH TIME ZONE` is a single 64-bit integer holding both the instant and a
time-zone key: the UTC milliseconds in the high bits, the zone key in the low 12. Its CPU
comparator is defined on the *instant* alone, so two values holding the same instant in
different zones are equal, and hash to the same bucket.

The cuDF operators compared and hashed the packed integer instead, so the zone key
decided. Five operators were affected, and every one of them returned wrong results
silently:

| operator | SQL shape | symptom |
|---|---|---|
| `CudfLocalPartition` | hash-partitioned exchange on the type | same-instant rows routed to different drivers |
| `CudfGroupby` | `GROUP BY` on the type | every group split in half |
| `CudfDistinct` | `SELECT DISTINCT` | duplicates kept |
| `CudfMarkDistinct` | `count(DISTINCT …)` | 204 distinct values where the answer is 102 |
| `CudfHashJoin` | equality join on the type | matched nothing |

`GROUP BY` needed two of these, not one: the operator's own hash table *and* the
partitioned exchange feeding it both keyed on the packed value, and fixing either alone
still split the groups.

## Design

One shared helper, `exec/KeyNormalization.{h,cpp}`, produces a normalized copy of the key
columns by masking the zone key off. That is the whole trick, and it works because
clearing the low bits is monotone and equality-preserving: it neither reorders values nor
merges distinct instants, and it floors correctly for pre-epoch instants where dividing
would truncate toward zero and land a millisecond late.

Two properties are worth stating because they shape every call site:

- **The normalized column is for comparison and hashing only, never for output.** It is
  not a valid value of the type — its zone key is gone. Operators that must emit the key
  recover the original column rather than the normalized one; `CudfGroupby` does that with
  a `MIN` request on the original alongside the aggregations, and `CudfDistinct` gathers
  the surviving row indices from the untouched input.
- **Lifetime matters in the join.** `cudf::hash_join` holds a view of its key table, so
  the normalized build keys have to outlive the build call. They live in the join bridge
  rather than being appended to the build table — appending would shift the column indices
  the AST filter's precompute instructions already refer to.

The helper is header-declared so the five operators share exactly one definition of what
normalization means. A per-operator copy is how two of these came to disagree in the first
place.

## Relationship to #17899

**Independent of it.** This branch applies to `main` and needs nothing from the timezone
expression PR: its unit tests build `TIMESTAMP WITH TIME ZONE` vectors directly rather
than through `at_timezone`/`from_unixtime`, so they need no GPU timezone functions.

There is one overlap to be aware of, in `exec/CudfHashJoin.cpp`, which #17899 also touches
to thread the session timezone into join filters. The two sets of hunks are in different
regions and do not collide, so whichever merges second needs a mechanical rebase and no
semantic reconciliation.

## Testing

- **Unit tests, against `main` with no other branch applied**: 322 pass across 7 cuDF
  binaries — key_normalization (10, new), aggregation (125), hash_join (143),
  mark_distinct (15), local_partition (12), order_by (6), topn (11). New test files cover
  the helper directly plus one per affected operator.
- **End-to-end**, against three live Presto clusters (a CPU oracle, a GPU cluster with
  `cudf.allow_cpu_fallback=false`, and one with fallback allowed and logged), comparing
  full result sets: 77 cases, 71 pass, 4 documented divergences, 2 skipped, 0 failures.
  Five of those cases exist specifically for these five shapes.

  End-to-end verification does require #17899 to be present, for a reason that is not a
  dependency of this code: on the GPU there is no other way to *produce* a
  `TIMESTAMP WITH TIME ZONE` column in SQL. Reading one needs the Iceberg reader, which
  cannot yet parse the type; constructing one needs `at_timezone`/`from_unixtime` or the
  `TIMESTAMP` cast, all of which #17899 adds. The unit tests sidestep this by building
  vectors directly, which is why they run against plain `main`.

## Unspecified behaviour: which zone a GROUP BY emits

Worth stating explicitly, because it is easy to mistake for a bug and easy to "fix" in the
wrong direction.

Grouping normalizes the key, so the emitted group key has to be recovered from the
original column — a `MIN` over the packed values of the group's rows. That gives **two
different levels of guarantee**:

- **The instant is guaranteed.** Grouping runs on the normalized keys, so every row of a
  group has identical high bits and the packed values differ only in the zone bits. The
  recovered value therefore always belongs to one of the group's own rows: never a
  fabricated value, never another group's instant, and never the bare UTC that
  normalization alone would leave.
- **Which of the tied zone keys is emitted is not guaranteed.** All rows of a group are
  equal values, because this type's comparator is defined on the instant alone, so any is
  a valid representative and SQL does not define which one a `GROUP BY` returns.

Measured on a live cluster, grouping one instant keyed to `Pacific/Kiritimati` (+14) and
`Pacific/Midway` (-11):

| | three consecutive runs | `task_concurrency=2` |
|---|---|---|
| CPU | `-11:00`, `-11:00`, `-11:00` | `+14:00` |
| this branch | `+14:00`, `-11:00`, `-11:00` | `-11:00` |

**Both engines are unstable.** `MIN` is deterministic within a single aggregation, but the
plan has partial and final stages behind a hash exchange and the surviving representative
follows scheduling; CPU keeps whatever its `RowContainer` retained, equally
scheduling-dependent. So a difference here should not be resolved by aligning this path to
CPU — there is no stable CPU answer to align to.

Any query that renders the group key with its offset (`to_iso8601`, `cast` to `varchar`,
`timezone_hour`, `format_datetime`) can therefore differ run to run on either engine. The
instant is the part that is contractual, and the end-to-end cases assert exactly that
under two concurrency settings while asserting nothing about the zone.

## Known gaps, deliberately not addressed here

These reach the same comparison and are very likely affected. None has a test yet, so they
are **unmeasured** rather than known-good, and cases should land before the fixes:

- **semi/anti join filters** — a separate mechanism that builds its own hash tables from
  raw views and never touches `cudf::hash_join`, so it is internally consistent (both
  sides raw) rather than half-fixed.
- **sort and TopN keys beyond the first.** A single key of this type is *not* wrong:
  packed order refines instant order, and CPU leaves tied instants unordered. It bites
  only with a secondary sort key.
- **window `PARTITION BY`**.
- **nested keys** — a `ROW` or `ARRAY` key column containing a field of this type becomes a
  cuDF `STRUCT`/`LIST` whose `int64` child still carries the zone bits. Normalization does
  not recurse into children. It is also not established whether Velox CPU honours the
  custom-comparison hook for nested children, so the correct target behaviour would have
  to be settled first.
