### PR TITLE
refactor(memory): Remove unused TestValue in ArbitrationOperation

### DIFF
--- a/velox/common/memory/ArbitrationOperation.cpp
+++ b/velox/common/memory/ArbitrationOperation.cpp
@@ -20,13 +20,9 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
 
-using facebook::velox::common::testutil::TestValue;
-
 namespace facebook::velox::memory {
-using namespace facebook::velox::memory;
 
 ArbitrationOperation::ArbitrationOperation(
     ScopedArbitrationParticipant&& participant,


### PR DESCRIPTION
The `TestValue` using-declaration in ArbitrationOperation.cpp is never
referenced in the file. Remove it, along with the TestValue.h include
that only existed to support it.

Also drop the using-directive for `facebook::velox::memory` inside that
namespace itself, which is redundant.