### PR TITLE
fix(presto): Allow empty quoted keys in JSON paths

### DIFF
--- a/velox/functions/prestosql/json/JsonPathTokenizer.cpp
+++ b/velox/functions/prestosql/json/JsonPathTokenizer.cpp
@@ -184,7 +184,7 @@ JsonPathTokenizer::matchQuotedSubscriptKey(char quote) {
     }
     index_++;
   }
-  if (escaped || token.empty() || !match(quote)) {
+  if (escaped || !match(quote)) {
     return std::nullopt;
   }
   return JsonPathTokenizer::Token{token, Selector::KEY};

--- a/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
@@ -263,6 +263,8 @@ TEST(JsonPathTokenizerTest, validPaths) {
       TokenList{
           {"a*a", Selector::KEY},
       });
+  assertValidPath(R"($[""])", TokenList{{"", Selector::KEY}});
+  assertValidPath(R"($[''])", TokenList{{"", Selector::KEY}});
   assertValidPath(
       "$.foo[*]",
       TokenList{

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -93,6 +93,8 @@ TEST_F(JsonExtractScalarTest, simple) {
   EXPECT_EQ(jsonExtractScalar(R"({"k1":"v1"})", "$.k1.k3"), std::nullopt);
   EXPECT_EQ(jsonExtractScalar(R"({"k1":[0,1,2]})", "$.k1"), std::nullopt);
   EXPECT_EQ(jsonExtractScalar(R"({"k1":""})", "$.k1"), "");
+  EXPECT_EQ(jsonExtractScalar(R"({"":123})", R"($[""])"), "123");
+  EXPECT_EQ(jsonExtractScalar(R"({"":123})", R"($[''])"), "123");
 
   // Nested
   EXPECT_EQ(jsonExtractScalar(R"({"k1":{"k2": 999}})", "$.k1.k2"), "999");


### PR DESCRIPTION
Summary:

- **Fix Presto JSON path parsing** for empty quoted object keys.
- `matchQuotedSubscriptKey()` now accepts an empty token after a valid pair of quotes.
- **Keep unquoted empty subscripts invalid**. Empty keys are accepted only when quoted.
- **Add coverage** for the double-quoted and single-quoted forms in tokenizer and `json_extract_scalar` tests.

Why:

Presto accepts empty quoted keys. This is needed for valid JSON objects such as {"": 123}.

Testing:

- `pre-commit run clang-format --files velox/functions/prestosql/json/JsonPathTokenizer.cpp velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp velox/functions/prestosql/tests/JsonExtractScalarTest.cpp`
- `pre-commit run license-header --files velox/functions/prestosql/json/JsonPathTokenizer.cpp velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp velox/functions/prestosql/tests/JsonExtractScalarTest.cpp`
- C++20 syntax checks and object compilation for all changed files.
- All 4 `JsonPathTokenizerTest` tests pass.
- `git diff --check`