### PR TITLE
fix(parquet): Handle out-of-range created_by versions

### DIFF
--- a/velox/dwio/parquet/reader/SemanticVersion.cpp
+++ b/velox/dwio/parquet/reader/SemanticVersion.cpp
@@ -16,7 +16,24 @@
 
 #include "SemanticVersion.h"
 
+#include <charconv>
+
 namespace facebook::velox::parquet {
+
+namespace {
+
+std::optional<int> parseVersionComponent(const std::string& input) {
+  int value;
+  const auto parseResult =
+      std::from_chars(input.data(), input.data() + input.size(), value);
+  if (parseResult.ec != std::errc{} ||
+      parseResult.ptr != input.data() + input.size()) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+} // namespace
 
 const re2::RE2 SemanticVersion::pattern_(
     "(.*?)\\s+version\\s+(\\d+)\\.(\\d+)\\.(\\d+)");
@@ -50,10 +67,13 @@ std::optional<SemanticVersion> SemanticVersion::parse(
           &major_str,
           &minor_str,
           &patch_str)) {
-    int major = std::stoi(major_str);
-    int minor = std::stoi(minor_str);
-    int patch = std::stoi(patch_str);
-    return SemanticVersion(application_str, major, minor, patch);
+    auto major = parseVersionComponent(major_str);
+    auto minor = parseVersionComponent(minor_str);
+    auto patch = parseVersionComponent(patch_str);
+    if (!major || !minor || !patch) {
+      return std::nullopt;
+    }
+    return SemanticVersion(application_str, *major, *minor, *patch);
   } else {
     return std::nullopt;
   }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1328,6 +1328,22 @@ TEST_F(ParquetReaderTest, shouldIgnoreStatsForParquetMRVersions) {
       << "ParquetStatsContext(parquet-mr 1.8.2) should not ignore string stats";
 }
 
+TEST_F(ParquetReaderTest, parseSemanticVersion) {
+  auto version = SemanticVersion::parse("parquet-mr version 1.8.2");
+
+  ASSERT_TRUE(version.has_value());
+  EXPECT_EQ(version->toString(), "1.8.2");
+}
+
+TEST_F(ParquetReaderTest, parseOutOfRangeSemanticVersion) {
+  for (const auto& input :
+       {"parquet-mr version 999999999999999999999999.1.0",
+        "parquet-mr version 1.999999999999999999999999.0",
+        "parquet-mr version 1.0.999999999999999999999999"}) {
+    EXPECT_NO_THROW({ EXPECT_FALSE(SemanticVersion::parse(input)); });
+  }
+}
+
 // This test is to verify filterRowGroups() doesn't fail if offset is 0
 TEST_F(ParquetReaderTest, filterRowGroupsWithZeroOffset) {
   auto rowType = ROW("IDX", INTEGER());


### PR DESCRIPTION
Summary:

- **Handle oversized Parquet writer versions** in the `created_by` metadata.
- **Return `std::nullopt`** when a major, minor, or patch component does not fit in `int`.
- Replace throwing `std::stoi` conversions with non-throwing `std::from_chars` parsing.
- **Add regression coverage** for a valid version and oversized values in each component.

Why:

The `created_by` value comes from file metadata. Previously, an oversized version component made `std::stoi` throw during reader initialization. It is now treated as an unknown writer version, which matches the optional parser API. When the writer version is unknown, Parquet statistics are ignored and row-group pruning is skipped for safety.

Testing:

- `pre-commit run clang-format --files velox/dwio/parquet/reader/SemanticVersion.cpp velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp`
- `pre-commit run license-header --files velox/dwio/parquet/reader/SemanticVersion.cpp velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp`
- C++20 syntax checks and object compilation for both changed files.
- `git diff --check`