### PR TITLE
fix(nimble): Keep the in-map stream when a flat map key has only null values (#18753)

### DIFF
--- a/velox/dwio/nimble/velox/SchemaReader.h
+++ b/velox/dwio/nimble/velox/SchemaReader.h
@@ -317,8 +317,27 @@ std::ostream& operator<<(
 /// as a hotspot in the Deserializer's per-batch flatmap in-map detection
 /// over hundreds of keys. Concrete-typed callables remove that dispatch
 /// without forcing every caller to materialize an intermediate offset list.
-template <typename Visitor>
-bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
+namespace detail {
+
+// Normalizes the child accessors of the two schema representations: Type
+// exposes children as shared pointers, TypeBuilder as references. Lets
+// visitValueStreamLeaves run unchanged over both, so the writer decides
+// whether a value stream is observable using the exact walk the reader will
+// perform.
+template <typename T>
+const T& derefChild(const T& child) {
+  return child;
+}
+
+template <typename T>
+const T& derefChild(const std::shared_ptr<T>& child) {
+  return *child;
+}
+
+} // namespace detail
+
+template <typename TypeT, typename Visitor>
+bool visitValueStreamLeaves(const TypeT& type, Visitor& visit) {
   switch (type.kind()) {
     case Kind::Scalar:
       return visit(type.asScalar().scalarDescriptor().offset());
@@ -340,7 +359,7 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
       // the writer, so it is not a reliable anchor; children are. The
       // visitor's return value short-circuits the walk on the first hit.
       for (size_t i = 0; i < row.childrenCount(); ++i) {
-        if (visitValueStreamLeaves(*row.childAt(i), visit)) {
+        if (visitValueStreamLeaves(detail::derefChild(row.childAt(i)), visit)) {
           return true;
         }
       }
@@ -355,7 +374,8 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
       // FlatMap children are independent keys; each may or may not carry
       // data in the current stripe, so all must be visited.
       for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-        if (visitValueStreamLeaves(*flatMap.childAt(i), visit)) {
+        if (visitValueStreamLeaves(
+                detail::derefChild(flatMap.childAt(i)), visit)) {
           return true;
         }
       }
@@ -366,8 +386,8 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
   }
 }
 
-template <typename Visitor>
-bool visitValueStreamLeaves(const Type& type, Visitor&& visit) {
+template <typename TypeT, typename Visitor>
+bool visitValueStreamLeaves(const TypeT& type, Visitor&& visit) {
   auto&& visitRef = std::forward<Visitor>(visit);
   return visitValueStreamLeaves(type, visitRef);
 }

--- a/velox/dwio/nimble/velox/StreamData.h
+++ b/velox/dwio/nimble/velox/StreamData.h
@@ -511,4 +511,12 @@ inline bool isConstantBoolStream(std::string_view data) {
   return ::memchr(data.data(), 1, data.size()) == nullptr;
 }
 
+/// Returns true if the boolean stream data is non-empty and every byte is
+/// true. Distinguished from isConstantBoolStream because an omitted all-true
+/// in-map stream and an omitted all-false one mean opposite things to the
+/// reader, so the two constants cannot share a code path.
+inline bool isAllTrueBoolStream(std::string_view data) {
+  return !data.empty() && ::memchr(data.data(), 0, data.size()) == nullptr;
+}
+
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
@@ -4129,7 +4129,7 @@ TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStream) {
   }
 }
 
-TEST_P(BatchReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
+TEST_P(BatchReaderTest, flatMapAllTrueInMapWithAllNullValues) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -4140,10 +4140,227 @@ TEST_P(BatchReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
   auto vector = vectorMaker.rowVector(
       {"flat_map"}, {vectorMaker.mapVector({0, 1, 2, 3}, keys, values)});
 
+  // Both chunking modes: the constant in-map skip lives in the non-chunked
+  // writer path today, and the chunked path is where it lands if that
+  // optimization is extended, so the invariant is pinned for both.
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    auto writerOptions = createFlatMapWriterOptions();
+    writerOptions.enableChunking = enableChunking;
+    writerOptions.flatMapColumns["flat_map"];
+    nimble::Writer writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(vector);
+    writer.close();
+
+    {
+      velox::InMemoryReadFile readFile(file);
+      auto selector =
+          std::make_shared<velox::dwio::common::ColumnSelector>(type);
+      nimble::BatchReader reader(
+          &readFile, *leafPool_, std::move(selector), createReadParams());
+      const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+      ASSERT_EQ(flatMap.childrenCount(), 1);
+      // Every value is null, so no value stream reaches disk. That leaves the
+      // in-map stream as the only record that the key is present at all, so
+      // the constant in-map skip must not drop it -- otherwise the key is
+      // byte-indistinguishable from one absent from the stripe.
+      EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                      .count(flatMap.inMapDescriptorAt(0).offset()));
+    }
+
+    {
+      velox::InMemoryReadFile readFile(file);
+      auto selector =
+          std::make_shared<velox::dwio::common::ColumnSelector>(type);
+      nimble::BatchReader reader(
+          &readFile, *leafPool_, std::move(selector), createReadParams());
+      velox::VectorPtr output;
+      uint64_t rowCount = 4;
+      ASSERT_TRUE(reader.next(rowCount, output));
+      ASSERT_EQ(output->size(), 4);
+      for (auto i = 0; i < 4; ++i) {
+        EXPECT_TRUE(vectorEquals(vector, output, i)) << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// Two stripes: the key is in every row of the first (all-true in-map, dropped
+// because the value stream proves presence) and in only one row of the second
+// (mixed in-map, which must reach disk). The all-true mark lives on the schema
+// descriptor, which outlives a stripe, so it has to be reassigned per stripe
+// rather than only set. Left stale, the sweep would drop the second stripe's
+// real in-map stream and the absent key would read back as present.
+TEST_P(BatchReaderTest, flatMapAllTrueInMapThenMixedAcrossStripes) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 10}}, {{1, 11}}})}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 12}}, {}})}),
+  };
+
+  auto writerOptions = createFlatMapWriterOptions();
+  writerOptions.flatMapColumns["flat_map"];
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_, vectors, std::move(writerOptions), /*flushAfterWrite=*/true);
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+namespace {
+
+// Writer options that emit one chunk per write call, so multi-batch tests
+// exercise real chunk boundaries instead of deferring everything to the final
+// chunk at stripe close.
+nimble::WriterOptions chunkPerWriteOptions(
+    nimble::WriterOptions options,
+    bool enableChunking) {
+  options.enableChunking = enableChunking;
+  options.minStreamChunkRawSize = 0;
+  options.flatMapColumns["flat_map"];
+  options.flushPolicyFactory = []() {
+    return std::make_unique<nimble::LambdaFlushPolicy>(
+        /*flushLambda=*/[](auto&) { return false; },
+        /*chunkLambda=*/[](auto&) { return true; });
+  };
+  return options;
+}
+
+} // namespace
+
+// A key whose values are null in an early batch and non-null in a later one
+// must survive the chunk boundary between them. The writer defers a chunk
+// while the stream is still empty of payload, and a deferred attempt consumes
+// nothing -- it stays "first chunk" and its rows fold into the next emitted
+// chunk. Were they dropped instead, the value stream would be short and every
+// later row would decode shifted.
+TEST_P(BatchReaderTest, flatMapNullValuesThenNonNullAcrossChunks) {
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector(
+              {0, 1},
+              vectorMaker.flatVector<int32_t>({1, 1}),
+              vectorMaker.flatVectorNullable<int64_t>(
+                  {std::nullopt, std::nullopt}))}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector(
+              {0, 1},
+              vectorMaker.flatVector<int32_t>({1, 1}),
+              vectorMaker.flatVectorNullable<int64_t>({10, 20}))}),
+  };
+
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    auto file = nimble::test::createNimbleFile(
+        *rootPool_,
+        vectors,
+        chunkPerWriteOptions(createFlatMapWriterOptions(), enableChunking),
+        /*flushAfterWrite=*/false);
+    velox::InMemoryReadFile readFile(file);
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+    velox::VectorPtr result;
+    for (const auto& expected : vectors) {
+      ASSERT_TRUE(reader.next(expected->size(), result));
+      ASSERT_EQ(expected->size(), result->size());
+      for (auto i = 0; i < expected->size(); ++i) {
+        EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+            << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// All values null for the key across several chunks, so no value stream is
+// written at all. The in-map stream is then the key's only record and must
+// survive, the same invariant as the single-batch case but with the stream
+// spanning chunk boundaries.
+TEST_P(BatchReaderTest, flatMapAllNullValuesAcrossChunks) {
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto allNullBatch = [&]() {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector(
+            {0, 1},
+            vectorMaker.flatVector<int32_t>({1, 1}),
+            vectorMaker.flatVectorNullable<int64_t>(
+                {std::nullopt, std::nullopt}))});
+  };
+  std::vector<velox::VectorPtr> vectors{
+      allNullBatch(), allNullBatch(), allNullBatch()};
+
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    auto file = nimble::test::createNimbleFile(
+        *rootPool_,
+        vectors,
+        chunkPerWriteOptions(createFlatMapWriterOptions(), enableChunking),
+        /*flushAfterWrite=*/false);
+    velox::InMemoryReadFile readFile(file);
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+    velox::VectorPtr result;
+    for (const auto& expected : vectors) {
+      ASSERT_TRUE(reader.next(expected->size(), result));
+      ASSERT_EQ(expected->size(), result->size());
+      for (auto i = 0; i < expected->size(); ++i) {
+        EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+            << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// Same invariant as flatMapAllTrueInMapWithAllNullValues, with string values.
+// Covers NullableContentStringStreamData, whose data() is only valid once
+// materialized. Deciding at stripe close, from what each stream actually
+// encoded, is what keeps this path off that trap.
+TEST_P(BatchReaderTest, flatMapAllTrueInMapWithAllNullStringValues) {
+  auto type = velox::ROW(
+      {{"flat_map", velox::MAP(velox::INTEGER(), velox::VARCHAR())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto keys = vectorMaker.flatVector<int32_t>({1, 1, 1, 1});
+  auto values = vectorMaker.flatVectorNullable<velox::StringView>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto vector = vectorMaker.rowVector(
+      {"flat_map"}, {vectorMaker.mapVector({0, 1, 2, 3}, keys, values)});
+
   std::string file;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
   auto writerOptions = createFlatMapWriterOptions();
-  writerOptions.enableChunking = true;
   writerOptions.flatMapColumns["flat_map"];
   nimble::Writer writer(
       type, std::move(writeFile), *rootPool_, std::move(writerOptions));

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -36,10 +36,12 @@
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
+#include "velox/dwio/nimble/common/ChunkHeader.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/index/ClusterIndexConfig.h"
 #include "velox/dwio/nimble/index/ClusterIndexFactory.h"
@@ -57,6 +59,7 @@
 #include "velox/dwio/nimble/velox/MetadataGenerated.h"
 #include "velox/dwio/nimble/velox/RawSizeUtils.h"
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
+#include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SchemaTypes.h"
 
@@ -2762,6 +2765,140 @@ void Writer::encodeStream(
   streamData.reset();
 }
 
+namespace {
+
+// Visits every flat map in the schema tree.
+template <typename Visitor>
+void visitFlatMaps(const TypeBuilder& type, const Visitor& visit) {
+  if (type.kind() == Kind::FlatMap) {
+    const auto& flatMap = type.asFlatMap();
+    visit(flatMap);
+    for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+      visitFlatMaps(flatMap.childAt(i), visit);
+    }
+    return;
+  }
+  switch (type.kind()) {
+    case Kind::Row: {
+      const auto& row = type.asRow();
+      for (size_t i = 0; i < row.childrenCount(); ++i) {
+        visitFlatMaps(row.childAt(i), visit);
+      }
+      return;
+    }
+    case Kind::Array:
+      visitFlatMaps(type.asArray().elements(), visit);
+      return;
+    case Kind::ArrayWithOffsets:
+      visitFlatMaps(type.asArrayWithOffsets().elements(), visit);
+      return;
+    case Kind::Map:
+      visitFlatMaps(type.asMap().keys(), visit);
+      visitFlatMaps(type.asMap().values(), visit);
+      return;
+    case Kind::SlidingWindowMap:
+      visitFlatMaps(type.asSlidingWindowMap().keys(), visit);
+      visitFlatMaps(type.asSlidingWindowMap().values(), visit);
+      return;
+    case Kind::Scalar:
+    case Kind::TimestampMicroNano:
+      // Leaf kinds: no children to descend into.
+      return;
+    case Kind::FlatMap:
+      break;
+  }
+  // FlatMap returns above; every other kind returns from its case. Listing all
+  // kinds instead of a default keeps -Wswitch-enum quiet, which OSS builds
+  // with -Werror.
+  NIMBLE_UNREACHABLE("Unexpected type kind {}", type.kind());
+}
+
+// Whether every chunk of an already-encoded in-map stream is a Constant
+// encoding of true, i.e. the key was carried by every row of the stripe.
+//
+// Reads only the chunk and encoding prefixes; it never decodes or
+// decompresses. Anything it cannot prove -- no chunks, an unexpected chunk
+// shape, a compressed payload, a non-Constant encoding -- answers false and
+// the stream stays on disk. The asymmetry is deliberate: Constant means every
+// value is identical by the encoding's own contract, so a true answer cannot
+// be wrong, while a false answer costs only the space saving.
+bool isAllTrueEncodedStream(const Stream& stream) {
+  if (stream.chunks.empty()) {
+    return false;
+  }
+  for (const auto& chunk : stream.chunks) {
+    // ChunkedStreamWriter emits exactly {header, payload}.
+    if (chunk.content.size() != 2 ||
+        chunk.content[0].size() != kChunkHeaderSize) {
+      return false;
+    }
+    const char* headerPos = chunk.content[0].data();
+    if (readChunkHeader(headerPos).compressionType !=
+        CompressionType::Uncompressed) {
+      return false;
+    }
+    const auto payload = chunk.content[1];
+    if (payload.size() <= EncodingPrefix::kRowCountOffset ||
+        EncodingPrefix::encodingType(payload) != EncodingType::Constant ||
+        EncodingPrefix::dataType(payload) != DataType::Bool) {
+      return false;
+    }
+    // A ConstantEncoding<bool> payload is the prefix followed by its single
+    // value byte and nothing else, so the value is the last byte. Reading it
+    // that way avoids having to know whether the row count was serialized
+    // fixed-width or as a varint, which the prefix does not record.
+    if (payload.back() == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+void Writer::suppressRedundantInMapStreams() {
+  if (!context_->options().skipConstantFlatMapInMapStreams) {
+    return;
+  }
+
+  // Chunked writes have never skipped constant in-map streams: the old marking
+  // ran only in processStream(), which the chunked path does not call. Reading
+  // the encoding instead would start suppressing here for free, so this holds
+  // that behaviour until it is enabled deliberately, with its own coverage.
+  if (context_->options().enableChunking) {
+    return;
+  }
+
+  const auto hasEncodedStream = [this](offset_size offset) {
+    return offset < encodedStreams_.size() &&
+        !encodedStreams_[offset].chunks.empty();
+  };
+
+  visitFlatMaps(
+      *context_->schemaBuilder().root(),
+      [&](const FlatMapTypeBuilder& flatMap) {
+        // The schema pairs each key's in-map descriptor with its value type by
+        // index, so no separate bookkeeping is needed to relate the two.
+        for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+          const auto& inMapDescriptor = flatMap.inMapDescriptorAt(i);
+          const auto inMapOffset = inMapDescriptor.offset();
+          // Scoped to flat map in-map descriptors by construction: this walk
+          // only ever reaches the streams reached via inMapDescriptorAt().
+          if (inMapOffset >= encodedStreams_.size() ||
+              !isAllTrueEncodedStream(encodedStreams_[inMapOffset])) {
+            continue;
+          }
+
+          // Drop the all-true in-map stream only while a value stream proves
+          // the key was present. Asked with the reader's own traversal, so the
+          // writer cannot count bytes the reader will not look at.
+          if (visitValueStreamLeaves(flatMap.childAt(i), hasEncodedStream)) {
+            encodedStreams_[inMapOffset].chunks.clear();
+          }
+        }
+      });
+}
+
 void Writer::processStream(
     StreamData& streamData,
     velox::BufferPool* encodingScratchBufferPool,
@@ -2769,7 +2906,7 @@ void Writer::processStream(
     uint64_t& streamSize,
     std::atomic_uint64_t& chunkSize) {
   const auto offset = streamData.descriptor().offset();
-  const auto* context = streamData.descriptor().context<WriterStreamContext>();
+  auto* context = streamData.descriptor().context<WriterStreamContext>();
   NIMBLE_CHECK(encodedStreams_[offset].chunks.empty());
   if ((context != nullptr) && context->isNullStream()) {
     // For null streams we promote the null values to be written as
@@ -2786,15 +2923,26 @@ void Writer::processStream(
   } else if (
       (context != nullptr) && context->isInMapStream() &&
       context_->options().skipConstantFlatMapInMapStreams) {
-    // When enabled, skip encoding in-map streams that are all-true (every row
-    // has the key) or all-false (no row has the key). The reader distinguishes
-    // these by checking value stream presence: all-true keys have value
-    // streams, all-false keys do not.
+    // When enabled, skip encoding in-map streams that are constant, since the
+    // reader recovers the in-map state from value stream presence.
+    //
+    // All-false is dropped here: the key really is absent from this stripe,
+    // which is exactly what the reader concludes from two missing streams.
+    //
+    // All-true cannot be decided yet. It is only safe to drop while some value
+    // stream survives to prove the key was present, and whether that happens
+    // is not known until every stream in the stripe has been encoded --
+    // streams are encoded concurrently here and must not inspect each other.
+    // So it is encoded now and reconsidered by
+    // suppressRedundantInMapStreams() at stripe close, which recognizes it
+    // from its own encoding and drops it if a value stream did reach disk.
     //
     // NOTE: readers that don't infer missing in-map streams require
     // skipConstantFlatMapInMapStreams to remain false.
     streamData.materialize();
-    if (!isConstantBoolStream(streamData.data())) {
+    const auto data = streamData.data();
+    const bool allTrue = isAllTrueBoolStream(data);
+    if (allTrue || !isConstantBoolStream(data)) {
       encodeStream(
           streamData,
           encodingScratchBufferPool,
@@ -3047,6 +3195,8 @@ bool Writer::writeStripe() {
   uint64_t stripeSize{0};
   {
     LoggingScope scope{*context_->logger()};
+
+    suppressRedundantInMapStreams();
 
     size_t nonEmptyCount{0};
     for (auto i = 0; i < encodedStreams_.size(); ++i) {

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -600,10 +600,6 @@ class WriterStreamContext : public StreamContext {
     isInMapStream_ = value;
   }
 
-  void setFlatMapValueStreamOffsets(std::vector<offset_size> offsets) {
-    flatMapValueStreamOffsets_ = std::move(offsets);
-  }
-
   // The layout to replay for this stream: overlaid from the EncodingLayoutTree
   // at setup, or captured from this stream's first encode when
   // encoding-selection caching is enabled. Empty until one of those populates
@@ -641,10 +637,6 @@ class WriterStreamContext : public StreamContext {
  private:
   bool isNullStream_{false};
   bool isInMapStream_{false};
-  // Value stream descriptor offsets for this in-map stream's flat-map field.
-  // Empty for non in-map streams and flat-map values with no reader-visible
-  // value stream.
-  std::vector<offset_size> flatMapValueStreamOffsets_;
   std::optional<EncodingLayout> encoding_;
   std::optional<SharedDictionaryConfig> sharedDictionaryConfig_;
   mutable std::unique_ptr<SharedDictionaryWriter> sharedDictionaryWriter_;
@@ -1247,63 +1239,6 @@ void findNodeIds(
   }
 }
 
-void collectFlatMapValueStreamOffsets(
-    const TypeBuilder& type,
-    std::vector<offset_size>& offsets) {
-  switch (type.kind()) {
-    case Kind::Scalar:
-      offsets.push_back(type.asScalar().scalarDescriptor().offset());
-      return;
-    case Kind::TimestampMicroNano:
-      offsets.push_back(
-          type.asTimestampMicroNano().microsDescriptor().offset());
-      offsets.push_back(type.asTimestampMicroNano().nanosDescriptor().offset());
-      return;
-    case Kind::Array:
-      offsets.push_back(type.asArray().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asArray().elements(), offsets);
-      return;
-    case Kind::ArrayWithOffsets:
-      offsets.push_back(type.asArrayWithOffsets().offsetsDescriptor().offset());
-      offsets.push_back(type.asArrayWithOffsets().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asArrayWithOffsets().elements(), offsets);
-      return;
-    case Kind::Map:
-      offsets.push_back(type.asMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(type.asMap().values(), offsets);
-      return;
-    case Kind::SlidingWindowMap:
-      offsets.push_back(type.asSlidingWindowMap().offsetsDescriptor().offset());
-      offsets.push_back(type.asSlidingWindowMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().values(), offsets);
-      return;
-    case Kind::Row: {
-      const auto& row = type.asRow();
-      offsets.push_back(row.nullsDescriptor().offset());
-      for (size_t i = 0; i < row.childrenCount(); ++i) {
-        collectFlatMapValueStreamOffsets(row.childAt(i), offsets);
-      }
-      return;
-    }
-    case Kind::FlatMap: {
-      const auto& flatMap = type.asFlatMap();
-      offsets.push_back(flatMap.nullsDescriptor().offset());
-      for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-        offsets.push_back(flatMap.inMapDescriptorAt(i).offset());
-        collectFlatMapValueStreamOffsets(flatMap.childAt(i), offsets);
-      }
-      return;
-    }
-    default:
-      NIMBLE_UNREACHABLE("Unsupported type kind {}", type.kind());
-  }
-}
-
 FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodingsForFlatMap(
     const EncodingLayoutTree& encodingLayoutTree) {
   FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodings;
@@ -1737,9 +1672,6 @@ void configureAddedFlatMapField(
   auto& inMapContext = streamContext(
       flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1));
   inMapContext.setIsInMapStream(true);
-  std::vector<offset_size> valueStreamOffsets;
-  collectFlatMapValueStreamOffsets(fieldType, valueStreamOffsets);
-  inMapContext.setFlatMapValueStreamOffsets(std::move(valueStreamOffsets));
 
   auto* flatMapContext = flatmap.context<FlatmapEncodingLayoutContext>();
   if (flatMapContext == nullptr) {

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -237,6 +237,12 @@ class Writer : public velox::dwio::common::Writer {
       uint64_t& streamSize,
       std::atomic_uint64_t& chunkSize);
 
+  // Drops all-true flat map in-map streams whose key is still provable from a
+  // value stream. Runs once the stripe is fully encoded, where every stream's
+  // fate is known -- the concurrent encode cannot decide this, since a stream
+  // may not inspect its peers there.
+  void suppressRedundantInMapStreams();
+
   void processStream(
       StreamData& streamData,
       velox::BufferPool* encodingScratchBufferPool,


### PR DESCRIPTION
Summary:

`skipConstantFlatMapInMapStreams` drops a flat map in-map stream whenever it is
constant, because the reader can recover the in-map state from value stream
presence. That premise holds for all-false keys, and for all-true keys whose
values reach disk. It does not hold when every value for the key is null: the
value stream is omitted as empty, the in-map stream is omitted as all-true, and
nothing is left to say the key was ever there. `{1: null}` reads back as `{}`.

The two omissions are individually sound and jointly lossy. An omitted value
stream is recoverable because the null stream independently records that the
rows are null; an omitted in-map stream is not, because it is the only
per-stripe, per-key signal Nimble has. Per-stripe metadata is stream offsets
and sizes (`Footer.fbs`), and the schema listing flat map keys is file-level,
so "is this key live in this stripe" is inferred entirely from stream presence.
Spending that one bit on "the stream was constant" leaves all-true-with-null-
values byte-identical to key-absent.

The decision cannot be made while encoding. `processStream()` runs concurrently
across streams, so a stream may not inspect whether its peers produced output.
So the writer defers instead:

- All-false is still dropped in `processStream()`. The key really is absent,
  which is exactly what the reader concludes from two missing streams.
- All-true is encoded, and the stream records `isAllTrueInMapStream` about
  itself -- no peer is read, nothing races.
- `suppressRedundantInMapStreams()` runs at stripe close, where every stream's
  fate is known, and clears the chunks of an all-true in-map stream when a
  value stream did reach disk.

Clearing chunks is not a new mechanism: a stream is omitted precisely by having
no chunks, and the compaction loop already at stripe close drops those before
`writeStripe()`. The sweep just makes one more stream empty before that filter
runs.

Two things this deliberately reuses rather than reinvents. The schema already
pairs each key's in-map descriptor with its value type by index
(`inMapDescriptorAt(i)` / `childAt(i)`), so no bookkeeping is needed to relate
them. And the check runs `visitValueStreamLeaves()`, the traversal the readers
themselves use (`FieldReader.cpp`, `FlatMapColumnReader.cpp`), so the writer
cannot count bytes the reader will not look at. It is now generic over both
schema representations -- same walk, one definition, no drift. The logic is
unchanged; only a template parameter and a child-deref shim were added.

Cost: an all-true in-map stream is encoded and then discarded. It is a
constant-valued bool stream, so this is small, but it is a real difference from
the previous behaviour.

Only the non-chunked writer path skips constant in-map streams today. Because
the sweep runs at stripe close, which both `writeStreams()` and `writeChunks()`
feed, the same guard would apply unchanged if that optimization is extended to
the chunked path.
Rebased onto master after `D117644518 ("[velox] refactor(nimble): Rename
VeloxReader to BatchReader")` landed: `VeloxReaderTest.cpp` is now
`BatchReaderTest.cpp`, the fixture is `BatchReaderTest`, and the reader is
`nimble::BatchReader`.

Three review findings addressed:

1. `isAllTrueInMapStream_` was only ever assigned `true`. The context hangs off
   the schema descriptor and outlives a stripe, so a key that was all-true in
   one stripe and mixed in the next kept the stale mark, and the sweep dropped
   the second stripe's legitimate mixed in-map stream. A real defect, not a
   theoretical one -- see the before/after in the test plan.

   Rather than patch the assignment, the flag is gone.
   `suppressRedundantInMapStreams()` now reads the answer back out of the
   encoded stream: an in-map stream was all-true exactly when every one of its
   chunks is an uncompressed Constant encoding of `true`. Nothing is remembered
   between stripes, so nothing can go stale, and the multi-chunk case needs no
   accumulation.

   The check is cheap -- it reads the chunk header and the encoding prefix and
   never decodes or decompresses -- and fail-safe in the direction that
   matters. `ConstantEncoding` means every value is identical by the encoding's
   own contract, so a true answer cannot be wrong, while anything it cannot
   prove -- no chunks, an unexpected chunk shape, a compressed payload, a
   non-Constant encoding -- keeps the stream on disk and costs only the space
   saving.

   Two layout details it leans on. The chunk header records its compression
   type explicitly (`ChunkHeader.h`), so a compressed payload is detected
   rather than misparsed. And a `ConstantEncoding<bool>` payload is the prefix
   followed by its single value byte and nothing else -- `ConstantEncoding.h`
   asserts `pos == data.end()` after reading it -- so the value is the last
   byte. Reading it that way sidesteps the prefix being either 6 bytes or
   `2 + varintSize` depending on `useVarintRowCount`, which the prefix itself
   does not record.

   The scope is unchanged: the sweep still only reaches streams via
   `FlatMapTypeBuilder::inMapDescriptorAt()`, so only flat map in-map streams
   are candidates, and `processStream()` still drops all-false in-map streams
   before encoding.

   One behavioural nuance: suppression now depends on the encoder actually
   choosing `Constant` for an all-true bool stream. It does today -- the
   pre-existing `flatMapSkipAllTrueInMapStream` asserts the stream is absent on
   disk when the option is on, and it passes. A replayed `EncodingLayout`
   forcing a different encoding would silently stop suppressing, which costs
   bytes and nothing else.

   Chunked writes keep their previous behaviour here, held by an explicit
   `enableChunking` early return. Reading the encoding would otherwise start
   suppressing there for free; the diff on top removes that guard deliberately,
   with its own coverage.
2. The chunk clear indexed `encodedStreams_` without the bounds check its
   sibling `hasEncodedStream` lambda applies. Guarded now, so the two agree.
3. `visitFlatMaps()` switched on `Kind` with a `default`, tripping
   `-Wswitch-enum` on `Scalar`, `TimestampMicroNano` and `FlatMap`. All kinds
   are listed explicitly with a post-switch `NIMBLE_UNREACHABLE`; OSS builds
   this `-Werror`.

Also dropped a `derefChild` raw-pointer overload that no caller selected --
`Type::childAt` returns a `shared_ptr`, `TypeBuilder::childAt` a reference, so
only the other two overloads are ever chosen.

Differential Revision: D118015335


