### PR TITLE
fix(parquet): Support Iceberg field ID fallback for legacy files with table property schema.name-mapping.default

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSource.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.cpp
@@ -42,6 +42,11 @@ IcebergDataSource::IcebergDataSource(
 std::unique_ptr<FileSplitReader> IcebergDataSource::createSplitReader() {
   prepareSplit();
   auto icebergSplit = checkedPointerCast<const HiveIcebergSplit>(split_);
+  if (icebergSplit->fileFormat == dwio::common::FileFormat::PARQUET &&
+      !nameMappingParsed_) {
+    nameMapping_ = parseDefaultNameMapping(*tableHandle_);
+    nameMappingParsed_ = true;
+  }
 
   auto reader = std::make_unique<IcebergSplitReader>(
       icebergSplit,
@@ -56,7 +61,8 @@ std::unique_ptr<FileSplitReader> IcebergDataSource::createSplitReader() {
       fileHandleFactory_,
       ioExecutor_,
       scanSpec_,
-      columnHandles_);
+      columnHandles_,
+      std::optional{nameMapping_});
 
   return reader;
 }

--- a/velox/connectors/hive/iceberg/IcebergDataSource.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/connectors/hive/HiveDataSource.h"
+#include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -48,6 +49,8 @@ class IcebergDataSource : public HiveDataSource {
  private:
   /// Column handles map for accessing column metadata.
   std::shared_ptr<ColumnHandleMap> columnHandles_;
+  std::shared_ptr<const IcebergNameMapping> nameMapping_;
+  bool nameMappingParsed_{false};
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -17,8 +17,11 @@
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 
 #include <algorithm>
+#include <limits>
+#include <string_view>
 
 #include <folly/ScopeGuard.h>
+#include <folly/json.h>
 #include <folly/lang/Bits.h>
 
 #include "velox/common/base/Exceptions.h"
@@ -81,6 +84,89 @@ void fillNullsWithInt64(
 namespace facebook::velox::connector::hive::iceberg {
 namespace {
 
+constexpr const char* kDefaultNameMappingProperty =
+    "schema.name-mapping.default";
+
+void collectFallbackNames(
+    const folly::dynamic& fields,
+    IcebergNameMapping& fallbackNames) {
+  VELOX_USER_CHECK(
+      fields.isArray(),
+      "Iceberg table property '{}' must be a JSON array",
+      kDefaultNameMappingProperty);
+  for (const auto& field : fields) {
+    VELOX_USER_CHECK(
+        field.isObject(),
+        "Entries in Iceberg table property '{}' must be JSON objects",
+        kDefaultNameMappingProperty);
+    const auto* names = field.get_ptr("names");
+    VELOX_USER_CHECK(
+        names != nullptr && names->isArray(),
+        "Each entry in Iceberg table property '{}' must contain a names array",
+        kDefaultNameMappingProperty);
+
+    std::vector<std::string> parsedNames;
+    parsedNames.reserve(names->size());
+    for (const auto& name : *names) {
+      VELOX_USER_CHECK(
+          name.isString(),
+          "Names in Iceberg table property '{}' must be strings",
+          kDefaultNameMappingProperty);
+      parsedNames.push_back(name.asString());
+    }
+
+    if (const auto* fieldId = field.get_ptr("field-id")) {
+      VELOX_USER_CHECK(
+          fieldId->isInt(),
+          "field-id in Iceberg table property '{}' must be an integer",
+          kDefaultNameMappingProperty);
+      const auto id = fieldId->asInt();
+      VELOX_USER_CHECK(
+          id > 0 && id <= std::numeric_limits<int32_t>::max(),
+          "field-id in Iceberg table property '{}' must be a positive 32-bit integer",
+          kDefaultNameMappingProperty);
+      const auto [_, inserted] = fallbackNames.emplace(
+          static_cast<int32_t>(id), std::move(parsedNames));
+      VELOX_USER_CHECK(
+          inserted,
+          "Duplicate field-id {} in Iceberg table property '{}'",
+          id,
+          kDefaultNameMappingProperty);
+    }
+
+    if (const auto* children = field.get_ptr("fields")) {
+      collectFallbackNames(*children, fallbackNames);
+    }
+  }
+}
+
+IcebergNameMapping parseDefaultNameMappingJson(std::string_view json) {
+  folly::dynamic fields;
+  try {
+    fields = folly::parseJson(json);
+  } catch (const std::exception& e) {
+    VELOX_USER_FAIL(
+        "Failed to parse Iceberg table property '{}': {}",
+        kDefaultNameMappingProperty,
+        e.what());
+  }
+  IcebergNameMapping fallbackNames;
+  collectFallbackNames(fields, fallbackNames);
+  return fallbackNames;
+}
+
+void applyFallbackNames(
+    const IcebergNameMapping& fallbackNames,
+    dwio::common::ParquetFieldId& fieldId) {
+  if (const auto it = fallbackNames.find(fieldId.fieldId);
+      it != fallbackNames.end()) {
+    fieldId.fallbackNames = it->second;
+  }
+  for (auto& child : fieldId.children) {
+    applyFallbackNames(fallbackNames, child);
+  }
+}
+
 // Indexes IcebergColumnHandles by their underlying data-column name.
 // Covers output-projected handles (columnHandles) and, when tableHandle is
 // non-null, filter-only handles (tableHandle->filterColumnHandles()) too.
@@ -129,6 +215,17 @@ bool shouldSkipBySequenceNumber(
 
 } // namespace
 
+std::shared_ptr<const IcebergNameMapping> parseDefaultNameMapping(
+    const FileTableHandle& tableHandle) {
+  const auto& tableParameters = tableHandle.tableParameters();
+  const auto it = tableParameters.find(kDefaultNameMappingProperty);
+  if (it == tableParameters.end()) {
+    return nullptr;
+  }
+  return std::make_shared<const IcebergNameMapping>(
+      parseDefaultNameMappingJson(it->second));
+}
+
 IcebergSplitReader::IcebergSplitReader(
     const std::shared_ptr<const HiveIcebergSplit>& icebergSplit,
     const FileTableHandlePtr& tableHandle,
@@ -142,7 +239,8 @@ IcebergSplitReader::IcebergSplitReader(
     FileHandleFactory* const fileHandleFactory,
     folly::Executor* executor,
     const std::shared_ptr<common::ScanSpec>& scanSpec,
-    std::shared_ptr<ColumnHandleMap> columnHandles)
+    std::shared_ptr<ColumnHandleMap> columnHandles,
+    std::optional<std::shared_ptr<const IcebergNameMapping>> nameMapping)
     : FileSplitReader(
           icebergSplit,
           tableHandle,
@@ -160,7 +258,12 @@ IcebergSplitReader::IcebergSplitReader(
       baseReadOffset_(0),
       splitOffset_(0),
       deleteBitmap_(nullptr),
-      columnHandles_(std::move(columnHandles)) {}
+      columnHandles_(std::move(columnHandles)),
+      nameMapping_(
+          nameMapping.has_value() ? std::move(nameMapping.value())
+              : icebergSplit->fileFormat == dwio::common::FileFormat::PARQUET
+              ? parseDefaultNameMapping(*tableHandle)
+              : nullptr) {}
 
 void IcebergSplitReader::configureBaseReaderOptions() {
   FileSplitReader::configureBaseReaderOptions();
@@ -168,6 +271,11 @@ void IcebergSplitReader::configureBaseReaderOptions() {
   if (fileFormat == dwio::common::FileFormat::PARQUET) {
     auto fieldIds = buildFieldIds();
     if (!fieldIds.empty()) {
+      if (nameMapping_) {
+        for (auto& fieldId : fieldIds) {
+          applyFallbackNames(*nameMapping_, fieldId);
+        }
+      }
       baseReaderOpts_.setColumnMappingMode(
           dwio::common::ColumnMappingMode::kParquetFieldId);
       baseReaderOpts_.setFieldIds(std::move(fieldIds));

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -29,6 +29,12 @@ namespace facebook::velox::connector::hive::iceberg {
 struct HiveIcebergSplit;
 struct IcebergDeleteFile;
 
+using IcebergNameMapping =
+    std::unordered_map<int32_t, std::vector<std::string>>;
+
+std::shared_ptr<const IcebergNameMapping> parseDefaultNameMapping(
+    const FileTableHandle& tableHandle);
+
 class IcebergSplitReader : public FileSplitReader {
  public:
   IcebergSplitReader(
@@ -44,7 +50,9 @@ class IcebergSplitReader : public FileSplitReader {
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
-      std::shared_ptr<ColumnHandleMap> columnHandles);
+      std::shared_ptr<ColumnHandleMap> columnHandles,
+      std::optional<std::shared_ptr<const IcebergNameMapping>> nameMapping =
+          std::nullopt);
 
   ~IcebergSplitReader() override = default;
 
@@ -213,5 +221,6 @@ class IcebergSplitReader : public FileSplitReader {
   /// Column handles map shared with IcebergDataSource.
   /// Used for accessing column metadata including initial-default values.
   std::shared_ptr<ColumnHandleMap> columnHandles_;
+  const std::shared_ptr<const IcebergNameMapping> nameMapping_;
 };
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -26,6 +26,9 @@
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/writer/Writer.h"
+#endif
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
@@ -132,13 +135,30 @@ class IcebergReadTest : public test::IcebergTestBase {
       const RowTypePtr& scanSpecType,
       const std::vector<FieldIdColumnSpec>& columns,
       const std::vector<RowVectorPtr>& expected,
-      const std::optional<std::string>& subfieldFilter = std::nullopt) {
+      const std::optional<std::string>& subfieldFilter = std::nullopt,
+      const std::unordered_map<std::string, std::string>& tableParameters =
+          {}) {
     exec::test::PlanBuilder planBuilder;
     auto& tableScanBuilder = planBuilder.startTableScan()
                                  .connectorId(test::kIcebergConnectorId)
                                  .outputType(outputType)
-                                 .dataColumns(scanSpecType)
-                                 .assignments(makeFieldIdAssignments(columns));
+                                 .dataColumns(scanSpecType);
+    if (tableParameters.empty()) {
+      tableScanBuilder.assignments(makeFieldIdAssignments(columns));
+    } else {
+      VELOX_CHECK(!subfieldFilter.has_value());
+      tableScanBuilder
+          .tableHandle(
+              std::make_shared<HiveTableHandle>(
+                  test::kIcebergConnectorId,
+                  "iceberg_table",
+                  common::SubfieldFilters{},
+                  nullptr,
+                  scanSpecType,
+                  std::vector<std::string>{},
+                  tableParameters))
+          .assignments(makeFieldIdAssignments(columns));
+    }
     if (subfieldFilter.has_value()) {
       tableScanBuilder.subfieldFilter(*subfieldFilter);
     }
@@ -156,6 +176,31 @@ class IcebergReadTest : public test::IcebergTestBase {
     const auto dataSink =
         createDataSinkAndAppendData(data, outputDirectory->getPath());
     dataSink->close();
+    return outputDirectory;
+  }
+
+  std::shared_ptr<test::TempDirectoryPath> writeLegacyParquetData(
+      const std::vector<RowVectorPtr>& data) {
+    VELOX_CHECK(!data.empty());
+    fileFormat_ = dwio::common::FileFormat::PARQUET;
+    auto outputDirectory = test::TempDirectoryPath::create();
+    const auto filePath =
+        fmt::format("{}/legacy.parquet", outputDirectory->getPath());
+
+    auto writerPool =
+        memory::memoryManager()->addRootPool("LegacyParquetWriter");
+    dwio::common::WriterOptions options;
+    options.memoryPool = writerPool.get();
+    options.formatSpecificOptions =
+        std::make_shared<parquet::ParquetWriterOptions>();
+    auto sink = dwio::common::FileSink::create(
+        fmt::format("file:{}", filePath), {.pool = writerPool.get()});
+    parquet::Writer writer(
+        std::move(sink), options, writerPool, data.front()->rowType());
+    for (const auto& vector : data) {
+      writer.write(vector);
+    }
+    writer.close();
     return outputDirectory;
   }
 
@@ -470,6 +515,55 @@ TEST_F(IcebergReadTest, readParquetFlatSchemaEvolutionByFieldId) {
         readCase.columns,
         {readCase.expected});
   }
+}
+
+TEST_F(IcebergReadTest, readLegacyParquetByFieldId) {
+  const auto physicalType =
+      ROW({"legacy_id", "legacy_label"}, {BIGINT(), VARCHAR()});
+  const std::vector<RowVectorPtr> data{makeRowVector(
+      physicalType->names(),
+      {makeFlatVector<int64_t>({10, 20, 30}),
+       makeFlatVector<std::string>({"a", "b", "c"})})};
+  const auto outputDirectory = writeLegacyParquetData(data);
+
+  const auto outputType = ROW({"label", "id"}, {VARCHAR(), BIGINT()});
+  const auto tableType = ROW({"id", "label"}, {BIGINT(), VARCHAR()});
+  assertParquetFieldIdRead(
+      outputDirectory->getPath(),
+      outputType,
+      tableType,
+      {
+          {"id", "id", BIGINT(), makeFieldId(1), {}},
+          {"label", "label", VARCHAR(), makeFieldId(2), {}},
+      },
+      {makeRowVector(
+          outputType->names(),
+          {makeFlatVector<std::string>({"a", "b", "c"}),
+           makeFlatVector<int64_t>({10, 20, 30})})},
+      std::nullopt,
+      {{"schema.name-mapping.default",
+        R"([{"field-id":1,"names":["legacy_id"]},{"field-id":2,"names":["legacy_label"]}])"}});
+}
+
+TEST_F(IcebergReadTest, defaultNameMappingDoesNotReuseName) {
+  const auto physicalType = ROW({"status"}, {VARCHAR()});
+  const std::vector<RowVectorPtr> data{makeRowVector(
+      physicalType->names(),
+      {makeFlatVector<std::string>({"old-a", "old-b", "old-c"})})};
+  const auto outputDirectory = writeLegacyParquetData(data);
+
+  assertParquetFieldIdRead(
+      outputDirectory->getPath(),
+      physicalType,
+      physicalType,
+      {{"status", "status", VARCHAR(), makeFieldId(2), {}}},
+      {makeRowVector(
+          physicalType->names(),
+          {makeNullableFlatVector<std::string>(
+              {std::nullopt, std::nullopt, std::nullopt})})},
+      std::nullopt,
+      {{"schema.name-mapping.default",
+        R"([{"field-id":1,"names":["status"]},{"field-id":2,"names":[]}])"}});
 }
 
 TEST_F(IcebergReadTest, readParquetFilterOnlyColumnByFieldId) {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -114,15 +114,8 @@ enum class ColumnMappingMode {
   /// entry describes the table field ID for the corresponding requested column,
   /// and nested children describe field IDs below structs, arrays, and maps.
   ///
-  /// Physical Parquet schema nodes that do not have field_id metadata are
-  /// treated as having a missing field ID and therefore do not match positive
-  /// Iceberg field IDs. This is expected for legacy Hive-style Parquet files or
-  /// files written by producers that do not preserve field IDs. In that case,
-  /// kParquetFieldId can still be used, but any requested positive field ID
-  /// without a matching physical field is read as missing and is materialized
-  /// by the connector as null or as the table format's default value. Use kName
-  /// or kPosition instead when reading files whose schema identity must come
-  /// from names or positions.
+  /// Files without field IDs use ParquetFieldId::fallbackNames. Mixed-ID files
+  /// do not use name fallback.
   ///
   /// This is Parquet-specific. Readers for other formats should reject this
   /// mode instead of interpreting it as a generic column identity mechanism.

--- a/velox/dwio/common/ParquetFieldId.h
+++ b/velox/dwio/common/ParquetFieldId.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace facebook::velox::dwio::common {
@@ -29,6 +30,7 @@ namespace facebook::velox::dwio::common {
 struct ParquetFieldId {
   int32_t fieldId;
   std::vector<ParquetFieldId> children;
+  std::vector<std::string> fallbackNames{};
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -76,6 +76,12 @@ int32_t fieldIdOrMissing(const thrift::SchemaElement& schemaElement) {
   return schemaElement.field_id().value_or(kMissingPhysicalFieldId);
 }
 
+bool hasAnyFieldId(const std::vector<thrift::SchemaElement>& schema) {
+  return std::any_of(schema.begin(), schema.end(), [](const auto& element) {
+    return element.field_id().has_value();
+  });
+}
+
 std::string schemaElementNameOrFieldId(
     const thrift::SchemaElement& schemaElement,
     dwio::common::ColumnMappingMode mode) {
@@ -334,6 +340,7 @@ class ReaderBase {
       const TypePtr& requestedType,
       const TypePtr& parentRequestedType,
       const ParquetFieldId* requestedFieldIds,
+      bool useFieldNameMapping,
       std::vector<std::string>& columnNames) const;
 
   TypePtr convertType(
@@ -511,6 +518,9 @@ void ReaderBase::initializeSchema() {
   std::vector<std::string> columnNames;
   const auto& fieldIds = options_.fieldIds();
   ParquetFieldId rootFieldIds{-1, fieldIds};
+  const bool useFieldNameMapping = options_.columnMappingMode() ==
+          dwio::common::ColumnMappingMode::kParquetFieldId &&
+      !hasAnyFieldId(*fileMetaData_->schema());
   // Setting the parent schema index of the root("hive_schema") to be 0, which
   // is the root itself. This is ok because it's never required to check the
   // parent of the root in getParquetColumnInfo().
@@ -524,6 +534,7 @@ void ReaderBase::initializeSchema() {
       options_.fileSchema(),
       nullptr,
       fieldIds.empty() ? nullptr : &rootFieldIds,
+      useFieldNameMapping,
       columnNames);
   schema_ = createRowType(
       schemaWithId_->getChildren(), isFileColumnNamesReadAsLowerCase());
@@ -547,6 +558,7 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     const TypePtr& requestedType,
     const TypePtr& parentRequestedType,
     const ParquetFieldId* requestedFieldIds,
+    bool useFieldNameMapping,
     std::vector<std::string>& columnNames) const {
   VELOX_CHECK(fileMetaData_ != nullptr);
   VELOX_CHECK_LT(schemaIdx, fileMetaData_->schema()->size());
@@ -626,6 +638,7 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     }
 
     std::unordered_map<int32_t, uint32_t> requestedIndexByFieldId;
+    std::unordered_map<std::string, uint32_t> requestedIndexByFallbackName;
     if (mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId &&
         requestedFieldIds != nullptr && requestedRowType != nullptr) {
       const auto numFields = std::min(
@@ -634,6 +647,24 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
       for (uint32_t fieldIndex = 0; fieldIndex < numFields; ++fieldIndex) {
         requestedIndexByFieldId.emplace(
             requestedFieldIds->children[fieldIndex].fieldId, fieldIndex);
+        if (useFieldNameMapping) {
+          const auto addFallbackName = [&](std::string fallbackName) {
+            if (isFileColumnNamesReadAsLowerCase()) {
+              fallbackName =
+                  functions::stringImpl::utf8StrToLowerCopy(fallbackName);
+            }
+            const auto [it, inserted] =
+                requestedIndexByFallbackName.emplace(fallbackName, fieldIndex);
+            VELOX_USER_CHECK(
+                inserted || it->second == fieldIndex,
+                "Parquet name mapping assigns '{}' to multiple fields",
+                fallbackName);
+          };
+          for (const auto& fallbackName :
+               requestedFieldIds->children[fieldIndex].fallbackNames) {
+            addFallbackName(fallbackName);
+          }
+        }
       }
     }
 
@@ -642,8 +673,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
       ++schemaIdx;
       auto childName =
           schemaElementNameOrFieldId(schema[schemaIdx], mappingMode);
+      auto childPhysicalName = *schema[schemaIdx].name();
       if (isFileColumnNamesReadAsLowerCase()) {
         childName = functions::stringImpl::utf8StrToLowerCopy(childName);
+        childPhysicalName =
+            functions::stringImpl::utf8StrToLowerCopy(childPhysicalName);
       }
 
       TypePtr childRequestedType = nullptr;
@@ -660,14 +694,25 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
             mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId) {
           if (requestedFieldIds != nullptr) {
             const auto fieldId = fieldIdOrMissing(schema[schemaIdx]);
-            const auto requestedIndex = requestedIndexByFieldId.find(fieldId);
+            auto requestedIndex = requestedIndexByFieldId.find(fieldId);
+            std::optional<uint32_t> requestedFieldIndex;
             if (requestedIndex != requestedIndexByFieldId.end()) {
+              requestedFieldIndex = requestedIndex->second;
+            } else if (
+                useFieldNameMapping && fieldId == kMissingPhysicalFieldId) {
+              const auto fallbackIndex =
+                  requestedIndexByFallbackName.find(childPhysicalName);
+              if (fallbackIndex != requestedIndexByFallbackName.end()) {
+                requestedFieldIndex = fallbackIndex->second;
+              }
+            }
+            if (requestedFieldIndex.has_value()) {
               columnNames.push_back(
-                  requestedRowType->nameOf(requestedIndex->second));
+                  requestedRowType->nameOf(*requestedFieldIndex));
               childRequestedType =
-                  requestedRowType->childAt(requestedIndex->second);
+                  requestedRowType->childAt(*requestedFieldIndex);
               childRequestedFieldIds =
-                  &requestedFieldIds->children[requestedIndex->second];
+                  &requestedFieldIds->children[*requestedFieldIndex];
             } else {
               followChild = false;
             }
@@ -749,6 +794,7 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
             childRequestedType,
             requestedType,
             childRequestedFieldIds,
+            useFieldNameMapping,
             columnNames);
         children.push_back(std::move(child));
       } else {

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -331,6 +331,107 @@ TEST_F(ParquetReaderTest, parquetFieldIdInsertedColumnNotNullFilled) {
       outputType, *readerBundle.rowReader, expected, *leafPool_);
 }
 
+TEST_F(ParquetReaderTest, parquetFieldIdRequiresNameMapping) {
+  const auto physicalType = ROW({"data", "id"}, {VARCHAR(), BIGINT()});
+  auto data = makeRowVector(
+      physicalType->names(),
+      {makeFlatVector<std::string>({"a", "b"}),
+       makeFlatVector<int64_t>({10, 20})});
+  auto* sink = write(data);
+
+  const auto outputType = ROW({"id", "data"}, {BIGINT(), VARCHAR()});
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setFileSchema(outputType);
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
+  readerOptions.setFieldIds({ParquetFieldId{10, {}}, ParquetFieldId{20, {}}});
+
+  auto readerBundle =
+      readerBuilder(*sink, outputType).options(readerOptions).build();
+  EXPECT_EQ(readerBundle.reader->typeWithId()->size(), 0);
+}
+
+TEST_F(ParquetReaderTest, parquetFieldIdDefaultNameMappingFallback) {
+  const auto nestedWriteType =
+      ROW({"legacy_label", "legacy_amount"}, {VARCHAR(), BIGINT()});
+  const auto physicalType =
+      ROW({"legacy_id", "legacy_nested", "legacy_ignored"},
+          {BIGINT(), nestedWriteType, BOOLEAN()});
+  auto data = makeRowVector(
+      physicalType->names(),
+      {makeFlatVector<int64_t>({10, 20}),
+       makeRowVector(
+           nestedWriteType->names(),
+           {makeFlatVector<std::string>({"a", "b"}),
+            makeFlatVector<int64_t>({100, 200})}),
+       makeFlatVector<bool>({true, false})});
+
+  auto* sink = write(data);
+
+  const auto nestedReadType = ROW({"label", "amount"}, {VARCHAR(), BIGINT()});
+  const auto outputType = ROW({"nested", "id"}, {nestedReadType, BIGINT()});
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setFileSchema(outputType);
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
+  readerOptions.setFieldIds({
+      ParquetFieldId{2, {ParquetFieldId{20, {}}, ParquetFieldId{21, {}}}},
+      ParquetFieldId{1, {}},
+  });
+
+  auto strictReaderBundle =
+      readerBuilder(*sink, outputType).options(readerOptions).build();
+  EXPECT_EQ(strictReaderBundle.reader->typeWithId()->size(), 0);
+
+  readerOptions.setFieldIds({
+      ParquetFieldId{
+          2,
+          {ParquetFieldId{20, {}, {"legacy_label"}},
+           ParquetFieldId{21, {}, {"legacy_amount"}}},
+          {"legacy_nested"}},
+      ParquetFieldId{1, {}, {"legacy_id"}},
+  });
+
+  auto readerBundle =
+      readerBuilder(*sink, outputType).options(readerOptions).build();
+  auto expected = makeRowVector(
+      outputType->names(),
+      {makeRowVector(
+           nestedReadType->names(),
+           {makeFlatVector<std::string>({"a", "b"}),
+            makeFlatVector<int64_t>({100, 200})}),
+       makeFlatVector<int64_t>({10, 20})});
+  assertReadWithReaderAndExpected(
+      outputType, *readerBundle.rowReader, expected, *leafPool_);
+}
+
+TEST_F(ParquetReaderTest, parquetFieldIdNameMappingRejectsMixedIdSchema) {
+  const auto physicalType = ROW({"legacy_id", "data"}, {BIGINT(), VARCHAR()});
+  auto data = makeRowVector(
+      physicalType->names(),
+      {makeFlatVector<int64_t>({10, 20}),
+       makeFlatVector<std::string>({"a", "b"})});
+  ParquetWriterOptions writerOptions;
+  // A negative ID is omitted from the physical Parquet schema.
+  writerOptions.parquetFieldIds = {
+      ParquetFieldId{-1, {}}, ParquetFieldId{2, {}}};
+  auto* sink = write(data, writerOptions);
+
+  const auto outputType = ROW({"id", "data"}, {BIGINT(), VARCHAR()});
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setFileSchema(outputType);
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
+  readerOptions.setFieldIds(
+      {ParquetFieldId{1, {}, {"legacy_id"}}, ParquetFieldId{2, {}, {"data"}}});
+
+  auto readerBundle =
+      readerBuilder(*sink, outputType).options(readerOptions).build();
+  auto expected = makeRowVector(
+      outputType->names(),
+      {makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt}),
+       makeFlatVector<std::string>({"a", "b"})});
+  assertReadWithReaderAndExpected(
+      outputType, *readerBundle.rowReader, expected, *leafPool_);
+}
+
 TEST_F(ParquetReaderTest, nestedNameColumnMapping) {
   auto data = makeRowVector(
       {"nested"},


### PR DESCRIPTION
Previously, Velox could not match Parquet columns when kParquetFieldId was active. Velox treated the columns as missing. The Iceberg connector then returned null values or configured default values.

This change lets Velox read legacy Parquet files that do not contain field IDs. 
These rules are added:
  1. If the Parquet file contains field IDs, match fields by ID.
  2. If the complete file has no field IDs, match fields by the Iceberg table property schema.name-mapping.default.
  3. If a safe match can't be found, it treats the field as missing.

matches: https://iceberg.apache.org/spec/#column-projection