### PR TITLE
fix(nimble): Re-size the merged flat map key buffer when the entry count repeats (#18706)

### DIFF
--- a/velox/dwio/nimble/velox/FieldReader.cpp
+++ b/velox/dwio/nimble/velox/FieldReader.cpp
@@ -3374,7 +3374,26 @@ class MergedFlatMapFieldReader final
     }
 
     velox::VectorPtr& valuesVector = vector->mapValues();
+    // The key vector holds one entry per map entry, but VectorInitializer above
+    // sized it from rowCount, which shrinks its values buffer to
+    // rowCount * sizeof(T). The resize below is what puts that back -- except
+    // FlatVector::resize returns early when handed the size the vector already
+    // has, which happens whenever two consecutive batches carry the same entry
+    // count. The vector is then left claiming totalMapEntries entries over a
+    // rowCount-sized buffer. Nothing notices on a plain read, because only
+    // wrapping the vector in a dictionary -- what a filtered read does when it
+    // drops rows -- ever validates it, and only in a debug build.
+    //
+    // Dropping to zero first makes the growth path always run. Capacity
+    // survives the shrink, so this costs no allocation.
+    //
+    // The zero-entry case is deliberately left alone: a batch with no entries
+    // keeps the previous batch's key length, which is the same inconsistency in
+    // miniature. Clearing it here regresses flat map feature projection
+    // (koski's NimbleTableTest.FeatureProjection*), so it needs its own
+    // investigation rather than a drive-by fix.
     if (totalMapEntries > 0) {
+      keysVector->resize(0, false);
       keysVector->resize(totalMapEntries, false);
       velox::BaseVector::prepareForReuse(valuesVector, totalMapEntries);
     }

--- a/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -7705,6 +7705,59 @@ TEST_P(MetadataReuseTest, metadataReuseCrossReaders) {
 // the input vector) is freed before a rehash, the map keys become dangling.
 // This test reproduces the issue by writing many batches with distinct string
 // keys, where each batch vector is destroyed before the next write.
+// A flat map's key vector holds one entry per map entry, but it used to be
+// sized from the row count, which shrinks its values buffer. The resize back up
+// to the entry count is skipped whenever FlatVector::resize is handed the size
+// the vector already has, so two consecutive batches carrying the same number
+// of map entries left the key vector claiming more entries than its buffer
+// held. A plain read never noticed, because only wrapping a vector in a
+// dictionary validates it; a filtered read that drops rows aborted in
+// FlatVector::validate with "values_->size() >= byteSize".
+TEST_P(VeloxReaderTest, flatMapKeyBufferSurvivesEqualEntryCountBatches) {
+  constexpr velox::vector_size_t kRowCount = 40;
+  constexpr velox::vector_size_t kBatchSize = 10;
+  constexpr velox::vector_size_t kEntriesPerRow = 3;
+
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  // Every row carries the same three keys, so every batch reports an identical
+  // total entry count and the second batch is the one that hits the skipped
+  // resize. Entries per row must exceed kBatchSize for the undersized buffer to
+  // be observable.
+  auto vector = vectorMaker.rowVector(
+      {"flat_map"},
+      {vectorMaker.mapVector<int32_t, int64_t>(
+          kRowCount,
+          [](velox::vector_size_t /*row*/) { return kEntriesPerRow; },
+          [](velox::vector_size_t idx) { return idx % kEntriesPerRow; },
+          [](velox::vector_size_t idx) { return idx; })});
+
+  auto writerOptions = createFlatMapWriterOptions();
+  writerOptions.flatMapColumns["flat_map"];
+  auto file = nimble::test::createNimbleFile(*rootPool_, vector, writerOptions);
+
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, selector, createReadParams());
+
+  velox::VectorPtr result;
+  velox::vector_size_t rowsRead = 0;
+  while (reader.next(kBatchSize, result)) {
+    // The assertion that fails without the fix: a vector's key buffer has to
+    // cover the number of entries it claims. Velox only runs this from
+    // DictionaryVector, so assert it directly rather than relying on a
+    // filtered read to trip it.
+    ASSERT_NO_THROW(result->validate({}))
+        << "invalid vector after reading rows [" << rowsRead << ", "
+        << rowsRead + result->size() << ")";
+    rowsRead += result->size();
+  }
+  EXPECT_EQ(rowsRead, kRowCount);
+}
+
 TEST_P(VeloxReaderTest, flatMapStringKeyOwnership) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::VARCHAR(), velox::BIGINT())}});


### PR DESCRIPTION
Summary:

`MergedFlatMapFieldReader::next` sizes the key vector through
`VectorInitializer<FlatVector<T>>::initialize`, which passes `rowCount` to
`ensureBuffer<T>`. On a reused vector that shrinks the values buffer to
`rowCount * sizeof(T)`. The `keysVector->resize(totalMapEntries, false)` a few
lines down is what puts it back -- except `FlatVector::resize` returns early
when handed the size the vector already carries, which is exactly what happens
when two consecutive batches have the same entry count. The batch is then left
with a key vector claiming `totalMapEntries` entries over a `rowCount`-sized
buffer:

```
keysLen=49 keysBufBytes=196 keysBufCap=288   <- differing counts, resize ran
keysLen=49 keysBufBytes=40  keysBufCap=288   <- equal counts, resize skipped
```

Writes still land inside the buffer's *capacity*, so nothing faults and no data
is wrong; only the recorded size is. Dropping to zero first makes the growth
path always run. Capacity survives the shrink, so this costs no allocation.

Scope of the symptom, which is narrower than it first looks: `FlatVector` is
only validated from `DictionaryVector::setInternalState`, and that call is
`#ifndef NDEBUG` (`velox/vector/DictionaryVector-inl.h:28-32`). So this is a
**debug-build abort**, not a production correctness bug. Confirmed by running
the repro below in `mode/opt` against unfixed code: it completes and returns
the correct checksum. Reproducing it takes a flat map, a filter that drops rows
(which is what makes `projectColumnsWithSelection` wrap the column in a
dictionary), and two consecutive batches with equal entry counts -- which is
why it survived until a randomized filter generator produced that combination.

The zero-entry case is deliberately left as it is. A batch with no entries
keeps the previous batch's key length, which is the same inconsistency in
miniature, but clearing it changes observable output: `keys()` is the physical
child, and production consumers that read it whole -- `DataPipelineWrapper::
convertMapToTensors` and `ColumnarTensorBuilder` size tensors off it -- would
see different shapes on empty batches, in every build mode. That wants the
df4ai owners in the loop rather than a drive-by, so it is called out in the
code comment instead.

Also fixes `NimbleTableTest` in koski, which this work exposed. Its three
feature-projection tests counted entries with `keys().size()`, the physical
child buffer, which koski's own review guide names as a bug pattern
(`koski/.llms/skills/koski-code-review/references/koski-correctness.md`):

```
// WRONG: physical buffer size, not logical
int total = mapSlice.keys().size();
// CORRECT: null-aware total element count
int total = mapSlice.elementCount();
```

On the empty batches that buffer still holds the previous batch's keys, so the
sums double-counted: the expected 16 and 32 were 8 and 16 real entries plus an
equal number of phantoms. The tests now count with `elementCount()`, walk
per-row ranges via `offsets()`/`sizes()` for the value assertions instead of
indexing the physical child from 0, and document the fixture's actual layout.
`FeatureProjectionEmpty` uses the same API but is not wrong -- measured,
`keys().size()` and `elementCount()` both give 3840 there -- so it is left
alone.

Reviewed By: raymondlin1, xiaoxmeng

Differential Revision: D117578358


