### PR TITLE
fix(serializers): Avoid string_view iterator-to-pointer use

### DIFF
--- a/velox/serializers/PrestoVectorLexer.h
+++ b/velox/serializers/PrestoVectorLexer.h
@@ -96,7 +96,7 @@ class PrestoVectorLexer {
   }
 
   void assertCommitted() const {
-    assert(committedPtr_ == source_.begin());
+    assert(committedPtr_ == source_.data());
   }
 
   void commit(TokenType tokenType);


### PR DESCRIPTION
Building Velox with **clang 21 and libc++** fails in PrestoVectorLexer.h:

    PrestoVectorLexer.h:99:26: error: invalid operands to binary expression ('const char *const' and 'const_iterator' (aka '__wrap_iter<const char *>'))

`assertCommitted()` compares the `const char*` member `committedPtr_` with
`source_.begin()`. That compiles with **libstdc++** and **older libc++**, where
`string_view::const_iterator` is `const char*` itself. Recent libc++ wraps the
iterator in `__wrap_iter`, which cannot be compared with a raw pointer
(llvm/llvm-project PR 74482). Use `source_.data()` instead. It points to the
same character and is portable across standard libraries.