### PR TITLE
perf(nimble): Add SliceEncoding for Nimble

### DIFF
--- a/velox/dwio/nimble/common/Types.cpp
+++ b/velox/dwio/nimble/common/Types.cpp
@@ -48,6 +48,7 @@ constexpr auto kEncodingTypes =
         {EncodingType::Huffman, "Huffman"},
         {EncodingType::DeltaBlock, "DeltaBlock"},
         {EncodingType::SharedDictionary, "SharedDictionary"},
+        {EncodingType::Slice, "Slice"},
     });
 
 constexpr auto kReadOnlyEncodingTypes = std::to_array<EncodingType>({

--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -161,6 +161,11 @@ enum class EncodingType {
   // external provider. The alphabet is resolved independently from the
   // encoded index stream.
   SharedDictionary = 22,
+  // A slice of another encoding: carries the source encoding verbatim plus
+  // the row offset at which the slice begins, deferring the slice work to
+  // decode time. Produced only by EncodingSliceFactory, never by encoding
+  // selection.
+  Slice = 23,
 };
 std::string toString(EncodingType encodingType);
 /// Returns the encoding type for 'name'. Throws if 'name' is unknown.

--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(
   SubIntSplitCostModels.h
   SubIntSplitConfig.h
   SparseBoolEncoding.h
+  SliceEncoding.h
   SimdForBitpackEncoding.h
   SharedDictionaryEncoding.h
   SharedDictionaryBuilder.h

--- a/velox/dwio/nimble/encodings/SliceEncoding.h
+++ b/velox/dwio/nimble/encodings/SliceEncoding.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/common/EncodingType.h"
+
+// Represents a slice of another encoding without performing the slice.
+//
+// Slicing an encoding normally means decoding enough of it to find the slice
+// boundaries, slicing every child, and re-serializing. For encodings whose
+// structure does not align with row offsets that is expensive: MainlyConstant
+// has to count how many common values precede the slice before it can locate
+// the corresponding sub-range of its otherValues child, which in the general
+// case means materializing every bool up to the slice end.
+//
+// This encoding skips all of it. It copies the source encoding verbatim and
+// records the row offset the consumer should start at, moving the work to
+// decode time, where the reader is walking the rows anyway. The trade is size:
+// the payload carries the whole source encoding rather than just the slice, so
+// it is only worthwhile where the source is already compact relative to the
+// cost of slicing it.
+
+namespace facebook::nimble {
+
+// Data layout is:
+// Standard Encoding prefix (size varies with Options::useVarintRowCount),
+//     whose row count is the SLICE length, not the inner encoding's row count.
+// 4 bytes: row offset into the inner encoding at which the slice begins.
+// remaining bytes: the inner encoding, verbatim.
+template <typename T>
+class SliceEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  SliceEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory = nullptr,
+      const Encoding::Options& options = {})
+      : TypedEncoding<T, physicalType>(pool, data, options),
+        stringBufferFactory_{std::move(stringBufferFactory)},
+        sliceOffset_{readSliceOffset(data, this->dataOffset())},
+        inner_{readInner(data, this->dataOffset())} {
+    reset();
+  }
+
+  void reset() final {
+    // Recreated rather than reset+skip: an encoding's reset() returns it to row
+    // zero, so the skip would have to be replayed on every reset anyway, and
+    // constructing is what establishes the child's own read state.
+    encoding_ = EncodingFactory{this->options_}.create(
+        *this->pool_, inner_, stringBufferFactory_);
+    if (sliceOffset_ > 0) {
+      encoding_->skip(sliceOffset_);
+    }
+  }
+
+  void skip(uint32_t rowCount) final {
+    encoding_->skip(rowCount);
+  }
+
+  void materialize(uint32_t rowCount, void* buffer) final {
+    encoding_->materialize(rowCount, buffer);
+  }
+
+  void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
+      override {
+    encoding_->materializeBoolsAsBits(rowCount, buffer, begin);
+  }
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(
+      DecoderVisitor& /*visitor*/,
+      ReadWithVisitorParams& /*params*/) {
+    // The selective reader path would need the visitor's row positions
+    // translated by sliceOffset_. Nothing produces this encoding for that path
+    // today -- it is emitted only by EncodingSliceFactory, whose output is
+    // consumed through materialize() -- so fail loudly rather than silently
+    // returning rows from the wrong offset.
+    NIMBLE_UNSUPPORTED(
+        "SliceEncoding does not support the selective reader path.");
+  }
+
+  std::string debugString(int offset) const override {
+    return fmt::format(
+        "{}{}<{}> rowCount={} sliceOffset={}\n{}",
+        std::string(offset, ' '),
+        toString(this->encodingType()),
+        toString(this->dataType()),
+        this->rowCount(),
+        sliceOffset_,
+        encoding_->debugString(offset + 2));
+  }
+
+  /// Wraps `encoded` so that a consumer sees `length` rows starting at
+  /// `offset`, without slicing it. `encoded` is copied into `buffer`.
+  static std::string_view wrap(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options) {
+    const auto prefixSize =
+        EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+    const auto encodingSize = prefixSize + sizeof(uint32_t) + encoded.size();
+    char* reserved = buffer.reserve(encodingSize);
+    char* pos = reserved;
+    EncodingPrefix::serialize(
+        EncodingType::Slice,
+        TypeTraits<T>::dataType,
+        length,
+        options.useVarintRowCount,
+        pos);
+    encoding::writeUint32(offset, pos);
+    std::memcpy(pos, encoded.data(), encoded.size());
+    pos += encoded.size();
+    NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
+ private:
+  // Reads the 4-byte row offset that follows the encoding prefix.
+  static uint32_t readSliceOffset(std::string_view data, uint32_t dataOffset) {
+    const char* pos = data.data() + dataOffset;
+    return encoding::readUint32(pos);
+  }
+
+  // Returns the inner encoding, stored verbatim after the row offset.
+  static std::string_view readInner(
+      std::string_view data,
+      uint32_t dataOffset) {
+    const char* pos = data.data() + dataOffset + sizeof(uint32_t);
+    return {pos, static_cast<size_t>(data.data() + data.size() - pos)};
+  }
+
+  const std::function<void*(uint32_t)> stringBufferFactory_;
+  const uint32_t sliceOffset_;
+  const std::string_view inner_;
+  // The only mutable member: reset() rebuilds the child rather than rewinding
+  // it, so this is reassigned on every reset().
+  std::unique_ptr<Encoding> encoding_;
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -36,6 +36,7 @@
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
 #include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/VarintEncoding.h"
@@ -128,6 +129,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::MainlyConstant: {
       RETURN_ENCODING_BY_NON_BOOL_TYPE(MainlyConstantEncoding, dataType);
+    }
+    case EncodingType::Slice: {
+      RETURN_ENCODING_BY_DATA_TYPE(SliceEncoding, dataType);
     }
     case EncodingType::Prefix: {
       NIMBLE_CHECK_EQ(

--- a/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -201,6 +201,11 @@ EncodingLayout EncodingLayoutCapture::capture(
     case EncodingType::Huffman:
       // Non nested encodings have zero children
       break;
+    case EncodingType::Slice:
+      // The wrapped encoding is carried verbatim rather than as a nested
+      // stream, and the layout tree describes how data is encoded, not how a
+      // slice was deferred. Reported as childless.
+      break;
     case EncodingType::ALP: {
       const char* pos = encoding.data() + prefixSize;
       const auto header = detail::alp::readHeader(pos);

--- a/velox/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(
   DictionaryEncodingViewTest.cpp
   EncodingLayoutTest.cpp
   EncodingSelectionTest.cpp
+  EncodingSliceTest.cpp
   EncodingViewFactoryTest.cpp
   CompressionTest.cpp
   EncodingTest.cpp

--- a/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
@@ -1,0 +1,664 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/encodings/EncodingSliceFactory.h"
+
+#include <algorithm>
+#include <memory>
+#include <random>
+#include <span>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "velox/dwio/nimble/encodings/ConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/DeltaEncoding.h"
+#include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/ForEncoding.h"
+#include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
+#include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/NullableEncoding.h"
+#include "velox/dwio/nimble/encodings/PFOREncoding.h"
+#include "velox/dwio/nimble/encodings/RLEEncoding.h"
+#include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
+#include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "velox/dwio/nimble/encodings/TrivialEncoding.h"
+#include "velox/dwio/nimble/encodings/VarintEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/tests/TestUtils.h"
+
+using namespace facebook;
+
+class EncodingSliceTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ =
+        velox::memory::memoryManager()->addRootPool("EncodingSliceTest");
+    pool_ = rootPool_->addLeafChild("EncodingSliceTestLeaf");
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  nimble::Vector<T> makeVector(std::initializer_list<T> values) {
+    nimble::Vector<T> result{pool_.get()};
+    result.insert(result.end(), values.begin(), values.end());
+    return result;
+  }
+
+  template <typename EncodingType>
+  nimble::Vector<typename EncodingType::cppDataType> makeValuesForEncoding() {
+    using DataType = typename EncodingType::cppDataType;
+    if constexpr (std::is_same_v<
+                      EncodingType,
+                      nimble::ConstantEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7)});
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::MainlyConstantEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(10),
+           static_cast<DataType>(10),
+           static_cast<DataType>(12),
+           static_cast<DataType>(10),
+           static_cast<DataType>(14),
+           static_cast<DataType>(10)});
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::HuffmanEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(10),
+           static_cast<DataType>(11),
+           static_cast<DataType>(10),
+           static_cast<DataType>(12),
+           static_cast<DataType>(10),
+           static_cast<DataType>(13)});
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::ALPEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(1.25),
+           static_cast<DataType>(2.5),
+           static_cast<DataType>(3.75),
+           static_cast<DataType>(4.0),
+           static_cast<DataType>(5.125),
+           static_cast<DataType>(6.25)});
+    } else {
+      return makeVector<DataType>(
+          {static_cast<DataType>(10),
+           static_cast<DataType>(11),
+           static_cast<DataType>(12),
+           static_cast<DataType>(13),
+           static_cast<DataType>(14),
+           static_cast<DataType>(15)});
+    }
+  }
+
+  template <typename EncodingType>
+  nimble::Vector<typename EncodingType::cppDataType>
+  makeRandomValuesForEncoding(std::mt19937& rng, uint32_t rowCount) {
+    using DataType = typename EncodingType::cppDataType;
+    nimble::Vector<DataType> values{pool_.get()};
+    values.reserve(rowCount);
+
+    const auto nextIntegerValue = [&] {
+      return static_cast<DataType>(
+          std::uniform_int_distribution<uint32_t>{0, 1024}(rng));
+    };
+
+    if constexpr (std::is_same_v<
+                      EncodingType,
+                      nimble::ConstantEncoding<DataType>>) {
+      const auto value = nextIntegerValue();
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(value);
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::MainlyConstantEncoding<DataType>>) {
+      const auto commonValue = nextIntegerValue();
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(i % 5 == 2 ? nextIntegerValue() : commonValue);
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::HuffmanEncoding<DataType>>) {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(
+            static_cast<DataType>(
+                std::uniform_int_distribution<uint32_t>{0, 7}(rng)));
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::PFOREncoding<DataType>>) {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(
+            static_cast<DataType>(
+                std::uniform_int_distribution<uint32_t>{0, 15}(rng)));
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::ALPEncoding<DataType>>) {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(
+            static_cast<DataType>(
+                std::uniform_int_distribution<uint32_t>{0, 4096}(rng) / 4.0));
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::RLEEncoding<DataType>>) {
+      while (values.size() < rowCount) {
+        const auto value = nextIntegerValue();
+        const auto runLength =
+            std::uniform_int_distribution<uint32_t>{1, 8}(rng);
+        for (uint32_t i = 0; i < runLength && values.size() < rowCount; ++i) {
+          values.push_back(value);
+        }
+      }
+    } else {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(nextIntegerValue());
+      }
+    }
+
+    return values;
+  }
+
+  std::unique_ptr<nimble::Encoding> createEncoding(std::string_view encoded) {
+    return nimble::EncodingFactory{}.create(
+        *pool_, encoded, [&](uint32_t totalLength) {
+          auto& buffer = stringBuffers_.emplace_back(
+              velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+          return buffer->asMutable<void>();
+        });
+  }
+
+  std::string_view
+  slice(std::string_view encoded, uint32_t offset, uint32_t length) {
+    return nimble::EncodingFactory::slice(
+        encoded, offset, length, *buffer_, nimble::Encoding::Options{});
+  }
+
+  template <typename T>
+  std::vector<T>
+  stdVector(const nimble::Vector<T>& values, uint32_t offset, uint32_t length) {
+    return std::vector<T>(
+        values.begin() + offset, values.begin() + offset + length);
+  }
+
+  template <typename EncodingType, typename T>
+  void expectSliceMaterializes(
+      std::string_view name,
+      nimble::EncodingType expectedEncodingType,
+      const nimble::Vector<T>& values,
+      uint32_t offset,
+      uint32_t length) {
+    SCOPED_TRACE(name);
+    const auto encoded =
+        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
+
+    const auto sliced = slice(encoded, offset, length);
+    EXPECT_NE(sliced.data(), encoded.data());
+
+    auto encoding = createEncoding(sliced);
+
+    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), length);
+
+    nimble::Vector<T> output{pool_.get(), length};
+    encoding->materialize(length, output.data());
+
+    EXPECT_EQ(
+        std::vector<T>(output.begin(), output.end()),
+        stdVector(values, offset, length));
+  }
+
+  template <typename EncodingType, typename T>
+  void expectFactorySliceMaterializes(
+      const nimble::Vector<T>& values,
+      uint32_t offset,
+      uint32_t length) {
+    const auto encoded =
+        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
+    const auto sliced = slice(encoded, offset, length);
+    auto encoding = createEncoding(sliced);
+
+    auto expectedEncodingType =
+        nimble::test::Encoder<EncodingType>::encodingType();
+    if constexpr (std::is_same_v<
+                      EncodingType,
+                      nimble::MainlyConstantEncoding<T>>) {
+      const auto fullRange = offset == 0 && length == values.size();
+      bool onlyCommonRows{true};
+      for (uint32_t row = offset; row < offset + length; ++row) {
+        onlyCommonRows &= row % 5 != 2;
+      }
+      if (!fullRange && onlyCommonRows) {
+        expectedEncodingType = nimble::EncodingType::Constant;
+      }
+    }
+
+    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), length);
+
+    nimble::Vector<T> output{pool_.get(), length};
+    encoding->materialize(length, output.data());
+
+    EXPECT_EQ(
+        std::vector<T>(output.begin(), output.end()),
+        stdVector(values, offset, length));
+  }
+
+  template <typename EncodingType>
+  void expectBoolSliceMaterializes(
+      std::string_view name,
+      nimble::EncodingType expectedEncodingType,
+      const nimble::Vector<bool>& values,
+      uint32_t offset,
+      uint32_t length) {
+    SCOPED_TRACE(name);
+    const auto encoded =
+        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
+
+    const auto sliced = slice(encoded, offset, length);
+    EXPECT_NE(sliced.data(), encoded.data());
+
+    auto encoding = createEncoding(sliced);
+
+    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
+    EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+    EXPECT_EQ(encoding->rowCount(), length);
+
+    nimble::Vector<bool> output{pool_.get(), length};
+    encoding->materialize(length, output.data());
+
+    EXPECT_EQ(
+        std::vector<bool>(output.begin(), output.end()),
+        stdVector(values, offset, length));
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+template <typename Encoding>
+struct EncodingSliceConfig {
+  using EncodingType = Encoding;
+};
+
+using EncodingSliceTypes = ::testing::Types<
+    EncodingSliceConfig<nimble::TrivialEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::DictionaryEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::FixedBitWidthEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::VarintEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::RLEEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::ConstantEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::MainlyConstantEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::DeltaEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::BlockBitPackingEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::PFOREncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::SimdForBitpackEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::HuffmanEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::ForEncoding<uint32_t>>,
+    EncodingSliceConfig<nimble::ALPEncoding<double>>>;
+
+template <typename Config>
+class EncodingSliceTypedTest : public EncodingSliceTest {};
+
+TYPED_TEST_CASE(EncodingSliceTypedTest, EncodingSliceTypes);
+
+TYPED_TEST(EncodingSliceTypedTest, materializesRange) {
+  using EncodingType = typename TypeParam::EncodingType;
+  const auto values = this->template makeValuesForEncoding<EncodingType>();
+  constexpr uint32_t offset{1};
+  constexpr uint32_t length{3};
+
+  this->template expectSliceMaterializes<EncodingType>(
+      nimble::toString(nimble::test::Encoder<EncodingType>::encodingType()),
+      nimble::test::Encoder<EncodingType>::encodingType(),
+      values,
+      offset,
+      length);
+}
+
+TYPED_TEST(EncodingSliceTypedTest, rejectsZeroLengthRange) {
+  using EncodingType = typename TypeParam::EncodingType;
+  const auto values = this->template makeValuesForEncoding<EncodingType>();
+  const auto encoded =
+      nimble::test::Encoder<EncodingType>::encode(*this->buffer_, values);
+
+  NIMBLE_ASSERT_THROW(this->slice(encoded, /*offset=*/0, /*length=*/0), "");
+}
+
+TEST_F(EncodingSliceTest, dictionaryRejectsZeroLengthRange) {
+  const auto values = makeVector<uint32_t>({10, 11, 10, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::DictionaryEncoding<uint32_t>>::encode(
+          *buffer_, values);
+
+  NIMBLE_ASSERT_THROW(
+      slice(encoded, /*offset=*/1, /*length=*/0), "Cannot slice zero rows.");
+}
+
+TYPED_TEST(EncodingSliceTypedTest, materializesRandomRanges) {
+  using EncodingType = typename TypeParam::EncodingType;
+  constexpr uint32_t kIterations{64};
+  std::mt19937 rng{
+      0x5eed0000u +
+      static_cast<uint32_t>(
+          nimble::test::Encoder<EncodingType>::encodingType())};
+
+  for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
+    SCOPED_TRACE(testing::Message() << "iteration=" << iteration);
+    constexpr bool kRequiresAtLeastTwoRows = std::is_same_v<
+        EncodingType,
+        nimble::HuffmanEncoding<typename EncodingType::cppDataType>>;
+    const auto rowCount = std::uniform_int_distribution<uint32_t>{
+        kRequiresAtLeastTwoRows ? 2U : 1U, 128}(rng);
+    const auto values =
+        this->template makeRandomValuesForEncoding<EncodingType>(rng, rowCount);
+    const auto offset = std::uniform_int_distribution<uint32_t>{
+        0, rowCount - (kRequiresAtLeastTwoRows ? 2U : 1U)}(rng);
+    const auto length = std::uniform_int_distribution<uint32_t>{
+        kRequiresAtLeastTwoRows ? 2U : 1U, rowCount - offset}(rng);
+
+    SCOPED_TRACE(
+        testing::Message() << "rowCount=" << rowCount << ", offset=" << offset
+                           << ", length=" << length);
+    this->template expectFactorySliceMaterializes<EncodingType>(
+        values, offset, length);
+  }
+}
+
+TEST_F(EncodingSliceTest, materializesNumericRange) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<int32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<int32_t> expected{12, 13, 14};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, fullRangeCopiesToOutputBuffer) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/0, /*length=*/4);
+
+  EXPECT_NE(sliced.data(), encoded.data());
+  EXPECT_EQ(sliced, encoded);
+}
+
+TEST_F(EncodingSliceTest, materializesAfterSkip) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/4);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+  encoding->skip(2);
+
+  nimble::Vector<int32_t> output{pool_.get(), 2};
+  encoding->materialize(2, output.data());
+
+  const std::vector<int32_t> expected{13, 14};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, materializesStringRange) {
+  const auto values =
+      makeVector<std::string_view>({"alpha", "beta", "gamma", "delta"});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<std::string_view>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/2);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  EXPECT_NE(sliced.find("beta"), std::string_view::npos);
+  EXPECT_NE(sliced.find("gamma"), std::string_view::npos);
+  EXPECT_EQ(sliced.find("alpha"), std::string_view::npos);
+  EXPECT_EQ(sliced.find("delta"), std::string_view::npos);
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::String);
+  EXPECT_EQ(encoding->rowCount(), 2);
+
+  nimble::Vector<std::string_view> output{pool_.get(), 2};
+  encoding->materialize(2, output.data());
+
+  const std::vector<std::string_view> expected{"beta", "gamma"};
+  EXPECT_EQ(
+      std::vector<std::string_view>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, materializesBoolBits) {
+  const auto values = makeVector<bool>({true, false, true, true, false});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<bool>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  uint64_t bits{0};
+  encoding->materializeBoolsAsBits(/*rowCount=*/3, &bits, /*begin=*/0);
+
+  EXPECT_FALSE(velox::bits::isBitSet(&bits, 0));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
+}
+
+TEST_F(EncodingSliceTest, materializesConstantRangeWithoutWrapper) {
+  const auto values = makeVector<int32_t>({7, 7, 7, 7, 7});
+  const auto encoded =
+      nimble::test::Encoder<nimble::ConstantEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/2);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Constant);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 2);
+
+  nimble::Vector<int32_t> output{pool_.get(), 2};
+  encoding->materialize(2, output.data());
+
+  const std::vector<int32_t> expected{7, 7};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, materializesRleRangeWithoutWrapper) {
+  const auto values = makeVector<int32_t>({10, 10, 11, 11, 11, 12, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/5);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::RLE);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 5);
+
+  nimble::Vector<int32_t> output{pool_.get(), 5};
+  encoding->materialize(5, output.data());
+
+  const std::vector<int32_t> expected{10, 11, 11, 11, 12};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, materializesRleBoolRangeWithoutWrapper) {
+  const auto values = makeVector<bool>({false, false, true, true, true, false});
+  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+      *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::RLE);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  uint64_t bits{0};
+  encoding->materializeBoolsAsBits(/*rowCount=*/3, &bits, /*begin=*/0);
+
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 0));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
+}
+
+TEST_F(EncodingSliceTest, materializesFixedBitWidthRangeWithoutWrapper) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14});
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::FixedBitWidth);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<int32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<int32_t> expected{11, 12, 13};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, materializesCompressedTrivialRangeWithoutWrapper) {
+  nimble::Vector<uint32_t> values{pool_.get()};
+  values.resize(1024);
+  std::fill(values.begin(), values.end(), 42);
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Zstd);
+
+  const auto sliced = slice(encoded, /*offset=*/128, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Uint32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<uint32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<uint32_t> expected{42, 42, 42};
+  EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, materializesNativeSliceForBoolEncoding) {
+  expectBoolSliceMaterializes<nimble::SparseBoolEncoding>(
+      "SparseBool",
+      nimble::EncodingType::SparseBool,
+      makeVector<bool>({false, true, false, false, true, false}),
+      /*offset=*/1,
+      /*length=*/3);
+}
+
+TEST_F(EncodingSliceTest, materializesNativeSliceForNullableEncoding) {
+  const auto values = makeVector<uint32_t>({10, 11, 12, 13, 14, 15});
+  const auto nulls = makeVector<bool>({true, true, true, true, true, true});
+  const auto encoded =
+      nimble::test::Encoder<nimble::NullableEncoding<uint32_t>>::encodeNullable(
+          *buffer_, values, nulls);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Nullable);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Uint32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<uint32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<uint32_t> expected{12, 13, 14};
+  EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(EncodingSliceTest, rejectsOutOfRangeSlice) {
+  const auto values = makeVector<int32_t>({10, 11, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  NIMBLE_ASSERT_THROW(slice(encoded, /*offset=*/2, /*length=*/2), "");
+}

--- a/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -14,39 +14,19 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/nimble/encodings/EncodingSliceFactory.h"
-
-#include <algorithm>
-#include <memory>
-#include <random>
-#include <span>
-#include <string_view>
-#include <type_traits>
-#include <vector>
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
 
 #include <gtest/gtest.h>
+
+#include <vector>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Vector.h"
-#include "velox/dwio/nimble/common/tests/GTestUtils.h"
-#include "velox/dwio/nimble/encodings/ALPEncoding.h"
-#include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
-#include "velox/dwio/nimble/encodings/ConstantEncoding.h"
-#include "velox/dwio/nimble/encodings/DeltaEncoding.h"
-#include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
-#include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "velox/dwio/nimble/encodings/ForEncoding.h"
-#include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
-#include "velox/dwio/nimble/encodings/NullableEncoding.h"
-#include "velox/dwio/nimble/encodings/PFOREncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
-#include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
-#include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
-#include "velox/dwio/nimble/encodings/VarintEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
@@ -72,593 +52,171 @@ class SliceEncodingTest : public ::testing::Test {
     return result;
   }
 
-  template <typename EncodingType>
-  nimble::Vector<typename EncodingType::cppDataType> makeValuesForEncoding() {
-    using DataType = typename EncodingType::cppDataType;
-    if constexpr (std::is_same_v<
-                      EncodingType,
-                      nimble::ConstantEncoding<DataType>>) {
-      return makeVector<DataType>(
-          {static_cast<DataType>(7),
-           static_cast<DataType>(7),
-           static_cast<DataType>(7),
-           static_cast<DataType>(7),
-           static_cast<DataType>(7),
-           static_cast<DataType>(7)});
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::MainlyConstantEncoding<DataType>>) {
-      return makeVector<DataType>(
-          {static_cast<DataType>(10),
-           static_cast<DataType>(10),
-           static_cast<DataType>(12),
-           static_cast<DataType>(10),
-           static_cast<DataType>(14),
-           static_cast<DataType>(10)});
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::HuffmanEncoding<DataType>>) {
-      return makeVector<DataType>(
-          {static_cast<DataType>(10),
-           static_cast<DataType>(11),
-           static_cast<DataType>(10),
-           static_cast<DataType>(12),
-           static_cast<DataType>(10),
-           static_cast<DataType>(13)});
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::ALPEncoding<DataType>>) {
-      return makeVector<DataType>(
-          {static_cast<DataType>(1.25),
-           static_cast<DataType>(2.5),
-           static_cast<DataType>(3.75),
-           static_cast<DataType>(4.0),
-           static_cast<DataType>(5.125),
-           static_cast<DataType>(6.25)});
-    } else {
-      return makeVector<DataType>(
-          {static_cast<DataType>(10),
-           static_cast<DataType>(11),
-           static_cast<DataType>(12),
-           static_cast<DataType>(13),
-           static_cast<DataType>(14),
-           static_cast<DataType>(15)});
-    }
-  }
-
-  template <typename EncodingType>
-  nimble::Vector<typename EncodingType::cppDataType>
-  makeRandomValuesForEncoding(std::mt19937& rng, uint32_t rowCount) {
-    using DataType = typename EncodingType::cppDataType;
-    nimble::Vector<DataType> values{pool_.get()};
-    values.reserve(rowCount);
-
-    const auto nextIntegerValue = [&] {
-      return static_cast<DataType>(
-          std::uniform_int_distribution<uint32_t>{0, 1024}(rng));
-    };
-
-    if constexpr (std::is_same_v<
-                      EncodingType,
-                      nimble::ConstantEncoding<DataType>>) {
-      const auto value = nextIntegerValue();
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        values.push_back(value);
-      }
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::MainlyConstantEncoding<DataType>>) {
-      const auto commonValue = nextIntegerValue();
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        values.push_back(i % 5 == 2 ? nextIntegerValue() : commonValue);
-      }
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::HuffmanEncoding<DataType>>) {
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        values.push_back(
-            static_cast<DataType>(
-                std::uniform_int_distribution<uint32_t>{0, 7}(rng)));
-      }
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::PFOREncoding<DataType>>) {
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        values.push_back(
-            static_cast<DataType>(
-                std::uniform_int_distribution<uint32_t>{0, 15}(rng)));
-      }
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::ALPEncoding<DataType>>) {
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        values.push_back(
-            static_cast<DataType>(
-                std::uniform_int_distribution<uint32_t>{0, 4096}(rng) / 4.0));
-      }
-    } else if constexpr (std::is_same_v<
-                             EncodingType,
-                             nimble::RLEEncoding<DataType>>) {
-      while (values.size() < rowCount) {
-        const auto value = nextIntegerValue();
-        const auto runLength =
-            std::uniform_int_distribution<uint32_t>{1, 8}(rng);
-        for (uint32_t i = 0; i < runLength && values.size() < rowCount; ++i) {
-          values.push_back(value);
-        }
-      }
-    } else {
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        values.push_back(nextIntegerValue());
-      }
-    }
-
-    return values;
-  }
-
   std::unique_ptr<nimble::Encoding> createEncoding(std::string_view encoded) {
     return nimble::EncodingFactory{}.create(
-        *pool_, encoded, [&](uint32_t totalLength) {
-          auto& buffer = stringBuffers_.emplace_back(
-              velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
-          return buffer->asMutable<void>();
+        *pool_, encoded, [](uint32_t /*totalLength*/) -> void* {
+          return nullptr;
         });
   }
 
-  std::string_view
-  slice(std::string_view encoded, uint32_t offset, uint32_t length) {
-    return nimble::EncodingFactory::slice(
-        encoded, offset, length, *buffer_, nimble::Encoding::Options{});
-  }
-
   template <typename T>
-  std::vector<T>
-  stdVector(const nimble::Vector<T>& values, uint32_t offset, uint32_t length) {
-    return std::vector<T>(
-        values.begin() + offset, values.begin() + offset + length);
-  }
-
-  template <typename EncodingType, typename T>
-  void expectSliceMaterializes(
-      std::string_view name,
-      nimble::EncodingType expectedEncodingType,
-      const nimble::Vector<T>& values,
-      uint32_t offset,
-      uint32_t length) {
-    SCOPED_TRACE(name);
-    const auto encoded =
-        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
-
-    const auto sliced = slice(encoded, offset, length);
-    EXPECT_NE(sliced.data(), encoded.data());
-
-    auto encoding = createEncoding(sliced);
-
-    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
-    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
-    EXPECT_EQ(encoding->rowCount(), length);
-
-    nimble::Vector<T> output{pool_.get(), length};
-    encoding->materialize(length, output.data());
-
-    EXPECT_EQ(
-        std::vector<T>(output.begin(), output.end()),
-        stdVector(values, offset, length));
-  }
-
-  template <typename EncodingType, typename T>
-  void expectFactorySliceMaterializes(
-      const nimble::Vector<T>& values,
-      uint32_t offset,
-      uint32_t length) {
-    const auto encoded =
-        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
-    const auto sliced = slice(encoded, offset, length);
-    auto encoding = createEncoding(sliced);
-
-    auto expectedEncodingType =
-        nimble::test::Encoder<EncodingType>::encodingType();
-    if constexpr (std::is_same_v<
-                      EncodingType,
-                      nimble::MainlyConstantEncoding<T>>) {
-      const auto fullRange = offset == 0 && length == values.size();
-      bool onlyCommonRows{true};
-      for (uint32_t row = offset; row < offset + length; ++row) {
-        onlyCommonRows &= row % 5 != 2;
-      }
-      if (!fullRange && onlyCommonRows) {
-        expectedEncodingType = nimble::EncodingType::Constant;
-      }
-    }
-
-    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
-    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
-    EXPECT_EQ(encoding->rowCount(), length);
-
-    nimble::Vector<T> output{pool_.get(), length};
-    encoding->materialize(length, output.data());
-
-    EXPECT_EQ(
-        std::vector<T>(output.begin(), output.end()),
-        stdVector(values, offset, length));
-  }
-
-  template <typename EncodingType>
-  void expectBoolSliceMaterializes(
-      std::string_view name,
-      nimble::EncodingType expectedEncodingType,
-      const nimble::Vector<bool>& values,
-      uint32_t offset,
-      uint32_t length) {
-    SCOPED_TRACE(name);
-    const auto encoded =
-        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
-
-    const auto sliced = slice(encoded, offset, length);
-    EXPECT_NE(sliced.data(), encoded.data());
-
-    auto encoding = createEncoding(sliced);
-
-    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
-    EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
-    EXPECT_EQ(encoding->rowCount(), length);
-
-    nimble::Vector<bool> output{pool_.get(), length};
-    encoding->materialize(length, output.data());
-
-    EXPECT_EQ(
-        std::vector<bool>(output.begin(), output.end()),
-        stdVector(values, offset, length));
+  std::vector<T> materialize(nimble::Encoding& encoding, uint32_t rowCount) {
+    nimble::Vector<T> output{pool_.get(), rowCount};
+    encoding.materialize(rowCount, output.data());
+    return std::vector<T>(output.begin(), output.end());
   }
 
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<nimble::Buffer> buffer_;
-  std::vector<velox::BufferPtr> stringBuffers_;
 };
 
-template <typename Encoding>
-struct SliceEncodingConfig {
-  using EncodingType = Encoding;
-};
-
-using SliceEncodingTypes = ::testing::Types<
-    SliceEncodingConfig<nimble::TrivialEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::DictionaryEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::FixedBitWidthEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::VarintEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::RLEEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::ConstantEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::MainlyConstantEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::DeltaEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::BlockBitPackingEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::PFOREncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::SimdForBitpackEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::HuffmanEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::ForEncoding<uint32_t>>,
-    SliceEncodingConfig<nimble::ALPEncoding<double>>>;
-
-template <typename Config>
-class SliceEncodingTypedTest : public SliceEncodingTest {};
-
-TYPED_TEST_CASE(SliceEncodingTypedTest, SliceEncodingTypes);
-
-TYPED_TEST(SliceEncodingTypedTest, materializesRange) {
-  using EncodingType = typename TypeParam::EncodingType;
-  const auto values = this->template makeValuesForEncoding<EncodingType>();
-  constexpr uint32_t offset{1};
-  constexpr uint32_t length{3};
-
-  this->template expectSliceMaterializes<EncodingType>(
-      nimble::toString(nimble::test::Encoder<EncodingType>::encodingType()),
-      nimble::test::Encoder<EncodingType>::encodingType(),
-      values,
-      offset,
-      length);
-}
-
-TYPED_TEST(SliceEncodingTypedTest, rejectsZeroLengthRange) {
-  using EncodingType = typename TypeParam::EncodingType;
-  const auto values = this->template makeValuesForEncoding<EncodingType>();
+TEST_F(SliceEncodingTest, wrapsWithoutSlicing) {
+  const auto values = makeVector<int32_t>({10, 10, 12, 10, 14, 10});
   const auto encoded =
-      nimble::test::Encoder<EncodingType>::encode(*this->buffer_, values);
-
-  NIMBLE_ASSERT_THROW(this->slice(encoded, /*offset=*/0, /*length=*/0), "");
-}
-
-TEST_F(SliceEncodingTest, dictionaryRejectsZeroLengthRange) {
-  const auto values = makeVector<uint32_t>({10, 11, 10, 12});
-  const auto encoded =
-      nimble::test::Encoder<nimble::DictionaryEncoding<uint32_t>>::encode(
+      nimble::test::Encoder<nimble::MainlyConstantEncoding<int32_t>>::encode(
           *buffer_, values);
 
-  NIMBLE_ASSERT_THROW(
-      slice(encoded, /*offset=*/1, /*length=*/0), "Cannot slice zero rows.");
-}
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/4, *buffer_, {});
 
-TYPED_TEST(SliceEncodingTypedTest, materializesRandomRanges) {
-  using EncodingType = typename TypeParam::EncodingType;
-  constexpr uint32_t kIterations{64};
-  std::mt19937 rng{
-      0x5eed0000u +
-      static_cast<uint32_t>(
-          nimble::test::Encoder<EncodingType>::encodingType())};
+  // The payload still carries every source row, so it is larger than the
+  // source rather than smaller: the slice was recorded, not performed.
+  EXPECT_GT(wrapped.size(), encoded.size());
 
-  for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
-    SCOPED_TRACE(testing::Message() << "iteration=" << iteration);
-    constexpr bool kRequiresAtLeastTwoRows = std::is_same_v<
-        EncodingType,
-        nimble::HuffmanEncoding<typename EncodingType::cppDataType>>;
-    const auto rowCount = std::uniform_int_distribution<uint32_t>{
-        kRequiresAtLeastTwoRows ? 2U : 1U, 128}(rng);
-    const auto values =
-        this->template makeRandomValuesForEncoding<EncodingType>(rng, rowCount);
-    const auto offset = std::uniform_int_distribution<uint32_t>{
-        0, rowCount - (kRequiresAtLeastTwoRows ? 2U : 1U)}(rng);
-    const auto length = std::uniform_int_distribution<uint32_t>{
-        kRequiresAtLeastTwoRows ? 2U : 1U, rowCount - offset}(rng);
-
-    SCOPED_TRACE(
-        testing::Message() << "rowCount=" << rowCount << ", offset=" << offset
-                           << ", length=" << length);
-    this->template expectFactorySliceMaterializes<EncodingType>(
-        values, offset, length);
-  }
-}
-
-TEST_F(SliceEncodingTest, materializesNumericRange) {
-  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
-  const auto encoded =
-      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
-          *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
-  EXPECT_NE(sliced.data(), encoded.data());
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Slice);
   EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
-  EXPECT_EQ(encoding->rowCount(), 3);
+  // The row count is the slice length, not the source's.
+  EXPECT_EQ(encoding->rowCount(), 4);
 
-  nimble::Vector<int32_t> output{pool_.get(), 3};
-  encoding->materialize(3, output.data());
-
-  const std::vector<int32_t> expected{12, 13, 14};
-  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+  const std::vector<int32_t> expected{10, 12, 10, 14};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected);
 }
 
-TEST_F(SliceEncodingTest, fullRangeCopiesToOutputBuffer) {
-  const auto values = makeVector<int32_t>({10, 11, 12, 13});
-  const auto encoded =
-      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
-          *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/0, /*length=*/4);
-
-  EXPECT_NE(sliced.data(), encoded.data());
-  EXPECT_EQ(sliced, encoded);
-}
-
-TEST_F(SliceEncodingTest, materializesAfterSkip) {
-  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
-  const auto encoded =
-      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
-          *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/4);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  auto encoding = createEncoding(sliced);
-  encoding->skip(2);
-
-  nimble::Vector<int32_t> output{pool_.get(), 2};
-  encoding->materialize(2, output.data());
-
-  const std::vector<int32_t> expected{13, 14};
-  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
-}
-
-TEST_F(SliceEncodingTest, materializesStringRange) {
-  const auto values =
-      makeVector<std::string_view>({"alpha", "beta", "gamma", "delta"});
-  const auto encoded =
-      nimble::test::Encoder<nimble::TrivialEncoding<std::string_view>>::encode(
-          *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/2);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  EXPECT_NE(sliced.find("beta"), std::string_view::npos);
-  EXPECT_NE(sliced.find("gamma"), std::string_view::npos);
-  EXPECT_EQ(sliced.find("alpha"), std::string_view::npos);
-  EXPECT_EQ(sliced.find("delta"), std::string_view::npos);
-
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::String);
-  EXPECT_EQ(encoding->rowCount(), 2);
-
-  nimble::Vector<std::string_view> output{pool_.get(), 2};
-  encoding->materialize(2, output.data());
-
-  const std::vector<std::string_view> expected{"beta", "gamma"};
-  EXPECT_EQ(
-      std::vector<std::string_view>(output.begin(), output.end()), expected);
-}
-
-TEST_F(SliceEncodingTest, materializesBoolBits) {
-  const auto values = makeVector<bool>({true, false, true, true, false});
-  const auto encoded =
-      nimble::test::Encoder<nimble::TrivialEncoding<bool>>::encode(
-          *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/3);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
-  EXPECT_EQ(encoding->rowCount(), 3);
-
-  uint64_t bits{0};
-  encoding->materializeBoolsAsBits(/*rowCount=*/3, &bits, /*begin=*/0);
-
-  EXPECT_FALSE(velox::bits::isBitSet(&bits, 0));
-  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
-  EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
-}
-
-TEST_F(SliceEncodingTest, materializesConstantRangeWithoutWrapper) {
-  const auto values = makeVector<int32_t>({7, 7, 7, 7, 7});
-  const auto encoded =
-      nimble::test::Encoder<nimble::ConstantEncoding<int32_t>>::encode(
-          *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/2);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Constant);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
-  EXPECT_EQ(encoding->rowCount(), 2);
-
-  nimble::Vector<int32_t> output{pool_.get(), 2};
-  encoding->materialize(2, output.data());
-
-  const std::vector<int32_t> expected{7, 7};
-  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
-}
-
-TEST_F(SliceEncodingTest, materializesRleRangeWithoutWrapper) {
-  const auto values = makeVector<int32_t>({10, 10, 11, 11, 11, 12, 12});
-  const auto encoded =
-      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
-          *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/5);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::RLE);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
-  EXPECT_EQ(encoding->rowCount(), 5);
-
-  nimble::Vector<int32_t> output{pool_.get(), 5};
-  encoding->materialize(5, output.data());
-
-  const std::vector<int32_t> expected{10, 11, 11, 11, 12};
-  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
-}
-
-TEST_F(SliceEncodingTest, materializesRleBoolRangeWithoutWrapper) {
-  const auto values = makeVector<bool>({false, false, true, true, true, false});
-  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
-      *buffer_, values);
-
-  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::RLE);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
-  EXPECT_EQ(encoding->rowCount(), 3);
-
-  uint64_t bits{0};
-  encoding->materializeBoolsAsBits(/*rowCount=*/3, &bits, /*begin=*/0);
-
-  EXPECT_TRUE(velox::bits::isBitSet(&bits, 0));
-  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
-  EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
-}
-
-TEST_F(SliceEncodingTest, materializesFixedBitWidthRangeWithoutWrapper) {
+TEST_F(SliceEncodingTest, wrapsZeroOffset) {
   const auto values = makeVector<int32_t>({10, 11, 12, 13, 14});
   const auto encoded =
-      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
           *buffer_, values);
 
-  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/3);
-  EXPECT_NE(sliced.data(), encoded.data());
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/3, *buffer_, {});
 
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::FixedBitWidth);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  auto encoding = createEncoding(wrapped);
   EXPECT_EQ(encoding->rowCount(), 3);
 
-  nimble::Vector<int32_t> output{pool_.get(), 3};
-  encoding->materialize(3, output.data());
-
-  const std::vector<int32_t> expected{11, 12, 13};
-  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+  const std::vector<int32_t> expected{10, 11, 12};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
 }
 
-TEST_F(SliceEncodingTest, materializesCompressedTrivialRangeWithoutWrapper) {
-  nimble::Vector<uint32_t> values{pool_.get()};
-  values.resize(1024);
-  std::fill(values.begin(), values.end(), 42);
-  const auto encoded =
-      nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
-          *buffer_, values, nimble::CompressionType::Zstd);
-
-  const auto sliced = slice(encoded, /*offset=*/128, /*length=*/3);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::Uint32);
-  EXPECT_EQ(encoding->rowCount(), 3);
-
-  nimble::Vector<uint32_t> output{pool_.get(), 3};
-  encoding->materialize(3, output.data());
-
-  const std::vector<uint32_t> expected{42, 42, 42};
-  EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
-}
-
-TEST_F(SliceEncodingTest, materializesNativeSliceForBoolEncoding) {
-  expectBoolSliceMaterializes<nimble::SparseBoolEncoding>(
-      "SparseBool",
-      nimble::EncodingType::SparseBool,
-      makeVector<bool>({false, true, false, false, true, false}),
-      /*offset=*/1,
-      /*length=*/3);
-}
-
-TEST_F(SliceEncodingTest, materializesNativeSliceForNullableEncoding) {
-  const auto values = makeVector<uint32_t>({10, 11, 12, 13, 14, 15});
-  const auto nulls = makeVector<bool>({true, true, true, true, true, true});
-  const auto encoded =
-      nimble::test::Encoder<nimble::NullableEncoding<uint32_t>>::encodeNullable(
-          *buffer_, values, nulls);
-
-  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
-  EXPECT_NE(sliced.data(), encoded.data());
-
-  auto encoding = createEncoding(sliced);
-
-  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Nullable);
-  EXPECT_EQ(encoding->dataType(), nimble::DataType::Uint32);
-  EXPECT_EQ(encoding->rowCount(), 3);
-
-  nimble::Vector<uint32_t> output{pool_.get(), 3};
-  encoding->materialize(3, output.data());
-
-  const std::vector<uint32_t> expected{12, 13, 14};
-  EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
-}
-
-TEST_F(SliceEncodingTest, rejectsOutOfRangeSlice) {
+TEST_F(SliceEncodingTest, wrapsFullRange) {
   const auto values = makeVector<int32_t>({10, 11, 12});
   const auto encoded =
       nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
           *buffer_, values);
 
-  NIMBLE_ASSERT_THROW(slice(encoded, /*offset=*/2, /*length=*/2), "");
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/3, *buffer_, {});
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  const std::vector<int32_t> expected{10, 11, 12};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, wrapsRle) {
+  const auto values = makeVector<int32_t>({10, 10, 11, 11, 11, 12, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/5, *buffer_, {});
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Slice);
+  EXPECT_EQ(encoding->rowCount(), 5);
+
+  const std::vector<int32_t> expected{10, 11, 11, 11, 12};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 5), expected);
+}
+
+TEST_F(SliceEncodingTest, wrapsBoolRle) {
+  // Bool is the null-stream case: StreamSlicer reads a sliced bool stream back
+  // through skip() + materializeBoolsAsBits() before any consumer sees it, so
+  // the wrapper has to honour both against the slice rather than the source.
+  const auto values =
+      makeVector<bool>({false, false, true, true, true, false, true});
+  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+      *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<bool>::wrap(
+      encoded, /*offset=*/2, /*length=*/4, *buffer_, {});
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Slice);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+  EXPECT_EQ(encoding->rowCount(), 4);
+
+  uint64_t bits{0};
+  encoding->materializeBoolsAsBits(/*rowCount=*/4, &bits, /*begin=*/0);
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 0));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
+  EXPECT_FALSE(velox::bits::isBitSet(&bits, 3));
+}
+
+TEST_F(SliceEncodingTest, boolSkipIsRelativeToSlice) {
+  const auto values =
+      makeVector<bool>({false, false, true, true, true, false, true});
+  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+      *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<bool>::wrap(
+      encoded, /*offset=*/2, /*length=*/4, *buffer_, {});
+
+  auto encoding = createEncoding(wrapped);
+  encoding->skip(2);
+
+  uint64_t bits{0};
+  encoding->materializeBoolsAsBits(/*rowCount=*/2, &bits, /*begin=*/0);
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 0));
+  EXPECT_FALSE(velox::bits::isBitSet(&bits, 1));
+}
+
+TEST_F(SliceEncodingTest, resetReturnsToSliceStart) {
+  const auto values = makeVector<int32_t>({10, 10, 12, 10, 14, 10});
+  const auto encoded =
+      nimble::test::Encoder<nimble::MainlyConstantEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/4, *buffer_, {});
+
+  auto encoding = createEncoding(wrapped);
+
+  // reset() must return to the slice start, not to the source's row zero.
+  const std::vector<int32_t> expected{10, 12, 10, 14};
+  for (int pass = 0; pass < 2; ++pass) {
+    EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected) << "pass " << pass;
+    encoding->reset();
+  }
+}
+
+TEST_F(SliceEncodingTest, skipsWithinSlice) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/2, /*length=*/4, *buffer_, {});
+
+  auto encoding = createEncoding(wrapped);
+  encoding->skip(1);
+
+  const std::vector<int32_t> expected{13, 14, 15};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
 }

--- a/velox/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/velox/dwio/nimble/tools/EncodingUtilities.cpp
@@ -52,6 +52,7 @@ void extractCompressionType(
            }});
       break;
     }
+    case EncodingType::Slice:
     case EncodingType::RLE:
     case EncodingType::Dictionary:
     case EncodingType::SharedDictionary:
@@ -138,7 +139,10 @@ void traverseEncodings(
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as having no nested
     // encoding to traverse.
-    case EncodingType::SubIntSplit: {
+    case EncodingType::SubIntSplit:
+    // The wrapped encoding is carried verbatim rather than as a nested
+    // stream, so there is nothing to traverse into here.
+    case EncodingType::Slice: {
       // don't have any nested encoding
       break;
     }


### PR DESCRIPTION
Summary:

Adds `SliceEncoding`, an encoding that records a slice instead of performing it.

Slicing an encoding normally means locating the slice boundaries, slicing every
child, and re-serializing. For encodings whose structure does not align with row
offsets that is expensive out of proportion to their size. `MainlyConstant` has
to count how many common values precede the slice before it can locate the
matching sub-range of its `otherValues` child, which in the general case means
materializing every bool up to the slice end. `RLE` has to walk run lengths from
run zero to find the runs containing each boundary, then re-encode the trimmed
length list.

This encoding skips all of it: it carries the source encoding verbatim plus the
row offset the consumer should start at, deferring the work to decode time where
the reader is walking rows anyway. Layout is prefix (row count = the SLICE
length) + a 4-byte offset + the source encoding.

Nothing produces it yet -- this diff adds the encoding, its factory
registration, and tooling support only. The slicing strategies that use it are
separate changes.

One deliberate limitation: `readWithVisitor` throws. The selective reader passes
absolute row positions, which would need translating by the slice offset.
Failing loudly beats silently returning rows from the wrong offset.

Naming note: the natural test file name `SliceEncodingTest.cpp` was already
taken by tests for `EncodingSliceFactory` (the eager slice path). Those tests
were renamed to `EncodingSliceTest.cpp` -- the file's actual subject -- so the
new class can take the name that mirrors its header. Fixture classes inside the
renamed file are renamed correspondingly (`EncodingSliceTest`,
`EncodingSliceTypedTest`, `EncodingSliceConfig`, `EncodingSliceTypes`) so both
test binaries link cleanly.

Reviewed By: xiaoxmeng

Differential Revision: D116084507
