### PR TITLE
perf(nimble): Optimize BlockBitPacking indexed view reads (#18754)

### DIFF
--- a/velox/dwio/nimble/common/FixedBitArray.h
+++ b/velox/dwio/nimble/common/FixedBitArray.h
@@ -59,6 +59,11 @@ class FixedBitArray {
   FixedBitArray(std::string_view buffer, int bitWidth)
       : FixedBitArray(const_cast<char*>(buffer.data()), bitWidth) {}
 
+  /// Convenience constructor for reading read-only data. Calling non-const
+  /// methods on instances constructed from this is undefined behavior.
+  FixedBitArray(const char* buffer, int bitWidth)
+      : FixedBitArray(const_cast<char*>(buffer), bitWidth) {}
+
   /// Sets the |index|'th slot to the given |value|. If value
   /// is >= 2^|bitWidth| behavior is undefined.
   ///

--- a/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/SharedDictionaryEncoding.h
@@ -324,16 +324,15 @@ class SharedDictionaryAlphabet {
       std::span<const uint32_t> indices,
       typename TypeTraits<T>::physicalType* output) const {
     checkEntryType<T>();
+    for (const auto index : indices) {
+      checkEntryIndex(index);
+    }
     if (entryView_ != nullptr) {
-      for (size_t i = 0; i < indices.size(); ++i) {
-        checkEntryIndex(indices[i]);
-        entryView_->readAt(indices[i], output + i);
-      }
+      entryView_->readAt(indices, output);
       return;
     }
     const auto entries = decodedEntries<T>();
     for (size_t i = 0; i < indices.size(); ++i) {
-      checkEntryIndex(indices[i]);
       output[i] = entries[indices[i]];
     }
   }

--- a/velox/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 #include <numeric>
+#include <random>
 #include <span>
 #include <string>
 #include <string_view>
@@ -41,6 +42,7 @@
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/PFOREncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
@@ -119,6 +121,28 @@ std::vector<uint32_t> clusteredPositions(uint32_t rows) {
   return positions;
 }
 
+std::vector<uint32_t> sharedDictionaryRandomIndices() {
+  std::mt19937 generator{1};
+  std::uniform_int_distribution<uint32_t> distribution{0, kRows - 1};
+  std::vector<uint32_t> indices(kPositions);
+  for (auto& index : indices) {
+    index = distribution(generator);
+  }
+  return indices;
+}
+
+std::vector<uint32_t> sharedDictionarySortedIndices() {
+  auto indices = sharedDictionaryRandomIndices();
+  std::sort(indices.begin(), indices.end());
+  return indices;
+}
+
+std::vector<uint32_t> sharedDictionaryClusteredIndices() {
+  std::vector<uint32_t> indices(kPositions);
+  std::iota(indices.begin(), indices.end(), (kRows - kPositions) / 2);
+  return indices;
+}
+
 template <typename T>
 void readPositionsWithView(
     const EncodingView& view,
@@ -130,6 +154,60 @@ void readPositionsWithView(
       view.readAt(position, &value);
       folly::doNotOptimizeAway(value);
     }
+  }
+}
+
+template <typename T>
+void readPositionsBatchWithView(
+    const EncodingView& view,
+    const std::vector<uint32_t>& positions,
+    uint32_t iters) {
+  using PhysicalType = typename TypeTraits<T>::physicalType;
+  std::vector<PhysicalType> output(positions.size());
+  while (iters--) {
+    view.readAt(positions, output.data());
+    folly::doNotOptimizeAway(output.data());
+  }
+}
+
+template <typename T>
+std::shared_ptr<const SharedDictionaryAlphabet> createSharedDictionaryAlphabet(
+    const Vector<T>& values) {
+  Buffer buffer{*benchmarkPool()};
+  const auto encoded = SharedDictionaryAlphabet::encode<T>(
+      {values.data(), values.size()},
+      std::array{EncodingType::BlockBitPacking},
+      buffer);
+  auto encodedOwner = std::make_shared<const std::string>(encoded);
+  const std::string_view encodedAlphabet{*encodedOwner};
+  return SharedDictionaryAlphabet::create(
+      encodedAlphabet, std::move(encodedOwner), benchmarkPool().get());
+}
+
+template <typename T>
+void readSharedDictionaryAlphabetScalar(
+    const SharedDictionaryAlphabet& alphabet,
+    const std::vector<uint32_t>& indices,
+    uint32_t iters) {
+  typename TypeTraits<T>::physicalType value;
+  while (iters--) {
+    for (const auto index : indices) {
+      value = alphabet.physicalValueAt<T>(index);
+      folly::doNotOptimizeAway(value);
+    }
+  }
+}
+
+template <typename T>
+void readSharedDictionaryAlphabetBatch(
+    const SharedDictionaryAlphabet& alphabet,
+    const std::vector<uint32_t>& indices,
+    uint32_t iters) {
+  using PhysicalType = typename TypeTraits<T>::physicalType;
+  std::vector<PhysicalType> output(indices.size());
+  while (iters--) {
+    alphabet.materialize<T>(indices, output.data());
+    folly::doNotOptimizeAway(output.data());
   }
 }
 
@@ -467,6 +545,31 @@ Vector<std::string_view> dictionaryStringData(
       view = createEncodingView(encoded, benchmarkPool().get()); \
     }                                                            \
     readRangesWithView<Type>(*view, iters);                      \
+  }
+
+#define BATCH_VIEW_BENCHMARK(Name, Type, EncodedExpr, PositionsExpr) \
+  BENCHMARK(Name, iters) {                                           \
+    std::string encoded;                                             \
+    std::vector<uint32_t> positions;                                 \
+    std::unique_ptr<EncodingView> view;                              \
+    BENCHMARK_SUSPEND {                                              \
+      encoded = EncodedExpr;                                         \
+      positions = PositionsExpr;                                     \
+      view = createEncodingView(encoded, benchmarkPool().get());     \
+    }                                                                \
+    readPositionsBatchWithView<Type>(*view, positions, iters);       \
+  }
+
+#define SHARED_DICTIONARY_ALPHABET_BENCHMARK(                      \
+    Name, Type, ValuesExpr, IndicesExpr, ReadFunction)             \
+  BENCHMARK(Name, iters) {                                         \
+    std::shared_ptr<const SharedDictionaryAlphabet> alphabet;      \
+    std::vector<uint32_t> indices;                                 \
+    BENCHMARK_SUSPEND {                                            \
+      alphabet = createSharedDictionaryAlphabet<Type>(ValuesExpr); \
+      indices = IndicesExpr;                                       \
+    }                                                              \
+    ReadFunction<Type>(*alphabet, indices, iters);                 \
   }
 
 #define UNALIGNED_RANGE_VIEW_BENCHMARK(Name, Type, EncodedExpr)  \
@@ -1026,6 +1129,77 @@ VIEW_BENCHMARK(
         EncodingType::BlockBitPacking,
         pforData()),
     randomPositions(kRows))
+VIEW_BENCHMARK(
+    View_BlockBitPackingUint32_Sorted130,
+    uint32_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking,
+        pforData()),
+    sortedRandomPositions(kRows))
+VIEW_BENCHMARK(
+    View_BlockBitPackingUint32_Clustered130,
+    uint32_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking,
+        pforData()),
+    clusteredPositions(kRows))
+BATCH_VIEW_BENCHMARK(
+    BatchView_BlockBitPackingUint32_Random130,
+    uint32_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking,
+        pforData()),
+    randomPositions(kRows))
+BATCH_VIEW_BENCHMARK(
+    BatchView_BlockBitPackingUint32_Sorted130,
+    uint32_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking,
+        pforData()),
+    sortedRandomPositions(kRows))
+BATCH_VIEW_BENCHMARK(
+    BatchView_BlockBitPackingUint32_Clustered130,
+    uint32_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking,
+        pforData()),
+    clusteredPositions(kRows))
+SHARED_DICTIONARY_ALPHABET_BENCHMARK(
+    SharedDictionary_BBP_Uint32_ScalarRandom130,
+    uint32_t,
+    huffmanUniformData(),
+    sharedDictionaryRandomIndices(),
+    readSharedDictionaryAlphabetScalar)
+SHARED_DICTIONARY_ALPHABET_BENCHMARK(
+    SharedDictionary_BBP_Uint32_BatchRandom130,
+    uint32_t,
+    huffmanUniformData(),
+    sharedDictionaryRandomIndices(),
+    readSharedDictionaryAlphabetBatch)
+SHARED_DICTIONARY_ALPHABET_BENCHMARK(
+    SharedDictionary_BBP_Uint32_ScalarSorted130,
+    uint32_t,
+    huffmanUniformData(),
+    sharedDictionarySortedIndices(),
+    readSharedDictionaryAlphabetScalar)
+SHARED_DICTIONARY_ALPHABET_BENCHMARK(
+    SharedDictionary_BBP_Uint32_BatchSorted130,
+    uint32_t,
+    huffmanUniformData(),
+    sharedDictionarySortedIndices(),
+    readSharedDictionaryAlphabetBatch)
+SHARED_DICTIONARY_ALPHABET_BENCHMARK(
+    SharedDictionary_BBP_Uint32_ScalarClustered130,
+    uint32_t,
+    huffmanUniformData(),
+    sharedDictionaryClusteredIndices(),
+    readSharedDictionaryAlphabetScalar)
+SHARED_DICTIONARY_ALPHABET_BENCHMARK(
+    SharedDictionary_BBP_Uint32_BatchClustered130,
+    uint32_t,
+    huffmanUniformData(),
+    sharedDictionaryClusteredIndices(),
+    readSharedDictionaryAlphabetBatch)
 RANGE_VIEW_BENCHMARK(
     RangeView_BlockBitPackingUint32_Range1024,
     uint32_t,
@@ -1053,6 +1227,8 @@ MATERIALIZE_BENCHMARK(
     randomPositions(kRows))
 
 #undef VIEW_BENCHMARK
+#undef BATCH_VIEW_BENCHMARK
+#undef SHARED_DICTIONARY_ALPHABET_BENCHMARK
 #undef RANGE_VIEW_BENCHMARK
 #undef UNALIGNED_RANGE_VIEW_BENCHMARK
 #undef MATERIALIZE_BENCHMARK

--- a/velox/dwio/nimble/encodings/tests/BlockBitPackingEncodingViewTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/BlockBitPackingEncodingViewTest.cpp
@@ -18,6 +18,10 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <span>
+#include <vector>
+
 #include "fmt/core.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 
@@ -36,6 +40,54 @@ TEST_F(EncodingViewTest, readsBlockBitPackingEncoding) {
   options.blockBitPackingBlockSize = 8;
   expectReads<nimble::BlockBitPackingEncoding<int32_t>>(
       values, {17, 0, 8, 9, 19, 3}, options);
+}
+
+TEST_F(BlockBitPackingEncodingViewTest, readsIndexedBlockRuns) {
+  using Encoding = nimble::BlockBitPackingEncoding<uint32_t>;
+  auto values = makeVector<uint32_t>({
+      42,  42,
+      42,  42,
+      42,  42,
+      42,  42,
+      100, 101,
+      103, 104,
+      108, 110,
+      111, 112,
+      0,   std::numeric_limits<uint32_t>::max(),
+      1,   std::numeric_limits<uint32_t>::max() - 1,
+      2,   std::numeric_limits<uint32_t>::max() - 2,
+      3,   std::numeric_limits<uint32_t>::max() - 3,
+      200, 205,
+      206, 210,
+      211, 212,
+      220, 221,
+  });
+
+  const std::vector<uint32_t> indices{
+      1, 7, 0, 8, 10, 15, 9, 16, 18, 23, 17, 24, 26, 29, 25, 31, 31, 30, 2};
+  std::vector<uint32_t> expected;
+  expected.reserve(indices.size());
+  for (const auto index : indices) {
+    expected.push_back(values[index]);
+  }
+
+  nimble::Encoding::Options baseOptions;
+  baseOptions.blockBitPackingBlockSize = 8;
+  for (const auto useVarintRowCount : {false, true}) {
+    SCOPED_TRACE(fmt::format("useVarintRowCount={}", useVarintRowCount));
+    auto options = baseOptions;
+    options.useVarintRowCount = useVarintRowCount;
+    auto serialized = nimble::test::Encoder<Encoding>::encode(
+        *buffer_, values, nimble::CompressionType::Uncompressed, options);
+    auto view = nimble::createEncodingView(serialized, pool_.get(), options);
+    ASSERT_NE(view, nullptr);
+
+    std::vector<uint32_t> actual(indices.size());
+    view->readAt(
+        std::span<const uint32_t>{indices.data(), indices.size()},
+        actual.data());
+    EXPECT_EQ(actual, expected);
+  }
 }
 
 TEST_F(BlockBitPackingEncodingViewTest, concurrent) {

--- a/velox/dwio/nimble/encodings/tests/EncodingViewTestUtils.h
+++ b/velox/dwio/nimble/encodings/tests/EncodingViewTestUtils.h
@@ -21,6 +21,7 @@
 #include <initializer_list>
 #include <memory>
 #include <random>
+#include <span>
 #include <string>
 #include <thread>
 #include <vector>
@@ -82,6 +83,8 @@ class EncodingViewTest : public ::testing::Test {
         const auto tailLength = std::min<uint32_t>(rowCount, 3);
         expectRangeRead(*view, values, rowCount - tailLength, tailLength);
       }
+      expectIndexedRead(*view, values, {});
+      expectIndexedRead(*view, values, positions);
     }
   }
 
@@ -165,6 +168,25 @@ class EncodingViewTest : public ::testing::Test {
     EXPECT_EQ(
         std::vector<PhysicalType>(actual.begin(), actual.end()),
         std::vector<PhysicalType>(expected, expected + length));
+  }
+
+  template <typename T>
+  void expectIndexedRead(
+      const nimble::EncodingView& view,
+      const nimble::Vector<T>& values,
+      const std::vector<uint32_t>& positions) {
+    SCOPED_TRACE(fmt::format("numPositions={}", positions.size()));
+    using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+    nimble::Vector<PhysicalType> actual{pool_.get(), positions.size()};
+    view.readAt(
+        std::span<const uint32_t>{positions.data(), positions.size()},
+        actual.data());
+    const auto* expected = reinterpret_cast<const PhysicalType*>(values.data());
+    for (size_t i = 0; i < positions.size(); ++i) {
+      SCOPED_TRACE(
+          fmt::format("positionIndex={}, position={}", i, positions[i]));
+      EXPECT_EQ(actual[i], expected[positions[i]]);
+    }
   }
 
   nimble::Vector<int32_t> randomInt32(uint32_t seed) {

--- a/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
@@ -892,6 +892,51 @@ TEST_F(SharedDictionaryEncodingTest, alphabetRoundTripsWithAndWithoutView) {
   }
 }
 
+DEBUG_ONLY_TEST_F(
+    SharedDictionaryEncodingTest,
+    alphabetRejectsOutOfRangeBatchIndicesWithAndWithoutView) {
+  struct TestCase {
+    std::string testName;
+    EncodingType encodingType;
+  };
+
+  const std::vector<TestCase> testCases{
+      {"view", EncodingType::FixedBitWidth},
+      {"decoded entries", EncodingType::Varint},
+  };
+  const std::vector<int32_t> values{10, 20, 30};
+  const std::vector<uint32_t> indices{0, static_cast<uint32_t>(values.size())};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.testName);
+    const auto alphabet = test::createSharedDictionaryAlphabet<int32_t>(
+        values, std::array{testCase.encodingType}, pool_.get());
+    std::vector<TypeTraits<int32_t>::physicalType> output(indices.size());
+
+    NIMBLE_ASSERT_THROW(
+        alphabet->materialize<int32_t>(indices, output.data()),
+        "Shared dictionary index exceeds alphabet size.");
+  }
+}
+
+TEST_F(
+    SharedDictionaryEncodingTest,
+    alphabetMaterializesBlockBitPackingIndexedRuns) {
+  const auto values = sequentialAlphabet(/*size=*/2'051);
+  const auto alphabet = test::createSharedDictionaryAlphabet<int32_t>(
+      values, std::array{EncodingType::BlockBitPacking}, pool_.get());
+  EXPECT_EQ(alphabet->encodingType(), EncodingType::BlockBitPacking);
+
+  const std::vector<uint32_t> indices{
+      3, 3, 4, 5, 1'023, 1'024, 1'025, 2'050, 1};
+  std::vector<TypeTraits<int32_t>::physicalType> materialized(indices.size());
+  alphabet->materialize<int32_t>(indices, materialized.data());
+
+  const std::vector<TypeTraits<int32_t>::physicalType> expected{
+      3, 3, 4, 5, 1'023, 1'024, 1'025, 2'050, 1};
+  EXPECT_EQ(materialized, expected);
+}
+
 TEST_F(SharedDictionaryEncodingTest, materializeAllIntegerTypes) {
   auto verify = [this]<typename T>() {
     SCOPED_TRACE(fmt::format("dataType={}", TypeTraits<T>::dataType));

--- a/velox/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
@@ -19,7 +19,6 @@
 #include <array>
 #include <cstring>
 #include <type_traits>
-#include <vector>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/nimble/common/FixedBitArray.h"
@@ -114,25 +113,29 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
 
  private:
   T readTypedAt(uint32_t index) const final {
+    return detail::castFromPhysicalType<T>(readPhysicalAt(index));
+  }
+
+  physicalType readPhysicalAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
     const auto indexBlock = blockIndex(index);
     const auto blockOffset = index - blockRowOffsets_[indexBlock];
-    const auto& block = blocks_[indexBlock];
+    return readBlockValue(indexBlock, blockOffset);
+  }
+
+  physicalType readBlockValue(uint32_t blockIndex, uint32_t blockOffset) const {
+    const auto& block = blocks_[blockIndex];
     if (block.bitWidth == BlockBitPackingEncoding<T>::kRawBlockBitWidth) {
       const auto* values =
           reinterpret_cast<const physicalType*>(packedData_ + block.offset);
-      return detail::castFromPhysicalType<T>(values[blockOffset]);
+      return values[blockOffset];
     }
     if (block.bitWidth == 0) {
-      return detail::castFromPhysicalType<T>(block.baseline);
+      return block.baseline;
     }
-    const auto numRows = blockRowCount(indexBlock);
-    FixedBitArray fba{
-        {packedData_ + block.offset,
-         FixedBitArray::bufferSize(numRows, block.bitWidth)},
-        block.bitWidth};
-    return detail::castFromPhysicalType<T>(
-        static_cast<physicalType>(fba.get(blockOffset) + block.baseline));
+    FixedBitArray fixedBitArray{packedData_ + block.offset, block.bitWidth};
+    return static_cast<physicalType>(
+        fixedBitArray.get(blockOffset) + block.baseline);
   }
 
   void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
@@ -219,10 +222,7 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
 
     // Rows after the full fastpack groups are stored as a FixedBitArray tail.
     if (blockOffset >= numFullGroupRows) {
-      FixedBitArray fba{
-          {remainderInput,
-           FixedBitArray::bufferSize(numRows - numFullGroupRows, bitWidth)},
-          bitWidth};
+      FixedBitArray fba{remainderInput, bitWidth};
       const auto remainderOffset = blockOffset - numFullGroupRows;
       fba.bulkGetWithBaseline(remainderOffset, length, output, baseline);
       return;
@@ -261,10 +261,7 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
     }
 
     if (outputOffset < length) {
-      FixedBitArray fba{
-          {remainderInput,
-           FixedBitArray::bufferSize(numRows - numFullGroupRows, bitWidth)},
-          bitWidth};
+      FixedBitArray fba{remainderInput, bitWidth};
       fba.bulkGetWithBaseline(
           blockOffset - numFullGroupRows,
           length - outputOffset,

--- a/velox/dwio/nimble/encodings/views/EncodingView.h
+++ b/velox/dwio/nimble/encodings/views/EncodingView.h
@@ -15,8 +15,11 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <string_view>
 
 #include "velox/common/memory/Memory.h"
@@ -36,6 +39,10 @@ class EncodingView {
   /// Reads the physical value at the given row index into a typed output
   /// buffer.
   virtual void readAt(uint32_t index, void* output) const = 0;
+
+  /// Reads physical values at the given row indices into a typed output buffer.
+  virtual void readAt(std::span<const uint32_t> indices, void* output)
+      const = 0;
 
   /// Reads physical values in the given row range into a typed output buffer.
   virtual void read(uint32_t offset, uint32_t length, void* output) const = 0;
@@ -111,13 +118,20 @@ class TypedEncodingView : public EncodingView {
     return readTypedAt(index);
   }
 
+  void readAt(std::span<const uint32_t> indices, physicalType* output) const {
+    readAt(indices, static_cast<void*>(output));
+  }
+
   void read(uint32_t offset, uint32_t length, physicalType* output) const {
     read(offset, length, static_cast<void*>(output));
   }
 
   void readAt(uint32_t index, void* output) const final {
-    *static_cast<physicalType*>(output) =
-        castToPhysicalType(readTypedAt(index));
+    *static_cast<physicalType*>(output) = readPhysicalAt(index);
+  }
+
+  void readAt(std::span<const uint32_t> indices, void* output) const final {
+    readPhysicalAt(indices, static_cast<physicalType*>(output));
   }
 
   void read(uint32_t offset, uint32_t length, void* output) const final {
@@ -135,6 +149,58 @@ class TypedEncodingView : public EncodingView {
       uint32_t offset,
       uint32_t length,
       physicalType* output) const = 0;
+
+  virtual physicalType readPhysicalAt(uint32_t index) const {
+    return castToPhysicalType(readTypedAt(index));
+  }
+
+  // Reads arbitrary row indices. Repeated and contiguous runs reuse cheaper
+  // scalar-fill and range reads before falling back to per-index reads.
+  virtual void readPhysicalAt(
+      std::span<const uint32_t> indices,
+      physicalType* output) const {
+    size_t outputOffset{0};
+    while (outputOffset < indices.size()) {
+      const auto firstIndex = indices[outputOffset];
+      if (outputOffset + 1 == indices.size()) {
+        output[outputOffset] = readPhysicalAt(firstIndex);
+        return;
+      }
+
+      const auto secondIndex = indices[outputOffset + 1];
+      if (secondIndex == firstIndex) {
+        size_t repeatedLength{2};
+        while (outputOffset + repeatedLength < indices.size() &&
+               indices[outputOffset + repeatedLength] == firstIndex) {
+          ++repeatedLength;
+        }
+        const auto value = readPhysicalAt(firstIndex);
+        std::fill(
+            output + outputOffset,
+            output + outputOffset + repeatedLength,
+            value);
+        outputOffset += repeatedLength;
+        continue;
+      }
+
+      if (secondIndex == static_cast<uint64_t>(firstIndex) + 1) {
+        size_t rangeLength{2};
+        while (outputOffset + rangeLength < indices.size() &&
+               indices[outputOffset + rangeLength] ==
+                   static_cast<uint64_t>(firstIndex) + rangeLength) {
+          ++rangeLength;
+        }
+        readPhysical(
+            firstIndex,
+            static_cast<uint32_t>(rangeLength),
+            output + outputOffset);
+        outputOffset += rangeLength;
+        continue;
+      }
+
+      output[outputOffset++] = readPhysicalAt(firstIndex);
+    }
+  }
 
   virtual T readTypedAt(uint32_t index) const = 0;
 


### PR DESCRIPTION
Summary:

Add a batched indexed read API to `EncodingView` and use it when materializing shared dictionary alphabets from view-backed encodings. The default implementation coalesces adjacent repeated and contiguous indices, avoiding scratch allocations while keeping random access near scalar cost.

Optimize BlockBitPacking scalar and range reads by constructing read-only `FixedBitArray` wrappers directly from encoded data, avoiding repeated `bufferSize()` calculation.

Add direct EncodingView and shared-dictionary alphabet benchmarks for random, sorted, and clustered access patterns.

Reviewed By: HuamengJiang

Differential Revision: D116900562


