### PR TITLE
fix(wave): Make the kernel cache safe to share between processes (#18727)

### DIFF
--- a/velox/experimental/wave/common/KernelFsCache.cpp
+++ b/velox/experimental/wave/common/KernelFsCache.cpp
@@ -17,17 +17,24 @@
 #include "velox/experimental/wave/common/KernelFsCache.h"
 
 #include <fmt/format.h>
+#include <glog/logging.h>
 #include <unistd.h>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <string_view>
 
 namespace fs = std::filesystem;
 
 namespace facebook::velox::wave {
 
 namespace {
+
+// Marks a file a compile is still writing. A stem carrying it is never taken
+// for a cache entry, so a triple left behind by a process that died between
+// writing its temporaries and renaming them is ignored rather than adopted.
+constexpr std::string_view kTempPrefix = ".tmp.";
 
 std::string readFile(const std::string& path) {
   std::ifstream in(path);
@@ -49,21 +56,85 @@ std::vector<std::string> readNames(const std::string& path) {
   return result;
 }
 
+// Names an entry by its own text, so two processes compiling the same kernel
+// choose the same file rather than racing for a shared counter. FNV-1a over
+// 128 bits: wide enough that a collision between two distinct kernels is not
+// worth planning for, and free of any dependency this target does not already
+// have. Not std::hash, which is 64 bits and whose value is free to differ
+// between builds -- a name has to mean the same thing to every process.
+std::string contentDigest(std::string_view text) {
+  __uint128_t hash = (static_cast<__uint128_t>(0x6c62272e07bb0142ULL) << 64) |
+      0x62b821756295c58dULL;
+  const __uint128_t prime =
+      (static_cast<__uint128_t>(0x1000000ULL) << 64) | 0x13bULL;
+  for (unsigned char byte : text) {
+    hash ^= byte;
+    hash *= prime;
+  }
+  return fmt::format(
+      "{:016x}{:016x}",
+      static_cast<uint64_t>(hash >> 64),
+      static_cast<uint64_t>(hash));
+}
+
+// Renames 'from' onto 'to' if it exists. Rename within a directory is atomic,
+// which is what lets a reader in another process see either the previous file
+// or the whole new one, never a prefix of it. Returns false if the temporary
+// is missing, which means the compiler wrote nothing to publish.
+bool publishFile(std::string_view from, std::string_view to) {
+  std::error_code error;
+  if (!fs::exists(from, error)) {
+    return false;
+  }
+  fs::rename(from, to, error);
+  return !error;
+}
+
 } // namespace
 
 KernelFsCache::KernelFsCache(const std::string& cacheDir)
     : cacheDir_(cacheDir) {}
 
-std::string KernelFsCache::cuPath(int32_t ordinal) const {
-  return fmt::format("{}/{}.cu", cacheDir_, ordinal);
+std::string KernelFsCache::cuPath(std::string_view stem) const {
+  return fmt::format("{}/{}.cu", cacheDir_, stem);
 }
 
-std::string KernelFsCache::cubinPath(int32_t ordinal) const {
-  return fmt::format("{}/{}.cubin", cacheDir_, ordinal);
+std::string KernelFsCache::cubinPath(std::string_view stem) const {
+  return fmt::format("{}/{}.cubin", cacheDir_, stem);
 }
 
-std::string KernelFsCache::namesPath(int32_t ordinal) const {
-  return fmt::format("{}/{}.cubin.names", cacheDir_, ordinal);
+std::string KernelFsCache::namesPath(std::string_view stem) const {
+  return fmt::format("{}/{}.cubin.names", cacheDir_, stem);
+}
+
+std::string KernelFsCache::tempStem() {
+  // The pid separates processes and the serial separates concurrent compiles
+  // within one, so no two writers on a host ever share a temporary. The
+  // kTempPrefix is what the scan in init() recognises them by; a process that
+  // dies mid-publish leaves a complete-looking triple behind, and without the
+  // prefix it would be picked up as an ordinary entry under a name no one can
+  // account for.
+  return fmt::format(
+      "{}{}.{}", kTempPrefix, static_cast<int64_t>(getpid()), compileSerial_++);
+}
+
+bool KernelFsCache::entryComplete(std::string_view stem) const {
+  // Non-empty rather than merely present: a writer that died, or ran out of
+  // disk, leaves an empty file that would otherwise read as a complete entry
+  // whose text matches nothing.
+  //
+  // The size has to be taken through an error_code that is then checked. The
+  // non-throwing fs::file_size reports failure by returning uintmax_t(-1),
+  // which would sail through a bare '> 0' -- so a file that another process
+  // trims between the stat and the read, precisely the race this guards, would
+  // be reported complete.
+  auto nonEmpty = [](const std::string& path) {
+    std::error_code error;
+    auto size = fs::file_size(path, error);
+    return !error && size > 0;
+  };
+  return nonEmpty(cuPath(stem)) && nonEmpty(cubinPath(stem)) &&
+      nonEmpty(namesPath(stem));
 }
 
 void KernelFsCache::init() {
@@ -72,26 +143,49 @@ void KernelFsCache::init() {
   }
   initialized_ = true;
 
-  if (!fs::exists(cacheDir_)) {
-    fs::create_directories(cacheDir_);
+  std::error_code error;
+  if (!fs::exists(cacheDir_, error)) {
+    fs::create_directories(cacheDir_, error);
+    if (error) {
+      // Not fatal: kernels still compile, they just are not cached. Said out
+      // loud because the symptom otherwise is silent recompilation on a
+      // directory that never fills up.
+      LOG(WARNING) << "Wave kernel cache disabled, cannot create " << cacheDir_
+                   << ": " << error.message();
+    }
     return;
   }
 
-  for (auto& entry : fs::directory_iterator(cacheDir_)) {
+  // Tolerate the directory changing underneath the walk. Another process
+  // publishing an entry, or trimming one, can make a name the iterator has
+  // already handed out disappear before it is opened; the throwing overloads
+  // would turn that into an exception on whatever thread happens to be
+  // compiling. A file that vanishes mid-scan is simply one this process does
+  // not know about yet.
+  fs::directory_iterator scan(cacheDir_, error);
+  if (error) {
+    return;
+  }
+  // Incremented through the error_code overload for the same reason: the
+  // range-for form advances with the throwing one.
+  for (; scan != fs::directory_iterator(); scan.increment(error)) {
+    if (error) {
+      break;
+    }
+    const auto& entry = *scan;
     if (entry.path().extension() != ".cu") {
       continue;
     }
+    // The stem is taken as written. An entry from an earlier version is named
+    // by an ordinal and one from this version by its digest; either is found
+    // by the text of its .cu, so a directory does not have to be discarded
+    // when the naming changes. The one stem that is not an entry is a
+    // temporary a dead process left mid-publish.
     auto stem = entry.path().stem().string();
-    int32_t ordinal;
-    try {
-      ordinal = std::stoi(stem);
-    } catch (...) {
+    if (std::string_view(stem).substr(0, kTempPrefix.size()) == kTempPrefix) {
       continue;
     }
-    auto cubinFile = cubinPath(ordinal);
-    auto namesFile = namesPath(ordinal);
-    if (!fs::exists(cubinFile) || fs::file_size(cubinFile) == 0 ||
-        !fs::exists(namesFile)) {
+    if (!entryComplete(stem)) {
       continue;
     }
     auto text = readFile(entry.path().string());
@@ -99,11 +193,8 @@ void KernelFsCache::init() {
       continue;
     }
     auto hash = std::hash<std::string>{}(text);
-    hashToEntries_[hash].push_back({ordinal});
+    hashToEntries_[hash].push_back({stem});
     ++numEntries_;
-    if (ordinal >= nextOrdinal_) {
-      nextOrdinal_ = ordinal + 1;
-    }
   }
 }
 
@@ -119,29 +210,42 @@ std::unique_ptr<CompiledKernel> KernelFsCache::getKernel(
   const std::string key =
       fmt::format("// wave-cache-salt:{:016x}\n", kernelCacheSalt()) + keyArg;
   auto hash = std::hash<std::string>{}(key);
-  auto assignedOrdinal = std::make_shared<std::atomic<int32_t>>(-1);
+  const std::string digest = contentDigest(key);
+  auto assignedTemp = std::make_shared<std::string>();
 
   auto wrappedGen = [this,
                      keyCopy = key,
                      hash,
+                     digest,
                      genFuncCopy = std::move(genFunc),
-                     assignedOrdinal]() -> KernelSpec {
+                     assignedTemp]() -> KernelSpec {
     std::unique_lock lock(mutex_);
     init();
+
+    // Adopt an entry another process published after this one scanned. Without
+    // this the scan is a snapshot taken once, and a long-lived process would
+    // recompile everything its neighbours added. Cheap because the entry's
+    // name follows from the text: this is a stat of one known path, not a
+    // rescan of the directory.
+    auto known = hashToEntries_.find(hash);
+    if (known == hashToEntries_.end() && entryComplete(digest) &&
+        readFile(cuPath(digest)) == keyCopy) {
+      hashToEntries_[hash].push_back({digest});
+      ++numEntries_;
+    }
 
     auto it = hashToEntries_.find(hash);
     if (it != hashToEntries_.end()) {
       for (auto& entry : it->second) {
-        auto text = readFile(cuPath(entry.ordinal));
+        auto text = readFile(cuPath(entry.stem));
         if (text != keyCopy) {
           continue;
         }
-        auto cubinFilePath = cubinPath(entry.ordinal);
-        auto namesFilePath = namesPath(entry.ordinal);
-        if (!fs::exists(cubinFilePath) || fs::file_size(cubinFilePath) == 0 ||
-            !fs::exists(namesFilePath)) {
+        if (!entryComplete(entry.stem)) {
           continue;
         }
+        auto namesFilePath = namesPath(entry.stem);
+        auto cubinFilePath = cubinPath(entry.stem);
         auto lowered = readNames(namesFilePath);
         lock.unlock();
         ++hits_;
@@ -157,24 +261,83 @@ std::unique_ptr<CompiledKernel> KernelFsCache::getKernel(
     auto spec = genFuncCopy();
     lock.lock();
 
-    auto ordinal = nextOrdinal_++;
-    assignedOrdinal->store(ordinal);
-    spec.cubinPath = cubinPath(ordinal);
+    // Compile into a private temporary. Publishing is a rename once the file
+    // is whole, so a concurrent reader never sees a partial cubin, and two
+    // processes compiling this same kernel cannot write over each other
+    // mid-write -- they each finish their own temporary and the last rename
+    // wins, both files being compilations of the same source.
+    auto temp = tempStem();
+    *assignedTemp = temp;
+    spec.cubinPath = cubinPath(temp);
 
-    spec.postCompile = [this, ordinal, hash, keyCopy](
+    spec.postCompile = [this, temp, digest, hash, keyCopy](
                            KernelSpec& /*compiled*/, std::exception_ptr error) {
       std::unique_lock lock(mutex_);
+      std::error_code removeError;
+      auto removeTemps = [&]() {
+        // Only ever this process's own temporaries. A file already under its
+        // final name may have been published by another process compiling the
+        // same kernel, and removing that is how one process destroys another's
+        // entry.
+        fs::remove(cuPath(temp), removeError);
+        fs::remove(cubinPath(temp), removeError);
+        fs::remove(namesPath(temp), removeError);
+      };
       if (error) {
-        std::error_code removeError;
-        fs::remove(cubinPath(ordinal), removeError);
-        fs::remove(cubinPath(ordinal) + ".names", removeError);
+        removeTemps();
         return;
       }
-      {
-        std::ofstream out(cuPath(ordinal));
-        out << keyCopy;
+      // A digest collision between two different kernels would otherwise have
+      // one overwrite the other. Vanishingly unlikely, but the cost of being
+      // wrong is serving the wrong machine code, so give the newcomer its own
+      // name and let the exact text compare below sort them out on lookup.
+      //
+      // A stat that fails is not evidence that a name is free. Taking it as
+      // free is the one way this walk can stop on a name another kernel owns:
+      // the three renames below are not atomic as a group, so a reader in that
+      // window would pair that kernel's source with this one's cubin. An
+      // unreadable name therefore ends the publish -- the entry goes uncached
+      // and recompiles next time, which costs work rather than correctness.
+      std::string stem = digest;
+      for (int32_t suffix = 1;; ++suffix) {
+        std::error_code statError;
+        if (!fs::exists(cuPath(stem), statError)) {
+          if (statError) {
+            removeTemps();
+            return;
+          }
+          break;
+        }
+        if (readFile(cuPath(stem)) == keyCopy) {
+          break;
+        }
+        stem = fmt::format("{}_{}", digest, suffix);
       }
-      hashToEntries_[hash].push_back({ordinal});
+
+      // Write the .cu before any rename. Of the steps left it is the only one
+      // that realistically fails -- a full disk -- and doing it first means a
+      // failure has published nothing and leaves nothing but temporaries to
+      // clean up.
+      auto tempCu = cuPath(temp);
+      {
+        std::ofstream out(tempCu);
+        out << keyCopy;
+        out.flush();
+        if (!out.good()) {
+          removeTemps();
+          return;
+        }
+      }
+      // The cubin and its names go first and the .cu last: the .cu is what
+      // marks an entry present, so publishing it last means an entry is never
+      // visible before the files it promises.
+      if (!publishFile(cubinPath(temp), cubinPath(stem)) ||
+          !publishFile(namesPath(temp), namesPath(stem)) ||
+          !publishFile(tempCu, cuPath(stem))) {
+        removeTemps();
+        return;
+      }
+      hashToEntries_[hash].push_back({stem});
       ++numEntries_;
     };
 
@@ -188,27 +351,15 @@ std::unique_ptr<CompiledKernel> KernelFsCache::getKernel(
     return CompiledKernel::getKernel(key, std::move(wrappedGen));
   } catch (...) {
     std::unique_lock lock(mutex_);
-    auto ordinal = assignedOrdinal->load();
-    if (ordinal >= 0) {
+    // Only this process's own temporaries are removed. The published entry, if
+    // one was reached, is named by content and may since have been adopted by
+    // another process; deleting by a name this process picked is what used to
+    // let one process delete another's files.
+    if (!assignedTemp->empty()) {
       std::error_code removeError;
-      fs::remove(cuPath(ordinal), removeError);
-      fs::remove(cubinPath(ordinal), removeError);
-      fs::remove(namesPath(ordinal), removeError);
-      auto it = hashToEntries_.find(hash);
-      if (it != hashToEntries_.end()) {
-        auto& entries = it->second;
-        entries.erase(
-            std::remove_if(
-                entries.begin(),
-                entries.end(),
-                [&](const CacheEntry& entry) {
-                  return entry.ordinal == ordinal;
-                }),
-            entries.end());
-        if (entries.empty()) {
-          hashToEntries_.erase(it);
-        }
-      }
+      fs::remove(cuPath(*assignedTemp), removeError);
+      fs::remove(cubinPath(*assignedTemp), removeError);
+      fs::remove(namesPath(*assignedTemp), removeError);
     }
     throw;
   }

--- a/velox/experimental/wave/common/KernelFsCache.h
+++ b/velox/experimental/wave/common/KernelFsCache.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include "velox/experimental/wave/common/Cuda.h"
@@ -28,6 +29,18 @@ namespace facebook::velox::wave {
 /// Stores .cu source, .cubin binaries, and .names (mangled entry points)
 /// in a directory. On lookup, hashes the source text and compares against
 /// cached entries to avoid recompilation across runs.
+///
+/// Safe to share one directory between concurrent processes. Two properties
+/// carry that: an entry's file name is derived from its own source text, so
+/// two processes compiling the same kernel converge on the same name instead
+/// of racing for a counter; and every file is published by renaming a
+/// process-private temporary into place, so a reader sees a whole file or no
+/// file. Neither process needs a lock, and a duplicate compile wastes work
+/// without corrupting anything.
+///
+/// Directories written by earlier versions, whose entries are named by an
+/// ordinal rather than by content, are still read: a cached entry is found by
+/// the text of its .cu, and the file name is not otherwise interpreted.
 class KernelFsCache {
  public:
   explicit KernelFsCache(const std::string& cacheDir);
@@ -56,32 +69,44 @@ class KernelFsCache {
 
  private:
   struct CacheEntry {
-    int32_t ordinal;
+    // File name of the entry without its extension. For an entry this version
+    // wrote it is the content digest; for one an earlier version wrote it is
+    // the ordinal it was allocated. Never parsed, only pasted into a path.
+    std::string stem;
   };
 
   /// Scans the cache directory and populates hashToEntries_ on first call.
   void init();
 
-  /// Returns the path for the .cu source file at the given cache ordinal.
-  std::string cuPath(int32_t ordinal) const;
-  /// Returns the path for the .cubin binary at the given cache ordinal.
-  std::string cubinPath(int32_t ordinal) const;
-  /// Returns the path for the .cubin.names sidecar at the given cache ordinal.
-  std::string namesPath(int32_t ordinal) const;
+  /// Returns the path for the .cu source file of the given entry.
+  std::string cuPath(std::string_view stem) const;
+  /// Returns the path for the .cubin binary of the given entry.
+  std::string cubinPath(std::string_view stem) const;
+  /// Returns the path for the .cubin.names sidecar of the given entry.
+  std::string namesPath(std::string_view stem) const;
+
+  // Stem of a temporary this process alone writes, unique across processes
+  // sharing the directory. The compiler writes the cubin and names here and
+  // they are renamed into place once whole.
+  std::string tempStem();
+
+  // True when all three files of 'stem' are present and neither the source nor
+  // the cubin is empty, i.e. the entry was fully published. A partially visible
+  // entry is reported as absent so the caller recompiles rather than loading a
+  // torn cubin.
+  bool entryComplete(std::string_view stem) const;
 
   // Directory holding the cached .cu, .cubin, and .cubin.names files.
   std::string cacheDir_;
   // True after the first call to init().
   bool initialized_{false};
-  // Protects hashToEntries_, nextOrdinal_, and initialized_.
+  // Protects hashToEntries_ and initialized_.
   std::mutex mutex_;
   // Maps source-text hash to cache entries sharing that hash.
   // Using unordered_map because adding folly::F14FastMap as a dependency
   // causes dependency count regressions across all downstream wave targets.
   std::unordered_map<size_t, std::vector<CacheEntry>> hashToEntries_;
-  // Next ordinal for new cache files.
-  std::atomic<int32_t> nextOrdinal_{0};
-  // Serial number for compile operations.
+  // Serial number for compile operations, part of the temporary file name.
   std::atomic<int32_t> compileSerial_{0};
   // Number of distinct cached entries.
   std::atomic<int32_t> numEntries_{0};

--- a/velox/experimental/wave/common/tests/KernelFsCacheTest.cu
+++ b/velox/experimental/wave/common/tests/KernelFsCacheTest.cu
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/KernelFsCache.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <filesystem>
+#include <fstream>
+
+#include "velox/experimental/wave/common/Cuda.h"
+#include "velox/experimental/wave/common/GpuArena.h"
+
+namespace facebook::velox::wave {
+namespace {
+
+namespace fs = std::filesystem;
+
+// Sharing one cache directory between processes is the case these tests are
+// about. A second process is modelled by a second KernelFsCache over the same
+// directory: the two have no state in common except the files, which is
+// exactly the relationship two processes have. Where a test needs the
+// in-process kernel cache out of the way as well, it clears that too.
+class KernelFsCacheTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    device_ = getDevice();
+    setDevice(device_);
+    arena_ = std::make_unique<GpuArena>(1 << 20, getAllocator(device_));
+    // One directory per test. Sharing it would let a compile still running
+    // for a finished test scan a directory the next test is deleting.
+    cacheDir_ = fmt::format(
+        "/tmp/kernel_fs_cache_test_{}_{}",
+        getpid(),
+        testing::UnitTest::GetInstance()->current_test_info()->name());
+    std::error_code error;
+    fs::remove_all(cacheDir_, error);
+  }
+
+  void TearDown() override {
+    // Drop the in-process cache first: it owns the futures the deferred
+    // compiles run on, so the directory is not removed while one is still
+    // scanning it.
+    CompiledKernel::clearCache();
+    std::error_code error;
+    fs::remove_all(cacheDir_, error);
+  }
+
+  // A kernel whose text, and so whose cache entry, varies with 'tag'.
+  static std::string kernelText(int32_t tag) {
+    // Plain int rather than int32_t: NVRTC compiles this text on its own, with
+    // no wave header in scope to declare the fixed-width names.
+    return fmt::format(
+        "namespace facebook::velox::wave {{\n"
+        "__global__ void addKernel(int* ints) {{\n"
+        "  ints[threadIdx.x] += {};\n"
+        "}}\n"
+        "}}\n",
+        tag);
+  }
+
+  static KernelGenFunc genFor(const std::string& text) {
+    return [text]() -> KernelSpec {
+      KernelSpec spec;
+      spec.code = text;
+      spec.entryPoints = {"facebook::velox::wave::addKernel"};
+      spec.filePath = "kernel_fs_cache_test.cu";
+      return spec;
+    };
+  }
+
+  // getKernel defers everything that touches the cache, so a test that asserts
+  // on hits, misses or files has to make the kernel real first. info() forces
+  // the deferred compile or load to finish.
+  std::unique_ptr<CompiledKernel> getReady(
+      KernelFsCache& cache,
+      const std::string& text) {
+    auto kernel = cache.getKernel(text, genFor(text));
+    kernel->info(0);
+    return kernel;
+  }
+
+  // Runs the kernel over 32 ints and returns what it added, so a test can tell
+  // that the cubin it loaded is the one belonging to its own source rather
+  // than another entry's.
+  int32_t runAndGetAddend(CompiledKernel& kernel) {
+    WaveBufferPtr ints = arena_->allocate<int32_t>(32);
+    auto* raw = ints->as<int32_t>();
+    for (auto i = 0; i < 32; ++i) {
+      raw[i] = 0;
+    }
+    void* params = &raw;
+    auto stream = std::make_unique<Stream>();
+    kernel.launch(0, 1, 32, 0, stream.get(), &params);
+    stream->wait();
+    return raw[0];
+  }
+
+  int32_t countFiles(const std::string& extension) {
+    int32_t count = 0;
+    std::error_code error;
+    if (!fs::exists(cacheDir_, error)) {
+      return 0;
+    }
+    for (auto& entry : fs::directory_iterator(cacheDir_)) {
+      if (entry.path().extension() == extension) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  Device* device_{nullptr};
+  std::unique_ptr<GpuArena> arena_;
+  std::string cacheDir_;
+};
+
+// Two caches over one directory, each compiling a different kernel, must not
+// land on the same file names. With entries named by an ordinal each picked
+// its own next number from the same starting point, so both wrote entry 0 and
+// one kernel's .cu ended up beside the other's .cubin -- a hit that returns
+// the wrong machine code. Naming by content is what separates them.
+TEST_F(KernelFsCacheTest, concurrentWritersDoNotCollide) {
+  auto firstText = kernelText(11);
+  auto secondText = kernelText(22);
+
+  KernelFsCache first(cacheDir_);
+  KernelFsCache second(cacheDir_);
+
+  // Both scan the directory while it is empty, as two processes starting
+  // together would, before either has published anything.
+  auto firstKernel = getReady(first, firstText);
+  auto secondKernel = getReady(second, secondText);
+
+  EXPECT_EQ(runAndGetAddend(*firstKernel), 11);
+  EXPECT_EQ(runAndGetAddend(*secondKernel), 22);
+
+  // Two distinct kernels, so two distinct entries rather than one overwriting
+  // the other.
+  EXPECT_EQ(countFiles(".cu"), 2);
+  EXPECT_EQ(countFiles(".cubin"), 2);
+
+  // Read back through a third cache, which sees only the files. If the two
+  // writers had collided this is where the wrong cubin would surface. The two
+  // kernels are released first: while one is held the in-process cache keeps
+  // serving it and the filesystem is never consulted.
+  firstKernel.reset();
+  secondKernel.reset();
+  CompiledKernel::clearCache();
+  KernelFsCache reader(cacheDir_);
+  EXPECT_EQ(runAndGetAddend(*getReady(reader, firstText)), 11);
+  EXPECT_EQ(runAndGetAddend(*getReady(reader, secondText)), 22);
+  EXPECT_EQ(reader.hits(), 2);
+  EXPECT_EQ(reader.misses(), 0);
+}
+
+// Both processes compiling the SAME kernel converge on one entry instead of
+// accumulating a copy each.
+TEST_F(KernelFsCacheTest, sameKernelFromTwoCachesSharesOneEntry) {
+  auto text = kernelText(7);
+
+  KernelFsCache first(cacheDir_);
+  KernelFsCache second(cacheDir_);
+
+  EXPECT_EQ(runAndGetAddend(*getReady(first, text)), 7);
+  CompiledKernel::clearCache();
+  EXPECT_EQ(runAndGetAddend(*getReady(second, text)), 7);
+
+  EXPECT_EQ(countFiles(".cu"), 1);
+  EXPECT_EQ(countFiles(".cubin"), 1);
+}
+
+// An entry published after this cache scanned the directory is still found.
+// The scan happens once, so without a second look a long-lived process
+// recompiles everything its neighbours added while it was running.
+TEST_F(KernelFsCacheTest, findsEntryPublishedAfterScan) {
+  auto scanned = kernelText(3);
+  auto later = kernelText(4);
+
+  KernelFsCache reader(cacheDir_);
+  // Force reader to scan the directory now, while it holds only 'scanned'.
+  {
+    KernelFsCache writer(cacheDir_);
+    getReady(writer, scanned);
+  }
+  CompiledKernel::clearCache();
+  getReady(reader, scanned);
+  EXPECT_EQ(reader.hits(), 1);
+
+  // A second process publishes another entry afterwards.
+  {
+    KernelFsCache writer(cacheDir_);
+    getReady(writer, later);
+  }
+  CompiledKernel::clearCache();
+
+  EXPECT_EQ(runAndGetAddend(*getReady(reader, later)), 4);
+  EXPECT_EQ(reader.hits(), 2);
+  EXPECT_EQ(reader.misses(), 0);
+}
+
+// A cubin that is present but truncated -- what a reader saw mid-write before
+// entries were published by rename -- is treated as absent and recompiled,
+// rather than loaded.
+TEST_F(KernelFsCacheTest, tornEntryIsRecompiledNotLoaded) {
+  auto text = kernelText(5);
+  {
+    KernelFsCache writer(cacheDir_);
+    getReady(writer, text);
+  }
+  CompiledKernel::clearCache();
+
+  // Truncate the cubin, leaving the .cu and .names in place.
+  for (auto& entry : fs::directory_iterator(cacheDir_)) {
+    if (entry.path().extension() == ".cubin") {
+      std::ofstream out(
+          entry.path().string(), std::ios::trunc | std::ios::binary);
+    }
+  }
+
+  KernelFsCache reader(cacheDir_);
+  EXPECT_EQ(runAndGetAddend(*getReady(reader, text)), 5);
+  EXPECT_EQ(reader.misses(), 1);
+  EXPECT_EQ(reader.hits(), 0);
+}
+
+// A directory written before entries were named by content is still usable.
+// Its entries are named by an ordinal; they must be found by the text of their
+// .cu like any other, so upgrading does not throw away a warm cache.
+TEST_F(KernelFsCacheTest, readsCacheWrittenWithOrdinalNames) {
+  auto text = kernelText(9);
+
+  // Build an entry, then rename it to the ordinal form an earlier version
+  // wrote, which is what an existing cache directory on disk looks like.
+  {
+    KernelFsCache writer(cacheDir_);
+    getReady(writer, text);
+  }
+  CompiledKernel::clearCache();
+  std::string stem;
+  for (auto& entry : fs::directory_iterator(cacheDir_)) {
+    if (entry.path().extension() == ".cu") {
+      stem = entry.path().stem().string();
+    }
+  }
+  ASSERT_FALSE(stem.empty());
+  std::error_code error;
+  fs::rename(
+      fmt::format("{}/{}.cu", cacheDir_, stem),
+      fmt::format("{}/0.cu", cacheDir_),
+      error);
+  fs::rename(
+      fmt::format("{}/{}.cubin", cacheDir_, stem),
+      fmt::format("{}/0.cubin", cacheDir_),
+      error);
+  fs::rename(
+      fmt::format("{}/{}.cubin.names", cacheDir_, stem),
+      fmt::format("{}/0.cubin.names", cacheDir_),
+      error);
+  ASSERT_FALSE(error);
+
+  KernelFsCache legacy(cacheDir_);
+  EXPECT_EQ(runAndGetAddend(*getReady(legacy, text)), 9);
+  EXPECT_EQ(legacy.hits(), 1);
+  EXPECT_EQ(legacy.misses(), 0);
+  // Served from the existing file rather than recompiled beside it.
+  EXPECT_EQ(countFiles(".cu"), 1);
+}
+
+// A process that dies between writing its temporaries and renaming them
+// leaves a complete-looking triple under a .tmp. stem. It must not be taken
+// for a cache entry: nothing accounts for that name, and adopting it would
+// make a half-finished publish permanent.
+TEST_F(KernelFsCacheTest, leftoverTemporaryIsNotAdopted) {
+  auto text = kernelText(13);
+  {
+    KernelFsCache writer(cacheDir_);
+    getReady(writer, text);
+  }
+  CompiledKernel::clearCache();
+
+  // Rename the published entry to the form a dead process would have left.
+  std::string stem;
+  for (auto& entry : fs::directory_iterator(cacheDir_)) {
+    if (entry.path().extension() == ".cu") {
+      stem = entry.path().stem().string();
+    }
+  }
+  ASSERT_FALSE(stem.empty());
+  const std::string temp = ".tmp.999999.0";
+  std::error_code error;
+  for (auto suffix : {".cu", ".cubin", ".cubin.names"}) {
+    fs::rename(
+        fmt::format("{}/{}{}", cacheDir_, stem, suffix),
+        fmt::format("{}/{}{}", cacheDir_, temp, suffix),
+        error);
+  }
+  ASSERT_FALSE(error);
+
+  KernelFsCache reader(cacheDir_);
+  EXPECT_EQ(runAndGetAddend(*getReady(reader, text)), 13);
+  // Recompiled rather than served from the leftover.
+  EXPECT_EQ(reader.hits(), 0);
+  EXPECT_EQ(reader.misses(), 1);
+}
+
+// A failed compile leaves nothing behind for another process to trip over.
+TEST_F(KernelFsCacheTest, failedCompileLeavesNoFiles) {
+  KernelFsCache cache(cacheDir_);
+  auto badText = std::string("#error intentional\n");
+  bool threw = false;
+  try {
+    auto kernel = cache.getKernel(badText, genFor(badText));
+    kernel->info(0);
+  } catch (...) {
+    threw = true;
+  }
+  EXPECT_TRUE(threw);
+  EXPECT_EQ(cache.size(), 0);
+  EXPECT_EQ(countFiles(".cu"), 0);
+  EXPECT_EQ(countFiles(".cubin"), 0);
+}
+
+} // namespace
+} // namespace facebook::velox::wave


### PR DESCRIPTION
Summary:

Two processes pointed at one `--kernel_cache_dir` could serve each other the wrong machine code. Each numbered its entries from a counter it seeded by scanning the directory, so two that started together both picked the same number and both wrote `N.cu`, `N.cubin` and `N.cubin.names`. One overwrote the other, and since a lookup identifies an entry by the text of its `.cu` and then loads the `.cubin` beside it, the survivor could pair one kernel's source with another kernel's binary. That is a hit returning the wrong kernel, not a miss.

An entry is now named by a digest of its own source text, so two processes compiling the same kernel converge on the same name and two compiling different kernels cannot collide. The counter is gone with it, and so is the cleanup path that deleted by number and could remove a file another process had just written.

Publication is now a rename. The compiler writes into a temporary private to the process and the files are renamed into place once whole, `.cu` last because that is what marks an entry present -- a reader sees a complete entry or no entry, never a prefix of one. The source text is written and checked before any of the three renames, so the one step that can plausibly fail on a full disk fails while nothing has been published yet; cleanup then removes only this process's own temporaries, never a file under a final name that a neighbour may have written. A lookup that finds an incomplete entry treats it as absent and recompiles rather than loading a torn cubin. The directory scan tolerates entries appearing and vanishing underneath it, which previously threw from whatever thread happened to be compiling.

A cache is no longer a snapshot taken once at startup. Because an entry's name follows from its text, a miss can stat the one path it would occupy and adopt an entry a neighbouring process published after the scan, instead of recompiling it.

Existing cache directories keep working. An entry is found by the text of its `.cu` and the file name is not otherwise interpreted, so the ordinal-named entries written by earlier versions are read exactly as before and a warm directory does not have to be discarded.

Reviewed By: Yuhta

Differential Revision: D117582640


