### PR TITLE
Remove Pyre mode headers in 29 fbcode directories

### DIFF
--- a/python/test/test_arrow.py
+++ b/python/test/test_arrow.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyre-unsafe
 
 import unittest
 import pyarrow

--- a/python/test/test_type.py
+++ b/python/test/test_type.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyre-unsafe
 
 import unittest
 from pyvelox.type import (

--- a/python/test/test_vector2.py
+++ b/python/test/test_vector2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pyre-unsafe
 
 import pyarrow
 import tempfile


### PR DESCRIPTION
Summary:
Remove standalone `# pyre-strict` and `# pyre-unsafe` mode headers from 595 Python files across 29 fbcode directories.

Pyrefly type-checks all files in one consistent mode, so these legacy per-file mode headers no longer have an effect. Other Pyre directives and generated files are left unchanged.

Pyrefly is now the default type checker across FBCode so this diff introduces no functional changes.

drop-conflicts
#pyreupgrade

Differential Revision: D117771223


