### PR TITLE
perf(expr): Compact low-selectivity peeled vectors

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -117,6 +117,13 @@ target_link_libraries(
   velox_functions_prestosql
 )
 
+add_executable(velox_benchmark_peeled_encoding PeeledEncodingBenchmark.cpp)
+target_link_libraries(
+  velox_benchmark_peeled_encoding
+  ${velox_benchmark_deps}
+  velox_functions_prestosql
+)
+
 add_executable(velox_format_datetime_benchmark FormatDateTimeBenchmark.cpp)
 target_link_libraries(
   velox_format_datetime_benchmark

--- a/velox/benchmarks/basic/PeeledEncodingBenchmark.cpp
+++ b/velox/benchmarks/basic/PeeledEncodingBenchmark.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Benchmarks expression evaluation over dictionary vectors whose base is much
+// larger than the selected outer batch.
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook;
+using namespace facebook::velox;
+
+namespace {
+
+RowVectorPtr makeDictionaryInput(
+    ExpressionBenchmarkBuilder& builder,
+    vector_size_t baseSize,
+    vector_size_t batchSize) {
+  auto& vectorMaker = builder.vectorMaker();
+  auto lhs = vectorMaker.flatVector<int64_t>(
+      baseSize, [](auto row) { return static_cast<int64_t>(row); });
+  auto rhs = vectorMaker.flatVector<int64_t>(
+      baseSize, [](auto row) { return static_cast<int64_t>(row * 3); });
+  auto indices = test::makeIndices(
+      batchSize,
+      [baseSize](auto row) { return (row * 251) % baseSize; },
+      lhs->pool());
+
+  return vectorMaker.rowVector(
+      {"a", "b"},
+      {BaseVector::wrapInDictionary(nullptr, indices, batchSize, lhs),
+       BaseVector::wrapInDictionary(nullptr, indices, batchSize, rhs)});
+}
+
+void addBenchmark(
+    ExpressionBenchmarkBuilder& builder,
+    vector_size_t baseSize,
+    vector_size_t batchSize) {
+  builder
+      .addBenchmarkSet(
+          fmt::format("base{}_batch{}", baseSize, batchSize),
+          makeDictionaryInput(builder, baseSize, batchSize))
+      .addExpression("plus", "a + b")
+      .withIterations(10);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::prestosql::registerAllScalarFunctions();
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  constexpr vector_size_t kBaseSize = 1 << 20;
+  addBenchmark(benchmarkBuilder, kBaseSize, 1 << 10);
+  addBenchmark(benchmarkBuilder, kBaseSize, 1 << 12);
+  addBenchmark(benchmarkBuilder, kBaseSize, 1 << 18);
+
+  benchmarkBuilder.testBenchmarks();
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -55,7 +55,9 @@ namespace facebook::velox::exec {
 SelectivityVector* PeeledEncoding::translateToInnerRows(
     const SelectivityVector& outerRows,
     LocalSelectivityVector& innerRowsHolder) const {
-  VELOX_CHECK(wrapEncoding_ != VectorEncoding::Simple::FLAT);
+  if (wrapEncoding_ == VectorEncoding::Simple::FLAT) {
+    return innerRowsHolder.get(outerRows);
+  }
   if (wrapEncoding_ == VectorEncoding::Simple::CONSTANT) {
     auto newRows = innerRowsHolder.get(constantWrapIndex_ + 1, false);
     newRows->setValid(constantWrapIndex_, true);
@@ -107,6 +109,62 @@ void PeeledEncoding::setDictionaryWrapping(
   auto wrapping = decoded.dictionaryWrapping(*firstWrapper.pool(), rows.end());
   wrap_ = std::move(wrapping.indices);
   wrapNulls_ = std::move(wrapping.nulls);
+}
+
+void PeeledEncoding::flattenPeeledVectors(
+    const SelectivityVector& rows,
+    const std::vector<bool>& constantFields,
+    std::vector<VectorPtr>& peeledVectors) {
+  VELOX_CHECK(flattenedVectors_.empty());
+  for (vector_size_t i = 0; i < peeledVectors.size(); ++i) {
+    if (!constantFields.empty() && constantFields[i]) {
+      continue;
+    }
+    if (peeledVectors[i]->isConstantEncoding() && !wrapNulls_) {
+      continue;
+    }
+    switch (peeledVectors[i]->typeKind()) {
+      case TypeKind::ARRAY:
+      case TypeKind::MAP:
+      case TypeKind::ROW:
+        return;
+      default:
+        if (isLazyNotLoaded(*peeledVectors[i])) {
+          return;
+        }
+    }
+  }
+
+  auto nonNullRows = rows;
+  if (wrapNulls_) {
+    nonNullRows.deselectNulls(
+        wrapNulls_->as<uint64_t>(), rows.begin(), rows.end());
+  }
+  for (vector_size_t i = 0; i < peeledVectors.size(); ++i) {
+    if (!constantFields.empty() && constantFields[i]) {
+      continue;
+    }
+    if (peeledVectors[i]->isConstantEncoding() && !wrapNulls_) {
+      if (peeledVectors[i]->size() < rows.end()) {
+        peeledVectors[i] =
+            BaseVector::wrapInConstant(rows.end(), 0, peeledVectors[i]);
+      }
+    } else {
+      auto flat = BaseVector::create(
+          peeledVectors[i]->type(), rows.end(), peeledVectors[i]->pool());
+      flat->copy(
+          peeledVectors[i].get(), nonNullRows, wrap_->as<vector_size_t>());
+      if (!nonNullRows.isAllSelected()) {
+        bits::andBits(
+            flat->mutableRawNulls(), nonNullRows.allBits(), 0, rows.end());
+      }
+      peeledVectors[i] = flat;
+      flattenedVectors_.push_back(std::move(flat));
+    }
+  }
+  wrapEncoding_ = VectorEncoding::Simple::FLAT;
+  baseSize_ = rows.end();
+  wrap_.reset();
 }
 
 bool PeeledEncoding::peelInternal(
@@ -220,6 +278,11 @@ bool PeeledEncoding::peelInternal(
       constantWrapIndex_ = innerIdx;
     } else {
       setDictionaryWrapping(decodedVector, rows, *firstWrapper);
+      if (baseSize_ / 8 > rows.end()) {
+        // Evaluating sparse rows against a large base otherwise allocates and
+        // initialises intermediates proportional to the base size.
+        flattenPeeledVectors(rows, constantFields, peeledVectors);
+      }
       // Make sure all the constant vectors have at least the same length as the
       // base vector after peeling. This will make sure any translated rows
       // point to valid rows in the constant vector.
@@ -245,7 +308,9 @@ VectorPtr PeeledEncoding::wrap(
     velox::memory::MemoryPool* pool,
     VectorPtr peeledResult,
     const SelectivityVector& rows) const {
-  VELOX_CHECK(wrapEncoding_ != VectorEncoding::Simple::FLAT);
+  if (wrapEncoding_ == VectorEncoding::Simple::FLAT) {
+    return peeledResult;
+  }
   VectorPtr wrappedResult;
   if (wrapEncoding_ == VectorEncoding::Simple::DICTIONARY) {
     if (!peeledResult) {

--- a/velox/expression/PeeledEncoding.h
+++ b/velox/expression/PeeledEncoding.h
@@ -173,7 +173,9 @@ class PeeledEncoding {
       if (wrapNulls && bits::isBitNull(wrapNulls, outerRow)) {
         return;
       }
-      vector_size_t innerRow = indices ? indices[outerRow] : constantWrapIndex_;
+      const auto innerRow = wrapEncoding_ == VectorEncoding::Simple::FLAT
+          ? outerRow
+          : (indices ? indices[outerRow] : constantWrapIndex_);
       func(outerRow, innerRow);
     });
   }
@@ -195,6 +197,13 @@ class PeeledEncoding {
       const SelectivityVector& rows,
       BaseVector& firstWrapper);
 
+  // O(vectors * rows.end()) time and space, independent of the peeled base
+  // size.
+  void flattenPeeledVectors(
+      const SelectivityVector& rows,
+      const std::vector<bool>& constantFields,
+      std::vector<VectorPtr>& peeledVectors);
+
   /// The encoding of the peel. Set after getPeeledVectors() is called. Is equal
   /// to Flat if getPeeledVectors() has not been called or peeling was not
   /// successful.
@@ -212,5 +221,8 @@ class PeeledEncoding {
 
   /// The constant index. Only valid if wrapEncoding_ = CONSTANT.
   vector_size_t constantWrapIndex_ = 0;
+
+  // Retains compacted vectors for at least the lifetime of this peel.
+  std::vector<VectorPtr> flattenedVectors_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2515,7 +2515,7 @@ TEST_F(ExprTest, memo) {
   // 1. correctly evaluates the unevaluated rows on subsequent runs
   // 2. Only caches results if it encounters the same base twice
   auto base = makeArrayVector<int64_t>(
-      1'000,
+      500,
       [](auto row) { return row % 5 + 1; },
       [](auto row, auto index) { return (row % 3) + index; });
 
@@ -2563,7 +2563,7 @@ TEST_F(ExprTest, memo) {
 
   // Create a new base
   base = makeArrayVector<int64_t>(
-      1'000,
+      500,
       [](auto row) { return row % 5 + 1; },
       [](auto row, auto index) { return (row % 3) + index; });
 

--- a/velox/expression/tests/PeeledEncodingTest.cpp
+++ b/velox/expression/tests/PeeledEncodingTest.cpp
@@ -72,6 +72,13 @@ class PeeledEncodingTest : public testing::Test, public VectorTestBase {
     }
   }
 
+  VectorPtr wrap(
+      const PeeledEncoding& peeledEncoding,
+      const VectorPtr& vector,
+      const SelectivityVector& rows) {
+    return peeledEncoding.wrap(vector->type(), pool(), vector, rows);
+  }
+
   void SetUp() override {
     VectorFuzzer::Options options;
     options.nullRatio = 0.3;
@@ -175,12 +182,22 @@ TEST_P(PeeledEncodingBasicTests, allCommonDictionaryLayers) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-  ASSERT_EQ(peeledVectors[0].get(), flat1.get());
-  ASSERT_EQ(peeledVectors[1].get(), const1.get());
-  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
+  if (rows.countSelected() > 1) {
+    ASSERT_EQ(
+        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(peeledVectors[0].get(), flat1.get());
+    ASSERT_EQ(peeledVectors[1].get(), const1.get());
+    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
+  } else {
+    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
+    ASSERT_EQ(peeledVectors[0]->encoding(), VectorEncoding::Simple::FLAT);
+  }
   assertEqualVectors(
-      input1, peeledEncoding->wrap(flat1->type(), pool(), flat1, rows), rows);
+      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
+  assertEqualVectors(
+      input2, wrap(*peeledEncoding, peeledVectors[1], rows), rows);
+  assertEqualVectors(
+      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, someCommonDictionaryLayers) {
@@ -200,14 +217,25 @@ TEST_P(PeeledEncodingBasicTests, someCommonDictionaryLayers) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
-  ASSERT_EQ(peeledVectors[1].get(), peelWrappings(1, input2).get());
-  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
+  if (rows.countSelected() > 1) {
+    ASSERT_EQ(
+        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
+    ASSERT_EQ(peeledVectors[1].get(), peelWrappings(1, input2).get());
+    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
+    assertEqualVectors(
+        wrapInDictionaryLayers(flat1, {&dictWrap1}),
+        peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
+        rows);
+  } else {
+    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
+  }
   assertEqualVectors(
-      wrapInDictionaryLayers(flat1, {&dictWrap1}),
-      peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
-      rows);
+      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
+  assertEqualVectors(
+      input2, wrap(*peeledEncoding, peeledVectors[1], rows), rows);
+  assertEqualVectors(
+      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, commonDictionaryLayersAndAConstant) {
@@ -228,15 +256,23 @@ TEST_P(PeeledEncodingBasicTests, commonDictionaryLayersAndAConstant) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-  ASSERT_EQ(peeledVectors[0].get(), flat1.get());
-  if (peeledVectors[1].get() != const1.get()) {
-    // In case the constant is resized to match other peeledVector's size.
-    assertEqualVectors(peeledVectors[1], const1, rows);
+  if (rows.countSelected() > 1) {
+    ASSERT_EQ(
+        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(peeledVectors[0].get(), flat1.get());
+    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
+    if (peeledVectors[1].get() != const1.get()) {
+      // In case the constant is resized to match other peeledVector's size.
+      assertEqualVectors(peeledVectors[1], const1, rows);
+    }
+  } else {
+    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
+    ASSERT_EQ(peeledVectors[1].get(), const1.get());
   }
-  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
   assertEqualVectors(
-      input1, peeledEncoding->wrap(flat1->type(), pool(), flat1, rows), rows);
+      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
+  assertEqualVectors(
+      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, singleConstantEncodedVector) {
@@ -412,17 +448,27 @@ TEST_P(PeeledEncodingBasicTests, dictionaryLayersHavingNulls) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2, input3}, rows, localDecodedVector, false, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 3);
-  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
-  if (peeledVectors[1].get() != const1.get()) {
-    // In case the constant is resized to match other peeledVector's size.
-    assertEqualVectors(peeledVectors[1], const1, rows);
+  if (rows.countSelected() > 1) {
+    ASSERT_EQ(
+        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
+    if (peeledVectors[1].get() != const1.get()) {
+      // In case the constant is resized to match other peeledVector's size.
+      assertEqualVectors(peeledVectors[1], const1, rows);
+    }
+    ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
+    assertEqualVectors(
+        wrapInDictionaryLayers(flat1, {&dictNoNulls}),
+        peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
+        rows);
+  } else {
+    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
+    ASSERT_EQ(peeledVectors[1].get(), const1.get());
   }
-  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
   assertEqualVectors(
-      wrapInDictionaryLayers(flat1, {&dictNoNulls}),
-      peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
-      rows);
+      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
+  assertEqualVectors(
+      input3, wrap(*peeledEncoding, peeledVectors[2], rows), rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, constantResize) {
@@ -440,15 +486,19 @@ TEST_P(PeeledEncodingBasicTests, constantResize) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1, input2}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 2);
-  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
-  ASSERT_EQ(peeledVectors[0].get(), flatLarge.get());
-  ASSERT_NE(peeledVectors[1].get(), const1.get());
-  ASSERT_EQ(peeledVectors[1]->encoding(), VectorEncoding::Simple::CONSTANT);
-  ASSERT_EQ(peeledVectors[1]->size(), 2 * vectorSize_);
+  if (rows.countSelected() > 1) {
+    ASSERT_EQ(
+        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(peeledVectors[0].get(), flatLarge.get());
+    ASSERT_NE(peeledVectors[1].get(), const1.get());
+    ASSERT_EQ(peeledVectors[1]->encoding(), VectorEncoding::Simple::CONSTANT);
+    ASSERT_EQ(peeledVectors[1]->size(), 2 * vectorSize_);
+  } else {
+    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
+    ASSERT_EQ(peeledVectors[1].get(), const1.get());
+  }
   assertEqualVectors(
-      input1,
-      peeledEncoding->wrap(flatLarge->type(), pool(), flatLarge, rows),
-      rows);
+      input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
 }
 
 TEST_P(PeeledEncodingBasicTests, intermidiateLazyLayer) {
@@ -467,13 +517,48 @@ TEST_P(PeeledEncodingBasicTests, intermidiateLazyLayer) {
   auto peeledEncoding = PeeledEncoding::peel(
       {input1}, rows, localDecodedVector, true, peeledVectors);
   ASSERT_EQ(peeledVectors.size(), 1);
-  ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
   ASSERT_TRUE(peeledVectors[0]->isFlatEncoding());
   // Loading generates a new vector so we compare their contents instead.
   LocalSelectivityVector traslatedRowsHolder(execCtx_);
   auto translatedRows =
       peeledEncoding->translateToInnerRows(rows, traslatedRowsHolder);
-  assertEqualVectors(peeledVectors[0], flat1, *translatedRows);
+  if (rows.countSelected() > 1) {
+    ASSERT_EQ(
+        peeledEncoding->wrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+    assertEqualVectors(peeledVectors[0], flat1, *translatedRows);
+  } else {
+    ASSERT_EQ(peeledEncoding->wrapEncoding(), VectorEncoding::Simple::FLAT);
+    assertEqualVectors(
+        input1, wrap(*peeledEncoding, peeledVectors[0], rows), rows);
+    ASSERT_EQ(*translatedRows, rows);
+  }
+}
+
+TEST_F(PeeledEncodingTest, compactLowSelectivityPrimitiveVector) {
+  constexpr vector_size_t kBaseSize = 4'096;
+  constexpr vector_size_t kOutputSize = 128;
+
+  auto base = makeFlatVector<int64_t>(
+      kBaseSize, [](auto row) { return static_cast<int64_t>(row * 7); });
+  auto indices = makeIndices(kOutputSize, [](auto row) { return row * 17; });
+  auto nulls = makeNulls(kOutputSize, nullEvery(11));
+  auto input = BaseVector::wrapInDictionary(
+      nulls, indices, kOutputSize, std::move(base));
+
+  SelectivityVector rows(kOutputSize);
+  LocalDecodedVector decodedVector(execCtx_);
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding =
+      PeeledEncoding::peel({input}, rows, decodedVector, true, peeledVectors);
+
+  ASSERT_EQ(VectorEncoding::Simple::FLAT, peeledEncoding->wrapEncoding());
+  ASSERT_EQ(1, peeledVectors.size());
+  EXPECT_TRUE(peeledVectors[0]->isFlatEncoding());
+  EXPECT_EQ(kOutputSize, peeledVectors[0]->size());
+
+  auto result =
+      peeledEncoding->wrap(input->type(), pool(), peeledVectors[0], rows);
+  assertEqualVectors(input, result);
 }
 
 TEST_F(PeeledEncodingTest, peelingFails) {


### PR DESCRIPTION
Summary:
- Compact primitive peeled vectors when the underlying base is more than eight times larger than the selected outer row range.
- Preserve dictionary wrapping for complex and unloaded lazy vectors.
- Retain compacted vectors for the lifetime of the peel.

This re-enables the optimisation reverted in #10742 after shared-expression cache lifetime tracking was corrected in #10837.

Fixes #18369