### PR TITLE
fix(nimble): Count shared dictionary alphabet bytes in column stats

### DIFF
--- a/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
+++ b/velox/dwio/nimble/velox/tests/SharedDictionaryE2ETest.cpp
@@ -1381,6 +1381,54 @@ TEST_P(SharedDictionaryE2EInputTypeTest, fileScopeRoundTrip) {
   verifyRoundTrip(file, inputType, stripeValueTypes);
 }
 
+// The stripe-scope alphabet stream has no StreamData, so it is written by a
+// separate pass that historically skipped the per-column size accounting. With
+// shared dictionary encoding most of a column's bytes live in that alphabet, so
+// the omission understated the column badly. Pin the invariant that the root
+// column's rolled-up physical size covers every byte the stripe wrote.
+TEST_F(SharedDictionaryE2ETest, sharedStripeDictionaryColumnPhysicalStats) {
+  auto options = makeSharedDictionaryWriterOptions();
+  addDictionary(
+      options,
+      InputType::FlatMapScalar,
+      sharedDictionaryConfig(
+          SharedDictionaryScope::Stripe, /*dictionaryId=*/0));
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  auto input =
+      makeStripe(InputType::FlatMapScalar, StripeValueType::Dictionary);
+  Writer writer{input->type(), std::move(writeFile), *rootPool_, options};
+  writer.write(input);
+  writer.close();
+
+  uint64_t reportedPhysicalSize{0};
+  for (const auto* stat : writer.columnStats()) {
+    reportedPhysicalSize =
+        std::max(reportedPhysicalSize, stat->getPhysicalSize());
+  }
+  ASSERT_GT(reportedPhysicalSize, 0);
+
+  // Total bytes actually written across every stream of every stripe.
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tabletOptions = test::makeTestTabletOptions(leafPool_.get());
+  auto tablet = TabletReader::create(readFile, leafPool_.get(), tabletOptions);
+  uint64_t writtenStreamBytes{0};
+  for (uint32_t stripe{0}; stripe < tablet->stripeCount(); ++stripe) {
+    const auto identifier = tablet->stripeIdentifier(stripe);
+    const auto streamCount = tablet->streamCount(identifier);
+    for (uint32_t streamId{0}; streamId < streamCount; ++streamId) {
+      writtenStreamBytes += tablet->streamSize(identifier, streamId);
+    }
+  }
+  ASSERT_GT(writtenStreamBytes, 0);
+
+  EXPECT_GE(reportedPhysicalSize, writtenStreamBytes)
+      << "root physical size " << reportedPhysicalSize << " does not cover the "
+      << writtenStreamBytes
+      << " bytes written; the shared dictionary alphabet is likely unaccounted";
+}
+
 TEST_F(SharedDictionaryE2ETest, fileScopeCompactRowCountRoundTrip) {
   const std::vector<StripeValueType> stripeValueTypes{
       StripeValueType::Dictionary, StripeValueType::Direct};

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -2162,7 +2162,7 @@ void Writer::writeStripeDictionaryStreams() {
   if (!context_->hasStripeDictionaryConfig()) {
     return;
   }
-  for (const auto& [_, streamData] : context_->streams()) {
+  for (const auto& [nodeId, streamData] : context_->streams()) {
     const auto* streamContext =
         streamData->descriptor().context<WriterStreamContext>();
     if (streamContext == nullptr) {
@@ -2184,6 +2184,16 @@ void Writer::writeStripeDictionaryStreams() {
     auto& dictionaryStream = encodedStreams_[streamId];
     NIMBLE_CHECK(dictionaryStream.chunks.empty());
     dictionaryStream.offset = streamId;
+    // The alphabet stream has no StreamData of its own, so it is not visited by
+    // the stream loops that do this accounting. Charge it to the value stream
+    // that owns the dictionary: with shared dictionary encoding most of the
+    // column's bytes live in the alphabet, so leaving it out understates the
+    // column and makes the encoding look cheaper than it is.
+    const auto alphabetBytes = alphabetChunk->contentSize();
+    if (auto statsCollector = context_->getStatsCollector(nodeId)) {
+      statsCollector->addPhysicalSize(alphabetBytes);
+    }
+    context_->updateStripeEncodedPhysicalSize(alphabetBytes);
     dictionaryStream.chunks.push_back(std::move(alphabetChunk.value()));
   }
 }


### PR DESCRIPTION
Summary:
A stripe-scope shared dictionary's alphabet bytes were not counted in any column's `physicalSize`, nor in the stripe's encoded-size running total.

The alphabet stream is unlike every other write-side stream: it has no `StreamData`, only a reserved offset from `SchemaBuilder::createSharedDictionaryStream()`. Because of that it is invisible to the loops in `writeStreams()` and `writeChunks()`, which are the only places `StatisticsCollector::addPhysicalSize()` and `WriterContext::updateStripeEncodedPhysicalSize()` are called. It is instead emitted by a separate pass, `Writer::writeStripeDictionaryStreams()`, which pushed the encoded chunk into the stripe and did no accounting at all.

That mis-states exactly the column the feature is meant to help. Under shared dictionary encoding the value stream shrinks to indices and the column's real bytes move into the alphabet, so the reported `physicalSize` collapses to the index stream and the encoding looks cheaper than it is. The numbers surface through `Writer::columnStats()`, `NimbleFileMetadata::ColumnStats::physicalSize`, `nimble_dump` and the DSL stats table.

`writeStripeDictionaryStreams()` already iterates `WriterContext::streams()` to find the dictionary writers, and that iteration carries the owning value stream's node id — it was being discarded. Charging the alphabet to that node id is enough, and it is the right attribution: the alphabet exists only to serve that value stream.

The same bytes are now added to the stripe's encoded-size total, so `maxStripePhysicalSize` sees them. Note this does not make the flush decision itself account for the alphabet: `shouldFlush()` runs while values are still being written, and the alphabet cannot be encoded until they are done. It only means the total is right once the stripe closes.

The on-disk stripe size was never affected. It is measured as a `TabletWriter::size()` delta after the dictionary streams are in place, so file size and `StripeFlushMetrics` were already correct; only the per-column statistics and the running total were short.

Differential Revision: D117980056


