### PR TITLE
fix(parquet): Advance struct reader subtree when skipping filtered rows

### DIFF
--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -163,7 +163,7 @@ class ParquetData : public dwio::common::FormatData {
     // 'nullsOnly' set and is responsible for reading however many nulls or
     // pages it takes to skip 'numValues' top level rows.
     if (nullsOnly) {
-      VELOX_DCHECK_NOT_NULL(reader_);
+      VELOX_CHECK_NOT_NULL(reader_);
       reader_->skipNullsOnly(numValues);
     }
     if (presetNulls_) {

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -163,6 +163,7 @@ class ParquetData : public dwio::common::FormatData {
     // 'nullsOnly' set and is responsible for reading however many nulls or
     // pages it takes to skip 'numValues' top level rows.
     if (nullsOnly) {
+      VELOX_DCHECK_NOT_NULL(reader_);
       reader_->skipNullsOnly(numValues);
     }
     if (presetNulls_) {

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -97,15 +97,28 @@ void enqueueChildren(
 }
 } // namespace
 
-void ensureRepDefs(
+void prepareRepDefsAndOffset(
     dwio::common::SelectiveColumnReader& reader,
-    int32_t numTop) {
-  auto& fileType =
-      *reinterpret_cast<const ParquetTypeWithId*>(&reader.fileType());
-  // Check that this is a direct child of the root struct.
-  if (fileType.parent() && !fileType.parent()->parent()) {
+    int64_t offset,
+    const RowSet& rows) {
+  const auto previousOffset = reader.readOffset();
+  const auto* parent = reader.fileType().parent();
+  // Only a direct child of the root struct owns the repdefs for its subtree.
+  if (parent && !parent->parent()) {
+    const int32_t numTop =
+        static_cast<int32_t>(offset + rows.back() + 1 - previousOffset);
     skipUnreadLengthsAndNulls(reader);
     readLeafRepDefs(&reader, numTop, true);
+
+    if (offset > previousOffset) {
+      // There is no page reader on this level so cannot call skipNullsOnly on
+      // it.
+      reader.skip(offset - previousOffset);
+    }
+  }
+
+  if (offset > previousOffset) {
+    reader.setReadOffset(offset);
   }
 }
 
@@ -193,15 +206,7 @@ void MapColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  // The topmost list reader reads the repdefs for the left subtree.
-  ensureRepDefs(*this, offset + rows.back() + 1 - readOffset_);
-  if (offset > readOffset_) {
-    // There is no page reader on this level so cannot call skipNullsOnly on it.
-    if (fileType().parent() && !fileType().parent()->parent()) {
-      skip(offset - readOffset_);
-    }
-    readOffset_ = offset;
-  }
+  prepareRepDefsAndOffset(*this, offset, rows);
   SelectiveMapColumnReader::read(offset, rows, incomingNulls);
 
   // The child should be at the end of the range provided to this
@@ -301,15 +306,7 @@ void ListColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  // The topmost list reader reads the repdefs for the left subtree.
-  ensureRepDefs(*this, offset + rows.back() + 1 - readOffset_);
-  if (offset > readOffset_) {
-    // There is no page reader on this level so cannot call skipNullsOnly on it.
-    if (fileType().parent() && !fileType().parent()->parent()) {
-      skip(offset - readOffset_);
-    }
-    readOffset_ = offset;
-  }
+  prepareRepDefsAndOffset(*this, offset, rows);
   SelectiveListColumnReader::read(offset, rows, incomingNulls);
 
   // The child should be at the end of the range provided to this

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -63,13 +63,6 @@ class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
       ParquetParams& params,
       common::ScanSpec& scanSpec);
 
-  void prepareRead(
-      vector_size_t offset,
-      RowSet rows,
-      const uint64_t* incomingNulls) {
-    // The prepare is done by the topmost list/map/struct.
-  }
-
   void seekToRowGroup(int64_t index) override;
 
   void enqueueRowGroup(uint32_t index, dwio::common::BufferedInput& input);
@@ -120,13 +113,6 @@ class ListColumnReader : public dwio::common::SelectiveListColumnReader {
       ParquetParams& params,
       common::ScanSpec& scanSpec);
 
-  void prepareRead(
-      vector_size_t offset,
-      RowSet rows,
-      const uint64_t* incomingNulls) {
-    // The prepare is done by the topmost list/struct.
-  }
-
   void seekToRowGroup(int64_t index) override;
 
   void enqueueRowGroup(uint32_t index, dwio::common::BufferedInput& input);
@@ -166,11 +152,15 @@ class ListColumnReader : public dwio::common::SelectiveListColumnReader {
   LevelInfo levelInfo_;
 };
 
-/// Sets nulls and lengths for 'reader' and its children for the
-/// next 'numTop' top level rows. 'reader' must be a complex type
-/// reader. 'reader' may be inside structs but may not be inside a
-/// repeated reader. The topmost repeated reader ensures repdefs for
-/// all its children.
-void ensureRepDefs(dwio::common::SelectiveColumnReader& reader, int32_t numTop);
+/// Prepares a complex Parquet reader for reading 'rows' at 'offset'. For a
+/// direct child of the root struct, decodes repetition and definition levels
+/// through the last requested row, populates nulls and lengths for its subtree,
+/// and skips rows before 'offset'. Advances the reader's logical read offset to
+/// 'offset' if needed. 'reader' must be a complex type reader. It may be inside
+/// structs but may not be inside a repeated reader.
+void prepareRepDefsAndOffset(
+    dwio::common::SelectiveColumnReader& reader,
+    int64_t offset,
+    const RowSet& rows);
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -115,14 +115,7 @@ void StructColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* /*incomingNulls*/) {
-  ensureRepDefs(*this, offset + rows.back() + 1 - readOffset_);
-  if (offset > readOffset_) {
-    // There is no page reader on this level so cannot call skipNullsOnly on it.
-    if (fileType().parent() && !fileType().parent()->parent()) {
-      skip(offset - readOffset_);
-    }
-    readOffset_ = offset;
-  }
+  prepareRepDefsAndOffset(*this, offset, rows);
   SelectiveStructColumnReader::read(offset, rows, nullptr);
 }
 

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -116,6 +116,13 @@ void StructColumnReader::read(
     const RowSet& rows,
     const uint64_t* /*incomingNulls*/) {
   ensureRepDefs(*this, offset + rows.back() + 1 - readOffset_);
+  if (offset > readOffset_) {
+    // There is no page reader on this level so cannot call skipNullsOnly on it.
+    if (fileType().parent() && !fileType().parent()->parent()) {
+      skip(offset - readOffset_);
+    }
+    readOffset_ = offset;
+  }
   SelectiveStructColumnReader::read(offset, rows, nullptr);
 }
 

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -2433,6 +2433,53 @@ TEST_F(ParquetTableScanTest, fileFormatRuntimeStats) {
   waitForAllTasksToBeDeleted();
 }
 
+TEST_F(ParquetTableScanTest, structSkipNulls) {
+  constexpr vector_size_t kNumRows = 500;
+
+  auto id = makeFlatVector<int64_t>(
+      kNumRows, [](auto row) { return static_cast<int64_t>(row); });
+  // A struct that is null for every row -- read for its null-ness only.
+  auto structColumn = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; }),
+      },
+      [](vector_size_t /*row*/) { return true; });
+
+  auto data = makeRowVector({"id", "s"}, {id, structColumn});
+  auto dataType = asRowType(data->type());
+
+  auto filePath = TempFilePath::create();
+  ParquetWriterOptions options;
+  writeToParquetFile(filePath->getPath(), {data}, options);
+  loadData(dataType, data);
+
+  parse::ParseOptions parseOptions;
+  parseOptions.parseDecimalAsDouble = false;
+  auto plan = PlanBuilder(pool_.get())
+                  .setParseOptions(parseOptions)
+                  .tableScan(
+                      dataType,
+                      {"id >= 200", "s IS NULL"},
+                      /*remainingFilter=*/"",
+                      /*dataColumns=*/nullptr,
+                      /*assignments=*/{})
+                  .planNode();
+
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits = {
+      makeSplit(filePath->getPath())};
+
+  // Small read batch: the leading rows (id < 200) fill whole batches that
+  // 'id >= 200' filters out entirely, so the nulls-only 's' column lags and is
+  // then skipped forward.
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "64")
+      .config(core::QueryConfig::kMaxOutputBatchRows, "64")
+      .splits(splits)
+      .assertResults("SELECT id, s FROM tmp WHERE id >= 200 AND s IS NULL");
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::Init init{&argc, &argv, false};


### PR DESCRIPTION
## Context
Pushdown filters are evaluated selectively and may produce a sparse row set. As a result, a struct reader can stop at the last selected row while the top-level scan advances to the end of the input batch.

In this case, `SelectiveColumnReader::seekTo` calls `ParquetData::skipNulls` with `nullsOnly` is true, where it access the null `reader_`, cause `SIGSEGV` error.

## Change
Handle forward seeks in `StructColumnReader::read()` in the same way as `MapColumnReader` and `ListColumnReader`:
- Prepare reps/defs and advance the offset in new helper function `prepareRepDefsAndOffset()` for complex reader
- Add a UT to cover this case