### PR TITLE
perf(nimble): Reduce index projector slice overhead (#18708)

### DIFF
--- a/velox/dwio/nimble/serializer/StreamSlicer.cpp
+++ b/velox/dwio/nimble/serializer/StreamSlicer.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "folly/ScopeGuard.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
@@ -368,15 +369,14 @@ StreamSlicer::SlicedStreams StreamSlicer::slice(
   }
 
   ScopedEncodingBuffer strippedStreamBuffer{pool_, &strippedStreamBufferPool_};
-  inputStreams_.resize(inputStreams.size());
-  for (size_t i = 0; i < inputStreams.size(); ++i) {
-    if (inputStreams[i].empty()) {
-      inputStreams_[i] = {};
-      continue;
-    }
-    inputStreams_[i] =
-        stripChunkHeaders(inputStreams[i], strippedStreamBuffer.get());
-  }
+  SCOPE_EXIT {
+    strippedStreamCache_.clear();
+  };
+  stripChunkHeaders(
+      inputStreams,
+      strippedStreamBuffer.get(),
+      inputStreams_,
+      strippedStreamCache_);
   Buffer outputBuffer{*pool_, totalBytes(inputStreams_)};
   return sliceStreams(
       inputStreams_,
@@ -396,13 +396,7 @@ StreamSlicer::SlicedStreams StreamSlicer::sliceStreams(
     const Encoding::Options& encodingOptions) const {
   SlicedStreams result;
   sliceType(
-      *schema_,
-      range,
-      inputStreams,
-      result.streams,
-      result.requiresNullBarrier,
-      outputBuffer,
-      encodingOptions);
+      *schema_, range, inputStreams, result, outputBuffer, encodingOptions);
   result.data = takeOwnershipAsIOBuf(result.streams, outputBuffer);
   return result;
 }
@@ -411,8 +405,7 @@ void StreamSlicer::sliceType(
     const Type& type,
     Range range,
     const std::vector<std::string_view>& inputStreams,
-    std::vector<std::string_view>& outputStreams,
-    bool& outputRequiresNullBarrier,
+    SlicedStreams& outputStreams,
     Buffer& outputBuffer,
     const Encoding::Options& encodingOptions) const {
   if (range.length == 0) {
@@ -425,9 +418,8 @@ void StreamSlicer::sliceType(
           type.asScalar().scalarDescriptor(),
           range,
           inputStreams,
-          outputStreams,
           /*isRowOrFlatMapNullStream=*/false,
-          outputRequiresNullBarrier,
+          outputStreams,
           outputBuffer,
           encodingOptions);
       return;
@@ -437,9 +429,8 @@ void StreamSlicer::sliceType(
           timestamp.microsDescriptor(),
           range,
           inputStreams,
-          outputStreams,
           /*isRowOrFlatMapNullStream=*/false,
-          outputRequiresNullBarrier,
+          outputStreams,
           outputBuffer,
           encodingOptions);
       auto nanosRange = range;
@@ -453,9 +444,8 @@ void StreamSlicer::sliceType(
           timestamp.nanosDescriptor(),
           nanosRange,
           inputStreams,
-          outputStreams,
           /*isRowOrFlatMapNullStream=*/false,
-          outputRequiresNullBarrier,
+          outputStreams,
           outputBuffer,
           encodingOptions);
       return;
@@ -468,9 +458,8 @@ void StreamSlicer::sliceType(
             row.nullsDescriptor(),
             range,
             inputStreams,
-            outputStreams,
             /*isRowOrFlatMapNullStream=*/true,
-            outputRequiresNullBarrier,
+            outputStreams,
             outputBuffer,
             encodingOptions);
         childRange = trueRange(
@@ -484,7 +473,6 @@ void StreamSlicer::sliceType(
             childRange,
             inputStreams,
             outputStreams,
-            outputRequiresNullBarrier,
             outputBuffer,
             encodingOptions);
       }
@@ -505,9 +493,8 @@ void StreamSlicer::sliceType(
           array.lengthsDescriptor(),
           range,
           inputStreams,
-          outputStreams,
           /*isRowOrFlatMapNullStream=*/false,
-          outputRequiresNullBarrier,
+          outputStreams,
           outputBuffer,
           encodingOptions);
       sliceType(
@@ -515,7 +502,6 @@ void StreamSlicer::sliceType(
           childRange,
           inputStreams,
           outputStreams,
-          outputRequiresNullBarrier,
           outputBuffer,
           encodingOptions);
       return;
@@ -535,9 +521,8 @@ void StreamSlicer::sliceType(
           map.lengthsDescriptor(),
           range,
           inputStreams,
-          outputStreams,
           /*isRowOrFlatMapNullStream=*/false,
-          outputRequiresNullBarrier,
+          outputStreams,
           outputBuffer,
           encodingOptions);
       sliceType(
@@ -545,7 +530,6 @@ void StreamSlicer::sliceType(
           childRange,
           inputStreams,
           outputStreams,
-          outputRequiresNullBarrier,
           outputBuffer,
           encodingOptions);
       sliceType(
@@ -553,7 +537,6 @@ void StreamSlicer::sliceType(
           childRange,
           inputStreams,
           outputStreams,
-          outputRequiresNullBarrier,
           outputBuffer,
           encodingOptions);
       return;
@@ -566,9 +549,8 @@ void StreamSlicer::sliceType(
             flatMap.nullsDescriptor(),
             range,
             inputStreams,
-            outputStreams,
             /*isRowOrFlatMapNullStream=*/true,
-            outputRequiresNullBarrier,
+            outputStreams,
             outputBuffer,
             encodingOptions);
         mapRange = trueRange(
@@ -590,9 +572,8 @@ void StreamSlicer::sliceType(
               inMapDescriptor,
               mapRange,
               inputStreams,
-              outputStreams,
               /*isRowOrFlatMapNullStream=*/false,
-              outputRequiresNullBarrier,
+              outputStreams,
               outputBuffer,
               encodingOptions);
           valueRange = trueRange(
@@ -605,7 +586,6 @@ void StreamSlicer::sliceType(
             valueRange,
             inputStreams,
             outputStreams,
-            outputRequiresNullBarrier,
             outputBuffer,
             encodingOptions);
       }
@@ -621,17 +601,16 @@ void StreamSlicer::sliceDescriptor(
     const StreamDescriptor& descriptor,
     Range range,
     const std::vector<std::string_view>& inputStreams,
-    std::vector<std::string_view>& outputStreams,
     bool isRowOrFlatMapNullStream,
-    bool& outputRequiresNullBarrier,
+    SlicedStreams& outputStreams,
     Buffer& outputBuffer,
     const Encoding::Options& encodingOptions) const {
   NIMBLE_CHECK_GT(range.length, 0, "Stream slice length must be positive");
   if (!hasStream(inputStreams, descriptor)) {
     return;
   }
-  if (descriptor.offset() >= outputStreams.size()) {
-    outputStreams.resize(descriptor.offset() + 1);
+  if (descriptor.offset() >= outputStreams.streams.size()) {
+    outputStreams.streams.resize(descriptor.offset() + 1);
   }
   auto sliced = EncodingFactory::slice(
       inputStreams[descriptor.offset()],
@@ -639,10 +618,10 @@ void StreamSlicer::sliceDescriptor(
       range.length,
       outputBuffer,
       encodingOptions);
-  outputStreams[descriptor.offset()] = sliced;
+  outputStreams.streams[descriptor.offset()] = sliced;
   if (isRowOrFlatMapNullStream) {
     NIMBLE_CHECK(!sliced.empty(), "Sliced null stream must not be empty");
-    outputRequiresNullBarrier |=
+    outputStreams.requiresNullBarrier |=
         countTrue(
             sliced, {.offset = 0, .length = range.length}, encodingOptions) <
         range.length;
@@ -662,6 +641,36 @@ bool StreamSlicer::hasFlatMapValues(
   return visitPresenceStreamOffsets(type, [&](offset_size offset) {
     return offset < inputStreams.size() && !inputStreams[offset].empty();
   });
+}
+
+void StreamSlicer::stripChunkHeaders(
+    const std::vector<std::string_view>& inputStreams,
+    Buffer& strippedStreamBuffer,
+    std::vector<std::string_view>& strippedStreams,
+    StrippedStreamCache& strippedStreamCache) {
+  strippedStreams.resize(inputStreams.size());
+  NIMBLE_CHECK(
+      strippedStreamCache.empty(),
+      "Stripped stream cache must be empty before slicing.");
+  strippedStreamCache.reserve(inputStreams.size());
+  for (size_t i = 0; i < inputStreams.size(); ++i) {
+    const auto input = inputStreams[i];
+    if (input.empty()) {
+      strippedStreams[i] = {};
+      continue;
+    }
+    // Multiple projected stream slots can alias the same tablet stream bytes.
+    // Strip once so duplicate slots share the same decoded view.
+    auto cached = strippedStreamCache.find(input);
+    if (cached != strippedStreamCache.end()) {
+      strippedStreams[i] = cached->second;
+      continue;
+    }
+    auto stripped =
+        facebook::nimble::serde::stripChunkHeaders(input, strippedStreamBuffer);
+    strippedStreamCache.emplace(input, stripped);
+    strippedStreams[i] = stripped;
+  }
 }
 
 StreamSlicer::Range StreamSlicer::nonNullRange(
@@ -735,9 +744,12 @@ uint32_t StreamSlicer::countTrue(
   if (range.length == 0) {
     return 0;
   }
-  auto encoding = createEncoding(encoded, pool_, encodingOptions);
   NIMBLE_CHECK_EQ(
-      encoding->dataType(), DataType::Bool, "Expected a bool stream");
+      EncodingPrefix::dataType(encoded),
+      DataType::Bool,
+      "Expected a bool stream");
+
+  auto encoding = createEncoding(encoded, pool_, encodingOptions);
   NIMBLE_CHECK_LE(range.offset, encoding->rowCount());
   NIMBLE_CHECK_LE(range.length, encoding->rowCount() - range.offset);
   encoding->skip(range.offset);

--- a/velox/dwio/nimble/serializer/StreamSlicer.h
+++ b/velox/dwio/nimble/serializer/StreamSlicer.h
@@ -16,10 +16,12 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <string_view>
 #include <vector>
 
+#include "folly/container/F14Map.h"
 #include "folly/io/IOBuf.h"
 #include "velox/buffer/BufferPool.h"
 #include "velox/common/memory/Memory.h"
@@ -63,12 +65,12 @@ class StreamSlicer {
   folly::IOBuf slice(std::string_view input, uint32_t offset, uint32_t length)
       const;
 
-  /// Sliced stream-set result backed by an owned IOBuf chain.
+  /// Sliced stream-set result.
   struct SlicedStreams {
     /// Owns the encoded bytes referenced by streams.
     folly::IOBuf data;
 
-    /// Views into data ordered by stream offset.
+    /// Views ordered by stream offset, backed by data.
     std::vector<std::string_view> streams;
 
     /// Indicates whether the stream set needs a row null-barrier on read.
@@ -95,8 +97,7 @@ class StreamSlicer {
       const Type& type,
       Range range,
       const std::vector<std::string_view>& inputStreams,
-      std::vector<std::string_view>& outputStreams,
-      bool& outputRequiresNullBarrier,
+      SlicedStreams& outputStreams,
       Buffer& outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
@@ -105,9 +106,8 @@ class StreamSlicer {
       const StreamDescriptor& descriptor,
       Range range,
       const std::vector<std::string_view>& inputStreams,
-      std::vector<std::string_view>& outputStreams,
       bool isRowOrFlatMapNullStream,
-      bool& outputRequiresNullBarrier,
+      SlicedStreams& outputStreams,
       Buffer& outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
@@ -127,6 +127,38 @@ class StreamSlicer {
   bool hasFlatMapValues(
       const Type& type,
       const std::vector<std::string_view>& inputStreams) const;
+
+  // Hashes stream views by backing storage identity, not by contents.
+  struct StreamViewIdentityHash {
+    size_t operator()(std::string_view stream) const {
+      const auto dataHash = std::hash<const void*>{}(stream.data());
+      const auto sizeHash = std::hash<size_t>{}(stream.size());
+      return dataHash ^
+          (sizeHash + 0x9e3779b9 + (dataHash << 6) + (dataHash >> 2));
+    }
+  };
+
+  // Compares stream views by backing pointer and length.
+  struct StreamViewIdentityEqual {
+    bool operator()(std::string_view lhs, std::string_view rhs) const {
+      return lhs.data() == rhs.data() && lhs.size() == rhs.size();
+    }
+  };
+
+  using StrippedStreamCache = folly::F14FastMap<
+      std::string_view,
+      std::string_view,
+      StreamViewIdentityHash,
+      StreamViewIdentityEqual>;
+
+  // Removes tablet chunk headers from the input stream set into
+  // strippedStreams. Reuses stripped views for aliased physical stream bytes
+  // within one slice.
+  static void stripChunkHeaders(
+      const std::vector<std::string_view>& inputStreams,
+      Buffer& strippedStreamBuffer,
+      std::vector<std::string_view>& strippedStreams,
+      StrippedStreamCache& strippedStreamCache);
 
   // Maps a nullable stream range to its non-null child-value range.
   Range nonNullRange(
@@ -166,7 +198,10 @@ class StreamSlicer {
   mutable velox::BufferPool bufferPool_;
   // Scratch arenas reused by nested EncodingFactory::slice() calls.
   mutable EncodingBufferPool encodingBufferPool_;
+  // Scratch arena used while removing tablet chunk headers before slicing.
   mutable EncodingBufferPool strippedStreamBufferPool_;
+  // Per-call cache for duplicate projected streams backed by the same bytes.
+  mutable StrippedStreamCache strippedStreamCache_;
   mutable std::vector<std::string_view> inputStreams_;
   mutable std::vector<uint32_t> streamSizes_;
   mutable Vector<char> headerBuffer_;

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -17,7 +17,6 @@
 #include "velox/dwio/nimble/velox/index/NimbleIndexProjector.h"
 
 #include <algorithm>
-#include <cmath>
 
 #include "folly/ScopeGuard.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -48,14 +47,21 @@ void validateReaderOptions(const velox::dwio::common::ReaderOptions& options) {
 
 std::string NimbleIndexProjector::Stats::toString() const {
   return fmt::format(
-      "Stats(numReadStripes={}, numReadRows={}, numProjectedRows={}, "
+      "Stats(numReadStripes={}, numSlicedStripes={}, "
+      "slicedStripePct={:.2f}%, numReadRows={}, numProjectedRows={}, "
       "numOutputBytes={}, "
-      "lookupTiming=[{}], scanTiming=[{}], projectionTiming=[{}])",
+      "lookupTiming=[{}], prepareTiming=[{}], scanTiming=[{}], "
+      "projectionTiming=[{}])",
       numReadStripes,
+      numSlicedStripes,
+      numReadStripes == 0
+          ? 0.0
+          : 100.0 * static_cast<double>(numSlicedStripes) / numReadStripes,
       numReadRows,
       numProjectedRows,
       velox::succinctBytes(numOutputBytes),
       lookupTiming.toString(),
+      prepareTiming.toString(),
       scanTiming.toString(),
       projectionTiming.toString());
 }
@@ -235,18 +241,6 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
   return processStripes();
 }
 
-void NimbleIndexProjector::pruneStripeRanges(
-    std::vector<StripeRange>& stripeRanges,
-    const std::vector<uint64_t>& rowsPerRequest) {
-  const auto maxRowsPerRequest = ctx_.options->maxRowsPerRequest;
-  if (maxRowsPerRequest == 0) {
-    return;
-  }
-  std::erase_if(stripeRanges, [&](const auto& range) {
-    return rowsPerRequest[range.requestIndex] >= maxRowsPerRequest;
-  });
-}
-
 void NimbleIndexProjector::setResumeKey(
     uint32_t requestIndex,
     uint32_t stripeOffset,
@@ -279,35 +273,51 @@ void NimbleIndexProjector::setResumeKey(
 }
 
 void NimbleIndexProjector::prepareStripes() {
+  velox::CpuWallTimer timer(stats_.prepareTiming);
   uint64_t totalRows{0};
   uint64_t totalBytes{0};
   const auto maxRowsPerRequest = ctx_.options->maxRowsPerRequest;
   const auto needResumeKey = ctx_.options->needResumeKey;
-  std::vector<uint64_t> rowsPerRequest(ctx_.numRequests, 0);
+  auto& rowsPerRequest = ctx_.rowsPerRequest;
+  rowsPerRequest.assign(ctx_.numRequests, 0);
   ctx_.hasStripeRanges.assign(ctx_.numRequests, false);
   ctx_.resumeKeys.assign(ctx_.numRequests, std::nullopt);
+  ctx_.plan.stripeIndices.reserve(ctx_.stripeRanges.numStripes);
+  ctx_.plan.numRows.reserve(ctx_.stripeRanges.numStripes);
+  ctx_.plan.requiresNullBarriers.reserve(ctx_.stripeRanges.numStripes);
+  ctx_.plan.numStreams.reserve(ctx_.stripeRanges.numStripes);
+  ctx_.plan.stripeFileOffsets.reserve(ctx_.stripeRanges.numStripes);
+  ctx_.plan.stripeRangeOffsets.reserve(ctx_.stripeRanges.numStripes + 1);
+  ctx_.plan.projectedStreams.reserve(
+      static_cast<size_t>(ctx_.stripeRanges.numStripes) *
+      projection_->streamOffsets.size());
+  ctx_.plan.stripeRanges.reserve(ctx_.stripeRanges.ranges.size());
 
   for (uint32_t offset = 0; offset < ctx_.stripeRanges.numStripes; ++offset) {
     auto spanRanges = ctx_.stripeRanges.getRanges(offset);
-    std::vector<StripeRange> stripeRanges(spanRanges.begin(), spanRanges.end());
-    pruneStripeRanges(stripeRanges, rowsPerRequest);
-    if (stripeRanges.empty()) {
-      continue;
-    }
-
     const uint32_t stripeIndex = ctx_.stripeRanges.startStripe + offset;
 
+    const auto rangeOffset = ctx_.plan.stripeRanges.size();
+    uint32_t numStripeRanges{0};
+
     uint64_t stripeRows{0};
-    for (auto& stripeRange : stripeRanges) {
+    for (const auto& range : spanRanges) {
+      auto stripeRange = range;
       const auto requestIndex = stripeRange.requestIndex;
       const auto numRows =
           static_cast<uint64_t>(stripeRange.rowRange.numRows());
       if (maxRowsPerRequest == 0) {
         rowsPerRequest[requestIndex] += numRows;
         stripeRows += numRows;
+        ctx_.hasStripeRanges[requestIndex] = true;
+        ctx_.plan.stripeRanges.push_back(stripeRange);
+        ++numStripeRanges;
         continue;
       }
 
+      if (rowsPerRequest[requestIndex] >= maxRowsPerRequest) {
+        continue;
+      }
       const auto remaining = maxRowsPerRequest - rowsPerRequest[requestIndex];
       const auto rowsToRead = std::min(numRows, remaining);
       rowsPerRequest[requestIndex] += rowsToRead;
@@ -327,26 +337,24 @@ void NimbleIndexProjector::prepareStripes() {
         setResumeKey(
             requestIndex, offset, stripeRange.rowRange.endRow, partialRead);
       }
+      ctx_.hasStripeRanges[requestIndex] = true;
+      ctx_.plan.stripeRanges.push_back(stripeRange);
+      ++numStripeRanges;
     }
 
-    for (const auto& range : stripeRanges) {
-      ctx_.hasStripeRanges[range.requestIndex] = true;
+    if (numStripeRanges == 0) {
+      continue;
     }
-
-    StripePlan stripePlan;
-    stripePlan.stripeIndex = stripeIndex;
-    stripePlan.stripeRanges = std::move(stripeRanges);
-    locateStripeStreams(stripePlan);
 
     totalRows += stripeRows;
-    totalBytes += stripePlan.projectedBytes;
-    ctx_.plan.stripePlans.push_back(std::move(stripePlan));
+    totalBytes += appendStripePlan(stripeIndex, rangeOffset);
     if ((ctx_.options->maxRows > 0 && totalRows >= ctx_.options->maxRows) ||
         (ctx_.options->maxBytes > 0 && totalBytes >= ctx_.options->maxBytes)) {
       ctx_.plan.truncated = true;
       break;
     }
   }
+  ctx_.plan.stripeRangeOffsets.push_back(ctx_.plan.stripeRanges.size());
 }
 
 void NimbleIndexProjector::initRequest(
@@ -371,14 +379,25 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.options = nullptr;
   ctx_.numRequests = 0;
   ctx_.stripeRanges.clear();
-  ctx_.plan.stripePlans.clear();
+  ctx_.plan.stripeIndices.clear();
+  ctx_.plan.numRows.clear();
+  ctx_.plan.requiresNullBarriers.clear();
+  ctx_.plan.numStreams.clear();
+  ctx_.plan.stripeFileOffsets.clear();
+  ctx_.plan.projectedStreams.clear();
+  ctx_.plan.stripeRangeOffsets.clear();
+  ctx_.plan.stripeRanges.clear();
   ctx_.plan.truncated = false;
   ctx_.hasStripeRanges.clear();
   ctx_.resumeKeys.clear();
   ctx_.dataInputIndices.clear();
   ctx_.dataHandle.reset();
   ctx_.packedStripes.clear();
+  ctx_.rowsPerRequest.clear();
+  ctx_.sliceCounts.clear();
+  ctx_.emittedSlices.clear();
   ctx_.packScratch.clear();
+  ctx_.streamViewsScratch.clear();
   dataInput_->clear();
 }
 
@@ -467,32 +486,33 @@ void NimbleIndexProjector::lookupStripes() {
 }
 
 void NimbleIndexProjector::loadStripes() {
-  const auto& stripePlans = ctx_.plan.stripePlans;
-  if (stripePlans.empty()) {
+  const auto numPlannedStripes = ctx_.plan.stripeIndices.size();
+  if (numPlannedStripes == 0) {
     return;
   }
   velox::CpuWallTimer timer(stats_.scanTiming);
 
   uint32_t totalStreams = 0;
-  for (const auto& plan : stripePlans) {
-    totalStreams += plan.numStreams;
+  for (const auto numStreams : ctx_.plan.numStreams) {
+    totalStreams += numStreams;
   }
   dataInput_->reserve(totalStreams);
 
   const auto numProjectedStreams = projection_->streamOffsets.size();
-  ctx_.dataInputIndices.resize(stripePlans.size() * numProjectedStreams);
-  for (size_t stripeOffset = 0; stripeOffset < stripePlans.size();
+  ctx_.dataInputIndices.resize(numPlannedStripes * numProjectedStreams);
+  for (size_t stripeOffset = 0; stripeOffset < numPlannedStripes;
        ++stripeOffset) {
     dataInput_->startGroup();
     const auto dataInputBase = stripeOffset * numProjectedStreams;
-    const auto& streams = stripePlans[stripeOffset].projectedStreams;
+    const auto streams = stripeProjectedStreams(stripeOffset);
+    const auto stripeFileOffset = ctx_.plan.stripeFileOffsets[stripeOffset];
     for (size_t streamIndex = 0; streamIndex < streams.size(); ++streamIndex) {
       const auto& stream = streams[streamIndex];
-      if (!stream.has_value()) {
+      if (stream.size == 0) {
         continue;
       }
-      ctx_.dataInputIndices[dataInputBase + streamIndex] =
-          dataInput_->enqueue(*stream);
+      ctx_.dataInputIndices[dataInputBase + streamIndex] = dataInput_->enqueue(
+          velox::common::Region{stripeFileOffset + stream.offset, stream.size});
     }
   }
   ctx_.dataHandle = dataInput_->load();
@@ -502,9 +522,9 @@ NimbleIndexProjector::Result NimbleIndexProjector::processStripes() {
   velox::CpuWallTimer timer(stats_.projectionTiming);
   Result result;
   result.responses.resize(ctx_.numRequests);
-  ctx_.packedStripes.resize(ctx_.plan.stripePlans.size());
+  ctx_.packedStripes.resize(ctx_.plan.stripeIndices.size());
 
-  for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
+  for (size_t i = 0; i < ctx_.plan.stripeIndices.size(); ++i) {
     ++stats_.numReadStripes;
     ctx_.packedStripes[i] = packStripe(i);
   }
@@ -513,58 +533,97 @@ NimbleIndexProjector::Result NimbleIndexProjector::processStripes() {
   return result;
 }
 
-void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
-  NIMBLE_CHECK(
-      stripePlan.projectedStreams.empty() && stripePlan.projectedBytes == 0,
-      "StripePlan already has located streams");
-  stripePlan.numRows = stripeRowCount(stripePlan.stripeIndex);
+uint64_t NimbleIndexProjector::appendStripePlan(
+    uint32_t stripeIndex,
+    size_t rangeOffset) {
+  auto& plan = ctx_.plan;
+  const auto stripeOffset = plan.stripeIndices.size();
+  const auto numProjectedStreams = projection_->streamOffsets.size();
+  plan.stripeIndices.push_back(stripeIndex);
+  plan.numRows.push_back(stripeRowCount(stripeIndex));
+  plan.requiresNullBarriers.push_back(false);
+  plan.numStreams.push_back(0);
+  plan.stripeFileOffsets.push_back(tablet_->stripeOffset(stripeIndex));
+  plan.stripeRangeOffsets.push_back(rangeOffset);
+  plan.projectedStreams.resize((stripeOffset + 1) * numProjectedStreams);
 
-  const auto stripeId = tablet_->stripeIdentifier(stripePlan.stripeIndex);
-  const auto stripeOffset = tablet_->stripeOffset(stripePlan.stripeIndex);
-
-  std::vector<TabletReader::StreamLocation> streamLocations(
-      projection_->streamOffsets.size());
+  const auto stripeId = tablet_->stripeIdentifier(stripeIndex);
+  auto projectedStreams = std::span{plan.projectedStreams}.subspan(
+      stripeOffset * numProjectedStreams, numProjectedStreams);
   tablet_->streamLocations(
-      stripeId, projection_->streamOffsets, streamLocations);
-  stripePlan.projectedStreams.resize(projection_->streamOffsets.size());
-  for (size_t i = 0; i < streamLocations.size(); ++i) {
-    const auto& streamLocation = streamLocations[i];
-    if (streamLocation.size == 0) {
+      stripeId, projection_->streamOffsets, projectedStreams);
+
+  uint64_t projectedBytes{0};
+  for (size_t i = 0; i < projectedStreams.size(); ++i) {
+    const auto& stream = projectedStreams[i];
+    if (stream.size == 0) {
       continue;
     }
-    stripePlan.projectedStreams[i] = velox::common::Region{
-        stripeOffset + streamLocation.offset, streamLocation.size};
-    ++stripePlan.numStreams;
-    stripePlan.projectedBytes += streamLocation.size;
+    ++plan.numStreams.back();
+    projectedBytes += stream.size;
     if (projection_->rowOrFlatMapNullStreams[i]) {
       // A present Row/FlatMap null stream means the slice may carry nulls.
-      stripePlan.requiresNullBarrier = true;
+      plan.requiresNullBarriers.back() = true;
     }
   }
+  return projectedBytes;
 }
 
-RowRange NimbleIndexProjector::stripeRowRangeToPack(
-    const StripePlan& stripePlan) const {
-  const RowRange stripeRange{0, stripePlan.numRows};
+std::span<const StripeGroup::StreamLocation>
+NimbleIndexProjector::stripeProjectedStreams(size_t stripeOffset) const {
+  const auto numProjectedStreams = projection_->streamOffsets.size();
+  const auto projectedStreamsOffset = stripeOffset * numProjectedStreams;
+  NIMBLE_CHECK_LE(
+      projectedStreamsOffset + numProjectedStreams,
+      ctx_.plan.projectedStreams.size(),
+      "Stripe projected stream range exceeds plan storage");
+  return std::span{ctx_.plan.projectedStreams}.subspan(
+      projectedStreamsOffset, numProjectedStreams);
+}
+
+std::span<const NimbleIndexProjector::StripeRange>
+NimbleIndexProjector::plannedStripeRanges(size_t stripeOffset) const {
+  NIMBLE_CHECK_LT(
+      stripeOffset,
+      ctx_.plan.stripeIndices.size(),
+      "Stripe offset out of range");
+  NIMBLE_CHECK_LT(
+      stripeOffset + 1,
+      ctx_.plan.stripeRangeOffsets.size(),
+      "Stripe range offsets must include a final sentinel");
+  const auto beginOffset = ctx_.plan.stripeRangeOffsets[stripeOffset];
+  const auto endOffset = ctx_.plan.stripeRangeOffsets[stripeOffset + 1];
+  NIMBLE_CHECK_LE(
+      endOffset,
+      ctx_.plan.stripeRanges.size(),
+      "Stripe request range exceeds plan storage");
+  return std::span{ctx_.plan.stripeRanges}.subspan(
+      beginOffset, endOffset - beginOffset);
+}
+
+RowRange NimbleIndexProjector::stripeRowRangeToPack(size_t stripeOffset) const {
+  const RowRange stripeRange{0, ctx_.plan.numRows[stripeOffset]};
   if (ctx_.options->maxOverfetchRowsRatio >= 1.0) {
     return stripeRange;
   }
 
-  uint32_t startRow = stripePlan.numRows;
+  uint32_t startRow = ctx_.plan.numRows[stripeOffset];
   uint32_t endRow = 0;
-  for (const auto& range : stripePlan.stripeRanges) {
+  for (const auto& range : plannedStripeRanges(stripeOffset)) {
     startRow = std::min(startRow, range.rowRange.startRow);
     endRow = std::max(endRow, range.rowRange.endRow);
   }
-  NIMBLE_CHECK_LT(startRow, endRow, "StripePlan must have non-empty ranges");
+  NIMBLE_CHECK_LT(
+      startRow, endRow, "Planned stripe must have non-empty ranges");
   const RowRange requestedRange{startRow, endRow};
   if (requestedRange == stripeRange) {
     return stripeRange;
   }
 
-  const auto overfetchRows = stripePlan.numRows - requestedRange.numRows();
+  const auto overfetchRows =
+      ctx_.plan.numRows[stripeOffset] - requestedRange.numRows();
   const auto overfetchRowsRatio =
-      static_cast<double>(overfetchRows) / stripePlan.numRows;
+      static_cast<double>(overfetchRows) / ctx_.plan.numRows[stripeOffset];
   return overfetchRowsRatio > ctx_.options->maxOverfetchRowsRatio
       ? requestedRange
       : stripeRange;
@@ -572,27 +631,28 @@ RowRange NimbleIndexProjector::stripeRowRangeToPack(
 
 NimbleIndexProjector::PackedStripe NimbleIndexProjector::packStripe(
     size_t stripeOffset) {
-  const auto& stripePlan = ctx_.plan.stripePlans[stripeOffset];
   const auto numProjectedStreams = projection_->streamOffsets.size();
   auto& packScratch = ctx_.packScratch;
   SCOPE_EXIT {
     packScratch.clear();
   };
   packScratch.reserve(numProjectedStreams);
-  const RowRange stripeRange{0, stripePlan.numRows};
-  const auto packRange = stripeRowRangeToPack(stripePlan);
-  return packRange == stripeRange ? packFullStripe(stripeOffset)
-                                  : packPartialStripe(stripeOffset, packRange);
+  const RowRange stripeRange{0, ctx_.plan.numRows[stripeOffset]};
+  const auto packRange = stripeRowRangeToPack(stripeOffset);
+  if (packRange == stripeRange) {
+    return packFullStripe(stripeOffset);
+  }
+  ++stats_.numSlicedStripes;
+  return packPartialStripe(stripeOffset, packRange);
 }
 
 NimbleIndexProjector::PackedStripe NimbleIndexProjector::packFullStripe(
     size_t stripeOffset) {
-  const auto& stripePlan = ctx_.plan.stripePlans[stripeOffset];
   const auto numProjectedStreams = projection_->streamOffsets.size();
   auto& packScratch = ctx_.packScratch;
-  const auto loadedStreams =
+  const auto& loadedStreams =
       collectStripeStreamViews(stripeOffset, /*resolveCanonicalStreams=*/true);
-  const auto numRows = stripePlan.numRows;
+  const auto numRows = ctx_.plan.numRows[stripeOffset];
   const RowRange stripeRange{0, numRows};
 
   // Each unique stream is wrapped zero-copy into the output chain. Streams that
@@ -629,8 +689,8 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packFullStripe(
   };
 
   uint32_t bodyOffset{0};
-  std::vector<std::optional<uint32_t>> streamSizeIndexByProjected(
-      numProjectedStreams);
+  auto& canonicalStreamSizeIndices = packScratch.canonicalStreamSizeIndices;
+  canonicalStreamSizeIndices.assign(numProjectedStreams, std::nullopt);
   for (const auto projectedIndex : loadedStreams.presentIndices) {
     const auto streamData = loadedStreams.streams[projectedIndex];
     NIMBLE_CHECK_GT(streamData.size(), 0, "Projected stream must not be empty");
@@ -640,18 +700,18 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packFullStripe(
         *loadedStreams.canonicalIndices[projectedIndex];
     if (canonicalProjectedIndex != projectedIndex) {
       NIMBLE_CHECK(
-          streamSizeIndexByProjected[canonicalProjectedIndex].has_value(),
+          canonicalStreamSizeIndices[canonicalProjectedIndex].has_value(),
           "Duplicate stream must refer to an earlier stream in the stripe");
       packScratch.streamSizeIndices.emplace_back(
-          *streamSizeIndexByProjected[canonicalProjectedIndex]);
-      streamSizeIndexByProjected[projectedIndex] =
-          streamSizeIndexByProjected[canonicalProjectedIndex];
+          *canonicalStreamSizeIndices[canonicalProjectedIndex]);
+      canonicalStreamSizeIndices[projectedIndex] =
+          canonicalStreamSizeIndices[canonicalProjectedIndex];
       continue;
     }
     const auto streamSize = static_cast<uint32_t>(streamData.size());
     const auto streamSizeIndex =
         static_cast<uint32_t>(packScratch.uniqueStreamSizes.size());
-    streamSizeIndexByProjected[projectedIndex] = streamSizeIndex;
+    canonicalStreamSizeIndices[projectedIndex] = streamSizeIndex;
     packScratch.streamSizeIndices.emplace_back(streamSizeIndex);
     packScratch.uniqueStreamSizes.emplace_back(streamSize);
     bodyOffset += streamSize;
@@ -694,31 +754,29 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packFullStripe(
   return {
       .body = std::move(*chain),
       .rowRange = stripeRange,
-      .requiresNullBarrier = stripePlan.requiresNullBarrier,
+      .requiresNullBarrier = ctx_.plan.requiresNullBarriers[stripeOffset],
       .streamHasChunkHeader = true,
   };
 }
 
-NimbleIndexProjector::StripeStreamViews
+NimbleIndexProjector::StripeStreamViews&
 NimbleIndexProjector::collectStripeStreamViews(
     size_t stripeOffset,
-    bool resolveCanonicalStreams) const {
-  const auto& stripePlan = ctx_.plan.stripePlans[stripeOffset];
+    bool resolveCanonicalStreams) {
+  const auto projectedStreams = stripeProjectedStreams(stripeOffset);
   const auto numProjectedStreams = projection_->streamOffsets.size();
-  StripeStreamViews loadedStreams{
-      .streams = std::vector<std::string_view>(numProjectedStreams),
-      .presentIndices = {},
-      .canonicalIndices = {},
-  };
+  auto& loadedStreams = ctx_.streamViewsScratch;
+  loadedStreams.clear();
+  loadedStreams.streams.assign(numProjectedStreams, {});
   if (resolveCanonicalStreams) {
-    loadedStreams.presentIndices.reserve(stripePlan.numStreams);
+    loadedStreams.presentIndices.reserve(ctx_.plan.numStreams[stripeOffset]);
     loadedStreams.canonicalIndices.resize(numProjectedStreams);
   }
 
   uint32_t streamEnqueueBase{0};
   const auto dataInputBase = stripeOffset * numProjectedStreams;
   for (size_t i = 0; i < numProjectedStreams; ++i) {
-    if (!stripePlan.projectedStreams[i].has_value()) {
+    if (projectedStreams[i].size == 0) {
       continue;
     }
     NIMBLE_CHECK(
@@ -728,11 +786,11 @@ NimbleIndexProjector::collectStripeStreamViews(
     if (loadedStreams.presentIndices.empty()) {
       streamEnqueueBase = enqueueIndex;
     }
-    const auto& streamRegion = *stripePlan.projectedStreams[i];
+    const auto& streamLocation = projectedStreams[i];
     const auto& bufferRef = dataInput_->bufferRef(enqueueIndex);
     NIMBLE_CHECK_EQ(
         bufferRef.length,
-        streamRegion.length,
+        streamLocation.size,
         "Loaded stream length must match projected stream length");
     loadedStreams.streams[i] =
         std::string_view(bufferRef.data, bufferRef.length);
@@ -771,34 +829,34 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packPartialStripe(
     const RowRange& packRange) {
   NIMBLE_CHECK_GT(
       packRange.numRows(), 0, "Partial stripe range must not be empty");
-  auto loadedStreams =
+  const auto& loadedStreams =
       collectStripeStreamViews(stripeOffset, /*resolveCanonicalStreams=*/false);
   auto sliced = streamSlicer_->slice(
       loadedStreams.streams, packRange.startRow, packRange.numRows());
 
   size_t bodySize{0};
   auto& packScratch = ctx_.packScratch;
-  for (size_t projectedIndex = 0; projectedIndex < sliced.streams.size();
+  for (uint32_t projectedIndex{0}; projectedIndex < sliced.streams.size();
        ++projectedIndex) {
-    const auto streamData = sliced.streams[projectedIndex];
-    if (streamData.empty()) {
+    const auto stream = sliced.streams[projectedIndex];
+    if (stream.empty()) {
       continue;
     }
-    packScratch.streamIds.emplace_back(static_cast<uint32_t>(projectedIndex));
+    packScratch.streamIds.emplace_back(projectedIndex);
     packScratch.streamSizeIndices.emplace_back(
         static_cast<uint32_t>(packScratch.uniqueStreamSizes.size()));
     packScratch.uniqueStreamSizes.emplace_back(
-        static_cast<uint32_t>(streamData.size()));
-    bodySize += streamData.size();
+        static_cast<uint32_t>(stream.size()));
+    bodySize += stream.size();
   }
-  NIMBLE_CHECK_EQ(
-      bodySize,
-      sliced.data.computeChainDataLength(),
-      "Sliced stream sizes must match the sliced body");
   NIMBLE_CHECK_GT(
       bodySize, 0, "Non-empty partial stripe must produce a sliced body");
 
   auto chain = std::make_unique<folly::IOBuf>(std::move(sliced.data));
+  NIMBLE_CHECK_EQ(
+      bodySize,
+      chain->computeChainDataLength(),
+      "Sliced stream sizes must match the sliced body");
 
   const auto estimatedTrailerSize = estimateTabletTrailerSize(
       packScratch.streamIds.size(), packScratch.uniqueStreamSizes.size());
@@ -812,8 +870,7 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packPartialStripe(
   bodySize += trailer->length();
   chain->appendToChain(std::move(trailer));
 
-  const auto& stripePlan = ctx_.plan.stripePlans[stripeOffset];
-  stats_.numReadRows += stripePlan.numRows;
+  stats_.numReadRows += ctx_.plan.numRows[stripeOffset];
   stats_.numOutputBytes += bodySize;
   return {
       .body = std::move(*chain),
@@ -835,9 +892,9 @@ void NimbleIndexProjector::setResumeKeys(Result& result) {
   if (!ctx_.plan.truncated) {
     return;
   }
-  const auto& lastPlan = ctx_.plan.stripePlans.back();
-  const auto stripeIndex = lastPlan.stripeIndex;
-  const auto& stripeRanges = lastPlan.stripeRanges;
+  const auto lastStripeOffset = ctx_.plan.stripeIndices.size() - 1;
+  const auto stripeIndex = ctx_.plan.stripeIndices[lastStripeOffset];
+  const auto stripeRanges = plannedStripeRanges(lastStripeOffset);
 
   // No next stripe in the range map — all mapped requests end at this stripe.
   const auto nextStripe = stripeIndex + 1;
@@ -915,9 +972,10 @@ folly::IOBuf assembleStripeSlice(
 
 void NimbleIndexProjector::buildResult(Result& result) {
   // Build per-response slice counts for reserve.
-  std::vector<size_t> sliceCounts(ctx_.numRequests, 0);
-  for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
-    for (const auto& range : ctx_.plan.stripePlans[i].stripeRanges) {
+  auto& sliceCounts = ctx_.sliceCounts;
+  sliceCounts.assign(ctx_.numRequests, 0);
+  for (size_t i = 0; i < ctx_.plan.stripeIndices.size(); ++i) {
+    for (const auto& range : plannedStripeRanges(i)) {
       ++sliceCounts[range.requestIndex];
     }
   }
@@ -927,13 +985,13 @@ void NimbleIndexProjector::buildResult(Result& result) {
 
   // Track per-response how many slices have been emitted so we know when
   // we're at the last one (for embedding the resume key).
-  std::vector<size_t> slicesEmitted(ctx_.numRequests, 0);
+  auto& emittedSlices = ctx_.emittedSlices;
+  emittedSlices.assign(ctx_.numRequests, 0);
 
-  for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
-    const auto& stripePlan = ctx_.plan.stripePlans[i];
+  for (size_t i = 0; i < ctx_.plan.stripeIndices.size(); ++i) {
     auto& packedStripe = ctx_.packedStripes[i];
 
-    for (const auto& range : stripePlan.stripeRanges) {
+    for (const auto& range : plannedStripeRanges(i)) {
       NIMBLE_CHECK(!range.rowRange.empty());
       NIMBLE_CHECK(
           packedStripe.rowRange.contains(range.rowRange),
@@ -944,9 +1002,9 @@ void NimbleIndexProjector::buildResult(Result& result) {
           range.rowRange.startRow - packedStripe.rowRange.startRow,
           range.rowRange.endRow - packedStripe.rowRange.startRow};
       stats_.numProjectedRows += range.rowRange.numRows();
-      ++slicesEmitted[range.requestIndex];
+      ++emittedSlices[range.requestIndex];
       const bool isLastSlice =
-          slicesEmitted[range.requestIndex] == sliceCounts[range.requestIndex];
+          emittedSlices[range.requestIndex] == sliceCounts[range.requestIndex];
       auto& response = result.responses[range.requestIndex];
       response.slices.emplace_back(assembleStripeSlice(
           packedStripe.rowRange.numRows(),

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -183,6 +183,8 @@ class NimbleIndexProjector {
   struct Stats {
     /// Number of stripes read from the tablet.
     uint32_t numReadStripes{0};
+    /// Number of read stripes serialized through stream slicing.
+    uint32_t numSlicedStripes{0};
     /// Total rows read from storage (entire stripe row counts). Includes
     /// rows outside the requested row ranges that are read because we
     /// fetch entire projected streams per stripe.
@@ -195,6 +197,8 @@ class NimbleIndexProjector {
 
     /// Time spent looking up stripes and row ranges via the tablet index.
     velox::CpuWallTiming lookupTiming;
+    /// Time spent building per-stripe stream and request-range plans.
+    velox::CpuWallTiming prepareTiming;
     /// Time spent loading stripe stream data from tablet.
     velox::CpuWallTiming scanTiming;
     /// Time spent serializing projected streams into kTablet format.
@@ -263,51 +267,45 @@ class NimbleIndexProjector {
   // Populates ctx_.stripeRanges.
   void lookupStripes();
 
-  // Per-stripe plan produced by prepareStripes(). Contains the stripe's
-  // projected stream locations (for IO) and the per-request row ranges
-  // (for result building).
-  struct StripePlan {
-    uint32_t stripeIndex{};
-    // Total rows in this stripe.
-    uint32_t numRows{0};
-    // True when any projected Row/FlatMap null stream is present in this
-    // stripe, i.e. the slice may carry nulls. Surfaced in the kTablet chunk
-    // header so the deserializer routes the slice to the per-batch barrier path
-    // instead of the dense-batch concat fast path.
-    bool requiresNullBarrier{false};
-    // Number of projected streams present in this stripe.
-    uint32_t numStreams{0};
-    // Total logical bytes across all projected streams in this stripe.
-    // Duplicate regions are counted once per projected stream.
-    uint64_t projectedBytes{0};
-    // Stream regions for projected columns. Indexed by projected stream
-    // offset; nullopt for streams absent in this stripe.
-    std::vector<std::optional<velox::common::Region>> projectedStreams;
-    // Per-request row ranges intersected with this stripe, after pruning
-    // saturated requests.
-    std::vector<StripeRange> stripeRanges;
-  };
-
-  // Output of prepareStripes(): the set of stripes to process and whether
-  // global limits (maxRows/maxBytes) caused early termination.
+  // Output of prepareStripes(). Per-stripe vectors are indexed by stripe
+  // offset in the compact plan and only contain stripes retained for
+  // processing.
   struct ScanPlan {
-    std::vector<StripePlan> stripePlans;
+    // Absolute stripe indices in processing order.
+    std::vector<uint32_t> stripeIndices;
+    // Total rows in each planned stripe.
+    std::vector<uint32_t> numRows;
+    // Whether each planned stripe needs the Row/FlatMap null-barrier path.
+    std::vector<bool> requiresNullBarriers;
+    // Number of projected streams present in each planned stripe.
+    std::vector<uint32_t> numStreams;
+    // File offsets for stripe stream payloads.
+    std::vector<uint64_t> stripeFileOffsets;
+    // Flat reusable storage for all per-stripe projected stream slots. Each
+    // stripe occupies projection_->streamOffsets.size() consecutive entries.
+    std::vector<StripeGroup::StreamLocation> projectedStreams;
+    // Start offsets into stripeRanges for each planned stripe. The last entry
+    // is the total range count.
+    std::vector<size_t> stripeRangeOffsets;
+    // Flat reusable storage for all request ranges retained by planned stripes.
+    std::vector<StripeRange> stripeRanges;
     bool truncated{false};
   };
 
-  // Locates projected streams for the stripe and populates projectedStreams
-  // and projectedBytes.
-  void locateStripeStreams(StripePlan& stripePlan);
+  // Returns this stripe's projected stream slots from the flat ScanPlan
+  // storage.
+  std::span<const StripeGroup::StreamLocation> stripeProjectedStreams(
+      size_t stripeOffset) const;
+
+  // Returns this stripe's request ranges from the flat ScanPlan storage.
+  std::span<const StripeRange> plannedStripeRanges(size_t stripeOffset) const;
+
+  // Appends one stripe to the plan and returns its projected byte count.
+  uint64_t appendStripePlan(uint32_t stripeIndex, size_t rangeOffset);
 
   // Computes the stripe-relative body range based on request row ranges and
   // Options::maxOverfetchRowsRatio.
-  RowRange stripeRowRangeToPack(const StripePlan& stripePlan) const;
-
-  // Removes row ranges for requests that have reached their maxRowsPerRequest
-  // budget.
-  void pruneStripeRanges(
-      std::vector<StripeRange>& stripeRanges,
-      const std::vector<uint64_t>& rowsPerRequest);
+  RowRange stripeRowRangeToPack(size_t stripeOffset) const;
 
   // Records the resume key for a request that reached its maxRowsPerRequest cap
   // in the stripe at `stripeOffset` (index relative to
@@ -338,6 +336,12 @@ class NimbleIndexProjector {
 
   // Loaded projected stream views and optional source deduplication metadata.
   struct StripeStreamViews {
+    void clear() {
+      streams.clear();
+      presentIndices.clear();
+      canonicalIndices.clear();
+    }
+
     // Indexed by projected stream index; absent streams have empty views.
     std::vector<std::string_view> streams;
     // Present stream indices in projected stream order. Populated only when
@@ -350,9 +354,9 @@ class NimbleIndexProjector {
 
   // Collects loaded stream views for one stripe. Optionally resolves source
   // deduplication and populates the canonical stream metadata.
-  StripeStreamViews collectStripeStreamViews(
+  StripeStreamViews& collectStripeStreamViews(
       size_t stripeOffset,
-      bool resolveCanonicalStreams) const;
+      bool resolveCanonicalStreams);
 
   // Serialized stripe body and metadata computed while packing.
   struct PackedStripe {
@@ -379,7 +383,7 @@ class NimbleIndexProjector {
   // data in an unprocessed stripe. No-op when needResumeKey is unset.
   void setResumeKeys(Result& result);
 
-  // Iterates ctx_.plan.stripePlans and ctx_.packedStripes to build per-request
+  // Iterates planned stripes and ctx_.packedStripes to build per-request
   // output slices. Each slice clones the shared stripe body and prepends a
   // per-request header with the row range and (on the last slice of a
   // truncated response) the resume key.
@@ -432,6 +436,10 @@ class NimbleIndexProjector {
     // Serialized stripe bodies and metadata, one per StripePlan. Populated by
     // processStripes(), consumed during buildResult().
     std::vector<PackedStripe> packedStripes;
+    // Reusable per-request vectors.
+    std::vector<uint64_t> rowsPerRequest;
+    std::vector<size_t> sliceCounts;
+    std::vector<size_t> emittedSlices;
 
     // Reusable per-stripe inputs for the kTablet trailer. packStripe()
     // rebuilds these vectors for each stripe and clears them on exit to avoid
@@ -441,12 +449,14 @@ class NimbleIndexProjector {
         streamIds.clear();
         streamSizeIndices.clear();
         uniqueStreamSizes.clear();
+        canonicalStreamSizeIndices.clear();
       }
 
       void reserve(uint32_t numProjectedStreams) {
         streamIds.reserve(numProjectedStreams);
         streamSizeIndices.reserve(numProjectedStreams);
         uniqueStreamSizes.reserve(numProjectedStreams);
+        canonicalStreamSizeIndices.reserve(numProjectedStreams);
       }
 
       // Present projected stream slots, in projected-stream order.
@@ -456,8 +466,13 @@ class NimbleIndexProjector {
       std::vector<uint32_t> streamSizeIndices;
       // Sizes for unique stream byte ranges, in body order.
       std::vector<uint32_t> uniqueStreamSizes;
+      // Index into uniqueStreamSizes for each projected stream slot. Duplicate
+      // slots reuse their canonical stream's index.
+      std::vector<std::optional<uint32_t>> canonicalStreamSizeIndices;
     };
     PackScratch packScratch;
+    // Reusable loaded-stream views filled while packing one stripe.
+    StripeStreamViews streamViewsScratch;
   };
   ProjectionContext ctx_;
 

--- a/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/dwio/nimble/common/ChunkHeader.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/common/tests/TestUtils.h"
@@ -205,14 +206,25 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
       const folly::F14FastMap<std::string, std::set<std::string>>&
           flatMapColumns = {},
       uint64_t stripeSize = 4 << 10 /* 4KB */,
-      bool enableStreamDeduplication = true) {
+      bool enableStreamDeduplication = true,
+      bool compactRowCountEncoding = false,
+      CompressionType chunkCompressionType = CompressionType::Uncompressed,
+      bool skipConstantFlatMapInMapStreams = false,
+      bool enableChunking = true) {
     sinkData_.clear();
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
 
     WriterOptions options;
-    options.enableChunking = true;
+    options.enableChunking = enableChunking;
     options.flatMapColumns = flatMapColumns;
     options.enableStreamDeduplication = enableStreamDeduplication;
+    options.experimentalCompactRowCountEncoding = compactRowCountEncoding;
+    options.chunkCompression = {
+        .type = chunkCompressionType,
+        // Retain compressed chunks when a small fuzzed stream grows slightly.
+        .acceptRatio = 10.0f,
+    };
+    options.skipConstantFlatMapInMapStreams = skipConstantFlatMapInMapStreams;
     options.clusterIndexConfig =
         ClusterIndexConfigBuilder{}
             .withKeyColumns(indexColumns)
@@ -812,6 +824,633 @@ TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
   // refcount-shared.
   EXPECT_GT(slice0.computeChainDataLength(), slice0.length());
   EXPECT_GT(slice0.prev()->length(), 0u);
+}
+
+TEST_P(NimbleIndexProjectorTest, slicesStripeBasedOnOverfetchRatio) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  constexpr int numRows = 200;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> values(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i;
+    values[i] = i * 10;
+  }
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(values)});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  struct TestCase {
+    double maxOverfetchRowsRatio;
+    uint32_t expectedRowCount;
+    RowRange expectedRowRange;
+    bool expectedStreamHasChunkHeader;
+    uint32_t expectedNumSlicedStripes;
+  };
+  const std::vector<TestCase> testCases = {
+      {0.0, 100, RowRange(0, 100), false, 1},
+      {0.4, 100, RowRange(0, 100), false, 1},
+      {0.5, numRows, RowRange(50, 150), true, 0},
+      {0.6, numRows, RowRange(50, 150), true, 0},
+      {1.0, numRows, RowRange(50, 150), true, 0},
+  };
+  const std::vector<int32_t> expectedValues(
+      values.begin() + 50, values.begin() + 150);
+  const auto expected = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});
+
+  for (const bool compactRowCountEncoding : {false, true}) {
+    SCOPED_TRACE(
+        ::testing::Message()
+        << "compactRowCountEncoding=" << compactRowCountEncoding);
+    writeData(
+        {batch},
+        {"key"},
+        {},
+        /*stripeSize=*/1 << 20,
+        /*enableStreamDeduplication=*/true,
+        compactRowCountEncoding);
+
+    for (const auto& testCase : testCases) {
+      SCOPED_TRACE(
+          ::testing::Message()
+          << "maxOverfetchRowsRatio=" << testCase.maxOverfetchRowsRatio);
+      auto projector = createProjector(subfields);
+      NimbleIndexProjector::Request request;
+      request.keyBounds = {makeRangeLookup(rowType, {"key"}, 50, 150)};
+      NimbleIndexProjector::Options options;
+      options.maxOverfetchRowsRatio = testCase.maxOverfetchRowsRatio;
+      auto result = projector->project(request, options);
+
+      ASSERT_EQ(result.responses.size(), 1);
+      ASSERT_EQ(result.responses[0].slices.size(), 1);
+      const auto header =
+          readEmbeddedTabletChunkHeader(result.responses[0].slices[0]);
+      EXPECT_EQ(header.rowCount, testCase.expectedRowCount);
+      EXPECT_EQ(header.rowRange, testCase.expectedRowRange);
+      EXPECT_EQ(
+          header.streamEncodingUsesVarintRowCount, compactRowCountEncoding);
+      EXPECT_EQ(
+          header.streamHasChunkHeader, testCase.expectedStreamHasChunkHeader);
+      EXPECT_EQ(projector->stats().numReadStripes, 1);
+      EXPECT_EQ(
+          projector->stats().numSlicedStripes,
+          testCase.expectedNumSlicedStripes);
+      expectVectorRows(
+          deserializeProjectedSlice(*projector, result.responses[0].slices[0]),
+          expected);
+    }
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, slicedRequestsShareShiftedBody) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  constexpr int numRows = 100;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> values(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i;
+    values[i] = i * 10;
+  }
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(values)});
+  writeData({batch}, {"key"}, {}, /*stripeSize=*/1 << 20);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  struct TestCase {
+    RowRange firstRequest;
+    RowRange secondRequest;
+    uint32_t expectedPackedRowCount;
+    RowRange expectedFirstRange;
+    RowRange expectedSecondRange;
+  };
+  const std::vector<TestCase> testCases = {
+      {
+          RowRange(10, 40),
+          RowRange(25, 70),
+          60,
+          RowRange(0, 30),
+          RowRange(15, 60),
+      },
+      {
+          RowRange(10, 80),
+          RowRange(30, 50),
+          70,
+          RowRange(0, 70),
+          RowRange(20, 40),
+      },
+      {
+          RowRange(60, 80),
+          RowRange(10, 30),
+          70,
+          RowRange(50, 70),
+          RowRange(0, 20),
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        ::testing::Message()
+        << "firstRequest=[" << testCase.firstRequest.startRow << ", "
+        << testCase.firstRequest.endRow << ") secondRequest=["
+        << testCase.secondRequest.startRow << ", "
+        << testCase.secondRequest.endRow << ")");
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {
+        makeRangeLookup(
+            rowType,
+            {"key"},
+            testCase.firstRequest.startRow,
+            testCase.firstRequest.endRow),
+        makeRangeLookup(
+            rowType,
+            {"key"},
+            testCase.secondRequest.startRow,
+            testCase.secondRequest.endRow),
+    };
+    NimbleIndexProjector::Options options;
+    options.maxOverfetchRowsRatio = 0.0;
+    auto result = projector->project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 2);
+    ASSERT_EQ(result.responses[0].slices.size(), 1);
+    ASSERT_EQ(result.responses[1].slices.size(), 1);
+
+    const auto& slice0 = result.responses[0].slices[0];
+    const auto& slice1 = result.responses[1].slices[0];
+    EXPECT_EQ(slice0.prev()->data(), slice1.prev()->data());
+    EXPECT_EQ(
+        readEmbeddedTabletChunkHeader(slice0).rowCount,
+        testCase.expectedPackedRowCount);
+    EXPECT_EQ(
+        readEmbeddedTabletChunkHeader(slice1).rowCount,
+        testCase.expectedPackedRowCount);
+    EXPECT_EQ(readEmbeddedRowRange(slice0), testCase.expectedFirstRange);
+    EXPECT_EQ(readEmbeddedRowRange(slice1), testCase.expectedSecondRange);
+
+    const std::vector<int32_t> expectedValues0(
+        values.begin() + testCase.firstRequest.startRow,
+        values.begin() + testCase.firstRequest.endRow);
+    const auto expected0 = vectorMaker_->rowVector(
+        {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues0)});
+    expectVectorRows(deserializeProjectedSlice(*projector, slice0), expected0);
+
+    const std::vector<int32_t> expectedValues1(
+        values.begin() + testCase.secondRequest.startRow,
+        values.begin() + testCase.secondRequest.endRow);
+    const auto expected1 = vectorMaker_->rowVector(
+        {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues1)});
+    expectVectorRows(deserializeProjectedSlice(*projector, slice1), expected1);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, projectsFlatMapWithoutConstantInMapStream) {
+  constexpr vector_size_t kNumRows{64};
+  constexpr uint32_t kRequestStart{10};
+  constexpr uint32_t kRequestEnd{30};
+  auto rowType = ROW({"key", "features"}, {BIGINT(), MAP(VARCHAR(), BIGINT())});
+  auto batch = vectorMaker_->rowVector(
+      {"key", "features"},
+      {vectorMaker_->flatVector<int64_t>(
+           kNumRows, [](auto row) { return static_cast<int64_t>(row); }),
+       vectorMaker_->mapVector<StringView, int64_t>(
+           kNumRows,
+           /*sizeAt=*/[](auto /*row*/) { return 1; },
+           /*keyAt=*/
+           [](auto /*row*/, auto /*mapIndex*/) { return StringView{"always"}; },
+           /*valueAt=*/
+           [](auto row, auto /*mapIndex*/) {
+             return static_cast<int64_t>(row * 100);
+           })});
+
+  writeData(
+      {batch},
+      {"key"},
+      {{"features", {"always"}}},
+      /*stripeSize=*/1 << 20,
+      /*enableStreamDeduplication=*/true,
+      /*compactRowCountEncoding=*/false,
+      CompressionType::Uncompressed,
+      /*skipConstantFlatMapInMapStreams=*/true,
+      // TODO: Enable chunking here once chunked writer skips constant FlatMap
+      // in-map streams.
+      /*enableChunking=*/false);
+
+  auto readFile =
+      std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
+  auto tablet = TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  ASSERT_EQ(tablet->stripeCount(), 1);
+  VeloxReader schemaReader(readFile.get(), *leafPool_);
+  const auto& flatMap = schemaReader.schema()->asRow().childAt(1)->asFlatMap();
+  ASSERT_EQ(flatMap.childrenCount(), 1);
+  ASSERT_EQ(flatMap.nameAt(0), "always");
+  const auto stripe = tablet->stripeIdentifier(0);
+  const auto inMapStream = flatMap.inMapDescriptorAt(0).offset();
+  EXPECT_TRUE(
+      inMapStream >= tablet->streamCount(stripe) ||
+      tablet->streamSize(stripe, inMapStream) == 0);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("features[\"always\"]");
+  const auto expected = vectorMaker_->rowVector(
+      {"features"},
+      {vectorMaker_->mapVector<StringView, int64_t>(
+          kRequestEnd - kRequestStart,
+          /*sizeAt=*/[](auto /*row*/) { return 1; },
+          /*keyAt=*/
+          [](auto /*row*/, auto /*mapIndex*/) { return StringView{"always"}; },
+          /*valueAt=*/
+          [](auto row, auto /*mapIndex*/) {
+            return static_cast<int64_t>((row + kRequestStart) * 100);
+          })});
+
+  for (const bool sliceStripe : {false, true}) {
+    SCOPED_TRACE(fmt::format("sliceStripe={}", sliceStripe));
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {
+        makeRangeLookup(rowType, {"key"}, kRequestStart, kRequestEnd)};
+    NimbleIndexProjector::Options options;
+    options.maxOverfetchRowsRatio = sliceStripe ? 0.0 : 1.0;
+    auto result = projector->project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    ASSERT_EQ(result.responses[0].slices.size(), 1);
+    const auto& slice = result.responses[0].slices[0];
+    const auto header = readEmbeddedTabletChunkHeader(slice);
+    EXPECT_EQ(
+        header.rowCount, sliceStripe ? kRequestEnd - kRequestStart : kNumRows);
+    EXPECT_EQ(
+        header.rowRange,
+        sliceStripe ? RowRange(0, kRequestEnd - kRequestStart)
+                    : RowRange(kRequestStart, kRequestEnd));
+    EXPECT_EQ(header.streamHasChunkHeader, !sliceStripe);
+    expectVectorRows(deserializeProjectedSlice(*projector, slice), expected);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, preservesStreamRowCountEncoding) {
+  constexpr vector_size_t kNumRows{64};
+  constexpr uint32_t kRequestStart{10};
+  constexpr uint32_t kRequestEnd{30};
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(
+           kNumRows, [](auto row) { return static_cast<int64_t>(row); }),
+       vectorMaker_->flatVector<int32_t>(
+           kNumRows, [](auto row) { return row * 10; })});
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  const auto expected = vectorMaker_->rowVector(
+      {"value"},
+      {vectorMaker_->flatVector<int32_t>(
+          kRequestEnd - kRequestStart,
+          [](auto row) { return (row + kRequestStart) * 10; })});
+
+  for (const bool streamsUseVarintRowCount : {false, true}) {
+    SCOPED_TRACE(
+        fmt::format("streamsUseVarintRowCount={}", streamsUseVarintRowCount));
+    writeData(
+        {batch},
+        {"key"},
+        {},
+        /*stripeSize=*/1 << 20,
+        /*enableStreamDeduplication=*/true,
+        /*compactRowCountEncoding=*/streamsUseVarintRowCount);
+
+    for (const bool sliceStripe : {false, true}) {
+      SCOPED_TRACE(fmt::format("sliceStripe={}", sliceStripe));
+      auto projector = createProjector(subfields);
+      NimbleIndexProjector::Request request;
+      request.keyBounds = {
+          makeRangeLookup(rowType, {"key"}, kRequestStart, kRequestEnd)};
+      NimbleIndexProjector::Options options;
+      options.maxOverfetchRowsRatio = sliceStripe ? 0.0 : 1.0;
+      auto result = projector->project(request, options);
+
+      ASSERT_EQ(result.responses.size(), 1);
+      ASSERT_EQ(result.responses[0].slices.size(), 1);
+      const auto& slice = result.responses[0].slices[0];
+      const auto header = readEmbeddedTabletChunkHeader(slice);
+      EXPECT_EQ(
+          header.streamEncodingUsesVarintRowCount, streamsUseVarintRowCount);
+      EXPECT_EQ(
+          header.rowCount,
+          sliceStripe ? kRequestEnd - kRequestStart : kNumRows);
+      EXPECT_EQ(
+          header.rowRange,
+          sliceStripe ? RowRange(0, kRequestEnd - kRequestStart)
+                      : RowRange(kRequestStart, kRequestEnd));
+      EXPECT_EQ(header.streamHasChunkHeader, !sliceStripe);
+      expectVectorRows(deserializeProjectedSlice(*projector, slice), expected);
+    }
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, fuzzesFlatMapPartialStripeProjection) {
+  constexpr vector_size_t kRows{256};
+  constexpr int kIterations{4};
+  const auto rowType =
+      ROW({"key", "features", "payload"},
+          {BIGINT(), MAP(VARCHAR(), BIGINT()), VARCHAR()});
+  const folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns = {
+      {"features", {"always", "never", "sparse"}}};
+
+  const auto seed = folly::Random::rand32();
+  LOG(INFO) << "fuzzesFlatMapPartialStripeProjection seed: " << seed;
+  folly::detail::DefaultGenerator random{seed};
+
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    const auto rangeStart =
+        8 + static_cast<uint32_t>(folly::Random::rand32(random) % 24);
+    const std::array<RowRange, 3> requestRanges = {
+        RowRange{rangeStart, rangeStart + 64},
+        RowRange{rangeStart + 16, rangeStart + 96},
+        RowRange{rangeStart + 80, rangeStart + 128},
+    };
+    SCOPED_TRACE(
+        fmt::format(
+            "seed={} iteration={} rangeStart={}", seed, iteration, rangeStart));
+
+    std::vector<bool> sparsePresent(kRows);
+    std::vector<bool> alwaysValueNull(kRows);
+    std::vector<bool> sparseValueNull(kRows);
+    for (vector_size_t row = 0; row < kRows; ++row) {
+      sparsePresent[row] = folly::Random::oneIn(2, random);
+      alwaysValueNull[row] = folly::Random::oneIn(5, random);
+      sparseValueNull[row] = folly::Random::oneIn(4, random);
+    }
+    sparsePresent[rangeStart] = false;
+    sparsePresent[rangeStart + 1] = true;
+    alwaysValueNull[rangeStart + 2] = true;
+    sparseValueNull[rangeStart + 1] = true;
+    vector_size_t numEntries{kRows};
+    for (const bool isPresent : sparsePresent) {
+      numEntries += isPresent;
+    }
+
+    auto offsets = allocateOffsets(kRows, leafPool_.get());
+    auto sizes = allocateSizes(kRows, leafPool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    auto mapKeys = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), numEntries, leafPool_.get());
+    auto mapValues = BaseVector::create<FlatVector<int64_t>>(
+        BIGINT(), numEntries, leafPool_.get());
+    vector_size_t entry{0};
+    for (vector_size_t row = 0; row < kRows; ++row) {
+      rawOffsets[row] = entry;
+      rawSizes[row] = sparsePresent[row] ? 2 : 1;
+      mapKeys->set(entry, StringView{"always"});
+      mapValues->set(entry, row * 100);
+      mapValues->setNull(entry, alwaysValueNull[row]);
+      ++entry;
+      if (sparsePresent[row]) {
+        mapKeys->set(entry, StringView{"sparse"});
+        mapValues->set(entry, row * 100 + 1);
+        mapValues->setNull(entry, sparseValueNull[row]);
+        ++entry;
+      }
+    }
+    ASSERT_EQ(entry, numEntries);
+
+    auto features = std::make_shared<MapVector>(
+        leafPool_.get(),
+        MAP(VARCHAR(), BIGINT()),
+        nullptr,
+        kRows,
+        offsets,
+        sizes,
+        mapKeys,
+        mapValues);
+    VectorFuzzer fuzzer(
+        {
+            .vectorSize = kRows,
+            .nullRatio = 0.25,
+            .useRandomNullPattern = true,
+            .stringLength = 256,
+            .stringVariableLength = false,
+        },
+        leafPool_.get(),
+        folly::Random::rand32(random));
+    auto payload = fuzzer.fuzzFlat(VARCHAR(), kRows);
+    payload->setNull(rangeStart + 3, true);
+    const std::string compressiblePayload(256, 'p');
+    auto* payloadValues = payload->as<FlatVector<StringView>>();
+    ASSERT_NE(payloadValues, nullptr);
+    for (vector_size_t row = 0; row < kRows; ++row) {
+      if (!payloadValues->isNullAt(row)) {
+        payloadValues->set(row, StringView{compressiblePayload});
+      }
+    }
+    auto batch = vectorMaker_->rowVector(
+        {"key", "features", "payload"},
+        {vectorMaker_->flatVector<int64_t>(
+             kRows, [](auto row) { return static_cast<int64_t>(row); }),
+         features,
+         payload});
+
+    for (const bool skipConstantInMapStreams : {false, true}) {
+      for (const bool compressChunks : {false, true}) {
+        SCOPED_TRACE(
+            fmt::format(
+                "skipConstantInMapStreams={} compressChunks={}",
+                skipConstantInMapStreams,
+                compressChunks));
+        const auto chunkCompressionType = compressChunks
+            ? CompressionType::Zstd
+            : CompressionType::Uncompressed;
+        writeData(
+            {batch},
+            {"key"},
+            flatMapColumns,
+            /*stripeSize=*/1 << 20,
+            /*enableStreamDeduplication=*/true,
+            /*compactRowCountEncoding=*/false,
+            chunkCompressionType,
+            skipConstantInMapStreams);
+
+        auto readFile =
+            std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
+        auto tablet = TabletReader::create(
+            readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+        ASSERT_EQ(tablet->stripeCount(), 1);
+        const auto stripe = tablet->stripeIdentifier(0);
+        VeloxReader schemaReader(readFile.get(), *leafPool_);
+        const auto& root = schemaReader.schema()->asRow();
+        const auto& flatMap = root.childAt(1)->asFlatMap();
+        const auto findFlatMapKey = [&](std::string_view key) {
+          for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+            if (flatMap.nameAt(i) == key) {
+              return i;
+            }
+          }
+          NIMBLE_FAIL("Missing FlatMap key {}", key);
+        };
+        const auto streamIsPresent = [&](uint32_t streamId) {
+          return streamId < tablet->streamCount(stripe) &&
+              tablet->streamSize(stripe, streamId) > 0;
+        };
+        EXPECT_EQ(
+            streamIsPresent(
+                flatMap.inMapDescriptorAt(findFlatMapKey("never")).offset()),
+            false);
+        EXPECT_TRUE(streamIsPresent(
+            flatMap.inMapDescriptorAt(findFlatMapKey("sparse")).offset()));
+
+        std::vector<uint32_t> streamIds(tablet->streamCount(stripe));
+        std::iota(streamIds.begin(), streamIds.end(), 0);
+        auto streams = tablet->load(stripe, streamIds);
+        bool sawCompressedChunk{false};
+        for (const auto& stream : streams) {
+          if (stream == nullptr) {
+            continue;
+          }
+          const auto streamData = stream->getStream();
+          const auto* position = streamData.data();
+          const auto* const end = position + streamData.size();
+          while (position < end) {
+            const auto chunkHeader = readChunkHeader(position);
+            ASSERT_LE(chunkHeader.length, end - position);
+            if (chunkHeader.compressionType == CompressionType::Zstd) {
+              sawCompressedChunk = true;
+            } else {
+              EXPECT_EQ(
+                  chunkHeader.compressionType, CompressionType::Uncompressed);
+            }
+            position += chunkHeader.length;
+          }
+          EXPECT_EQ(position, end);
+        }
+        EXPECT_EQ(sawCompressedChunk, compressChunks);
+
+        std::vector<Subfield> subfields;
+        subfields.emplace_back("features[\"always\"]");
+        subfields.emplace_back("features[\"never\"]");
+        subfields.emplace_back("features[\"sparse\"]");
+        subfields.emplace_back("payload");
+        auto projector = createProjector(subfields);
+        NimbleIndexProjector::Request request;
+        for (const auto& requestRange : requestRanges) {
+          request.keyBounds.push_back(makeRangeLookup(
+              rowType, {"key"}, requestRange.startRow, requestRange.endRow));
+        }
+        NimbleIndexProjector::Options options;
+        options.maxOverfetchRowsRatio = 0.0;
+        auto result = projector->project(request, options);
+
+        ASSERT_EQ(result.responses.size(), requestRanges.size());
+        const RowRange packRange{
+            requestRanges.front().startRow, requestRanges.back().endRow};
+        const folly::IOBuf* sharedBody{nullptr};
+        for (size_t requestIndex = 0; requestIndex < requestRanges.size();
+             ++requestIndex) {
+          const auto& response = result.responses[requestIndex];
+          ASSERT_EQ(response.slices.size(), 1);
+          const auto& slice = response.slices[0];
+          ASSERT_TRUE(slice.isChained());
+          if (sharedBody == nullptr) {
+            sharedBody = slice.prev();
+          } else {
+            EXPECT_EQ(slice.prev()->data(), sharedBody->data());
+          }
+
+          const auto header = readEmbeddedTabletChunkHeader(slice);
+          EXPECT_EQ(header.rowCount, packRange.numRows());
+          const RowRange expectedRowRange{
+              requestRanges[requestIndex].startRow - packRange.startRow,
+              requestRanges[requestIndex].endRow - packRange.startRow};
+          EXPECT_EQ(header.rowRange, expectedRowRange);
+          EXPECT_FALSE(header.streamHasChunkHeader);
+
+          auto output = deserializeProjectedSlice(*projector, slice);
+          ASSERT_NE(output, nullptr);
+          ASSERT_EQ(output->size(), requestRanges[requestIndex].numRows());
+          const auto* outputRow = output->as<RowVector>();
+          ASSERT_NE(outputRow, nullptr);
+          const auto* outputFeatures = outputRow->childAt(0)->as<MapVector>();
+          const auto* outputPayload =
+              outputRow->childAt(1)->as<FlatVector<StringView>>();
+          ASSERT_NE(outputFeatures, nullptr);
+          ASSERT_NE(outputPayload, nullptr);
+          const auto* outputMapKeys =
+              outputFeatures->mapKeys()->as<FlatVector<StringView>>();
+          const auto* outputMapValues =
+              outputFeatures->mapValues()->as<FlatVector<int64_t>>();
+          ASSERT_NE(outputMapKeys, nullptr);
+          ASSERT_NE(outputMapValues, nullptr);
+          const auto* inputPayload = payload->as<FlatVector<StringView>>();
+          ASSERT_NE(inputPayload, nullptr);
+
+          for (vector_size_t outputIndex = 0; outputIndex < output->size();
+               ++outputIndex) {
+            const auto inputIndex = static_cast<vector_size_t>(
+                requestRanges[requestIndex].startRow + outputIndex);
+            SCOPED_TRACE(
+                fmt::format(
+                    "requestIndex={} outputIndex={} inputIndex={}",
+                    requestIndex,
+                    outputIndex,
+                    inputIndex));
+            EXPECT_EQ(
+                outputPayload->isNullAt(outputIndex),
+                inputPayload->isNullAt(inputIndex));
+            if (!inputPayload->isNullAt(inputIndex)) {
+              EXPECT_EQ(
+                  outputPayload->valueAt(outputIndex),
+                  inputPayload->valueAt(inputIndex));
+            }
+
+            bool sawAlways{false};
+            bool sawSparse{false};
+            const auto mapOffset = outputFeatures->offsetAt(outputIndex);
+            const auto mapSize = outputFeatures->sizeAt(outputIndex);
+            for (vector_size_t mapIndex = 0; mapIndex < mapSize; ++mapIndex) {
+              const auto outputEntry = mapOffset + mapIndex;
+              const auto key = outputMapKeys->valueAt(outputEntry).str();
+              if (key == "always") {
+                sawAlways = true;
+                EXPECT_EQ(
+                    outputMapValues->isNullAt(outputEntry),
+                    alwaysValueNull[inputIndex]);
+                if (!alwaysValueNull[inputIndex]) {
+                  EXPECT_EQ(
+                      outputMapValues->valueAt(outputEntry), inputIndex * 100);
+                }
+              } else if (key == "sparse") {
+                sawSparse = true;
+                EXPECT_TRUE(sparsePresent[inputIndex]);
+                EXPECT_EQ(
+                    outputMapValues->isNullAt(outputEntry),
+                    sparseValueNull[inputIndex]);
+                if (!sparseValueNull[inputIndex]) {
+                  EXPECT_EQ(
+                      outputMapValues->valueAt(outputEntry),
+                      inputIndex * 100 + 1);
+                }
+              } else {
+                ADD_FAILURE() << "Unexpected FlatMap key: " << key;
+              }
+            }
+            EXPECT_TRUE(sawAlways);
+            EXPECT_EQ(sawSparse, sparsePresent[inputIndex]);
+          }
+        }
+      }
+    }
+  }
 }
 
 TEST_P(NimbleIndexProjectorTest, deduplicatedProjectedStreamsReadOnce) {
@@ -2096,6 +2735,7 @@ TEST_P(NimbleIndexProjectorTest, stats) {
     // Timings should be non-zero for a hit.
     EXPECT_GT(proj->stats().lookupTiming.count, 0);
     EXPECT_GT(proj->stats().lookupTiming.wallNanos, 0);
+    EXPECT_GT(proj->stats().prepareTiming.wallNanos, 0);
     EXPECT_GT(proj->stats().scanTiming.wallNanos, 0);
     EXPECT_GT(proj->stats().projectionTiming.wallNanos, 0);
 
@@ -2301,14 +2941,17 @@ TEST_P(NimbleIndexProjectorTest, localReadModeStats) {
 TEST_P(NimbleIndexProjectorTest, statsToString) {
   NimbleIndexProjector::Stats stats;
   stats.numReadStripes = 3;
+  stats.numSlicedStripes = 1;
   stats.numReadRows = 1'000;
   stats.numProjectedRows = 800;
   stats.numOutputBytes = 8'192;
   EXPECT_EQ(
       stats.toString(),
-      "Stats(numReadStripes=3, numReadRows=1000, numProjectedRows=800, "
+      "Stats(numReadStripes=3, numSlicedStripes=1, "
+      "slicedStripePct=33.33%, numReadRows=1000, numProjectedRows=800, "
       "numOutputBytes=8.00KB, "
       "lookupTiming=[count: 0, wallTime: 0ns, cpuTime: 0ns], "
+      "prepareTiming=[count: 0, wallTime: 0ns, cpuTime: 0ns], "
       "scanTiming=[count: 0, wallTime: 0ns, cpuTime: 0ns], "
       "projectionTiming=[count: 0, wallTime: 0ns, cpuTime: 0ns])");
 }

--- a/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -4046,6 +4046,53 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStream) {
   }
 }
 
+TEST_P(VeloxReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto keys = vectorMaker.flatVector<int32_t>({1, 1, 1, 1});
+  auto values = vectorMaker.flatVectorNullable<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto vector = vectorMaker.rowVector(
+      {"flat_map"}, {vectorMaker.mapVector({0, 1, 2, 3}, keys, values)});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  auto writerOptions = createFlatMapWriterOptions();
+  writerOptions.enableChunking = true;
+  writerOptions.flatMapColumns["flat_map"];
+  nimble::Writer writer(
+      type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+  writer.write(vector);
+  writer.close();
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+    nimble::VeloxReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                    .count(flatMap.inMapDescriptorAt(0).offset()));
+  }
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+    nimble::VeloxReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    velox::VectorPtr output;
+    uint64_t rowCount = 4;
+    ASSERT_TRUE(reader.next(rowCount, output));
+    ASSERT_EQ(output->size(), 4);
+    for (auto i = 0; i < 4; ++i) {
+      EXPECT_TRUE(vectorEquals(vector, output, i)) << "Mismatch at row " << i;
+    }
+  }
+}
+
 // Verify mixed in-map streams: some keys present in all rows (all-true,
 // skipped), some keys present in only some rows (not all-true, written).
 TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamMixed) {


### PR DESCRIPTION
Summary:

Flatten per-call projector planning storage into reusable vectors and reduce per-slice setup work. The projector stores projected stream locations and retained row ranges in flat ScanPlan vectors instead of per-stripe vectors, while StreamSlicer reuses duplicate chunk-header stripping results within a slice. Follow-up diffs handle present-stream iteration and reusable slice output buffers.

Reviewed By: tanjialiang, HuamengJiang

Differential Revision: D115579176


