### PR TITLE
refactor(nimble): Address review comments on shared string dictionary (#18750)

### DIFF
--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -415,11 +415,19 @@ constexpr bool isStringType() {
   return std::is_same_v<T, std::string_view> || std::is_same_v<T, std::string>;
 }
 
+/// Reports whether the physical type T can be stored in a shared dictionary.
+/// This is the compile-time form, for `if constexpr` branches and
+/// `static_assert`s inside the templated encoding and writer code. The
+/// `DataType` overload below answers the same question at run time, for call
+/// sites that only have a `DataType` value; the two are deliberate
+/// counterparts, not duplicates.
 template <typename T>
 constexpr bool isSharedDictionaryType() {
   return isIntegralType<T>() || std::is_same_v<T, std::string_view>;
 }
 
+/// Run-time counterpart of the templated overload above. Kept in sync with it:
+/// integral types plus strings.
 constexpr bool isSharedDictionaryType(DataType dataType) {
   switch (dataType) {
     case DataType::Int8:

--- a/velox/dwio/nimble/encodings/SharedDictionaryBuilder.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryBuilder.h
@@ -16,8 +16,7 @@
 #pragma once
 
 #include <cstdint>
-#include <deque>
-#include <optional>
+#include <memory>
 #include <span>
 #include <string>
 #include <string_view>
@@ -28,6 +27,7 @@
 #include <fmt/core.h>
 
 #include "absl/container/flat_hash_map.h"
+#include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
@@ -192,6 +192,9 @@ class StreamingSharedDictionaryBuilder final
         scope,
         SharedDictionaryScope::External,
         "Streaming shared dictionary builder cannot use external scope.");
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      stringBuffer_ = std::make_unique<Buffer>(*this->pool());
+    }
   }
 
   Kind kind() const final {
@@ -237,16 +240,19 @@ class StreamingSharedDictionaryBuilder final
   }
 
   void resetImpl() final {
+    // Clear the views before the storage they point into: Buffer::reset()
+    // invalidates every string_view previously handed out.
     alphabet_.clear();
     alphabetIndex_.clear();
-    stringValues_.clear();
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      stringBuffer_->reset();
+    }
   }
 
  private:
   T storeValue(const T& value) {
     if constexpr (std::is_same_v<T, std::string_view>) {
-      stringValues_.emplace_back(value);
-      return stringValues_.back();
+      return stringBuffer_->writeString(value);
     } else {
       return value;
     }
@@ -254,7 +260,14 @@ class StreamingSharedDictionaryBuilder final
 
   Vector<T> alphabet_;
   DictionaryIndexType<T> alphabetIndex_;
-  std::deque<std::string> stringValues_;
+  // Backing storage for the alphabet's string bytes. Both alphabet_ and
+  // alphabetIndex_ hold string_views into it, so it must keep earlier views
+  // valid as it grows; Buffer's chunks never move already-written bytes.
+  // Held by pointer, not by value or optional: Buffer embeds a mutex and its
+  // chunk bookkeeping, and only string alphabets ever need one. Null for
+  // numeric alphabets, which also avoids Buffer allocating its first chunk in
+  // its constructor.
+  std::unique_ptr<Buffer> stringBuffer_;
 };
 
 /// Builder for externally supplied dictionaries.

--- a/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
@@ -865,6 +865,10 @@ std::string_view SharedDictionaryEncoding<T>::encodeMaterializedDictionarySlice(
       Statistics<physicalType>::create(
           std::span<const physicalType>{values.data(), values.size()}),
       std::move(policy)};
+  // TODO: Reuses the Dictionary nested-encoding identifiers. That is
+  // unambiguous today because the shared-dictionary streams are already
+  // distinguishable by their dictionary stream identifiers, but dedicated
+  // EncodingIdentifiers::SharedDictionary entries would be more future proof.
   const auto serializedAlphabet = selection.template encodeNested<physicalType>(
       EncodingIdentifiers::Dictionary::Alphabet,
       std::span<const physicalType>{values.data(), values.size()},

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
@@ -287,7 +287,7 @@ class SharedDictionaryE2ETest : public testing::Test {
 
   static void useSharedDictionarySelectionPolicy(WriterOptions& options) {
     test::configureSharedDictionarySelectionPolicy(
-        options, {.forceDictionaryForSharedTypes = false});
+        options, {.forceDictionaryForEligibleTypes = false});
   }
 
   std::shared_ptr<const ExternalDictionaryResolver> makeExternalResolver(

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<EncodingSelectionPolicyBase> sharedDictionarySelectionPolicy(
     SharedDictionarySelectionPolicyOptions selectionOptions) {
   std::vector<std::pair<EncodingType, float>> readFactors;
   if (isSharedDictionaryType(dataType)) {
-    if (selectionOptions.forceDictionaryForSharedTypes) {
+    if (selectionOptions.forceDictionaryForEligibleTypes) {
       readFactors = {{EncodingType::Dictionary, 1.0}};
     } else {
       readFactors = {

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h
@@ -58,7 +58,7 @@ struct SharedDictionarySelectionPolicyOptions {
   // Force eligible shared-dictionary streams toward Dictionary encoding before
   // shared-dictionary wrapping. Integration tests disable this when they need a
   // mixed direct and shared-dictionary stripe sequence.
-  bool forceDictionaryForSharedTypes{true};
+  bool forceDictionaryForEligibleTypes{true};
 };
 
 /// Installs the shared-dictionary selection policy on writer options.

--- a/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryWriterTest.cpp
@@ -109,6 +109,9 @@ EncodingSelectionPolicyCreator testEncodingSelectionPolicyCreator(
   return
       [valueEncodingReadFactors = std::move(valueEncodingReadFactors)](
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        // TODO: Only Int32, Uint32 and String are given tailored read
+        // factors; the remaining fixed-width types fall through to the shared
+        // default. Extend the pool so they are exercised distinctly too.
         EncodingReadFactors encodingReadFactors;
         switch (dataType) {
           case DataType::Int32:

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -706,7 +706,9 @@ bool isSharedDictionaryScalarKind(ScalarKind scalarKind) {
       scalarKind == ScalarKind::Binary;
 }
 
-bool isSharedDictionaryVeloxType(const velox::Type& type) {
+bool isSharedDictionaryLogicalType(const velox::Type& type) {
+  // Enumerated exhaustively rather than defaulted, so adding a TypeKind is a
+  // compile-time decision about shared-dictionary eligibility.
   switch (type.kind()) {
     case velox::TypeKind::TINYINT:
     case velox::TypeKind::SMALLINT:
@@ -715,9 +717,23 @@ bool isSharedDictionaryVeloxType(const velox::Type& type) {
     case velox::TypeKind::VARCHAR:
     case velox::TypeKind::VARBINARY:
       return true;
-    default:
+    case velox::TypeKind::BOOLEAN:
+    case velox::TypeKind::REAL:
+    case velox::TypeKind::DOUBLE:
+    case velox::TypeKind::TIMESTAMP:
+    case velox::TypeKind::HUGEINT:
+    case velox::TypeKind::ARRAY:
+    case velox::TypeKind::MAP:
+    case velox::TypeKind::ROW:
+    case velox::TypeKind::UNKNOWN:
+    case velox::TypeKind::FUNCTION:
+    case velox::TypeKind::OPAQUE:
+    case velox::TypeKind::INVALID:
       return false;
   }
+  NIMBLE_UNREACHABLE(
+      fmt::format(
+          "Unknown Velox type kind: {}.", static_cast<int>(type.kind())));
 }
 
 template <typename T>
@@ -1403,7 +1419,7 @@ DictionaryConfigs collectDictionaryConfigs(
         "node {}.",
         valueNodeId);
     NIMBLE_USER_CHECK(
-        isSharedDictionaryVeloxType(*valueType.type()),
+        isSharedDictionaryLogicalType(*valueType.type()),
         "Shared dictionary column '{}' must resolve to an integer or string "
         "scalar, array element, or map value, got {}.",
         columnDictionary.fieldPath,


### PR DESCRIPTION
Summary:

Follow-up to D117560358 ("[velox] feat(nimble): Add string shared dictionary encoding"), which landed with review comments still open. This addresses them; no behavior change.

`isSharedDictionaryVeloxType` -> `isSharedDictionaryLogicalType`. Three predicates now answer "is this shared-dictionary eligible?" over three different type systems — `isSharedDictionaryType` over Nimble's `DataType`, `isSharedDictionaryScalarKind` over Nimble's `ScalarKind`, and this one over `velox::Type`. Naming the last one after "Velox" said nothing useful inside Velox; "logical type" is what a `velox::Type` actually is next to Nimble's physical types.

Documented the two `isSharedDictionaryType` overloads in `common/Types.h`. They are not duplicates: the templated form is the compile-time answer, used by ten `if constexpr` and `static_assert` sites in the encoding and writer templates, and the `DataType` form is the run-time answer for call sites that only hold a value. `Writer.cpp` uses both within a few lines of each other, which is exactly what made the pair look accidental. The comments say which is which and that they must stay in sync.

`forceDictionaryForSharedTypes` -> `forceDictionaryForEligibleTypes` in the test selection-policy options, as suggested inline. The flag gates the types that are *eligible* for shared dictionaries, not types that are already shared.

Made `isSharedDictionaryLogicalType`'s switch exhaustive over `velox::TypeKind` instead of defaulting. The rename touches those lines, so the existing `clang-diagnostic-switch-enum` warning there would otherwise have re-fired on this diff. Listing every kind also turns adding a `TypeKind` into a compile-time decision about shared-dictionary eligibility rather than a silent `false`.

Shared-dictionary string storage is now memory tracked. `StreamingSharedDictionaryBuilder` kept the alphabet's string bytes in a `std::deque<std::string>`, which is invisible to the writer's `MemoryPool`. It is now a pool-backed `nimble::Buffer`. The deque was there for reference stability -- `alphabet_` and `alphabetIndex_` both hold `string_view`s into that storage -- and `Buffer` gives the same guarantee, since its chunks never move bytes that were already written. The buffer is held by `std::unique_ptr` and created only for string alphabets. A pointer rather than a value or an `optional` because `Buffer` embeds a mutex and its chunk bookkeeping, so an inline member would grow every numeric builder by the whole object to hold something they never use; it also avoids `Buffer` allocating its first chunk in its constructor.

Two behavioural notes on that swap. `Buffer::reset()` rewinds and keeps its chunks for reuse where `deque::clear()` freed them, so a builder now holds its peak string capacity until destruction instead of returning it per stripe; for a per-stripe reset loop that trades retained-but-tracked memory for fewer allocations. And chunks are at least 1MB (`addChunk` clamps to `kMinChunkSize`), so a small string dictionary now shows 1MB of tracked usage that was previously untracked heap.

Two comments raised future work rather than a change to make now, so they are recorded as TODOs at the code they refer to instead of being lost in the review thread:

- `encodings/SharedDictionaryEncoding.h` reuses `EncodingIdentifiers::Dictionary::Alphabet`/`::Indices` for the nested shared-dictionary encodings. That is unambiguous today because the streams are distinguishable by their dictionary stream identifiers, but dedicated `EncodingIdentifiers::SharedDictionary` entries would be more future proof.
- `SharedDictionaryWriterTest.cpp` gives tailored encoding read factors only to `Int32`, `Uint32` and `String`; the other fixed-width types fall through to the shared default and are not exercised distinctly.

Reviewed By: xiaoxmeng

Differential Revision: D117853961


