### PR TITLE
perf: Add all-null fast path to nullable materialization (#18722)

### DIFF
--- a/velox/dwio/nimble/encodings/NullableEncoding.h
+++ b/velox/dwio/nimble/encodings/NullableEncoding.h
@@ -269,6 +269,17 @@ uint32_t NullableEncoding<T>::materializeNullable(
       scatterSize,
       rowCount,
       "Scattered output must have at least rowCount positions");
+
+  // A column that is entirely null over this batch would still walk every
+  // position in the scatter loop below to set nothing. Short-circuit to the
+  // cleared bitmap.
+  if (nonNullCount == 0 && scatterSize != 0) {
+    velox::bits::BitmapBuilder nullBits{getOutputNulls(), offset + scatterSize};
+    nullBits.clear(offset, offset + scatterSize);
+    row_ += rowCount;
+    return 0;
+  }
+
   if (nonNullCount != scatterSize) {
     void* nullBitmap = getOutputNulls();
     velox::bits::BitmapBuilder nullBits{nullBitmap, offset + scatterSize};

--- a/velox/dwio/nimble/encodings/legacy/NullableEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/NullableEncoding.h
@@ -201,6 +201,17 @@ uint32_t NullableEncoding<T>::materializeNullable(
 
   const auto scatterSize =
       scatterOutputBitmap ? scatterOutputBitmap->size() - offset : rowCount;
+
+  // A column that is entirely null over this batch would still walk every
+  // position in the scatter loop below to set nothing. Short-circuit to the
+  // cleared bitmap.
+  if (nonNullCount == 0 && scatterSize != 0) {
+    velox::bits::BitmapBuilder nullBits{getOutputNulls(), offset + scatterSize};
+    nullBits.clear(offset, offset + scatterSize);
+    row_ += rowCount;
+    return 0;
+  }
+
   if (nonNullCount != scatterSize) {
     void* nullBitmap = getOutputNulls();
     velox::bits::BitmapBuilder nullBits{nullBitmap, offset + scatterSize};

--- a/velox/dwio/nimble/velox/FieldReader.cpp
+++ b/velox/dwio/nimble/velox/FieldReader.cpp
@@ -798,6 +798,9 @@ class LegacyStringFieldReader final : public FieldReader {
         scatterBitmap);
     size_t totalLength = 0;
     const bool hasNulls = (nonNullCount != rowCount);
+    // A column that is entirely null over this batch would make both passes
+    // over |rowCount| below run only to move nothing.
+    const bool allNull = (nonNullCount == 0);
     if (!hasNulls) {
       vector->resetNulls();
       for (uint32_t i = 0; i < rowCount; ++i) {
@@ -805,9 +808,11 @@ class LegacyStringFieldReader final : public FieldReader {
       }
     } else {
       vector->setNullCount(rowCount - nonNullCount);
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        if (!vector->isNullAt(i)) {
-          totalLength += buffer_[i].length();
+      if (!allNull) {
+        for (uint32_t i = 0; i < rowCount; ++i) {
+          if (!vector->isNullAt(i)) {
+            totalLength += buffer_[i].length();
+          }
         }
       }
     }
@@ -824,7 +829,7 @@ class LegacyStringFieldReader final : public FieldReader {
             velox::StringView(dataPtr + currentOffset, buffer_[i].length());
         currentOffset += buffer_[i].length();
       }
-    } else {
+    } else if (!allNull) {
       for (uint32_t i = 0; i < rowCount; ++i) {
         if (!vector->isNullAt(i)) {
           std::copy(


### PR DESCRIPTION
Summary:

`NullableEncoding<T>` stores a nullable column as two sub-streams: a `nulls_`
stream with one boolean per row, and a `nonNullValues_` stream holding only the
values that exist. To hand Velox a vector, `materializeNullable` scatters the
dense values back out to their row positions, walking backward so it never
overwrites a value it has not moved yet.

The loop terminates on `output != lastNonNull`, so it iterates once per null
slot. When a column holds no values at all over a batch, `nonNullCount` is 0 and
`lastNonNull` sits at `buffer - 1`, so the gap never closes early and the loop
runs the full `scatterSize` iterations, testing a byte and decrementing two
pointers each time, to produce a bitmap it had already cleared before entering.

`LegacyStringFieldReader::next` had the same defect independently: two complete
passes over every row, one summing string lengths and one copying bytes, each
calling `isNullAt`, followed by a zero-byte buffer allocation.

No single iteration is expensive; there are simply a great many of them. The
loop is O(`scatterSize`) per column per batch and cannot be vectorized, because
`lastNonNull` only advances inside the branch and the exit test depends on it,
so the trip count is unknown to the compiler. It is also driven by the output
span rather than by the column's own data: under a nullable parent that span is
the parent's row count, so an empty column pays in proportion to its neighbours.
On a 1,011-column corpus of 52.2M rows that works out to roughly 5e10
iterations, and a perf profile attributed ~41% of decode to `materializeNullable`
across five type instantiations, against 1.3% for `ZSTD_decompressSequences`.

The replacement is the range clear that already ran ahead of the loop, which
settles ~64 positions per store with no branch.

Both short-circuits are guarded to fire only where the code they replace would
have run. For the scatter, `nonNullCount == 0 && scatterSize != 0` is exactly
`nonNullCount == 0 && nonNullCount != scatterSize`, which matters because
`getOutputNulls()` is not a pure accessor: it allocates the output null buffer,
and `ChunkedStreamDecoder` keys its back-fill logic on whether it was called.
The fast path is also placed after `nonNullValues_->materialize()` so the
sub-encodings' internal row cursors advance exactly as before.

The same guard is added to the non-legacy `encodings/NullableEncoding.h`.
`legacy::EncodingFactory` is what every `VeloxReader` gets by default, so the
legacy copy is the one on the hot path today, but the modern copy carries the
identical omission.

Reviewed By: xiaoxmeng

Differential Revision: D115675657


