### PR TITLE
refactor(nimble): Rename VeloxReader to BatchReader (#18713)

### DIFF
--- a/velox/dwio/nimble/docs/architecture/string_dictionary_optimization.html
+++ b/velox/dwio/nimble/docs/architecture/string_dictionary_optimization.html
@@ -189,7 +189,7 @@ code, .mono { font-family:'JetBrains Mono',monospace; font-size:0.82rem; }
   <div class="card card-sm">
     <h3>Batch Reader (<code>nimble/velox/</code>)</h3>
     <div class="step-code" style="display:block; margin-top:0.3rem; font-size:0.65rem">
-      VeloxReader<br>
+      BatchReader<br>
       &nbsp;&nbsp;→ FieldReader tree (one per schema node)<br>
       &nbsp;&nbsp;&nbsp;&nbsp;→ StringFieldReader (for string columns)<br>
       &nbsp;&nbsp;&nbsp;&nbsp;→ StructFieldReader, ArrayFieldReader, ...<br>

--- a/velox/dwio/nimble/docs/develop/nimble_metadata_cache.rst
+++ b/velox/dwio/nimble/docs/develop/nimble_metadata_cache.rst
@@ -59,7 +59,7 @@ Three Reasons for the Split
      - CachedBufferedInput caches compressed bytes → decompress on every access. CachedMetadataInput caches decompressed → zero-cost on cache hit.
    * - 3
      - Shared component
-     - TabletReader is used by both the selective reader (has CachedBufferedInput ) and batch VeloxReader (has no BufferedInput at all). Can't depend on it.
+     - TabletReader is used by both the selective reader (has CachedBufferedInput ) and batch BatchReader (has no BufferedInput at all). Can't depend on it.
 
 What Goes Where
 ^^^^^^^^^^^^^^^

--- a/velox/dwio/nimble/docs/develop/nimble_selective_reader.rst
+++ b/velox/dwio/nimble/docs/develop/nimble_selective_reader.rst
@@ -35,12 +35,12 @@ selective_nimble_reader_enabled = true
         ├── FileSplitReader
             ├── SelectiveNimbleReader (dwio::common::Reader)
             │
-            │   createReader(): uses VeloxReader temporarily to extract schema/type
+            │   createReader(): uses BatchReader temporarily to extract schema/type
             │   createRowReader(): builds SelectiveNimbleRowReader
             │
             └── SelectiveNimbleRowReader (dwio::common::RowReader)
                   │   next() → own column reader tree
-                  └── TabletReader (direct, no VeloxReader in the loop)
+                  └── TabletReader (direct, no BatchReader in the loop)
 
 Batch Path
 
@@ -56,7 +56,7 @@ selective_nimble_reader_enabled = false
             │   createRowReader(): builds NimbleRowReader
             │
             └── NimbleRowReader (dwio::common::RowReader)
-                  ├── VeloxReader.next()
+                  ├── BatchReader.next()
                   │     ├── FieldReader tree
                   │     └── TabletReader
 

--- a/velox/dwio/nimble/fuzzer/encoding_selection/CMakeLists.txt
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(
   nimble_random_encoding_selection_policy
   nimble_tablet_reader
   nimble_velox_schema_serialization
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_velox_selective
   nimble_writer
   velox_memory

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -54,9 +54,9 @@
 #include "velox/dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/stats/ColumnStatistics.h"
 #include "velox/dwio/nimble/velox/stats/VectorizedStatistics.h"
 #include "velox/dwio/nimble/writer/EncodingSelectionPolicyFactory.h"
@@ -871,9 +871,9 @@ void compareDecodedChunk(
 std::string_view toString(ReaderPath readerPath) {
   switch (readerPath) {
     case ReaderPath::kLegacyFactory:
-      return "VeloxReader/legacyFactory";
+      return "BatchReader/legacyFactory";
     case ReaderPath::kDefaultFactory:
-      return "VeloxReader/defaultFactory";
+      return "BatchReader/defaultFactory";
     case ReaderPath::kSelectiveLegacyDispatch:
       return "selective/legacyDispatch";
     case ReaderPath::kSelectiveDefaultDispatch:
@@ -1575,7 +1575,7 @@ void NimbleWriterFuzzer::verifySchemaAndStripeGroupConsistency(
 
   // Schema roundtrip: the Velox type reconstructed from the file must match
   // the type that was written.
-  VeloxReader reader(
+  BatchReader reader(
       std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
   NIMBLE_CHECK(
       schema->equivalent(*reader.type()),
@@ -1724,7 +1724,7 @@ void NimbleWriterFuzzer::readAndVerify(
 
   if (readerPath == ReaderPath::kLegacyFactory ||
       readerPath == ReaderPath::kDefaultFactory) {
-    VeloxReadParams params;
+    BatchReadParams params;
     if (readerPath == ReaderPath::kDefaultFactory) {
       params.encodingFactory =
           [](velox::memory::MemoryPool& pool,
@@ -1733,7 +1733,7 @@ void NimbleWriterFuzzer::readAndVerify(
             return EncodingFactory().create(pool, data, stringBufferFactory);
           };
     }
-    VeloxReader reader(readFile, *leafPool_, /*selector=*/nullptr, params);
+    BatchReader reader(readFile, *leafPool_, /*selector=*/nullptr, params);
     checkSchema(*reader.type());
 
     VectorPtr result;

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.h
@@ -93,10 +93,10 @@ struct PairCoverage {
 /// repairing both legacy tables by hand (D114295784); covering all four here
 /// turns that class of gap into a fuzzer failure.
 enum class ReaderPath {
-  /// nimble::VeloxReader with the default legacy::EncodingFactory.
+  /// nimble::BatchReader with the default legacy::EncodingFactory.
   kLegacyFactory,
 
-  /// nimble::VeloxReader with the non-legacy EncodingFactory.
+  /// nimble::BatchReader with the non-legacy EncodingFactory.
   kDefaultFactory,
 
   /// Selective reader, legacy::LegacyEncodingTrait visitor dispatch.

--- a/velox/dwio/nimble/index/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/index/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(
   nimble_index_test_utils
   nimble_tablet_reader
   nimble_tablet_writer
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_writer
   velox_core
   velox_file

--- a/velox/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
+++ b/velox/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
@@ -31,7 +31,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 #include "velox/vector/FlatVector.h"
 

--- a/velox/dwio/nimble/index/tests/HashIndexTest.cpp
+++ b/velox/dwio/nimble/index/tests/HashIndexTest.cpp
@@ -34,7 +34,7 @@
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/TabletWriter.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 #include "velox/vector/FlatVector.h"
 

--- a/velox/dwio/nimble/index/tests/SortedIndexTest.cpp
+++ b/velox/dwio/nimble/index/tests/SortedIndexTest.cpp
@@ -37,7 +37,7 @@
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/TabletWriter.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 #include "velox/vector/FlatVector.h"
 

--- a/velox/dwio/nimble/tools/CMakeLists.txt
+++ b/velox/dwio/nimble/tools/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(
   nimble_encodings
   nimble_tablet_common
   nimble_tablet_reader
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_writer
   nimble_velox_stats_fb
   velox_file
@@ -63,7 +63,7 @@ target_link_libraries(
   nimble_tools_common
   nimble_common
   nimble_tablet_reader
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_velox_schema_reader
   nimble_column_stats
   velox_file

--- a/velox/dwio/nimble/tools/NimbleDslLib.cpp
+++ b/velox/dwio/nimble/tools/NimbleDslLib.cpp
@@ -25,8 +25,8 @@
 #include "velox/dwio/nimble/tablet/FileLayout.h"
 #include "velox/dwio/nimble/tools/EncodingUtilities.h"
 #include "velox/dwio/nimble/tools/NimbleDslLib.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/StreamLabels.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/stats/ColumnStatistics.h"
 #include "velox/dwio/nimble/velox/stats/VectorizedStatistics.h"
 
@@ -345,7 +345,7 @@ void NimbleDslLib::select(
   auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
 
   // First create a reader without projection to get the full schema.
-  VeloxReader schemaReader{tablet, *pool_};
+  BatchReader schemaReader{tablet, *pool_};
   const auto& fullType = schemaReader.type();
 
   // If a stripe is specified, compute the row range.
@@ -386,7 +386,7 @@ void NimbleDslLib::select(
         fullType, columns);
   }
 
-  VeloxReader reader{tablet, *pool_, selector};
+  BatchReader reader{tablet, *pool_, selector};
   const auto& projectedType = reader.type();
 
   if (effectiveOffset > 0) {
@@ -449,7 +449,7 @@ void NimbleDslLib::describe() {
   tabletOptions.ioOptions.emplace(pool_.get())
       .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
   auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
-  VeloxReader reader{tablet, *pool_};
+  BatchReader reader{tablet, *pool_};
   const auto& veloxType = reader.type();
 
   TableFormatter formatter{
@@ -544,7 +544,7 @@ void NimbleDslLib::showStats() {
   tabletOptions.ioOptions.emplace(pool_.get())
       .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
   auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
-  VeloxReader reader{tablet, *pool_};
+  BatchReader reader{tablet, *pool_};
 
   auto statsSection =
       tablet->loadOptionalSection(tabletOptions.preloadOptionalSections[0]);
@@ -654,7 +654,7 @@ void NimbleDslLib::showEncoding(std::optional<uint32_t> stripeId) {
   tabletOptions.ioOptions.emplace(pool_.get())
       .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
   auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
-  VeloxReader reader{tablet, *pool_};
+  BatchReader reader{tablet, *pool_};
   StreamLabels labels{reader.schema()};
 
   TableFormatter formatter{

--- a/velox/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/velox/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -36,8 +36,8 @@
 #include "velox/dwio/nimble/tablet/FileLayout.h"
 #include "velox/dwio/nimble/tools/EncodingUtilities.h"
 #include "velox/dwio/nimble/tools/NimbleDumpLib.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/StatsGenerated.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/stats/ColumnStatistics.h"
 #include "velox/dwio/nimble/velox/stats/VectorizedStatistics.h"
 #include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
@@ -491,7 +491,7 @@ void NimbleDumpLib::emitInfo() {
   ostream_ << "Row Count: " << commaSeparated(tablet->tabletRowCount())
            << std::endl;
 
-  VeloxReader reader{tablet, *pool_};
+  BatchReader reader{tablet, *pool_};
 
   auto statsSection = tablet->loadOptionalSection(std::string(kStatsSection));
   ostream_ << "Raw Data Size: ";
@@ -522,7 +522,7 @@ void NimbleDumpLib::emitSchema(bool collapseFlatMap) {
   options.ioOptions.emplace(pool_.get())
       .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
   auto tablet = TabletReader::create(file_, pool_.get(), options);
-  VeloxReader reader{tablet, *pool_};
+  BatchReader reader{tablet, *pool_};
 
   auto emitOffsets = [](const Type& type) {
     std::string offsets;
@@ -708,12 +708,12 @@ void NimbleDumpLib::emitStreams(
   std::optional<StreamLabels> labels{};
   std::unordered_set<uint32_t> inMapStreams;
   if (showStreamLabels || showInMapStream) {
-    VeloxReader reader{tabletReader, *pool_};
+    BatchReader reader{tabletReader, *pool_};
     if (showStreamLabels) {
       labels.emplace(reader.schema());
     }
     if (showInMapStream) {
-      VeloxReader inMapReader{tabletReader, *pool_};
+      BatchReader inMapReader{tabletReader, *pool_};
       SchemaReader::traverseSchema(
           inMapReader.schema(),
           [&](auto /*level*/, const Type& type, auto /*info*/) {
@@ -1528,7 +1528,7 @@ void NimbleDumpLib::emitStats(bool noHeader) {
     auto fileStats = VectorizedFileStats::deserialize(
         vectorizedStatsSection->content(), *pool_);
 
-    VeloxReader reader{tabletReader, *pool_};
+    BatchReader reader{tabletReader, *pool_};
     auto columnStats =
         fileStats->toColumnStatistics(reader.type(), reader.schema());
 

--- a/velox/dwio/nimble/velox/BatchReader.cpp
+++ b/velox/dwio/nimble/velox/BatchReader.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
@@ -211,7 +211,7 @@ uint64_t NimbleUnit::getIoSize() {
   return ioSize_.value();
 }
 
-// Builds `TabletReader::Options` for `VeloxReader`'s convenience constructors.
+// Builds `TabletReader::Options` for `BatchReader`'s convenience constructors.
 TabletReader::Options tabletReaderOptions(
     velox::memory::MemoryPool* pool,
     std::shared_ptr<const ExternalDictionaryResolver>
@@ -227,12 +227,12 @@ TabletReader::Options tabletReaderOptions(
 
 } // namespace
 
-VeloxReader::VeloxReader(
+BatchReader::BatchReader(
     velox::ReadFile* file,
     velox::memory::MemoryPool& pool,
     std::shared_ptr<const velox::dwio::common::ColumnSelector> selector,
-    const VeloxReadParams& params)
-    : VeloxReader(
+    const BatchReadParams& params)
+    : BatchReader(
           TabletReader::create(
               std::shared_ptr<velox::ReadFile>(file, [](auto*) {}),
               &pool,
@@ -241,12 +241,12 @@ VeloxReader::VeloxReader(
           std::move(selector),
           params) {}
 
-VeloxReader::VeloxReader(
+BatchReader::BatchReader(
     std::shared_ptr<velox::ReadFile> file,
     velox::memory::MemoryPool& pool,
     std::shared_ptr<const velox::dwio::common::ColumnSelector> selector,
-    const VeloxReadParams& params)
-    : VeloxReader(
+    const BatchReadParams& params)
+    : BatchReader(
           TabletReader::create(
               std::move(file),
               &pool,
@@ -255,11 +255,11 @@ VeloxReader::VeloxReader(
           std::move(selector),
           params) {}
 
-VeloxReader::VeloxReader(
+BatchReader::BatchReader(
     std::shared_ptr<const TabletReader> tabletReader,
     velox::memory::MemoryPool& pool,
     std::shared_ptr<const velox::dwio::common::ColumnSelector> selector,
-    VeloxReadParams params)
+    BatchReadParams params)
     : pool_{pool},
       tabletReader_{std::move(tabletReader)},
       parameters_{std::move(params)},
@@ -354,13 +354,13 @@ VeloxReader::VeloxReader(
   unitLoader_ = getUnitLoader();
 }
 
-void VeloxReader::loadStripeIfAny() {
+void BatchReader::loadStripeIfAny() {
   if (nextStripe_ < lastStripe_) {
     loadNextStripe();
   }
 }
 
-VeloxReadParams::StreamEncodingFactory VeloxReader::createStreamEncodingFactory(
+BatchReadParams::StreamEncodingFactory BatchReader::createStreamEncodingFactory(
     uint32_t valueStreamId,
     std::unique_ptr<StreamLoader> dictionaryStream) const {
   if (dictionaryStream == nullptr &&
@@ -400,7 +400,7 @@ VeloxReadParams::StreamEncodingFactory VeloxReader::createStreamEncodingFactory(
   };
 }
 
-void VeloxReader::loadNextStripe() {
+void BatchReader::loadNextStripe() {
   if (loadedStripe_.has_value() && loadedStripe_.value() == nextStripe_) {
     // We are not reloading the current stripe, but we expect all
     // decoders/readers to be reset after calling loadNextStripe(), therefore,
@@ -491,7 +491,7 @@ void VeloxReader::loadNextStripe() {
   }
 }
 
-uint64_t VeloxReader::estimatedRowSize() {
+uint64_t BatchReader::estimatedRowSize() {
   if (!loadedStripe_.has_value() || rowsRemainingInStripe_ == 0) {
     // We don't load to do the estimation if there isn't any stripe loaded or we
     // are currently at stripe boundary. Instead we return a highly conservative
@@ -510,7 +510,7 @@ uint64_t VeloxReader::estimatedRowSize() {
   return cachedRowSizeEstimation_;
 }
 
-bool VeloxReader::next(uint64_t rowCount, velox::VectorPtr& result) {
+bool BatchReader::next(uint64_t rowCount, velox::VectorPtr& result) {
   if (rowsRemainingInStripe_ == 0) {
     if (nextStripe_ < lastStripe_) {
       loadNextStripe();
@@ -541,19 +541,19 @@ bool VeloxReader::next(uint64_t rowCount, velox::VectorPtr& result) {
   return true;
 }
 
-const TabletReader& VeloxReader::tabletReader() const {
+const TabletReader& BatchReader::tabletReader() const {
   return *tabletReader_;
 }
 
-const std::shared_ptr<const velox::RowType>& VeloxReader::type() const {
+const std::shared_ptr<const velox::RowType>& BatchReader::type() const {
   return type_;
 }
 
-const std::shared_ptr<const Type>& VeloxReader::schema() const {
+const std::shared_ptr<const Type>& BatchReader::schema() const {
   return schema_;
 }
 
-const std::map<std::string, std::string>& VeloxReader::metadata() const {
+const std::map<std::string, std::string>& BatchReader::metadata() const {
   if (!metadata_.has_value()) {
     metadata_ = loadMetadata(*tabletReader_);
   }
@@ -561,7 +561,7 @@ const std::map<std::string, std::string>& VeloxReader::metadata() const {
   return metadata_.value();
 }
 
-uint64_t VeloxReader::seekToRow(uint64_t rowNumber) {
+uint64_t BatchReader::seekToRow(uint64_t rowNumber) {
   if (isEmptyFile()) {
     return 0;
   }
@@ -592,7 +592,7 @@ uint64_t VeloxReader::seekToRow(uint64_t rowNumber) {
   return rowNumber;
 }
 
-uint64_t VeloxReader::skipRows(uint64_t numberOfRowsToSkip) {
+uint64_t BatchReader::skipRows(uint64_t numberOfRowsToSkip) {
   if (isEmptyFile() || numberOfRowsToSkip == 0) {
     LOG(INFO) << "Nothing to skip!";
     return 0;
@@ -625,7 +625,7 @@ uint64_t VeloxReader::skipRows(uint64_t numberOfRowsToSkip) {
   return numberOfRowsToSkip;
 }
 
-uint64_t VeloxReader::skipStripes(
+uint64_t BatchReader::skipStripes(
     uint32_t startStripeIndex,
     uint64_t rowsToSkip) {
   NIMBLE_DCHECK(
@@ -647,7 +647,7 @@ uint64_t VeloxReader::skipStripes(
   return totalRowsToSkip - rowsToSkip;
 }
 
-void VeloxReader::skipInCurrentStripe(uint64_t rowsToSkip) {
+void BatchReader::skipInCurrentStripe(uint64_t rowsToSkip) {
   NIMBLE_DCHECK(
       rowsToSkip <= rowsRemainingInStripe_,
       "Not Enough rows to skip in stripe!");
@@ -657,9 +657,9 @@ void VeloxReader::skipInCurrentStripe(uint64_t rowsToSkip) {
   rootReader_->skip(rowsToSkip);
 }
 
-VeloxReader::~VeloxReader() = default;
+BatchReader::~BatchReader() = default;
 
-std::unique_ptr<velox::dwio::common::UnitLoader> VeloxReader::getUnitLoader() {
+std::unique_ptr<velox::dwio::common::UnitLoader> BatchReader::getUnitLoader() {
   if (lastStripe_ <= firstStripe_) {
     return nullptr;
   }
@@ -681,16 +681,16 @@ std::unique_ptr<velox::dwio::common::UnitLoader> VeloxReader::getUnitLoader() {
   return factory.create(std::move(units), 0);
 }
 
-uint32_t VeloxReader::getUnitIndex(uint32_t stripeIndex) const {
+uint32_t BatchReader::getUnitIndex(uint32_t stripeIndex) const {
   return stripeIndex - firstStripe_;
 }
 
-uint32_t VeloxReader::getCurrentRowInStripe() const {
+uint32_t BatchReader::getCurrentRowInStripe() const {
   return tabletReader_->stripeRowCount(loadedStripe_.value()) -
       static_cast<uint32_t>(rowsRemainingInStripe_);
 }
 
-uint64_t VeloxReader::getRowNumber() {
+uint64_t BatchReader::getRowNumber() {
   if (!loadedStripe_.has_value()) {
     return firstRow_;
   }

--- a/velox/dwio/nimble/velox/BatchReader.h
+++ b/velox/dwio/nimble/velox/BatchReader.h
@@ -35,13 +35,13 @@
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 
-// The VeloxReader reads (a projection from) a file into a velox VectorPtr.
+// The BatchReader reads (a projection from) a file into a velox VectorPtr.
 // The current implementation only uses FlatVector rather than any of the
 // fancier vectors (dictionary, etc), and only supports the types needed for ML.
 
 namespace facebook::nimble {
 
-struct VeloxReadParams : public FieldReaderParams {
+struct BatchReadParams : public FieldReaderParams {
   uint64_t fileRangeStartOffset = 0;
   uint64_t fileRangeEndOffset = std::numeric_limits<uint64_t>::max();
 
@@ -90,32 +90,32 @@ struct VeloxReadParams : public FieldReaderParams {
   };
 };
 
-class VeloxReader {
+class BatchReader {
  public:
   static constexpr uint64_t kConservativeEstimatedRowSize = 1L << 20; // 1MB
 
-  VeloxReader(
+  BatchReader(
       velox::ReadFile* file,
       velox::memory::MemoryPool& pool,
       std::shared_ptr<const velox::dwio::common::ColumnSelector> selector =
           nullptr,
-      const VeloxReadParams& params = {});
+      const BatchReadParams& params = {});
 
-  VeloxReader(
+  BatchReader(
       std::shared_ptr<velox::ReadFile> file,
       velox::memory::MemoryPool& pool,
       std::shared_ptr<const velox::dwio::common::ColumnSelector> selector =
           nullptr,
-      const VeloxReadParams& params = {});
+      const BatchReadParams& params = {});
 
-  VeloxReader(
+  BatchReader(
       std::shared_ptr<const TabletReader> tabletReader,
       velox::memory::MemoryPool& pool,
       std::shared_ptr<const velox::dwio::common::ColumnSelector> selector =
           nullptr,
-      VeloxReadParams params = {});
+      BatchReadParams params = {});
 
-  ~VeloxReader();
+  ~BatchReader();
 
   // Returns the estimated row size from the current stripe in bytes.
   uint64_t estimatedRowSize();
@@ -167,7 +167,7 @@ class VeloxReader {
   void loadNextStripe();
 
   // Returns the base encoding factory unless the stream has an alphabet.
-  VeloxReadParams::StreamEncodingFactory createStreamEncodingFactory(
+  BatchReadParams::StreamEncodingFactory createStreamEncodingFactory(
       uint32_t valueStreamId,
       std::unique_ptr<StreamLoader> dictionaryStream) const;
 
@@ -196,7 +196,7 @@ class VeloxReader {
   velox::memory::MemoryPool& pool_;
   std::shared_ptr<const TabletReader> tabletReader_;
   std::optional<StripeIdentifier> stripeIdentifier_;
-  const VeloxReadParams parameters_;
+  const BatchReadParams parameters_;
   std::shared_ptr<const Type> schema_;
   std::shared_ptr<const velox::RowType> type_;
   std::vector<uint32_t> offsets_;
@@ -230,7 +230,7 @@ class VeloxReader {
 
   std::unique_ptr<velox::dwio::common::UnitLoader> unitLoader_;
 
-  friend class VeloxReaderHelper;
+  friend class BatchReaderHelper;
 };
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/CMakeLists.txt
@@ -149,18 +149,18 @@ target_link_libraries(
 )
 
 add_library(
-  nimble_velox_reader
+  nimble_batch_reader
   ChunkedStream.cpp
   ChunkedStreamDecoder.cpp
   StreamLabels.cpp
-  VeloxReader.cpp
-  VeloxReader.h
+  BatchReader.cpp
+  BatchReader.h
   StreamLabels.h
   ChunkedStreamDecoder.h
   ChunkedStream.h
 )
 target_link_libraries(
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_velox_common
   nimble_velox_schema
   nimble_velox_schema_serialization

--- a/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -29,10 +29,10 @@
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/TabletReaderCache.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaUtils.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/tests/SchemaUtils.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 
@@ -1089,7 +1089,7 @@ TEST_P(NimbleIndexProjectorTest, projectsFlatMapWithoutConstantInMapStream) {
   auto tablet = TabletReader::create(
       readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
   ASSERT_EQ(tablet->stripeCount(), 1);
-  VeloxReader schemaReader(readFile.get(), *leafPool_);
+  BatchReader schemaReader(readFile.get(), *leafPool_);
   const auto& flatMap = schemaReader.schema()->asRow().childAt(1)->asFlatMap();
   ASSERT_EQ(flatMap.childrenCount(), 1);
   ASSERT_EQ(flatMap.nameAt(0), "always");
@@ -1326,7 +1326,7 @@ TEST_P(NimbleIndexProjectorTest, fuzzesFlatMapPartialStripeProjection) {
             readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
         ASSERT_EQ(tablet->stripeCount(), 1);
         const auto stripe = tablet->stripeIdentifier(0);
-        VeloxReader schemaReader(readFile.get(), *leafPool_);
+        BatchReader schemaReader(readFile.get(), *leafPool_);
         const auto& root = schemaReader.schema()->asRow();
         const auto& flatMap = root.childAt(1)->asFlatMap();
         const auto findFlatMapKey = [&](std::string_view key) {
@@ -3845,7 +3845,7 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     std::vector<TabletReader::StreamLocation> streamLocations(streamCount);
     tablet->streamLocations(stripeId, streamLocations);
 
-    VeloxReader reader(readFile.get(), *leafPool_);
+    BatchReader reader(readFile.get(), *leafPool_);
     const auto& flatMap = reader.schema()->asRow().childAt(1)->asFlatMap();
 
     std::unordered_map<std::string, uint32_t> keyToValueStreamId;

--- a/velox/dwio/nimble/velox/selective/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/selective/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(
   nimble_velox_selective
   nimble_tablet_reader_cache
   nimble_compression
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_writer
   nimble_velox_common
 )

--- a/velox/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -49,10 +49,10 @@
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
 #include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -3159,7 +3159,7 @@ TEST_P(SelectiveNimbleReaderTest, pinMetadata) {
   }
 }
 
-// Verifies that within the same TabletReader, the second VeloxReader pass
+// Verifies that within the same TabletReader, the second BatchReader pass
 // does not re-read metadata. The weak-pointer cache retains entries while the
 // tablet is alive, so metadata is always reused regardless of pinMetadata,
 // cacheMetadata, or whether cache infrastructure is provided.
@@ -3235,11 +3235,11 @@ TEST_P(SelectiveNimbleReaderTest, metadataReuseWithSameReader) {
 
     auto tablet = TabletReader::create(trackingFile, pool(), tabletOptions);
 
-    nimble::VeloxReadParams readParams;
+    nimble::BatchReadParams readParams;
     readParams.decodingExecutor =
         std::make_shared<folly::CPUThreadPoolExecutor>(1);
 
-    auto reader1 = std::make_unique<nimble::VeloxReader>(
+    auto reader1 = std::make_unique<nimble::BatchReader>(
         tablet, *pool(), selector, readParams);
     VectorPtr result;
     ASSERT_TRUE(reader1->next(100, result));
@@ -3255,10 +3255,10 @@ TEST_P(SelectiveNimbleReaderTest, metadataReuseWithSameReader) {
 
     const auto ramHitsAfterFirstPass = metadataIoStats_->ramHit().count();
 
-    // Second pass: new VeloxReader on the same TabletReader. Metadata is
+    // Second pass: new BatchReader on the same TabletReader. Metadata is
     // always reused within the same tablet regardless of settings.
     trackingFile->resetMaxReadOffset();
-    auto reader2 = std::make_unique<nimble::VeloxReader>(
+    auto reader2 = std::make_unique<nimble::BatchReader>(
         tablet, *pool(), selector, readParams);
     ASSERT_TRUE(reader2->next(100, result));
     ASSERT_EQ(result->size(), 100);
@@ -3370,10 +3370,10 @@ TEST_P(SelectiveNimbleReaderTest, metadataReuseCrossReaders) {
     ASSERT_EQ(stripeGroupsMeta.size(), 1);
     const auto metadataBoundary = stripeGroupsMeta[0].offset();
 
-    nimble::VeloxReadParams readParams;
+    nimble::BatchReadParams readParams;
     readParams.decodingExecutor =
         std::make_shared<folly::CPUThreadPoolExecutor>(1);
-    auto reader1 = std::make_unique<nimble::VeloxReader>(
+    auto reader1 = std::make_unique<nimble::BatchReader>(
         tablet1, *pool(), selector, readParams);
     VectorPtr result;
     ASSERT_TRUE(reader1->next(100, result));
@@ -3394,7 +3394,7 @@ TEST_P(SelectiveNimbleReaderTest, metadataReuseCrossReaders) {
     auto metadataIoStats2 = std::make_shared<io::IoStatistics>();
     std::unique_ptr<FileHandle> fh2;
     auto tablet2 = makeTablet(metadataIoStats2, fh2);
-    auto reader3 = std::make_unique<nimble::VeloxReader>(
+    auto reader3 = std::make_unique<nimble::BatchReader>(
         tablet2, *pool(), selector, readParams);
     ASSERT_TRUE(reader3->next(100, result));
     ASSERT_EQ(result->size(), 100);

--- a/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
@@ -48,10 +48,10 @@
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
 #include "velox/dwio/nimble/velox/SchemaUtils.h"
 #include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 #include "velox/type/CppToType.h"
@@ -477,7 +477,7 @@ struct TestParam {
   }
 };
 
-class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
+class BatchReaderTest : public ::testing::TestWithParam<TestParam> {
  public:
   static std::vector<TestParam> getTestParams() {
     std::vector<TestParam> params;
@@ -595,21 +595,21 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     return nimble::TabletReader::create(readFile, pool, tabletOptions);
   }
 
-  // Creates a VeloxReader with cache support when enabled.
-  std::unique_ptr<nimble::VeloxReader> createVeloxReader(
+  // Creates a BatchReader with cache support when enabled.
+  std::unique_ptr<nimble::BatchReader> createBatchReader(
       std::shared_ptr<velox::ReadFile> readFile,
       velox::memory::MemoryPool& pool,
       std::shared_ptr<const velox::dwio::common::ColumnSelector> selector =
           nullptr,
-      nimble::VeloxReadParams params = {}) {
+      nimble::BatchReadParams params = {}) {
     params = configureWithTestParam(std::move(params));
     if (enableCache() || pinMetadata()) {
       auto tablet =
           createTablet(readFile, &pool, params.externalDictionaryResolver);
-      return std::make_unique<nimble::VeloxReader>(
+      return std::make_unique<nimble::BatchReader>(
           std::move(tablet), pool, std::move(selector), std::move(params));
     }
-    return std::make_unique<nimble::VeloxReader>(
+    return std::make_unique<nimble::BatchReader>(
         readFile.get(), pool, std::move(selector), std::move(params));
   }
 
@@ -620,8 +620,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     return options;
   }
 
-  nimble::VeloxReadParams configureWithTestParam(
-      nimble::VeloxReadParams params) const {
+  nimble::BatchReadParams configureWithTestParam(
+      nimble::BatchReadParams params) const {
     params.optimizeStringBufferHandling = optimizeStringBufferHandling();
     if (params.optimizeStringBufferHandling) {
       params.encodingFactory =
@@ -651,8 +651,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     return params;
   }
 
-  nimble::VeloxReadParams createReadParams() const {
-    nimble::VeloxReadParams params;
+  nimble::BatchReadParams createReadParams() const {
+    nimble::BatchReadParams params;
     return configureWithTestParam(std::move(params));
   }
 
@@ -672,10 +672,10 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
         std::dynamic_pointer_cast<const velox::RowType>(expected->type()));
-    nimble::VeloxReadParams readParams;
+    nimble::BatchReadParams readParams;
     readParams.externalDictionaryResolver =
         std::move(externalDictionaryResolver);
-    auto reader = createVeloxReader(readFile, *leafPool_, selector, readParams);
+    auto reader = createBatchReader(readFile, *leafPool_, selector, readParams);
 
     velox::VectorPtr result;
     velox::vector_size_t rowOffset{0};
@@ -699,7 +699,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     ASSERT_FALSE(reader->next(1, result));
 
     auto skipReader =
-        createVeloxReader(readFile, *leafPool_, selector, readParams);
+        createBatchReader(readFile, *leafPool_, selector, readParams);
     const auto skipOffset = expected->size() / 3;
     ASSERT_EQ(skipReader->skipRows(skipOffset), skipOffset);
     ASSERT_TRUE(skipReader->next(/*rowCount=*/32, result));
@@ -714,8 +714,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
   }
 
   void verifyReadersEqual(
-      std::unique_ptr<nimble::VeloxReader> lhs,
-      std::unique_ptr<nimble::VeloxReader> rhs,
+      std::unique_ptr<nimble::BatchReader> lhs,
+      std::unique_ptr<nimble::BatchReader> rhs,
       int32_t expectedNumTotalArrays,
       int32_t expectedNumUniqueArrays) {
     velox::VectorPtr leftResult;
@@ -776,11 +776,11 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
         nimble::test::createNimbleFile(*rootPool_, vector, writerOptions);
     auto inMemFile = velox::InMemoryReadFile(file);
 
-    nimble::VeloxReader veloxReader(
+    nimble::BatchReader batchReader(
         &inMemFile,
         memoryPool,
         std::make_shared<velox::dwio::common::ColumnSelector>(veloxRowType));
-    const auto& veloxTypeResult = convertToVeloxType(*veloxReader.schema());
+    const auto& veloxTypeResult = convertToVeloxType(*batchReader.schema());
 
     EXPECT_EQ(*veloxRowType, *veloxTypeResult)
         << "Expected: " << veloxRowType->toString()
@@ -835,10 +835,10 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     writer.write(vector);
     writer.close();
 
-    nimble::VeloxReadParams readParams = createReadParams();
+    nimble::BatchReadParams readParams = createReadParams();
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), readParams);
 
     velox::VectorPtr output;
@@ -913,7 +913,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
           velox::vector_size_t)> validator,
       size_t batchCount,
       nimble::WriterOptions writerOptions = {},
-      nimble::VeloxReadParams readParams = {},
+      nimble::BatchReadParams readParams = {},
       std::function<bool(std::string&)> isKeyPresent = nullptr,
       std::function<void(const velox::VectorPtr&)> comparator = nullptr,
       bool multiSkip = false,
@@ -939,7 +939,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     auto readerPool = leakDetectPool->addLeafChild("reader_pool");
 
     auto reader =
-        createVeloxReader(readFile, *readerPool, selector, readParams);
+        createBatchReader(readFile, *readerPool, selector, readParams);
     if (folly::Random::oneIn(2, rng)) {
       LOG(INFO) << "using executor";
       readParams.decodingExecutor =
@@ -973,8 +973,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
 
       // validate skip
       if (i % 2 == 0) {
-        auto reader1 = createVeloxReader(readFile, pool, selector, readParams);
-        auto reader2 = createVeloxReader(readFile, pool, selector, readParams);
+        auto reader1 = createBatchReader(readFile, pool, selector, readParams);
+        auto reader2 = createBatchReader(readFile, pool, selector, readParams);
         auto rowCount = expected.at(0)->size();
         velox::vector_size_t remaining = rowCount;
         uint32_t skipCount = 0;
@@ -1020,12 +1020,12 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     }
   }
 
-  std::unique_ptr<nimble::VeloxReader> getReaderForLifeCycleTest(
+  std::unique_ptr<nimble::BatchReader> getReaderForLifeCycleTest(
       const std::shared_ptr<const velox::RowType> schema,
       size_t batchSize,
       std::mt19937& rng,
       nimble::WriterOptions writerOptions = {},
-      nimble::VeloxReadParams readParams = {}) {
+      nimble::BatchReadParams readParams = {}) {
     // Merge the base parameter (optimizeStringBufferHandling)
     readParams = configureWithTestParam(std::move(readParams));
 
@@ -1043,13 +1043,13 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
         readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
     auto selector =
         std::make_shared<velox::dwio::common::ColumnSelector>(schema);
-    std::unique_ptr<nimble::VeloxReader> reader =
-        std::make_unique<nimble::VeloxReader>(
+    std::unique_ptr<nimble::BatchReader> reader =
+        std::make_unique<nimble::BatchReader>(
             tablet, *leafPool_, std::move(selector), readParams);
     return reader;
   }
 
-  std::unique_ptr<nimble::VeloxReader> getReaderForWrite(
+  std::unique_ptr<nimble::BatchReader> getReaderForWrite(
       velox::memory::MemoryPool& pool,
       const velox::RowTypePtr& type,
       std::vector<std::function<velox::VectorPtr(const velox::RowTypePtr&)>>
@@ -1062,7 +1062,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
         pool, type, generators, decodeCounterUnused);
   }
 
-  std::unique_ptr<nimble::VeloxReader> getReaderForWriteWithDecodeCounter(
+  std::unique_ptr<nimble::BatchReader> getReaderForWriteWithDecodeCounter(
       velox::memory::MemoryPool& pool,
       const velox::RowTypePtr& type,
       std::vector<std::function<velox::VectorPtr(const velox::RowTypePtr&)>>
@@ -1070,7 +1070,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       int& decodeCounter) {
     nimble::WriterOptions writerOptions;
     // Merge the base parameter (optimizeStringBufferHandling)
-    nimble::VeloxReadParams readParams = createReadParams();
+    nimble::BatchReadParams readParams = createReadParams();
 
     std::string file;
     auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
@@ -1098,7 +1098,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     auto readFile = std::make_unique<velox::InMemoryReadFile>(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
 
-    return std::make_unique<nimble::VeloxReader>(
+    return std::make_unique<nimble::BatchReader>(
         std::move(readFile),
         *leafPool_,
         std::move(selector),
@@ -1404,7 +1404,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     VeloxMapGenerator generator(leafPool_.get(), generatorConfig);
     velox::test::VectorMaker vectorMaker{leafPool_.get()};
 
-    nimble::VeloxReadParams params = createReadParams();
+    nimble::BatchReadParams params = createReadParams();
     params.readFlatMapFieldAsStruct.insert("id_list_features");
     for (int i = 0; i < features.size(); ++i) {
       params.flatMapFeatureSelector["id_list_features"].features.push_back(
@@ -1472,15 +1472,15 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       std::make_shared<velox::io::IoStatistics>()};
   std::shared_ptr<velox::cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
-  // Held alive for the duration of createTablet/createVeloxReader.
+  // Held alive for the duration of createTablet/createBatchReader.
   std::unique_ptr<velox::FileHandle> fileHandle_;
   std::unique_ptr<velox::io::ReaderOptions> ioReaderOptions_;
   uint64_t nextFileId_{0};
 };
 
-class FsstStringBatchReaderTest : public VeloxReaderTest {};
+class FsstStringBatchReaderTest : public BatchReaderTest {};
 
-class MetadataReuseTest : public VeloxReaderTest {};
+class MetadataReuseTest : public BatchReaderTest {};
 
 nimble::EncodingLayout makeFsstEncodingLayout() {
   return nimble::EncodingLayout{
@@ -1494,9 +1494,9 @@ nimble::EncodingLayout makeFsstEncodingLayout() {
 }
 
 // Exercises read-path stream-selection across every StripeGroup metadata
-// format. Parameterized on the format alone (independent of VeloxReaderTest's
+// format. Parameterized on the format alone (independent of BatchReaderTest's
 // cache/pin matrix) because these tests only assert which streams are read.
-class VeloxReaderStripeGroupFormatTest
+class BatchReaderStripeGroupFormatTest
     : public ::testing::TestWithParam<nimble::StripeGroup::EncodingLayout> {
  protected:
   static void SetUpTestCase() {
@@ -1513,7 +1513,7 @@ class VeloxReaderStripeGroupFormatTest
   std::shared_ptr<velox::memory::MemoryPool> leafPool_;
 };
 
-TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnselectedColumnsFromFile) {
+TEST_P(BatchReaderStripeGroupFormatTest, dontReadUnselectedColumnsFromFile) {
   auto type = velox::ROW({
       {"tinyint_val", velox::TINYINT()},
       {"smallint_val", velox::SMALLINT()},
@@ -1546,8 +1546,8 @@ TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnselectedColumnsFromFile) {
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
         std::dynamic_pointer_cast<const velox::RowType>(vector->type()),
         selectedColumnNames);
-    nimble::VeloxReader reader(
-        &readFile, *leafPool_, std::move(selector), nimble::VeloxReadParams{});
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), nimble::BatchReadParams{});
 
     velox::VectorPtr result;
     reader.next(readSize, result);
@@ -1564,7 +1564,7 @@ TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnselectedColumnsFromFile) {
   }
 }
 
-TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnprojectedFeaturesFromFile) {
+TEST_P(BatchReaderStripeGroupFormatTest, dontReadUnprojectedFeaturesFromFile) {
   auto type = velox::ROW({
       {"float_features", velox::MAP(velox::INTEGER(), velox::REAL())},
   });
@@ -1601,7 +1601,7 @@ TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnprojectedFeaturesFromFile) {
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
         std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
 
-    nimble::VeloxReadParams params;
+    nimble::BatchReadParams params;
     params.readFlatMapFieldAsStruct.insert("float_features");
     auto& selectedFeatures =
         params.flatMapFeatureSelector["float_features"].features;
@@ -1620,7 +1620,7 @@ TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnprojectedFeaturesFromFile) {
     LOG(INFO) << "Selected features (" << selectedFeatures.size()
               << ") :" << folly::join(", ", selectedFeatures);
 
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), params);
 
     uint32_t readSize = 1000;
@@ -1677,8 +1677,8 @@ TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnprojectedFeaturesFromFile) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    VeloxReaderStripeGroupFormatTestSuite,
-    VeloxReaderStripeGroupFormatTest,
+    BatchReaderStripeGroupFormatTestSuite,
+    BatchReaderStripeGroupFormatTest,
     ::testing::Values(
         nimble::StripeGroup::EncodingLayout::kRaw,
         nimble::StripeGroup::EncodingLayout::kStreamMajor),
@@ -1693,7 +1693,7 @@ INSTANTIATE_TEST_SUITE_P(
       return "Unknown";
     });
 
-TEST_P(VeloxReaderTest, sharedDictionary) {
+TEST_P(BatchReaderTest, sharedDictionary) {
   const auto valueUniverse = sharedDictionaryValueUniverse();
   const std::array<nimble::SharedDictionaryScope, 3> scopes{
       nimble::SharedDictionaryScope::Stripe,
@@ -1746,7 +1746,7 @@ TEST_P(VeloxReaderTest, sharedDictionary) {
   }
 }
 
-TEST_P(VeloxReaderTest, sharedDictionaryRandomizedSourcesAndStripes) {
+TEST_P(BatchReaderTest, sharedDictionaryRandomizedSourcesAndStripes) {
   constexpr uint32_t kSeed{0xB117D1C7};
   SCOPED_TRACE(fmt::format("seed={}", kSeed));
 
@@ -1803,7 +1803,7 @@ TEST_P(VeloxReaderTest, sharedDictionaryRandomizedSourcesAndStripes) {
   validateSharedDictionaryRead(input, file, resolver, readSizes);
 }
 
-TEST_P(VeloxReaderTest, readComplexData) {
+TEST_P(BatchReaderTest, readComplexData) {
   auto type = velox::ROW({
       {"tinyint_val", velox::TINYINT()},
       {"smallint_val", velox::SMALLINT()},
@@ -1867,7 +1867,7 @@ TEST_P(VeloxReaderTest, readComplexData) {
         auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
             std::dynamic_pointer_cast<const velox::RowType>(
                 upcast ? typeUpcast : vector->type()));
-        nimble::VeloxReader reader(
+        nimble::BatchReader reader(
             &readFile, *leafPool_, std::move(selector), createReadParams());
 
         velox::vector_size_t rowIndex = 0;
@@ -1928,7 +1928,7 @@ TEST_P(VeloxReaderTest, readComplexData) {
   }
 }
 
-TEST_P(VeloxReaderTest, lifetime) {
+TEST_P(BatchReaderTest, lifetime) {
   velox::StringView s{"012345678901234567890123456789"};
   std::vector<velox::StringView> strings{s, s, s, s, s};
   std::vector<std::vector<velox::StringView>> stringsOfStrings{
@@ -1956,7 +1956,7 @@ TEST_P(VeloxReaderTest, lifetime) {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
         std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
 
     ASSERT_TRUE(reader.next(vector->size(), result));
@@ -2007,7 +2007,7 @@ TEST_P(FsstStringBatchReaderTest, fsstStringBatchReader) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
-  auto reader = createVeloxReader(readFile, *leafPool_, std::move(selector));
+  auto reader = createBatchReader(readFile, *leafPool_, std::move(selector));
 
   velox::VectorPtr result;
   int32_t offset = 0;
@@ -2022,7 +2022,7 @@ TEST_P(FsstStringBatchReaderTest, fsstStringBatchReader) {
   ASSERT_FALSE(reader->next(1, result));
 }
 
-TEST_P(VeloxReaderTest, allValuesNulls) {
+TEST_P(BatchReaderTest, allValuesNulls) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   auto vector = vectorMaker.rowVector(
       {vectorMaker.flatVectorNullable<int32_t>(
@@ -2050,12 +2050,12 @@ TEST_P(VeloxReaderTest, allValuesNulls) {
     options.dictionaryArrayColumns.insert("c4");
     auto file = nimble::test::createNimbleFile(*rootPool_, vector, options);
     velox::InMemoryReadFile readFile(file);
-    nimble::VeloxReadParams params = createReadParams();
+    nimble::BatchReadParams params = createReadParams();
     params.readFlatMapFieldAsStruct.insert("c3");
     params.flatMapFeatureSelector.insert({"c3", {{"1"}}});
     auto selector =
         std::make_shared<velox::dwio::common::ColumnSelector>(projectedType);
-    nimble::VeloxReader reader(&readFile, *leafPool_, selector, params);
+    nimble::BatchReader reader(&readFile, *leafPool_, selector, params);
 
     ASSERT_TRUE(reader.next(vector->size(), result));
     ASSERT_FALSE(reader.next(vector->size(), result));
@@ -2079,7 +2079,7 @@ TEST_P(VeloxReaderTest, allValuesNulls) {
   }
 }
 
-TEST_P(VeloxReaderTest, stringBuffers) {
+TEST_P(BatchReaderTest, stringBuffers) {
   // Creating a string column with 10 identical strings.
   // We will perform 2 reads of 5 rows each, and compare the string buffers
   // generated.
@@ -2095,7 +2095,7 @@ TEST_P(VeloxReaderTest, stringBuffers) {
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
 
   ASSERT_TRUE(reader.next(5, result));
@@ -2145,7 +2145,7 @@ TEST_P(VeloxReaderTest, stringBuffers) {
   EXPECT_EQ(bufferSizeFirst, bufferSizeSecond);
 }
 
-TEST_P(VeloxReaderTest, nullVectors) {
+TEST_P(BatchReaderTest, nullVectors) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 
   // In the following table, the first 5 rows contain nulls and the last 5
@@ -2186,7 +2186,7 @@ TEST_P(VeloxReaderTest, nullVectors) {
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
 
   velox::VectorPtr result;
@@ -2234,7 +2234,7 @@ TEST_P(VeloxReaderTest, nullVectors) {
   ASSERT_FALSE(reader.next(1, result));
 }
 
-TEST_P(VeloxReaderTest, slidingWindowMapSizeOne) {
+TEST_P(BatchReaderTest, slidingWindowMapSizeOne) {
   verifySlidingWindowMap(
       /* deduplicatedMapCount */ 1,
       /* keys */ {1, 2},
@@ -2250,7 +2250,7 @@ TEST_P(VeloxReaderTest, slidingWindowMapSizeOne) {
       /* nulls */ {1});
 }
 
-TEST_P(VeloxReaderTest, slidingWindowMapSizeTwo) {
+TEST_P(BatchReaderTest, slidingWindowMapSizeTwo) {
   verifySlidingWindowMap(
       /* deduplicatedMapCount */ 1,
       /* keys */ {1, 2, 1, 2},
@@ -2266,7 +2266,7 @@ TEST_P(VeloxReaderTest, slidingWindowMapSizeTwo) {
       /* nulls */ {1});
 }
 
-TEST_P(VeloxReaderTest, slidingWindowMapEmpty) {
+TEST_P(BatchReaderTest, slidingWindowMapEmpty) {
   verifySlidingWindowMap(
       /* deduplicatedMapCount */ 1,
       /* keys */ {},
@@ -2288,7 +2288,7 @@ TEST_P(VeloxReaderTest, slidingWindowMapEmpty) {
       /* nulls */ {1});
 }
 
-TEST_P(VeloxReaderTest, slidingWindowMapMixedEmptyLength) {
+TEST_P(BatchReaderTest, slidingWindowMapMixedEmptyLength) {
   verifySlidingWindowMap(
       /* deduplicatedMapCount */ 5,
       /* keys */ {1, 2, 2, 1, 1, 2, 4, 4},
@@ -2304,7 +2304,7 @@ TEST_P(VeloxReaderTest, slidingWindowMapMixedEmptyLength) {
       /* nulls */ {9});
 }
 
-TEST_P(VeloxReaderTest, arrayWithOffsetsCaching) {
+TEST_P(BatchReaderTest, arrayWithOffsetsCaching) {
   auto type = velox::ROW({
       {"dictionaryArray", velox::ARRAY(velox::INTEGER())},
   });
@@ -2570,7 +2570,7 @@ TEST_P(VeloxReaderTest, arrayWithOffsetsCaching) {
       expectedUniqueArrays);
 }
 
-TEST_P(VeloxReaderTest, dictionaryEncodedPassthrough) {
+TEST_P(BatchReaderTest, dictionaryEncodedPassthrough) {
   // test duplicate in first index
   auto offsets = std::vector<std::optional<velox::vector_size_t>>{0, 0, 1, 2};
   auto dictionaryValues =
@@ -2682,7 +2682,7 @@ TEST_P(VeloxReaderTest, dictionaryEncodedPassthrough) {
       offsets, dictionaryValues, fullArrayVectorNullable);
 }
 
-TEST_P(VeloxReaderTest, dictionaryEncodedPassthroughDecoding) {
+TEST_P(BatchReaderTest, dictionaryEncodedPassthroughDecoding) {
   auto offsets = std::vector<std::optional<velox::vector_size_t>>{0, 0, 1, 2};
   auto dictionaryValues =
       std::vector<std::vector<int32_t>>{{10, 15, 20}, {30, 40, 50}, {3, 4, 5}};
@@ -2713,7 +2713,7 @@ TEST_P(VeloxReaderTest, dictionaryEncodedPassthroughDecoding) {
   ASSERT_EQ(decodeDictionaryCount, 1);
 }
 
-TEST_P(VeloxReaderTest, dictionaryEncodingPassthroughCaching) {
+TEST_P(BatchReaderTest, dictionaryEncodingPassthroughCaching) {
   auto firstWriteOffsets =
       std::vector<std::optional<velox::vector_size_t>>{0, 0, 1, 2};
   auto firstWriteDictValues =
@@ -2919,7 +2919,7 @@ TEST_P(VeloxReaderTest, dictionaryEncodingPassthroughCaching) {
   ASSERT_TRUE(true);
 }
 
-TEST_P(VeloxReaderTest, fuzzSimple) {
+TEST_P(BatchReaderTest, fuzzSimple) {
   auto type = velox::ROW({
       {"bool_val", velox::BOOLEAN()},
       {"byte_val", velox::TINYINT()},
@@ -3001,7 +3001,7 @@ TEST_P(VeloxReaderTest, fuzzSimple) {
   }
 }
 
-TEST_P(VeloxReaderTest, fuzzComplex) {
+TEST_P(BatchReaderTest, fuzzComplex) {
   auto type = velox::ROW(
       {{"array", velox::ARRAY(velox::REAL())},
        {"dict_array", velox::ARRAY(velox::REAL())},
@@ -3128,7 +3128,7 @@ TEST_P(VeloxReaderTest, fuzzComplex) {
 // string-keyed maps, and a bigint-keyed boolean-valued map. fuzzComplex covers
 // INTEGER-keyed maps and REAL arrays but none of these key/value combos, so
 // this pins the round-trip for them, with and without nulls.
-TEST_P(VeloxReaderTest, fuzzMigrationComplexTypes) {
+TEST_P(BatchReaderTest, fuzzMigrationComplexTypes) {
   auto type = velox::ROW({
       {"array_bigint", velox::ARRAY(velox::BIGINT())},
       {"array_varchar", velox::ARRAY(velox::VARCHAR())},
@@ -3186,7 +3186,7 @@ TEST_P(VeloxReaderTest, fuzzMigrationComplexTypes) {
   }
 }
 
-TEST_P(VeloxReaderTest, arrayWithOffsets) {
+TEST_P(BatchReaderTest, arrayWithOffsets) {
   auto type = velox::ROW({
       {"dictionaryArray", velox::ARRAY(velox::INTEGER())},
   });
@@ -3445,7 +3445,7 @@ TEST_P(VeloxReaderTest, arrayWithOffsets) {
   }
 }
 
-TEST_P(VeloxReaderTest, arrayWithOffsetsNullable) {
+TEST_P(BatchReaderTest, arrayWithOffsetsNullable) {
   auto type = velox::ROW({
       {"dictionaryArray", velox::ARRAY(velox::INTEGER())},
   });
@@ -3656,7 +3656,7 @@ TEST_P(VeloxReaderTest, arrayWithOffsetsNullable) {
   }
 }
 
-TEST_P(VeloxReaderTest, arrayWithOffsetsMultiskips) {
+TEST_P(BatchReaderTest, arrayWithOffsetsMultiskips) {
   auto type = velox::ROW({
       {"dictionaryArray", velox::ARRAY(velox::INTEGER())},
   });
@@ -3819,7 +3819,7 @@ bool compareMapToFlatMap(
   return true;
 }
 
-TEST_P(VeloxReaderTest, flatMapDictionaryWrappedFlatMapVector) {
+TEST_P(BatchReaderTest, flatMapDictionaryWrappedFlatMapVector) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -3883,7 +3883,7 @@ TEST_P(VeloxReaderTest, flatMapDictionaryWrappedFlatMapVector) {
 
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
   velox::VectorPtr output;
   uint64_t rowCount = numRows;
@@ -3894,7 +3894,7 @@ TEST_P(VeloxReaderTest, flatMapDictionaryWrappedFlatMapVector) {
   }
 }
 
-TEST_P(VeloxReaderTest, flatMapMigrationTypes) {
+TEST_P(BatchReaderTest, flatMapMigrationTypes) {
   auto type = velox::ROW({
       {"map_bigint_boolean", velox::MAP(velox::BIGINT(), velox::BOOLEAN())},
       {"map_varchar_double", velox::MAP(velox::VARCHAR(), velox::DOUBLE())},
@@ -3930,7 +3930,7 @@ TEST_P(VeloxReaderTest, flatMapMigrationTypes) {
 
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
   velox::VectorPtr output;
   uint64_t rowCount = numRows;
@@ -3941,7 +3941,7 @@ TEST_P(VeloxReaderTest, flatMapMigrationTypes) {
   }
 }
 
-TEST_P(VeloxReaderTest, flatMapNullValues) {
+TEST_P(BatchReaderTest, flatMapNullValues) {
   testFlatMapNullValues<int8_t>();
   testFlatMapNullValues<int16_t>();
   testFlatMapNullValues<int32_t>();
@@ -3953,7 +3953,7 @@ TEST_P(VeloxReaderTest, flatMapNullValues) {
 
 // Verify that the writer skips encoding all-true in-map streams and the reader
 // correctly handles missing in-map streams as "all rows are in-map".
-TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStream) {
+TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStream) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -3985,7 +3985,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStream) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
     auto offsets = existingStreamOffsets(*leafPool_, &readFile, 0);
@@ -4007,7 +4007,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStream) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     velox::VectorPtr output;
     uint64_t rowCount = 4;
@@ -4022,10 +4022,10 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStream) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReadParams readParams = createReadParams();
+    nimble::BatchReadParams readParams = createReadParams();
     readParams.readFlatMapFieldAsStruct.insert("flat_map");
     readParams.flatMapFeatureSelector["flat_map"].features = {"1", "2", "3"};
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), readParams);
     velox::VectorPtr output;
     uint64_t rowCount = 4;
@@ -4046,7 +4046,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStream) {
   }
 }
 
-TEST_P(VeloxReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
+TEST_P(BatchReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -4070,7 +4070,7 @@ TEST_P(VeloxReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
     ASSERT_EQ(flatMap.childrenCount(), 1);
@@ -4081,7 +4081,7 @@ TEST_P(VeloxReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     velox::VectorPtr output;
     uint64_t rowCount = 4;
@@ -4095,7 +4095,7 @@ TEST_P(VeloxReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
 
 // Verify mixed in-map streams: some keys present in all rows (all-true,
 // skipped), some keys present in only some rows (not all-true, written).
-TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamMixed) {
+TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStreamMixed) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -4126,7 +4126,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamMixed) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
     auto offsets = existingStreamOffsets(*leafPool_, &readFile, 0);
@@ -4150,7 +4150,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamMixed) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     velox::VectorPtr output;
     uint64_t rowCount = 4;
@@ -4165,10 +4165,10 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamMixed) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReadParams readParams = createReadParams();
+    nimble::BatchReadParams readParams = createReadParams();
     readParams.readFlatMapFieldAsStruct.insert("flat_map");
     readParams.flatMapFeatureSelector["flat_map"].features = {"1", "2", "3"};
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), readParams);
     velox::VectorPtr output;
     uint64_t rowCount = 4;
@@ -4196,7 +4196,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamMixed) {
 // Verify that the writer skips encoding all-false in-map streams (key absent
 // from all rows in a stripe) and the reader correctly handles this by skipping
 // the key. Uses multi-stripe write where key 3 appears only in stripe 2.
-TEST_P(VeloxReaderTest, flatMapSkipAllFalseInMapStream) {
+TEST_P(BatchReaderTest, flatMapSkipAllFalseInMapStream) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -4233,7 +4233,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllFalseInMapStream) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
     ASSERT_EQ(flatMap.childrenCount(), 3);
@@ -4277,7 +4277,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllFalseInMapStream) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     velox::VectorPtr output;
     uint64_t rowCount = 2;
@@ -4299,10 +4299,10 @@ TEST_P(VeloxReaderTest, flatMapSkipAllFalseInMapStream) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReadParams readParams = createReadParams();
+    nimble::BatchReadParams readParams = createReadParams();
     readParams.readFlatMapFieldAsStruct.insert("flat_map");
     readParams.flatMapFeatureSelector["flat_map"].features = {"1", "2", "3"};
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), readParams);
     velox::VectorPtr output;
     uint64_t rowCount = 2;
@@ -4332,7 +4332,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllFalseInMapStream) {
 }
 
 // Verify roundtrip with null map rows alongside all-true in-map streams.
-TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamWithNulls) {
+TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStreamWithNulls) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -4381,7 +4381,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamWithNulls) {
   {
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
     velox::VectorPtr output;
     uint64_t rowCount = 4;
@@ -4393,7 +4393,7 @@ TEST_P(VeloxReaderTest, flatMapSkipAllTrueInMapStreamWithNulls) {
   }
 }
 
-TEST_P(VeloxReaderTest, slidingWindowMapNestedInFlatMap) {
+TEST_P(BatchReaderTest, slidingWindowMapNestedInFlatMap) {
   auto type = velox::ROW({
       {"nested_map",
        velox::MAP(
@@ -4421,7 +4421,7 @@ TEST_P(VeloxReaderTest, slidingWindowMapNestedInFlatMap) {
 
   nimble::WriterOptions writerOptions;
   writerOptions.flatMapColumns["nested_map"];
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   params.readFlatMapFieldAsStruct.insert("nested_map");
   params.flatMapFeatureSelector.insert({"nested_map", {{"1"}}});
   writerOptions.deduplicatedMapColumns.insert("nested_map");
@@ -4458,7 +4458,7 @@ TEST_P(VeloxReaderTest, slidingWindowMapNestedInFlatMap) {
   }
 }
 
-TEST_P(VeloxReaderTest, flatmapPassthroughBasicTest) {
+TEST_P(BatchReaderTest, flatmapPassthroughBasicTest) {
   // normal flatmap
   auto features = std::vector<std::string>{"123", "234", "345", "456"};
   auto valueArrays = std::vector<
@@ -4505,7 +4505,7 @@ TEST_P(VeloxReaderTest, flatmapPassthroughBasicTest) {
   verifyFlatMapPassthrough(features, valueArrays);
 }
 
-TEST_P(VeloxReaderTest, flatMapPassthroughFuzzer) {
+TEST_P(BatchReaderTest, flatMapPassthroughFuzzer) {
   auto type = velox::ROW(
       {{"id_list_features",
         velox::MAP(velox::INTEGER(), velox::ARRAY(velox::BIGINT()))}});
@@ -4526,7 +4526,7 @@ TEST_P(VeloxReaderTest, flatMapPassthroughFuzzer) {
   nimble::WriterOptions writerOptions;
   writerOptions.flatMapColumns["id_list_features"];
 
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   params.readFlatMapFieldAsStruct.insert("id_list_features");
   for (auto i = 0; i < 5; ++i) {
     params.flatMapFeatureSelector["id_list_features"].features.push_back(
@@ -4594,7 +4594,7 @@ TEST_P(VeloxReaderTest, flatMapPassthroughFuzzer) {
   }
 }
 
-TEST_P(VeloxReaderTest, mapToFlatMapAndPassthrough) {
+TEST_P(BatchReaderTest, mapToFlatMapAndPassthrough) {
   auto mapType = velox::ROW(
       {{"id_list_features",
         velox::MAP(velox::INTEGER(), velox::ARRAY(velox::BIGINT()))}});
@@ -4635,14 +4635,14 @@ TEST_P(VeloxReaderTest, mapToFlatMapAndPassthrough) {
           "memory_leak_detect");
   auto readerPool = leakDetectPool->addLeafChild("reader_pool");
 
-  nimble::VeloxReadParams readParams = createReadParams();
+  nimble::BatchReadParams readParams = createReadParams();
   readParams.readFlatMapFieldAsStruct.insert("id_list_features");
   for (auto i = 0; i < numFeatures; ++i) {
     readParams.flatMapFeatureSelector["id_list_features"].features.push_back(
         folly::to<std::string>(i));
   }
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *readerPool.get(), selector, readParams);
 
   auto rootTypeFromSchema = convertToVeloxType(*reader.schema());
@@ -4681,7 +4681,7 @@ TEST_P(VeloxReaderTest, mapToFlatMapAndPassthrough) {
   EXPECT_EQ(nextExpected.size(), fullReadResult.size());
 
   velox::InMemoryReadFile flatMapReadFile(newFile);
-  nimble::VeloxReader flatReader(
+  nimble::BatchReader flatReader(
       &flatMapReadFile, *readerPool.get(), selector, readParams);
 
   auto flatRootTypeFromSchema = convertToVeloxType(*flatReader.schema());
@@ -4703,7 +4703,7 @@ TEST_P(VeloxReaderTest, mapToFlatMapAndPassthrough) {
   ASSERT_FALSE(flatReader.next(1, lastFlatResult));
 }
 
-TEST_P(VeloxReaderTest, flatMapToStruct) {
+TEST_P(BatchReaderTest, flatMapToStruct) {
   auto floatFeatures = velox::MAP(velox::INTEGER(), velox::REAL());
   auto idListFeatures =
       velox::MAP(velox::INTEGER(), velox::ARRAY(velox::BIGINT()));
@@ -4733,7 +4733,7 @@ TEST_P(VeloxReaderTest, flatMapToStruct) {
   writerOptions.flatMapColumns["id_score_list_features"];
   writerOptions.flatMapColumns["row_column"];
 
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   params.readFlatMapFieldAsStruct.insert("float_features");
   params.readFlatMapFieldAsStruct.insert("id_list_features");
   params.readFlatMapFieldAsStruct.insert("id_score_list_features");
@@ -4764,7 +4764,7 @@ TEST_P(VeloxReaderTest, flatMapToStruct) {
   }
 }
 
-TEST_P(VeloxReaderTest, flatMapToStructForComplexType) {
+TEST_P(BatchReaderTest, flatMapToStructForComplexType) {
   auto rowColumn = velox::MAP(
       velox::INTEGER(),
       velox::ROW(
@@ -4785,7 +4785,7 @@ TEST_P(VeloxReaderTest, flatMapToStructForComplexType) {
   nimble::WriterOptions writerOptions;
   writerOptions.flatMapColumns["row_column"];
 
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   params.readFlatMapFieldAsStruct.insert("row_column");
   for (auto i = 0; i < 10; ++i) {
     params.flatMapFeatureSelector["row_column"].features.push_back(
@@ -4807,7 +4807,7 @@ TEST_P(VeloxReaderTest, flatMapToStructForComplexType) {
   }
 }
 
-TEST_P(VeloxReaderTest, stringKeyFlatMapAsStruct) {
+TEST_P(BatchReaderTest, stringKeyFlatMapAsStruct) {
   auto stringKeyFeatures = velox::MAP(velox::VARCHAR(), velox::REAL());
   auto type = velox::ROW({
       {"string_key_feature", stringKeyFeatures},
@@ -4825,7 +4825,7 @@ TEST_P(VeloxReaderTest, stringKeyFlatMapAsStruct) {
   };
   VeloxMapGenerator generator(leafPool_.get(), generatorConfig);
 
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   params.readFlatMapFieldAsStruct.emplace("string_key_feature");
   for (auto i = 0; i < 10; ++i) {
     params.flatMapFeatureSelector["string_key_feature"].features.push_back(
@@ -4861,7 +4861,7 @@ TEST_P(VeloxReaderTest, stringKeyFlatMapAsStruct) {
   }
 }
 
-TEST_P(VeloxReaderTest, flatMapAsMapEncoding) {
+TEST_P(BatchReaderTest, flatMapAsMapEncoding) {
   auto floatFeatures = velox::MAP(velox::INTEGER(), velox::REAL());
   auto idListFeatures =
       velox::MAP(velox::INTEGER(), velox::ARRAY(velox::BIGINT()));
@@ -4896,7 +4896,7 @@ TEST_P(VeloxReaderTest, flatMapAsMapEncoding) {
   writerOptions.dictionaryArrayColumns.emplace("deduplicated_id_list_features");
   // Verify the flatmap read without feature selection they are read as
   // MapEncoding
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   auto iterations = 10;
   auto batches = 10;
   for (auto i = 0; i < iterations; ++i) {
@@ -5064,7 +5064,7 @@ TEST_P(VeloxReaderTest, flatMapAsMapEncoding) {
   }
 }
 
-TEST_P(VeloxReaderTest, stringKeyFlatMapAsMapEncoding) {
+TEST_P(BatchReaderTest, stringKeyFlatMapAsMapEncoding) {
   auto stringKeyFeatures = velox::MAP(velox::VARCHAR(), velox::REAL());
   auto type = velox::ROW({
       {"string_key_feature", stringKeyFeatures},
@@ -5081,7 +5081,7 @@ TEST_P(VeloxReaderTest, stringKeyFlatMapAsMapEncoding) {
   nimble::WriterOptions writerOptions;
   writerOptions.flatMapColumns["string_key_feature"];
 
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   // Selecting only keys with even index to it
   for (auto i = 0; i < 10; ++i) {
     if (i % 2 == 0) {
@@ -5145,10 +5145,10 @@ class TestNimbleReaderFactory {
             vectors[0]->type())},
         pool_{&leafPool} {}
 
-  nimble::VeloxReader createReader(const nimble::VeloxReadParams& params = {}) {
+  nimble::BatchReader createReader(const nimble::BatchReadParams& params = {}) {
     auto selector =
         std::make_shared<velox::dwio::common::ColumnSelector>(type_);
-    return nimble::VeloxReader(
+    return nimble::BatchReader(
         file_.get(), *this->pool_, std::move(selector), params);
   }
 
@@ -5208,7 +5208,7 @@ std::vector<velox::VectorPtr> createSkipSeekVectors(
 }
 
 void readAndVerifyContent(
-    nimble::VeloxReader& reader,
+    nimble::BatchReader& reader,
     std::vector<velox::VectorPtr> expectedVectors,
     uint32_t rowsToRead,
     uint32_t expectedNumberOfRows,
@@ -5237,7 +5237,7 @@ void readAndVerifyContent(
   }
 }
 
-TEST_P(VeloxReaderTest, readerSeekTest) {
+TEST_P(BatchReaderTest, readerSeekTest) {
   // Generate an Nimble file with 3 stripes and 10 rows each
   auto vectors = createSkipSeekVectors(*leafPool_, {10, 10, 10});
   nimble::WriterOptions writerOptions;
@@ -5336,7 +5336,7 @@ TEST_P(VeloxReaderTest, readerSeekTest) {
   }
 }
 
-TEST_P(VeloxReaderTest, readerSkipTest) {
+TEST_P(BatchReaderTest, readerSkipTest) {
   // Generate an Nimble file with 3 stripes and 10 rows each
   auto vectors = createSkipSeekVectors(*leafPool_, {10, 10, 10});
   nimble::WriterOptions writerOptions;
@@ -5559,7 +5559,7 @@ TEST_P(VeloxReaderTest, readerSkipTest) {
   }
 }
 
-TEST_P(VeloxReaderTest, readerSkipSingleStripeTest) {
+TEST_P(BatchReaderTest, readerSkipSingleStripeTest) {
   // Generate an Nimble file with 1 stripe and 12 rows
   auto vectors = createSkipSeekVectors(*leafPool_, {12});
   nimble::WriterOptions writerOptions;
@@ -5612,7 +5612,7 @@ TEST_P(VeloxReaderTest, readerSkipSingleStripeTest) {
   }
 }
 
-TEST_P(VeloxReaderTest, readerSeekSingleStripeTest) {
+TEST_P(BatchReaderTest, readerSeekSingleStripeTest) {
   // Generate an Nimble file with 1 stripes and 11 rows
   auto vectors = createSkipSeekVectors(*leafPool_, {11});
   nimble::WriterOptions writerOptions;
@@ -5646,7 +5646,7 @@ TEST_P(VeloxReaderTest, readerSeekSingleStripeTest) {
   }
 }
 
-TEST_P(VeloxReaderTest, readerSkipUnevenStripesTest) {
+TEST_P(BatchReaderTest, readerSkipUnevenStripesTest) {
   // Generate an Nimble file with 4 stripes
   auto vectors = createSkipSeekVectors(*leafPool_, {12, 15, 25, 18});
   nimble::WriterOptions writerOptions;
@@ -5682,7 +5682,7 @@ TEST_P(VeloxReaderTest, readerSkipUnevenStripesTest) {
 // initialize the value for optimized builds. T() we have used a bit in the
 // code to zero out the result. This is a dummy test to fail fast if it is not
 // zero initialized for primitive types
-TEST_P(VeloxReaderTest, testPrimitiveFieldDefaultValue) {
+TEST_P(BatchReaderTest, testPrimitiveFieldDefaultValue) {
   verifyDefaultValue<velox::vector_size_t>(2, 0, 10);
   verifyDefaultValue<int8_t>(2, 0, 30);
   verifyDefaultValue<uint8_t>(2, 0, 30);
@@ -5714,7 +5714,7 @@ struct RangeTestParams {
   std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> expectedSkips;
 };
 
-TEST_P(VeloxReaderTest, rangeReads) {
+TEST_P(BatchReaderTest, rangeReads) {
   // Generate an Nimble file with 4 stripes
   auto vectors = createSkipSeekVectors(*leafPool_, {10, 15, 25, 9});
   nimble::WriterOptions writerOptions;
@@ -5724,7 +5724,7 @@ TEST_P(VeloxReaderTest, rangeReads) {
       *leafPool_, *rootPool_, vectors, writerOptions);
 
   auto test = [&readerFactory, &vectors](RangeTestParams params) {
-    nimble::VeloxReadParams readParams;
+    nimble::BatchReadParams readParams;
     readParams.fileRangeStartOffset = params.rangeStart;
     readParams.fileRangeEndOffset = params.rangeEnd;
     auto reader = readerFactory.createReader(readParams);
@@ -6052,7 +6052,7 @@ TEST_P(VeloxReaderTest, rangeReads) {
   });
 }
 
-TEST_P(VeloxReaderTest, DISABLED_testScalarFieldLifeCycle) {
+TEST_P(BatchReaderTest, DISABLED_testScalarFieldLifeCycle) {
   const auto testScalarFieldLifeCycle =
       [&](const std::shared_ptr<const velox::RowType> schema,
           int32_t batchSize,
@@ -6118,7 +6118,7 @@ TEST_P(VeloxReaderTest, DISABLED_testScalarFieldLifeCycle) {
   }
 }
 
-TEST_P(VeloxReaderTest, testArrayFieldLifeCycle) {
+TEST_P(BatchReaderTest, testArrayFieldLifeCycle) {
   const uint32_t seed = FLAGS_reader_tests_seed > 0 ? FLAGS_reader_tests_seed
                                                     : folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
@@ -6164,7 +6164,7 @@ TEST_P(VeloxReaderTest, testArrayFieldLifeCycle) {
   }
 }
 
-TEST_P(VeloxReaderTest, testMapFieldLifeCycle) {
+TEST_P(BatchReaderTest, testMapFieldLifeCycle) {
   const auto testMapFieldLifeCycle =
       [&](const std::shared_ptr<const velox::RowType> type,
           int32_t batchSize,
@@ -6217,7 +6217,7 @@ TEST_P(VeloxReaderTest, testMapFieldLifeCycle) {
   }
 }
 
-TEST_P(VeloxReaderTest, testFlatMapAsMapFieldLifeCycle) {
+TEST_P(BatchReaderTest, testFlatMapAsMapFieldLifeCycle) {
   const auto testFlatMapFieldLifeCycle =
       [&](const std::shared_ptr<const velox::RowType> type,
           int32_t batchSize,
@@ -6265,7 +6265,7 @@ TEST_P(VeloxReaderTest, testFlatMapAsMapFieldLifeCycle) {
   }
 }
 
-TEST_P(VeloxReaderTest, testRowFieldLifeCycle) {
+TEST_P(BatchReaderTest, testRowFieldLifeCycle) {
   const auto testRowFieldLifeCycle =
       [&](const std::shared_ptr<const velox::RowType> type,
           int32_t batchSize,
@@ -6316,7 +6316,7 @@ TEST_P(VeloxReaderTest, testRowFieldLifeCycle) {
   }
 }
 
-TEST_P(VeloxReaderTest, veloxTypeFromNimbleSchema) {
+TEST_P(BatchReaderTest, veloxTypeFromNimbleSchema) {
   auto type = velox::ROW({
       {"tinyint_val", velox::TINYINT()},
       {"smallint_val", velox::SMALLINT()},
@@ -6353,7 +6353,7 @@ TEST_P(VeloxReaderTest, veloxTypeFromNimbleSchema) {
   testVeloxTypeFromNimbleSchema(*leafPool_, writerOptions, vector);
 }
 
-TEST_P(VeloxReaderTest, veloxTypeFromNimbleSchemaEmptyFlatMap) {
+TEST_P(BatchReaderTest, veloxTypeFromNimbleSchemaEmptyFlatMap) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   uint32_t numRows = 5;
   auto vector = vectorMaker.rowVector(
@@ -6381,7 +6381,7 @@ TEST_P(VeloxReaderTest, veloxTypeFromNimbleSchemaEmptyFlatMap) {
   testVeloxTypeFromNimbleSchema(*leafPool_, writerOptions, vector);
 }
 
-TEST_P(VeloxReaderTest, missingMetadata) {
+TEST_P(BatchReaderTest, missingMetadata) {
   if (nimble::detail::defaultMetadata().empty()) {
     GTEST_SKIP() << "This build injects no default metadata "
                     "(WriterDefaultMetadataOSS.cpp returns an empty map), so a "
@@ -6398,7 +6398,7 @@ TEST_P(VeloxReaderTest, missingMetadata) {
     nimble::testing::InMemoryTrackableReadFile readFile(
         file, useChainedBuffers);
 
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, nullptr, createReadParams());
     {
       readFile.resetChunks();
@@ -6419,7 +6419,7 @@ TEST_P(VeloxReaderTest, missingMetadata) {
   }
 }
 
-TEST_P(VeloxReaderTest, withMetadata) {
+TEST_P(BatchReaderTest, withMetadata) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   auto vector =
       vectorMaker.rowVector({vectorMaker.flatVector<int32_t>({1, 2, 3})});
@@ -6432,7 +6432,7 @@ TEST_P(VeloxReaderTest, withMetadata) {
     nimble::testing::InMemoryTrackableReadFile readFile(
         file, useChainedBuffers);
 
-    nimble::VeloxReader reader(&readFile, *leafPool_);
+    nimble::BatchReader reader(&readFile, *leafPool_);
 
     {
       readFile.resetChunks();
@@ -6462,7 +6462,7 @@ TEST_P(VeloxReaderTest, withMetadata) {
   }
 }
 
-TEST_P(VeloxReaderTest, inaccurateSchemaWithSelection) {
+TEST_P(BatchReaderTest, inaccurateSchemaWithSelection) {
   // Some compute engines (e.g. Presto) sometimes don't have the full schema
   // to pass into the reader (if column projection is used). The reader needs
   // the schema in order to correctly construct the output vector. However,
@@ -6511,7 +6511,7 @@ TEST_P(VeloxReaderTest, inaccurateSchemaWithSelection) {
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
         inaccurateType,
         std::vector<uint64_t>{projected.begin(), projected.end()});
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), createReadParams());
 
     ASSERT_TRUE(reader.next(vector->size(), result));
@@ -6533,7 +6533,7 @@ TEST_P(VeloxReaderTest, inaccurateSchemaWithSelection) {
   }
 }
 
-TEST_P(VeloxReaderTest, chunkStreamsWithNulls) {
+TEST_P(BatchReaderTest, chunkStreamsWithNulls) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   std::vector<facebook::velox::VectorPtr> vectors{
       vectorMaker.rowVector({
@@ -6574,7 +6574,7 @@ TEST_P(VeloxReaderTest, chunkStreamsWithNulls) {
     auto file = nimble::test::createNimbleFile(
         *rootPool_, vectors, options, /* flushAfterWrite */ false);
     velox::InMemoryReadFile readFile(file);
-    nimble::VeloxReader reader(
+    nimble::BatchReader reader(
         &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
     velox::VectorPtr result;
@@ -6596,7 +6596,7 @@ TEST_P(VeloxReaderTest, chunkStreamsWithNulls) {
     // minStreamChunkRawSize=0 fix, small writes would be merged into one
     // chunk.
     if (enableChunking) {
-      nimble::VeloxReader chunkReader(
+      nimble::BatchReader chunkReader(
           &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
       const auto& tablet = chunkReader.tabletReader();
       const auto stripeId = tablet.stripeIdentifier(0);
@@ -6627,7 +6627,7 @@ TEST_P(VeloxReaderTest, chunkStreamsWithNulls) {
   }
 }
 
-TEST_P(VeloxReaderTest, estimatedRowSizeSimple) {
+TEST_P(BatchReaderTest, estimatedRowSizeSimple) {
   const uint32_t rowCount = 100;
   const double kMaxErrorRate = 0.2;
   auto testPrimitive = [&, rootPool = rootPool_, leafPool = leafPool_](
@@ -6642,11 +6642,11 @@ TEST_P(VeloxReaderTest, estimatedRowSizeSimple) {
       auto vector = fuzzer.fuzzInputFlatRow(velox::ROW({{"simple_col", type}}));
       auto file = nimble::test::createNimbleFile(*rootPool, vector);
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, nullptr, createReadParams());
       velox::VectorPtr result;
       ASSERT_EQ(
-          nimble::VeloxReader::kConservativeEstimatedRowSize,
+          nimble::BatchReader::kConservativeEstimatedRowSize,
           reader.estimatedRowSize());
       reader.next(1, result);
       if (type->isFixedWidth()) {
@@ -6699,7 +6699,7 @@ TEST_P(VeloxReaderTest, estimatedRowSizeSimple) {
 // boost the reported retained size (without actually allocating more memory).
 // This is ok for velox compute engines because they don't use the c++ Nimble
 // batch readers.
-TEST_P(VeloxReaderTest, estimatedRowSizeComplex) {
+TEST_P(BatchReaderTest, estimatedRowSizeComplex) {
   // For string cases and with null cases, it is really hard to get an even
   // close estimation as velox always over provision memory for vectors. Loose
   // or very loose error rate is applied to the test verification as there is no
@@ -6741,11 +6741,11 @@ TEST_P(VeloxReaderTest, estimatedRowSizeComplex) {
       auto file = nimble::test::createNimbleFile(*rootPool_, vector);
 
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, nullptr, createReadParams());
       velox::VectorPtr result;
       ASSERT_EQ(
-          nimble::VeloxReader::kConservativeEstimatedRowSize,
+          nimble::BatchReader::kConservativeEstimatedRowSize,
           reader.estimatedRowSize());
       // Read 1 less row so that it does not reach stripe boundary.
       reader.next(numRows - 1, result);
@@ -6822,7 +6822,7 @@ TEST_P(VeloxReaderTest, estimatedRowSizeComplex) {
       auto file =
           nimble::test::createNimbleFile(*rootPool_, vector, writerOptions);
 
-      nimble::VeloxReadParams readParams = createReadParams();
+      nimble::BatchReadParams readParams = createReadParams();
       if (readFlatMapFieldAsStruct) {
         readParams.readFlatMapFieldAsStruct.insert("flat_map_col");
         for (auto i = 0; i < numFeatures; ++i) {
@@ -6839,10 +6839,10 @@ TEST_P(VeloxReaderTest, estimatedRowSizeComplex) {
       }
 
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(&readFile, *leafPool_, nullptr, readParams);
+      nimble::BatchReader reader(&readFile, *leafPool_, nullptr, readParams);
       velox::VectorPtr result;
       ASSERT_EQ(
-          nimble::VeloxReader::kConservativeEstimatedRowSize,
+          nimble::BatchReader::kConservativeEstimatedRowSize,
           reader.estimatedRowSize());
       // Read 1 less row so that it does not reach stripe boundary.
       reader.next(rowCount - 1, result);
@@ -6923,7 +6923,7 @@ TEST_P(VeloxReaderTest, estimatedRowSizeComplex) {
       /* maxErrorRateString= */ kMaxErrorRateLoose);
 }
 
-TEST_P(VeloxReaderTest, estimatedRowSizeMix) {
+TEST_P(BatchReaderTest, estimatedRowSizeMix) {
   const double kMaxErrorRate = 0.2;
   const double kMaxErrorRateLoose = 0.4;
 
@@ -6972,11 +6972,11 @@ TEST_P(VeloxReaderTest, estimatedRowSizeMix) {
           nimble::test::createNimbleFile(*rootPool_, vector, writerOptions);
 
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, nullptr, createReadParams());
       velox::VectorPtr result;
       ASSERT_EQ(
-          nimble::VeloxReader::kConservativeEstimatedRowSize,
+          nimble::BatchReader::kConservativeEstimatedRowSize,
           reader.estimatedRowSize());
       reader.next(numRows - 1, result);
       int64_t estimateBasedOnRetainedSize = result->retainedSize() / numRows;
@@ -7040,7 +7040,7 @@ TEST_P(VeloxReaderTest, estimatedRowSizeMix) {
       /* maxErrorRateString= */ kMaxErrorRateLoose);
 }
 
-TEST_P(VeloxReaderTest, readNonExistingFlatMapFeature) {
+TEST_P(BatchReaderTest, readNonExistingFlatMapFeature) {
   auto testFlatMap = [&](uint32_t rowCount,
                          uint32_t numFeatures,
                          bool readFlatMapFieldAsStruct,
@@ -7090,7 +7090,7 @@ TEST_P(VeloxReaderTest, readNonExistingFlatMapFeature) {
     auto file =
         nimble::test::createNimbleFile(*rootPool_, vector, writerOptions);
 
-    nimble::VeloxReadParams readParams = createReadParams();
+    nimble::BatchReadParams readParams = createReadParams();
     if (readFlatMapFieldAsStruct) {
       readParams.readFlatMapFieldAsStruct.insert("flat_map_col");
     }
@@ -7099,10 +7099,10 @@ TEST_P(VeloxReaderTest, readNonExistingFlatMapFeature) {
         folly::to<std::string>(-1));
 
     velox::InMemoryReadFile readFile(file);
-    nimble::VeloxReader reader(&readFile, *leafPool_, nullptr, readParams);
+    nimble::BatchReader reader(&readFile, *leafPool_, nullptr, readParams);
     velox::VectorPtr result;
     ASSERT_EQ(
-        nimble::VeloxReader::kConservativeEstimatedRowSize,
+        nimble::BatchReader::kConservativeEstimatedRowSize,
         reader.estimatedRowSize());
     const uint64_t numReadRows = rowCount / 2;
     reader.next(numReadRows, result);
@@ -7183,7 +7183,7 @@ TEST_P(VeloxReaderTest, readNonExistingFlatMapFeature) {
       /* hasNulls= */ true);
 }
 
-TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
+TEST_P(BatchReaderTest, vectorVectorResetWithBufferReuse) {
   {
     velox::test::VectorMaker vectorMaker{leafPool_.get()};
     std::vector<facebook::velox::VectorPtr> vectors{
@@ -7198,7 +7198,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7214,7 +7214,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7243,7 +7243,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7259,7 +7259,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7278,7 +7278,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7311,7 +7311,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7327,7 +7327,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7346,7 +7346,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7379,7 +7379,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
     {
       auto file = nimble::test::createNimbleFile(*rootPool_, vectors, {});
       velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(
+      nimble::BatchReader reader(
           &readFile, *leafPool_, /* selector */ nullptr, createReadParams());
 
       velox::VectorPtr result;
@@ -7395,7 +7395,7 @@ TEST_P(VeloxReaderTest, vectorVectorResetWithBufferReuse) {
 }
 
 // Timestamp tests that might not be covered by fuzzer
-TEST_P(VeloxReaderTest, timestampAllNulls) {
+TEST_P(BatchReaderTest, timestampAllNulls) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 
   auto vector = vectorMaker.rowVector(
@@ -7407,7 +7407,7 @@ TEST_P(VeloxReaderTest, timestampAllNulls) {
 
   auto file = nimble::test::createNimbleFile(*rootPool_, vector, {});
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, createReadParams());
 
   velox::VectorPtr result;
@@ -7420,7 +7420,7 @@ TEST_P(VeloxReaderTest, timestampAllNulls) {
 }
 
 // Test that all-null top-level row vector short-circuits correctly
-TEST_P(VeloxReaderTest, rowVectorAllNulls) {
+TEST_P(BatchReaderTest, rowVectorAllNulls) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 
   // Create a row vector with a child column, where ALL top-level rows are null
@@ -7446,7 +7446,7 @@ TEST_P(VeloxReaderTest, rowVectorAllNulls) {
 
   auto file = nimble::test::createNimbleFile(*rootPool_, vector, {});
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, createReadParams());
 
   velox::VectorPtr result;
@@ -7459,7 +7459,7 @@ TEST_P(VeloxReaderTest, rowVectorAllNulls) {
   EXPECT_EQ(result->getNullCount().value(), rowCount);
 }
 
-TEST_P(VeloxReaderTest, timestampLargeRowCount) {
+TEST_P(BatchReaderTest, timestampLargeRowCount) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 
   const velox::vector_size_t rowCount = 10'000'000;
@@ -7472,7 +7472,7 @@ TEST_P(VeloxReaderTest, timestampLargeRowCount) {
 
   auto file = nimble::test::createNimbleFile(*rootPool_, vector, {});
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
 
   velox::VectorPtr result;
   velox::vector_size_t totalReads = 0;
@@ -7494,7 +7494,7 @@ TEST_P(VeloxReaderTest, timestampLargeRowCount) {
   ASSERT_EQ(totalReads, rowCount);
 }
 
-// Verifies that within the same TabletReader, the second VeloxReader pass
+// Verifies that within the same TabletReader, the second BatchReader pass
 // does not re-read metadata. The weak-pointer cache retains entries while the
 // tablet is alive, so metadata is always reused regardless of pinMetadata,
 // cacheMetadata, or whether cache infrastructure is provided.
@@ -7567,7 +7567,7 @@ TEST_P(MetadataReuseTest, metadataReuseWithSameReader) {
         trackingFile, leafPool_.get(), tabletOptions);
     auto readParams = createReadParams();
 
-    auto reader1 = std::make_unique<nimble::VeloxReader>(
+    auto reader1 = std::make_unique<nimble::BatchReader>(
         tablet, *leafPool_, selector, readParams);
     velox::VectorPtr result;
     ASSERT_TRUE(reader1->next(100, result));
@@ -7583,10 +7583,10 @@ TEST_P(MetadataReuseTest, metadataReuseWithSameReader) {
 
     const auto ramHitsAfterFirstPass = metadataIoStats_->ramHit().count();
 
-    // Second pass: new VeloxReader on the same TabletReader. Metadata is
+    // Second pass: new BatchReader on the same TabletReader. Metadata is
     // always reused within the same tablet regardless of settings.
     trackingFile->resetMaxReadOffset();
-    auto reader2 = std::make_unique<nimble::VeloxReader>(
+    auto reader2 = std::make_unique<nimble::BatchReader>(
         tablet, *leafPool_, selector, readParams);
     ASSERT_TRUE(reader2->next(100, result));
     ASSERT_EQ(result->size(), 100);
@@ -7695,7 +7695,7 @@ TEST_P(MetadataReuseTest, metadataReuseCrossReaders) {
     const auto metadataBoundary = stripeGroupsMeta[0].offset();
 
     auto readParams = createReadParams();
-    auto reader1 = std::make_unique<nimble::VeloxReader>(
+    auto reader1 = std::make_unique<nimble::BatchReader>(
         tablet1, *leafPool_, selector, readParams);
     velox::VectorPtr result;
     ASSERT_TRUE(reader1->next(100, result));
@@ -7716,7 +7716,7 @@ TEST_P(MetadataReuseTest, metadataReuseCrossReaders) {
     auto metadataIoStats2 = std::make_shared<velox::io::IoStatistics>();
     std::unique_ptr<velox::FileHandle> fh2;
     auto tablet2 = makeTablet(metadataIoStats2, fh2);
-    auto reader3 = std::make_unique<nimble::VeloxReader>(
+    auto reader3 = std::make_unique<nimble::BatchReader>(
         tablet2, *leafPool_, selector, readParams);
     ASSERT_TRUE(reader3->next(100, result));
     ASSERT_EQ(result->size(), 100);
@@ -7760,7 +7760,7 @@ TEST_P(MetadataReuseTest, metadataReuseCrossReaders) {
 // held. A plain read never noticed, because only wrapping a vector in a
 // dictionary validates it; a filtered read that drops rows aborted in
 // FlatVector::validate with "values_->size() >= byteSize".
-TEST_P(VeloxReaderTest, flatMapKeyBufferSurvivesEqualEntryCountBatches) {
+TEST_P(BatchReaderTest, flatMapKeyBufferSurvivesEqualEntryCountBatches) {
   constexpr velox::vector_size_t kRowCount = 40;
   constexpr velox::vector_size_t kBatchSize = 10;
   constexpr velox::vector_size_t kEntriesPerRow = 3;
@@ -7787,7 +7787,7 @@ TEST_P(VeloxReaderTest, flatMapKeyBufferSurvivesEqualEntryCountBatches) {
 
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, selector, createReadParams());
 
   velox::VectorPtr result;
@@ -7805,7 +7805,7 @@ TEST_P(VeloxReaderTest, flatMapKeyBufferSurvivesEqualEntryCountBatches) {
   EXPECT_EQ(rowsRead, kRowCount);
 }
 
-TEST_P(VeloxReaderTest, flatMapStringKeyOwnership) {
+TEST_P(BatchReaderTest, flatMapStringKeyOwnership) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::VARCHAR(), velox::BIGINT())}});
 
@@ -7861,7 +7861,7 @@ TEST_P(VeloxReaderTest, flatMapStringKeyOwnership) {
   // Read back and verify all rows are present.
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
   velox::VectorPtr output;
   uint64_t totalRows = kBatches;
@@ -7869,7 +7869,7 @@ TEST_P(VeloxReaderTest, flatMapStringKeyOwnership) {
   ASSERT_EQ(output->size(), kBatches);
 }
 
-TEST_P(VeloxReaderTest, openZLCompressionRoundTrip) {
+TEST_P(BatchReaderTest, openZLCompressionRoundTrip) {
   // E2E: write numeric columns (covering every width OpenZL has a numeric graph
   // for) plus double/string columns that exercise the zstd-fallback path, with
   // the OpenZL codec forced. Verify the data round-trips across all reader
@@ -7952,11 +7952,11 @@ TEST_P(VeloxReaderTest, openZLCompressionRoundTrip) {
 // End-to-end attributes propagation through the writer/reader pipeline.
 //
 // Validates WriterOptions::schemaAttributes round-trips through the
-// writer pipeline, the schema flatbuffer, and back through VeloxReader to
+// writer pipeline, the schema flatbuffer, and back through BatchReader to
 // the deserialized Type tree exposed by reader.schema(). Node ids are pre-order
 // (TypeWithId::id()); ids with no matching node must be ignored.
 // ---------------------------------------------------------------------------
-TEST_P(VeloxReaderTest, attributesByColumnRoundTrip) {
+TEST_P(BatchReaderTest, attributesByColumnRoundTrip) {
   facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
 
   // ROW{id BIGINT, user ROW{name VARCHAR, age INTEGER}}
@@ -8000,7 +8000,7 @@ TEST_P(VeloxReaderTest, attributesByColumnRoundTrip) {
   // Read back and inspect the deserialized Type tree's attributes().
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
   const auto& root = reader.schema();
   ASSERT_EQ(nimble::Kind::Row, root->kind());
@@ -8055,7 +8055,7 @@ TEST_P(VeloxReaderTest, attributesByColumnRoundTrip) {
 // Validates that the list element and map key/value nodes (pre-order ids)
 // round-trip their attributes. Ids with no matching node must be ignored.
 // ---------------------------------------------------------------------------
-TEST_P(VeloxReaderTest, attributesByColumnRoundTripCollections) {
+TEST_P(BatchReaderTest, attributesByColumnRoundTripCollections) {
   facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
 
   // ROW{tags ARRAY<INTEGER>, props MAP<INTEGER, BIGINT>}
@@ -8091,7 +8091,7 @@ TEST_P(VeloxReaderTest, attributesByColumnRoundTripCollections) {
 
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
   const auto& root = reader.schema();
   const auto& rowSchema = root->asRow();
@@ -8127,7 +8127,7 @@ TEST_P(VeloxReaderTest, attributesByColumnRoundTripCollections) {
 // produce a NIMBLE file whose deserialized Type tree exposes empty
 // attributes on every node. Pins the no-op upgrade path for every
 // existing NIMBLE writer.
-TEST_P(VeloxReaderTest, attributesByColumnEmptyByDefault) {
+TEST_P(BatchReaderTest, attributesByColumnEmptyByDefault) {
   facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
 
   auto type = velox::ROW({"a", "b"}, {velox::BIGINT(), velox::VARCHAR()});
@@ -8146,7 +8146,7 @@ TEST_P(VeloxReaderTest, attributesByColumnEmptyByDefault) {
 
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), createReadParams());
   const auto& root = reader.schema();
   ASSERT_EQ(nimble::Kind::Row, root->kind());
@@ -8160,7 +8160,7 @@ TEST_P(VeloxReaderTest, attributesByColumnEmptyByDefault) {
 INSTANTIATE_TEST_SUITE_P(
     FsstStringBatchReaderTestSuite,
     FsstStringBatchReaderTest,
-    ::testing::ValuesIn(VeloxReaderTest::getFsstTestParams()),
+    ::testing::ValuesIn(BatchReaderTest::getFsstTestParams()),
     [](const ::testing::TestParamInfo<TestParam>& info) {
       return info.param.debugString();
     });
@@ -8168,15 +8168,15 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     MetadataReuseTestSuite,
     MetadataReuseTest,
-    ::testing::ValuesIn(VeloxReaderTest::getMetadataReuseTestParams()),
+    ::testing::ValuesIn(BatchReaderTest::getMetadataReuseTestParams()),
     [](const ::testing::TestParamInfo<TestParam>& info) {
       return info.param.debugString();
     });
 
 INSTANTIATE_TEST_SUITE_P(
-    VeloxReaderTestSuite,
-    VeloxReaderTest,
-    ::testing::ValuesIn(VeloxReaderTest::getTestParams()),
+    BatchReaderTestSuite,
+    BatchReaderTest,
+    ::testing::ValuesIn(BatchReaderTest::getTestParams()),
     [](const ::testing::TestParamInfo<TestParam>& info) {
       return info.param.debugString();
     });

--- a/velox/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(
 add_library(nimble_writer_test_utils WriterTestUtils.cpp WriterTestUtils.h)
 target_link_libraries(
   nimble_writer_test_utils
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_velox_schema_reader
   nimble_common
   nimble_encodings_tests_utils
@@ -85,12 +85,12 @@ add_executable(
   StreamDataTest.cpp
   StreamLabelsTest.cpp
   TypeTest.cpp
-  VeloxReaderTest.cpp
+  BatchReaderTest.cpp
   WriterTest.cpp
   FieldWriterStatsTest.cpp
   TestUtils.h
 )
-# VeloxReaderTest accounts for almost all of this binary's runtime: its cases are
+# BatchReaderTest accounts for almost all of this binary's runtime: its cases are
 # parameterized over sixteen combinations, and the whole suite runs well past
 # ctest's default fifteen hundred second limit as a single test. Register it as
 # four gtest shards instead so ctest schedules them concurrently, and give each
@@ -113,7 +113,7 @@ target_link_libraries(
   nimble_velox_schema_utils
   nimble_shared_dictionary_test_utils
   nimble_writer_test_utils
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_velox_shared_dictionary_config
   nimble_writer
   nimble_velox_layout_planner
@@ -142,7 +142,7 @@ add_test(nimble_writer_chunking_fuzz_tests nimble_writer_chunking_fuzz_tests)
 target_link_libraries(
   nimble_writer_chunking_fuzz_tests
   nimble_writer_test_utils
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_writer
   nimble_common
   velox_memory
@@ -159,7 +159,7 @@ add_test(nimble_writer_fuzz_tests nimble_writer_fuzz_tests)
 target_link_libraries(
   nimble_writer_fuzz_tests
   nimble_writer_test_utils
-  nimble_velox_reader
+  nimble_batch_reader
   nimble_writer
   nimble_velox_schema_reader
   nimble_common

--- a/velox/dwio/nimble/velox/tests/NimbleWriterPassthroughFlatmapRaceTest.cpp
+++ b/velox/dwio/nimble/velox/tests/NimbleWriterPassthroughFlatmapRaceTest.cpp
@@ -34,7 +34,7 @@
 
 #include "velox/common/file/File.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 #include "velox/dwio/nimble/writer/WriterOptions.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -127,7 +127,7 @@ TEST_F(NimbleWriterPassthroughFlatmapRaceTest, passthroughNewKeysRoundTrip) {
       auto readerRoot = velox::memory::memoryManager()->addRootPool("");
       auto readerLeaf = readerRoot->addLeafChild("reader");
       auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-      nimble::VeloxReader reader(readFile.get(), *readerLeaf);
+      nimble::BatchReader reader(readFile.get(), *readerLeaf);
       uint64_t rows = 0;
       velox::VectorPtr result;
       while (reader.next(1'000, result)) {

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
@@ -46,10 +46,10 @@
 #include "velox/dwio/nimble/tablet/SharedDictionaryReader.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -1247,9 +1247,9 @@ class SharedDictionaryE2ETest : public testing::Test {
       std::shared_ptr<const ExternalDictionaryResolver> externalResolver =
           nullptr) {
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    VeloxReadParams params;
+    BatchReadParams params;
     params.externalDictionaryResolver = std::move(externalResolver);
-    VeloxReader reader{readFile, *leafPool_, nullptr, params};
+    BatchReader reader{readFile, *leafPool_, nullptr, params};
     velox::VectorPtr output;
     for (const auto stripeValueType : stripeValueTypes) {
       ASSERT_TRUE(reader.next(kStripeRows, output));
@@ -1267,7 +1267,7 @@ class SharedDictionaryE2ETest : public testing::Test {
       ScalarValueType valueType,
       const std::vector<StripeValueType>& stripeValueTypes) {
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    VeloxReader reader{readFile, *leafPool_};
+    BatchReader reader{readFile, *leafPool_};
     velox::VectorPtr output;
     for (const auto stripeValueType : stripeValueTypes) {
       ASSERT_TRUE(reader.next(kStripeRows, output));
@@ -1285,7 +1285,7 @@ class SharedDictionaryE2ETest : public testing::Test {
       FileDictionaryAlphabetOrder alphabetOrder,
       size_t stripeCount = 1) {
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    VeloxReader reader{readFile, *leafPool_};
+    BatchReader reader{readFile, *leafPool_};
     velox::VectorPtr output;
     auto expected = makeFileDictionaryStripe(alphabetOrder);
     for (size_t stripeIndex{0}; stripeIndex < stripeCount; ++stripeIndex) {
@@ -1453,7 +1453,7 @@ TEST_F(SharedDictionaryE2ETest, fileScopeCompactRowCountRoundTrip) {
       sharedDictionaryValueStreamIds(*tablet, InputType::FlatMapScalar);
   ASSERT_EQ(valueStreamIds.size(), 1);
 
-  VeloxReadParams params;
+  BatchReadParams params;
   const Encoding::Options encodingOptions{.useVarintRowCount = true};
   params.encodingFactory =
       [encodingOptions](
@@ -1465,7 +1465,7 @@ TEST_F(SharedDictionaryE2ETest, fileScopeCompactRowCountRoundTrip) {
         pool, data, std::move(stringBufferFactory));
   };
   auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-  VeloxReader reader{readFile, *leafPool_, nullptr, std::move(params)};
+  BatchReader reader{readFile, *leafPool_, nullptr, std::move(params)};
   velox::VectorPtr output;
   for (const auto stripeValueType : stripeValueTypes) {
     ASSERT_TRUE(reader.next(kStripeRows, output));
@@ -1990,7 +1990,7 @@ TEST_P(SharedDictionaryE2EExternalDictionaryFailureTest, fails) {
           {StripeValueType::Dictionary, StripeValueType::Direct},
           resolver);
       auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-      VeloxReader reader{readFile, *leafPool_};
+      BatchReader reader{readFile, *leafPool_};
       velox::VectorPtr output;
       NIMBLE_ASSERT_USER_THROW(
           reader.next(kStripeRows, output),

--- a/velox/dwio/nimble/velox/tests/TypeTest.cpp
+++ b/velox/dwio/nimble/velox/tests/TypeTest.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/dwio/nimble/common/tests/NimbleFileWriter.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/writer/WriterOptions.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
@@ -72,7 +72,7 @@ TEST_F(TypeTests, matchingSchema) {
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
-  nimble::VeloxReader reader(&readFile, *leafPool_, std::move(selector));
+  nimble::BatchReader reader(&readFile, *leafPool_, std::move(selector));
 
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(batchSize, result));
@@ -137,7 +137,7 @@ TEST_F(TypeTests, extraColumnWithRename) {
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(newType));
-  nimble::VeloxReader reader(&readFile, *leafPool_, std::move(selector));
+  nimble::BatchReader reader(&readFile, *leafPool_, std::move(selector));
 
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(batchSize, result));
@@ -196,7 +196,7 @@ TEST_F(TypeTests, sameTypeWithProjection) {
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(type),
       std::vector<std::string>{"array", "nested", "arraywithoffsets"});
-  nimble::VeloxReader reader(&readFile, *leafPool_, std::move(selector));
+  nimble::BatchReader reader(&readFile, *leafPool_, std::move(selector));
 
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(batchSize, result));
@@ -272,7 +272,7 @@ TEST_F(TypeTests, projectingNewColumn) {
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(newType),
       std::vector<std::string>{"struct_rename", "new"});
-  nimble::VeloxReader reader(&readFile, *leafPool_, std::move(selector));
+  nimble::BatchReader reader(&readFile, *leafPool_, std::move(selector));
 
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(batchSize, result));
@@ -360,7 +360,7 @@ TEST_F(TypeTests, flatMapFeatureSelection) {
   auto expectedInnerType =
       velox::ROW({velox::BIGINT(), velox::BIGINT(), velox::BIGINT()});
 
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   params.readFlatMapFieldAsStruct = {"map"},
   params.flatMapFeatureSelector = {
       {"map",
@@ -368,7 +368,7 @@ TEST_F(TypeTests, flatMapFeatureSelection) {
          folly::to<std::string>(existingKey),
          folly::to<std::string>(nonExistingKey2)}}}};
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, std::move(selector), std::move(params));
 
   velox::VectorPtr result;

--- a/velox/dwio/nimble/velox/tests/WriterChunkingFuzzTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterChunkingFuzzTest.cpp
@@ -22,7 +22,7 @@
 #include "folly/Random.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/SharedArbitrator.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/tests/WriterTestUtils.h"
 #include "velox/dwio/nimble/writer/FlushPolicy.h"
 #include "velox/dwio/nimble/writer/Writer.h"
@@ -149,7 +149,7 @@ TEST_F(WriterChunkingFuzzTest, fuzzComplex) {
         writer.close();
 
         velox::InMemoryReadFile readFile(file);
-        nimble::VeloxReader reader(&readFile, *leafPool_);
+        nimble::BatchReader reader(&readFile, *leafPool_);
         validateChunkSize(
             reader,
             writerOptions.minStreamChunkRawSize,

--- a/velox/dwio/nimble/velox/tests/WriterFuzzTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterFuzzTest.cpp
@@ -22,7 +22,7 @@
 #include "folly/Random.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/SharedArbitrator.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/tests/WriterTestUtils.h"
 #include "velox/dwio/nimble/writer/FlushPolicy.h"
 #include "velox/dwio/nimble/writer/Writer.h"
@@ -157,7 +157,7 @@ TEST_F(WriterTest, fuzzComplex) {
         writer.close();
 
         velox::InMemoryReadFile readFile(file);
-        nimble::VeloxReader reader(&readFile, *leafPool_);
+        nimble::BatchReader reader(&readFile, *leafPool_);
         validateChunkSize(
             reader,
             writerOptions.minStreamChunkRawSize,

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -50,13 +50,13 @@
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/tablet/FileLayout.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/dwio/nimble/velox/ChunkedStream.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SchemaUtils.h"
 #include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
 #include "velox/dwio/nimble/velox/StatsGenerated.h"
-#include "velox/dwio/nimble/velox/VeloxReader.h"
 #include "velox/dwio/nimble/velox/stats/VectorizedStatistics.h"
 #include "velox/dwio/nimble/velox/tests/WriterTestUtils.h"
 #include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
@@ -385,7 +385,7 @@ class WriterTest : public ::testing::Test {
     // Every output row must equal the corresponding input row, across all
     // columns (BaseVector::equalValueAt is type-agnostic and null-aware).
     {
-      nimble::VeloxReader reader(readFile.get(), *leafPool_);
+      nimble::BatchReader reader(readFile.get(), *leafPool_);
       velox::VectorPtr result;
       size_t batchIndex = 0;
       velox::vector_size_t rowInBatch = 0;
@@ -588,7 +588,7 @@ TEST_F(WriterTest, emptyFile) {
   EXPECT_TRUE(layout.indexPartitions.empty());
   EXPECT_TRUE(layout.stripesInfo.empty());
 
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   velox::VectorPtr result;
   ASSERT_FALSE(reader.next(1, result));
 }
@@ -654,7 +654,7 @@ TEST_F(WriterTest, mainlyConstantRoundTrip) {
 
   // Both columns must read back exactly.
   auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(vector->size(), result));
   ASSERT_EQ(result->size(), vector->size());
@@ -967,7 +967,7 @@ TEST_F(WriterTest, emptyFileWithIndexEnabled) {
   EXPECT_TRUE(layout.indexPartitions.empty());
   EXPECT_TRUE(layout.stripesInfo.empty());
 
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   velox::VectorPtr result;
   ASSERT_FALSE(reader.next(1, result));
 }
@@ -1060,7 +1060,7 @@ TEST_F(WriterTest, emptyFileNoSchema) {
   writer.close();
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
 
   velox::VectorPtr result;
   ASSERT_FALSE(reader.next(batchSize, result));
@@ -1104,7 +1104,7 @@ TEST_F(WriterTest, rootHasNulls) {
   EXPECT_EQ(layout.stripesInfo[0].stripeGroupIndex, 0);
   EXPECT_GT(layout.stripesInfo[0].size, 0);
 
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(batchSize, result));
   ASSERT_EQ(result->size(), batchSize);
@@ -1135,7 +1135,7 @@ TEST_F(WriterTest, schemaGrowthExtraColumn) {
   writer.close();
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
 
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(3, result));
@@ -1172,7 +1172,7 @@ TEST_F(WriterTest, schemaGrowthExtraSubField) {
   writer.close();
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
 
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(3, result));
@@ -1404,7 +1404,7 @@ TEST_F(WriterTest, featureReorderingStreamCollocation) {
         streamCount);
     tablet->streamLocations(stripeId, streamLocations);
 
-    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    nimble::BatchReader reader(readFile.get(), *leafPool_);
     const auto& flatMap =
         reader.schema()->asRow().childAt(flatmapOrdinal)->asFlatMap();
 
@@ -1544,7 +1544,7 @@ TEST_F(WriterTest, featureReorderingSharedDictionaryStreamCollocation) {
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
     {
-      nimble::VeloxReader reader(readFile.get(), *leafPool_);
+      nimble::BatchReader reader(readFile.get(), *leafPool_);
       velox::VectorPtr result;
       ASSERT_TRUE(reader.next(kNumRows, result));
       ASSERT_EQ(result->size(), vector->size());
@@ -1568,7 +1568,7 @@ TEST_F(WriterTest, featureReorderingSharedDictionaryStreamCollocation) {
         streamCount);
     tablet->streamLocations(stripeId, streamLocations);
 
-    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    nimble::BatchReader reader(readFile.get(), *leafPool_);
     const auto& flatMap =
         reader.schema()->asRow().childAt(flatmapOrdinal)->asFlatMap();
 
@@ -1692,7 +1692,7 @@ TEST_F(
       streamCount);
   tablet->streamLocations(stripeId, streamLocations);
 
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   const auto& rowSchema = reader.schema()->asRow();
   ASSERT_EQ(1, rowSchema.childrenCount());
   EXPECT_EQ("flatmap", rowSchema.nameAt(0));
@@ -1766,7 +1766,7 @@ TEST_F(WriterTest, encodingLayoutTreeWithOmittedClusterIndexKey) {
   }
 
   auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   const auto& schema = reader.schema()->asRow();
   ASSERT_EQ(schema.childrenCount(), 1);
   EXPECT_EQ(schema.nameAt(0), "flatmap");
@@ -1873,7 +1873,7 @@ TEST_P(StripeRawSizeFlushPolicyTest, stripeRawSizeFlushPolicy) {
 
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
-  nimble::VeloxReader reader(&readFile, *leafPool_, std::move(selector));
+  nimble::BatchReader reader(&readFile, *leafPool_, std::move(selector));
 
   EXPECT_EQ(GetParam().stripeCount, reader.tabletReader().stripeCount());
 }
@@ -2063,7 +2063,7 @@ TEST_F(WriterTest, flushHugeStrings) {
   velox::InMemoryReadFile readFile(file);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
-  nimble::VeloxReader reader(&readFile, *leafPool_, std::move(selector));
+  nimble::BatchReader reader(&readFile, *leafPool_, std::move(selector));
 
   EXPECT_EQ(3, reader.tabletReader().stripeCount());
 }
@@ -2426,7 +2426,7 @@ TEST_F(WriterTest, openZLCompressionNumericRoundTrip) {
   EXPECT_TRUE(anyOpenZL)
       << "Expected at least one numeric stream to be OpenZL-compressed";
 
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
   ASSERT_EQ(kRowCount, result->size());
@@ -2811,10 +2811,10 @@ TEST_F(WriterTest, combineMultipleLayersOfDictionaries) {
   writer.write(vector);
   writer.close();
   InMemoryReadFile readFile(file);
-  nimble::VeloxReadParams params;
+  nimble::BatchReadParams params;
   params.readFlatMapFieldAsStruct = {"c0"};
   params.flatMapFeatureSelector["c0"].features = {"c0"};
-  nimble::VeloxReader reader(&readFile, *leafPool_, nullptr, params);
+  nimble::BatchReader reader(&readFile, *leafPool_, nullptr, params);
   VectorPtr result;
   ASSERT_TRUE(reader.next(4, result));
   ASSERT_EQ(result->size(), 4);
@@ -2891,7 +2891,7 @@ void testChunks(
       tabletReadFile, leafPool.get(), makeTestTabletOptions(leafPool.get()));
   verifier(*tablet);
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       std::make_shared<velox::InMemoryReadFile>(file), *leafPool);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(expected->size(), result));
@@ -3043,7 +3043,7 @@ TEST_F(WriterTest, omitsAllNonNullRowNullStreams) {
         readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
     ASSERT_EQ(1, tablet->stripeCount());
 
-    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    nimble::BatchReader reader(readFile.get(), *leafPool_);
     const auto& root = reader.schema()->asRow();
     const auto& nested = root.childAt(0)->asRow();
     const auto rootNullOffset = root.nullsDescriptor().offset();
@@ -4204,7 +4204,7 @@ TEST_P(ChunkFlushPolicyTest, chunkFlushPolicyIntegration) {
   }
   writer.close();
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
   ChunkSizeResults result = validateChunkSize(
       reader,
       GetParam().minStreamChunkRawSize,
@@ -4309,7 +4309,7 @@ TEST_F(WriterTest, batchedChunkingRelievesMemoryPressure) {
     EXPECT_FALSE(actualChunkingDecisions[1]);
 
     velox::InMemoryReadFile readFile(file);
-    nimble::VeloxReader reader(&readFile, *leafPool_);
+    nimble::BatchReader reader(&readFile, *leafPool_);
     validateChunkSize(
         reader,
         writerOptions.minStreamChunkRawSize,
@@ -4348,7 +4348,7 @@ TEST_F(WriterTest, ignoreTopLevelNulls) {
         writer.close();
 
         velox::InMemoryReadFile readFile(file);
-        nimble::VeloxReader reader(&readFile, pool);
+        nimble::BatchReader reader(&readFile, pool);
         velox::VectorPtr output;
         reader.next(expected->size(), output);
         ASSERT_EQ(output->size(), expected->size());
@@ -4412,7 +4412,7 @@ class TimestampEdgeCaseTest
     : public WriterTest,
       public ::testing::WithParamInterface<TimestampTestCase> {};
 
-// We rely on fuzz tests in VeloxReaderTests for more complex data shapes.
+// We rely on fuzz tests in BatchReaderTests for more complex data shapes.
 TEST_P(TimestampEdgeCaseTest, roundTrip) {
   auto testCase = GetParam();
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
@@ -4429,7 +4429,7 @@ TEST_P(TimestampEdgeCaseTest, roundTrip) {
   writer.close();
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(1, result));
 
@@ -4987,7 +4987,7 @@ TEST_F(WriterTest, cachedEncodingLayoutMultiType) {
     std::vector<float> actualC2;
     std::vector<int64_t> actualC3;
     {
-      nimble::VeloxReader reader(readFile.get(), *leafPool_);
+      nimble::BatchReader reader(readFile.get(), *leafPool_);
       velox::VectorPtr result;
       while (reader.next(kRowsPerChunk, result)) {
         auto* row = result->as<velox::RowVector>();
@@ -5136,7 +5136,7 @@ TEST_F(WriterTest, cachedEncodingLayoutNullableEncoding) {
     // corrupt values or nulls.
     std::vector<std::optional<int64_t>> actual;
     {
-      nimble::VeloxReader reader(readFile.get(), *leafPool_);
+      nimble::BatchReader reader(readFile.get(), *leafPool_);
       velox::VectorPtr result;
       while (reader.next(kRowsPerChunk, result)) {
         auto* c0 =
@@ -6166,7 +6166,7 @@ class WriterIndexTest : public WriterTest,
       const std::vector<velox::RowVectorPtr>& expectedBatches,
       uint32_t readBatchSize = 100) {
     velox::InMemoryReadFile readFile(file);
-    nimble::VeloxReader reader(&readFile, *leafPool_);
+    nimble::BatchReader reader(&readFile, *leafPool_);
 
     auto expected = velox::BaseVector::create(type, 0, leafPool_.get());
     for (const auto& batch : expectedBatches) {
@@ -6807,7 +6807,7 @@ TEST_P(WriterIndexTest, omitClusterIndexKeyColumnStorage) {
           .clusterIndexKeyColumnsWithOmittedStorage(),
       (std::vector<std::string>{"key_col"}));
 
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   auto actualStoredType = nimble::convertToVeloxType(*reader.schema());
   EXPECT_EQ(*storedType, *actualStoredType);
 
@@ -6866,7 +6866,7 @@ TEST_P(
   writer.close();
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
   const auto& rowSchema = reader.schema()->asRow();
   ASSERT_EQ(2, rowSchema.childrenCount());
   EXPECT_EQ("value_col", rowSchema.nameAt(0));
@@ -7075,7 +7075,7 @@ TEST_F(WriterTest, indexEnforceKeyOrder) {
 
         // Verify file was written successfully
         velox::InMemoryReadFile readFile(file);
-        nimble::VeloxReader reader(&readFile, *leafPool_);
+        nimble::BatchReader reader(&readFile, *leafPool_);
         EXPECT_TRUE(reader.tabletReader().hasOptionalSection(
             std::string(nimble::kIndexSection)));
       }
@@ -7696,7 +7696,7 @@ TEST_F(WriterTest, disableStatsCollection) {
   // Verify the file is readable and data round-trips.
   {
     velox::InMemoryReadFile readFile(file);
-    nimble::VeloxReader reader(&readFile, *leafPool_);
+    nimble::BatchReader reader(&readFile, *leafPool_);
     velox::VectorPtr result;
     uint64_t totalRows = 0;
     while (reader.next(100, result)) {
@@ -7761,8 +7761,8 @@ nimble::EncodingLayoutTree singleScalarLayoutTree(
       {{nimble::Kind::Scalar, {{0, std::move(layout)}}, ""}}};
 }
 
-nimble::VeloxReadParams nonLegacyReadParams() {
-  nimble::VeloxReadParams params;
+nimble::BatchReadParams nonLegacyReadParams() {
+  nimble::BatchReadParams params;
   params.encodingFactory =
       [](velox::memory::MemoryPool& pool,
          std::string_view data,
@@ -7883,7 +7883,7 @@ TEST_F(WriterTest, encodingLayoutDelta) {
   }
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -7918,7 +7918,7 @@ TEST_F(WriterTest, encodingLayoutDeltaWithRestatements) {
   verifyDeltaEncoding(file, *leafPool_);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -7951,7 +7951,7 @@ TEST_F(WriterTest, encodingLayoutDeltaInt32) {
   verifyDeltaEncoding(file, *leafPool_, true);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -7988,7 +7988,7 @@ TEST_F(WriterTest, encodingLayoutDeltaNegativeValues) {
   verifyDeltaEncoding(file, *leafPool_);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -8032,7 +8032,7 @@ TEST_F(WriterTest, encodingLayoutDeltaNullable) {
   verifyDeltaEncoding(file, *leafPool_, true);
 
   velox::InMemoryReadFile readFile2(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile2, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -8084,7 +8084,7 @@ TEST_F(WriterTest, encodingLayoutDeltaMultiStripe) {
 
   // Read back all rows across stripes.
   velox::InMemoryReadFile readFile2(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile2, *leafPool_, nullptr, nonLegacyReadParams());
   int32_t totalRows = 0;
   int32_t batchIdx = 0;
@@ -8192,7 +8192,7 @@ TEST_F(WriterTest, encodingLayoutDeltaMultiColumn) {
   }
 
   velox::InMemoryReadFile readFile2(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile2, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -8233,7 +8233,7 @@ TEST_F(WriterTest, encodingLayoutDeltaMultipleBatches) {
   verifyDeltaEncoding(file, *leafPool_, true);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   int32_t totalRows = 0;
@@ -8277,9 +8277,9 @@ TEST_F(WriterTest, encodingLayoutDeltaLegacyRead) {
 
   verifyDeltaEncoding(file, *leafPool_, true);
 
-  // Read using default VeloxReader (legacy encoding factory).
+  // Read using default BatchReader (legacy encoding factory).
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
   ASSERT_EQ(result->size(), kRowCount);
@@ -8315,7 +8315,7 @@ TEST_F(WriterTest, encodingLayoutDeltaWithRestatementsLegacyRead) {
   verifyDeltaEncoding(file, *leafPool_);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
   ASSERT_EQ(result->size(), kRowCount);
@@ -8368,7 +8368,7 @@ TEST_F(WriterTest, encodingLayoutDeltaMultiStripeLegacyRead) {
   verifyDeltaEncoding(file, *leafPool_, true);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
   int32_t totalRows = 0;
   int32_t batchIdx = 0;
   int32_t batchOffset = 0;
@@ -8411,7 +8411,7 @@ TEST_F(WriterTest, encodingLayoutDeltaInt16) {
   verifyDeltaEncoding(file, *leafPool_, true);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -8443,9 +8443,9 @@ TEST_F(WriterTest, encodingLayoutDeltaSeekToRow) {
 
   verifyDeltaEncoding(file, *leafPool_);
 
-  // Read using default (legacy) VeloxReader with seekToRow.
+  // Read using default (legacy) BatchReader with seekToRow.
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
 
   constexpr int32_t kSeekRow = 100;
   reader.seekToRow(kSeekRow);
@@ -8487,9 +8487,9 @@ TEST_F(WriterTest, encodingLayoutDeltaNullableLegacyRead) {
 
   verifyDeltaEncoding(file, *leafPool_, true);
 
-  // Read using default VeloxReader (legacy encoding factory).
+  // Read using default BatchReader (legacy encoding factory).
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
+  nimble::BatchReader reader(&readFile, *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
   ASSERT_EQ(result->size(), kRowCount);
@@ -8523,7 +8523,7 @@ TEST_F(WriterTest, encodingLayoutDeltaSawtooth) {
   verifyDeltaEncoding(file, *leafPool_, true);
 
   velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       &readFile, *leafPool_, nullptr, nonLegacyReadParams());
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kRowCount, result));
@@ -8581,9 +8581,9 @@ TEST_F(WriterTest, flatmapColumnsKeysSchemaConsistency) {
   auto file1 = writeWithKeyOrder(false);
   auto file2 = writeWithKeyOrder(true);
 
-  nimble::VeloxReader reader1(
+  nimble::BatchReader reader1(
       std::make_shared<velox::InMemoryReadFile>(file1), *leafPool_);
-  nimble::VeloxReader reader2(
+  nimble::BatchReader reader2(
       std::make_shared<velox::InMemoryReadFile>(file2), *leafPool_);
 
   const auto& flatMap1 = reader1.schema()->asRow().childAt(0)->asFlatMap();
@@ -8648,7 +8648,7 @@ TEST_F(WriterTest, flatmapColumnsKeysRoundtrip) {
     writer.close();
   }
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(kTotalRows, result));
@@ -8706,7 +8706,7 @@ TEST_F(WriterTest, flatmapColumnsKeysVarchar) {
     writer.close();
   }
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
 
   // Verify schema key order.
@@ -8783,7 +8783,7 @@ TEST_F(WriterTest, flatmapColumnsKeysMultipleBatches) {
     writer.close();
   }
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
 
   // Schema should have all 8 keys in predefined (sorted) order.
@@ -8840,7 +8840,7 @@ TEST_F(WriterTest, flatmapColumnsKeysEmptyData) {
     writer.close();
   }
 
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
   const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
   ASSERT_EQ(flatMap.childrenCount(), kNumKeys);
@@ -8968,7 +8968,7 @@ TEST_F(WriterTest, flatmapColumnsKeysImplicitFlatMapColumn) {
   }
 
   // Verify it was written as a flatmap (schema has FlatMap kind).
-  nimble::VeloxReader reader(
+  nimble::BatchReader reader(
       std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
   const auto& child = reader.schema()->asRow().childAt(0);
   EXPECT_EQ(child->kind(), nimble::Kind::FlatMap);
@@ -9064,8 +9064,8 @@ TEST_P(ParallelEncodeWriterTest, rowParallelEncode) {
 
   auto seqRead = std::make_shared<velox::InMemoryReadFile>(seqFile);
   auto parRead = std::make_shared<velox::InMemoryReadFile>(parFile);
-  nimble::VeloxReader seqReader(seqRead.get(), *leafPool_);
-  nimble::VeloxReader parReader(parRead.get(), *leafPool_);
+  nimble::BatchReader seqReader(seqRead.get(), *leafPool_);
+  nimble::BatchReader parReader(parRead.get(), *leafPool_);
 
   velox::VectorPtr seqResult;
   velox::VectorPtr parResult;
@@ -9129,8 +9129,8 @@ TEST_P(ParallelEncodeWriterTest, flatMapParallelEncode) {
 
   auto seqRead = std::make_shared<velox::InMemoryReadFile>(seqFile);
   auto parRead = std::make_shared<velox::InMemoryReadFile>(parFile);
-  nimble::VeloxReader seqReader(seqRead.get(), *leafPool_);
-  nimble::VeloxReader parReader(parRead.get(), *leafPool_);
+  nimble::BatchReader seqReader(seqRead.get(), *leafPool_);
+  nimble::BatchReader parReader(parRead.get(), *leafPool_);
 
   velox::VectorPtr seqResult;
   velox::VectorPtr parResult;
@@ -9221,7 +9221,7 @@ DEBUG_ONLY_TEST_F(WriterTest, bufferingRemainsSequential) {
     EXPECT_EQ(parallelWriteCount, 0);
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    nimble::BatchReader reader(readFile.get(), *leafPool_);
     velox::VectorPtr result;
     ASSERT_TRUE(reader.next(numBatches * 100, result));
     EXPECT_EQ(result->size(), numBatches * 100);
@@ -9333,7 +9333,7 @@ DEBUG_ONLY_TEST_F(WriterTest, flatMapBufferingRemainsSequential) {
   EXPECT_EQ(flatMapParallelCount, 0);
 
   auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(numBatches * 100, result));
   EXPECT_EQ(result->size(), numBatches * 100);
@@ -9366,7 +9366,7 @@ TEST_F(WriterTest, randomEncodingSelectionRoundTrip) {
         *rootPool_, vector, makeRandomEncodingSelectionPolicyCreator(seed));
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    nimble::BatchReader reader(readFile.get(), *leafPool_);
     velox::VectorPtr result;
     ASSERT_TRUE(reader.next(vector->size(), result));
     ASSERT_EQ(result->size(), vector->size());

--- a/velox/dwio/nimble/velox/tests/WriterTestUtils.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTestUtils.cpp
@@ -45,7 +45,7 @@ std::vector<velox::RowVectorPtr> generateBatches(
 }
 
 ChunkSizeResults validateChunkSize(
-    nimble::VeloxReader& reader,
+    nimble::BatchReader& reader,
     const uint64_t minStreamChunkRawSize,
     const uint64_t maxStreamChunkRawSize) {
   constexpr int kRowCountOffset = 2;

--- a/velox/dwio/nimble/velox/tests/WriterTestUtils.h
+++ b/velox/dwio/nimble/velox/tests/WriterTestUtils.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <vector>
 
-#include "velox/dwio/nimble/velox/VeloxReader.h"
+#include "velox/dwio/nimble/velox/BatchReader.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
 
@@ -45,7 +45,7 @@ struct ChunkSizeResults {
 // raw sizes stay within [minStreamChunkRawSize, maxStreamChunkRawSize] (modulo
 // a tolerance and string-value edge cases), returning per-stream chunk counts.
 ChunkSizeResults validateChunkSize(
-    nimble::VeloxReader& reader,
+    nimble::BatchReader& reader,
     uint64_t minStreamChunkRawSize,
     uint64_t maxStreamChunkRawSize);
 


### PR DESCRIPTION
Summary:

`VeloxReader` is Nimble's non-selective, whole-batch reader, but the name does not say that — it reads as "the reader for Velox", which describes every reader in the tree, the selective one included. The surrounding code has already settled on "batch reader" for exactly this class: `NimbleReaderFactory` dispatches between the selective reader and `detail::createBatchReader`, the open-source stub is `velox/dwio/nimble/velox/reader/BatchReaderOSS.cpp`, and Velox's `RowVector` exposes `rawVectorForBatchReader()`. This renames the class to the vocabulary already in use around it.

Mechanical rename with no behavior change — 833 insertions and 833 deletions, all of them the same identifier substitutions:

- `VeloxReader` -> `BatchReader` (638 sites), including the derived `VeloxReaderHelper`, `VeloxReaderTest`, and `VeloxReaderStripeGroupFormatTest` names
- `VeloxReadParams` -> `BatchReadParams` (95 sites)
- `veloxReader` -> `batchReader` (7 local variables)
- Buck target `velox_reader` -> `batch_reader` (99 references across 58 BUCK files)
- CMake target `nimble_velox_reader` -> `nimble_batch_reader` (11 references across 7 CMakeLists)

Files were moved with `sl mv` so history follows them: `velox/dwio/nimble/velox/VeloxReader.{h,cpp}` -> `BatchReader.{h,cpp}`, `velox/dwio/nimble/velox/tests/VeloxReaderTest.cpp` -> `BatchReaderTest.cpp`, and the compatibility shim `dwio/nimble/velox/VeloxReader.h` -> `BatchReader.h`. The shim was renamed rather than kept under the old filename because every consumer has to edit its code regardless — the type name changed — so leaving a stale filename behind would buy nothing.

Several unrelated `VeloxReader` symbols were deliberately left alone. The one worth flagging is `facebook::dwio::api::VeloxReader` in `dwio/api/ReaderFactory.cpp`: a different class entirely, backing DWIO's SST/Avro/Parquet dispatch, which a blanket rewrite would have silently broken. Also untouched: `veloxReader` in `gluten` (a `VeloxShuffleReader*`), `cosco_cpp/native/storage/tests/ReadAheadTest.cpp`, `scripts/pkl/main.cpp`, the `xldb/validation-service` Java page reader, and a Koski design doc under `playai/`. Three further tokens were protected during the build-target rewrite and verified intact afterwards: `nimble_velox_reader_factory` (a distinct concept — the `dwio::common::ReaderFactory` registration), `velox_reader_init_flag` in `crystaldb`, and `VeloxReadFileAdapter`.

Note for the reviewer: `velox/dwio/nimble/public_tld/AGENTS.md` is OSS-exported, so that one-line doc change flows out to the public Velox repo.

Reviewed By: xiaoxmeng

Differential Revision: D117644518
