### PR TITLE
fix(vector): Handle short children in RowVector::slice

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -453,7 +453,17 @@ VectorPtr RowVector::slice(vector_size_t offset, vector_size_t length) const {
   std::vector<VectorPtr> children(children_.size());
   for (int i = 0; i < children_.size(); ++i) {
     if (children_[i]) {
-      children[i] = children_[i]->slice(offset, length);
+      const auto childSize = children_[i]->size();
+      if (offset >= childSize) {
+        // A RowVector can have a shorter child when its trailing rows are
+        // null. Use an empty slice if the requested range starts after the
+        // end of such a child. This also keeps the offset valid for nested
+        // short children.
+        children[i] = children_[i]->slice(0, 0);
+      } else {
+        children[i] = children_[i]->slice(
+            offset, std::min(length, childSize - offset));
+      }
     }
   }
   return std::make_shared<RowVector>(

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1614,6 +1614,48 @@ TEST_F(VectorTest, rowResize) {
       rowWithLazyChild->resize(20), "Resize on a lazy vector is not allowed");
 }
 
+TEST_F(VectorTest, rowSliceWithShortChildAndTrailingNulls) {
+  constexpr vector_size_t inputSize = 512;
+  constexpr vector_size_t nestedSize = 1'000;
+  constexpr vector_size_t childSize = 496;
+
+  auto arrayVector = makeArrayVector<int32_t>(
+      childSize,
+      [](auto /* row */) { return 1; },
+      [](auto row, auto /* index */) { return row; });
+  auto nestedRow = std::make_shared<RowVector>(
+      pool(),
+      ROW({"array"}, {arrayVector->type()}),
+      nullptr,
+      nestedSize,
+      std::vector<VectorPtr>{arrayVector});
+  for (vector_size_t row = childSize; row < nestedSize; ++row) {
+    nestedRow->setNull(row, true);
+  }
+  ASSERT_NO_THROW(nestedRow->validate(VectorValidateOptions{}));
+
+  // Slicing the outer row recursively slices nestedRow. The nested row is
+  // valid even though its ArrayVector child is shorter because its trailing
+  // rows are null.
+  auto outerRow = std::make_shared<RowVector>(
+      pool(),
+      ROW({"nested"}, {nestedRow->type()}),
+      nullptr,
+      inputSize,
+      std::vector<VectorPtr>{nestedRow});
+
+  auto sliced = std::dynamic_pointer_cast<RowVector>(
+      outerRow->slice(0, inputSize));
+  ASSERT_NE(sliced, nullptr);
+  ASSERT_EQ(sliced->size(), inputSize);
+
+  auto slicedNested = sliced->childAt(0)->as<RowVector>();
+  ASSERT_EQ(slicedNested->size(), inputSize);
+  ASSERT_EQ(slicedNested->childAt(0)->size(), childSize);
+  ASSERT_TRUE(slicedNested->isNullAt(childSize));
+  ASSERT_NO_THROW(sliced->validate(VectorValidateOptions{}));
+}
+
 TEST_F(VectorTest, rowPrepareForReuse) {
   const int oldSize = 10;
   for (const int newSize : {10, 20, 5, 0}) {


### PR DESCRIPTION
## Summary

- Handle short child vectors when slicing a `RowVector`.
- Add a regression test for nested `RowVector` values with trailing nulls.

## Problem

`RowVector::validate()` allows a child vector to be shorter than its parent when the missing rows correspond to trailing nulls in the parent.

However, `RowVector::slice()` unconditionally passed the requested `offset` and `length` to every child. For a nested `ArrayVector`, this could cause its offsets and sizes buffers to be sliced beyond their bounds.

## Fix

Clamp the slice range for each child to the child vector's size. If the requested offset is beyond the child size, an empty slice is created.

## Tests

Added:

`VectorTest.rowSliceWithShortChildAndTrailingNulls`

Fixes #18733