### PR TITLE
feat(gcs): Add user-agent support in GCS storage adapter

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -134,6 +134,10 @@ std::optional<std::string> HiveConfig::gcsAuthAccessTokenProvider() const {
       std::string(kLegacyPrefix) + kGcsAuthAccessTokenProvider);
 }
 
+std::optional<std::string> HiveConfig::gcsUserAgent() const {
+  return config_->get<std::string>(kGcsUserAgent);
+}
+
 int32_t HiveConfig::numCacheFileHandles() const {
   return config_->get<int32_t>(kNumCacheFileHandles, 20'000);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -226,6 +226,10 @@ class HiveConfig : public FileConfig {
   static constexpr const char* kGcsAuthAccessTokenProvider =
       "gcs.auth.access-token-provider";
 
+  /// The custom GCS user-agent product string. "velox" is appended unless
+  /// already present.
+  static constexpr const char* kGcsUserAgent = "gcs.user-agent";
+
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
 
@@ -259,6 +263,8 @@ class HiveConfig : public FileConfig {
   std::optional<std::string> gcsMaxRetryTime() const;
 
   std::optional<std::string> gcsAuthAccessTokenProvider() const;
+
+  std::optional<std::string> gcsUserAgent() const;
 
   int32_t numCacheFileHandles() const;
 

--- a/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
@@ -23,11 +23,13 @@
 #include "velox/connectors/hive/storage_adapters/gcs/GcsWriteFile.h"
 #include "velox/core/QueryConfig.h"
 
+#include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
 #include <glog/logging.h>
 #include <memory>
 #include <stdexcept>
 
+#include <google/cloud/options.h>
 #include <google/cloud/storage/client.h>
 
 namespace facebook::velox {
@@ -137,6 +139,18 @@ class GcsFileSystem::Impl {
       LOG(WARNING)
           << "Config hive.gcs.json-key-file-path is empty or key file path not found";
     }
+
+    std::vector<std::string> userAgentProducts;
+    if (auto userAgent = hiveConfig_->gcsUserAgent();
+        userAgent && !userAgent->empty()) {
+      userAgentProducts.push_back(std::move(*userAgent));
+    }
+
+    if (userAgentProducts.empty() ||
+        !boost::algorithm::icontains(userAgentProducts.back(), "velox")) {
+      userAgentProducts.emplace_back("velox");
+    }
+    options.set<gc::UserAgentProductsOption>(std::move(userAgentProducts));
 
     client_ = std::make_shared<gcs::Client>(options);
   }

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
@@ -126,7 +126,8 @@ class GcsEmulator : public testing::Environment {
     ASSERT_TRUE(bucket.ok()) << "Failed to create bucket <" << bucketName_
                              << ">, status=" << bucket.status();
 
-    auto object = client.InsertObject(bucketName_, objectName_, kLoremIpsum);
+    auto object =
+        client.InsertObject(bucketName_, objectName_, std::string(kLoremIpsum));
     ASSERT_TRUE(object.ok()) << "Failed to create object <" << objectName_
                              << ">, status=" << object.status();
   }

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
@@ -314,6 +314,25 @@ TEST_F(GcsFileSystemTest, credentialsProvider) {
   }
 }
 
+TEST_F(GcsFileSystemTest, userAgent) {
+  for (const auto& userAgent :
+       {"custom-agent", "my-custom-engine-using-velox", "Velox-Engine"}) {
+    SCOPED_TRACE(userAgent);
+    std::unordered_map<std::string, std::string> configOverride = {
+        {connector::hive::HiveConfig::kGcsUserAgent, userAgent}};
+    auto hiveConfig = emulator_->hiveConfig(configOverride);
+
+    filesystems::GcsFileSystem gcfs(
+        emulator_->preexistingBucketName(), hiveConfig);
+    gcfs.initializeClient();
+    const auto gcsFile = gcsURI(
+        emulator_->preexistingBucketName(), emulator_->preexistingObjectName());
+    auto readFile = gcfs.openFileForRead(gcsFile);
+    EXPECT_EQ(readFile->size(), kLoremIpsum.length());
+    EXPECT_EQ(readFile->pread(0, readFile->size()), kLoremIpsum);
+  }
+}
+
 TEST_F(GcsFileSystemTest, defaultCacheKey) {
   registerGcsFileSystem();
   std::unordered_map<std::string, std::string> configWithoutEndpoint = {};

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -65,6 +65,7 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.immutablePartitions(), false);
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
+  ASSERT_FALSE(hiveConfig.gcsUserAgent().has_value());
   ASSERT_FALSE(hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()));
 
   ASSERT_EQ(hiveConfig.maxCoalescedBytes(emptySession.get()), 128 << 20);
@@ -102,6 +103,7 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kImmutablePartitions, "true"},
       {HiveConfig::kGcsEndpoint, "hey"},
       {HiveConfig::kGcsCredentialsPath, "hey"},
+      {HiveConfig::kGcsUserAgent, "custom-agent"},
       {HiveConfig::kFileColumnNamesReadAsLowerCase, "true"},
       {HiveConfig::kAllowNullPartitionKeys, "false"},
       {HiveConfig::kMaxCoalescedBytes, "100"},
@@ -137,6 +139,7 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_TRUE(hiveConfig.immutablePartitions());
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "hey");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "hey");
+  ASSERT_EQ(hiveConfig.gcsUserAgent(), "custom-agent");
   ASSERT_TRUE(hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()));
   ASSERT_FALSE(hiveConfig.allowNullPartitionKeys(emptySession.get()));
   ASSERT_EQ(hiveConfig.maxCoalescedBytes(emptySession.get()), 100);
@@ -205,6 +208,7 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_FALSE(hiveConfig.immutablePartitions());
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
+  ASSERT_FALSE(hiveConfig.gcsUserAgent().has_value());
   ASSERT_TRUE(hiveConfig.isFileColumnNamesReadAsLowerCase(session.get()));
 
   ASSERT_EQ(hiveConfig.maxCoalescedBytes(session.get()), 128 << 20);

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1332,6 +1332,10 @@ These semantics are similar to the `Apache Hadoop-Aws module <https://hadoop.apa
      - A custom OAuth credential provider, if specified, will be used to create the client in favor of other
        authentication mechanisms.
        The provider must be registered using "registerGcsOAuthCredentialsProvider" before it can be used.
+   * - gcs.user-agent
+     - string
+     -
+     - Custom user agent product string to include in GCS requests. "velox" is appended by default unless already present in the string.
 
 ``Azure Blob Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Summary

This PR adds support for configuring a custom `User-Agent` product string (`gcs.user-agent`) in the GCS storage adapter (`GcsFileSystem`).

Adding a user-agent product string allows higher-level query engines (e.g., Trino, Presto, Spark, custom engines) to identify themselves in GCS requests, improving telemetry, request metrics, and debugging capabilities on Google Cloud Storage.

### Changes

1. **Configuration**: Added `kGcsUserAgent = "gcs.user-agent"` to `HiveConfig`.

2. **GCS Client Options**: Configured `google::cloud::UserAgentProductsOption` in `GcsFileSystem::Impl::initializeClient()`.


3. **Tests**:
   - Added unit test cases to `HiveConfigTest` for default, override, and session configurations.
   - Added integration tests to `GcsFileSystemTest` covering simple, compound, and case-insensitive user-agent strings against the local GCS testbench emulator.

4. **Documentation**: Documented `gcs.user-agent` in `velox/docs/configs.rst`.

### Testing

Ran all Hive connector and GCS storage adapter unit and integration tests:

```bash
_build/debug/velox/connectors/hive/tests/velox_hive_connector_test --gtest_filter="HiveConfigTest.*"
_build/debug/velox/connectors/hive/storage_adapters/gcs/tests/velox_gcs_file_test --gtest_filter="GcsFileSystemTest.*"
```

Ran pre-commit hooks (clang-format, clang-tidy, license-header, EOF, whitespace):

```
pre-commit run --files \
   velox/connectors/hive/HiveConfig.cpp \
   velox/connectors/hive/HiveConfig.h \
   velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp \
   velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp \
   velox/connectors/hive/tests/HiveConfigTest.cpp \
   velox/docs/configs.rst
```

  All tests and linter checks passed.