### PR TITLE
feat(nimble): Parallelize stream encoding

### DIFF
--- a/velox/common/time/Timer.cpp
+++ b/velox/common/time/Timer.cpp
@@ -16,12 +16,44 @@
 
 #include "velox/common/time/Timer.h"
 
+#include <sys/resource.h>
+
 #include "velox/common/testutil/ScopedTestTime.h"
+#include "velox/common/time/CpuWallTimer.h"
 
 namespace facebook::velox {
 
 using namespace std::chrono;
 using common::testutil::ScopedTestTime;
+
+ProcessCpuWallTimer::ProcessCpuWallTimer(CpuWallTiming& timing)
+    : wallTimeStart_{steady_clock::now()},
+      cpuTimeStart_{processCpuNanos()},
+      timing_{timing} {
+  ++timing_.count;
+}
+
+ProcessCpuWallTimer::~ProcessCpuWallTimer() {
+  const auto cpuTimeEnd = processCpuNanos();
+  if (cpuTimeStart_ != kUnavailableCpuTime &&
+      cpuTimeEnd != kUnavailableCpuTime) {
+    timing_.cpuNanos += cpuTimeEnd - cpuTimeStart_;
+  }
+  timing_.wallNanos +=
+      duration_cast<nanoseconds>(steady_clock::now() - wallTimeStart_).count();
+}
+
+uint64_t ProcessCpuWallTimer::processCpuNanos() noexcept {
+  rusage usage{};
+  if (getrusage(RUSAGE_SELF, &usage) != 0) {
+    return kUnavailableCpuTime;
+  }
+  const auto toNanos = [](const timeval& value) {
+    return static_cast<uint64_t>(value.tv_sec) * 1'000'000'000 +
+        static_cast<uint64_t>(value.tv_usec) * 1'000;
+  };
+  return toNanos(usage.ru_utime) + toNanos(usage.ru_stime);
+}
 
 #ifndef NDEBUG
 

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -19,11 +19,14 @@
 #include <folly/chrono/Hardware.h>
 #include <atomic>
 #include <chrono>
+#include <limits>
 #include <optional>
 
 #include "velox/common/process/ProcessBase.h"
 
 namespace facebook::velox {
+
+struct CpuWallTiming;
 
 /// Measures wall time (steady_clock) between construction and destruction,
 /// incrementing a user-supplied counter in microseconds.
@@ -97,6 +100,32 @@ class NanosecondCPUTimer {
  private:
   uint64_t* timer_;
   uint64_t start_;
+};
+
+/// Adds process-wide CPU and wall time to a CpuWallTiming. Unlike
+/// CpuWallTimer, which measures CPU consumed by the calling thread, this timer
+/// includes user and system CPU consumed by all process threads. CPU time can
+/// exceed wall time when background thread pools run work concurrently.
+class ProcessCpuWallTimer {
+ public:
+  explicit ProcessCpuWallTimer(CpuWallTiming& timing);
+  ~ProcessCpuWallTimer();
+
+  ProcessCpuWallTimer(const ProcessCpuWallTimer&) = delete;
+  ProcessCpuWallTimer& operator=(const ProcessCpuWallTimer&) = delete;
+  ProcessCpuWallTimer(ProcessCpuWallTimer&&) = delete;
+  ProcessCpuWallTimer& operator=(ProcessCpuWallTimer&&) = delete;
+
+ private:
+  // Returns user and system CPU consumed across all process threads.
+  static uint64_t processCpuNanos() noexcept;
+
+  static constexpr uint64_t kUnavailableCpuTime{
+      std::numeric_limits<uint64_t>::max()};
+
+  const std::chrono::steady_clock::time_point wallTimeStart_;
+  const uint64_t cpuTimeStart_;
+  CpuWallTiming& timing_;
 };
 
 using MicrosecondTimer = MicrosecondWallTimer;

--- a/velox/common/time/tests/CpuWallTimerTest.cpp
+++ b/velox/common/time/tests/CpuWallTimerTest.cpp
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <atomic>
+#include <latch>
 #include <thread>
 
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/common/time/Timer.h"
 
 using namespace facebook::velox;
 
@@ -102,6 +106,45 @@ TEST_F(CpuWallTimerTest, cpuWallTimer) {
   EXPECT_EQ(2, timing.count);
   EXPECT_LT(sleepTime.count() * 2, timing.wallNanos);
   EXPECT_LT(cpuFirstTime, timing.cpuNanos);
+}
+
+TEST_F(CpuWallTimerTest, processCpuWallTimerIncludesBackgroundThreads) {
+  constexpr uint32_t numWorkers{4};
+  folly::CPUThreadPoolExecutor executor{numWorkers};
+  std::latch allStarted{numWorkers};
+  std::latch startWork{1};
+  std::latch finished{numWorkers};
+  std::atomic<uint64_t> totalIterations{0};
+  constexpr uint64_t iterationsPerWorker{2'000'000};
+  for (uint32_t worker = 0; worker < numWorkers; ++worker) {
+    executor.add([&] {
+      allStarted.count_down();
+      startWork.wait();
+      for (uint64_t iteration = 0; iteration < iterationsPerWorker;
+           ++iteration) {
+        totalIterations.fetch_add(1, std::memory_order_relaxed);
+      }
+      finished.count_down();
+    });
+  }
+  allStarted.wait();
+
+  CpuWallTiming threadTiming;
+  CpuWallTiming processTiming;
+  {
+    ProcessCpuWallTimer processTimer{processTiming};
+    CpuWallTimer threadTimer{threadTiming};
+    startWork.count_down();
+    finished.wait();
+  }
+
+  EXPECT_EQ(
+      totalIterations.load(std::memory_order_relaxed),
+      numWorkers * iterationsPerWorker);
+  EXPECT_EQ(processTiming.count, 1);
+  EXPECT_EQ(threadTiming.count, 1);
+  EXPECT_GT(processTiming.cpuNanos, threadTiming.cpuNanos + 10'000'000);
+  EXPECT_GE(processTiming.wallNanos, threadTiming.wallNanos);
 }
 
 TEST_F(CpuWallTimerTest, deltaCpuWallTimer) {

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -151,6 +151,62 @@ These stats are reported only by TableWriter operator
      - nanos
      - The walltime spent on file write data compression.
 
+Nimble Writer
+~~~~~~~~~~~~~
+These stats are reported by TableWriter when writing Nimble files. Encoding
+CPU time is summed across encoding worker threads and can exceed the
+corresponding wall time when parallel encoding is enabled.
+
+.. list-table::
+   :widths: 50 25 50
+   :header-rows: 1
+
+   * - Stats
+     - Unit
+     - Description
+   * - nimble.writtenBytes
+     - bytes
+     - Total number of bytes written to the Nimble file.
+   * - nimble.inputBytes
+     - bytes
+     - Uncompressed size of the input written to the Nimble file.
+   * - nimble.writeCpuNanos
+     - nanos
+     - CPU time spent writing encoded stripes through the tablet writer.
+   * - nimble.writeWallNanos
+     - nanos
+     - Wall time spent writing encoded stripes through the tablet writer.
+   * - nimble.ingestionCpuNanos
+     - nanos
+     - CPU time spent ingesting input vectors into field-writer buffers.
+   * - nimble.ingestionWallNanos
+     - nanos
+     - Wall time spent ingesting input vectors into field-writer buffers.
+   * - nimble.encodingCpuNanos
+     - nanos
+     - CPU time spent encoding and compressing streams, summed across all
+       encoding worker threads.
+   * - nimble.encodingWallNanos
+     - nanos
+     - Wall time spent encoding and compressing streams.
+   * - nimble.encodingSelectionCpuNanos
+     - nanos
+     - CPU time spent selecting encodings. This is a subset of
+       ``nimble.encodingCpuNanos``.
+   * - nimble.rowsPerStripe
+     -
+     - Distribution of row counts per stripe. The metric count is the number
+       of stripes written.
+   * - nimble.chunkSizeBytes
+     - bytes
+     - Distribution of encoded chunk sizes.
+   * - nimble.duplicateStreamCount
+     -
+     - Number of streams deduplicated by the tablet writer.
+   * - nimble.duplicateStreamBytes
+     - bytes
+     - Number of encoded bytes deduplicated by the tablet writer.
+
 LookupIndexJoin
 ---------------
 These stats are reported only by IndexLookupJoin operator

--- a/velox/dwio/nimble/velox/FieldWriter.cpp
+++ b/velox/dwio/nimble/velox/FieldWriter.cpp
@@ -15,12 +15,8 @@
  */
 #include "velox/dwio/nimble/velox/FieldWriter.h"
 
-#include <folly/coro/BlockingWait.h>
-#include <folly/coro/Collect.h>
-#include <folly/coro/Invoke.h>
 #include <folly/system/HardwareConcurrency.h>
 #include "velox/common/base/CompareFlags.h"
-#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/velox/DeduplicationUtils.h"
 #include "velox/dwio/nimble/velox/RawSizeUtils.h"
@@ -626,55 +622,10 @@ class RowFieldWriter : public FieldWriter {
 
   void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
       override {
-    if (parallelWriteEnabled(static_cast<uint32_t>(fields_.size()))) {
-      folly::coro::blockingWait(co_write(vector, ranges));
-      return;
-    }
     auto ctx = prepareChildRanges(vector, ranges);
     for (auto i = 0; i < fields_.size(); ++i) {
       fields_[i]->write(ctx.row->childAt(i), *ctx.childRangesPtr);
     }
-    collectStatistics(ctx.nullCount, ctx.size);
-  }
-
-  folly::coro::Task<void> co_write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges) override {
-    auto ctx = prepareChildRanges(vector, ranges);
-
-    const uint32_t numChildren = static_cast<uint32_t>(fields_.size());
-    const uint32_t taskCount = computeParallelWriteTaskCount(numChildren);
-    velox::common::testutil::TestValue::adjust(
-        "facebook::nimble::RowFieldWriter::co_write",
-        const_cast<uint32_t*>(&taskCount));
-
-    const uint32_t childrenPerTask = numChildren / taskCount;
-    const uint32_t numRemainderChildren = numChildren % taskCount;
-
-    auto writeRange = [this, &ctx](uint32_t startIdx, uint32_t endIdx) {
-      for (uint32_t i = startIdx; i < endIdx; ++i) {
-        fields_[i]->write(ctx.row->childAt(i), *ctx.childRangesPtr);
-      }
-    };
-
-    std::vector<folly::coro::TaskWithExecutor<void>> tasks;
-    tasks.reserve(taskCount);
-    uint32_t nextChildIdx = 0;
-    for (uint32_t taskId = 0; taskId < taskCount; ++taskId) {
-      const uint32_t endChildIdx = nextChildIdx + childrenPerTask +
-          (taskId < numRemainderChildren ? 1 : 0);
-      tasks.emplace_back(co_withExecutor(
-          context_.encodeExecutor(),
-          folly::coro::co_invoke(
-              [&writeRange, nextChildIdx, endChildIdx]()
-                  -> folly::coro::Task<void> {
-                writeRange(nextChildIdx, endChildIdx);
-                co_return;
-              })));
-      nextChildIdx = endChildIdx;
-    }
-
-    co_await folly::coro::collectAllRange(std::move(tasks));
     collectStatistics(ctx.nullCount, ctx.size);
   }
 
@@ -693,8 +644,7 @@ class RowFieldWriter : public FieldWriter {
   }
 
  private:
-  // Result of null processing and child range computation, shared between
-  // the synchronous write() and coroutine co_write() paths.
+  // Result of null processing and child range computation.
   struct PrepareContext {
     // Decoded row vector (either direct cast or decoded from encoded input).
     const velox::RowVector* row{};
@@ -1516,14 +1466,8 @@ class FlatMapFieldWriter : public FieldWriter {
 
   FlatMapPassthroughValueFieldWriter& createPassthroughValueFieldWriter(
       const std::string& key) {
-    // Creating a new passthrough value field mutates shared context state:
-    // FieldWriter::create() appends to the shared streams_ and schemaBuilder_,
-    // and handleFlatmapFieldAddEvent() updates shared context. Sibling flat-map
-    // columns are written concurrently by RowFieldWriter::co_write when
-    // parallel write is enabled, so these mutations must be serialized. This
-    // mirrors getValueFieldWriter(), which already guards the identical
-    // operations with flatMapSchemaMutex_; the passthrough path was missing the
-    // lock.
+    // Keep dynamic schema mutations in the same critical section as the
+    // injected-key path below.
     std::scoped_lock<std::mutex> lock{context_.flatMapSchemaMutex()};
     auto fieldWriter = FieldWriter::create(context_, valueType_);
     auto& inMapDescriptor =
@@ -1930,14 +1874,8 @@ class FlatMapFieldWriter : public FieldWriter {
     // Now actually ingest the map values
     if (nonNullCount > 0) {
       auto& values = map->mapValues();
-
-      if (parallelWriteEnabled(
-              static_cast<uint32_t>(currentValueFields_.size()))) {
-        folly::coro::blockingWait(co_writeMapValues(values, nonNullCount));
-      } else {
-        for (auto& pair : currentValueFields_) {
-          pair.second->write(values, nonNullCount);
-        }
+      for (auto& pair : currentValueFields_) {
+        pair.second->write(values, nonNullCount);
       }
     }
     nonNullCount_ += nonNullCount;
@@ -1986,52 +1924,6 @@ class FlatMapFieldWriter : public FieldWriter {
   }
 
  private:
-  folly::coro::Task<void> co_writeMapValues(
-      const velox::VectorPtr& values,
-      uint32_t nonNullCount) {
-    std::vector<FlatMapValueFieldWriter*> valueWriters;
-    valueWriters.reserve(currentValueFields_.size());
-    for (auto& pair : currentValueFields_) {
-      valueWriters.push_back(pair.second);
-    }
-
-    const uint32_t taskCount = computeParallelWriteTaskCount(
-        static_cast<uint32_t>(valueWriters.size()));
-    velox::common::testutil::TestValue::adjust(
-        "facebook::nimble::FlatMapFieldWriter::co_writeMapValues",
-        const_cast<uint32_t*>(&taskCount));
-
-    const uint32_t writersPerTask =
-        static_cast<uint32_t>(valueWriters.size()) / taskCount;
-    const uint32_t numRemainderWriters =
-        static_cast<uint32_t>(valueWriters.size()) % taskCount;
-
-    auto writeRange = [&valueWriters, &values, nonNullCount](
-                          uint32_t startIdx, uint32_t endIdx) {
-      for (uint32_t idx = startIdx; idx < endIdx; ++idx) {
-        valueWriters[idx]->write(values, nonNullCount);
-      }
-    };
-
-    std::vector<folly::coro::TaskWithExecutor<void>> tasks;
-    tasks.reserve(taskCount);
-    uint32_t nextIdx = 0;
-    for (uint32_t taskId = 0; taskId < taskCount; ++taskId) {
-      const uint32_t endIdx =
-          nextIdx + writersPerTask + (taskId < numRemainderWriters ? 1 : 0);
-      tasks.emplace_back(co_withExecutor(
-          context_.encodeExecutor(),
-          folly::coro::co_invoke(
-              [&writeRange, nextIdx, endIdx]() -> folly::coro::Task<void> {
-                writeRange(nextIdx, endIdx);
-                co_return;
-              })));
-      nextIdx = endIdx;
-    }
-
-    co_await folly::coro::collectAllRange(std::move(tasks));
-  }
-
   inline bool hasPredefinedKeys() const {
     return context_.getFlatMapNodeKeys(nodeId_) != nullptr;
   }
@@ -2868,22 +2760,6 @@ std::unique_ptr<FieldWriter> FieldWriter::create(
   }
   context.handleAddedType(*field->typeBuilder(), type->id());
   return field;
-}
-
-uint32_t FieldWriter::computeParallelWriteTaskCount(
-    uint32_t numChildren) const {
-  if (numChildren == 0) {
-    return 0;
-  }
-  const uint32_t maxByStreams =
-      numChildren / std::max(1u, context_.minStreamsPerEncodeUnit());
-  return std::clamp(
-      std::min(context_.maxEncodeParallelism(), maxByStreams), 1u, numChildren);
-}
-
-bool FieldWriter::parallelWriteEnabled(uint32_t numChildren) const {
-  return context_.encodeExecutor() != nullptr &&
-      computeParallelWriteTaskCount(numChildren) > 1;
 }
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/FieldWriter.h
+++ b/velox/dwio/nimble/velox/FieldWriter.h
@@ -18,9 +18,6 @@
 
 #include <set>
 
-#include <folly/Executor.h>
-#include <folly/coro/Task.h>
-
 #include "folly/container/F14Map.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -251,28 +248,6 @@ class FieldWriterContext {
     maxFlatMapKeys_ = value;
   }
 
-  void setParallelEncoding(
-      folly::Executor* executor,
-      uint32_t maxEncodeParallelism = 8,
-      uint32_t minStreamsPerEncodeUnit = 2) {
-    NIMBLE_CHECK_NOT_NULL(executor, "encodeExecutor must not be null");
-    encodeExecutor_ = executor;
-    maxEncodeParallelism_ = maxEncodeParallelism;
-    minStreamsPerEncodeUnit_ = minStreamsPerEncodeUnit;
-  }
-
-  folly::Executor* encodeExecutor() const {
-    return encodeExecutor_;
-  }
-
-  uint32_t maxEncodeParallelism() const {
-    return maxEncodeParallelism_;
-  }
-
-  uint32_t minStreamsPerEncodeUnit() const {
-    return minStreamsPerEncodeUnit_;
-  }
-
   inline std::unique_ptr<InputBufferGrowthPolicy>& inputBufferGrowthPolicy() {
     return inputBufferGrowthPolicy_;
   }
@@ -497,10 +472,6 @@ class FieldWriterContext {
   bool disableSharedStringBuffers_{false};
   uint32_t maxFlatMapKeys_{kDefaultMaxFlatMapKeys};
 
-  folly::Executor* encodeExecutor_{nullptr};
-  uint32_t maxEncodeParallelism_{0};
-  uint32_t minStreamsPerEncodeUnit_{1};
-
   std::unique_ptr<InputBufferGrowthPolicy> inputBufferGrowthPolicy_;
   std::unique_ptr<InputBufferGrowthPolicy> stringBufferGrowthPolicy_;
   InputBufferGrowthStats inputBufferGrowthStats_;
@@ -646,13 +617,6 @@ class FieldWriter {
       const velox::VectorPtr& vector,
       const OrderedRanges& ranges) = 0;
 
-  virtual folly::coro::Task<void> co_write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges) {
-    write(vector, ranges);
-    co_return;
-  }
-
   // Collects stats and clears interanl state and any accumulated data in
   // internal buffers.
   virtual void reset() = 0;
@@ -675,13 +639,6 @@ class FieldWriter {
       std::function<void(TypeBuilder&, uint32_t)> typeAddedHandler);
 
  protected:
-  // Computes the number of parallel write tasks based on max parallelism and
-  // minimum streams per task. The result is clamped to [1, numChildren].
-  uint32_t computeParallelWriteTaskCount(uint32_t numChildren) const;
-
-  // Returns true if child fields should be written in parallel.
-  bool parallelWriteEnabled(uint32_t numChildren) const;
-
   FieldWriterContext& context_;
   std::shared_ptr<TypeBuilder> typeBuilder_;
 };

--- a/velox/dwio/nimble/velox/tests/NimbleWriterPassthroughFlatmapRaceTest.cpp
+++ b/velox/dwio/nimble/velox/tests/NimbleWriterPassthroughFlatmapRaceTest.cpp
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-// Regression test for a data race in the flat-map passthrough write path.
+// Regression coverage for the flat-map passthrough schema-creation path.
 //
 // FlatMapFieldWriter's passthrough new-field path
 // (createPassthroughValueFieldWriter) mints a value field for a new key, which
 // mutates shared FieldWriterContext state: FieldWriter::create appends to the
 // shared streams_ and schemaBuilder_, and handleFlatmapFieldAddEvent updates
-// shared context. The injected-key path (getValueFieldWriter) guards the
-// identical mutations with flatMapSchemaMutex_, but the passthrough path was
-// missing the lock. When flat-map columns are passed through with parallel
-// write enabled, the root RowFieldWriter writes multiple columns concurrently
-// (RowFieldWriter::co_write); if two of them mint a new passthrough key at the
-// same time they race the shared registration and corrupt the written file.
+// shared context. The passthrough and injected-key paths use the same critical
+// section for these mutations.
 //
 // The input is many flat-map columns with disjoint key sets, all keys present
-// in the first batch, so the first write() mints every passthrough value field
-// concurrently across columns -- exactly the racing shape. Reading back must
-// return every row; a corrupt stripe/stream index throws or short-counts.
-//
-// Run under ThreadSanitizer to catch the data race directly.
+// in the first batch, so the first write() mints every passthrough value field.
+// Reading back must return every row; a corrupt stripe/stream index throws or
+// short-counts.
 
 #include <folly/executors/GlobalExecutor.h>
 #include <glog/logging.h>
@@ -97,16 +91,15 @@ class NimbleWriterPassthroughFlatmapRaceTest
     for (int column = 0; column < kNumColumns; ++column) {
       options.flatMapColumns["c" + folly::to<std::string>(column)];
     }
-    // Parallel write/encode across the flat-map columns on the shared
-    // process-global executor.
+    // Encode streams on the shared process-global executor.
     options.encodingExecutor = folly::getGlobalCPUExecutor();
     options.maxEncodeParallelism = 8;
-    options.minStreamsPerEncodeUnit = 1;
+    options.minStreamsPerEncodingTask = 1;
     return options;
   }
 };
 
-TEST_F(NimbleWriterPassthroughFlatmapRaceTest, concurrentPassthroughNewKeys) {
+TEST_F(NimbleWriterPassthroughFlatmapRaceTest, passthroughNewKeysRoundTrip) {
   const auto schema = makeBatch()->type();
   uint32_t corrupt = 0;
 

--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -4820,6 +4820,7 @@ TEST_F(WriterTest, runtimeStatsPublishesEveryCounter) {
           ::testing::Key("nimble.writeCpuNanos"),
           ::testing::Key("nimble.writeWallNanos"),
           ::testing::Key("nimble.ingestionCpuNanos"),
+          ::testing::Key("nimble.ingestionWallNanos"),
           ::testing::Key("nimble.encodingCpuNanos"),
           ::testing::Key("nimble.encodingWallNanos"),
           ::testing::Key("nimble.encodingSelectionCpuNanos"),
@@ -8993,13 +8994,13 @@ TEST_F(WriterTest, flatmapColumnsKeysImplicitFlatMapColumn) {
 
 struct ParallelEncodeParam {
   uint32_t maxEncodeParallelism;
-  uint32_t minStreamsPerEncodeUnit;
+  uint32_t minStreamsPerEncodingTask;
 
   std::string debugString() const {
     return fmt::format(
         "maxParallel_{}_minStreams_{}",
         maxEncodeParallelism,
-        minStreamsPerEncodeUnit);
+        minStreamsPerEncodingTask);
   }
 };
 
@@ -9012,7 +9013,7 @@ class ParallelEncodeWriterTest
     executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(4);
     options.encodingExecutor = folly::getKeepAliveToken(*executor_);
     options.maxEncodeParallelism = GetParam().maxEncodeParallelism;
-    options.minStreamsPerEncodeUnit = GetParam().minStreamsPerEncodeUnit;
+    options.minStreamsPerEncodingTask = GetParam().minStreamsPerEncodingTask;
     return options;
   }
 
@@ -9156,7 +9157,7 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.debugString();
     });
 
-DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeRowTaskCount) {
+DEBUG_ONLY_TEST_F(WriterTest, bufferingRemainsSequential) {
   velox::common::testutil::TestValue::enable();
 
   auto type = velox::ROW({
@@ -9175,17 +9176,14 @@ DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeRowTaskCount) {
 
   struct TestCase {
     uint32_t maxEncodeParallelism;
-    uint32_t minStreamsPerEncodeUnit;
-    uint32_t expectedTaskCount;
+    uint32_t minStreamsPerEncodingTask;
   };
 
   const std::vector<TestCase> testCases = {
-      {2, 1, 2},
-      {4, 1, 4},
-      {8, 1, 8},
-      {4, 4, 2},
-      {8, 4, 2},
-      {100, 1, 8},
+      {4, 0},
+      {2, 1},
+      {4, 1},
+      {8, 4},
   };
 
   folly::CPUThreadPoolExecutor executor(4);
@@ -9193,24 +9191,21 @@ DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeRowTaskCount) {
   for (const auto& testCase : testCases) {
     SCOPED_TRACE(
         fmt::format(
-            "maxParallel={}, minStreams={}, expected={}",
+            "maxParallel={}, minStreams={}",
             testCase.maxEncodeParallelism,
-            testCase.minStreamsPerEncodeUnit,
-            testCase.expectedTaskCount));
+            testCase.minStreamsPerEncodingTask));
 
     nimble::WriterOptions writerOptions;
     writerOptions.encodingExecutor = folly::getKeepAliveToken(executor);
     writerOptions.maxEncodeParallelism = testCase.maxEncodeParallelism;
-    writerOptions.minStreamsPerEncodeUnit = testCase.minStreamsPerEncodeUnit;
+    writerOptions.minStreamsPerEncodingTask =
+        testCase.minStreamsPerEncodingTask;
 
-    uint32_t parallelWriteCount = 0;
-    std::vector<uint32_t> observedTaskCounts;
+    uint32_t parallelWriteCount{0};
     SCOPED_TESTVALUE_SET(
         "facebook::nimble::RowFieldWriter::co_write",
-        std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
-          ++parallelWriteCount;
-          observedTaskCounts.emplace_back(*taskCount);
-        }));
+        std::function<void(const uint32_t*)>(
+            [&](const uint32_t*) { ++parallelWriteCount; }));
 
     std::string file;
     auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
@@ -9223,10 +9218,7 @@ DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeRowTaskCount) {
     }
     writer.close();
 
-    EXPECT_EQ(parallelWriteCount, numBatches);
-    for (const auto taskCount : observedTaskCounts) {
-      EXPECT_EQ(taskCount, testCase.expectedTaskCount);
-    }
+    EXPECT_EQ(parallelWriteCount, 0);
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
     nimble::VeloxReader reader(readFile.get(), *leafPool_);
@@ -9236,7 +9228,73 @@ DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeRowTaskCount) {
   }
 }
 
-DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeFlatMapTaskCount) {
+DEBUG_ONLY_TEST_F(WriterTest, parallelEncodingTaskCount) {
+  velox::common::testutil::TestValue::enable();
+
+  auto type = velox::ROW({
+      {"a", velox::BIGINT()},
+      {"b", velox::BIGINT()},
+      {"c", velox::BIGINT()},
+      {"d", velox::BIGINT()},
+      {"e", velox::BIGINT()},
+      {"f", velox::BIGINT()},
+      {"g", velox::BIGINT()},
+      {"h", velox::BIGINT()},
+  });
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = 100, .nullRatio = 0}, leafPool_.get());
+  folly::CPUThreadPoolExecutor executor{8};
+
+  struct TestCase {
+    uint32_t maxEncodeParallelism;
+    uint32_t minStreamsPerEncodingTask;
+    uint32_t expectedTaskCount;
+  };
+  const std::vector<TestCase> testCases = {
+      {4, 0, 4},
+      {4, 1, 4},
+      {4, 3, 3},
+      {2, 3, 2},
+      {8, 32, 0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "maxParallel={}, minStreams={}, expected={}",
+            testCase.maxEncodeParallelism,
+            testCase.minStreamsPerEncodingTask,
+            testCase.expectedTaskCount));
+
+    std::atomic<uint32_t> taskCount{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::nimble::Writer::parallelEncodeTask",
+        std::function<void(const uint32_t*)>([&](const uint32_t*) {
+          taskCount.fetch_add(1, std::memory_order_relaxed);
+        }));
+
+    nimble::WriterOptions writerOptions;
+    writerOptions.enableChunking = false;
+    writerOptions.encodingExecutor = folly::getKeepAliveToken(executor);
+    writerOptions.maxEncodeParallelism = testCase.maxEncodeParallelism;
+    writerOptions.minStreamsPerEncodingTask =
+        testCase.minStreamsPerEncodingTask;
+
+    std::string file;
+    nimble::Writer writer(
+        type,
+        std::make_unique<velox::InMemoryWriteFile>(&file),
+        *rootPool_,
+        writerOptions);
+    writer.write(fuzzer.fuzzInputRow(type));
+    writer.close();
+
+    EXPECT_EQ(
+        taskCount.load(std::memory_order_relaxed), testCase.expectedTaskCount);
+  }
+}
+
+DEBUG_ONLY_TEST_F(WriterTest, flatMapBufferingRemainsSequential) {
   velox::common::testutil::TestValue::enable();
 
   auto type = velox::ROW({
@@ -9254,15 +9312,13 @@ DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeFlatMapTaskCount) {
   writerOptions.flatMapColumns = {{"flatmap", {}}};
   writerOptions.encodingExecutor = folly::getKeepAliveToken(executor);
   writerOptions.maxEncodeParallelism = 4;
-  writerOptions.minStreamsPerEncodeUnit = 1;
+  writerOptions.minStreamsPerEncodingTask = 1;
 
-  uint32_t flatMapParallelCount = 0;
+  uint32_t flatMapParallelCount{0};
   SCOPED_TESTVALUE_SET(
       "facebook::nimble::FlatMapFieldWriter::co_writeMapValues",
-      std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
-        ++flatMapParallelCount;
-        EXPECT_GT(*taskCount, 1);
-      }));
+      std::function<void(const uint32_t*)>(
+          [&](const uint32_t*) { ++flatMapParallelCount; }));
 
   std::string file;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
@@ -9274,7 +9330,7 @@ DEBUG_ONLY_TEST_F(WriterTest, parallelEncodeFlatMapTaskCount) {
   }
   writer.close();
 
-  EXPECT_GT(flatMapParallelCount, 0);
+  EXPECT_EQ(flatMapParallelCount, 0);
 
   auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
   nimble::VeloxReader reader(readFile.get(), *leafPool_);
@@ -9372,7 +9428,7 @@ TEST_F(WriterTest, randomEncodingSelectionVariesByChunkContents) {
   auto parallelOptions = makeOptions();
   parallelOptions.encodingExecutor = folly::getKeepAliveToken(executor);
   parallelOptions.maxEncodeParallelism = 2;
-  parallelOptions.minStreamsPerEncodeUnit = 1;
+  parallelOptions.minStreamsPerEncodingTask = 1;
   const auto parallel = writeAndCaptureChunkLayouts(
       rowType, batches, std::move(parallelOptions), /*expectedStripeCount=*/1);
   ASSERT_THAT(parallel, ::testing::SizeIs(first.size()));
@@ -9425,7 +9481,7 @@ TEST_F(WriterTest, randomEncodingSelectionDeterministic) {
       makeRandomEncodingSelectionPolicyCreator(seed);
   parallelOptions.encodingExecutor = folly::getKeepAliveToken(executor);
   parallelOptions.maxEncodeParallelism = 4;
-  parallelOptions.minStreamsPerEncodeUnit = 1;
+  parallelOptions.minStreamsPerEncodingTask = 1;
   EXPECT_EQ(
       file,
       writeWithWriterOptions(*rootPool_, vector, std::move(parallelOptions)));

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -90,13 +90,6 @@ class WriterContext : public FieldWriterContext {
     ignoreTopLevelNulls_ = options_.ignoreTopLevelNulls;
     disableSharedStringBuffers_ = options_.disableSharedStringBuffers;
     maxFlatMapKeys_ = options_.maxFlatMapKeys;
-    if (this->options_.encodingExecutor &&
-        this->options_.maxEncodeParallelism > 0) {
-      setParallelEncoding(
-          this->options_.encodingExecutor.get(),
-          this->options_.maxEncodeParallelism,
-          this->options_.minStreamsPerEncodeUnit);
-    }
   }
 
   const WriterOptions& options() const {
@@ -2583,6 +2576,7 @@ void Writer::reportRuntimeStats() const {
   reportNanos(Keys::kWriteCpuNanos);
   reportNanos(Keys::kWriteWallNanos);
   reportNanos(Keys::kIngestionCpuNanos);
+  reportNanos(Keys::kIngestionWallNanos);
   reportNanos(Keys::kEncodingSelectionCpuNanos);
 
   // Distributions are published whole, so they replace rather than accumulate.
@@ -2632,15 +2626,19 @@ std::unique_ptr<EncodingBufferPool> Writer::makeEncodingBufferPool() const {
       encodingMemoryPool_.get(), maxCachedBuffers);
 }
 
-uint32_t Writer::encodingConcurrency(uint32_t taskCount) const {
-  if (taskCount == 0) {
+uint32_t Writer::encodingConcurrency(uint32_t streamCount) const {
+  if (streamCount == 0) {
     return 0;
   }
   const auto& options = context_->options();
   if (!options.encodingExecutor || options.maxEncodeParallelism == 0) {
     return 1;
   }
-  return std::min(taskCount, options.maxEncodeParallelism);
+  const auto minStreamsPerEncodingTask =
+      std::max(1u, options.minStreamsPerEncodingTask);
+  const auto maxByStreams =
+      std::max(1u, streamCount / minStreamsPerEncodingTask);
+  return std::min({streamCount, options.maxEncodeParallelism, maxByStreams});
 }
 
 void Writer::ensureEncodingScratchBufferPools(uint32_t poolCount) {
@@ -2731,37 +2729,43 @@ void Writer::writeStreams() {
       NIMBLE_CHECK(
           encodingExecutor,
           "Encoding executor is required for parallel encoding.");
-      for (uint32_t start = 0; start < streamCount; start += concurrency) {
-        velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
-        const auto batchSize = std::min(concurrency, streamCount - start);
-        for (uint32_t index = 0; index < batchSize; ++index) {
-          auto& [nodeId, streamData] = streams[start + index];
-          auto* encodingScratchBufferPool =
-              this->encodingScratchBufferPool(index);
-          auto* encodingBufferPool = this->encodingBufferPool(index);
-          barrier.add([&,
-                       statsCollector = context_->getStatsCollector(nodeId),
-                       _streamData = streamData.get(),
-                       encodingScratchBufferPool,
-                       encodingBufferPool]() {
-            uint64_t startCpuNs = velox::process::threadCpuNanos();
-            uint64_t streamSize{0};
-            processStream(
-                *_streamData,
-                encodingScratchBufferPool,
-                encodingBufferPool,
-                streamSize,
-                chunkSize);
-            if (statsCollector) {
-              statsCollector->addPhysicalSize(streamSize);
-            }
-            encodingCpuNanos.fetch_add(
-                velox::process::threadCpuNanos() - startCpuNs,
-                std::memory_order_relaxed);
-          });
-        }
-        barrier.waitAll();
+      std::atomic_uint32_t nextStream{0};
+      velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
+      for (uint32_t taskId = 0; taskId < concurrency; ++taskId) {
+        auto* encodingScratchBufferPool =
+            this->encodingScratchBufferPool(taskId);
+        auto* encodingBufferPool = this->encodingBufferPool(taskId);
+        barrier.add(
+            [&, taskId, encodingScratchBufferPool, encodingBufferPool]() {
+              velox::common::testutil::TestValue::adjust(
+                  "facebook::nimble::Writer::parallelEncodeTask",
+                  const_cast<uint32_t*>(&taskId));
+              const auto startCpuNanos = velox::process::threadCpuNanos();
+              while (true) {
+                const auto streamIndex =
+                    nextStream.fetch_add(1, std::memory_order_relaxed);
+                if (streamIndex >= streamCount) {
+                  break;
+                }
+                auto& [nodeId, streamData] = streams[streamIndex];
+                uint64_t streamSize{0};
+                processStream(
+                    *streamData,
+                    encodingScratchBufferPool,
+                    encodingBufferPool,
+                    streamSize,
+                    chunkSize);
+                auto* statsCollector = context_->getStatsCollector(nodeId);
+                if (statsCollector) {
+                  statsCollector->addPhysicalSize(streamSize);
+                }
+              }
+              encodingCpuNanos.fetch_add(
+                  velox::process::threadCpuNanos() - startCpuNanos,
+                  std::memory_order_relaxed);
+            });
       }
+      barrier.waitAll();
     } else {
       auto* encodingScratchBufferPool = this->encodingScratchBufferPool();
       auto* encodingBufferPool = this->encodingBufferPool();
@@ -2964,31 +2968,33 @@ bool Writer::writeChunks(
       NIMBLE_CHECK(
           encodingExecutor,
           "Encoding executor is required for parallel encoding.");
-      for (uint32_t start = 0; start < streamCount; start += concurrency) {
-        velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
-        const auto batchSize = std::min(concurrency, streamCount - start);
-        for (uint32_t index = 0; index < batchSize; ++index) {
-          const auto streamIndex = streamIndices[start + index];
-          auto& [nodeId, streamData] = streams[streamIndex];
-          const auto offset = streamData->descriptor().offset();
-          auto* encodedStream = &encodedStreams_[offset];
-          auto* encodingScratchBufferPool =
-              this->encodingScratchBufferPool(index);
-          auto* encodingBufferPool = this->encodingBufferPool(index);
-          barrier.add([&,
-                       streamDataPtr = streamData.get(),
-                       encodedStream,
-                       encodingScratchBufferPool,
-                       encodingBufferPool,
-                       statsCollector = context_->getStatsCollector(nodeId)] {
-            uint64_t startCpuNs = velox::process::threadCpuNanos();
-            uint64_t streamSize = 0;
+      std::atomic_uint32_t nextStream{0};
+      velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
+      for (uint32_t taskId = 0; taskId < concurrency; ++taskId) {
+        auto* encodingScratchBufferPool =
+            this->encodingScratchBufferPool(taskId);
+        auto* encodingBufferPool = this->encodingBufferPool(taskId);
+        barrier.add([&, taskId, encodingScratchBufferPool, encodingBufferPool] {
+          velox::common::testutil::TestValue::adjust(
+              "facebook::nimble::Writer::parallelEncodeTask",
+              const_cast<uint32_t*>(&taskId));
+          const auto startCpuNanos = velox::process::threadCpuNanos();
+          while (true) {
+            const auto inputIndex =
+                nextStream.fetch_add(1, std::memory_order_relaxed);
+            if (inputIndex >= streamCount) {
+              break;
+            }
+            const auto streamIndex = streamIndices[inputIndex];
+            auto& [nodeId, streamData] = streams[streamIndex];
+            const auto offset = streamData->descriptor().offset();
+            uint64_t streamSize{0};
             if (encodeStreamChunk(
-                    *streamDataPtr,
+                    *streamData,
                     minChunkSize,
                     maxChunkSize,
                     ensureFullChunks,
-                    *encodedStream,
+                    encodedStreams_[offset],
                     encodingScratchBufferPool,
                     encodingBufferPool,
                     streamSize,
@@ -2996,16 +3002,17 @@ bool Writer::writeChunks(
                     logicalBytes)) {
               writtenChunk = true;
             }
+            auto* statsCollector = context_->getStatsCollector(nodeId);
             if (statsCollector) {
               statsCollector->addPhysicalSize(streamSize);
             }
-            encodingCpuNanos.fetch_add(
-                velox::process::threadCpuNanos() - startCpuNs,
-                std::memory_order_relaxed);
-          });
-        }
-        barrier.waitAll();
+          }
+          encodingCpuNanos.fetch_add(
+              velox::process::threadCpuNanos() - startCpuNanos,
+              std::memory_order_relaxed);
+        });
       }
+      barrier.waitAll();
     } else {
       auto* encodingScratchBufferPool = this->encodingScratchBufferPool();
       auto* encodingBufferPool = this->encodingBufferPool();
@@ -3226,6 +3233,8 @@ folly::F14FastMap<std::string, velox::RuntimeMetric> Writer::runtimeStats()
        nanosMetric(context_->writeTiming().wallNanos)},
       {std::string{Keys::kIngestionCpuNanos},
        nanosMetric(context_->ingestionTiming().cpuNanos)},
+      {std::string{Keys::kIngestionWallNanos},
+       nanosMetric(context_->ingestionTiming().wallNanos)},
       {std::string{Keys::kEncodingCpuNanos},
        nanosMetric(context_->encodingTiming().cpuNanos)},
       {std::string{Keys::kEncodingWallNanos},

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -90,10 +90,12 @@ class Writer : public velox::dwio::common::Writer {
     static constexpr std::string_view kWriteCpuNanos = "nimble.writeCpuNanos";
     /// Wall clock time spent in tabletWriter write.
     static constexpr std::string_view kWriteWallNanos = "nimble.writeWallNanos";
-    /// CPU time spent ingesting vectors into field writer buffers. Sequential —
-    /// no wall time needed.
+    /// CPU time spent ingesting vectors into field writer buffers.
     static constexpr std::string_view kIngestionCpuNanos =
         "nimble.ingestionCpuNanos";
+    /// Wall clock time spent ingesting vectors into field writer buffers.
+    static constexpr std::string_view kIngestionWallNanos =
+        "nimble.ingestionWallNanos";
     /// CPU time spent on encoding and compression.
     // TODO: Separate encoding and compression costs.
     static constexpr std::string_view kEncodingCpuNanos =
@@ -323,7 +325,7 @@ class Writer : public velox::dwio::common::Writer {
   // by sequential writes; parallel writes use one pool per concurrent encode
   // task because EncodingBufferPool is not thread-safe.
   std::unique_ptr<EncodingBufferPool> makeEncodingBufferPool() const;
-  uint32_t encodingConcurrency(uint32_t taskCount) const;
+  uint32_t encodingConcurrency(uint32_t streamCount) const;
   void ensureEncodingScratchBufferPools(uint32_t poolCount);
   void ensureEncodingBufferPools(uint32_t poolCount);
   velox::BufferPool* encodingScratchBufferPool(uint32_t index = 0);

--- a/velox/dwio/nimble/writer/WriterOptions.h
+++ b/velox/dwio/nimble/writer/WriterOptions.h
@@ -365,11 +365,13 @@ struct WriterOptions {
   /// until all KeepAlive references are destructed.
   folly::Executor::KeepAlive<> encodingExecutor{};
 
-  /// When maxEncodeParallelism > 0 and encodingExecutor is set,
-  /// FieldWriter::write() operations will be parallelized using coroutines
-  /// scheduled on encodingExecutor.
+  /// Caps concurrent stream-encoding tasks. Callers should not set this above
+  /// the executor's available thread count.
   uint32_t maxEncodeParallelism{0};
-  uint32_t minStreamsPerEncodeUnit{1};
+
+  /// Targets at least this many streams per parallel encoding task. Zero is
+  /// treated as one.
+  uint32_t minStreamsPerEncodingTask{1};
 
   bool enableChunking{true};
 


### PR DESCRIPTION
Summary:
Allow Nimble writers to encode independent streams concurrently while keeping input ingestion sequential. A fixed number of executor tasks claim streams from a shared index, which avoids repeated scheduling rounds while `maxEncodeParallelism` and `minStreamsPerEncodingTask` bound concurrency and task granularity.

Publish ingestion wall time alongside the existing writer runtime stats and document the Nimble TableWriter metrics. Add `ProcessCpuWallTimer` for measurements that must include CPU consumed by background thread pools.

Reviewed By: zacw7

Differential Revision: D118036061


