### PR TITLE
fix(rpc): Guard the backend stats read on close(), and split isBlocked() by mode (#18743)

### DIFF
--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -81,11 +81,11 @@ void RPCOperator::initialize() {
   for (const auto& input : callInputs) {
     inputTypes.push_back(input->type());
     if (auto* field = input->asUnchecked<core::FieldAccessTypedExpr>()) {
-      const auto idx = sourceType->getChildIdx(field->name());
+      const auto index = sourceType->getChildIdx(field->name());
       argumentSources_.push_back(
           ArgumentSource{
               .isConstant = false,
-              .sourceChannel = static_cast<column_index_t>(idx),
+              .sourceChannel = static_cast<column_index_t>(index),
           });
       constantInputs.push_back(nullptr);
     } else if (auto* constant = input->asUnchecked<core::ConstantTypedExpr>()) {
@@ -202,22 +202,22 @@ void RPCOperator::addInput(RowVectorPtr input) {
   // the source column; a constant argument wraps its single-element constant to
   // the batch row count, so the function sees the same arg list (order + count)
   // as it would for a column. Keeps null-input handling identical.
-  std::vector<VectorPtr> args;
+  std::vector<VectorPtr> arguments;
   if (!argumentSources_.empty()) {
-    args.reserve(argumentSources_.size());
-    for (const auto& argSource : argumentSources_) {
-      if (argSource.isConstant) {
-        args.push_back(
+    arguments.reserve(argumentSources_.size());
+    for (const auto& argumentSource : argumentSources_) {
+      if (argumentSource.isConstant) {
+        arguments.push_back(
             BaseVector::wrapInConstant(
-                input->size(), 0, argSource.constantValue));
+                input->size(), 0, argumentSource.constantValue));
       } else {
-        args.push_back(input->childAt(argSource.sourceChannel));
+        arguments.push_back(input->childAt(argumentSource.sourceChannel));
       }
     }
   } else {
     // Fallback: use all input columns as arguments.
     for (auto i = 0; i < input->childrenSize(); ++i) {
-      args.push_back(input->childAt(i));
+      arguments.push_back(input->childAt(i));
     }
   }
 
@@ -238,7 +238,7 @@ void RPCOperator::addInput(RowVectorPtr input) {
     // vector at once, which would overrun both the per-driver window and the
     // shared admission control. needsInput() returns false until this buffer is
     // drained, so exactly one input vector is buffered at a time.
-    pendingArgs_ = std::move(args);
+    pendingArgs_ = std::move(arguments);
     pendingNumRows_ = static_cast<vector_size_t>(input->size());
     pendingCursor_ = 0;
     pendingBatchIndex_ = state_->storeInputBatch(
@@ -246,7 +246,7 @@ void RPCOperator::addInput(RowVectorPtr input) {
     dispatchRowsUnderAdmission();
   } else {
     // BATCH: function accumulates typed data internally.
-    auto rowIndices = function_->accumulateBatch(rows, args);
+    auto rowIndices = function_->accumulateBatch(rows, arguments);
 
     auto batchIndex = state_->storeInputBatch(
         flattenedColumns, static_cast<int64_t>(rowIndices.size()));
@@ -284,7 +284,7 @@ void RPCOperator::dispatchRowsUnderAdmission() {
     // the driver count.
     // One grant for the whole chunk: reserving row by row would take the
     // backend's exclusive lock once per row, and that lock also carries
-    // available(), waitForCapacity() and the adaptation callbacks.
+    // available(), admitOrWait() and the adaptation callbacks.
     auto reserved = limiter_->tryAcquireUpTo(want);
     if (reserved.empty()) {
       break;
@@ -323,8 +323,8 @@ void RPCOperator::dispatchRowsUnderAdmission() {
                 resp.rowId = rowId;
                 return resp;
               })
-              .deferError([token](folly::exception_wrapper ew) {
-                return folly::makeSemiFuture<RPCResponse>(std::move(ew));
+              .deferError([token](folly::exception_wrapper error) {
+                return folly::makeSemiFuture<RPCResponse>(std::move(error));
               });
       state_->addPendingRow(
           state_,
@@ -343,6 +343,70 @@ void RPCOperator::dispatchRowsUnderAdmission() {
     pendingBatchIndex_ = -1;
   }
 }
+
+namespace {
+
+// Turns a whole-batch failure into one errored response per row, so the per-row
+// error policy (meta_ai_on_error) applies downstream instead of the query
+// hard-failing. Responses carry batch-position rowIds, so the scatter stamps
+// global ids identically to the success path.
+std::vector<RPCResponse> degradeBatchFailureToRowErrors(
+    const std::vector<int64_t>& rowIds,
+    const folly::exception_wrapper& error) {
+  // Mirrors the client-layer fan-out but covers every backend and the
+  // operator-level timeout uniformly. Both AIMD controllers still back off,
+  // since evaluateCongestion reads a batch failure as overload.
+  RPC_OP_LOG(ERROR) << "RPC batch failed, " << rowIds.size()
+                    << " rows will carry a per-row error: " << error.what();
+  std::vector<RPCResponse> errored(rowIds.size());
+  for (size_t i = 0; i < rowIds.size(); ++i) {
+    // Batch-position rowId, so the scatter stamps global ids the same way it
+    // does on the success path.
+    errored[i].rowId = static_cast<int64_t>(i);
+    errored[i].error =
+        std::string("[RPC_BATCH] batch error: ") + error.what().toStdString();
+    errored[i].errorKind = velox::rpc::RPCErrorKind::kBackendError;
+  }
+  return errored;
+}
+
+// Reorders responses into batch position using each response's
+// function-assigned rowId, then stamps the global rowIds. Functions may return
+// out of order, and pairing responses[i] with rowLocations[i] would silently
+// mis-map results onto the wrong passthrough rows. Invariant violations are
+// fatal by design.
+std::vector<RPCResponse> scatterIntoBatchOrder(
+    std::vector<RPCResponse> responses,
+    const std::vector<int64_t>& rowIds) {
+  VELOX_CHECK_EQ(
+      responses.size(),
+      rowIds.size(),
+      "RPC batch response count ({}) does not match row count ({})",
+      responses.size(),
+      rowIds.size());
+  std::vector<RPCResponse> sorted(responses.size());
+  std::vector<bool> seen(responses.size(), false);
+  for (auto& response : responses) {
+    const auto batchIndex = response.rowId;
+    VELOX_CHECK_GE(batchIndex, 0);
+    VELOX_CHECK_LT(
+        static_cast<size_t>(batchIndex),
+        rowIds.size(),
+        "RPC batch response rowId ({}) out of range (0-{})",
+        batchIndex,
+        rowIds.size() - 1);
+    VELOX_CHECK(
+        !seen[static_cast<size_t>(batchIndex)],
+        "Duplicate batch response rowId ({})",
+        batchIndex);
+    seen[static_cast<size_t>(batchIndex)] = true;
+    response.rowId = rowIds[static_cast<size_t>(batchIndex)];
+    sorted[static_cast<size_t>(batchIndex)] = std::move(response);
+  }
+  return sorted;
+}
+
+} // namespace
 
 bool RPCOperator::flushBatchRequests(int32_t maxRows) {
   if (function_->pendingBatchSize() == 0) {
@@ -395,69 +459,21 @@ bool RPCOperator::flushBatchRequests(int32_t maxRows) {
   // (wrong response count / duplicate / out-of-range rowId) — those must still
   // hard-fail the query, not be silently degraded to NULL rows.
   auto rowIdsPtr = std::make_shared<std::vector<int64_t>>(std::move(rowIds));
+  // Order matters: deferError runs BEFORE deferValue, so a whole-batch failure
+  // is first turned into one errored response per row and then flows through
+  // the same scatter as real responses. That keeps the scatter's invariant
+  // checks fatal for genuine function-contract violations -- wrong response
+  // count, duplicate or out-of-range rowId -- rather than degrading them to
+  // NULL rows. Both lambdas hold 'token' only to keep the tier slot reserved
+  // until the batch settles.
   auto wrapped =
       std::move(future)
           .within(kBatchRpcTimeout)
-          .deferError([rowIdsPtr, token](folly::exception_wrapper ew) {
-            // A whole-batch failure (e.g. an operator-level batch/RPC timeout)
-            // degrades to per-row errored responses so the per-row error policy
-            // (meta_ai_on_error) applies downstream, instead of hard-failing
-            // the whole query. Mirrors the client-layer fan-out, but covers all
-            // backends and the operator-level timeout uniformly. Both AIMD
-            // controllers still back off via evaluateCongestion (a batch
-            // failure is overload). Responses carry batch-position rowId
-            // (0..N-1) so the scatter below stamps global rowIds identically to
-            // the success path.
-            const auto& rowIds = *rowIdsPtr;
-            RPC_OP_LOG(ERROR)
-                << "RPC batch failed, " << rowIds.size()
-                << " rows will carry a per-row error: " << ew.what();
-            std::vector<RPCResponse> errResponses(rowIds.size());
-            for (size_t i = 0; i < rowIds.size(); ++i) {
-              errResponses[i].rowId = static_cast<int64_t>(i);
-              errResponses[i].error = std::string("[RPC_BATCH] batch error: ") +
-                  ew.what().toStdString();
-              errResponses[i].errorKind =
-                  velox::rpc::RPCErrorKind::kBackendError;
-            }
-            return errResponses;
+          .deferError([rowIdsPtr, token](folly::exception_wrapper error) {
+            return degradeBatchFailureToRowErrors(*rowIdsPtr, error);
           })
-          // Scatter responses into batch-position order using each response's
-          // function-assigned rowId (its position within the batch), then stamp
-          // the global rowIds. Functions may return results out of order (e.g.,
-          // MetaGen's batchDialogCompletion streams results in arbitrary
-          // order). Without this, responses[i] would be paired with
-          // rowLocations[i] in buildOutputFromReadyBatch, silently mis-mapping
-          // results to wrong passthrough rows. Invariant violations here are
-          // fatal by design.
-          .deferValue([rowIdsPtr, token](std::vector<RPCResponse> resps) {
-            const auto& rowIds = *rowIdsPtr;
-            VELOX_CHECK_EQ(
-                resps.size(),
-                rowIds.size(),
-                "RPC batch response count ({}) does not match row count ({})",
-                resps.size(),
-                rowIds.size());
-            std::vector<RPCResponse> sorted(resps.size());
-            std::vector<bool> seen(resps.size(), false);
-            for (auto& resp : resps) {
-              auto batchIdx = resp.rowId;
-              VELOX_CHECK_GE(batchIdx, 0);
-              VELOX_CHECK_LT(
-                  static_cast<size_t>(batchIdx),
-                  rowIds.size(),
-                  "RPC batch response rowId ({}) out of range (0-{})",
-                  batchIdx,
-                  rowIds.size() - 1);
-              VELOX_CHECK(
-                  !seen[static_cast<size_t>(batchIdx)],
-                  "Duplicate batch response rowId ({})",
-                  batchIdx);
-              seen[static_cast<size_t>(batchIdx)] = true;
-              resp.rowId = rowIds[static_cast<size_t>(batchIdx)];
-              sorted[static_cast<size_t>(batchIdx)] = std::move(resp);
-            }
-            return sorted;
+          .deferValue([rowIdsPtr, token](std::vector<RPCResponse> responses) {
+            return scatterIntoBatchOrder(std::move(responses), *rowIdsPtr);
           });
 
   state_->addPendingBatch(state_, std::move(wrapped), std::move(rowLocations));
@@ -524,18 +540,10 @@ std::optional<exec::BlockingReason> RPCOperator::drainOrParkOnAdmission(
   }
   if (state_->numInFlight() == 0) {
     // Nothing of ours is in flight, so only another driver's release can help.
-    // admitOrWait() decides and enrols under one lock, so a slot freeing here
-    // cannot leave us waiting on nothing, and this never falls through to a
-    // wait that nothing could fulfil.
-    auto admission = limiter_->admitOrWait();
-    if (admission.admitted) {
-      // Room appeared; come back round and dispatch into it.
-      return exec::BlockingReason::kNotBlocked;
-    }
-    *future = std::move(admission.wait);
-    blockWaitStartNs_ = getCurrentTimeNano();
-    blockWaitIsBackpressure_ = true;
-    return exec::BlockingReason::kWaitForRPC;
+    // parkOnTierCapacity() decides and enrols under one lock, so a slot
+    // freeing here cannot leave us waiting on nothing, and this never falls
+    // through to a wait that nothing could fulfil.
+    return parkOnTierCapacity(future);
   }
   // Our own completions will free slots and wake the wait below.
   return std::nullopt;
@@ -562,341 +570,262 @@ void RPCOperator::dispatchBatchUnderAdmission(DispatchScope scope) {
   }
 }
 
-RowVectorPtr RPCOperator::getOutput() {
-  auto streamingMode = state_->streamingMode();
+RowVectorPtr RPCOperator::finishIfDrained() {
+  if (isDraining() && state_->isFinished()) {
+    finished_ = true;
+    finishDrain();
+  }
+  return nullptr;
+}
 
-  if (streamingMode == RPCStreamingMode::kPerRow) {
-    // Drip more buffered rows now that in-flight completions may have
-    // freed window / tier capacity.
-    dispatchRowsUnderAdmission();
-
-    if (claimedRows_.empty()) {
-      // If draining and nothing left to output, check finish.
-      if (isDraining() && state_->isFinished()) {
-        finished_ = true;
-        finishDrain();
-      }
-      return nullptr;
-    }
-
-    // Drain additional ready rows (non-blocking) for batched output.
-    // This amortizes RowVector allocation across multiple completed rows.
-    state_->drainReadyRows(claimedRows_, outputBatchRows_);
-
-    // Materialize responses, locations, and round-trip latencies once — reused
-    // for the congestion signal and the output vector (no extra copy).
-    auto numRows = static_cast<int64_t>(claimedRows_.size());
-    std::vector<RPCResponse> responses;
-    std::vector<std::pair<int32_t, vector_size_t>> locations;
-    std::vector<int64_t> roundTripTimesNs;
-    responses.reserve(claimedRows_.size());
-    locations.reserve(claimedRows_.size());
-    roundTripTimesNs.reserve(claimedRows_.size());
-    for (auto& row : claimedRows_) {
-      const bool hasError = row.response.hasError();
-      if (hasError) {
-        numErrors_++;
-        recordErrorKind(row.response.errorKind);
-      }
-      locations.emplace_back(row.location.batchIndex, row.location.rowIndex);
-      // Only successful rows feed the gradient. Errored rows (e.g. null_input,
-      // client-side rejections) complete without a real round trip, so their
-      // artificially small RTT would pull down the per-window minimum and skew
-      // the gradient/baseline.
-      if (!hasError) {
-        roundTripTimesNs.push_back(row.rttNs);
-      }
-      responses.push_back(std::move(row.response));
-    }
-
-    // Two AIMD controllers at different scopes, BOTH backing off on the
-    // function's overload verdict (see RPCRateLimiter.h /
-    // CongestionController.h / the function's CongestionPolicy):
-    //  - Window (per-driver): halve on overload; otherwise feed the successful
-    //    rows' RTTs to the latency gradient.
-    //  - Rate limiter (one per provisioned capacity): halve the cap on
-    //    overload,
-    //    additive-recover on success.
-    // The policy classifies overload as rate-limit / timeout / majority error
-    // (ignoring null_input). Both scopes must back off on it: a rate-limit
-    // storm is LOW-latency, so the latency gradient alone is blind to it — the
-    // error verdict is what makes the per-driver window back off, not just
-    // latency.
-    const auto signal = function_->evaluateCongestion(responses);
-    if (signal == AsyncRPCFunction::CongestionSignal::kError) {
-      state_->onUnitError();
-      limiter_->onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
-    } else if (signal == AsyncRPCFunction::CongestionSignal::kSuccess) {
-      // Feed the whole drained batch of successful RTTs to the gradient in one
-      // lock acquisition; its size is the success count driving AIMD recovery.
-      state_->onUnitSamples(roundTripTimesNs);
-      limiter_->onOutcome(
-          RPCRateLimiter::Outcome::kSuccess,
-          static_cast<int64_t>(roundTripTimesNs.size()));
-    }
-
-    auto output = buildOutputVector(responses, locations);
-    numResponsesReceived_ += numRows;
-    claimedRows_.clear();
-    return output;
-  } else {
-    if (!claimedBatch_.has_value()) {
-      // If draining and nothing left to output, check finish.
-      if (isDraining() && state_->isFinished()) {
-        finished_ = true;
-        finishDrain();
-      }
-      return nullptr;
-    }
-
-    // Fail loudly on batch errors instead of silently dropping rows.
-    if (claimedBatch_->error.has_value()) {
-      auto error = claimedBatch_->error.value();
-      claimedBatch_.reset();
-      VELOX_FAIL("RPC batch failed: {}", error);
-    }
-
-    auto numRows = static_cast<int64_t>(claimedBatch_->responses.size());
-    for (const auto& response : claimedBatch_->responses) {
-      if (response.hasError()) {
-        numErrors_++;
-        recordErrorKind(response.errorKind);
-      }
-    }
-
-    // Both AIMD controllers back off on the function's overload verdict (see
-    // PER_ROW above): the window (per-driver) halves on overload, else feeds
-    // the batch RTT to the latency gradient; tier capacity (shared) halves
-    // the cap on overload and recovers on success.
-    const auto signal = function_->evaluateCongestion(claimedBatch_->responses);
-    if (signal == AsyncRPCFunction::CongestionSignal::kError) {
-      state_->onUnitError();
-      limiter_->onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
-    } else if (signal == AsyncRPCFunction::CongestionSignal::kSuccess) {
-      // Feed the measured round-trip latency to the gradient window so it
-      // learns the in-flight-batch sweet spot without a fixed ceiling.
-      state_->onUnitSample(claimedBatch_->rttNs);
-      // One successful batch, credited as one unit, because BATCH reserves one
-      // slot per flushBatch() regardless of row count. onSuccess() steps
-      // capacity by units/capacity, so crediting the row count against a
-      // capacity counted in batches makes recovery accelerate as capacity
-      // shrinks -- the opposite of additive increase.
-      limiter_->onOutcome(RPCRateLimiter::Outcome::kSuccess, /*units=*/1);
-    }
-
-    auto output = buildOutputFromReadyBatch(*claimedBatch_);
-    numResponsesReceived_ += numRows;
-    claimedBatch_.reset();
-    return output;
+void RPCOperator::recordCongestion(
+    AsyncRPCFunction::CongestionSignal signal,
+    const std::vector<int64_t>& roundTripTimesNs,
+    int64_t successUnits) {
+  // Two AIMD controllers at different scopes, both driven by the function's
+  // overload verdict (see RPCRateLimiter.h / CongestionController.h and the
+  // function's CongestionPolicy):
+  //  - the per-driver window halves on overload, else feeds the successful
+  //    round trips to its latency gradient;
+  //  - the backend's shared cap halves on overload and recovers additively on
+  //    success.
+  // The policy classifies overload as rate-limit / timeout / majority error,
+  // ignoring null_input. Both scopes must back off on it: a rate-limit storm
+  // is LOW-latency, so the gradient alone is blind to it and the error verdict
+  // is what makes the window shrink.
+  if (signal == AsyncRPCFunction::CongestionSignal::kError) {
+    state_->onUnitError();
+    limiter_->onOutcome(RPCRateLimiter::Outcome::kOverload, 0);
+    return;
+  }
+  if (signal == AsyncRPCFunction::CongestionSignal::kSuccess) {
+    state_->onUnitSamples(roundTripTimesNs);
+    limiter_->onOutcome(RPCRateLimiter::Outcome::kSuccess, successUnits);
   }
 }
 
-exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
-  // End any previous block wait measurement.
-  if (blockWaitStartNs_.has_value()) {
-    auto elapsed = getCurrentTimeNano() - blockWaitStartNs_.value();
-    if (blockWaitIsBackpressure_) {
-      totalBackpressureWaitNanos_ += elapsed;
-    } else {
-      totalBlockWaitNanos_ += elapsed;
+RowVectorPtr RPCOperator::outputPerRow() {
+  // Drip more buffered rows now that in-flight completions may have freed
+  // window / tier capacity.
+  dispatchRowsUnderAdmission();
+
+  if (claimedRows_.empty()) {
+    return finishIfDrained();
+  }
+
+  // Drain additional ready rows (non-blocking) for batched output. This
+  // amortizes RowVector allocation across multiple completed rows.
+  state_->drainReadyRows(claimedRows_, outputBatchRows_);
+
+  // Materialize responses, locations and round-trip latencies once -- reused
+  // for the congestion signal and the output vector (no extra copy).
+  const auto numRows = static_cast<int64_t>(claimedRows_.size());
+  std::vector<RPCResponse> responses;
+  std::vector<std::pair<int32_t, vector_size_t>> locations;
+  std::vector<int64_t> roundTripTimesNs;
+  responses.reserve(claimedRows_.size());
+  locations.reserve(claimedRows_.size());
+  roundTripTimesNs.reserve(claimedRows_.size());
+  for (auto& row : claimedRows_) {
+    const bool hasError = row.response.hasError();
+    if (hasError) {
+      numErrors_++;
+      recordErrorKind(row.response.errorKind);
     }
-    blockWaitStartNs_ = std::nullopt;
+    // Only successful rows feed the gradient. Errored rows (e.g. null_input,
+    // client-side rejections) complete without a real round trip, so their
+    // artificially small RTT would pull down the per-window minimum and skew
+    // the gradient/baseline.
+    if (!hasError) {
+      roundTripTimesNs.push_back(row.rttNs);
+    }
+    responses.push_back(std::move(row.response));
+    locations.emplace_back(row.location.batchIndex, row.location.rowIndex);
   }
 
-  // Emit ready output / report finished BEFORE any backpressure gate: a driver
-  // holding completed rows (or with its own in-flight completions to harvest)
-  // must never park behind the backend's shared cap held by OTHER drivers.
-  // That wait is applied as a last resort below, only when
-  // this operator has buffered rows and nothing in-flight (i.e. it is genuinely
-  // blocked on the global cap, with no local completion to wake it).
-  if (!claimedRows_.empty() || claimedBatch_.has_value()) {
+  recordCongestion(
+      function_->evaluateCongestion(responses),
+      roundTripTimesNs,
+      static_cast<int64_t>(roundTripTimesNs.size()));
+
+  auto output = buildOutputVector(responses, locations);
+  numResponsesReceived_ += numRows;
+  claimedRows_.clear();
+  return output;
+}
+
+RowVectorPtr RPCOperator::outputBatch() {
+  if (!claimedBatch_.has_value()) {
+    return finishIfDrained();
+  }
+
+  // Fail loudly on batch errors instead of silently dropping rows.
+  if (claimedBatch_->error.has_value()) {
+    auto error = claimedBatch_->error.value();
+    claimedBatch_.reset();
+    VELOX_FAIL("RPC batch failed: {}", error);
+  }
+
+  const auto numRows = static_cast<int64_t>(claimedBatch_->responses.size());
+  for (const auto& response : claimedBatch_->responses) {
+    if (response.hasError()) {
+      numErrors_++;
+      recordErrorKind(response.errorKind);
+    }
+  }
+
+  // One measured round trip for the whole batch, so the gradient gets a single
+  // sample. The cap recovers by one unit, not by the row count: BATCH reserves
+  // one slot per flushBatch() regardless of rows, and onSuccess() steps by
+  // units/capacity, so crediting rows against a batch-denominated capacity
+  // makes recovery accelerate as capacity shrinks.
+  const std::vector<int64_t> roundTripTimesNs{claimedBatch_->rttNs};
+  recordCongestion(
+      function_->evaluateCongestion(claimedBatch_->responses),
+      roundTripTimesNs,
+      /*successUnits=*/1);
+
+  auto output = buildOutputFromReadyBatch(*claimedBatch_);
+  numResponsesReceived_ += numRows;
+  claimedBatch_.reset();
+  return output;
+}
+
+RowVectorPtr RPCOperator::getOutput() {
+  return state_->streamingMode() == RPCStreamingMode::kPerRow ? outputPerRow()
+                                                              : outputBatch();
+}
+
+void RPCOperator::endBlockWait() {
+  if (!blockWaitStartNs_.has_value()) {
+    return;
+  }
+  const auto elapsed = getCurrentTimeNano() - blockWaitStartNs_.value();
+  if (blockWaitIsBackpressure_) {
+    totalBackpressureWaitNanos_ += elapsed;
+  } else {
+    totalBlockWaitNanos_ += elapsed;
+  }
+  blockWaitStartNs_ = std::nullopt;
+}
+
+exec::BlockingReason RPCOperator::park(
+    ContinueFuture* future,
+    ContinueFuture waitFuture,
+    bool isBackpressure) {
+  *future = std::move(waitFuture);
+  blockWaitStartNs_ = getCurrentTimeNano();
+  blockWaitIsBackpressure_ = isBackpressure;
+  return exec::BlockingReason::kWaitForRPC;
+}
+
+void RPCOperator::claimBatch(RPCState::ReadyBatch batch) {
+  if (batch.error.has_value()) {
+    RPC_OP_LOG(WARNING) << "Received batch with error: " << batch.error.value();
+  }
+  claimedBatch_ = std::move(batch);
+}
+
+bool RPCOperator::hasUndispatchableWork() const {
+  if (state_->streamingMode() == RPCStreamingMode::kPerRow) {
+    return hasPendingRows();
+  }
+  // A chunk is ready to flush and the tier is refusing it. dispatchBatchSize_
+  // of 0 means buffer-everything, so nothing flushes until noMoreInput().
+  return dispatchBatchSize_ > 0 &&
+      function_->pendingBatchSize() >= dispatchBatchSize_ &&
+      limiter_->available() == 0;
+}
+
+exec::BlockingReason RPCOperator::parkOnTierCapacity(ContinueFuture* future) {
+  auto admission = limiter_->admitOrWait();
+  if (admission.admitted) {
+    // Room appeared; come back round and dispatch into it.
     return exec::BlockingReason::kNotBlocked;
   }
+  return park(future, std::move(admission.wait), /*isBackpressure=*/true);
+}
 
-  // If finished, don't block.
-  if (finished_) {
-    return exec::BlockingReason::kNotBlocked;
-  }
-
-  auto streamingMode = state_->streamingMode();
-
-  if (streamingMode == RPCStreamingMode::kPerRow) {
-    if (!noMoreInput_ && !isDraining()) {
-      // A completion may have freed headroom — try to drip more.
-      dispatchRowsUnderAdmission();
-      auto claimedRow = state_->tryClaimReady();
-      if (claimedRow) {
-        claimedRows_.push_back(std::move(*claimedRow));
-        return exec::BlockingReason::kNotBlocked;
-      }
-      // No ready output. Wait on the per-state completion future ONLY when this
-      // operator has in-flight rows — those are guaranteed to fire that future.
-      // If rows are buffered but nothing is in-flight, they are blocked solely
-      // on the backend's shared admission capacity (held by other
-      // drivers); the per-state future would never resolve, so returning
-      // kWaitForRPC here would hang the driver. Instead fall through to
-      // kNotBlocked and let the next isBlocked() re-check
-      // RPCRateLimiter::admitOrWait(), which a slot-freeing release on
-      // any driver wakes. needsInput() stays false while the buffer is
-      // non-empty, so no new input arrives meanwhile.
-      if (state_->numInFlight() > 0) {
-        std::optional<RPCState::ReadyRow> waited;
-        ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
-        auto result = state_->tryClaimOrWait(&waitFuture, &waited);
-        switch (result) {
-          case RPCState::ClaimResult::kClaimed:
-            claimedRows_.push_back(std::move(*waited));
-            return exec::BlockingReason::kNotBlocked;
-          case RPCState::ClaimResult::kFinished:
-            return exec::BlockingReason::kNotBlocked;
-          case RPCState::ClaimResult::kMustWait:
-            *future = std::move(waitFuture);
-            blockWaitStartNs_ = getCurrentTimeNano();
-            blockWaitIsBackpressure_ = false;
-            return exec::BlockingReason::kWaitForRPC;
-        }
-      }
-      // Buffered rows but nothing in-flight: this operator is blocked solely on
-      // the backend's shared cap (its slots held by other drivers). Park
-      // on the tier's waiter queue — woken by any driver's slot-freeing release
-      // — rather than busy-spinning via repeated kNotBlocked.
-      if (hasPendingRows()) {
-        auto admission = limiter_->admitOrWait();
-        if (admission.admitted) {
-          // Room appeared; come back round and dispatch into it.
-          return exec::BlockingReason::kNotBlocked;
-        }
-        *future = std::move(admission.wait);
-        blockWaitStartNs_ = getCurrentTimeNano();
-        blockWaitIsBackpressure_ = true;
-        return exec::BlockingReason::kWaitForRPC;
-      }
+std::optional<exec::BlockingReason> RPCOperator::tryClaimOrParkOnRow(
+    ContinueFuture* future) {
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyRow> claimed;
+  switch (state_->tryClaimOrWait(&waitFuture, &claimed)) {
+    case RPCState::ClaimResult::kClaimed:
+      claimedRows_.push_back(std::move(*claimed));
       return exec::BlockingReason::kNotBlocked;
-    }
+    case RPCState::ClaimResult::kMustWait:
+      return park(future, std::move(waitFuture), /*isBackpressure=*/false);
+    case RPCState::ClaimResult::kFinished:
+      return std::nullopt;
+  }
+  VELOX_UNREACHABLE();
+}
 
+std::optional<exec::BlockingReason> RPCOperator::tryClaimOrParkOnBatch(
+    ContinueFuture* future,
+    bool isBackpressure) {
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyBatch> polled;
+  switch (state_->tryPollBatchOrWait(&waitFuture, &polled)) {
+    case RPCState::BatchPollResult::kGotBatch:
+      claimBatch(std::move(*polled));
+      return exec::BlockingReason::kNotBlocked;
+    case RPCState::BatchPollResult::kMustWait:
+      return park(future, std::move(waitFuture), isBackpressure);
+    case RPCState::BatchPollResult::kFinished:
+      return std::nullopt;
+  }
+  VELOX_UNREACHABLE();
+}
+
+exec::BlockingReason RPCOperator::blockedInPerRow(ContinueFuture* future) {
+  if (noMoreInput_ || isDraining()) {
     // Resume the drain: rows admission held back still have to go out, and
-    // noMoreInput()/startDrain() deferred the end-of-input signal until they
-    // do. Mirrors the BATCH path below. Completions free slots, and this runs
-    // on the same wake-ups that deliver them.
+    // noMoreInput()/startDrain() defer the end-of-input signal until they do.
+    // Mirrors blockedInBatch(); defensive for the same reason described on the
+    // guard in noMoreInput().
     if (auto reason = drainOrParkOnAdmission(future)) {
       return reason.value();
     }
 
-    std::optional<RPCState::ReadyRow> claimedRow;
-    ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
-    auto result = state_->tryClaimOrWait(&waitFuture, &claimedRow);
-
-    switch (result) {
-      case RPCState::ClaimResult::kClaimed:
-        claimedRows_.push_back(std::move(*claimedRow));
-        return exec::BlockingReason::kNotBlocked;
-
-      case RPCState::ClaimResult::kFinished:
-        finished_ = true;
-        return exec::BlockingReason::kNotBlocked;
-
-      case RPCState::ClaimResult::kMustWait:
-        *future = std::move(waitFuture);
-        blockWaitStartNs_ = getCurrentTimeNano();
-        blockWaitIsBackpressure_ = false;
-        return exec::BlockingReason::kWaitForRPC;
+    // Finishing: nothing more will be dispatched, so the only outcomes are a
+    // completed row, a wait on one, or the stream running out.
+    if (auto reason = tryClaimOrParkOnRow(future)) {
+      return reason.value();
     }
-  } else {
-    // BATCH mode
-    if (!noMoreInput_ && !isDraining()) {
-      // A completion may have freed a slot. BATCH otherwise only flushes on
-      // new input, so once needsInput() stops taking input a full accumulator
-      // would sit here indefinitely with capacity going unused.
-      dispatchBatchUnderAdmission(DispatchScope::kFullChunksOnly);
+    finished_ = true;
+    return exec::BlockingReason::kNotBlocked;
+  }
 
-      auto readyBatch = state_->tryPollReady();
-      if (readyBatch) {
-        if (readyBatch->error.has_value()) {
-          RPC_OP_LOG(WARNING)
-              << "Received batch with error: " << readyBatch->error.value();
-        }
-        claimedBatch_ = std::move(*readyBatch);
-        return exec::BlockingReason::kNotBlocked;
-      }
-      // No ready batch. Under back-pressure (in-flight batches at the window
-      // limit, so needsInput() returns false), PARK on an in-flight batch
-      // rather than returning kNotBlocked: otherwise a driver that halts its
-      // upstream walk at this full operator (transitive back-pressure) would
-      // busy-spin here until a batch completes, monopolizing its thread and
-      // starving co-scheduled queries. When not under back-pressure we can
-      // still accept input, so report not-blocked and let the driver call
-      // needsInput()/addInput(). tryPollBatchOrWait registers a waiter that a
-      // batch completion fulfills, so this cannot hang while batches are
-      // in-flight (guaranteed by isUnderBackpressure()).
-      if (state_->isUnderBackpressure()) {
-        ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
-        std::optional<RPCState::ReadyBatch> polledBatch;
-        switch (state_->tryPollBatchOrWait(&waitFuture, &polledBatch)) {
-          case RPCState::BatchPollResult::kGotBatch:
-            if (polledBatch->error.has_value()) {
-              RPC_OP_LOG(WARNING) << "Received batch with error: "
-                                  << polledBatch->error.value();
-            }
-            claimedBatch_ = std::move(*polledBatch);
-            return exec::BlockingReason::kNotBlocked;
-          case RPCState::BatchPollResult::kMustWait:
-            *future = std::move(waitFuture);
-            blockWaitStartNs_ = getCurrentTimeNano();
-            blockWaitIsBackpressure_ = false;
-            return exec::BlockingReason::kWaitForRPC;
-          case RPCState::BatchPollResult::kFinished:
-            // Not expected mid-stream (noMoreInput_ is false); fall through to
-            // not-blocked defensively.
-            break;
-        }
-      }
+  // A completion may have freed headroom -- try to drip more.
+  dispatchRowsUnderAdmission();
+  if (auto claimed = state_->tryClaimReady()) {
+    claimedRows_.push_back(std::move(*claimed));
+    return exec::BlockingReason::kNotBlocked;
+  }
 
-      // Admission refused a flush this driver is otherwise ready to make.
-      // Yield the thread rather than report not-blocked: needsInput() also
-      // refuses while the accumulator holds an unflushable chunk, so the
-      // driver would come straight back here with nothing to do.
-      if (dispatchBatchSize_ > 0 &&
-          function_->pendingBatchSize() >= dispatchBatchSize_ &&
-          limiter_->available() == 0) {
-        // Same order as the PER_ROW path: prefer this driver's own in-flight
-        // batches, whose completion both frees a slot and is guaranteed to
-        // fire. Only with nothing of ours in flight is the cap held entirely
-        // by other drivers, and the tier's waiter queue the one thing that can
-        // wake us.
-        if (state_->numInFlight() > 0) {
-          ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
-          std::optional<RPCState::ReadyBatch> polledBatch;
-          switch (state_->tryPollBatchOrWait(&waitFuture, &polledBatch)) {
-            case RPCState::BatchPollResult::kGotBatch:
-              if (polledBatch->error.has_value()) {
-                RPC_OP_LOG(WARNING) << "Received batch with error: "
-                                    << polledBatch->error.value();
-              }
-              claimedBatch_ = std::move(*polledBatch);
-              return exec::BlockingReason::kNotBlocked;
-            case RPCState::BatchPollResult::kMustWait:
-              *future = std::move(waitFuture);
-              blockWaitStartNs_ = getCurrentTimeNano();
-              blockWaitIsBackpressure_ = true;
-              return exec::BlockingReason::kWaitForRPC;
-            case RPCState::BatchPollResult::kFinished:
-              break;
-          }
-        } else {
-          auto admission = limiter_->admitOrWait();
-          if (admission.admitted) {
-            // Room appeared; come back round and dispatch into it.
-            return exec::BlockingReason::kNotBlocked;
-          }
-          *future = std::move(admission.wait);
-          blockWaitStartNs_ = getCurrentTimeNano();
-          blockWaitIsBackpressure_ = true;
-          return exec::BlockingReason::kWaitForRPC;
-        }
+  // Nothing ready. Park on whatever can wake us; with rows buffered and
+  // nothing in flight that is the tier's queue, since the per-state future
+  // would never fire. needsInput() stays false meanwhile, so no new input
+  // arrives. Finished is not expected mid-stream, so it falls through.
+  if (state_->numInFlight() > 0 || hasUndispatchableWork()) {
+    // Prefer this driver's own in-flight work: that completion is guaranteed
+    // to fire AND frees a slot, whereas the tier's queue depends on another
+    // driver releasing. blockedInBatch() applies the same order.
+    if (state_->numInFlight() > 0) {
+      if (auto reason = tryClaimOrParkOnRow(future)) {
+        return reason.value();
       }
-      return exec::BlockingReason::kNotBlocked;
+    } else {
+      return parkOnTierCapacity(future);
     }
+  }
+  return exec::BlockingReason::kNotBlocked;
+}
 
+exec::BlockingReason RPCOperator::blockedInBatch(ContinueFuture* future) {
+  if (noMoreInput_ || isDraining()) {
     // Resume the drain: noMoreInput() dispatched only what admission allowed,
     // so anything still accumulated is waiting on a slot. Completions free
     // slots, and this runs on the same wake-ups that deliver them.
@@ -904,32 +833,72 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
       return reason.value();
     }
 
-    std::optional<RPCState::ReadyBatch> readyBatch;
-    ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
-    auto result = state_->tryPollBatchOrWait(&waitFuture, &readyBatch);
-
-    switch (result) {
-      case RPCState::BatchPollResult::kGotBatch:
-        if (readyBatch->error.has_value()) {
-          RPC_OP_LOG(WARNING)
-              << "Received batch with error: " << readyBatch->error.value();
-        }
-        claimedBatch_ = std::move(*readyBatch);
-        return exec::BlockingReason::kNotBlocked;
-
-      case RPCState::BatchPollResult::kFinished:
-        finished_ = true;
-        return exec::BlockingReason::kNotBlocked;
-
-      case RPCState::BatchPollResult::kMustWait:
-        *future = std::move(waitFuture);
-        blockWaitStartNs_ = getCurrentTimeNano();
-        blockWaitIsBackpressure_ = false;
-        return exec::BlockingReason::kWaitForRPC;
+    if (auto reason = tryClaimOrParkOnBatch(future, /*isBackpressure=*/false)) {
+      return reason.value();
     }
+    finished_ = true;
+    return exec::BlockingReason::kNotBlocked;
   }
 
-  VELOX_UNREACHABLE();
+  // A completion may have freed a slot. BATCH otherwise only flushes on new
+  // input, so once needsInput() stops taking input a full accumulator would
+  // sit here indefinitely with capacity going unused.
+  dispatchBatchUnderAdmission(DispatchScope::kFullChunksOnly);
+
+  if (auto ready = state_->tryPollReady()) {
+    claimBatch(std::move(*ready));
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  // Under window back-pressure needsInput() is false, so a driver that halted
+  // its upstream walk here would busy-spin until a batch completes,
+  // monopolizing its thread. Park on an in-flight batch instead. Off
+  // back-pressure we can still accept input, so report not-blocked and let the
+  // driver call needsInput()/addInput().
+  if (state_->isUnderBackpressure()) {
+    if (auto reason = tryClaimOrParkOnBatch(future, /*isBackpressure=*/false)) {
+      return reason.value();
+    }
+    // Finished is not expected mid-stream; fall through defensively.
+  }
+
+  // Admission refused a flush this driver is otherwise ready to make. Yield
+  // the thread rather than report not-blocked: needsInput() also refuses while
+  // the accumulator holds an unflushable chunk, so the driver would come
+  // straight back here with nothing to do.
+  if (hasUndispatchableWork()) {
+    // Same order as blockedInPerRow(): this driver's own in-flight batches
+    // first, the tier's queue only when it has none.
+    if (state_->numInFlight() > 0) {
+      if (auto reason =
+              tryClaimOrParkOnBatch(future, /*isBackpressure=*/true)) {
+        return reason.value();
+      }
+    } else {
+      return parkOnTierCapacity(future);
+    }
+  }
+  return exec::BlockingReason::kNotBlocked;
+}
+
+exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
+  endBlockWait();
+
+  // Emit ready output / report finished BEFORE any backpressure gate: a driver
+  // holding completed rows, or with its own completions to harvest, must never
+  // park behind the backend's shared cap held by OTHER drivers. That wait is
+  // a last resort, taken only when this operator has buffered work and nothing
+  // in flight of its own to wake it.
+  if (!claimedRows_.empty() || claimedBatch_.has_value()) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+  if (finished_) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  return state_->streamingMode() == RPCStreamingMode::kPerRow
+      ? blockedInPerRow(future)
+      : blockedInBatch(future);
 }
 
 bool RPCOperator::isFinished() {
@@ -1111,18 +1080,25 @@ void RPCOperator::recordRuntimeStats() {
         kRpcErrorKindBackendError, RuntimeCounter(numErrorsBackend_));
   }
 
-  // Per-tier admission capacity trajectory (the shared capacity this
-  // operator drips against). Distinct from the per-driver rpcCongestion*
-  // window. Emitted unconditionally — including for the empty/default tier,
-  // which is the bucket the meta.ai per-row-key path uses; gating on a
-  // non-empty tierKey_ would hide the cap on exactly that main path.
-  const auto limiterStats = limiter_->stats();
-  lockedStats->addRuntimeStat(
-      kRpcRateLimiterCap, RuntimeCounter(limiterStats.capacity));
-  lockedStats->addRuntimeStat(
-      kRpcRateLimiterPeakPending, RuntimeCounter(limiterStats.peakPending));
-  lockedStats->addRuntimeStat(
-      kRpcRateLimiterMinCap, RuntimeCounter(limiterStats.lowWaterCapacity));
+  // The backend's admission capacity trajectory: the capacity this operator
+  // shares with every other driver dispatching to the same backend, as
+  // distinct from the per-driver rpcCongestion* window. Emitted for every
+  // backend including the default one, whose key is empty; gating on a
+  // non-empty key would hide the cap on exactly the most common path.
+  //
+  // limiter_ is resolved in initialize(), but Driver::closeOperators() closes
+  // every operator whether or not initializeOperators() ran -- a task that
+  // terminates during setup reaches close() first. There is no limiter to
+  // report in that case, and no stats worth reporting either.
+  if (limiter_ != nullptr) {
+    const auto limiterStats = limiter_->stats();
+    lockedStats->addRuntimeStat(
+        kRpcRateLimiterCap, RuntimeCounter(limiterStats.capacity));
+    lockedStats->addRuntimeStat(
+        kRpcRateLimiterPeakPending, RuntimeCounter(limiterStats.peakPending));
+    lockedStats->addRuntimeStat(
+        kRpcRateLimiterMinCap, RuntimeCounter(limiterStats.lowWaterCapacity));
+  }
 }
 
 RowVectorPtr RPCOperator::buildOutputFromReadyBatch(
@@ -1200,12 +1176,13 @@ RowVectorPtr RPCOperator::buildOutputVector(
       auto combined = BaseVector::create(
           outputType->childAt(proj.outputChannel), numRows, pool);
       for (vector_size_t rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-        const auto& [batchIdx, rowInBatch] = locations[rowIdx];
-        auto it = batchColsCache.find(batchIdx);
+        const auto& [batchIndex, rowInBatch] = locations[rowIdx];
+        auto it = batchColsCache.find(batchIndex);
         if (it == batchColsCache.end()) {
-          it = batchColsCache
-                   .emplace(batchIdx, state_->getInputBatchColumns(batchIdx))
-                   .first;
+          it =
+              batchColsCache
+                  .emplace(batchIndex, state_->getInputBatchColumns(batchIndex))
+                  .first;
         }
         const auto& batchCols = it->second;
         if (proj.sourceChannel <
@@ -1233,8 +1210,8 @@ RowVectorPtr RPCOperator::buildOutputVector(
   for (const auto& loc : locations) {
     batchReleaseCounts[loc.first]++;
   }
-  for (const auto& [batchIdx, count] : batchReleaseCounts) {
-    state_->releaseRows(batchIdx, count);
+  for (const auto& [batchIndex, count] : batchReleaseCounts) {
+    state_->releaseRows(batchIndex, count);
   }
 
   return std::make_shared<RowVector>(

--- a/velox/exec/rpc/RPCOperator.h
+++ b/velox/exec/rpc/RPCOperator.h
@@ -177,30 +177,80 @@ class RPCOperator : public exec::Operator {
   // the whole input against a busy backend.
   bool inputBufferIsFull() const;
 
-  /// Flush accumulated batch rows via function_->flushBatch().
-  /// Called when threshold is reached or at noMoreInput/drain time.
-  /// @param maxRows Maximum rows to flush. 0 means flush all.
   // Returns false when the flush did not happen: nothing accumulated, or the
   // tier had no free slot. Callers loop on this so they stop rather than spin.
   bool flushBatchRequests(int32_t maxRows = 0);
 
-  /// Build output RowVector from a ready batch (BATCH mode).
+  // Builds the output RowVector from a completed batch (BATCH mode).
   RowVectorPtr buildOutputFromReadyBatch(RPCState::ReadyBatch& readyBatch);
 
-  /// Common helper: build output vector from responses + input data lookup.
+  // Builds an output vector from RPC responses paired with the buffered
+  // input rows they came from. Shared by both streaming modes.
   RowVectorPtr buildOutputVector(
       const std::vector<RPCResponse>& responses,
       const std::vector<std::pair<int32_t, vector_size_t>>& locations);
 
-  /// Precompute output column projections from source type to output type.
-  /// Called once in initialize() to avoid repeated string lookups in
-  /// buildOutputVector().
+  // Precomputes output column projections from the source type to the output
+  // type. Called once in initialize() so buildOutputVector() does not repeat
+  // the name lookups per batch.
   void initOutputProjections();
 
   // Increment the per-error-kind counter for a single response.
   void recordErrorKind(velox::rpc::RPCErrorKind kind);
 
-  // The PER_ROW arm of drainPending(): dispatch buffered rows up to the
+  // getOutput() decomposed, mirroring the isBlocked() split below. The two
+  // modes differ in how they claim and shape output, not in how they report
+  // finishing or feed the controllers -- those are shared, so a change to one
+  // mode cannot silently diverge from the other.
+  RowVectorPtr outputPerRow();
+  RowVectorPtr outputBatch();
+
+  // Nothing left to emit: settle the drain if one is in progress. Always
+  // returns nullptr, so callers can `return finishIfDrained();`.
+  RowVectorPtr finishIfDrained();
+
+  // Feeds one drained unit's verdict to both controllers -- the per-driver
+  // window and the backend's shared cap. They must back off together: a
+  // rate-limit storm is low-latency, so the latency gradient alone is blind to
+  // it and only the error verdict makes the window shrink.
+  void recordCongestion(
+      AsyncRPCFunction::CongestionSignal signal,
+      const std::vector<int64_t>& roundTripTimesNs,
+      int64_t successUnits);
+
+  // isBlocked() decomposed. Each returns the reason to hand the driver; the
+  // try* helpers return nullopt when the state reports finished, which the
+  // streaming and finishing paths treat differently.
+  exec::BlockingReason blockedInPerRow(ContinueFuture* future);
+  exec::BlockingReason blockedInBatch(ContinueFuture* future);
+  std::optional<exec::BlockingReason> tryClaimOrParkOnRow(
+      ContinueFuture* future);
+  std::optional<exec::BlockingReason> tryClaimOrParkOnBatch(
+      ContinueFuture* future,
+      bool isBackpressure);
+  // Asks the backend whether it can take work and parks on the answer.
+  // admitOrWait() decides and enrols under one lock, so there is no window in
+  // which the caller is neither admitted nor waiting on anything.
+  exec::BlockingReason parkOnTierCapacity(ContinueFuture* future);
+
+  // Hands 'waitFuture' to the driver and starts a block-wait measurement.
+  exec::BlockingReason
+  park(ContinueFuture* future, ContinueFuture waitFuture, bool isBackpressure);
+
+  // Closes the measurement started by the last park().
+  void endBlockWait();
+
+  // Takes a completed batch as this operator's claimed output, logging first
+  // if it carried an error.
+  void claimBatch(RPCState::ReadyBatch batch);
+
+  // True when this driver holds work that admission will not let it dispatch:
+  // buffered rows in PER_ROW, an unflushable chunk in BATCH. isBlocked() parks
+  // on it and needsInput() refuses more input because of it, so both modes
+  // read the same predicate rather than each spelling out its own.
+  bool hasUndispatchableWork() const;
+
+  // PER_ROW admission control: dispatch buffered rows up to the
   // available headroom = min(per-driver window headroom, this backend's
   // rate-limiter headroom). Called from addInput()/getOutput()/isBlocked() so a
   // whole input vector is dripped at the sustainable rate instead of blasted.
@@ -211,7 +261,7 @@ class RPCOperator : public exec::Operator {
     return pendingCursor_ < pendingNumRows_;
   }
 
-  /// Record runtime stats into operator stats. Called from close().
+  // Records the RPC runtime stats into operator stats. Called from close().
   void recordRuntimeStats();
 
   std::shared_ptr<const core::RPCNode> rpcNode_;

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -466,6 +466,30 @@ TEST_F(RPCOperatorTest, batchDrainCompletesWhileTheTierIsHeld) {
   runContendedDrain(/*batchMode=*/true);
 }
 
+// close() runs on operators that never initialized. Driver::closeOperators()
+// walks every operator regardless of whether Driver::initializeOperators() ran,
+// so a task that terminates during setup reaches close() with limiter_ still
+// null -- and recordRuntimeStats() dereferenced it unconditionally, taking the
+// worker down with SIGSEGV rather than failing the query.
+//
+// An unregistered function name reaches that state deterministically:
+// initialize() throws at the "Unknown RPC function" check, which runs long
+// before limiter_ is assigned. The query must surface that error; without the
+// guard the process dies instead.
+TEST_F(RPCOperatorTest, closeWithoutInitializeDoesNotCrash) {
+  auto input =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"a", "b", "c"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "no_such_rpc_function_registered");
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool()),
+      "Unknown RPC function");
+}
+
 TEST_F(RPCOperatorTest, batchDispatchRespectsTheTierCap) {
   constexpr int64_t kCeiling = 1;
   std::vector<std::string> storage;


### PR DESCRIPTION
Summary:

Two changes to `RPCOperator`: a crash fix, and the `isBlocked()` /
`getOutput()` split the diff was originally written for.

## The crash

`recordRuntimeStats()` dereferenced `limiter_` unconditionally, and `close()`
calls it unconditionally. `limiter_` is only assigned in `initialize()`, so any
operator closed without a successful initialize dereferenced null.

`Driver::closeOperators()` walks every operator regardless of whether
`Driver::initializeOperators()` ran, and both `Driver::close()` and
`Driver::closeByTask()` reach it -- so a task that terminates during setup gets
there first. `initialize()` also throws before the assignment on any bad plan:
the `VELOX_CHECK` for an unknown function name runs about sixty lines ahead of
`limiter_ = &RPCRateLimiterRegistry::global().get(tierKey_)`.

The result was SIGSEGV in the worker rather than a failed query. Observed on
pnb3_verifier_t10_3: thirteen workers took `Signal 11 ... address not mapped to
object` over two and a half hours, with the stack naming `close()` ->
`recordRuntimeStats()` -> `RPCRateLimiter::stats()`. Node count dipped to 150
and recovered as they restarted, and a regression case failed with "Could not
communicate with the remote task" because the worker died under it.

This is a regression, not a latent bug. Before the per-backend limiter landed,
`recordRuntimeStats()` read the static facade by string key
(`RPCRateLimiter::currentLimit(tierKey_)` and friends) and there was no
`limiter_` member to dereference. Introducing the pointer did not revisit the
close path. `state_` in the same function is already guarded with `if (state_)`;
`limiter_` was not.

Guarded now. An operator with no limiter has no admission stats worth
reporting, so the three `rpcRateLimiter*` stats are simply absent.

## The split

`isBlocked()` had grown to 240 lines and `getOutput()` to 128, both branching
the same way: two streaming modes, each with its own path, and the shared parts
written out twice. `isBlocked()` is now 19 lines and `getOutput()` 4, each
dispatching to a per-mode helper. `flushBatchRequests()` shrinks from 119 to 71
by the same move -- the two pure response transforms it performed inline become
free functions in an anonymous namespace.

The modes stay separate because they diverge at six concrete points, one of
which is a block that exists only in BATCH:

| | PER_ROW | BATCH |
|---|---|---|
| make progress | `dispatchRowsUnderAdmission()` | `dispatchBatchUnderAdmission(scope)` |
| claim ready | `tryClaimReady()` -> `claimedRows_` | `tryPollReady()` -> `claimBatch()` |
| park on own work | `tryClaimOrParkOnRow()` | `tryClaimOrParkOnBatch()` |
| backpressure pre-gate | absent | present |
| stuck-work guard | `numInFlight() > 0 \|\| hasUndispatchableWork()` | `hasUndispatchableWork()` |
| park flavour | row claim | batch claim, `isBackpressure=true` |

Merging them would mean five mode branches threaded through one 70-line body.
Side by side, the fourth row is visible; merged, it is an `if` in the middle of
a long function. Every divergence bug in this work came from one mode gaining a
behaviour the other did not.

The shared parts are named rather than duplicated: `park()` / `endBlockWait()`
for the wait measurement, `parkOnTierCapacity()`, `claimBatch()`,
`finishIfDrained()`, `recordCongestion()`, and `hasUndispatchableWork()` --
which `isBlocked()` parks on and `needsInput()` refuses input for, so both read
one predicate.

The split itself changes no behaviour: every definition it adds is an
extraction from `isBlocked()`, `getOutput()` or `flushBatchRequests()`, and
those three are the only functions it rewrites. The behaviour change in this
diff is the null guard above.

Reviewed By: abhinavmuk04

Differential Revision: D117820911


