### PR TITLE
fix(khyperloglog): Correct varchar and REAL join key hashes (#18726)

### DIFF
--- a/velox/functions/lib/KHyperLogLogImpl.h
+++ b/velox/functions/lib/KHyperLogLogImpl.h
@@ -67,30 +67,20 @@ static uint64_t hashUii(const TUii& uii) {
 
 template <typename TJoinKey>
 static int64_t hashKey(TJoinKey joinKey) {
-  int64_t result;
-  if constexpr (std::is_same_v<TJoinKey, Timestamp>) {
-    result = joinKey.toMillis();
-  } else if constexpr (
+  if constexpr (
       std::is_same_v<TJoinKey, int128_t> ||
       std::is_same_v<TJoinKey, uint128_t>) {
     return Murmur3Hash128::hash64(&joinKey, sizeof(joinKey), 0);
-  } else if constexpr (std::is_integral_v<TJoinKey>) {
-    result = static_cast<int64_t>(joinKey);
-  } else if constexpr (std::is_same_v<TJoinKey, float>) {
-    // Cast to double first, then extract bits, based on implicit coercion
-    double dbl = static_cast<double>(joinKey);
-    std::memcpy(&result, &dbl, sizeof(result));
-  } else if constexpr (std::is_same_v<TJoinKey, double>) {
-    std::memcpy(&result, &joinKey, sizeof(result));
   } else if constexpr (std::is_same_v<TJoinKey, StringView>) {
-    result =
-        common::hll::Murmur3Hash128::hash64(joinKey.data(), joinKey.size(), 0);
+    // Presto hashes a string key once with Murmur3 over the bytes, unlike the
+    // numeric path below which hashes the long bit pattern.
+    return Murmur3Hash128::hash64(
+        joinKey.data(), static_cast<int32_t>(joinKey.size()), 0);
   } else {
-    VELOX_UNREACHABLE("Unsupported input type: {}", typeid(TJoinKey).name());
+    return Murmur3Hash128::hash64ForLong(toLongBits(joinKey), 0);
   }
-
-  return Murmur3Hash128::hash64(&result, sizeof(result), 0);
 }
+
 } // namespace detail
 
 template <typename TUii, typename TAllocator>

--- a/velox/functions/lib/tests/KHyperLogLogTest.cpp
+++ b/velox/functions/lib/tests/KHyperLogLogTest.cpp
@@ -19,6 +19,7 @@
 #include <folly/Random.h>
 #include <folly/String.h>
 #include <gtest/gtest.h>
+#include <limits>
 #include <set>
 #include <unordered_set>
 #include "velox/type/Timestamp.h"
@@ -258,6 +259,56 @@ TEST_F(KHyperLogLogTest, uiiVarcharIsPreHashedWithXxHash64) {
   }
 
   EXPECT_EQ(serialized(asVarchar), serialized(asBigint));
+}
+
+// Presto hashes a string join key once, not twice.
+TEST_F(KHyperLogLogTest, varcharJoinKeyIsHashedOnce) {
+  const std::string key = "abc";
+  EXPECT_EQ(
+      common::hll::detail::hashKey(StringView(key)),
+      -5'434'086'359'492'102'041LL);
+}
+
+// Presto carries a REAL as its floatToIntBits() pattern, so a REAL key must
+// hash to the same value as an INTEGER key holding those bits.
+TEST_F(KHyperLogLogTest, realJoinKeyUsesFloatToIntBits) {
+  for (float value :
+       {3.5f,
+        -3.5f,
+        0.0f,
+        -0.0f,
+        1e-30f,
+        std::numeric_limits<float>::quiet_NaN()}) {
+    int32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    EXPECT_EQ(
+        common::hll::detail::hashKey(value), common::hll::detail::hashKey(bits))
+        << "value=" << value;
+  }
+
+  // -0.0f and 0.0f compare equal but carry different bit patterns, so they are
+  // distinct keys. NaN is not canonicalized: the raw payload is hashed, which
+  // matches HllAccumulator but differs from Java's floatToIntBits(), which
+  // collapses every NaN to 0x7fc00000.
+  EXPECT_NE(
+      common::hll::detail::hashKey(0.0f), common::hll::detail::hashKey(-0.0f));
+}
+
+// Expected values come from the airlift/slice definition, not from the code
+// under test, so a change to toLongBits() or hash64ForLong() is caught here.
+TEST_F(KHyperLogLogTest, numericJoinKeysHashTheirLongBits) {
+  EXPECT_EQ(
+      common::hll::detail::hashKey(int64_t{42}), -5'283'633'198'602'748'424LL);
+  EXPECT_EQ(common::hll::detail::hashKey(1.5), -981'000'774'749'194'061LL);
+  EXPECT_EQ(
+      common::hll::detail::hashKey(Timestamp(1'234, 0)),
+      1'508'765'520'729'823'031LL);
+
+  // A narrow integral key is widened, so it agrees with the BIGINT of the same
+  // value.
+  EXPECT_EQ(
+      common::hll::detail::hashKey(int32_t{42}),
+      common::hll::detail::hashKey(int64_t{42}));
 }
 
 namespace {


### PR DESCRIPTION
Summary:

Two join key types produce a different MinHash key from other producers of the KHyperLogLog format, so sketches built on a VARCHAR or REAL key do not merge correctly across implementations. Neither type appears in a production `khyperloglog_agg` call today, so this is latent rather than observed.

A VARCHAR key was hashed twice. The `StringView` branch computed the Murmur3 of the bytes into a local, then fell through into the trailing hash of that local. The `int128_t` branch immediately above it returns directly, so the fall through is an oversight rather than a choice, and the format hashes a string key once.

A REAL key was widened to a DOUBLE before its bits were taken. The format carries a REAL as its 32 bit `floatToIntBits` pattern, sign extended, into the numeric path. A REAL key must therefore land on the same MinHash key as an INTEGER key holding those bits, which it did not.

Both branches now route through the widening helper introduced for the uii, which reduces `hashKey` from seven cases to three: a 128 bit key, a `StringView` key hashed once, and everything else widened to a long. The trailing `hash64` over eight bytes becomes `hash64ForLong`, which is the same value now that the Murmur3 tail is zero extended.

Reviewed By: HeidiHan0000

Differential Revision: D117630657


