### PR TITLE
fix: Fix CacheShard::shutdown race and leak

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -864,6 +864,8 @@ void AsyncDataCache::shutdown() {
 }
 
 void CacheShard::shutdown() {
+  std::lock_guard<std::mutex> l(mutex_);
+  entryMap_.clear();
   entries_.clear();
   freeEntries_.clear();
 }


### PR DESCRIPTION
Summary:
CacheShard::shutdown() cleared `entries_` and `freeEntries_` without
holding `mutex_` and without clearing `entryMap_`. A concurrent
`findOrCreate()` that inserts into `entryMap_` (F14FastMap) can race
with `entries_.clear()`, corrupting the F14 table and triggering the
rehash assert `hp.second == srcChunk->tag(srcI)` (SIGABRT) observed in
`AxelServerCacheShutdownTest.cacheReleasedOnStop`. The leaked
`entryMap_` also kept allocator-backed pages pinned after
`AxelServer::stop()` until `~MmapAllocator` at process exit.

Fix by acquiring `mutex_` and clearing `entryMap_` before clearing
`entries_`/`freeEntries_`, so shutdown is serialized with all
`lookupLocked` paths and the allocator pages are released promptly.

Differential Revision: D117553318


