### PR TITLE
test(nimble): Exclude Huffman from writer fuzzing

### DIFF
--- a/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
@@ -314,6 +314,7 @@ TEST_F(
   fuzzer.run();
 
   EXPECT_EQ(fuzzer.numUnfilteredFilesWritten(), kNumUnfilteredRounds);
+  EXPECT_FALSE(fuzzer.coverage().contains(EncodingType::Huffman));
   for (const auto encodingType : allCandidateEncodings()) {
     SCOPED_TRACE(toString(encodingType));
     const auto entry = fuzzer.coverage().find(encodingType);

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -74,9 +74,11 @@ using ::facebook::velox::VectorPtr;
 using ::facebook::velox::fuzzer::FuzzerGenerator;
 
 // Writable encodings that this fuzzer target intentionally does not force.
-// This is not a global unsupported-encoding list.
+// The unfiltered random policy also omits these; this list keeps the repair
+// phase and coverage gate from adding them back. This is not a global
+// unsupported-encoding list.
 constexpr auto kExcludedFuzzerCandidateEncodings =
-    std::to_array({EncodingType::SubIntSplit});
+    std::to_array({EncodingType::Huffman, EncodingType::SubIntSplit});
 
 // Scalar types the Nimble writer round-trips with type identity.
 // FieldWriter::create dispatches on the physical TypeKind, so DATE, TIME,
@@ -2155,7 +2157,7 @@ void NimbleWriterFuzzer::run() {
       missingEncodings.size(),
       fmt::join(missingEncodingNames, ", "));
 
-  // The default random policy omits the integral-only four because its
+  // The default random policy omits the integral-only candidates because its
   // write-side and read-side floating-point gates disagree (T283330065), so
   // they always reach this repair phase. gateFloatingPointStreams holds them
   // off float streams alone while still exercising integer streams in a mixed


### PR DESCRIPTION
Summary:
CONTEXT: The Nimble writer fuzzer is becoming a blocking release-conveyor gate. Huffman is outside the default random-policy candidate set and has recently made forced-encoding runs unstable, so requiring it makes the release signal depend on an encoding that should remain outside this fuzzing surface.

WHAT: Add `Huffman` to the writer fuzzer candidate exclusion list so the repair phase and coverage gate do not force it. Assert that a normal fuzzer run records no Huffman coverage. Dedicated Huffman encoding tests remain unchanged.

Reviewed By: kewang1024

Differential Revision: D117727351


