### PR TITLE
feat(nimble fuzzer): Vary random encoding by chunk data (#18729)

### DIFF
--- a/velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp
+++ b/velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<EncodingSelectionPolicyBase>
 RandomEncodingSelectionPolicyFactory::createPolicy(DataType dataType) const {
   // Derive the root policy's seed from the base seed and the column's data type
   // so top-level columns of different types diverge; createImpl then folds in
-  // each nested slot. Deterministic and independent of encode thread order.
+  // each nested slot.
   const uint64_t rootSeed = folly::hash::hash_combine(
       seed_, static_cast<std::underlying_type_t<DataType>>(dataType));
   UNIQUE_PTR_FACTORY(

--- a/velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h
+++ b/velox/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h
@@ -34,9 +34,10 @@
 // ingestion.
 namespace facebook::nimble::testing {
 
-/// Randomized encoding selection for fuzz/stress testing. For each stream it
-/// picks uniformly at random among the encodings that are compatible with the
-/// data. Compatibility is defined exactly as encoding-size estimability:
+/// Randomized encoding selection for fuzz/stress testing. For each encoded
+/// chunk it picks uniformly at random among the encodings that are compatible
+/// with the data. Compatibility is defined exactly as encoding-size
+/// estimability:
 /// EncodingSizeEstimation returns nullopt for any encoding that cannot encode
 /// the given physical type or data statistics (e.g. Dictionary/FixedBitWidth/
 /// Varint on bool, Varint on non-integers, Constant on non-constant data), so
@@ -94,9 +95,9 @@ class RandomEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       };
     }
 
-    // Seed a fresh generator from this policy's derived seed so the single pick
-    // is deterministic and independent of encode thread order.
-    std::mt19937_64 generator{seed_};
+    const auto selectionSeed = folly::hash::hash_combine(
+        seed_, folly::hash::hash_range(values.begin(), values.end()));
+    std::mt19937_64 generator{selectionSeed};
     std::uniform_int_distribution<size_t> distribution(
         0, compatibleEncodings.size() - 1);
     const auto selectedEncoding = compatibleEncodings[distribution(generator)];
@@ -172,13 +173,14 @@ class RandomEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
 };
 
 /// Produces RandomEncodingSelectionPolicy instances seeded deterministically
-/// from a single base seed, so an entire file's random encoding tree is
-/// reproducible from that seed. Intended for fuzz/stress testing only.
+/// from a single base seed. Each selection additionally derives its seed from
+/// the input values, keeping the result reproducible independently of policy
+/// creation and encode thread order. Intended for fuzz/stress testing only.
 class RandomEncodingSelectionPolicyFactory {
  public:
   /// The candidate encodings the random policy draws from (the production
   /// Learned/Manual default set). EncodingSizeEstimation filters this per
-  /// stream down to the encodings compatible with the actual data.
+  /// selection down to the encodings compatible with the actual data.
   static std::vector<EncodingType> defaultEncodingChoices();
 
   /// Builds a factory from a nimble.encoding_selection_config string of the

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -443,13 +443,29 @@ nimble::EncodingSelectionPolicyCreator makeEncodingSelectionPolicyCreator(
   };
 }
 
-nimble::EncodingSelectionPolicyCreator createRandomEncodingSelectionFactory(
-    uint64_t seed) {
-  nimble::testing::RandomEncodingSelectionPolicyFactory factory{seed};
+nimble::EncodingSelectionPolicyCreator makeRandomEncodingSelectionPolicyCreator(
+    uint64_t seed,
+    std::vector<nimble::EncodingType> candidateEncodingTypes = nimble::testing::
+        RandomEncodingSelectionPolicyFactory::defaultEncodingChoices()) {
+  nimble::testing::RandomEncodingSelectionPolicyFactory factory{
+      seed, std::move(candidateEncodingTypes)};
   return [factory = std::move(factory)](nimble::DataType dataType)
              -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
     return factory.createPolicy(dataType);
   };
+}
+
+std::string writeWithWriterOptions(
+    velox::memory::MemoryPool& rootPool,
+    const velox::RowVectorPtr& vector,
+    nimble::WriterOptions options) {
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::Writer writer(
+      vector->type(), std::move(writeFile), rootPool, std::move(options));
+  writer.write(vector);
+  writer.close();
+  return file;
 }
 
 // Writes |vector| to an in-memory Nimble file using |creator| for encoding
@@ -460,13 +476,7 @@ std::string writeWithEncodingSelectionCreator(
     nimble::EncodingSelectionPolicyCreator creator) {
   nimble::WriterOptions options;
   options.encodingSelectionPolicyCreator = std::move(creator);
-  std::string file;
-  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
-  nimble::Writer writer(
-      vector->type(), std::move(writeFile), rootPool, std::move(options));
-  writer.write(vector);
-  writer.close();
-  return file;
+  return writeWithWriterOptions(rootPool, vector, std::move(options));
 }
 
 // A schema spanning the scalar physical types plus array/map/row nesting, so
@@ -9297,7 +9307,7 @@ TEST_F(WriterTest, randomEncodingSelectionRoundTrip) {
     auto vector = fuzzer.fuzzInputFlatRow(rowType);
 
     const auto file = writeWithEncodingSelectionCreator(
-        *rootPool_, vector, createRandomEncodingSelectionFactory(seed));
+        *rootPool_, vector, makeRandomEncodingSelectionPolicyCreator(seed));
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
     nimble::VeloxReader reader(readFile.get(), *leafPool_);
@@ -9312,13 +9322,80 @@ TEST_F(WriterTest, randomEncodingSelectionRoundTrip) {
   }
 }
 
+TEST_F(WriterTest, randomEncodingSelectionVariesByChunkContents) {
+  constexpr int kNumChunks = 16;
+  constexpr int kNumRowsPerChunk = 1'000;
+  constexpr uint64_t kSeed = 42;
+  const auto rowType =
+      velox::ROW({{"c0", velox::BIGINT()}, {"c1", velox::BIGINT()}});
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  std::vector<velox::RowVectorPtr> batches;
+  batches.reserve(kNumChunks);
+  for (int chunkIndex = 0; chunkIndex < kNumChunks; ++chunkIndex) {
+    std::vector<int64_t> values(kNumRowsPerChunk);
+    std::vector<int64_t> otherValues(kNumRowsPerChunk);
+    for (int row = 0; row < kNumRowsPerChunk; ++row) {
+      values[row] = (row + chunkIndex) % (17 + chunkIndex);
+      otherValues[row] = (row * 3 + chunkIndex) % (23 + chunkIndex);
+    }
+    batches.push_back(vectorMaker.rowVector(
+        {"c0", "c1"},
+        {vectorMaker.flatVector<int64_t>(values),
+         vectorMaker.flatVector<int64_t>(otherValues)}));
+  }
+
+  auto makeOptions = [] {
+    nimble::WriterOptions options;
+    options.enableChunking = true;
+    options.minStreamChunkRawSize = 0;
+    options.flushPolicyFactory = [] {
+      return std::make_unique<nimble::LambdaFlushPolicy>(
+          /*flushLambda=*/[](auto&) { return false; },
+          /*chunkLambda=*/[](auto&) { return true; });
+    };
+    options.encodingSelectionPolicyCreator =
+        makeRandomEncodingSelectionPolicyCreator(
+            kSeed,
+            {nimble::EncodingType::Trivial, nimble::EncodingType::Dictionary});
+    return options;
+  };
+
+  const auto options = makeOptions();
+  const auto first = writeAndCaptureChunkLayouts(
+      rowType, batches, options, /*expectedStripeCount=*/1);
+  const auto second = writeAndCaptureChunkLayouts(
+      rowType, batches, options, /*expectedStripeCount=*/1);
+  ASSERT_THAT(first, ::testing::SizeIs(kNumChunks));
+  ASSERT_THAT(second, ::testing::SizeIs(first.size()));
+
+  folly::CPUThreadPoolExecutor executor{2};
+  auto parallelOptions = makeOptions();
+  parallelOptions.encodingExecutor = folly::getKeepAliveToken(executor);
+  parallelOptions.maxEncodeParallelism = 2;
+  parallelOptions.minStreamsPerEncodeUnit = 1;
+  const auto parallel = writeAndCaptureChunkLayouts(
+      rowType, batches, std::move(parallelOptions), /*expectedStripeCount=*/1);
+  ASSERT_THAT(parallel, ::testing::SizeIs(first.size()));
+
+  std::vector<nimble::EncodingType> firstTypes;
+  std::vector<nimble::EncodingType> secondTypes;
+  std::vector<nimble::EncodingType> parallelTypes;
+  for (size_t chunk = 0; chunk < first.size(); ++chunk) {
+    firstTypes.push_back(first[chunk].encodingType());
+    secondTypes.push_back(second[chunk].encodingType());
+    parallelTypes.push_back(parallel[chunk].encodingType());
+  }
+
+  EXPECT_THAT(secondTypes, ::testing::ElementsAreArray(firstTypes));
+  EXPECT_THAT(parallelTypes, ::testing::ElementsAreArray(firstTypes));
+  EXPECT_THAT(firstTypes, ::testing::Contains(nimble::EncodingType::Trivial));
+  EXPECT_THAT(
+      firstTypes, ::testing::Contains(nimble::EncodingType::Dictionary));
+}
+
 // The random layout is reproducible from its seed: identical input + seed
-// yields byte-identical files (Nimble writer output is deterministic for
-// identical input). Concurrency-independence is guaranteed by construction --
-// each policy derives its seed from its structural path, never from encode
-// thread order, and shares no state across the encode executor's threads -- so
-// it is not exercised here (it would depend on the coroutine encode path). A
-// different seed selects a different layout.
+// yields byte-identical files independently of encode thread order. A different
+// seed selects a different layout.
 TEST_F(WriterTest, randomEncodingSelectionDeterministic) {
   const uint32_t seed = FLAGS_writer_tests_seed > 0 ? FLAGS_writer_tests_seed
                                                     : folly::Random::rand32();
@@ -9335,12 +9412,23 @@ TEST_F(WriterTest, randomEncodingSelectionDeterministic) {
   auto vector = fuzzer.fuzzInputFlatRow(rowType);
 
   const auto file = writeWithEncodingSelectionCreator(
-      *rootPool_, vector, createRandomEncodingSelectionFactory(seed));
+      *rootPool_, vector, makeRandomEncodingSelectionPolicyCreator(seed));
   // Same seed reproduces the exact file.
   EXPECT_EQ(
       file,
       writeWithEncodingSelectionCreator(
-          *rootPool_, vector, createRandomEncodingSelectionFactory(seed)));
+          *rootPool_, vector, makeRandomEncodingSelectionPolicyCreator(seed)));
+
+  folly::CPUThreadPoolExecutor executor{4};
+  nimble::WriterOptions parallelOptions;
+  parallelOptions.encodingSelectionPolicyCreator =
+      makeRandomEncodingSelectionPolicyCreator(seed);
+  parallelOptions.encodingExecutor = folly::getKeepAliveToken(executor);
+  parallelOptions.maxEncodeParallelism = 4;
+  parallelOptions.minStreamsPerEncodeUnit = 1;
+  EXPECT_EQ(
+      file,
+      writeWithWriterOptions(*rootPool_, vector, std::move(parallelOptions)));
   // A different seed should be able to select a different layout. For a given
   // fuzzed input some nodes may have a singleton compatible-encoding set, so an
   // individual alternate seed can legitimately reproduce the same file; only
@@ -9353,7 +9441,7 @@ TEST_F(WriterTest, randomEncodingSelectionDeterministic) {
         writeWithEncodingSelectionCreator(
             *rootPool_,
             vector,
-            createRandomEncodingSelectionFactory(seed ^ delta)) != file;
+            makeRandomEncodingSelectionPolicyCreator(seed ^ delta)) != file;
   }
   EXPECT_TRUE(anyDifferent)
       << "no alternate seed produced a different layout for seed " << seed;


### PR DESCRIPTION
Summary:

The test-only random encoding policy previously seeded every root selection using only the configured seed and physical type. When multiple chunks had the same compatible encoding set, each chunk restarted the random generator and selected the same encoding. This prevented fuzzers from exercising encoding transitions within one file.

Derive each selection from the configured seed, physical type, and chunk values. Chunks with different contents can therefore choose different compatible encodings without shared mutable state. Selection remains reproducible when `WriterOptions` are copied and when streams are encoded in parallel. Chunks with identical contents intentionally make the same choice.

Add writer coverage for value-dependent multi-chunk variation, round-trip correctness, copied option reuse, and matching serial and parallel layouts.

Reviewed By: apurva-meta

Differential Revision: D117594185


