### PR TITLE
feat(nimble): Add string shared dictionary encoding

### DIFF
--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -400,6 +400,32 @@ constexpr bool isStringType() {
 }
 
 template <typename T>
+constexpr bool isSharedDictionaryType() {
+  return isIntegralType<T>() || std::is_same_v<T, std::string_view>;
+}
+
+constexpr bool isSharedDictionaryType(DataType dataType) {
+  switch (dataType) {
+    case DataType::Int8:
+    case DataType::Uint8:
+    case DataType::Int16:
+    case DataType::Uint16:
+    case DataType::Int32:
+    case DataType::Uint32:
+    case DataType::Int64:
+    case DataType::Uint64:
+    case DataType::String:
+      return true;
+    case DataType::Undefined:
+    case DataType::Float:
+    case DataType::Double:
+    case DataType::Bool:
+      return false;
+  }
+  return false;
+}
+
+template <typename T>
 constexpr bool isBoolType() {
   return std::is_same_v<T, bool>;
 }

--- a/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -189,6 +189,24 @@ std::string_view sliceDictionary(
       DictionaryEncoding<T>::slice(encoded, offset, length, buffer, options));
 }
 
+template <typename T>
+std::string_view sliceSharedDictionaryTyped(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options,
+    DataType dataType) {
+  if constexpr (isSharedDictionaryType<T>()) {
+    return SharedDictionaryEncoding<T>::slice(
+        encoded, offset, length, buffer, options);
+  }
+  NIMBLE_INCOMPATIBLE_ENCODING(
+      "Cannot slice SharedDictionary encoding for an incompatible data type "
+      "{}.",
+      dataType);
+}
+
 std::string_view sliceSharedDictionary(
     std::string_view encoded,
     DataType dataType,
@@ -196,11 +214,11 @@ std::string_view sliceSharedDictionary(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
-  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(
+  NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE(
       dataType,
       T,
-      SharedDictionaryEncoding<T>::slice(
-          encoded, offset, length, buffer, options));
+      sliceSharedDictionaryTyped<T>(
+          encoded, offset, length, buffer, options, dataType));
 }
 
 std::string_view sliceFixedBitWidth(

--- a/velox/dwio/nimble/encodings/SharedDictionaryBuilder.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryBuilder.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <optional>
 #include <span>
 #include <string>
@@ -219,15 +220,16 @@ class StreamingSharedDictionaryBuilder final
           kMaxSharedDictionarySize,
           "Shared dictionary size exceeds maximum.");
       const auto dictionaryIndex = static_cast<uint32_t>(index);
+      const auto storedValue = storeValue(value);
       const auto [alphabetIndexIt, inserted] =
-          alphabetIndex_.emplace(value, dictionaryIndex);
+          alphabetIndex_.emplace(storedValue, dictionaryIndex);
       NIMBLE_CHECK(
           inserted,
           "Shared dictionary mapping insertion failed because the value already exists: value={}, existingIndex={}, newIndex={}.",
           value,
           alphabetIndexIt->second,
           dictionaryIndex);
-      alphabet_.push_back(value);
+      alphabet_.push_back(storedValue);
       ++mapping.newEntryCount_;
       mapping.indices_.push_back(dictionaryIndex);
     }
@@ -237,11 +239,22 @@ class StreamingSharedDictionaryBuilder final
   void resetImpl() final {
     alphabet_.clear();
     alphabetIndex_.clear();
+    stringValues_.clear();
   }
 
  private:
+  T storeValue(const T& value) {
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      stringValues_.emplace_back(value);
+      return stringValues_.back();
+    } else {
+      return value;
+    }
+  }
+
   Vector<T> alphabet_;
   DictionaryIndexType<T> alphabetIndex_;
+  std::deque<std::string> stringValues_;
 };
 
 /// Builder for externally supplied dictionaries.

--- a/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
@@ -569,7 +569,7 @@ SharedDictionaryEncoding<T>::SharedDictionaryEncoding(
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>{pool, data, options} {
-  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  static_assert(isSharedDictionaryType<T>());
   NIMBLE_CHECK_NOT_NULL(
       options.sharedDictionaryAlphabet,
       "Shared dictionary encoding requires an alphabet.");
@@ -651,7 +651,7 @@ std::string_view SharedDictionaryEncoding<T>::encode(
     const EncodingSelectionPolicyCreator& nestedPolicyCreator,
     Buffer& buffer,
     const Encoding::Options& options) {
-  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  static_assert(isSharedDictionaryType<T>());
 
   ScopedEncodingBuffer scopedBuffer{
       &buffer.getMemoryPool(), options.encodingBufferPool};
@@ -687,7 +687,7 @@ std::string_view SharedDictionaryEncoding<T>::encodeNullable(
     std::span<const bool> nulls,
     Buffer& buffer,
     const Encoding::Options& options) {
-  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  static_assert(isSharedDictionaryType<T>());
 
   auto nullsPolicy = selection.template createNestedPolicy<bool>(
       EncodingType::Nullable, EncodingIdentifiers::Nullable::Nulls);
@@ -714,7 +714,7 @@ std::string_view SharedDictionaryEncoding<T>::encodeIndices(
     const EncodingSelectionPolicyCreator& nestedPolicyCreator,
     Buffer& buffer,
     const Encoding::Options& options) {
-  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  static_assert(isSharedDictionaryType<T>());
   NIMBLE_CHECK_LE(
       indices.size(),
       kMaxSharedDictionarySize,
@@ -739,7 +739,7 @@ std::string_view SharedDictionaryEncoding<T>::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
-  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  static_assert(isSharedDictionaryType<T>());
   const auto sourceRowCount =
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
@@ -790,6 +790,15 @@ void SharedDictionaryEncoding<T>::materializeLocalDictionaryIndices(
   }
 }
 
+template <typename ValueType>
+uint64_t getValueSize(const ValueType& value) {
+  if constexpr (isStringType<ValueType>()) {
+    return sizeof(uint32_t) + value.size();
+  } else {
+    return sizeof(ValueType);
+  }
+}
+
 template <typename T>
 std::string_view SharedDictionaryEncoding<T>::encodeMaterializedDictionarySlice(
     const SharedDictionaryAlphabet& alphabet,
@@ -825,7 +834,7 @@ std::string_view SharedDictionaryEncoding<T>::encodeMaterializedDictionarySlice(
   if (uniqueIndices.size() == 1) {
     const uint64_t encodingSize =
         EncodingPrefix::serializedSize(length, options.useVarintRowCount) +
-        sizeof(physicalType);
+        getValueSize(values[0]);
     char* reserved = buffer.reserve(encodingSize);
     char* writePos = reserved;
     EncodingPrefix::serialize(

--- a/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -58,6 +58,23 @@ std::span<const typename TypeTraits<T>::physicalType> toPhysicalSpan(
       values.size());
 }
 
+template <typename T>
+std::unique_ptr<Encoding> createSharedDictionaryEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& stringBufferFactory,
+    const Encoding::Options& options,
+    DataType dataType) {
+  if constexpr (isSharedDictionaryType<T>()) {
+    return std::make_unique<SharedDictionaryEncoding<T>>(
+        pool, data, std::move(stringBufferFactory), options);
+  }
+  NIMBLE_INCOMPATIBLE_ENCODING(
+      "Trying to deserialize a SharedDictionary stream for an incompatible "
+      "data type {}.",
+      dataType);
+}
+
 } // namespace
 
 std::unique_ptr<Encoding> EncodingFactory::create(
@@ -83,7 +100,11 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       RETURN_ENCODING_BY_NON_BOOL_TYPE(DictionaryEncoding, dataType);
     }
     case EncodingType::SharedDictionary: {
-      RETURN_ENCODING_BY_INTEGER_TYPE(SharedDictionaryEncoding, dataType);
+      NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE(
+          dataType,
+          T,
+          createSharedDictionaryEncoding<T>(
+              pool, data, stringBufferFactory, options, dataType));
     }
     case EncodingType::FixedBitWidth: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(FixedBitWidthEncoding, dataType);
@@ -284,7 +305,7 @@ std::string_view EncodingFactory::encode(
           selection, castedValues, buffer, options);
     }
     case EncodingType::SharedDictionary: {
-      if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+      if constexpr (isSharedDictionaryType<T>()) {
         const auto& sharedDictionaryInput = selection.sharedDictionaryInput();
         NIMBLE_CHECK(
             sharedDictionaryInput.has_value(),
@@ -312,7 +333,7 @@ std::string_view EncodingFactory::encode(
             options);
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
-          "SharedDictionary encoding only supports non-bool integer data "
+          "SharedDictionary encoding only supports integer or string data "
           "types.");
     }
     case EncodingType::FixedBitWidth: {
@@ -457,12 +478,12 @@ std::string_view EncodingFactory::encodeNullable(
           selection, physicalValues, nulls, buffer, options);
     }
     case EncodingType::SharedDictionary: {
-      if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+      if constexpr (isSharedDictionaryType<T>()) {
         return SharedDictionaryEncoding<T>::encodeNullable(
             std::move(selection), physicalValues, nulls, buffer, options);
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
-          "SharedDictionary encoding only supports non-bool integer data "
+          "SharedDictionary encoding only supports integer or string data "
           "types.");
     }
     default: {

--- a/velox/dwio/nimble/velox/SharedDictionaryWriter.h
+++ b/velox/dwio/nimble/velox/SharedDictionaryWriter.h
@@ -111,7 +111,7 @@ class TypedSharedDictionaryWriter final : public SharedDictionaryWriter {
  public:
   using Options = SharedDictionaryWriter::Options;
 
-  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  static_assert(isSharedDictionaryType<T>());
 
   TypedSharedDictionaryWriter(
       velox::memory::MemoryPool* pool,

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
@@ -130,6 +130,20 @@ enum class FileDictionaryAlphabetOrder {
   Unsorted,
 };
 
+enum class ScalarValueType {
+  Tinyint,
+  Smallint,
+  Integer,
+  Bigint,
+  Varchar,
+  Varbinary,
+};
+
+struct ScalarValueRoundTripTestCase {
+  ScalarValueType valueType;
+  SharedDictionaryScope scope;
+};
+
 struct TabletReaderDictionaryApiTestCase {
   SharedDictionaryScope scope;
   bool hasStripeDictionaries;
@@ -210,6 +224,24 @@ std::string_view fileDictionaryAlphabetOrderName(
   NIMBLE_UNREACHABLE("Unsupported file dictionary alphabet order.");
 }
 
+std::string_view scalarValueTypeName(ScalarValueType valueType) {
+  switch (valueType) {
+    case ScalarValueType::Tinyint:
+      return "Tinyint";
+    case ScalarValueType::Smallint:
+      return "Smallint";
+    case ScalarValueType::Integer:
+      return "Integer";
+    case ScalarValueType::Bigint:
+      return "Bigint";
+    case ScalarValueType::Varchar:
+      return "Varchar";
+    case ScalarValueType::Varbinary:
+      return "Varbinary";
+  }
+  NIMBLE_UNREACHABLE("Unsupported scalar value type.");
+}
+
 class FixedFileResolver final : public ExternalDictionaryResolver {
  public:
   FixedFileResolver(
@@ -255,7 +287,7 @@ class SharedDictionaryE2ETest : public testing::Test {
 
   static void useSharedDictionarySelectionPolicy(WriterOptions& options) {
     test::configureSharedDictionarySelectionPolicy(
-        options, {.forceDictionaryForInt32 = false});
+        options, {.forceDictionaryForSharedTypes = false});
   }
 
   std::shared_ptr<const ExternalDictionaryResolver> makeExternalResolver(
@@ -314,6 +346,74 @@ class SharedDictionaryE2ETest : public testing::Test {
       return directStripeValue(position);
     }
     return dictionaryStripeValue(position);
+  }
+
+  static std::string stringStripeValue(
+      StripeValueType stripeValueType,
+      velox::vector_size_t position) {
+    if (stripeValueType == StripeValueType::Direct) {
+      return fmt::format("direct-string-{}", position);
+    }
+    return position % 2 == 0 ? "alpha" : "bravo";
+  }
+
+  template <typename T>
+  static T scalarStripeValue(
+      StripeValueType stripeValueType,
+      velox::vector_size_t position) {
+    if (stripeValueType == StripeValueType::Direct) {
+      return static_cast<T>(position % 97 + 30);
+    }
+    return static_cast<T>(position % 2 == 0 ? 1 : 2);
+  }
+
+  template <typename T>
+  velox::RowVectorPtr makeNumericScalarStripe(StripeValueType stripeValueType) {
+    velox::test::VectorMaker maker{leafPool_.get()};
+    return maker.rowVector(
+        {"nested"},
+        {maker.rowVector(
+            {"value"},
+            {maker.flatVector<T>(kStripeRows, [stripeValueType](auto row) {
+              return scalarStripeValue<T>(stripeValueType, row);
+            })})});
+  }
+
+  velox::RowVectorPtr makeStringStripe(
+      StripeValueType stripeValueType,
+      const velox::TypePtr& type) {
+    velox::test::VectorMaker maker{leafPool_.get()};
+    return maker.rowVector(
+        {"nested"},
+        {maker.rowVector(
+            {"value"},
+            {maker.flatVector<std::string>(
+                kStripeRows,
+                [stripeValueType](auto row) {
+                  return stringStripeValue(stripeValueType, row);
+                },
+                nullptr,
+                type)})});
+  }
+
+  velox::RowVectorPtr makeScalarStripe(
+      ScalarValueType valueType,
+      StripeValueType stripeValueType) {
+    switch (valueType) {
+      case ScalarValueType::Tinyint:
+        return makeNumericScalarStripe<int8_t>(stripeValueType);
+      case ScalarValueType::Smallint:
+        return makeNumericScalarStripe<int16_t>(stripeValueType);
+      case ScalarValueType::Integer:
+        return makeNumericScalarStripe<int32_t>(stripeValueType);
+      case ScalarValueType::Bigint:
+        return makeNumericScalarStripe<int64_t>(stripeValueType);
+      case ScalarValueType::Varchar:
+        return makeStringStripe(stripeValueType, velox::VARCHAR());
+      case ScalarValueType::Varbinary:
+        return makeStringStripe(stripeValueType, velox::VARBINARY());
+    }
+    NIMBLE_UNREACHABLE("Unsupported scalar value type.");
   }
 
   velox::RowVectorPtr makeStripe(
@@ -1162,6 +1262,24 @@ class SharedDictionaryE2ETest : public testing::Test {
     EXPECT_FALSE(reader.next(kStripeRows, output));
   }
 
+  void verifyScalarRoundTrip(
+      const std::string& file,
+      ScalarValueType valueType,
+      const std::vector<StripeValueType>& stripeValueTypes) {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    VeloxReader reader{readFile, *leafPool_};
+    velox::VectorPtr output;
+    for (const auto stripeValueType : stripeValueTypes) {
+      ASSERT_TRUE(reader.next(kStripeRows, output));
+      auto expected = makeScalarStripe(valueType, stripeValueType);
+      ASSERT_EQ(output->size(), expected->size());
+      for (velox::vector_size_t i = 0; i < output->size(); ++i) {
+        ASSERT_TRUE(output->equalValueAt(expected.get(), i, i));
+      }
+    }
+    EXPECT_FALSE(reader.next(kStripeRows, output));
+  }
+
   void verifyFileDictionaryRoundTrip(
       const std::string& file,
       FileDictionaryAlphabetOrder alphabetOrder,
@@ -1196,6 +1314,22 @@ class SharedDictionaryE2EFlatMapRowValueSubfieldsTest
 class SharedDictionaryE2EFlatMapDefaultValueSubfieldTest
     : public SharedDictionaryE2ETest,
       public testing::WithParamInterface<InputType> {};
+
+class SharedDictionaryE2EScalarValueTypeTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<ScalarValueRoundTripTestCase> {};
+
+class SharedDictionaryE2EInvalidDictionaryTargetTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<InvalidDictionaryTarget> {};
+
+class SharedDictionaryE2EFileDictionaryAlphabetOrderTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<FileDictionaryAlphabetOrder> {};
+
+class SharedDictionaryE2EExternalDictionaryFailureTest
+    : public SharedDictionaryE2ETest,
+      public testing::WithParamInterface<ExternalDictionaryFailure> {};
 
 class SharedDictionaryE2ETabletReaderApiTest
     : public SharedDictionaryE2ETest,
@@ -1294,6 +1428,35 @@ TEST_F(SharedDictionaryE2ETest, fileScopeCompactRowCountRoundTrip) {
     }
   }
   EXPECT_FALSE(reader.next(kStripeRows, output));
+}
+
+TEST_P(SharedDictionaryE2EScalarValueTypeTest, columnRoundTrip) {
+  const auto testCase = GetParam();
+  const std::vector<StripeValueType> stripeValueTypes{
+      StripeValueType::Dictionary};
+  auto options = makeSharedDictionaryWriterOptions();
+  test::configureSharedDictionarySelectionPolicy(options);
+  addColumnDictionary(
+      options,
+      sharedDictionaryConfig(testCase.scope, /*dictionaryId=*/7),
+      "nested.value");
+
+  std::vector<velox::RowVectorPtr> stripeInputs;
+  stripeInputs.reserve(stripeValueTypes.size());
+  for (const auto stripeValueType : stripeValueTypes) {
+    stripeInputs.push_back(
+        makeScalarStripe(testCase.valueType, stripeValueType));
+  }
+  const auto file = writeInput(stripeInputs, std::move(options));
+
+  auto tablet = openTablet(file);
+  const auto schema = readSchema(*tablet);
+  const auto valueStreamId =
+      scalarStreamId(*schema->asRow().childAt(0)->asRow().childAt(0));
+  ASSERT_TRUE(hasSharedDictionary(*tablet, valueStreamId));
+  expectDictionaryValueEncodingTypes(
+      *tablet, valueStreamId, testCase.scope, stripeValueTypes);
+  verifyScalarRoundTrip(file, testCase.valueType, stripeValueTypes);
 }
 
 TEST_P(SharedDictionaryE2EFlatMapRowValueSubfieldsTest, roundTrip) {
@@ -1461,6 +1624,53 @@ INSTANTIATE_TEST_SUITE_P(
       return std::string{SharedDictionaryScopeName::toName(testInfo.param)};
     });
 
+INSTANTIATE_TEST_SUITE_P(
+    ValueTypesAndScopes,
+    SharedDictionaryE2EScalarValueTypeTest,
+    testing::Values(
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Tinyint,
+            SharedDictionaryScope::Stripe},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Tinyint,
+            SharedDictionaryScope::File},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Smallint,
+            SharedDictionaryScope::Stripe},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Smallint,
+            SharedDictionaryScope::File},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Integer,
+            SharedDictionaryScope::Stripe},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Integer,
+            SharedDictionaryScope::File},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Bigint,
+            SharedDictionaryScope::Stripe},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Bigint,
+            SharedDictionaryScope::File},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Varchar,
+            SharedDictionaryScope::Stripe},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Varchar,
+            SharedDictionaryScope::File},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Varbinary,
+            SharedDictionaryScope::Stripe},
+        ScalarValueRoundTripTestCase{
+            ScalarValueType::Varbinary,
+            SharedDictionaryScope::File}),
+    [](const testing::TestParamInfo<ScalarValueRoundTripTestCase>& testInfo) {
+      return fmt::format(
+          "{}_{}",
+          scalarValueTypeName(testInfo.param.valueType),
+          SharedDictionaryScopeName::toName(testInfo.param.scope));
+    });
+
 TEST_F(SharedDictionaryE2ETest, stripeScopeRejectsConfiguredDictionaryId) {
   auto input = makeDictionaryStripe(InputType::FlatMapScalar);
   WriterOptions options;
@@ -1576,61 +1786,69 @@ INSTANTIATE_TEST_SUITE_P(
           SharedDictionaryScopeName::toName(testInfo.param.scope)};
     });
 
-TEST_F(SharedDictionaryE2ETest, dictionaryConfigRejected) {
-  for (const auto target :
-       {InvalidDictionaryTarget::FlatMapWholeRowValue,
-        InvalidDictionaryTarget::RegularRowColumnValue}) {
-    SCOPED_TRACE(fmt::format("target={}", invalidDictionaryTargetName(target)));
-    velox::test::VectorMaker maker{leafPool_.get()};
-    velox::RowVectorPtr input;
-    WriterOptions options;
-    switch (target) {
-      case InvalidDictionaryTarget::FlatMapWholeRowValue:
-        input = maker.rowVector(
-            {"features"},
-            {maker.mapVector(
-                std::vector<velox::vector_size_t>{0},
-                std::vector<velox::vector_size_t>{1},
-                maker.flatVector<int64_t>({10}),
-                maker.rowVector(
-                    {"a", "b"},
-                    {maker.flatVector<int64_t>({1}),
-                     maker.flatVector<int64_t>({2})}))});
-        options.flatMapColumns.emplace("features", std::set<std::string>{});
-        addFlatmapDictionary(
-            options,
-            sharedDictionaryConfig(
-                SharedDictionaryScope::File, /*dictionaryId=*/17));
-        break;
-      case InvalidDictionaryTarget::RegularRowColumnValue:
-        input = maker.rowVector(
-            {"nested"},
-            {maker.rowVector(
-                {"a", "b"},
-                {maker.flatVector<int32_t>({1}),
-                 maker.flatVector<int32_t>({2})})});
-        useSharedDictionarySelectionPolicy(options);
-        options.experimentalSharedDictionaryEncoding =
-            SharedDictionaryEncodingConfig::builder()
-                .addColumnDictionary(
-                    "nested",
-                    sharedDictionaryConfig(
-                        SharedDictionaryScope::File, /*dictionaryId=*/17))
-                .build();
-        break;
-    }
-    ASSERT_NE(input, nullptr);
-    auto writeInvalidTarget = [&]() {
-      std::string file;
-      auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
-      Writer writer{
-          input->type(), std::move(writeFile), *rootPool_, std::move(options)};
-      writer.write(input);
-    };
-    NIMBLE_ASSERT_USER_THROW(
-        writeInvalidTarget(), "must resolve to an integer scalar");
+TEST_P(
+    SharedDictionaryE2EInvalidDictionaryTargetTest,
+    dictionaryConfigRejected) {
+  const auto target = GetParam();
+  velox::test::VectorMaker maker{leafPool_.get()};
+  velox::RowVectorPtr input;
+  WriterOptions options;
+  switch (target) {
+    case InvalidDictionaryTarget::FlatMapWholeRowValue:
+      input = maker.rowVector(
+          {"features"},
+          {maker.mapVector(
+              std::vector<velox::vector_size_t>{0},
+              std::vector<velox::vector_size_t>{1},
+              maker.flatVector<int64_t>({10}),
+              maker.rowVector(
+                  {"a", "b"},
+                  {maker.flatVector<int64_t>({1}),
+                   maker.flatVector<int64_t>({2})}))});
+      options.flatMapColumns.emplace("features", std::set<std::string>{});
+      addFlatmapDictionary(
+          options,
+          sharedDictionaryConfig(
+              SharedDictionaryScope::File, /*dictionaryId=*/17));
+      break;
+    case InvalidDictionaryTarget::RegularRowColumnValue:
+      input = maker.rowVector(
+          {"nested"},
+          {maker.rowVector(
+              {"a", "b"},
+              {maker.flatVector<int32_t>({1}),
+               maker.flatVector<int32_t>({2})})});
+      useSharedDictionarySelectionPolicy(options);
+      options.experimentalSharedDictionaryEncoding =
+          SharedDictionaryEncodingConfig::builder()
+              .addColumnDictionary(
+                  "nested",
+                  sharedDictionaryConfig(
+                      SharedDictionaryScope::File, /*dictionaryId=*/17))
+              .build();
+      break;
   }
+  ASSERT_NE(input, nullptr);
+  auto writeInvalidTarget = [&]() {
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    Writer writer{
+        input->type(), std::move(writeFile), *rootPool_, std::move(options)};
+    writer.write(input);
+  };
+  NIMBLE_ASSERT_USER_THROW(
+      writeInvalidTarget(), "must resolve to an integer or string scalar");
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    Targets,
+    SharedDictionaryE2EInvalidDictionaryTargetTest,
+    testing::Values(
+        InvalidDictionaryTarget::FlatMapWholeRowValue,
+        InvalidDictionaryTarget::RegularRowColumnValue),
+    [](const testing::TestParamInfo<InvalidDictionaryTarget>& testInfo) {
+      return std::string{invalidDictionaryTargetName(testInfo.param)};
+    });
 
 TEST_F(
     SharedDictionaryE2ETest,
@@ -1659,31 +1877,36 @@ TEST_F(
       std::vector<StripeValueType>(kStripeCount, StripeValueType::Dictionary));
 }
 
-TEST_F(SharedDictionaryE2ETest, fileScopePrebuiltAlphabetPreservesEncoding) {
+TEST_P(
+    SharedDictionaryE2EFileDictionaryAlphabetOrderTest,
+    fileScopePrebuiltAlphabetPreservesEncoding) {
   constexpr size_t kStripeCount{2};
-  for (const auto alphabetOrder :
-       {FileDictionaryAlphabetOrder::Sorted,
-        FileDictionaryAlphabetOrder::Unsorted}) {
-    SCOPED_TRACE(
-        fmt::format(
-            "alphabetOrder={}",
-            fileDictionaryAlphabetOrderName(alphabetOrder)));
-    const auto file = writeWithFileDictionary(kStripeCount, alphabetOrder);
-    auto tablet = openTablet(file);
-    const auto valueStreamIds =
-        sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapScalar);
-    ASSERT_EQ(valueStreamIds.size(), 1);
-    const auto valueStreamId = valueStreamIds.front();
-    const auto encodingTypes =
-        streamEncodingTypesByStripe(*tablet, valueStreamId);
-    ASSERT_EQ(encodingTypes.size(), kStripeCount);
-    expectAllStripeEncodingTypes(encodingTypes, EncodingType::SharedDictionary);
-    EXPECT_EQ(fileDictionaryValues(file), fileDictionaryValues(alphabetOrder));
-    EXPECT_EQ(
-        fileDictionaryAlphabetEncodingType(file), EncodingType::FixedBitWidth);
-    verifyFileDictionaryRoundTrip(file, alphabetOrder, kStripeCount);
-  }
+  const auto alphabetOrder = GetParam();
+  const auto file = writeWithFileDictionary(kStripeCount, alphabetOrder);
+  auto tablet = openTablet(file);
+  const auto valueStreamIds =
+      sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapScalar);
+  ASSERT_EQ(valueStreamIds.size(), 1);
+  const auto valueStreamId = valueStreamIds.front();
+  const auto encodingTypes =
+      streamEncodingTypesByStripe(*tablet, valueStreamId);
+  ASSERT_EQ(encodingTypes.size(), kStripeCount);
+  expectAllStripeEncodingTypes(encodingTypes, EncodingType::SharedDictionary);
+  EXPECT_EQ(fileDictionaryValues(file), fileDictionaryValues(alphabetOrder));
+  EXPECT_EQ(
+      fileDictionaryAlphabetEncodingType(file), EncodingType::FixedBitWidth);
+  verifyFileDictionaryRoundTrip(file, alphabetOrder, kStripeCount);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    AlphabetOrders,
+    SharedDictionaryE2EFileDictionaryAlphabetOrderTest,
+    testing::Values(
+        FileDictionaryAlphabetOrder::Sorted,
+        FileDictionaryAlphabetOrder::Unsorted),
+    [](const testing::TestParamInfo<FileDictionaryAlphabetOrder>& testInfo) {
+      return std::string{fileDictionaryAlphabetOrderName(testInfo.param)};
+    });
 
 TEST_P(SharedDictionaryE2EInputTypeTest, externalScopeRoundTrip) {
   const auto inputType = GetParam();
@@ -1708,43 +1931,48 @@ TEST_P(SharedDictionaryE2EInputTypeTest, externalScopeRoundTrip) {
   verifyRoundTrip(file, inputType, stripeValueTypes, resolver);
 }
 
-TEST_F(SharedDictionaryE2ETest, externalDictionaryFailures) {
-  for (const auto failure :
-       {ExternalDictionaryFailure::MissingResolver,
-        ExternalDictionaryFailure::MissingValue}) {
-    SCOPED_TRACE(
-        fmt::format("failure={}", externalDictionaryFailureName(failure)));
-    switch (failure) {
-      case ExternalDictionaryFailure::MissingResolver: {
-        auto resolver = makeExternalResolver(externalDictionaryValues());
-        const auto file = write(
-            InputType::FlatMapScalar,
-            SharedDictionaryScope::External,
-            {StripeValueType::Dictionary, StripeValueType::Direct},
-            resolver);
-        auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-        VeloxReader reader{readFile, *leafPool_};
-        velox::VectorPtr output;
-        NIMBLE_ASSERT_USER_THROW(
-            reader.next(kStripeRows, output),
-            "External shared dictionary 17 requires an "
-            "ExternalDictionaryResolver.");
-        break;
-      }
-      case ExternalDictionaryFailure::MissingValue: {
-        auto resolver = makeExternalResolver(kDictionaryStripeAlphabetValues);
-        NIMBLE_ASSERT_USER_THROW(
-            write(
-                InputType::FlatMapScalar,
-                SharedDictionaryScope::External,
-                {StripeValueType::Dictionary, StripeValueType::Direct},
-                resolver),
-            "External shared dictionary 17 does not contain value 10000.");
-        break;
-      }
+TEST_P(SharedDictionaryE2EExternalDictionaryFailureTest, fails) {
+  const auto failure = GetParam();
+  switch (failure) {
+    case ExternalDictionaryFailure::MissingResolver: {
+      auto resolver = makeExternalResolver(externalDictionaryValues());
+      const auto file = write(
+          InputType::FlatMapScalar,
+          SharedDictionaryScope::External,
+          {StripeValueType::Dictionary, StripeValueType::Direct},
+          resolver);
+      auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+      VeloxReader reader{readFile, *leafPool_};
+      velox::VectorPtr output;
+      NIMBLE_ASSERT_USER_THROW(
+          reader.next(kStripeRows, output),
+          "External shared dictionary 17 requires an "
+          "ExternalDictionaryResolver.");
+      break;
+    }
+    case ExternalDictionaryFailure::MissingValue: {
+      auto resolver = makeExternalResolver(kDictionaryStripeAlphabetValues);
+      NIMBLE_ASSERT_USER_THROW(
+          write(
+              InputType::FlatMapScalar,
+              SharedDictionaryScope::External,
+              {StripeValueType::Dictionary, StripeValueType::Direct},
+              resolver),
+          "External shared dictionary 17 does not contain value 10000.");
+      break;
     }
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    Failures,
+    SharedDictionaryE2EExternalDictionaryFailureTest,
+    testing::Values(
+        ExternalDictionaryFailure::MissingResolver,
+        ExternalDictionaryFailure::MissingValue),
+    [](const testing::TestParamInfo<ExternalDictionaryFailure>& testInfo) {
+      return std::string{externalDictionaryFailureName(testInfo.param)};
+    });
 
 TEST_F(
     SharedDictionaryE2ETest,

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.cpp
@@ -36,31 +36,15 @@ std::unique_ptr<EncodingSelectionPolicyBase> sharedDictionarySelectionPolicy(
     DataType dataType,
     SharedDictionarySelectionPolicyOptions selectionOptions) {
   std::vector<std::pair<EncodingType, float>> readFactors;
-  switch (dataType) {
-    case DataType::Int32:
-      if (selectionOptions.forceDictionaryForInt32) {
-        readFactors = {{EncodingType::Dictionary, 1.0}};
-      } else {
-        readFactors = {
-            {EncodingType::Trivial, 1.0}, {EncodingType::Dictionary, 1.0}};
-      }
-      break;
-    case DataType::Uint32:
-      readFactors = {{EncodingType::FixedBitWidth, 1.0}};
-      break;
-    case DataType::Undefined:
-    case DataType::Int8:
-    case DataType::Uint8:
-    case DataType::Int16:
-    case DataType::Uint16:
-    case DataType::Int64:
-    case DataType::Uint64:
-    case DataType::Float:
-    case DataType::Double:
-    case DataType::Bool:
-    case DataType::String:
-      readFactors = {{EncodingType::Trivial, 1.0}};
-      break;
+  if (isSharedDictionaryType(dataType)) {
+    if (selectionOptions.forceDictionaryForSharedTypes) {
+      readFactors = {{EncodingType::Dictionary, 1.0}};
+    } else {
+      readFactors = {
+          {EncodingType::Trivial, 1.0}, {EncodingType::Dictionary, 1.0}};
+    }
+  } else {
+    readFactors = {{EncodingType::Trivial, 1.0}};
   }
   return ManualEncodingSelectionPolicyFactory{
       readFactors, /*compressionOptions=*/std::nullopt}

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h
@@ -55,10 +55,10 @@ class SharedDictionaryTestResolver final : public ExternalDictionaryResolver {
 };
 
 struct SharedDictionarySelectionPolicyOptions {
-  // Force int32 streams toward Dictionary encoding before shared-dictionary
-  // wrapping. Integration tests disable this when they need a mixed direct and
-  // shared-dictionary stripe sequence.
-  bool forceDictionaryForInt32{true};
+  // Force eligible shared-dictionary streams toward Dictionary encoding before
+  // shared-dictionary wrapping. Integration tests disable this when they need a
+  // mixed direct and shared-dictionary stripe sequence.
+  bool forceDictionaryForSharedTypes{true};
 };
 
 /// Installs the shared-dictionary selection policy on writer options.

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
@@ -48,6 +48,8 @@ namespace facebook::nimble {
 namespace {
 
 using TestSharedDictionaryWriter = TypedSharedDictionaryWriter<int32_t>;
+using TestStringSharedDictionaryWriter =
+    TypedSharedDictionaryWriter<std::string_view>;
 using EncodingReadFactors = std::vector<std::pair<EncodingType, float>>;
 
 EncodingReadFactors dictionaryValueEncoding() {
@@ -110,6 +112,7 @@ EncodingSelectionPolicyCreator testEncodingSelectionPolicyCreator(
         EncodingReadFactors encodingReadFactors;
         switch (dataType) {
           case DataType::Int32:
+          case DataType::String:
             encodingReadFactors = valueEncodingReadFactors;
             break;
           case DataType::Uint32:
@@ -125,7 +128,6 @@ EncodingSelectionPolicyCreator testEncodingSelectionPolicyCreator(
           case DataType::Float:
           case DataType::Double:
           case DataType::Bool:
-          case DataType::String:
             encodingReadFactors = {{EncodingType::Trivial, 1.0}};
             break;
         }
@@ -188,15 +190,55 @@ class TestDictionaryResolver final : public ExternalDictionaryResolver {
   const std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
 };
 
+class TestStringDictionaryResolver final : public ExternalDictionaryResolver {
+ public:
+  TestStringDictionaryResolver(
+      uint32_t dictionaryId,
+      std::span<const std::string_view> values,
+      velox::memory::MemoryPool* pool,
+      std::span<const EncodingType> candidateEncodings = {})
+      : dictionaryId_{dictionaryId},
+        alphabet_{test::createSharedDictionaryAlphabet<std::string_view>(
+            values,
+            candidateEncodings,
+            pool)} {}
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      uint32_t dictionaryId,
+      DataType dataType) const final {
+    if (dictionaryId != dictionaryId_ || dataType != DataType::String) {
+      return nullptr;
+    }
+    return alphabet_;
+  }
+
+ private:
+  const uint32_t dictionaryId_;
+  const std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
+};
+
 std::string_view bytesOf(std::span<const int32_t> values) {
   return {
       reinterpret_cast<const char*>(values.data()),
       values.size() * sizeof(int32_t)};
 }
 
+std::string_view bytesOf(std::span<const std::string_view> values) {
+  return {
+      reinterpret_cast<const char*>(values.data()),
+      values.size() * sizeof(std::string_view)};
+}
+
 StreamDataView streamView(
     const StreamDescriptorBuilder& descriptor,
     std::span<const int32_t> values) {
+  return StreamDataView{
+      descriptor, bytesOf(values), static_cast<uint32_t>(values.size())};
+}
+
+StreamDataView streamView(
+    const StreamDescriptorBuilder& descriptor,
+    std::span<const std::string_view> values) {
   return StreamDataView{
       descriptor, bytesOf(values), static_cast<uint32_t>(values.size())};
 }
@@ -225,13 +267,13 @@ std::vector<int32_t> repeatedValues(
   return values;
 }
 
-std::vector<TypeTraits<int32_t>::physicalType> physicalValues(
-    std::span<const int32_t> values) {
-  std::vector<TypeTraits<int32_t>::physicalType> physical;
+template <typename T>
+std::vector<typename TypeTraits<T>::physicalType> physicalValues(
+    std::span<const T> values) {
+  std::vector<typename TypeTraits<T>::physicalType> physical;
   physical.reserve(values.size());
   for (const auto value : values) {
-    physical.push_back(
-        EncodingPhysicalType<int32_t>::asEncodingPhysicalType(value));
+    physical.push_back(EncodingPhysicalType<T>::asEncodingPhysicalType(value));
   }
   return physical;
 }
@@ -335,13 +377,14 @@ std::vector<uint32_t> sharedDictionaryIndices(
     std::string_view encoded,
     uint32_t rowCount,
     velox::memory::MemoryPool* pool,
-    bool useVarintRowCount = false) {
+    bool useVarintRowCount = false,
+    DataType dataType = DataType::Int32) {
   const auto encodingType = EncodingPrefix::encodingType(encoded);
   EXPECT_EQ(encodingType, EncodingType::SharedDictionary);
   if (encodingType != EncodingType::SharedDictionary) {
     return {};
   }
-  EXPECT_EQ(EncodingPrefix::dataType(encoded), DataType::Int32);
+  EXPECT_EQ(EncodingPrefix::dataType(encoded), dataType);
   EXPECT_EQ(EncodingPrefix::readRowCount(encoded, useVarintRowCount), rowCount);
 
   const char* pos =
@@ -390,6 +433,24 @@ std::string_view encodeValues(
         std::move(policy), values, streamData.nonNulls(), buffer, options);
   }
   return EncodingFactory::encode<int32_t>(
+      std::move(policy), values, buffer, options);
+}
+
+std::string_view encodeValues(
+    TestStringSharedDictionaryWriter& writer,
+    size_t stripeIndex,
+    const StreamData& streamData,
+    Buffer& buffer,
+    const Encoding::Options& options = {}) {
+  NIMBLE_CHECK_EQ(
+      streamData.data().size() % sizeof(std::string_view),
+      0,
+      "Test stream has incomplete string values.");
+  const std::span<const std::string_view> values{
+      reinterpret_cast<const std::string_view*>(streamData.data().data()),
+      streamData.data().size() / sizeof(std::string_view)};
+  auto policy = writer.createEncodingPolicy(stripeIndex);
+  return EncodingFactory::encode<std::string_view>(
       std::move(policy), values, buffer, options);
 }
 
@@ -447,12 +508,16 @@ std::vector<uint32_t> nullableSharedDictionaryIndices(
       encodedNonNullValues, nonNullRowCount, pool, useVarintRowCount);
 }
 
+template <typename Values>
 void expectAlphabetEntries(
     const Chunk& alphabetChunk,
-    std::span<const int32_t> expectedValues,
+    const Values& expectedValues,
     velox::memory::MemoryPool* pool) {
+  using T = typename Values::value_type;
+  const std::span<const T> expectedValuesSpan{
+      expectedValues.data(), expectedValues.size()};
   EXPECT_EQ(
-      alphabetChunk.rowCount, static_cast<uint32_t>(expectedValues.size()));
+      alphabetChunk.rowCount, static_cast<uint32_t>(expectedValuesSpan.size()));
   ASSERT_EQ(alphabetChunk.content.size(), 1);
 
   auto encodedAlphabetOwner =
@@ -460,12 +525,12 @@ void expectAlphabetEntries(
   const std::string_view encodedAlphabet{*encodedAlphabetOwner};
   const auto alphabet = SharedDictionaryAlphabet::create(
       encodedAlphabet, std::move(encodedAlphabetOwner), pool);
-  std::vector<uint32_t> alphabetIndices(expectedValues.size());
+  std::vector<uint32_t> alphabetIndices(expectedValuesSpan.size());
   std::iota(alphabetIndices.begin(), alphabetIndices.end(), 0);
-  std::vector<TypeTraits<int32_t>::physicalType> entries(
+  std::vector<typename TypeTraits<T>::physicalType> entries(
       alphabetIndices.size());
-  alphabet->materialize<int32_t>(alphabetIndices, entries.data());
-  EXPECT_EQ(entries, physicalValues(expectedValues));
+  alphabet->materialize<T>(alphabetIndices, entries.data());
+  EXPECT_EQ(entries, physicalValues<T>(expectedValuesSpan));
 }
 
 class SharedDictionaryWriterTest : public testing::Test {
@@ -477,6 +542,16 @@ class SharedDictionaryWriterTest : public testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   StreamDescriptorBuilder descriptor_{11, ScalarKind::Int32};
 };
+
+struct StringScopeTestParam {
+  SharedDictionaryScope scope;
+  uint32_t dictionaryId;
+  bool usesResolver;
+};
+
+class StringSharedDictionaryWriterTest
+    : public SharedDictionaryWriterTest,
+      public testing::WithParamInterface<StringScopeTestParam> {};
 
 TEST_F(SharedDictionaryWriterTest, stripeScope) {
   struct StripeInput {
@@ -567,6 +642,90 @@ TEST_F(SharedDictionaryWriterTest, stripeScope) {
     }
   }
 }
+
+TEST_P(StringSharedDictionaryWriterTest, roundTrip) {
+  const auto testParam = GetParam();
+  StreamDescriptorBuilder descriptor{12, ScalarKind::String};
+  const std::array<std::string_view, 3> expectedAlphabet{
+      "bravo", "alpha", "charlie"};
+  std::shared_ptr<const ExternalDictionaryResolver> resolver;
+  if (testParam.usesResolver) {
+    resolver = std::make_shared<TestStringDictionaryResolver>(
+        testParam.dictionaryId, expectedAlphabet, pool_.get());
+  }
+  auto writer = TestStringSharedDictionaryWriter{
+      pool_.get(),
+      writerOptions(testParam.scope, testParam.dictionaryId, resolver)};
+  Buffer buffer{*pool_};
+
+  const std::vector<std::string_view> values{
+      "bravo", "alpha", "bravo", "charlie", "alpha"};
+  const auto encoded = encodeValues(
+      writer, /*stripeIndex=*/0, streamView(descriptor, values), buffer);
+
+  EXPECT_FALSE(encoded.empty());
+  EXPECT_EQ(
+      sharedDictionaryIndices(
+          encoded,
+          static_cast<uint32_t>(values.size()),
+          pool_.get(),
+          /*useVarintRowCount=*/false,
+          DataType::String),
+      (std::vector<uint32_t>{0, 1, 0, 2, 1}));
+
+  Encoding::Options options;
+  if (testParam.scope == SharedDictionaryScope::External) {
+    NIMBLE_ASSERT_THROW(
+        writer.encodeAlphabet(buffer),
+        "External shared dictionary 29 cannot encode an alphabet; its "
+        "resolver owns the alphabet.");
+    options.sharedDictionaryAlphabet =
+        resolver->resolve(testParam.dictionaryId, DataType::String);
+  } else {
+    const auto alphabetChunk = writer.encodeAlphabet(buffer);
+    ASSERT_TRUE(alphabetChunk.has_value());
+    expectAlphabetEntries(*alphabetChunk, expectedAlphabet, pool_.get());
+    auto encodedAlphabetOwner =
+        std::make_shared<const std::string>(alphabetChunk->content.front());
+    const std::string_view encodedAlphabet{*encodedAlphabetOwner};
+    options.sharedDictionaryAlphabet = SharedDictionaryAlphabet::create(
+        encodedAlphabet, std::move(encodedAlphabetOwner), pool_.get());
+  }
+  ASSERT_NE(options.sharedDictionaryAlphabet, nullptr);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding = EncodingFactory{options}.create(
+      *pool_, encoded, [&](uint32_t totalLength) -> void* {
+        auto& stringBuffer = stringBuffers.emplace_back(
+            velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+        return stringBuffer->asMutable<void>();
+      });
+
+  std::vector<std::string_view> materialized(encoding->rowCount());
+  encoding->materialize(encoding->rowCount(), materialized.data());
+  EXPECT_EQ(materialized, values);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Scopes,
+    StringSharedDictionaryWriterTest,
+    testing::Values(
+        StringScopeTestParam{
+            .scope = SharedDictionaryScope::Stripe,
+            .dictionaryId = 7,
+            .usesResolver = false},
+        StringScopeTestParam{
+            .scope = SharedDictionaryScope::File,
+            .dictionaryId = 17,
+            .usesResolver = false},
+        StringScopeTestParam{
+            .scope = SharedDictionaryScope::External,
+            .dictionaryId = 29,
+            .usesResolver = true}),
+    [](const testing::TestParamInfo<StringScopeTestParam>& testInfo) {
+      return std::string{
+          SharedDictionaryScopeName::toName(testInfo.param.scope)};
+    });
 
 TEST_F(SharedDictionaryWriterTest, nullableStripeScope) {
   auto writer = createTestWriter(

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -707,25 +707,23 @@ bool hasDictionaryConfig(const StreamData& streamData) {
       streamContext->sharedDictionaryConfig().has_value();
 }
 
-bool isSharedDictionaryValueType(DataType dataType) {
-  switch (dataType) {
-    case DataType::Int8:
-    case DataType::Uint8:
-    case DataType::Int16:
-    case DataType::Uint16:
-    case DataType::Int32:
-    case DataType::Uint32:
-    case DataType::Int64:
-    case DataType::Uint64:
+bool isSharedDictionaryScalarKind(ScalarKind scalarKind) {
+  return isIntegerScalarKind(scalarKind) || scalarKind == ScalarKind::String ||
+      scalarKind == ScalarKind::Binary;
+}
+
+bool isSharedDictionaryVeloxType(const velox::Type& type) {
+  switch (type.kind()) {
+    case velox::TypeKind::TINYINT:
+    case velox::TypeKind::SMALLINT:
+    case velox::TypeKind::INTEGER:
+    case velox::TypeKind::BIGINT:
+    case velox::TypeKind::VARCHAR:
+    case velox::TypeKind::VARBINARY:
       return true;
-    case DataType::Undefined:
-    case DataType::Float:
-    case DataType::Double:
-    case DataType::Bool:
-    case DataType::String:
+    default:
       return false;
   }
-  NIMBLE_UNREACHABLE("Unsupported data type {}.", dataType);
 }
 
 template <typename T>
@@ -789,11 +787,11 @@ std::unique_ptr<EncodingSelectionPolicy<T>> makeEncodingPolicy(
     const StreamData& streamData) {
   if (hasDictionaryConfig(streamData)) {
     NIMBLE_USER_CHECK(
-        isSharedDictionaryValueType(TypeTraits<T>::dataType),
-        "Shared dictionary encoding only supports non-bool integer streams, "
+        isSharedDictionaryType(TypeTraits<T>::dataType),
+        "Shared dictionary encoding only supports integer or string streams, "
         "got {}.",
         TypeTraits<T>::dataType);
-    if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+    if constexpr (isSharedDictionaryType<T>()) {
       auto* dictionaryWriter = sharedDictionaryWriter<T>(
           streamData,
           context,
@@ -829,8 +827,9 @@ void configureDictionary(
     case Kind::Scalar: {
       const auto& scalar = typeBuilder.asScalar();
       NIMBLE_USER_CHECK(
-          isIntegerScalarKind(scalar.scalarDescriptor().scalarKind()),
-          "Shared dictionary value must be an integer scalar, got {}.",
+          isSharedDictionaryScalarKind(scalar.scalarDescriptor().scalarKind()),
+          "Shared dictionary value must be an integer or string scalar, got "
+          "{}.",
           scalar.scalarDescriptor().scalarKind());
       if (config.scope == SharedDictionaryScope::Stripe) {
         NIMBLE_USER_CHECK_EQ(
@@ -868,8 +867,8 @@ void configureDictionary(
     case Kind::Row:
     case Kind::FlatMap:
       NIMBLE_USER_FAIL(
-          "Shared dictionary value must resolve to an integer scalar, array "
-          "element, or map value, got {}.",
+          "Shared dictionary value must resolve to an integer or string "
+          "scalar, array element, or map value, got {}.",
           typeBuilder.kind());
   }
 }
@@ -996,12 +995,12 @@ const TypeWithId& resolveDictionaryValueType(
     case velox::TypeKind::SMALLINT:
     case velox::TypeKind::INTEGER:
     case velox::TypeKind::BIGINT:
+    case velox::TypeKind::VARCHAR:
+    case velox::TypeKind::VARBINARY:
       return type;
     case velox::TypeKind::BOOLEAN:
     case velox::TypeKind::REAL:
     case velox::TypeKind::DOUBLE:
-    case velox::TypeKind::VARCHAR:
-    case velox::TypeKind::VARBINARY:
     case velox::TypeKind::TIMESTAMP:
     case velox::TypeKind::HUGEINT:
     case velox::TypeKind::ROW:
@@ -1010,8 +1009,8 @@ const TypeWithId& resolveDictionaryValueType(
     case velox::TypeKind::OPAQUE:
     case velox::TypeKind::INVALID:
       NIMBLE_USER_FAIL(
-          "Shared dictionary column '{}' must resolve to an integer scalar, "
-          "array element, or map value, got {}.",
+          "Shared dictionary column '{}' must resolve to an integer or string "
+          "scalar, array element, or map value, got {}.",
           fieldPath,
           type.type()->toString());
   }
@@ -1410,9 +1409,9 @@ DictionaryConfigs collectDictionaryConfigs(
         "node {}.",
         valueNodeId);
     NIMBLE_USER_CHECK(
-        valueType.type()->isInteger(),
-        "Shared dictionary column '{}' must resolve to an integer scalar, "
-        "array element, or map value, got {}.",
+        isSharedDictionaryVeloxType(*valueType.type()),
+        "Shared dictionary column '{}' must resolve to an integer or string "
+        "scalar, array element, or map value, got {}.",
         columnDictionary.fieldPath,
         valueType.type()->toString());
     maybeAddFileDictionaryId(columnDictionary.dictionary, fileDictionaryIds);


### PR DESCRIPTION
Summary:
Shared dictionary encoding can now store string columns instead of rejecting them as non-integer values. A string column configured for shared dictionary encoding writes dictionary indices and decodes back to the original values.

The encoding type check now accepts `std::string_view` alongside integer types. Factory and slice dispatch keep unsupported scalar types out of the shared dictionary path while allowing strings.

Differential Revision: D117560358


