### PR TITLE
perf(nimble): Preallocate index projector slice output buffer (#18712)

### DIFF
--- a/velox/dwio/nimble/serializer/StreamSlicer.cpp
+++ b/velox/dwio/nimble/serializer/StreamSlicer.cpp
@@ -174,17 +174,15 @@ uint32_t streamCount(const std::shared_ptr<const Type>& schema) {
   return maxStreamOffset(*schema) + 1;
 }
 
-using OwnedBufferChunks = std::vector<velox::BufferPtr>;
+using BufferChunks = std::vector<velox::BufferPtr>;
 
-void freeOwnedBufferChunks(void* /* buf */, void* userData) {
-  delete static_cast<std::shared_ptr<OwnedBufferChunks>*>(userData);
+void freeIOBufOwner(void* /* buf */, void* userData) {
+  delete static_cast<std::shared_ptr<const void>*>(userData);
 }
 
 // transferBuffers() transfers allocation ownership only, so capacity is the
 // valid ownership range for stream views.
-bool isBackedByChunks(
-    std::string_view stream,
-    const OwnedBufferChunks& chunks) {
+bool isBackedByChunks(std::string_view stream, const BufferChunks& chunks) {
   const auto streamBegin = reinterpret_cast<uintptr_t>(stream.data());
   const auto streamEnd = streamBegin + stream.size();
   for (const auto& chunk : chunks) {
@@ -199,7 +197,7 @@ bool isBackedByChunks(
 
 void checkStreamsBackedByChunks(
     const std::vector<std::string_view>& streams,
-    const OwnedBufferChunks& chunks) {
+    const BufferChunks& chunks) {
   for (const auto stream : streams) {
     if (stream.empty()) {
       continue;
@@ -212,9 +210,8 @@ void checkStreamsBackedByChunks(
 
 folly::IOBuf takeOwnershipAsIOBuf(
     const std::vector<std::string_view>& streams,
-    Buffer& buffer) {
-  auto chunks = std::make_shared<OwnedBufferChunks>(buffer.transferBuffers());
-  checkStreamsBackedByChunks(streams, *chunks);
+    std::shared_ptr<const void> owner) {
+  NIMBLE_CHECK_NOT_NULL(owner, "Stream owner must be initialized");
 
   std::unique_ptr<folly::IOBuf> chain;
   const char* runData{nullptr};
@@ -227,8 +224,8 @@ folly::IOBuf takeOwnershipAsIOBuf(
         const_cast<char*>(runData),
         runLength,
         runLength,
-        freeOwnedBufferChunks,
-        new std::shared_ptr<OwnedBufferChunks>(chunks));
+        freeIOBufOwner,
+        new std::shared_ptr<const void>(owner));
     if (chain == nullptr) {
       chain = std::move(node);
     } else {
@@ -281,6 +278,22 @@ StreamSlicer::StreamSlicer(
   NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool cannot be null");
 }
 
+folly::IOBuf StreamSlicer::takeOwnershipAsIOBuf(
+    const std::vector<std::string_view>& streams,
+    Buffer& buffer) {
+  auto chunks = std::make_shared<BufferChunks>(buffer.transferBuffers());
+  checkStreamsBackedByChunks(streams, *chunks);
+  return takeOwnershipAsIOBuf(
+      streams, std::shared_ptr<const void>{std::move(chunks)});
+}
+
+folly::IOBuf StreamSlicer::takeOwnershipAsIOBuf(
+    const std::vector<std::string_view>& streams,
+    std::shared_ptr<const void> owner) {
+  return ::facebook::nimble::serde::takeOwnershipAsIOBuf(
+      streams, std::move(owner));
+}
+
 folly::IOBuf StreamSlicer::slice(
     std::string_view input,
     uint32_t offset,
@@ -299,19 +312,16 @@ folly::IOBuf StreamSlicer::slice(
 
   inputStreams_.clear();
   inputStreams_.reserve(streamCount_);
-  size_t inputBodyBytes{0};
   parser.iterateStreams([&](uint32_t streamId, std::string_view streamData) {
     if (streamId >= inputStreams_.size()) {
       inputStreams_.resize(streamId + 1);
     }
     inputStreams_[streamId] = streamData;
-    inputBodyBytes += streamData.size();
   });
-  Buffer outputBuffer{*pool_, inputBodyBytes};
   auto slicedStreams = sliceStreams(
       inputStreams_,
       {.offset = offset, .length = length},
-      outputBuffer,
+      /*outputBuffer=*/nullptr,
       streamEncodingOptions(
           parser.streamEncodingUsesVarintRowCount(),
           &bufferPool_,
@@ -349,23 +359,21 @@ folly::IOBuf StreamSlicer::slice(
 StreamSlicer::SlicedStreams StreamSlicer::slice(
     const std::vector<std::string_view>& inputStreams,
     uint32_t offset,
-    uint32_t length) const {
+    uint32_t length,
+    Buffer* outputBuffer) const {
   NIMBLE_CHECK_GT(length, 0, "Slice length must be positive");
   NIMBLE_CHECK(
       !options_.streamHasChunkHeader || isTabletVersion(options_.streamVersion),
       "Chunk headers are only supported for kTablet streams");
+  const auto encodingOptions = streamEncodingOptions(
+      options_.streamVersion,
+      options_.streamsUseVarintRowCount,
+      &bufferPool_,
+      &encodingBufferPool_);
+  const Range range{.offset = offset, .length = length};
 
   if (!options_.streamHasChunkHeader) {
-    Buffer outputBuffer{*pool_, totalBytes(inputStreams)};
-    return sliceStreams(
-        inputStreams,
-        {.offset = offset, .length = length},
-        outputBuffer,
-        streamEncodingOptions(
-            options_.streamVersion,
-            options_.streamsUseVarintRowCount,
-            &bufferPool_,
-            &encodingBufferPool_));
+    return sliceStreams(inputStreams, range, outputBuffer, encodingOptions);
   }
 
   ScopedEncodingBuffer strippedStreamBuffer{pool_, &strippedStreamBufferPool_};
@@ -377,27 +385,30 @@ StreamSlicer::SlicedStreams StreamSlicer::slice(
       strippedStreamBuffer.get(),
       inputStreams_,
       strippedStreamCache_);
-  Buffer outputBuffer{*pool_, totalBytes(inputStreams_)};
-  return sliceStreams(
-      inputStreams_,
-      {.offset = offset, .length = length},
-      outputBuffer,
-      streamEncodingOptions(
-          options_.streamVersion,
-          options_.streamsUseVarintRowCount,
-          &bufferPool_,
-          &encodingBufferPool_));
+  return sliceStreams(inputStreams_, range, outputBuffer, encodingOptions);
 }
 
 StreamSlicer::SlicedStreams StreamSlicer::sliceStreams(
     const std::vector<std::string_view>& inputStreams,
     Range range,
-    Buffer& outputBuffer,
+    Buffer* outputBuffer,
     const Encoding::Options& encodingOptions) const {
   SlicedStreams result;
+  if (outputBuffer != nullptr) {
+    sliceType(
+        *schema_, range, inputStreams, result, *outputBuffer, encodingOptions);
+    return result;
+  }
+
+  Buffer ownedOutputBuffer{*pool_, totalBytes(inputStreams)};
   sliceType(
-      *schema_, range, inputStreams, result, outputBuffer, encodingOptions);
-  result.data = takeOwnershipAsIOBuf(result.streams, outputBuffer);
+      *schema_,
+      range,
+      inputStreams,
+      result,
+      ownedOutputBuffer,
+      encodingOptions);
+  result.data = takeOwnershipAsIOBuf(result.streams, ownedOutputBuffer);
   return result;
 }
 

--- a/velox/dwio/nimble/serializer/StreamSlicer.h
+++ b/velox/dwio/nimble/serializer/StreamSlicer.h
@@ -67,10 +67,12 @@ class StreamSlicer {
 
   /// Sliced stream-set result.
   struct SlicedStreams {
-    /// Owns the encoded bytes referenced by streams.
+    /// Owns the encoded bytes referenced by streams. Empty when slice() writes
+    /// into a caller-provided output buffer.
     folly::IOBuf data;
 
-    /// Views ordered by stream offset, backed by data.
+    /// Views ordered by stream offset, backed by either data or the output
+    /// buffer supplied to slice().
     std::vector<std::string_view> streams;
 
     /// Indicates whether the stream set needs a row null-barrier on read.
@@ -79,11 +81,26 @@ class StreamSlicer {
 
   /// Returns compact raw streams containing rows [offset, offset + length).
   /// The raw-stream input format is configured in Options. The returned
-  /// streams never contain chunk headers.
+  /// streams never contain chunk headers. When outputBuffer is non-null, the
+  /// returned stream views point into it and the caller must keep its chunks
+  /// alive for as long as those views are used.
   SlicedStreams slice(
       const std::vector<std::string_view>& inputStreams,
       uint32_t offset,
-      uint32_t length) const;
+      uint32_t length,
+      Buffer* outputBuffer = nullptr) const;
+
+  /// Returns an IOBuf chain over non-empty streams backed by transferred buffer
+  /// chunks. Empty streams are skipped and adjacent views share one IOBuf node.
+  static folly::IOBuf takeOwnershipAsIOBuf(
+      const std::vector<std::string_view>& streams,
+      Buffer& buffer);
+
+  /// Returns an IOBuf chain over non-empty streams and retains owner on each
+  /// node. Streams may point to other storage that the caller keeps alive.
+  static folly::IOBuf takeOwnershipAsIOBuf(
+      const std::vector<std::string_view>& streams,
+      std::shared_ptr<const void> owner);
 
  private:
   // Top-level row range in the current stream's row domain.
@@ -111,11 +128,12 @@ class StreamSlicer {
       Buffer& outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
-  // Returns sliced stream views backed by an owned output buffer.
+  // Returns sliced streams. When outputBuffer is non-null, stream views are
+  // backed by it. Otherwise data owns the output bytes.
   SlicedStreams sliceStreams(
       const std::vector<std::string_view>& inputStreams,
       Range range,
-      Buffer& outputBuffer,
+      Buffer* outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
   // Returns true when the descriptor points to a present, non-empty stream.

--- a/velox/dwio/nimble/serializer/tests/StreamSlicerTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/StreamSlicerTest.cpp
@@ -358,27 +358,31 @@ class StreamSlicerTest : public ::testing::Test {
     };
   }
 
-  // Only the formats the payload overload accepts. Tablet payloads are
-  // rejected there, which `slicesScalarPayload` covers; tablet slicing itself
-  // stays covered through the raw-stream API.
-  std::vector<SlicerPayload> makePayloads(
+  SlicerPayload makePayload(
       const std::string& serialized,
       const std::shared_ptr<const nimble::Type>& schema,
-      const std::vector<std::string>& columnNames) {
-    auto [projected, projectedSchema] =
-        projectAllColumns(serialized, schema, columnNames);
-    return {
-        {
-            .kind = SlicerPayloadKind::kSerialization,
+      const std::vector<std::string>& columnNames,
+      SlicerPayloadKind kind) {
+    switch (kind) {
+      case SlicerPayloadKind::kSerialization:
+        return {
+            .kind = kind,
             .data = serialized,
             .schema = schema,
-        },
-        {
-            .kind = SlicerPayloadKind::kProjection,
+        };
+      case SlicerPayloadKind::kProjection: {
+        auto [projected, projectedSchema] =
+            projectAllColumns(serialized, schema, columnNames);
+        return {
+            .kind = kind,
             .data = std::move(projected),
             .schema = std::move(projectedSchema),
-        },
-    };
+        };
+      }
+      case SlicerPayloadKind::kTabletUncompressed:
+      case SlicerPayloadKind::kTabletZstd:
+        NIMBLE_FAIL("Unsupported payload kind: {}", toString(kind));
+    }
   }
 
   VectorPtr deserialize(
@@ -414,6 +418,15 @@ class StreamSlicerTest : public ::testing::Test {
     EXPECT_EQ(readColumn<int32_t>(vector), expected);
   }
 
+  static size_t inputStreamBytes(
+      const std::vector<std::string_view>& inputStreams) {
+    size_t bytes{0};
+    for (const auto stream : inputStreams) {
+      bytes += stream.size();
+    }
+    return bytes;
+  }
+
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
@@ -421,6 +434,14 @@ class StreamSlicerTest : public ::testing::Test {
 class StreamSlicerPayloadVersionTest
     : public StreamSlicerTest,
       public ::testing::WithParamInterface<SlicerPayloadKind> {};
+
+class StreamSlicerPayloadApiTest
+    : public StreamSlicerTest,
+      public ::testing::WithParamInterface<SlicerPayloadKind> {};
+
+class StreamSlicerRawStreamApiTest
+    : public StreamSlicerTest,
+      public ::testing::WithParamInterface<bool> {};
 
 TEST_P(StreamSlicerPayloadVersionTest, slicesScalarPayload) {
   const auto payloadKind = GetParam();
@@ -490,10 +511,11 @@ INSTANTIATE_TEST_SUITE_P(
         SlicerPayloadKind::kTabletZstd),
     [](const auto& info) { return toString(info.param); });
 
-TEST_F(StreamSlicerTest, fuzzesRandomSchemasAndNullableData) {
+TEST_P(StreamSlicerPayloadApiTest, fuzzesRandomSchemasAndNullableData) {
   constexpr uint32_t kSeed{12345};
   constexpr uint32_t kIterations{32};
   constexpr uint32_t kMinSliceRows{8};
+  const auto payloadKind = GetParam();
   const std::vector<TypePtr> scalarTypes{
       BOOLEAN(), INTEGER(), BIGINT(), REAL(), DOUBLE(), VARCHAR()};
   VectorFuzzer fuzzer(
@@ -567,21 +589,21 @@ TEST_F(StreamSlicerTest, fuzzesRandomSchemasAndNullableData) {
       projectionSubfields.emplace_back(
           fmt::format("flat_map[{}]", flatMap.nameAt(i)));
     }
-    for (const auto& payload :
-         makePayloads(serialized, schema, projectionSubfields)) {
-      SCOPED_TRACE(toString(payload.kind));
-      StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
-      auto sliced = iobufToString(slicer.slice(payload.data, offset, length));
-      auto output = deserialize(sliced, payload.schema);
-      ASSERT_EQ(output->size(), length);
-      for (uint32_t i = 0; i < length; ++i) {
-        EXPECT_TRUE(input->equalValueAt(output.get(), offset + i, i));
-      }
+    auto payload =
+        makePayload(serialized, schema, projectionSubfields, payloadKind);
+    SCOPED_TRACE(toString(payload.kind));
+    StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
+    auto sliced = iobufToString(slicer.slice(payload.data, offset, length));
+    auto output = deserialize(sliced, payload.schema);
+    ASSERT_EQ(output->size(), length);
+    for (uint32_t i = 0; i < length; ++i) {
+      EXPECT_TRUE(input->equalValueAt(output.get(), offset + i, i));
     }
   }
 }
 
-TEST_F(StreamSlicerTest, fuzzesRawStreamApi) {
+TEST_P(StreamSlicerRawStreamApiTest, fuzzesRawStreamApi) {
+  const bool useOutputBuffer = GetParam();
   std::mt19937 rng{67890};
   auto type = ROW({{"id", INTEGER()}});
 
@@ -627,7 +649,16 @@ TEST_F(StreamSlicerTest, fuzzesRawStreamApi) {
                 .streamsUseVarintRowCount = useVarintRowCount,
             };
       StreamSlicer slicer{schema, pool_.get(), options};
-      auto sliced = slicer.slice(inputStreams, offset, length);
+      std::optional<Buffer> outputBuffer;
+      if (useOutputBuffer) {
+        outputBuffer.emplace(*pool_, inputStreamBytes(inputStreams));
+      }
+      auto sliced = slicer.slice(
+          inputStreams,
+          offset,
+          length,
+          outputBuffer.has_value() ? &outputBuffer.value() : nullptr);
+      EXPECT_EQ(sliced.data.computeChainDataLength() == 0, useOutputBuffer);
       ASSERT_LT(streamId, sliced.streams.size());
       ASSERT_FALSE(sliced.streams[streamId].empty());
 
@@ -644,7 +675,102 @@ TEST_F(StreamSlicerTest, fuzzesRawStreamApi) {
   }
 }
 
-TEST_F(StreamSlicerTest, slicesFlatMap) {
+TEST_F(StreamSlicerTest, ownsSlicedStreamOutputBuffers) {
+  auto writeStreams = [&](Buffer& buffer) {
+    return std::vector<std::string_view>{
+        buffer.writeString("abc"),
+        {},
+        buffer.writeString("def"),
+    };
+  };
+
+  {
+    Buffer buffer{*pool_};
+    const auto streams = writeStreams(buffer);
+    auto body = StreamSlicer::takeOwnershipAsIOBuf(streams, buffer);
+    EXPECT_EQ(iobufToString(body), "abcdef");
+  }
+
+  {
+    Buffer buffer{*pool_};
+    const auto streams = writeStreams(buffer);
+    auto chunks = std::make_shared<std::vector<velox::BufferPtr>>(
+        buffer.transferBuffers());
+    auto body = StreamSlicer::takeOwnershipAsIOBuf(
+        streams, std::shared_ptr<const void>{std::move(chunks)});
+    EXPECT_EQ(iobufToString(body), "abcdef");
+  }
+
+  {
+    Buffer buffer{*pool_};
+    auto body = StreamSlicer::takeOwnershipAsIOBuf(
+        std::vector<std::string_view>{}, buffer);
+    EXPECT_EQ(body.computeChainDataLength(), 0);
+  }
+}
+
+TEST_F(StreamSlicerTest, fuzzesSlicedStreamOutputBufferOwnership) {
+  constexpr uint32_t kSeed{0x136a7329};
+  constexpr uint32_t kIterations{128};
+  std::mt19937 rng{kSeed};
+  std::uniform_int_distribution<size_t> numStreamsDistribution{0, 32};
+  std::uniform_int_distribution<size_t> streamSizeDistribution{0, 256};
+  std::uniform_int_distribution<int> byteDistribution{0, 255};
+
+  auto makeBody = [&](bool useSharedOwner,
+                      std::string& expected) -> folly::IOBuf {
+    Buffer buffer{*pool_, /*initialChunkSize=*/64};
+    std::vector<std::string_view> streams;
+    const auto numStreams = numStreamsDistribution(rng);
+    streams.reserve(numStreams);
+    expected.clear();
+    for (size_t i{0}; i < numStreams; ++i) {
+      const auto streamSize = streamSizeDistribution(rng);
+      if (streamSize == 0) {
+        streams.emplace_back();
+        continue;
+      }
+      std::string payload(streamSize, '\0');
+      for (char& byte : payload) {
+        byte = static_cast<char>(byteDistribution(rng));
+      }
+      streams.emplace_back(buffer.writeString(payload));
+      expected.append(payload);
+    }
+
+    if (useSharedOwner) {
+      auto chunks = std::make_shared<std::vector<velox::BufferPtr>>(
+          buffer.transferBuffers());
+      return StreamSlicer::takeOwnershipAsIOBuf(
+          streams, std::shared_ptr<const void>{std::move(chunks)});
+    }
+    return StreamSlicer::takeOwnershipAsIOBuf(streams, buffer);
+  };
+
+  for (uint32_t iteration{0}; iteration < kIterations; ++iteration) {
+    for (const bool useSharedOwner : {false, true}) {
+      SCOPED_TRACE(
+          fmt::format(
+              "seed={} iteration={} useSharedOwner={}",
+              kSeed,
+              iteration,
+              useSharedOwner));
+      std::string expected;
+      auto body = makeBody(useSharedOwner, expected);
+      EXPECT_EQ(iobufToString(body), expected);
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OutputStorage,
+    StreamSlicerRawStreamApiTest,
+    ::testing::Bool(),
+    [](const auto& info) {
+      return info.param ? "CallerOutputBuffer" : "OwnedOutputBuffer";
+    });
+
+TEST_P(StreamSlicerPayloadApiTest, slicesFlatMap) {
   auto type = ROW({{"features", MAP(INTEGER(), INTEGER())}});
   auto features = makeMapVector(
       {2, 1, 0, 1, 2},
@@ -663,36 +789,35 @@ TEST_F(StreamSlicerTest, slicesFlatMap) {
   auto schema =
       SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
 
-  for (const auto& payload :
-       makePayloads(serialized, schema, {"features[1]", "features[2]"})) {
-    SCOPED_TRACE(toString(payload.kind));
-    StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
-    auto sliced =
-        iobufToString(slicer.slice(payload.data, /*offset=*/1, /*length=*/3));
+  auto payload = makePayload(
+      serialized, schema, {"features[1]", "features[2]"}, GetParam());
+  StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
+  auto sliced =
+      iobufToString(slicer.slice(payload.data, /*offset=*/1, /*length=*/3));
 
-    const char* pos = sliced.data();
-    const auto header =
-        readSerializationHeader(pos, sliced.data() + sliced.size(), true);
-    EXPECT_TRUE(header.flags.requiresNullBarrier);
+  const char* pos = sliced.data();
+  const auto header =
+      readSerializationHeader(pos, sliced.data() + sliced.size(), true);
+  EXPECT_TRUE(header.flags.requiresNullBarrier);
 
-    auto output = deserialize(sliced, payload.schema);
-    ASSERT_EQ(output->size(), 3);
-    for (uint32_t i = 0; i < 3; ++i) {
-      EXPECT_TRUE(input->equalValueAt(output.get(), i + 1, i));
-    }
+  auto output = deserialize(sliced, payload.schema);
+  ASSERT_EQ(output->size(), 3);
+  for (uint32_t i = 0; i < 3; ++i) {
+    EXPECT_TRUE(input->equalValueAt(output.get(), i + 1, i));
   }
 }
 
-TEST_F(StreamSlicerTest, slicesEmptyArrayElementRange) {
+TEST_P(StreamSlicerPayloadApiTest, slicesEmptyArrayElementRange) {
   auto type = ROW({{"items", ARRAY(INTEGER())}});
   auto items =
       makeArrayVector({2, 0, 3}, makeFlatVector<int32_t>({10, 11, 20, 21, 22}));
   auto input = makeRowVector({"items"}, {items});
   auto [serialized, schema] = serialize(input, type);
+  auto payload = makePayload(serialized, schema, {"items"}, GetParam());
 
-  StreamSlicer slicer{schema, pool_.get(), StreamSlicer::Options{}};
-  auto sliced = iobufToString(slicer.slice(serialized, /*offset=*/1, 1));
-  auto output = deserialize(sliced, schema);
+  StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
+  auto sliced = iobufToString(slicer.slice(payload.data, /*offset=*/1, 1));
+  auto output = deserialize(sliced, payload.schema);
 
   ASSERT_EQ(output->size(), 1);
   auto* row = output->as<RowVector>();
@@ -702,23 +827,24 @@ TEST_F(StreamSlicerTest, slicesEmptyArrayElementRange) {
   EXPECT_EQ(arrays->sizeAt(0), 0);
 }
 
-TEST_F(StreamSlicerTest, returnsInputForFullPayloadSlice) {
+TEST_P(StreamSlicerPayloadApiTest, returnsInputForFullPayloadSlice) {
   auto type = ROW({{"id", INTEGER()}});
   auto input =
       makeRowVector({"id"}, {makeFlatVector<int32_t>({10, 20, 30, 40, 50})});
   auto [serialized, schema] = serialize(input, type);
+  auto payload = makePayload(serialized, schema, {"id"}, GetParam());
 
-  StreamSlicer slicer{schema, pool_.get(), StreamSlicer::Options{}};
+  StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
   auto sliced = iobufToString(slicer.slice(
-      serialized, /*offset=*/0, static_cast<uint32_t>(input->size())));
+      payload.data, /*offset=*/0, static_cast<uint32_t>(input->size())));
 
-  EXPECT_EQ(sliced, serialized);
-  auto output = deserialize(sliced, schema);
+  EXPECT_EQ(sliced, payload.data);
+  auto output = deserialize(sliced, payload.schema);
   const std::vector<int32_t> expected{10, 20, 30, 40, 50};
   EXPECT_EQ(readColumn<int32_t>(output), expected);
 }
 
-TEST_F(StreamSlicerTest, slicesForcedIntegerEncodings) {
+TEST_P(StreamSlicerPayloadApiTest, slicesForcedIntegerEncodings) {
   const std::vector<std::pair<EncodingType, std::vector<int32_t>>> cases{
       {EncodingType::RLE, {10, 10, 20, 20, 20, 30, 40}},
       {EncodingType::Dictionary, {10, 20, 10, 30, 20, 40, 10}},
@@ -739,33 +865,35 @@ TEST_F(StreamSlicerTest, slicesForcedIntegerEncodings) {
     auto input = makeRowVector({"id"}, {makeFlatVector<int32_t>(values)});
     auto [serialized, schema] = serialize(
         input, type, encodingType, /*compressionOptions=*/std::nullopt);
+    auto payload = makePayload(serialized, schema, {"id"}, GetParam());
 
-    StreamSlicer slicer{schema, pool_.get(), StreamSlicer::Options{}};
-    auto sliced = iobufToString(slicer.slice(serialized, 2, 3));
-    auto output = deserialize(sliced, schema);
+    StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
+    auto sliced = iobufToString(slicer.slice(payload.data, 2, 3));
+    auto output = deserialize(sliced, payload.schema);
 
     const std::vector<int32_t> expected{values.begin() + 2, values.begin() + 5};
     EXPECT_EQ(readColumn<int32_t>(output), expected);
   }
 }
 
-TEST_F(StreamSlicerTest, slicesAlpEncoding) {
+TEST_P(StreamSlicerPayloadApiTest, slicesAlpEncoding) {
   auto type = ROW({{"value", REAL()}});
   const std::vector<float> values{
       1.25f, 1.50f, 1.75f, 2.00f, 2.25f, 2.50f, 2.75f};
   auto input = makeRowVector({"value"}, {makeFlatVector<float>(values)});
   auto [serialized, schema] = serialize(
       input, type, EncodingType::ALP, /*compressionOptions=*/std::nullopt);
+  auto payload = makePayload(serialized, schema, {"value"}, GetParam());
 
-  StreamSlicer slicer{schema, pool_.get(), StreamSlicer::Options{}};
-  auto sliced = iobufToString(slicer.slice(serialized, 2, 3));
-  auto output = deserialize(sliced, schema);
+  StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
+  auto sliced = iobufToString(slicer.slice(payload.data, 2, 3));
+  auto output = deserialize(sliced, payload.schema);
 
   const std::vector<float> expected{values.begin() + 2, values.begin() + 5};
   EXPECT_EQ(readColumn<float>(output), expected);
 }
 
-TEST_F(StreamSlicerTest, slicesCompressedTrivialStream) {
+TEST_P(StreamSlicerPayloadApiTest, slicesCompressedTrivialStream) {
   auto type = ROW({{"id", INTEGER()}});
   std::vector<int32_t> values(1024, 7);
   for (size_t i = 0; i < values.size(); i += 128) {
@@ -779,26 +907,28 @@ TEST_F(StreamSlicerTest, slicesCompressedTrivialStream) {
   };
   auto [serialized, schema] = serialize(
       input, type, EncodingType::Trivial, std::move(compressionOptions));
+  auto payload = makePayload(serialized, schema, {"id"}, GetParam());
 
-  StreamSlicer slicer{schema, pool_.get(), StreamSlicer::Options{}};
-  auto sliced = iobufToString(slicer.slice(serialized, 127, 4));
-  auto output = deserialize(sliced, schema);
+  StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
+  auto sliced = iobufToString(slicer.slice(payload.data, 127, 4));
+  auto output = deserialize(sliced, payload.schema);
 
   const std::vector<int32_t> expected{
       values.begin() + 127, values.begin() + 131};
   EXPECT_EQ(readColumn<int32_t>(output), expected);
 }
 
-TEST_F(StreamSlicerTest, slicesArrayChildRange) {
+TEST_P(StreamSlicerPayloadApiTest, slicesArrayChildRange) {
   auto elements = makeFlatVector<int32_t>({10, 11, 20, 21, 22, 30});
   auto arrays = makeArrayVector({2, 0, 3, 1}, elements);
   auto type = ROW({{"items", ARRAY(INTEGER())}});
   auto input = makeRowVector({"items"}, {arrays});
   auto [serialized, schema] = serialize(input, type);
+  auto payload = makePayload(serialized, schema, {"items"}, GetParam());
 
-  StreamSlicer slicer{schema, pool_.get(), StreamSlicer::Options{}};
-  auto sliced = iobufToString(slicer.slice(serialized, 2, 2));
-  auto output = deserialize(sliced, schema);
+  StreamSlicer slicer{payload.schema, pool_.get(), StreamSlicer::Options{}};
+  auto sliced = iobufToString(slicer.slice(payload.data, 2, 2));
+  auto output = deserialize(sliced, payload.schema);
 
   ASSERT_EQ(output->size(), 2);
   auto* row = output->as<RowVector>();
@@ -814,6 +944,14 @@ TEST_F(StreamSlicerTest, slicesArrayChildRange) {
   EXPECT_EQ(values->valueAt(2), 22);
   EXPECT_EQ(values->valueAt(3), 30);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    AcceptedPayload,
+    StreamSlicerPayloadApiTest,
+    ::testing::Values(
+        SlicerPayloadKind::kSerialization,
+        SlicerPayloadKind::kProjection),
+    [](const auto& info) { return toString(info.param); });
 
 TEST_F(StreamSlicerTest, rejectsZeroLengthSlice) {
   auto type = ROW({{"id", INTEGER()}});

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/nimble/velox/index/NimbleIndexProjector.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "folly/ScopeGuard.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -286,6 +287,7 @@ void NimbleIndexProjector::prepareStripes() {
   ctx_.plan.numRows.reserve(ctx_.stripeRanges.numStripes);
   ctx_.plan.requiresNullBarriers.reserve(ctx_.stripeRanges.numStripes);
   ctx_.plan.numStreams.reserve(ctx_.stripeRanges.numStripes);
+  ctx_.plan.projectedBytes.reserve(ctx_.stripeRanges.numStripes);
   ctx_.plan.stripeFileOffsets.reserve(ctx_.stripeRanges.numStripes);
   ctx_.plan.stripeRangeOffsets.reserve(ctx_.stripeRanges.numStripes + 1);
   ctx_.plan.projectedStreams.reserve(
@@ -383,6 +385,7 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.plan.numRows.clear();
   ctx_.plan.requiresNullBarriers.clear();
   ctx_.plan.numStreams.clear();
+  ctx_.plan.projectedBytes.clear();
   ctx_.plan.stripeFileOffsets.clear();
   ctx_.plan.projectedStreams.clear();
   ctx_.plan.stripeRangeOffsets.clear();
@@ -393,9 +396,12 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.dataInputIndices.clear();
   ctx_.dataHandle.reset();
   ctx_.packedStripes.clear();
+  ctx_.stripePackRanges.clear();
   ctx_.rowsPerRequest.clear();
   ctx_.sliceCounts.clear();
   ctx_.emittedSlices.clear();
+  ctx_.sliceOutputBuffer.reset();
+  ctx_.sliceOutputChunks.reset();
   ctx_.packScratch.clear();
   ctx_.streamViewsScratch.clear();
   dataInput_->clear();
@@ -523,14 +529,85 @@ NimbleIndexProjector::Result NimbleIndexProjector::processStripes() {
   Result result;
   result.responses.resize(ctx_.numRequests);
   ctx_.packedStripes.resize(ctx_.plan.stripeIndices.size());
+  const auto estimatedSliceOutputBytes = prepareStripePackRanges();
+  const bool hasSlicedStripes = estimatedSliceOutputBytes > 0;
+  if (hasSlicedStripes) {
+    ctx_.sliceOutputBuffer =
+        std::make_unique<Buffer>(*pool_, estimatedSliceOutputBytes);
+    ctx_.sliceOutputChunks = std::make_shared<std::vector<velox::BufferPtr>>();
+  }
 
   for (size_t i = 0; i < ctx_.plan.stripeIndices.size(); ++i) {
     ++stats_.numReadStripes;
-    ctx_.packedStripes[i] = packStripe(i);
+    ctx_.packedStripes[i] = packStripe(i, ctx_.stripePackRanges[i]);
+  }
+  if (hasSlicedStripes) {
+    finalizeSliceOutputBuffer();
   }
   setResumeKeys(result);
   buildResult(result);
   return result;
+}
+
+uint64_t NimbleIndexProjector::prepareStripePackRanges() {
+  uint64_t estimatedSlicedBytes{0};
+  ctx_.stripePackRanges.resize(ctx_.plan.stripeIndices.size());
+  for (size_t stripeOffset{0}; stripeOffset < ctx_.plan.stripeIndices.size();
+       ++stripeOffset) {
+    const RowRange stripeRange{0, ctx_.plan.numRows[stripeOffset]};
+    const auto packRange = stripeRowRangeToPack(stripeOffset);
+    ctx_.stripePackRanges[stripeOffset] = packRange;
+    if (packRange != stripeRange) {
+      // Full-stripe packing reuses loaded stream views; only sliced stripes
+      // need caller-owned output buffer capacity.
+      estimatedSlicedBytes +=
+          estimateSlicedStripeBytes(stripeOffset, packRange);
+    }
+  }
+  return estimatedSlicedBytes;
+}
+
+uint64_t NimbleIndexProjector::estimateSlicedStripeBytes(
+    size_t stripeOffset,
+    const RowRange& packRange) const {
+  NIMBLE_CHECK_LT(
+      stripeOffset,
+      ctx_.plan.stripeIndices.size(),
+      "Stripe offset is out of range");
+  const auto numRows = ctx_.plan.numRows[stripeOffset];
+  NIMBLE_CHECK_GT(numRows, 0, "Stripe must contain rows");
+  NIMBLE_CHECK_LE(
+      packRange.numRows(), numRows, "Pack range cannot exceed stripe rows");
+  const auto scaledBytes = static_cast<uint64_t>(std::ceil(
+      static_cast<double>(ctx_.plan.projectedBytes[stripeOffset]) *
+      packRange.numRows() / numRows));
+  // Sliced stream payload bytes scale with rows, but per-stream metadata and
+  // output-buffer allocation granularity need extra room.
+  const auto estimatedStreamOverheadBytes =
+      static_cast<uint64_t>(ctx_.plan.numStreams[stripeOffset]) * 32 + 4096;
+  return std::max(
+             scaledBytes + scaledBytes / 4,
+             ctx_.plan.projectedBytes[stripeOffset] / 2) +
+      estimatedStreamOverheadBytes;
+}
+
+Buffer& NimbleIndexProjector::sliceOutputBuffer() {
+  NIMBLE_CHECK_NOT_NULL(
+      ctx_.sliceOutputBuffer, "Sliced output buffer must be initialized");
+  return *ctx_.sliceOutputBuffer;
+}
+
+void NimbleIndexProjector::finalizeSliceOutputBuffer() {
+  NIMBLE_CHECK_NOT_NULL(
+      ctx_.sliceOutputBuffer, "Sliced output buffer must be initialized");
+  NIMBLE_CHECK_NOT_NULL(
+      ctx_.sliceOutputChunks, "Sliced output chunk owner must be initialized");
+  // Partial-stripe IOBuf nodes already hold shared_ptr copies to this vector.
+  // Populate it now so those nodes keep the transferred Buffer chunks alive,
+  // then drop the context's reference.
+  *ctx_.sliceOutputChunks = ctx_.sliceOutputBuffer->transferBuffers();
+  ctx_.sliceOutputBuffer.reset();
+  ctx_.sliceOutputChunks.reset();
 }
 
 uint64_t NimbleIndexProjector::appendStripePlan(
@@ -543,6 +620,7 @@ uint64_t NimbleIndexProjector::appendStripePlan(
   plan.numRows.push_back(stripeRowCount(stripeIndex));
   plan.requiresNullBarriers.push_back(false);
   plan.numStreams.push_back(0);
+  plan.projectedBytes.push_back(0);
   plan.stripeFileOffsets.push_back(tablet_->stripeOffset(stripeIndex));
   plan.stripeRangeOffsets.push_back(rangeOffset);
   plan.projectedStreams.resize((stripeOffset + 1) * numProjectedStreams);
@@ -566,6 +644,7 @@ uint64_t NimbleIndexProjector::appendStripePlan(
       plan.requiresNullBarriers.back() = true;
     }
   }
+  plan.projectedBytes.back() = projectedBytes;
   return projectedBytes;
 }
 
@@ -630,7 +709,8 @@ RowRange NimbleIndexProjector::stripeRowRangeToPack(size_t stripeOffset) const {
 }
 
 NimbleIndexProjector::PackedStripe NimbleIndexProjector::packStripe(
-    size_t stripeOffset) {
+    size_t stripeOffset,
+    const RowRange& packRange) {
   const auto numProjectedStreams = projection_->streamOffsets.size();
   auto& packScratch = ctx_.packScratch;
   SCOPE_EXIT {
@@ -638,7 +718,6 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packStripe(
   };
   packScratch.reserve(numProjectedStreams);
   const RowRange stripeRange{0, ctx_.plan.numRows[stripeOffset]};
-  const auto packRange = stripeRowRangeToPack(stripeOffset);
   if (packRange == stripeRange) {
     return packFullStripe(stripeOffset);
   }
@@ -832,7 +911,10 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packPartialStripe(
   const auto& loadedStreams =
       collectStripeStreamViews(stripeOffset, /*resolveCanonicalStreams=*/false);
   auto sliced = streamSlicer_->slice(
-      loadedStreams.streams, packRange.startRow, packRange.numRows());
+      loadedStreams.streams,
+      packRange.startRow,
+      packRange.numRows(),
+      &sliceOutputBuffer());
 
   size_t bodySize{0};
   auto& packScratch = ctx_.packScratch;
@@ -852,7 +934,9 @@ NimbleIndexProjector::PackedStripe NimbleIndexProjector::packPartialStripe(
   NIMBLE_CHECK_GT(
       bodySize, 0, "Non-empty partial stripe must produce a sliced body");
 
-  auto chain = std::make_unique<folly::IOBuf>(std::move(sliced.data));
+  auto slicedBody = serde::StreamSlicer::takeOwnershipAsIOBuf(
+      sliced.streams, std::shared_ptr<const void>{ctx_.sliceOutputChunks});
+  auto chain = std::make_unique<folly::IOBuf>(std::move(slicedBody));
   NIMBLE_CHECK_EQ(
       bodySize,
       chain->computeChainDataLength(),

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -25,6 +25,7 @@
 #include "velox/common/caching/FileHandle.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/index/ClusterIndex.h"
 #include "velox/dwio/nimble/tablet/DataInput.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
@@ -279,6 +280,8 @@ class NimbleIndexProjector {
     std::vector<bool> requiresNullBarriers;
     // Number of projected streams present in each planned stripe.
     std::vector<uint32_t> numStreams;
+    // Total logical bytes across all projected streams in each planned stripe.
+    std::vector<uint64_t> projectedBytes;
     // File offsets for stripe stream payloads.
     std::vector<uint64_t> stripeFileOffsets;
     // Flat reusable storage for all per-stripe projected stream slots. Each
@@ -334,6 +337,23 @@ class NimbleIndexProjector {
   // and finalizes the result.
   Result processStripes();
 
+  // Computes per-stripe pack ranges and returns the upper-bound byte estimate
+  // used to allocate the sliced-output arena. Returns 0 when no stripe will be
+  // sliced.
+  uint64_t prepareStripePackRanges();
+
+  // Estimates sliced stream bytes for a partial stripe pack.
+  uint64_t estimateSlicedStripeBytes(
+      size_t stripeOffset,
+      const RowRange& packRange) const;
+
+  // Returns the per-project() sliced-output arena.
+  Buffer& sliceOutputBuffer();
+
+  // Transfers sliced-output arena chunks to the shared owner referenced by the
+  // packed stripe IOBufs.
+  void finalizeSliceOutputBuffer();
+
   // Loaded projected stream views and optional source deduplication metadata.
   struct StripeStreamViews {
     void clear() {
@@ -367,7 +387,7 @@ class NimbleIndexProjector {
   };
 
   // Selects full or partial packing based on the requested stripe range.
-  PackedStripe packStripe(size_t stripeOffset);
+  PackedStripe packStripe(size_t stripeOffset, const RowRange& packRange);
 
   // Packs a full stripe zero-copy while preserving source stream deduplication.
   PackedStripe packFullStripe(size_t stripeOffset);
@@ -421,7 +441,7 @@ class NimbleIndexProjector {
     StripeRanges stripeRanges;
     // Populated by prepareStripes().
     ScanPlan plan;
-    // Per-request flag: true if the request has ranges in any StripePlan.
+    // Per-request flag: true if the request has ranges in any planned stripe.
     // Set by prepareStripes(), used by setResumeKeys().
     std::vector<bool> hasStripeRanges;
     // Per-request resume keys set when a request reaches maxRowsPerRequest and
@@ -433,13 +453,21 @@ class NimbleIndexProjector {
     std::vector<std::optional<uint32_t>> dataInputIndices;
     // Handle keeping loaded data alive for zero-copy BufferRefs.
     DataInput::Handle dataHandle;
-    // Serialized stripe bodies and metadata, one per StripePlan. Populated by
-    // processStripes(), consumed during buildResult().
+    // Serialized stripe bodies and metadata, one per planned stripe. Populated
+    // by processStripes(), consumed during buildResult().
     std::vector<PackedStripe> packedStripes;
+    // Per planned stripe row range selected for packing. Full-stripe ranges use
+    // zero-copy packing; narrower ranges use StreamSlicer.
+    std::vector<RowRange> stripePackRanges;
     // Reusable per-request vectors.
     std::vector<uint64_t> rowsPerRequest;
     std::vector<size_t> sliceCounts;
     std::vector<size_t> emittedSlices;
+    // Shared arena for all sliced stream bytes produced by one project() call.
+    // The arena is transferred into sliceOutputChunks after all sliced stripes
+    // have been packed, letting result IOBufs share the same chunk owner.
+    std::unique_ptr<Buffer> sliceOutputBuffer;
+    std::shared_ptr<std::vector<velox::BufferPtr>> sliceOutputChunks;
 
     // Reusable per-stripe inputs for the kTablet trailer. packStripe()
     // rebuilds these vectors for each stripe and clears them on exit to avoid

--- a/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -907,6 +907,44 @@ TEST_P(NimbleIndexProjectorTest, slicesStripeBasedOnOverfetchRatio) {
   }
 }
 
+TEST_P(NimbleIndexProjectorTest, slicesPartialStripesAroundFullStripe) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  writeResumeKeyTestData(/*rowsPerBatch=*/100, /*numBatches=*/3);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {makeRangeLookup(rowType, {"key"}, 10, 290)};
+  NimbleIndexProjector::Options options;
+  options.maxOverfetchRowsRatio = 0.0;
+  auto result = projector->project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 3);
+
+  const auto firstHeader =
+      readEmbeddedTabletChunkHeader(result.responses[0].slices[0]);
+  const auto middleHeader =
+      readEmbeddedTabletChunkHeader(result.responses[0].slices[1]);
+  const auto lastHeader =
+      readEmbeddedTabletChunkHeader(result.responses[0].slices[2]);
+  EXPECT_EQ(firstHeader.rowCount, 90);
+  EXPECT_EQ(firstHeader.rowRange, RowRange(0, 90));
+  EXPECT_FALSE(firstHeader.streamHasChunkHeader);
+  EXPECT_EQ(middleHeader.rowCount, 100);
+  EXPECT_EQ(middleHeader.rowRange, RowRange(0, 100));
+  EXPECT_TRUE(middleHeader.streamHasChunkHeader);
+  EXPECT_EQ(lastHeader.rowCount, 90);
+  EXPECT_EQ(lastHeader.rowRange, RowRange(0, 90));
+  EXPECT_FALSE(lastHeader.streamHasChunkHeader);
+
+  const auto& stats = projector->stats();
+  EXPECT_EQ(stats.numReadStripes, 3);
+  EXPECT_EQ(stats.numSlicedStripes, 2);
+}
+
 TEST_P(NimbleIndexProjectorTest, slicedRequestsShareShiftedBody) {
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
 


### PR DESCRIPTION
Summary:

Reuse a caller-owned `StreamSlicer` output buffer across sliced stripes in one `NimbleIndexProjector::project()` call. The projector transfers the accumulated Velox buffer chunks into the returned `IOBuf` bodies so repeated stripe slices avoid per-slice output buffer allocation churn.

Reviewed By: tanjialiang

Differential Revision: D117381815


