### PR TITLE
fix(khyperloglog): Widen the uii to a long before hashing (#18725)

### DIFF
--- a/velox/functions/lib/KHyperLogLogImpl.h
+++ b/velox/functions/lib/KHyperLogLogImpl.h
@@ -18,7 +18,9 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/IOUtils.h"
+#include "velox/common/base/XxHashInline.h"
 #include "velox/common/hyperloglog/Murmur3Hash128.h"
+#include "velox/functions/lib/KHyperLogLog.h"
 #include "velox/type/HugeInt.h"
 
 namespace facebook::velox::common::hll {
@@ -28,6 +30,40 @@ constexpr uint8_t kVersionByte = 1;
 constexpr int64_t kHashOutputHalfRange = INT64_MAX;
 constexpr size_t kHeaderSize = sizeof(uint8_t) // version
     + 4 * sizeof(int32_t); // maxSize, hllBuckets, minhashSize, hllsTotalSize;
+
+// Presto carries a REAL as its floatToIntBits() pattern, not as a widened
+// DOUBLE, so float and double take different branches.
+template <typename T>
+static int64_t toLongBits(const T& value) {
+  if constexpr (std::is_same_v<T, Timestamp>) {
+    return value.toMillis();
+  } else if constexpr (std::is_same_v<T, float>) {
+    int32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return bits;
+  } else if constexpr (std::is_same_v<T, double>) {
+    int64_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return bits;
+  } else if constexpr (std::is_integral_v<T>) {
+    return static_cast<int64_t>(value);
+  } else {
+    VELOX_UNREACHABLE("Unsupported input type: {}", typeid(T).name());
+  }
+}
+
+// Presto pre-hashes a varchar uii with XxHash64. A varchar join key instead
+// hashes the bytes once with Murmur3, and approx_set adds the raw bytes, so
+// neither hashKey() nor HllAccumulator::hashOne() can be reused here.
+template <typename TUii>
+static uint64_t hashUii(const TUii& uii) {
+  if constexpr (std::is_same_v<TUii, StringView>) {
+    return Murmur3Hash128::hash64ForLong(
+        static_cast<int64_t>(XXH64(uii.data(), uii.size(), 0)), 0);
+  } else {
+    return Murmur3Hash128::hash64ForLong(toLongBits(uii), 0);
+  }
+}
 
 template <typename TJoinKey>
 static int64_t hashKey(TJoinKey joinKey) {
@@ -226,7 +262,7 @@ void KHyperLogLog<TUii, TAllocator>::update(int64_t hash, TUii uii) {
     decreaseTotalHllSize(*hll);
   }
 
-  hll->append(uii);
+  hll->insertHash(detail::hashUii(uii));
 
   increaseTotalHllSize(*hll);
   removeOverflowEntries();

--- a/velox/functions/lib/tests/KHyperLogLogTest.cpp
+++ b/velox/functions/lib/tests/KHyperLogLogTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/memory/Memory.h"
 
 #include <folly/Random.h>
+#include <folly/String.h>
 #include <gtest/gtest.h>
 #include <set>
 #include <unordered_set>
@@ -210,6 +211,102 @@ TEST_F(KHyperLogLogTest, merge) {
   auto larger = createLarger();
   larger->mergeWith(*createSmaller());
   EXPECT_NE(larger->cardinality(), largerFist->cardinality());
+}
+namespace {
+template <typename TUii>
+std::string serialized(KHyperLogLog<TUii, HashStringAllocator>& khll) {
+  std::string buffer(khll.estimatedSerializedSize(), '\0');
+  khll.serialize(buffer.data());
+  return buffer;
+}
+} // namespace
+
+// Presto coerces a narrower integer uii to BIGINT, so the column width must
+// not change the sketch.
+TEST_F(KHyperLogLogTest, uiiHashIgnoresIntegerWidth) {
+  KHyperLogLog<int64_t, HashStringAllocator> asBigint(allocator_);
+  KHyperLogLog<int32_t, HashStringAllocator> asInteger(allocator_);
+  KHyperLogLog<int16_t, HashStringAllocator> asSmallint(allocator_);
+
+  for (int32_t i = 0; i < 100; ++i) {
+    asBigint.add(int64_t{1}, static_cast<int64_t>(i));
+    asInteger.add(int64_t{1}, static_cast<int32_t>(i));
+    asSmallint.add(int64_t{1}, static_cast<int16_t>(i));
+  }
+
+  EXPECT_EQ(serialized(asBigint), serialized(asInteger));
+  EXPECT_EQ(serialized(asBigint), serialized(asSmallint));
+}
+
+// A varchar uii must behave like a BIGINT uii holding its XxHash64. Expected
+// values come from:
+//
+//     SELECT from_big_endian_64(xxhash64(to_utf8(<text>)))
+TEST_F(KHyperLogLogTest, uiiVarcharIsPreHashedWithXxHash64) {
+  const std::vector<std::pair<std::string, int64_t>> uiis = {
+      {"abc", 4'952'883'123'889'572'249LL},
+      {"caf\xc3\xa9", -7'331'673'579'364'787'606LL},
+      {"aaaaaa\xc3\xa9", 8'051'246'313'758'655'368LL},
+  };
+
+  KHyperLogLog<StringView, HashStringAllocator> asVarchar(allocator_);
+  KHyperLogLog<int64_t, HashStringAllocator> asBigint(allocator_);
+
+  for (const auto& [text, xxHash] : uiis) {
+    asVarchar.add(int64_t{1}, StringView(text));
+    asBigint.add(int64_t{1}, xxHash);
+  }
+
+  EXPECT_EQ(serialized(asVarchar), serialized(asBigint));
+}
+
+namespace {
+// A KHyperLogLog produced by a conforming writer of the serialization format.
+// Ten join keys, each carrying the same three uii strings rebuilt below.
+const char* const kReferenceSketchHex =
+    "0100100000000100000A000000A00000001000000010000000100000001000000010"
+    "0000001000000010000000100000001000000010000000C1B66A4810D219B4A8C076"
+    "6CA02008DE4AC405FBB703440053262CD578ECC9061B776C9BF6C5D40F721E622C39"
+    "342F12E6D7EADF801D341BB28F7F259329E13079DFF0068CD287390C8B48B239583D"
+    "5B02080300C1A3074DC1AB008500B025CB02080300018AC70A03B2A43603682FCF02"
+    "08030042B20A008077C14CC213FD830208030080507B29C029F1AD00D232D1020803"
+    "008066C33F8050BF4C0176739A0208030086584C5742285D6F4101CB9D0208030081"
+    "BA8552002385A0C386A9A802080300C4A8D542408A4999C06D8FF00208030001A0E0"
+    "0201430DA0407273C902080300C037210C40C1E4694185A773";
+} // namespace
+
+// The uii hash is part of the serialization format. Two producers that disagree
+// on it put the same element in different buckets, and a merge double counts.
+TEST_F(KHyperLogLogTest, mergeWithReferenceSketchDoesNotDoubleCount) {
+  constexpr int64_t kKeys = 10;
+  constexpr int64_t kUiisPerKey = 3;
+
+  std::vector<std::string> uiis;
+  for (int64_t key = 1; key <= kKeys; ++key) {
+    for (int64_t i = 1; i <= kUiisPerKey; ++i) {
+      uiis.push_back(fmt::format("u{}_{}", key, i));
+    }
+  }
+
+  KHyperLogLog<StringView, HashStringAllocator> sketch(allocator_);
+  size_t next = 0;
+  for (int64_t key = 1; key <= kKeys; ++key) {
+    for (int64_t i = 0; i < kUiisPerKey; ++i) {
+      sketch.add(key, StringView(uiis[next++]));
+    }
+  }
+
+  const auto reference = folly::unhexlify<std::string>(kReferenceSketchHex);
+  sketch.mergeWith(StringView(reference), allocator_);
+
+  // The reference carries the same ten keys, so cardinality must not grow.
+  // Non-overlapping keys would make the uniqueness check below vacuous.
+  EXPECT_EQ(sketch.cardinality(), kKeys);
+
+  // Every key must still report three distinct uii.
+  const auto histogram = sketch.uniquenessDistribution(kKeys);
+  EXPECT_NEAR(histogram.at(kUiisPerKey), 1.0, 1e-9);
+  EXPECT_NEAR(histogram.at(2 * kUiisPerKey), 0.0, 1e-9);
 }
 
 TEST_F(KHyperLogLogTest, serde) {


### PR DESCRIPTION
Summary:

`khyperloglog_agg` hashes the uii inconsistently: the same logical value produces a different sketch depending on the declared width of the column.

    khyperloglog_agg(k, CAST(v AS INTEGER))   ->  8D4AA7E10BEB4DCA9AA2B8C02F9D41B9
    khyperloglog_agg(k, CAST(v AS BIGINT))    ->  C6D4C719F46C1F931D3EB785EFFC7485

Same values, same keys; only the declared type differs. `approx_set` does not have this problem, and `KHYPERLOGLOG` is the only sketch aggregate that does, because it is the only one registering narrow integer types natively instead of coercing them to BIGINT. The practical effect is that widening a column from INTEGER to BIGINT -- a value preserving schema change -- silently invalidates every sketch previously written from it.

After this change the INTEGER form produces `C6D4C719...`, the value Velox already produced for BIGINT. The narrow types are brought onto the behavior the wide type already had, rather than the other way round.

The second half of the fix concerns a VARCHAR uii, and the reason is that merging stops double counting. `KHYPERLOGLOG` is not a Velox native type: it is a serialization format carrying a version byte, written by one producer and read and merged by another. Velox hashed a VARCHAR uii over the value's own bytes, where the format pre-hashes it with XxHash64 and adds the resulting long. When two sketches disagree on that, the same element lands in two different buckets and the merge counts it twice. Measured on sketches covering 127 keys with 73 keys in common, each carrying three distinct uii:

    before:  uniqueness_distribution = {3: 0.43, 6: 0.57}
    after:   uniqueness_distribution = {3: 1.00}

57% of keys reported six distinct uii where the truth is three, matching the key overlap exactly. A sketch that reports an element twice after a merge is wrong on its own terms, independently of who else implements the format.

The uii hash now goes through a `hashUii` helper rather than `HllAccumulator::hashOne`. It cannot live in `hashOne` because plain `approx_set` genuinely does add the raw bytes, so the two callers need different behavior for the same input type.

This changes the value of persisted KHyperLogLog sketches wherever the uii is not already BIGINT, DOUBLE or TIMESTAMP. The MinHash key set is unaffected, so `cardinality`, `intersection_cardinality` and `jaccard_index` do not move.

The new test calls `folly::unhexlify`. Its `//folly:string` buck dependency is added at the top of the stack rather than here, so that this diff contains only files present in the open source tree.

Differential Revision: D117630696


