### PR TITLE
fix: Restore Huffman 12-bit guard, fix NaN stats compare

### DIFF
--- a/velox/dwio/nimble/encodings/HuffmanEncoding.h
+++ b/velox/dwio/nimble/encodings/HuffmanEncoding.h
@@ -133,6 +133,22 @@ class HuffmanEncoding final
         : frequency(frequency), left(left), right(right), symbol(symbol) {}
   };
 
+  struct QueueEntry {
+    uint64_t frequency;
+    int32_t node;
+
+    // Explicit constructor keeps priority_queue::emplace() working on OSS GCC
+    // versions that do not apply parenthesized aggregate initialization here.
+    QueueEntry(uint64_t frequency, int32_t node)
+        : frequency(frequency), node(node) {}
+
+    bool operator>(const QueueEntry& other) const {
+      // Node order makes equal-frequency trees deterministic.
+      return frequency != other.frequency ? frequency > other.frequency
+                                          : node > other.node;
+    }
+  };
+
   // Maps tableLog_ lookahead bits to an alphabet index and the number of bits
   // consumed for that symbol.
   struct DecodeEntry {
@@ -150,23 +166,52 @@ class HuffmanEncoding final
     return reversed;
   }
 
-  // Derive leaf depths for canonical code construction. Distributions that
-  // exceed the bounded decoder table are rejected as incompatible.
-  static void assignCodeLengths(
-      const Vector<TreeNode>& nodes,
+  template <typename NodeContainer, typename LengthContainer>
+  static bool assignCodeLengths(
+      const NodeContainer& nodes,
       int32_t node,
       uint8_t depth,
-      Vector<uint8_t>& lengths) {
+      LengthContainer& lengths) {
     if (nodes[node].symbol >= 0) {
       if (depth > kMaxCodeBits) {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "Huffman tree exceeds the {}-bit limit", kMaxCodeBits);
+        return false;
       }
       lengths[nodes[node].symbol] = std::max<uint8_t>(1, depth);
-      return;
+      return true;
     }
-    assignCodeLengths(nodes, nodes[node].left, depth + 1, lengths);
-    assignCodeLengths(nodes, nodes[node].right, depth + 1, lengths);
+    return assignCodeLengths(nodes, nodes[node].left, depth + 1, lengths) &&
+        assignCodeLengths(nodes, nodes[node].right, depth + 1, lengths);
+  }
+
+  template <
+      typename FrequencyContainer,
+      typename NodeContainer,
+      typename LengthContainer>
+  static bool buildCodeLengths(
+      const FrequencyContainer& frequencies,
+      NodeContainer& nodes,
+      LengthContainer& lengths) {
+    std::priority_queue<
+        QueueEntry,
+        std::vector<QueueEntry>,
+        std::greater<QueueEntry>>
+        queue;
+    for (uint32_t symbol = 0; symbol < frequencies.size(); ++symbol) {
+      nodes.emplace_back(
+          frequencies[symbol], -1, -1, static_cast<int32_t>(symbol));
+      queue.emplace(frequencies[symbol], static_cast<int32_t>(symbol));
+    }
+    while (queue.size() > 1) {
+      const auto left = queue.top();
+      queue.pop();
+      const auto right = queue.top();
+      queue.pop();
+      const auto node = static_cast<int32_t>(nodes.size());
+      nodes.emplace_back(
+          left.frequency + right.frequency, left.node, right.node, -1);
+      queue.emplace(left.frequency + right.frequency, node);
+    }
+    return assignCodeLengths(nodes, queue.top().node, 0, lengths);
   }
 
   physicalType decodeValue(uint32_t row) const;
@@ -292,6 +337,24 @@ std::optional<uint64_t> HuffmanEncoding<T>::estimateSize(
     return std::nullopt;
   }
 
+  folly::F14FastMap<physicalType, uint32_t> symbolByValue;
+  std::vector<uint32_t> frequencies;
+  frequencies.reserve(uniqueCounts->size());
+  for (const auto value : values) {
+    auto [it, inserted] =
+        symbolByValue.emplace(value, static_cast<uint32_t>(frequencies.size()));
+    if (inserted) {
+      frequencies.push_back(0);
+    }
+    ++frequencies[it->second];
+  }
+  std::vector<TreeNode> nodes;
+  nodes.reserve(2 * frequencies.size() - 1);
+  std::vector<uint8_t> lengths(frequencies.size());
+  if (!buildCodeLengths(frequencies, nodes, lengths)) {
+    return std::nullopt;
+  }
+
   uint64_t encodedBits = 0;
   const uint64_t rowsMinusOne = values.size() - 1;
   for (const auto& [value, count] : uniqueCounts.value()) {
@@ -343,46 +406,12 @@ std::string_view HuffmanEncoding<T>::encode(
         "Huffman encoding requires at least two symbols");
   }
 
-  struct QueueEntry {
-    uint64_t frequency;
-    int32_t node;
-
-    // Explicit constructor so priority_queue::emplace() works under compilers
-    // that do not apply parenthesized aggregate initialization (P0960) inside
-    // construct_at (e.g. the OSS GCC build).
-    QueueEntry(uint64_t frequency, int32_t node)
-        : frequency(frequency), node(node) {}
-
-    bool operator>(const QueueEntry& other) const {
-      // Node order makes equal-frequency trees deterministic.
-      return frequency != other.frequency ? frequency > other.frequency
-                                          : node > other.node;
-    }
-  };
   Vector<TreeNode> nodes{pool};
-  std::priority_queue<
-      QueueEntry,
-      std::vector<QueueEntry>,
-      std::greater<QueueEntry>>
-      queue;
-  for (uint32_t symbol = 0; symbol < frequencies.size(); ++symbol) {
-    nodes.emplace_back(
-        frequencies[symbol], -1, -1, static_cast<int32_t>(symbol));
-    queue.emplace(frequencies[symbol], static_cast<int32_t>(symbol));
-  }
-  while (queue.size() > 1) {
-    const auto left = queue.top();
-    queue.pop();
-    const auto right = queue.top();
-    queue.pop();
-    const auto node = static_cast<int32_t>(nodes.size());
-    nodes.emplace_back(
-        left.frequency + right.frequency, left.node, right.node, -1);
-    queue.emplace(left.frequency + right.frequency, node);
-  }
-
   Vector<uint8_t> lengths{pool, alphabet.size()};
-  assignCodeLengths(nodes, queue.top().node, /*depth=*/0, lengths);
+  if (!buildCodeLengths(frequencies, nodes, lengths)) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "Huffman tree exceeds the {}-bit limit", kMaxCodeBits);
+  }
   const uint8_t tableLog = *std::max_element(lengths.begin(), lengths.end());
 
   // Number of symbols assigned to each code length, indexed by bit length.

--- a/velox/dwio/nimble/encodings/tests/HuffmanEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/HuffmanEncodingTest.cpp
@@ -299,6 +299,24 @@ TEST_F(HuffmanEncodingTest, estimateRejectsUnsupportedCardinality) {
       std::nullopt);
 }
 
+TEST_F(HuffmanEncodingTest, estimateRejectsCodeTreePastLimit) {
+  constexpr std::array<uint32_t, 14> kFrequencies = {
+      1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377};
+  Vector<uint32_t> values{pool_.get()};
+  for (uint32_t symbol = 0; symbol < kFrequencies.size(); ++symbol) {
+    for (uint32_t count = 0; count < kFrequencies[symbol]; ++count) {
+      values.push_back(symbol);
+    }
+  }
+
+  const std::span<const uint32_t> input{values.data(), values.size()};
+  NIMBLE_ASSERT_THROW(encode(values), "Huffman tree exceeds");
+  EXPECT_EQ(
+      HuffmanEncoding<uint32_t>::estimateSize(
+          input, Statistics<uint32_t>::create(input)),
+      std::nullopt);
+}
+
 TEST_F(HuffmanEncodingTest, estimateSizeIncludesCodesAndCheckpoints) {
   std::vector<uint32_t> values;
   values.insert(values.end(), 128, 0);

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -1520,18 +1520,24 @@ void NimbleWriterFuzzer::verifyColumnStatistics(
             expectedCommon.get());
     if (actualDbl != nullptr && expectedDbl != nullptr &&
         expectedDbl->getMinimum().has_value()) {
-      NIMBLE_CHECK_EQ(
-          *actualDbl->getMinimum(),
-          *expectedDbl->getMinimum(),
-          "Node {} double min mismatch (seed {}).",
-          node,
-          options_.seed);
-      NIMBLE_CHECK_EQ(
-          *actualDbl->getMaximum(),
-          *expectedDbl->getMaximum(),
-          "Node {} double max mismatch (seed {}).",
-          node,
-          options_.seed);
+      // Both bounds are NaN whenever the column carries one, because the
+      // fuzzer generates NaN on purpose. Comparing with == would report those
+      // agreeing statistics as a mismatch, so reuse the round-trip
+      // comparison's NaN handling.
+      const auto checkBound = [&](std::string_view bound,
+                                  double actualValue,
+                                  double expectedValue) {
+        NIMBLE_CHECK(
+            decodedValueEquals(actualValue, expectedValue),
+            "Node {} double {} mismatch ({} vs. {}, seed {}).",
+            node,
+            bound,
+            actualValue,
+            expectedValue,
+            options_.seed);
+      };
+      checkBound("min", *actualDbl->getMinimum(), *expectedDbl->getMinimum());
+      checkBound("max", *actualDbl->getMaximum(), *expectedDbl->getMaximum());
     }
 
     auto* actualStr =


### PR DESCRIPTION
Summary:
Two independent aborts take down `cogwheel_nimble_writer_fuzzer-test`
(T285832751).  This fixes both.

**1. Huffman `estimateSize` guard.**  DiffTrain fixup D115111041 reset
`HuffmanEncoding.h` to its pre-D114703429 state, dropping the guard that makes
`estimateSize` decline inputs whose Huffman tree exceeds the 12-bit decoder
limit.  `estimateSize` is the compatibility gate `RandomEncodingSelectionPolicy`
uses to pick candidates, so without it the selector offers Huffman for data the
encoder then refuses: `assignCodeLengths` throws `INCOMPATIBLE_ENCODING`, and
the fresh-selection path in `Writer` has no fallback to catch it.

Reland the `HuffmanEncoding.h` and `HuffmanEncodingTest.cpp` portions of
D114703429 unchanged.  `estimateSize` and `encode` again share
`buildCodeLengths`, so the gate is exact -- the estimator declines precisely
when the encoder would throw, and the repair phase records a fallback instead
of aborting.

**2. NaN in the statistics comparison.**  `verifyColumnStatistics` compared
double min/max with `==` while the fuzzer generates NaN on purpose
(`dataSpec.includeNaN`), so any column carrying one failed with
`(nan vs. nan) double min mismatch`.  Route those two checks through
`decodedValueEquals`, the NaN-aware comparison the round-trip path in the same
file already uses.  Integer and string bounds are left alone -- they cannot be
NaN, and this is the only remaining raw floating-point `==` in the fuzzer.

This second abort was masked until now: the run never survived past the Huffman
one to reach it.

The rest of D114703429 is already on master; the fuzzer sources have taken
further changes since and are otherwise left alone.  Its
`writer/CMakeLists.txt` hunk is deliberately omitted --
`EncodingSelectionPolicyFactory.cpp` is now built by the existing library, so
the extra target would compile it twice.

Differential Revision: D117529734


