### PR TITLE
fix(metaai): Handle null optional LLM inference arguments [velox][bug-fix] (#18701)

### DIFF
--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
@@ -39,11 +39,17 @@ AsyncRPCFunctionRegistry::signatureStore() {
   return instance;
 }
 
+std::unordered_map<std::string, AsyncRPCFunctionRegistry::Metadata>&
+AsyncRPCFunctionRegistry::metadataStore() {
+  static std::unordered_map<std::string, Metadata> instance;
+  return instance;
+}
+
 bool AsyncRPCFunctionRegistry::registerFunction(
     const std::string& name,
     Factory factory) {
   std::lock_guard<std::mutex> lock(mutex());
-  return registerEntryLocked(name, std::move(factory), {});
+  return registerEntryLocked(name, std::move(factory), {}, {});
 }
 
 bool AsyncRPCFunctionRegistry::registerFunction(
@@ -51,13 +57,25 @@ bool AsyncRPCFunctionRegistry::registerFunction(
     Factory factory,
     Signatures signatures) {
   std::lock_guard<std::mutex> lock(mutex());
-  return registerEntryLocked(name, std::move(factory), std::move(signatures));
+  return registerEntryLocked(
+      name, std::move(factory), std::move(signatures), {});
+}
+
+bool AsyncRPCFunctionRegistry::registerFunction(
+    const std::string& name,
+    Factory factory,
+    Signatures signatures,
+    Metadata metadata) {
+  std::lock_guard<std::mutex> lock(mutex());
+  return registerEntryLocked(
+      name, std::move(factory), std::move(signatures), std::move(metadata));
 }
 
 bool AsyncRPCFunctionRegistry::registerEntryLocked(
     const std::string& name,
     Factory factory,
-    Signatures signatures) {
+    Signatures signatures,
+    Metadata metadata) {
   auto& registry = factories();
   if (registry.count(name) > 0) {
     return false; // Already registered
@@ -65,6 +83,7 @@ bool AsyncRPCFunctionRegistry::registerEntryLocked(
   registry[name] = std::move(factory);
   if (!signatures.empty()) {
     signatureStore()[name] = std::move(signatures);
+    metadataStore()[name] = std::move(metadata);
   }
   // Note: Do NOT use LOG() here as this function is called during static
   // initialization, before glog is initialized. Using LOG() would cause
@@ -75,11 +94,13 @@ bool AsyncRPCFunctionRegistry::registerEntryLocked(
 void AsyncRPCFunctionRegistry::registerStubs(
     const std::string& namespacePrefix) {
   std::unordered_map<std::string, Signatures> sigsCopy;
+  std::unordered_map<std::string, Metadata> metadataCopy;
   {
     std::lock_guard<std::mutex> lock(mutex());
     for (const auto& [name, sigs] : signatureStore()) {
       if (!sigs.empty()) {
         sigsCopy[name] = sigs;
+        metadataCopy[name] = metadataStore()[name];
       }
     }
   }
@@ -89,7 +110,8 @@ void AsyncRPCFunctionRegistry::registerStubs(
     std::string stubName = namespacePrefix + name;
     LOG(INFO) << "[RPC] registerStubs: registering stub '" << stubName
               << "' with " << sigs.size() << " signature(s)";
-    registerRPCFunctionStub(stubName, std::move(sigs));
+    registerRPCFunctionStub(
+        stubName, std::move(sigs), std::move(metadataCopy[name]));
   }
   LOG(INFO) << "[RPC] registerStubs: completed, registered " << sigsCopy.size()
             << " stub(s)";
@@ -125,6 +147,7 @@ void AsyncRPCFunctionRegistry::testingClear() {
   std::lock_guard<std::mutex> lock(mutex());
   factories().clear();
   signatureStore().clear();
+  metadataStore().clear();
 }
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.h
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.h
@@ -24,6 +24,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "velox/expression/FunctionMetadata.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/rpc/AsyncRPCFunction.h"
 
@@ -75,6 +76,10 @@ class AsyncRPCFunctionRegistry {
   /// Signature list type for stub registration.
   using Signatures = std::vector<std::shared_ptr<exec::FunctionSignature>>;
 
+  /// Declaration attached to the stub. Read by the sidecar, not by any
+  /// executor: RPC functions run in RPCOperator and never reach the stub.
+  using Metadata = exec::VectorFunctionMetadata;
+
   /// Registers an AsyncRPCFunction factory for the given function name.
   /// Thread-safe. Safe to call during static initialization.
   ///
@@ -91,6 +96,16 @@ class AsyncRPCFunctionRegistry {
       const std::string& name,
       Factory factory,
       Signatures signatures);
+
+  /// Registers a factory, its signatures, and the metadata the stub is declared
+  /// with. Use this when the default declaration is wrong for the function --
+  /// most importantly when a NULL in one argument does not mean a NULL result,
+  /// which the default 'defaultNullBehavior{true}' asserts.
+  static bool registerFunction(
+      const std::string& name,
+      Factory factory,
+      Signatures signatures,
+      Metadata metadata);
 
   /// Registers stub Velox functions for all functions that provided signatures.
   /// Must be called during server startup (after config is available).
@@ -132,12 +147,14 @@ class AsyncRPCFunctionRegistry {
   static std::mutex& mutex();
   static std::unordered_map<std::string, Factory>& factories();
   static std::unordered_map<std::string, Signatures>& signatureStore();
+  static std::unordered_map<std::string, Metadata>& metadataStore();
 
   /// Registers an entry under the lock. Caller must hold mutex().
   static bool registerEntryLocked(
       const std::string& name,
       Factory factory,
-      Signatures signatures);
+      Signatures signatures,
+      Metadata metadata);
 };
 
 /// Helper class for static registration of AsyncRPCFunction implementations.
@@ -159,6 +176,15 @@ class AsyncRPCFunctionRegistrar {
       AsyncRPCFunctionRegistry::Signatures signatures) {
     AsyncRPCFunctionRegistry::registerFunction(
         name, std::move(factory), std::move(signatures));
+  }
+
+  AsyncRPCFunctionRegistrar(
+      const std::string& name,
+      AsyncRPCFunctionRegistry::Factory factory,
+      AsyncRPCFunctionRegistry::Signatures signatures,
+      AsyncRPCFunctionRegistry::Metadata metadata) {
+    AsyncRPCFunctionRegistry::registerFunction(
+        name, std::move(factory), std::move(signatures), std::move(metadata));
   }
 };
 
@@ -197,5 +223,15 @@ class AsyncRPCFunctionRegistrar {
 #define VELOX_REGISTER_RPC_FUNCTION_CUSTOM_FACTORY(name, factory, sigs) \
   static ::facebook::velox::exec::rpc::AsyncRPCFunctionRegistrar        \
   _VELOX_RPC_REGISTRAR_VAR2(name, __LINE__)(#name, (factory), (sigs))
+
+/// Register an RPC function with a custom factory, explicit signatures, and an
+/// explicit stub declaration. Needed when the defaults are wrong for the
+/// function -- see AsyncRPCFunctionRegistry::Metadata.
+/// Usage: VELOX_REGISTER_RPC_FUNCTION_WITH_METADATA(
+///            my_rpc, myFactoryFn, MyClass::signatures(), myMetadata());
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+#define VELOX_REGISTER_RPC_FUNCTION_WITH_METADATA(name, factory, sigs, meta) \
+  static ::facebook::velox::exec::rpc::AsyncRPCFunctionRegistrar             \
+  _VELOX_RPC_REGISTRAR_VAR2(name, __LINE__)(#name, (factory), (sigs), (meta))
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/RPCFunctionStubs.cpp
+++ b/velox/expression/rpc/RPCFunctionStubs.cpp
@@ -53,7 +53,8 @@ class RPCStubFunction : public exec::VectorFunction {
 
 void registerRPCFunctionStub(
     const std::string& name,
-    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures) {
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures,
+    exec::VectorFunctionMetadata metadata) {
   LOG(INFO) << "[RPC] registerRPCFunctionStub: registering Velox stub '" << name
             << "' with " << signatures.size() << " signature(s)";
   exec::registerStatefulVectorFunction(
@@ -64,7 +65,8 @@ void registerRPCFunctionStub(
           const std::vector<exec::VectorFunctionArg>& /*inputArgs*/,
           const core::QueryConfig& /*config*/) {
         return std::make_shared<RPCStubFunction>(name);
-      });
+      },
+      std::move(metadata));
   LOG(INFO) << "[RPC] registerRPCFunctionStub: successfully registered '"
             << name << "' in Velox function registry";
 }

--- a/velox/expression/rpc/RPCFunctionStubs.h
+++ b/velox/expression/rpc/RPCFunctionStubs.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "velox/expression/FunctionMetadata.h"
 #include "velox/expression/FunctionSignature.h"
 
 namespace facebook::velox::exec::rpc {
@@ -30,8 +31,12 @@ namespace facebook::velox::exec::rpc {
 ///
 /// @param name Full 3-part Velox name (e.g., "native.rpc.fb_llm_inference")
 /// @param signatures Function signatures (arg types, return type)
+/// @param metadata Declaration forwarded to the Velox registry. The stub never
+/// executes, so this is read only by the sidecar, which turns it into the
+/// determinism and null-call clause it publishes to the coordinator.
 void registerRPCFunctionStub(
     const std::string& name,
-    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures);
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures,
+    exec::VectorFunctionMetadata metadata);
 
 } // namespace facebook::velox::exec::rpc


### PR DESCRIPTION
Summary:


fb_llm_inference registers no VectorFunctionMetadata, so it inherits Velox's
default defaultNullBehavior{true}. The sidecar publishes that as
RETURNS_NULL_ON_NULL_INPUT, and RowExpressionInterpreter then folds any call
carrying a NULL argument to a NULL constant at plan time
(presto-main-base/.../planner/RowExpressionInterpreter.java:222-228). But
system_prompt and options are OPTIONAL arguments of this function, so "no system
prompt" gets folded into "no answer".

The result is that the SAME logical call returns two different things depending
on whether the optimizer can see the NULL. One query,
20260825_192513_53185_abtha, both arms in the same row:

  fb_llm_inference(prompt, model, <a column that IS NULL>, opts)  -> "Tokyo."
  fb_llm_inference(prompt, model, CAST(NULL AS VARCHAR),   opts)  -> NULL

The column arm confirms it is really NULL in the same SELECT. So the runtime
path already treats a NULL system_prompt as "not supplied" and calls the model;
only the plan-time fold disagrees, and it wins whenever the NULL is a literal.
20260825_191032_60235_8wmpy shows the literal case across all four arguments,
and 20260825_190831_59682_8wmpy shows there is no RPC behind it: with
fb_llm_inference_with_error a literal NULL system_prompt returns a NULL ROW, so
neither result nor error is populated.

This is not intended behavior. Three independent signals:

1. FbLlmInference.cpp already has null-tolerant branches for both optional
   arguments, in both execution modes: system_prompt at :385 and :624, options
   at :420 and :642. Each reads a NULL as "not supplied" and carries on. That is
   the behavior the column arm above actually gets, and the declaration
   contradicts it.
2. The rewrite plugin's rules doc states it directly:
   presto-facebook-expression-rewrite-plugin/.llms/rules/ai-function-rewrite.md
   -- "No NULL short-circuit -- NULL args are passed through to the RPC
   service."
3. Every meta.ai.* entry in configerator is explicitly
   nullCallClause="CALLED_ON_NULL_INPUT". The RPC primitive those calls compile
   down to disagrees with the surface they are declared as.

Fix: give the registry an optional metadata slot, plumb it through to
registerRPCFunctionStub, and register the fb_llm_inference family with
defaultNullBehavior=false. The arguments that genuinely cannot be NULL are
checked per row in hasNullRequiredArgument(): prompt always, and model when the
call actually binds that argument and it was not folded into constantModel_.
So NULL prompt and NULL model keep returning NULL; NULL system_prompt and NULL
options now behave the way the column arm already does.

WHAT THIS DOES NOT CHANGE, measured rather than assumed:

- Runtime column NULLs. RPCOperator.cpp:187 builds SelectivityVector over every
  input row and never consults defaultNullBehavior, so those rows are dispatched
  today and are dispatched after. See the column arm above.
- meta.ai.classify / meta.ai.translate. These synthesize system_prompt from a
  user argument (AIFunctionRewriteOptimizer.java:480, :492), and concat and
  array_join are both RETURNS_NULL_ON_NULL_INPUT, so a NULL label list makes the
  whole system_prompt NULL. I expected this diff to turn those rows from NULL
  into a garbage answer. It does not, because the rewrite runs at
  PlanOptimizers.java:688, AFTER the last SimplifyRowExpressions pass at :640,
  so the synthesized call is never folded. Measured on
  20260825_192100_66842_d68zx:

    meta.ai.classify(text, ARRAY['positive','negative'], model, key) -> "negative"
    meta.ai.classify(text, CAST(NULL AS ARRAY(VARCHAR)), model, key) IS NULL -> false
      value: "I'm so sorry to hear that you had a poor dining experience. ..."

  A NULL label list already returns a chatty non-answer instead of NULL, before
  this diff. That is a separate pre-existing bug and it belongs in
  AIFunctionRewriteOptimizer as a guard on the derived argument. Filing it
  separately; it is not caused or worsened here.

Scope: only defaultNullBehavior is overridden. determinism stays at its default.
It is wrong for an LLM, but flipping it changes CSE and constant folding on
every existing plan, which is a separate decision. The sibling FbEmbedding
family keeps the 3-arg macro and the default declaration; whether it has the
same defect is not established here.

Known gap: nothing in the tree asserts NULL behavior for a non-first argument of
these functions -- not TestAIFunctionRewriteOptimizer, not the velox rpc test
dirs, not regress_*.sh, not the 247 meta_ai sql_tests. The unit tests below pin
the C++ rule; the plan-level fold is covered only by the query IDs above.

Reviewed By: zhichenxu-meta

Differential Revision: D117401318


