### PR TITLE
fix(build): Build folly on mac with `VELOX_BUILD_SHARED = ON`

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -57,6 +57,18 @@ function install_folly {
   if [[ ${VELOX_BUILD_SHARED} != "ON" ]]; then
     FOLLY_FLAGS+=(-DGFLAGS_SHARED=FALSE)
   fi
+  # folly compiles blake3 calls whenever <blake3.h> is on the include path, but
+  # its CMake never links blake3. On macOS the header always resolves through
+  # brew, so a shared folly fails to link without this. Linux installs no
+  # blake3, so the calls compile out there.
+  if [[ ${VELOX_BUILD_SHARED} == "ON" && "$(uname)" == "Darwin" ]]; then
+    local BLAKE3_LDFLAGS
+    BLAKE3_LDFLAGS="-L$(brew --prefix)/lib -lblake3"
+    FOLLY_FLAGS+=(
+      "-DCMAKE_EXE_LINKER_FLAGS=${BLAKE3_LDFLAGS}"
+      "-DCMAKE_SHARED_LINKER_FLAGS=${BLAKE3_LDFLAGS}"
+    )
+  fi
   cmake_install_dir folly "${FOLLY_FLAGS[@]}"
 }
 

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -43,7 +43,7 @@ export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 # gflags and glog are installed from source to ensure version compatibility.
 # Homebrew's glog 0.7.x has breaking API changes that are incompatible with folly.
-MACOS_VELOX_DEPS="bison double-conversion fast_float flex googletest icu4c libevent libsodium lz4 openssl simdjson snappy xz xxhash zstd"
+MACOS_VELOX_DEPS="bison blake3 double-conversion fast_float flex googletest icu4c libevent libsodium lz4 openssl simdjson snappy xz xxhash zstd"
 MACOS_BUILD_DEPS="ninja cmake"
 
 SUDO="${SUDO:-""}"


### PR DESCRIPTION
fixes: https://github.com/facebookincubator/velox/issues/18721
folly gating blake3 on __has_include(<blake3.h>) with no corresponding find_package/target_link_libraries is an upstream packaging bug
https://github.com/facebook/folly/blob/main/folly/hash/UniqueHashKey.cpp#L26

this patch fixes mac build with VELOX_BUILD_SHARED == ON of folly by to installing `blake3` and the linking target