### PR TITLE
perf(nimble): Optimize boolean stream slicing (#18748)

### DIFF
--- a/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -32,6 +32,7 @@
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/RLEEncoding.h"
 #include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
@@ -646,15 +647,58 @@ class MainlyConstantEncodingBase
     }
   }
 
-  static std::pair<uint32_t, uint32_t> countCommonForSlice(
+  // Carries common-value counts and, when available, a sliced isCommon stream.
+  struct SlicedCommonResult {
+    // Number of common-value rows before the requested slice.
+    uint32_t numCommonBeforeSlice{0};
+    // Number of common-value rows inside the requested slice.
+    uint32_t numCommonInSlice{0};
+    // Encoded isCommon slice when producing it was already needed for counting.
+    std::string_view slicedIsCommon;
+  };
+
+  static SlicedCommonResult countCommonForSlice(
       std::string_view encoded,
       uint32_t offset,
       uint32_t length,
       Buffer& buffer,
       const Encoding::Options& options) {
+    NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
     const auto rowEnd = offset + length;
-    if (rowEnd == 0) {
-      return {0, 0};
+
+    const auto encodingType = EncodingPrefix::encodingType(encoded);
+    if (encodingType == EncodingType::Constant) {
+      NIMBLE_CHECK_EQ(
+          EncodingPrefix::dataType(encoded),
+          DataType::Bool,
+          "MainlyConstant isCommon child must be boolean.");
+      const char* pos = encoded.data() +
+          EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+      const bool value = encoding::read<bool>(pos);
+      return {
+          .numCommonBeforeSlice = value ? offset : 0,
+          .numCommonInSlice = value ? length : 0,
+          .slicedIsCommon = {},
+      };
+    }
+    if (encodingType == EncodingType::RLE) {
+      RLEEncoding<bool>::RangeCounts counts;
+      RLEEncoding<bool>::countTrue(
+          encoded, offset, length, buffer, counts, options);
+      return {
+          .numCommonBeforeSlice = counts.numTrueBeforeRange,
+          .numCommonInSlice = counts.numTrueInRange,
+          .slicedIsCommon = {},
+      };
+    }
+    if (encodingType == EncodingType::SparseBool) {
+      const auto sliceResult = SparseBoolEncoding::sliceAndCount(
+          encoded, offset, length, buffer, options);
+      return {
+          .numCommonBeforeSlice = sliceResult.counts.numTrueBeforeRange,
+          .numCommonInSlice = sliceResult.counts.numTrueInRange,
+          .slicedIsCommon = sliceResult.sliced,
+      };
     }
 
     auto* pool = &buffer.getMemoryPool();
@@ -665,8 +709,12 @@ class MainlyConstantEncodingBase
     encoding->materialize(rowEnd, values.data());
     const auto sliceBegin = values.begin() + offset;
     return {
-        std::count(values.begin(), sliceBegin, true),
-        std::count(sliceBegin, values.end(), true)};
+        .numCommonBeforeSlice =
+            static_cast<uint32_t>(std::count(values.begin(), sliceBegin, true)),
+        .numCommonInSlice =
+            static_cast<uint32_t>(std::count(sliceBegin, values.end(), true)),
+        .slicedIsCommon = {},
+    };
   }
 
   static std::string_view slice(
@@ -692,10 +740,12 @@ class MainlyConstantEncodingBase
     const std::string_view commonValue{
         pos, static_cast<size_t>(encoded.end() - pos)};
 
-    const auto [commonBefore, commonInSlice] =
-        countCommonForSlice(isCommon, offset, length, buffer, options);
-    const auto otherOffset = offset - commonBefore;
-    const auto otherCount = length - commonInSlice;
+    auto* pool = &buffer.getMemoryPool();
+    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+    const auto slicedCommonResult = countCommonForSlice(
+        isCommon, offset, length, scopedBuffer.get(), options);
+    const auto otherOffset = offset - slicedCommonResult.numCommonBeforeSlice;
+    const auto otherCount = length - slicedCommonResult.numCommonInSlice;
 
     if (otherCount == 0) {
       const auto prefixSize =
@@ -715,10 +765,11 @@ class MainlyConstantEncodingBase
       return {reserved, encodingSize};
     }
 
-    auto* pool = &buffer.getMemoryPool();
-    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
-    const auto slicedIsCommon = EncodingFactory::slice(
-        isCommon, offset, length, scopedBuffer.get(), options);
+    auto slicedIsCommon = slicedCommonResult.slicedIsCommon;
+    if (slicedIsCommon.empty()) {
+      slicedIsCommon = EncodingFactory::slice(
+          isCommon, offset, length, scopedBuffer.get(), options);
+    }
     const auto slicedOtherValues = EncodingFactory::slice(
         otherValues, otherOffset, otherCount, scopedBuffer.get(), options);
 

--- a/velox/dwio/nimble/encodings/RLEEncoding.cpp
+++ b/velox/dwio/nimble/encodings/RLEEncoding.cpp
@@ -16,6 +16,23 @@
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
 
 namespace facebook::nimble {
+namespace {
+
+// Counts true rows before rowLimit for alternating bool RLE runs that all have
+// the same run length.
+uint64_t countTrueWithConstantRunLength(
+    bool value,
+    uint32_t runLength,
+    uint64_t rowLimit) {
+  NIMBLE_CHECK_GT(runLength, 0, "RLE run length must be positive.");
+  const uint64_t numFullRuns = rowLimit / runLength;
+  const uint64_t tail = rowLimit % runLength;
+  const uint64_t trueFullRuns = value ? (numFullRuns + 1) / 2 : numFullRuns / 2;
+  const bool tailIsTrue = (numFullRuns % 2 == 0) ? value : !value;
+  return trueFullRuns * runLength + (tailIsTrue ? tail : 0);
+}
+
+} // namespace
 
 RLEEncoding<bool>::RLEEncoding(
     velox::memory::MemoryPool& pool,
@@ -65,6 +82,117 @@ void RLEEncoding<bool>::materializeBoolsAsBits(
     rowsLeft -= copiesRemaining_;
     copiesRemaining_ = 0;
   }
+}
+
+void RLEEncoding<bool>::countTrue(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    RangeCounts& counts,
+    const Encoding::Options& options) {
+  counts = {};
+  NIMBLE_CHECK_EQ(
+      EncodingPrefix::encodingType(encoded),
+      EncodingType::RLE,
+      "Expected RLE encoding.");
+  NIMBLE_CHECK_EQ(
+      EncodingPrefix::dataType(encoded),
+      DataType::Bool,
+      "Expected boolean RLE encoding.");
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot count zero rows.");
+
+  const char* pos = encoded.data() +
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const uint32_t runLengthsSize = encoding::readUint32(pos);
+  const std::string_view runLengthsData{pos, runLengthsSize};
+  pos += runLengthsSize;
+  NIMBLE_CHECK_EQ(
+      pos + sizeof(bool), encoded.end(), "Unexpected boolean RLE encoding end");
+  bool value = encoding::read<bool>(pos);
+
+  NIMBLE_CHECK_EQ(
+      EncodingPrefix::dataType(runLengthsData),
+      DataType::Uint32,
+      "RLE run-length child must be uint32.");
+  const auto runCount =
+      EncodingPrefix::readRowCount(runLengthsData, options.useVarintRowCount);
+  NIMBLE_CHECK_GT(runCount, 0, "Boolean RLE must have at least one run.");
+
+  const uint64_t rangeEnd = static_cast<uint64_t>(offset) + length;
+  if (EncodingPrefix::encodingType(runLengthsData) == EncodingType::Constant) {
+    const char* runLengthPos = runLengthsData.data() +
+        EncodingPrefix::prefixSize(runLengthsData, options.useVarintRowCount);
+    const uint32_t runLength = encoding::readUint32(runLengthPos);
+    NIMBLE_CHECK_GE(
+        static_cast<uint64_t>(runLength) * runCount,
+        rangeEnd,
+        "Boolean RLE run lengths are too short.");
+    const auto numTrueBeforeRange =
+        countTrueWithConstantRunLength(value, runLength, offset);
+    const auto numTrueAtRangeEnd =
+        countTrueWithConstantRunLength(value, runLength, rangeEnd);
+    counts = {
+        .numTrueBeforeRange = static_cast<uint32_t>(numTrueBeforeRange),
+        .numTrueInRange =
+            static_cast<uint32_t>(numTrueAtRangeEnd - numTrueBeforeRange)};
+    return;
+  }
+
+  auto* pool = &buffer.getMemoryPool();
+  auto runLengthsEncoding = EncodingFactory{options}.create(
+      *pool, runLengthsData, [](uint32_t /*totalLength*/) -> void* {
+        return nullptr;
+      });
+  constexpr uint32_t kRunLengthChunkSize{256};
+  ScopedVector<uint32_t> runLengths{
+      std::min<uint32_t>(runCount, kRunLengthChunkSize),
+      pool,
+      options.bufferPool};
+  uint64_t row{0};
+  for (uint32_t run = 0; run < runCount;) {
+    const auto chunkSize =
+        std::min<uint32_t>(runLengths->size(), runCount - run);
+    runLengthsEncoding->materialize(chunkSize, runLengths->data());
+    for (uint32_t i = 0; i < chunkSize; ++i, ++run) {
+      const uint64_t runStart = row;
+      const uint64_t runEnd = row + (*runLengths)[i];
+      NIMBLE_CHECK_GT((*runLengths)[i], 0, "RLE run length must be positive.");
+      if (value) {
+        if (runStart < offset) {
+          counts.numTrueBeforeRange += static_cast<uint32_t>(
+              std::min<uint64_t>(runEnd, offset) - runStart);
+        }
+        const auto rangeStart = std::max<uint64_t>(runStart, offset);
+        const auto rangeLimit = std::min<uint64_t>(runEnd, rangeEnd);
+        if (rangeStart < rangeLimit) {
+          counts.numTrueInRange +=
+              static_cast<uint32_t>(rangeLimit - rangeStart);
+        }
+      }
+      row = runEnd;
+      if (row >= rangeEnd) {
+        return;
+      }
+      value = !value;
+    }
+  }
+  NIMBLE_CHECK_GE(row, rangeEnd, "Boolean RLE run lengths are too short.");
+}
+
+uint32_t RLEEncoding<bool>::countTrue(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  RangeCounts counts;
+  countTrue(encoded, offset, length, buffer, counts, options);
+  return counts.numTrueInRange;
 }
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/RLEEncoding.h
+++ b/velox/dwio/nimble/encodings/RLEEncoding.h
@@ -337,6 +337,7 @@ class RLEEncodingBase
     NIMBLE_CHECK_GT(
         runCount, 0, "Cannot slice a non-empty range from empty RLE runs.");
     auto* pool = &buffer.getMemoryPool();
+
     RLESliceRuns result;
 
     EncodingFactory encodingFactory{options};
@@ -768,6 +769,33 @@ class RLEEncoding<bool> final
 
   void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
       final;
+
+  /// True counts before and inside a row range.
+  struct RangeCounts {
+    /// Number of true values before the range offset.
+    uint32_t numTrueBeforeRange{0};
+
+    /// Number of true values inside the range.
+    uint32_t numTrueInRange{0};
+  };
+
+  /// Fills true counts before and inside non-empty rows [offset, offset +
+  /// length).
+  static void countTrue(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      RangeCounts& counts,
+      const Encoding::Options& options = {});
+
+  /// Counts true values in non-empty rows [offset, offset + length).
+  static uint32_t countTrue(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   static uint64_t estimateSize(
       uint64_t /*rowCount*/,

--- a/velox/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/velox/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <algorithm>
-
 #include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
+
+#include <array>
+#include <utility>
 
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
@@ -23,49 +24,6 @@
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 namespace facebook::nimble {
-
-namespace {
-
-std::string_view sliceSparseIndices(
-    std::string_view encodedIndices,
-    uint32_t offset,
-    uint32_t length,
-    Buffer& buffer,
-    const Encoding::Options& options) {
-  auto* pool = &buffer.getMemoryPool();
-  const auto indexCount =
-      EncodingPrefix::readRowCount(encodedIndices, options.useVarintRowCount);
-  Vector<uint32_t> sparseIndices{pool, indexCount};
-  EncodingFactory{options}
-      .create(
-          *pool,
-          encodedIndices,
-          [](uint32_t /* totalLength */) -> void* { return nullptr; })
-      ->materialize(indexCount, sparseIndices.data());
-
-  const auto end = offset + length;
-  Vector<uint32_t> sliceIndices{pool};
-  sliceIndices.reserve(std::min<uint32_t>(length, indexCount));
-  for (uint32_t i = 0; i + 1 < indexCount; ++i) {
-    const auto index = sparseIndices[i];
-    if (index >= end) {
-      break;
-    }
-    if (index >= offset) {
-      sliceIndices.push_back(index - offset);
-    }
-  }
-  sliceIndices.push_back(length);
-
-  return EncodingFactory::encodeWithCapturedLayout<uint32_t>(
-      encodedIndices,
-      std::span<const uint32_t>{sliceIndices.data(), sliceIndices.size()},
-      buffer,
-      options,
-      "Captured SparseBool index layout");
-}
-
-} // namespace
 
 SparseBoolEncoding::SparseBoolEncoding(
     velox::memory::MemoryPool& pool,
@@ -176,6 +134,52 @@ uint32_t SparseBoolEncoding::skipSparseIndices(uint32_t rowCount) {
   return count;
 }
 
+void SparseBoolEncoding::countTrue(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    velox::memory::MemoryPool* pool,
+    RangeCounts& counts,
+    const Encoding::Options& options) {
+  counts = {};
+  NIMBLE_CHECK_NOT_NULL(pool, "Memory pool cannot be null");
+  const auto rowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, rowCount);
+  NIMBLE_CHECK_LE(length, rowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot count zero rows.");
+
+  SparseBoolEncoding sparseBool{
+      *pool,
+      encoded,
+      [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+      options};
+  const auto numSkippedSparseBeforeRange = sparseBool.skipSparseIndices(offset);
+  const auto numSkippedSparseInRange = sparseBool.skipSparseIndices(length);
+  if (sparseBool.sparseValue()) {
+    counts = {
+        .numTrueBeforeRange = numSkippedSparseBeforeRange,
+        .numTrueInRange = numSkippedSparseInRange,
+    };
+    return;
+  }
+  counts = {
+      .numTrueBeforeRange = offset - numSkippedSparseBeforeRange,
+      .numTrueInRange = length - numSkippedSparseInRange,
+  };
+}
+
+uint32_t SparseBoolEncoding::countTrue(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    velox::memory::MemoryPool* pool,
+    const Encoding::Options& options) {
+  RangeCounts counts;
+  countTrue(encoded, offset, length, pool, counts, options);
+  return counts.numTrueInRange;
+}
+
 std::string_view SparseBoolEncoding::encode(
     EncodingSelection<bool>& selection,
     std::span<const bool> values,
@@ -245,11 +249,23 @@ std::string_view SparseBoolEncoding::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
-  const auto sourceRowCount =
-      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
-  NIMBLE_CHECK_LE(offset, sourceRowCount);
-  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  return sliceAndCount(encoded, offset, length, buffer, options).sliced;
+}
+
+std::string_view SparseBoolEncoding::encodeWithSlicedIndices(
+    std::string_view encoded,
+    uint32_t length,
+    std::span<const uint32_t> slicedIndicesWithSentinel,
+    Buffer& buffer,
+    const Encoding::Options& options) {
   NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+  NIMBLE_CHECK(
+      !slicedIndicesWithSentinel.empty(),
+      "SparseBool slice indices must include row-count sentinel.");
+  NIMBLE_CHECK_EQ(
+      slicedIndicesWithSentinel.back(),
+      length,
+      "SparseBool slice sentinel must match slice length.");
 
   const char* readPos = encoded.data() +
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
@@ -258,7 +274,12 @@ std::string_view SparseBoolEncoding::slice(
       readPos, static_cast<size_t>(encoded.end() - readPos)};
 
   const auto serializedIndices =
-      sliceSparseIndices(encodedIndices, offset, length, buffer, options);
+      EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+          encodedIndices,
+          slicedIndicesWithSentinel,
+          buffer,
+          options,
+          "Captured SparseBool index layout");
 
   const auto prefixSize =
       EncodingPrefix::serializedSize(length, options.useVarintRowCount);
@@ -276,6 +297,76 @@ std::string_view SparseBoolEncoding::slice(
   encoding::writeBytes(serializedIndices, pos);
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
+}
+
+SparseBoolEncoding::SliceResult SparseBoolEncoding::sliceAndCount(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  auto* pool = &buffer.getMemoryPool();
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  SparseBoolEncoding source{
+      *pool,
+      encoded,
+      [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+      options};
+  const auto numSkippedSparse = source.skipSparseIndices(offset);
+
+  const auto rowEnd = source.row_ + length;
+  if (source.nextIndex_ >= rowEnd) {
+    const RangeCounts counts = source.sparseValue()
+        ? RangeCounts{
+              .numTrueBeforeRange = numSkippedSparse,
+              .numTrueInRange = 0,
+          }
+        : RangeCounts{
+              .numTrueBeforeRange = offset - numSkippedSparse,
+              .numTrueInRange = length,
+          };
+    const std::array<uint32_t, 1> slicedIndicesWithSentinel{length};
+    return {
+        .sliced = encodeWithSlicedIndices(
+            encoded, length, slicedIndicesWithSentinel, buffer, options),
+        .counts = counts,
+    };
+  }
+
+  const auto maxSlicePositions =
+      std::min<uint32_t>(length, source.indices_.rowCount() - 1);
+  ScopedVector<uint32_t> slicedIndicesWithSentinel{
+      maxSlicePositions + 1, pool, options.bufferPool};
+  slicedIndicesWithSentinel->resize(0);
+  const auto numSparseInSlice =
+      source.materializeSparseIndices(length, *slicedIndicesWithSentinel);
+  slicedIndicesWithSentinel->push_back(length);
+
+  const RangeCounts counts = source.sparseValue()
+      ? RangeCounts{
+            .numTrueBeforeRange = numSkippedSparse,
+            .numTrueInRange = numSparseInSlice,
+        }
+      : RangeCounts{
+            .numTrueBeforeRange = offset - numSkippedSparse,
+            .numTrueInRange = length - numSparseInSlice,
+        };
+  return {
+      .sliced = encodeWithSlicedIndices(
+          encoded,
+          length,
+          std::span<const uint32_t>{
+              slicedIndicesWithSentinel->data(),
+              slicedIndicesWithSentinel->size()},
+          buffer,
+          options),
+      .counts = counts,
+  };
 }
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/velox/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -76,6 +76,51 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   /// Advances rowCount rows and returns how many sparse positions were skipped.
   uint32_t skipSparseIndices(uint32_t rowCount);
 
+  /// True counts before and inside a row range.
+  struct RangeCounts {
+    /// Number of true values before the range offset.
+    uint32_t numTrueBeforeRange{0};
+
+    /// Number of true values inside the range.
+    uint32_t numTrueInRange{0};
+  };
+
+  /// Sliced SparseBool stream plus true counts needed by nested slicers.
+  struct SliceResult {
+    /// Encoded slice covering the requested row range.
+    std::string_view sliced;
+
+    /// True counts before and inside the requested row range.
+    RangeCounts counts;
+  };
+
+  /// Fills true counts before and inside non-empty rows [offset, offset +
+  /// length).
+  static void countTrue(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      velox::memory::MemoryPool* pool,
+      RangeCounts& counts,
+      const Encoding::Options& options = {});
+
+  /// Counts true values in non-empty rows [offset, offset + length).
+  static uint32_t countTrue(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options = {});
+
+  /// Slices rows [offset, offset + length) and counts true values before and
+  /// inside the slice while walking sparse positions once.
+  static SliceResult sliceAndCount(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 
@@ -124,6 +169,15 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   }
 
  private:
+  // Encodes a sliced SparseBool stream from sparse positions relative to the
+  // slice start and with the row-count sentinel appended.
+  static std::string_view encodeWithSlicedIndices(
+      std::string_view encoded,
+      uint32_t length,
+      std::span<const uint32_t> slicedIndicesWithSentinel,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
   // SparseBool stores one byte after the common encoding prefix to indicate
   // whether the sparse indices refer to set bits or unset bits.
   static constexpr int kPrefixSize = sizeof(uint8_t);

--- a/velox/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -20,6 +20,10 @@
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/common/tests/NimbleCompare.h"
+#include "velox/dwio/nimble/encodings/ConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/RLEEncoding.h"
+#include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -460,5 +464,189 @@ TEST(MainlyConstantEncodingV1Test, materializeSparseBoolIsCommon) {
     EXPECT_EQ(
         std::vector<int32_t>(partial.begin(), partial.end()),
         std::vector<int32_t>({7, 40, 7, 7}));
+  }
+}
+
+TEST(MainlyConstantEncodingV1Test, slicesWithSpecializedIsCommonEncodings) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  const auto toBoolVector = [&](std::initializer_list<bool> values) {
+    nimble::Vector<bool> vector{pool.get()};
+    vector.insert(vector.end(), values.begin(), values.end());
+    return vector;
+  };
+  const auto toInt32Vector = [&](const std::vector<int32_t>& values) {
+    nimble::Vector<int32_t> vector{pool.get()};
+    vector.insert(vector.end(), values.data(), values.data() + values.size());
+    return vector;
+  };
+
+  struct TestCase {
+    const char* name;
+    nimble::EncodingType isCommonEncodingType;
+    nimble::Vector<bool> isCommon;
+  };
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+    const std::vector<TestCase> testCases{
+        {
+            .name = "constant",
+            .isCommonEncodingType = nimble::EncodingType::Constant,
+            .isCommon = toBoolVector(
+                {false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false}),
+        },
+        {
+            .name = "rle",
+            .isCommonEncodingType = nimble::EncodingType::RLE,
+            .isCommon = toBoolVector(
+                {true,
+                 true,
+                 false,
+                 false,
+                 true,
+                 false,
+                 false,
+                 true,
+                 true,
+                 false}),
+        },
+        {
+            .name = "sparseBool",
+            .isCommonEncodingType = nimble::EncodingType::SparseBool,
+            .isCommon = toBoolVector(
+                {true,
+                 true,
+                 false,
+                 true,
+                 false,
+                 true,
+                 true,
+                 false,
+                 true,
+                 true}),
+        },
+    };
+
+    for (const auto& testCase : testCases) {
+      SCOPED_TRACE(testCase.name);
+      nimble::Buffer childBuffer{*pool};
+      nimble::Buffer mainlyConstantBuffer{*pool};
+      std::vector<velox::BufferPtr> stringBuffers;
+      const auto stringBufferFactory = [&](uint32_t totalLength) {
+        return stringBuffers
+            .emplace_back(
+                velox::AlignedBuffer::allocate<char>(totalLength, pool.get()))
+            ->template asMutable<void>();
+      };
+
+      std::vector<int32_t> expected;
+      std::vector<int32_t> otherValues;
+      expected.reserve(testCase.isCommon.size());
+      for (uint32_t row{0}; row < testCase.isCommon.size(); ++row) {
+        if (testCase.isCommon[row]) {
+          expected.push_back(7);
+        } else {
+          const auto value = static_cast<int32_t>(100 + row);
+          expected.push_back(value);
+          otherValues.push_back(value);
+        }
+      }
+
+      std::string_view serializedIsCommon;
+      switch (testCase.isCommonEncodingType) {
+        case nimble::EncodingType::Constant:
+          serializedIsCommon =
+              nimble::test::Encoder<nimble::ConstantEncoding<bool>>::encode(
+                  childBuffer,
+                  testCase.isCommon,
+                  nimble::CompressionType::Uncompressed,
+                  options);
+          break;
+        case nimble::EncodingType::RLE:
+          serializedIsCommon =
+              nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+                  childBuffer,
+                  testCase.isCommon,
+                  nimble::CompressionType::Uncompressed,
+                  options);
+          break;
+        case nimble::EncodingType::SparseBool:
+          serializedIsCommon =
+              nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+                  childBuffer,
+                  testCase.isCommon,
+                  nimble::CompressionType::Uncompressed,
+                  options);
+          break;
+        default:
+          NIMBLE_UNREACHABLE("Unexpected isCommon encoding type.");
+      }
+      const auto serializedOtherValues =
+          nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+              childBuffer,
+              toInt32Vector(otherValues),
+              nimble::CompressionType::Uncompressed,
+              options);
+
+      const uint32_t rowCount = testCase.isCommon.size();
+      const uint32_t encodingSize =
+          nimble::EncodingPrefix::serializedSize(rowCount, useVarint) + 8 +
+          serializedIsCommon.size() + serializedOtherValues.size() +
+          sizeof(uint32_t);
+      char* const reserved = mainlyConstantBuffer.reserve(encodingSize);
+      char* pos = reserved;
+      nimble::EncodingPrefix::serialize(
+          nimble::EncodingType::MainlyConstant,
+          nimble::DataType::Int32,
+          rowCount,
+          useVarint,
+          pos);
+      nimble::encoding::writeString(serializedIsCommon, pos);
+      nimble::encoding::writeString(serializedOtherValues, pos);
+      nimble::encoding::write<uint32_t>(7, pos);
+      ASSERT_EQ(pos - reserved, encodingSize);
+
+      for (const auto range :
+           {Range{/*offset=*/0, /*length=*/1},
+            Range{/*offset=*/0, /*length=*/10},
+            Range{/*offset=*/2, /*length=*/4},
+            Range{/*offset=*/5, /*length=*/3},
+            Range{/*offset=*/9, /*length=*/1}}) {
+        SCOPED_TRACE(
+            testing::Message()
+            << "offset=" << range.offset << ", length=" << range.length);
+        nimble::Buffer sliceBuffer{*pool};
+        const auto sliced = nimble::MainlyConstantEncoding<int32_t>::slice(
+            {reserved, encodingSize},
+            range.offset,
+            range.length,
+            sliceBuffer,
+            options);
+        auto slicedEncoding = nimble::EncodingFactory{options}.create(
+            *pool, sliced, stringBufferFactory);
+        nimble::Vector<int32_t> result{pool.get(), range.length};
+        slicedEncoding->materialize(range.length, result.data());
+        EXPECT_EQ(
+            std::vector<int32_t>(result.begin(), result.end()),
+            std::vector<int32_t>(
+                expected.begin() + range.offset,
+                expected.begin() + range.offset + range.length));
+      }
+    }
   }
 }

--- a/velox/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
@@ -420,3 +420,124 @@ TYPED_TEST(RleEncodingTest, invalidSliceRange) {
           options),
       "");
 }
+
+TEST(RleEncodingBoolTest, countTrue) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+  const auto verify = [&](std::initializer_list<bool> input, bool useVarint) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    nimble::Buffer buffer{*pool};
+    nimble::Vector<bool> values{pool.get()};
+    for (const bool value : input) {
+      values.push_back(value);
+    }
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    const auto encoded =
+        nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+            buffer, values, nimble::CompressionType::Uncompressed, options);
+
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/3},
+          Range{/*offset=*/2, /*length=*/5},
+          Range{/*offset=*/4, /*length=*/4},
+          Range{/*offset=*/7, /*length=*/5}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << ", length=" << range.length);
+      nimble::Buffer scratch{*pool};
+      const auto expected = static_cast<uint32_t>(std::count(
+          values.begin() + range.offset,
+          values.begin() + range.offset + range.length,
+          true));
+      EXPECT_EQ(
+          nimble::RLEEncoding<bool>::countTrue(
+              encoded, range.offset, range.length, scratch, options),
+          expected);
+      nimble::RLEEncoding<bool>::RangeCounts counts;
+      nimble::RLEEncoding<bool>::countTrue(
+          encoded, range.offset, range.length, scratch, counts, options);
+
+      EXPECT_EQ(
+          counts.numTrueBeforeRange,
+          std::count(values.begin(), values.begin() + range.offset, true));
+      EXPECT_EQ(counts.numTrueInRange, expected);
+    }
+  };
+
+  for (const bool useVarint : {false, true}) {
+    verify(
+        {true,
+         true,
+         true,
+         false,
+         false,
+         true,
+         true,
+         false,
+         true,
+         true,
+         true,
+         false},
+        useVarint);
+    verify(
+        {true,
+         true,
+         false,
+         false,
+         true,
+         true,
+         false,
+         false,
+         true,
+         true,
+         false,
+         false},
+        useVarint);
+  }
+}
+
+TEST(RleEncodingBoolTest, invalidCountTrueRange) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    nimble::Buffer buffer{*pool};
+    nimble::Vector<bool> values{pool.get()};
+    for (const bool value :
+         {false, false, true, false, true, false, false, true, false, false}) {
+      values.push_back(value);
+    }
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    const auto encoded =
+        nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+            buffer, values, nimble::CompressionType::Uncompressed, options);
+
+    auto expectZeroLengthRange = [&](uint32_t offset) {
+      SCOPED_TRACE(testing::Message() << "offset=" << offset);
+      nimble::Buffer scratch{*pool};
+      NIMBLE_ASSERT_THROW(
+          nimble::RLEEncoding<bool>::countTrue(
+              encoded,
+              offset,
+              /*length=*/0,
+              scratch,
+              options),
+          "Cannot count zero rows.");
+      nimble::RLEEncoding<bool>::RangeCounts counts;
+      NIMBLE_ASSERT_THROW(
+          nimble::RLEEncoding<bool>::countTrue(
+              encoded,
+              offset,
+              /*length=*/0,
+              scratch,
+              counts,
+              options),
+          "Cannot count zero rows.");
+    };
+    expectZeroLengthRange(/*offset=*/0);
+    expectZeroLengthRange(/*offset=*/4);
+  }
+}

--- a/velox/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -25,6 +25,8 @@
 #include "velox/dwio/nimble/encodings/common/EncodingType.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
+#include <algorithm>
+#include <array>
 #include <vector>
 
 using namespace facebook;
@@ -303,6 +305,276 @@ TYPED_TEST(SparseBoolEncodingTest, slice) {
   }
 }
 
+TYPED_TEST(SparseBoolEncodingTest, sliceAndCount) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  struct TestCase {
+    const char* name;
+    nimble::Vector<bool> values;
+  };
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  const std::vector<TestCase> testCases{
+      {
+          .name = "allFalse",
+          .values = this->toVector(
+              {false,
+               false,
+               false,
+               false,
+               false,
+               false,
+               false,
+               false,
+               false,
+               false}),
+      },
+      {
+          .name = "allTrue",
+          .values = this->toVector(
+              {true, true, true, true, true, true, true, true, true, true}),
+      },
+      {
+          .name = "sparseTrue",
+          .values = this->toVector(
+              {false,
+               false,
+               true,
+               false,
+               true,
+               false,
+               false,
+               true,
+               false,
+               false}),
+      },
+      {
+          .name = "sparseFalse",
+          .values = this->toVector(
+              {true, true, false, true, false, true, true, false, true, true}),
+      },
+      {
+          .name = "alternating",
+          .values = this->toVector(
+              {true,
+               false,
+               true,
+               false,
+               true,
+               false,
+               true,
+               false,
+               true,
+               false}),
+      },
+  };
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    const auto& values = testCase.values;
+    const auto encoded =
+        nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+            *this->buffer_,
+            values,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/1},
+          Range{/*offset=*/0, /*length=*/10},
+          Range{/*offset=*/1, /*length=*/3},
+          Range{/*offset=*/2, /*length=*/1},
+          Range{/*offset=*/5, /*length=*/2},
+          Range{/*offset=*/9, /*length=*/1}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << ", length=" << range.length);
+      const auto expectedBefore = static_cast<uint32_t>(
+          std::count(values.begin(), values.begin() + range.offset, true));
+      const auto expected = static_cast<uint32_t>(std::count(
+          values.begin() + range.offset,
+          values.begin() + range.offset + range.length,
+          true));
+
+      nimble::Buffer sliceBuffer{*this->pool_};
+      const auto sliceResult = nimble::SparseBoolEncoding::sliceAndCount(
+          encoded, range.offset, range.length, sliceBuffer, options);
+      EXPECT_EQ(sliceResult.counts.numTrueBeforeRange, expectedBefore);
+      EXPECT_EQ(sliceResult.counts.numTrueInRange, expected);
+
+      nimble::SparseBoolEncoding slicedEncoding{
+          *this->pool_,
+          sliceResult.sliced,
+          [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+          options};
+      EXPECT_EQ(slicedEncoding.rowCount(), range.length);
+      nimble::Vector<bool> result(this->pool_.get(), range.length);
+      slicedEncoding.materialize(range.length, result.data());
+      for (uint32_t i = 0; i < range.length; ++i) {
+        EXPECT_EQ(result[i], values[range.offset + i]) << "index " << i;
+      }
+    }
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, countTrue) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  for (const auto& values :
+       {this->toVector(
+            {false,
+             false,
+             true,
+             false,
+             true,
+             false,
+             false,
+             true,
+             false,
+             false}),
+        this->toVector(
+            {true, true, false, true, false, true, true, false, true, true})}) {
+    const auto encoded =
+        nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+            *this->buffer_,
+            values,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    struct Range {
+      uint32_t offset;
+      uint32_t length;
+    };
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/4},
+          Range{/*offset=*/2, /*length=*/6},
+          Range{/*offset=*/5, /*length=*/2},
+          Range{/*offset=*/7, /*length=*/3}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << ", length=" << range.length);
+      const auto expected = static_cast<uint32_t>(std::count(
+          values.begin() + range.offset,
+          values.begin() + range.offset + range.length,
+          true));
+      const auto expectedBefore = static_cast<uint32_t>(
+          std::count(values.begin(), values.begin() + range.offset, true));
+      EXPECT_EQ(
+          nimble::SparseBoolEncoding::countTrue(
+              encoded, range.offset, range.length, this->pool_.get(), options),
+          expected);
+      nimble::SparseBoolEncoding::RangeCounts counts;
+      nimble::SparseBoolEncoding::countTrue(
+          encoded,
+          range.offset,
+          range.length,
+          this->pool_.get(),
+          counts,
+          options);
+      EXPECT_EQ(counts.numTrueBeforeRange, expectedBefore);
+      EXPECT_EQ(counts.numTrueInRange, expected);
+    }
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, estimateSize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const std::array<bool, 10> sparseTrueValues{
+      false, false, true, false, true, false, false, true, false, false};
+  const auto sparseTrueStats =
+      nimble::Statistics<bool>::create(sparseTrueValues);
+  EXPECT_EQ(
+      nimble::SparseBoolEncoding::estimateSize(
+          sparseTrueValues.size(), sparseTrueStats, options),
+      nimble::SparseBoolEncoding::estimateSize(
+          sparseTrueValues.size(), /*exceptionCount=*/3, options));
+
+  const std::array<bool, 10> sparseFalseValues{
+      true, true, false, true, false, true, true, false, true, true};
+  const auto sparseFalseStats =
+      nimble::Statistics<bool>::create(sparseFalseValues);
+  EXPECT_EQ(
+      nimble::SparseBoolEncoding::estimateSize(
+          sparseFalseValues.size(), sparseFalseStats, options),
+      nimble::SparseBoolEncoding::estimateSize(
+          sparseFalseValues.size(), /*exceptionCount=*/3, options));
+}
+
+TYPED_TEST(SparseBoolEncodingTest, invalidCountTrueRange) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto values = this->toVector(
+      {false, false, true, false, true, false, false, true, false, false});
+  const auto encoded =
+      nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  auto expectZeroLengthRange = [&](uint32_t offset) {
+    SCOPED_TRACE(testing::Message() << "offset=" << offset);
+    NIMBLE_ASSERT_THROW(
+        nimble::SparseBoolEncoding::countTrue(
+            encoded,
+            offset,
+            /*length=*/0,
+            this->pool_.get(),
+            options),
+        "Cannot count zero rows.");
+    nimble::SparseBoolEncoding::RangeCounts counts;
+    NIMBLE_ASSERT_THROW(
+        nimble::SparseBoolEncoding::countTrue(
+            encoded,
+            offset,
+            /*length=*/0,
+            this->pool_.get(),
+            counts,
+            options),
+        "Cannot count zero rows.");
+  };
+  expectZeroLengthRange(/*offset=*/0);
+  expectZeroLengthRange(/*offset=*/4);
+
+  auto expectInvalidRange = [&](uint32_t offset, uint32_t length) {
+    SCOPED_TRACE(
+        testing::Message() << "offset=" << offset << ", length=" << length);
+    NIMBLE_ASSERT_THROW(
+        nimble::SparseBoolEncoding::countTrue(
+            encoded, offset, length, this->pool_.get(), options),
+        "");
+    nimble::SparseBoolEncoding::RangeCounts counts;
+    NIMBLE_ASSERT_THROW(
+        nimble::SparseBoolEncoding::countTrue(
+            encoded, offset, length, this->pool_.get(), counts, options),
+        "");
+  };
+  expectInvalidRange(/*offset=*/11, /*length=*/0);
+  expectInvalidRange(/*offset=*/9, /*length=*/2);
+
+  NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::countTrue(
+          encoded,
+          /*offset=*/0,
+          /*length=*/1,
+          /*pool=*/nullptr,
+          options),
+      "Memory pool cannot be null");
+  nimble::SparseBoolEncoding::RangeCounts counts;
+  NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::countTrue(
+          encoded,
+          /*offset=*/0,
+          /*length=*/1,
+          /*pool=*/nullptr,
+          counts,
+          options),
+      "Memory pool cannot be null");
+}
+
 TYPED_TEST(SparseBoolEncodingTest, invalidSliceRange) {
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
@@ -325,6 +597,14 @@ TYPED_TEST(SparseBoolEncodingTest, invalidSliceRange) {
           options),
       "");
   NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::sliceAndCount(
+          encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "Cannot slice zero rows.");
+  NIMBLE_ASSERT_THROW(
       nimble::SparseBoolEncoding::slice(
           encoded,
           /*offset=*/11,
@@ -333,7 +613,23 @@ TYPED_TEST(SparseBoolEncodingTest, invalidSliceRange) {
           options),
       "");
   NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::sliceAndCount(
+          encoded,
+          /*offset=*/11,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
       nimble::SparseBoolEncoding::slice(
+          encoded,
+          /*offset=*/9,
+          /*length=*/2,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::sliceAndCount(
           encoded,
           /*offset=*/9,
           /*length=*/2,

--- a/velox/dwio/nimble/serializer/StreamSlicer.cpp
+++ b/velox/dwio/nimble/serializer/StreamSlicer.cpp
@@ -23,6 +23,8 @@
 #include "folly/ScopeGuard.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/RLEEncoding.h"
+#include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -449,6 +451,7 @@ void StreamSlicer::sliceType(
         nanosRange = nonNullRange(
             inputStreams[timestamp.microsDescriptor().offset()],
             range,
+            outputBuffer,
             encodingOptions);
       }
       sliceDescriptor(
@@ -476,6 +479,7 @@ void StreamSlicer::sliceType(
         childRange = trueRange(
             inputStreams[row.nullsDescriptor().offset()],
             range,
+            outputBuffer,
             encodingOptions);
       }
       for (size_t i = 0; i < row.childrenCount(); ++i) {
@@ -567,6 +571,7 @@ void StreamSlicer::sliceType(
         mapRange = trueRange(
             inputStreams[flatMap.nullsDescriptor().offset()],
             range,
+            outputBuffer,
             encodingOptions);
       }
       for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
@@ -590,6 +595,7 @@ void StreamSlicer::sliceType(
           valueRange = trueRange(
               inputStreams[inMapDescriptor.offset()],
               mapRange,
+              outputBuffer,
               encodingOptions);
         }
         sliceType(
@@ -634,8 +640,10 @@ void StreamSlicer::sliceDescriptor(
     NIMBLE_CHECK(!sliced.empty(), "Sliced null stream must not be empty");
     outputStreams.requiresNullBarrier |=
         countTrue(
-            sliced, {.offset = 0, .length = range.length}, encodingOptions) <
-        range.length;
+            sliced,
+            {.offset = 0, .length = range.length},
+            outputBuffer,
+            encodingOptions) < range.length;
   }
 }
 
@@ -687,22 +695,79 @@ void StreamSlicer::stripChunkHeaders(
 StreamSlicer::Range StreamSlicer::nonNullRange(
     std::string_view encoded,
     Range range,
+    Buffer& outputBuffer,
     const Encoding::Options& encodingOptions) const {
   return {
       .offset = countNonNull(
-          encoded, {.offset = 0, .length = range.offset}, encodingOptions),
-      .length = countNonNull(encoded, range, encodingOptions),
+          encoded,
+          {.offset = 0, .length = range.offset},
+          outputBuffer,
+          encodingOptions),
+      .length = countNonNull(encoded, range, outputBuffer, encodingOptions),
   };
 }
 
 StreamSlicer::Range StreamSlicer::trueRange(
     std::string_view encoded,
     Range range,
+    Buffer& outputBuffer,
     const Encoding::Options& encodingOptions) const {
+  if (range.length == 0) {
+    return {};
+  }
+  NIMBLE_CHECK_EQ(
+      EncodingPrefix::dataType(encoded),
+      DataType::Bool,
+      "Expected a bool stream");
+  const auto rowCount =
+      EncodingPrefix::readRowCount(encoded, encodingOptions.useVarintRowCount);
+  NIMBLE_CHECK_LE(range.offset, rowCount);
+  NIMBLE_CHECK_LE(range.length, rowCount - range.offset);
+  const auto encodingType = EncodingPrefix::encodingType(encoded);
+  switch (encodingType) {
+    case EncodingType::Constant: {
+      const char* pos = encoded.data() +
+          EncodingPrefix::prefixSize(
+                            encoded, encodingOptions.useVarintRowCount);
+      const bool value = encoding::read<bool>(pos);
+      return {
+          .offset = value ? range.offset : 0,
+          .length = value ? range.length : 0,
+      };
+    }
+    case EncodingType::RLE: {
+      RLEEncoding<bool>::RangeCounts counts;
+      RLEEncoding<bool>::countTrue(
+          encoded,
+          range.offset,
+          range.length,
+          outputBuffer,
+          counts,
+          encodingOptions);
+      return {
+          .offset = counts.numTrueBeforeRange,
+          .length = counts.numTrueInRange,
+      };
+    }
+    case EncodingType::SparseBool: {
+      SparseBoolEncoding::RangeCounts counts;
+      SparseBoolEncoding::countTrue(
+          encoded, range.offset, range.length, pool_, counts, encodingOptions);
+      return {
+          .offset = counts.numTrueBeforeRange,
+          .length = counts.numTrueInRange,
+      };
+    }
+    default:
+      break;
+  }
   return {
       .offset = countTrue(
-          encoded, {.offset = 0, .length = range.offset}, encodingOptions),
-      .length = countTrue(encoded, range, encodingOptions),
+          encoded,
+          {.offset = 0, .length = range.offset},
+          outputBuffer,
+          encodingOptions),
+      .length = countTrue(encoded, range, outputBuffer, encodingOptions),
   };
 }
 
@@ -733,6 +798,7 @@ StreamSlicer::Range StreamSlicer::offsetsRange(
 uint32_t StreamSlicer::countNonNull(
     std::string_view encoded,
     Range range,
+    Buffer& outputBuffer,
     const Encoding::Options& encodingOptions) const {
   if (range.length == 0) {
     return 0;
@@ -745,12 +811,16 @@ uint32_t StreamSlicer::countNonNull(
     return range.length;
   }
   return countTrue(
-      nullableNullsStream(encoded, encodingOptions), range, encodingOptions);
+      nullableNullsStream(encoded, encodingOptions),
+      range,
+      outputBuffer,
+      encodingOptions);
 }
 
 uint32_t StreamSlicer::countTrue(
     std::string_view encoded,
     Range range,
+    Buffer& outputBuffer,
     const Encoding::Options& encodingOptions) const {
   if (range.length == 0) {
     return 0;
@@ -759,10 +829,29 @@ uint32_t StreamSlicer::countTrue(
       EncodingPrefix::dataType(encoded),
       DataType::Bool,
       "Expected a bool stream");
+  const auto rowCount =
+      EncodingPrefix::readRowCount(encoded, encodingOptions.useVarintRowCount);
+  NIMBLE_CHECK_LE(range.offset, rowCount);
+  NIMBLE_CHECK_LE(range.length, rowCount - range.offset);
+  const auto encodingType = EncodingPrefix::encodingType(encoded);
+  switch (encodingType) {
+    case EncodingType::Constant: {
+      const char* pos = encoded.data() +
+          EncodingPrefix::prefixSize(
+                            encoded, encodingOptions.useVarintRowCount);
+      return encoding::read<bool>(pos) ? range.length : 0;
+    }
+    case EncodingType::RLE:
+      return RLEEncoding<bool>::countTrue(
+          encoded, range.offset, range.length, outputBuffer, encodingOptions);
+    case EncodingType::SparseBool:
+      return SparseBoolEncoding::countTrue(
+          encoded, range.offset, range.length, pool_, encodingOptions);
+    default:
+      break;
+  }
 
   auto encoding = createEncoding(encoded, pool_, encodingOptions);
-  NIMBLE_CHECK_LE(range.offset, encoding->rowCount());
-  NIMBLE_CHECK_LE(range.length, encoding->rowCount() - range.offset);
   encoding->skip(range.offset);
   ScopedVector<uint64_t> bits{
       velox::bits::nwords(range.length), pool_, encodingOptions.bufferPool};

--- a/velox/dwio/nimble/serializer/StreamSlicer.h
+++ b/velox/dwio/nimble/serializer/StreamSlicer.h
@@ -182,12 +182,14 @@ class StreamSlicer {
   Range nonNullRange(
       std::string_view encoded,
       Range range,
+      Buffer& outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
   // Maps a boolean stream range to the range covering true positions.
   Range trueRange(
       std::string_view encoded,
       Range range,
+      Buffer& outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
   // Maps an offsets stream range to the child-element range it references.
@@ -200,12 +202,14 @@ class StreamSlicer {
   uint32_t countNonNull(
       std::string_view encoded,
       Range range,
+      Buffer& outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
   // Counts true values in the range.
   uint32_t countTrue(
       std::string_view encoded,
       Range range,
+      Buffer& outputBuffer,
       const Encoding::Options& encodingOptions) const;
 
   const std::shared_ptr<const Type> schema_;

--- a/velox/dwio/nimble/serializer/tests/StreamSlicerTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/StreamSlicerTest.cpp
@@ -320,6 +320,32 @@ class StreamSlicerTest : public ::testing::Test {
     return std::string(encoded);
   }
 
+  std::string encodeBoolStream(
+      EncodingType encodingType,
+      const std::vector<bool>& values,
+      bool useVarintRowCount) {
+    nimble::Vector<bool> nimbleValues{pool_.get()};
+    nimbleValues.reserve(values.size());
+    for (const bool value : values) {
+      nimbleValues.push_back(value);
+    }
+
+    Buffer buffer{*pool_};
+    ManualEncodingSelectionPolicyFactory factory{
+        {{encodingType, 1.0}}, /*compressionOptions=*/std::nullopt};
+    auto policyBase = factory.createPolicy(DataType::Bool);
+    auto policy = std::unique_ptr<EncodingSelectionPolicy<bool>>(
+        static_cast<EncodingSelectionPolicy<bool>*>(policyBase.release()));
+    Encoding::Options options;
+    options.useVarintRowCount = useVarintRowCount;
+    const auto encoded = EncodingFactory::encode<bool>(
+        std::move(policy),
+        std::span<const bool>{nimbleValues.data(), nimbleValues.size()},
+        buffer,
+        options);
+    return std::string(encoded);
+  }
+
   std::string makeTabletPayload(
       uint32_t rowCount,
       uint32_t streamId,
@@ -672,6 +698,101 @@ TEST_P(StreamSlicerRawStreamApiTest, fuzzesRawStreamApi) {
           values.begin() + offset, values.begin() + offset + length};
       EXPECT_EQ(actual, expected);
     }
+  }
+}
+
+TEST_P(StreamSlicerRawStreamApiTest, slicesFlatMapBoolInMapFastPath) {
+  const bool useOutputBuffer = GetParam();
+  auto type = ROW({{"features", MAP(INTEGER(), INTEGER())}});
+  auto input = makeRowVector(
+      {"features"},
+      {makeMapVector(
+          {1, 1},
+          makeFlatVector<int32_t>({10, 10}),
+          makeFlatVector<int32_t>({1, 2}))});
+  auto [_, schema] = serialize(
+      input,
+      type,
+      /*encodingType=*/std::nullopt,
+      /*compressionOptions=*/std::nullopt,
+      /*flatMapColumns=*/{{"features", {}}});
+
+  const auto& flatMap = schema->asRow().childAt(0)->asFlatMap();
+  const auto keyIndex = flatMap.findChild("10");
+  ASSERT_TRUE(keyIndex.has_value());
+  const auto inMapStreamId =
+      flatMap.inMapDescriptorAt(keyIndex.value()).offset();
+  const auto valueStreamId =
+      flatMap.childAt(keyIndex.value())->asScalar().scalarDescriptor().offset();
+  std::vector<std::string_view> inputStreams(
+      std::max(inMapStreamId, valueStreamId) + 1);
+
+  struct Case {
+    EncodingType encodingType;
+    std::vector<bool> inMap;
+    std::vector<int32_t> values;
+    std::vector<bool> expectedInMap;
+    std::vector<int32_t> expectedValues;
+  };
+  const std::vector<Case> cases{
+      {
+          .encodingType = EncodingType::Constant,
+          .inMap = {true, true, true, true, true, true, true, true},
+          .values = {10, 20, 30, 40, 50, 60, 70, 80},
+          .expectedInMap = {true, true, true, true, true},
+          .expectedValues = {30, 40, 50, 60, 70},
+      },
+      {
+          .encodingType = EncodingType::RLE,
+          .inMap = {true, true, false, false, true, true, true, false},
+          .values = {10, 20, 40, 50, 60},
+          .expectedInMap = {false, false, true, true, true},
+          .expectedValues = {40, 50, 60},
+      },
+      {
+          .encodingType = EncodingType::SparseBool,
+          .inMap = {false, true, false, true, false, false, true, false},
+          .values = {11, 33, 66},
+          .expectedInMap = {false, true, false, false, true},
+          .expectedValues = {33, 66},
+      },
+  };
+
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(toString(testCase.encodingType));
+    const auto encodedInMap = encodeBoolStream(
+        testCase.encodingType, testCase.inMap, /*useVarintRowCount=*/true);
+    const auto encodedValues =
+        encodeIntStream(testCase.values, /*useVarintRowCount=*/true);
+    inputStreams[inMapStreamId] = encodedInMap;
+    inputStreams[valueStreamId] = encodedValues;
+
+    StreamSlicer slicer{schema, pool_.get(), StreamSlicer::Options{}};
+    std::optional<Buffer> outputBuffer;
+    if (useOutputBuffer) {
+      outputBuffer.emplace(*pool_, inputStreamBytes(inputStreams));
+    }
+    auto sliced = slicer.slice(
+        inputStreams,
+        /*offset=*/2,
+        /*length=*/5,
+        outputBuffer.has_value() ? &outputBuffer.value() : nullptr);
+
+    Encoding::Options encodingOptions;
+    encodingOptions.useVarintRowCount = true;
+    auto inMapEncoding = EncodingFactory{encodingOptions}.create(
+        *pool_, sliced.streams[inMapStreamId], nullptr);
+    nimble::Vector<bool> actualInMap{pool_.get(), 5};
+    inMapEncoding->materialize(5, actualInMap.data());
+    for (size_t i = 0; i < testCase.expectedInMap.size(); ++i) {
+      EXPECT_EQ(actualInMap[i], testCase.expectedInMap[i]);
+    }
+
+    auto valuesEncoding = EncodingFactory{encodingOptions}.create(
+        *pool_, sliced.streams[valueStreamId], nullptr);
+    std::vector<int32_t> actualValues(testCase.expectedValues.size());
+    valuesEncoding->materialize(actualValues.size(), actualValues.data());
+    EXPECT_EQ(actualValues, testCase.expectedValues);
   }
 }
 


### PR DESCRIPTION
Summary:

Add slice-time fast paths for boolean streams used by StreamSlicer. SparseBool now slices and counts true values in one traversal, RLE handles true counts and constant run-length slices without materializing the whole child stream, and MainlyConstant uses those counts when slicing its is-common child.

Reviewed By: tanjialiang

Differential Revision: D117834624


