### PR TITLE
misc(fuzzer): Bound the nimble encoding fuzzers by wall clock (#18709)

### DIFF
--- a/velox/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/velox/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -16,8 +16,12 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <bit>
+#include <chrono>
 #include <cmath>
+#include <functional>
+#include <iostream>
 #include <iterator>
 #include <limits>
 #include <random>
@@ -38,6 +42,124 @@
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
 namespace facebook::nimble::test {
+
+/// Process-wide wall-clock budget shared by every typed test in a fuzzer
+/// binary.
+///
+/// An iteration count cannot self-limit. If per-iteration cost grows, the
+/// binary overruns the Cogwheel `execution_timeout_seconds` and the job is
+/// killed, which reads as a failed run rather than a short one -- and the only
+/// way to notice is a wave of TIMEOUTs. A deadline started once, at the first
+/// test, bounds the whole binary no matter how many typed tests it
+/// instantiates; a per-test deadline would multiply by the number of tests.
+///
+/// The completed-iteration total then becomes the measurement that the
+/// iteration count used to be a guess at: a drop in it means per-iteration
+/// cost regressed, which is exactly what silently broke the tuning before.
+class FuzzerBudget {
+ public:
+  /// Zero means no deadline, which is the default so existing callers and
+  /// local runs keep their iteration-count behaviour unchanged.
+  static void start(uint32_t durationSec) {
+    deadline() = durationSec == 0
+        ? std::chrono::steady_clock::time_point::max()
+        : std::chrono::steady_clock::now() + std::chrono::seconds(durationSec);
+  }
+
+  static bool expired() {
+    return std::chrono::steady_clock::now() >= deadline();
+  }
+
+  static void recordIteration() {
+    completed().fetch_add(1, std::memory_order_relaxed);
+  }
+
+  static uint64_t completedIterations() {
+    return completed().load(std::memory_order_relaxed);
+  }
+
+  /// Parsed by the Cogwheel test, which reports it as result metadata. Keep the
+  /// key stable.
+  static void report() {
+    std::cout << "FUZZER_ITERATIONS_COMPLETED=" << completedIterations()
+              << std::endl;
+  }
+
+ private:
+  static std::chrono::steady_clock::time_point& deadline() {
+    static std::chrono::steady_clock::time_point value =
+        std::chrono::steady_clock::time_point::max();
+    return value;
+  }
+
+  static std::atomic<uint64_t>& completed() {
+    static std::atomic<uint64_t> value{0};
+    return value;
+  }
+};
+
+/// Names the seed of a failing test on stdout, next to the iteration total.
+///
+/// Seeds are already logged at INFO, one line per typed test, but a Cogwheel
+/// result row carries no logs -- so without this, replaying a failure means
+/// opening the job log and matching the failing test back to its seed by
+/// encoding and dtype.
+///
+/// This is a listener rather than a check at the end of the fuzzer loop because
+/// an `ASSERT_*` failure returns from the fuzzer function immediately, so any
+/// reporting placed after the loop is exactly what a hard failure skips.
+class FuzzerSeedReporter : public ::testing::EmptyTestEventListener {
+ public:
+  static void setCurrentSeed(uint32_t seed) {
+    current().store(seed, std::memory_order_relaxed);
+  }
+
+  void OnTestEnd(const ::testing::TestInfo& testInfo) override {
+    if (testInfo.result() == nullptr || !testInfo.result()->Failed()) {
+      return;
+    }
+
+    // Parsed by the Cogwheel test, which reports it as result metadata. Keep
+    // the key stable.
+    std::cout << "FUZZER_FAILED_SEED=" << testInfo.test_suite_name() << "."
+              << testInfo.name() << ":"
+              << current().load(std::memory_order_relaxed) << std::endl;
+  }
+
+ private:
+  static std::atomic<uint32_t>& current() {
+    static std::atomic<uint32_t> value{0};
+    return value;
+  }
+};
+
+/// Starts the budget before the first test and prints the total after the last.
+class FuzzerBudgetEnvironment : public ::testing::Environment {
+ public:
+  /// Takes a getter rather than a value: registration happens during static
+  /// initialization, before gflags has parsed the command line, so reading the
+  /// flag here would always see its default. SetUp runs after parsing.
+  explicit FuzzerBudgetEnvironment(std::function<uint32_t()> durationSec)
+      : durationSec_{std::move(durationSec)} {}
+
+  void SetUp() override {
+    FuzzerBudget::start(durationSec_());
+
+    // Appended here rather than at static initialization because gtest owns the
+    // listener list only once InitGoogleTest has run. SetUp is inside
+    // RUN_ALL_TESTS but before any test dispatches an event, so no listener
+    // iteration is in flight.
+    ::testing::UnitTest::GetInstance()->listeners().Append(
+        new FuzzerSeedReporter());
+  }
+
+  void TearDown() override {
+    FuzzerBudget::report();
+  }
+
+ private:
+  const std::function<uint32_t()> durationSec_;
+};
 
 // ============================================================================
 // Data generators
@@ -498,9 +620,14 @@ class EncodingFuzzer {
               << toString(Encoder<EncodingClass>::encodingType())
               << " dtype: " << toString(TypeTraits<T>::dataType)
               << " iterations: " << iterations_ << " maxRows: " << maxRows_;
+    FuzzerSeedReporter::setCurrentSeed(seed);
     std::mt19937 rng(seed);
 
     for (uint32_t iter = 0; iter < iterations_; ++iter) {
+      if (FuzzerBudget::expired()) {
+        break;
+      }
+      FuzzerBudget::recordIteration();
       buffer_ = std::make_unique<Buffer>(*pool_);
       auto datasets = generateDatasets(rng);
 

--- a/velox/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -67,6 +67,18 @@ DEFINE_uint32(fuzzer_iterations, 50, "Number of fuzzer iterations per test");
 DEFINE_uint32(fuzzer_max_rows, 5000, "Maximum rows per fuzzer iteration");
 DEFINE_uint32(fuzzer_seed, 42, "Fuzzer seed (0 = random each run)");
 DEFINE_bool(fuzzer_compression, true, "Test with compression enabled");
+DEFINE_uint32(
+    fuzzer_duration_sec,
+    0,
+    "Wall-clock budget for the whole binary, across every typed test. Zero "
+    "means the iteration counts are the only bound. Prefer setting this in "
+    "automation: an iteration count cannot self-limit, so overshoot shows up "
+    "as the job being killed rather than a short run.");
+
+static ::testing::Environment* const kFuzzerBudget =
+    ::testing::AddGlobalTestEnvironment(
+        new facebook::nimble::test::FuzzerBudgetEnvironment(
+            [] { return FLAGS_fuzzer_duration_sec; }));
 
 using namespace facebook;
 using namespace facebook::nimble;

--- a/velox/dwio/nimble/fuzzer/encoding/EncodingViewFuzzerTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding/EncodingViewFuzzerTest.cpp
@@ -48,6 +48,18 @@ DEFINE_uint32(
     5000,
     "Maximum rows per EncodingView fuzzer iteration");
 DEFINE_uint32(view_fuzzer_seed, 42, "EncodingView fuzzer seed (0 = random)");
+DEFINE_uint32(
+    view_fuzzer_duration_sec,
+    0,
+    "Wall-clock budget for the whole binary, across every typed test. Zero "
+    "means the iteration counts are the only bound. Prefer setting this in "
+    "automation: an iteration count cannot self-limit, so overshoot shows up "
+    "as the job being killed rather than a short run.");
+
+static ::testing::Environment* const kViewFuzzerBudget =
+    ::testing::AddGlobalTestEnvironment(
+        new facebook::nimble::test::FuzzerBudgetEnvironment(
+            [] { return FLAGS_view_fuzzer_duration_sec; }));
 
 using namespace facebook;
 using namespace facebook::nimble;
@@ -178,9 +190,14 @@ void runEncodingViewFuzzer(
             << " encoding: " << toString(Encoder<EncodingClass>::encodingType())
             << " dtype: " << toString(TypeTraits<T>::dataType)
             << " iterations: " << iterations << " maxRows: " << maxRows;
+  FuzzerSeedReporter::setCurrentSeed(seed);
   std::mt19937 rng(seed);
 
   for (uint32_t iter = 0; iter < iterations; ++iter) {
+    if (FuzzerBudget::expired()) {
+      break;
+    }
+    FuzzerBudget::recordIteration();
     const auto rowCount = 1 + folly::Random::rand32(rng) % maxRows;
     auto datasets =
         makeDatasets<EncodingClass>(*pool, rng, rowCount, dataBuffer.get());


### PR DESCRIPTION
Summary:

The two Nimble encoding fuzzers were bounded by iteration count, which cannot
self-limit: an overshoot is not a short run, it is the Cogwheel job being killed
at `execution_timeout_seconds`. Counts extrapolated from short local runs
overshot badly -- `7000`/`21000` produced ~68% TIMEOUT -- because real cost per
iteration is well above what that line predicts and varies by encoding and dtype.
The parent diff halved the counts as mitigation; this replaces the mechanism.

**Wall-clock bound.** `FuzzerBudget` in `EncodingFuzzer.h` holds a process-global
deadline plus an atomic counter of completed iterations. Both fuzzer loops check
`FuzzerBudget::expired()` and break. `FuzzerBudgetEnvironment` is a gtest global
environment that arms the deadline in `SetUp`. It takes a *getter* rather than a
value because registration happens during static initialization, before gflags
parses the command line -- reading the flag at registration would always see its
default.

New flags `--fuzzer_duration_sec` and `--view_fuzzer_duration_sec` default to
`0`, which disables the deadline, so every existing invocation (local runs, the
`buck2 test` targets, CI) behaves exactly as before.

**Reporting what the budget bought.** Per-iteration cost can now change freely
without turning into TIMEOUTs; what varies instead is how many iterations fit in
the window. `FuzzerBudget::report()` prints `FUZZER_ITERATIONS_COMPLETED=<n>` on
stdout at `TearDown`, and the Cogwheel test parses it and forwards it via
`add_result_metadata`, so achieved coverage lands in
`testinfra_db_results.result_metadata` and is queryable instead of guessed at.
No new Scuba dataset and no extra logging -- it rides the existing JSON map.

**Reporting how to replay a failure.** The seed is what a failure has to be
reproduced from, but there is no single seed: with `--fuzzer_seed=0` each typed
test draws its own, so a run emits ~139 `EncodingFuzzer seed:` lines and they
live only in the job log, which a Cogwheel result row does not carry.
`FuzzerSeedReporter` is a gtest listener that, on each failing test, prints
`FUZZER_FAILED_SEED=<suite>.<test>:<seed>` -- and the Cogwheel test forwards the
deduplicated list as a second metadata key. A failed run then carries its own
replay recipe in Scuba instead of requiring the log to be opened and the failing
test matched back to a seed by encoding and dtype.

It is a listener rather than a check after the fuzzer loop because an `ASSERT_*`
failure returns from the fuzzer function immediately, so anything placed after
the loop is exactly what a hard failure skips. The listener is appended in the
environment's `SetUp` rather than at static initialization, since gtest owns the
listener list only once `InitGoogleTest` has run; `SetUp` is inside
`RUN_ALL_TESTS` but before any test dispatches an event, so no listener
iteration is in flight.

The Cogwheel side passes `--fuzzer_duration_sec=9000` (2.5h against the target's
3h `execution_timeout_seconds`, leaving headroom for fbpkg setup and the
iteration in flight at the deadline) and keeps the iteration flag only as a
non-binding backstop, since it is per typed test and its `50` default would
otherwise end the run instantly.

**Drive-by fix.** The comment added in the parent diff claimed the replay seed
was visible as long as `--minloglevel=1` was not passed. That is wrong: these
binaries default to a `minloglevel` above `INFO`, so `--logtostderr=1` alone
dropped every `EncodingFuzzer seed:` line and no Cogwheel failure was ever
replayable. Verified directly -- without `--minloglevel=0` both stdout and
stderr contain zero seed lines; with it, stderr carries one per typed test.
`_run_encoding_fuzzer` now passes it, and captures stdout only so those seeds
still stream live on stderr rather than being held back until the process exits.

Reviewed By: xiaoxmeng

Differential Revision: D116874682


