### PR TITLE
feat(encoding): Add experimental MainlyConstantV2

### DIFF
--- a/velox/dwio/nimble/common/Types.cpp
+++ b/velox/dwio/nimble/common/Types.cpp
@@ -48,6 +48,7 @@ constexpr auto kEncodingTypes =
         {EncodingType::Huffman, "Huffman"},
         {EncodingType::DeltaBlock, "DeltaBlock"},
         {EncodingType::SharedDictionary, "SharedDictionary"},
+        {EncodingType::MainlyConstantV2, "MainlyConstantV2"},
     });
 
 constexpr auto kReadOnlyEncodingTypes = std::to_array<EncodingType>({

--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -161,6 +161,11 @@ enum class EncodingType {
   // external provider. The alphabet is resolved independently from the
   // encoded index stream.
   SharedDictionary = 22,
+  /// Stores one common value plus direct row positions and values for
+  /// exceptions. Preserves row order for non-boolean numeric streams.
+  /// EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  /// without consulting the Nimble team (oncall: dwios).
+  MainlyConstantV2 = 23,
 };
 std::string toString(EncodingType encodingType);
 /// Returns the encoding type for 'name'. Throws if 'name' is unknown.

--- a/velox/dwio/nimble/common/tests/TypesTest.cpp
+++ b/velox/dwio/nimble/common/tests/TypesTest.cpp
@@ -40,6 +40,7 @@ TEST(TypesTest, encodingTypeStringConversion) {
       {EncodingType::Delta, "Delta"},
       {EncodingType::Constant, "Constant"},
       {EncodingType::MainlyConstant, "MainlyConstant"},
+      {EncodingType::MainlyConstantV2, "MainlyConstantV2"},
       {EncodingType::Prefix, "Prefix"},
       {EncodingType::ALP, "ALP"},
       {EncodingType::PFOR, "PFOR"},

--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(
   PFOREncoding.h
   NullableEncoding.h
   MainlyConstantEncoding.h
+  MainlyConstantV2Encoding.h
   FsstEncoding.h
   FrequencyPartitionEncoding.h
   ForEncoding.h

--- a/velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h
+++ b/velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <limits>
+#include <optional>
+#include <span>
+
+#include <fmt/core.h>
+
+#include "velox/common/base/SimdUtil.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/common/EncodingType.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingIdentifier.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
+
+namespace facebook::nimble {
+
+/// Encodes streams with one common value and stores exception row positions
+/// directly as an outer child stream.
+///
+/// Decode fills the output with the common value, then scatters exception
+/// values at the stored positions. Supports non-boolean numeric types.
+///
+/// Wire format:
+///   prefix
+///   common value
+///   uint32_t exception positions stream byte size
+///   exception positions stream bytes
+///   uint32_t exception values stream byte size
+///   exception values stream bytes
+template <typename T>
+class MainlyConstantV2Encoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  /// Logical C++ value type exposed by this encoding.
+  using cppDataType = T;
+
+  /// Physical value type stored in the encoded stream.
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  /// Deserializes an encoded stream and validates its child streams.
+  MainlyConstantV2Encoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {})
+      : TypedEncoding<T, physicalType>(pool, data, options),
+        exceptionPositions_(&pool),
+        exceptionValuesBuffer_(this->template getVectorBuffer<physicalType>()) {
+    const char* cursor = data.data() + this->dataOffset();
+    const char* const end = data.end();
+    const auto requireBytes = [&](size_t size, std::string_view field) {
+      NIMBLE_CHECK_FILE(
+          cursor <= end && static_cast<size_t>(end - cursor) >= size,
+          "Truncated MainlyConstantV2 {}.",
+          field);
+    };
+
+    requireBytes(sizeof(physicalType), "common value");
+    commonValue_ = encoding::read<physicalType>(cursor);
+
+    requireBytes(sizeof(uint32_t), "exception positions size");
+    const uint32_t exceptionPositionsBytes = encoding::readUint32(cursor);
+    requireBytes(
+        static_cast<size_t>(exceptionPositionsBytes) + sizeof(uint32_t),
+        "exception positions stream");
+    if (exceptionPositionsBytes != 0) {
+      const std::string_view encodedPositions{cursor, exceptionPositionsBytes};
+      auto positionsEncoding = EncodingFactory{options}.create(
+          *this->pool_, encodedPositions, stringBufferFactory);
+      NIMBLE_CHECK_FILE(
+          positionsEncoding->dataType() == DataType::Uint32,
+          "MainlyConstantV2 positions child must use Uint32.");
+      exceptionPositions_.resize(positionsEncoding->rowCount());
+      positionsEncoding->materialize(
+          exceptionPositions_.size(), exceptionPositions_.data());
+    }
+    cursor += exceptionPositionsBytes;
+
+    requireBytes(sizeof(uint32_t), "exception values size");
+    const uint32_t exceptionValuesBytes = encoding::readUint32(cursor);
+    requireBytes(exceptionValuesBytes, "exception values stream");
+    NIMBLE_CHECK_FILE(
+        (exceptionPositionsBytes == 0) == (exceptionValuesBytes == 0),
+        "MainlyConstantV2 child streams must both be empty or non-empty.");
+    if (exceptionValuesBytes != 0) {
+      exceptionValues_ = EncodingFactory{options}.create(
+          *this->pool_, {cursor, exceptionValuesBytes}, stringBufferFactory);
+      NIMBLE_CHECK_FILE(
+          exceptionValues_->dataType() == TypeTraits<physicalType>::dataType,
+          "MainlyConstantV2 values child has an unexpected data type.");
+      NIMBLE_CHECK_FILE(
+          exceptionValues_->rowCount() == exceptionPositions_.size(),
+          "MainlyConstantV2 child row counts do not match.");
+    }
+    cursor += exceptionValuesBytes;
+
+    NIMBLE_CHECK_FILE(cursor == end, "Unexpected MainlyConstantV2 end.");
+    for (uint32_t i = 0; i < exceptionPositions_.size(); ++i) {
+      NIMBLE_CHECK_FILE(
+          exceptionPositions_[i] < this->rowCount(),
+          "MainlyConstantV2 exception position is out of range.");
+      NIMBLE_CHECK_FILE(
+          i == 0 || exceptionPositions_[i - 1] < exceptionPositions_[i],
+          "MainlyConstantV2 exception positions must be strictly increasing.");
+    }
+  }
+
+  /// Releases the reusable exception-values buffer.
+  ~MainlyConstantV2Encoding() override {
+    this->releaseVectorBuffer(exceptionValuesBuffer_);
+  }
+
+  /// Resets sequential decoding to the first row.
+  void reset() final {
+    row_ = 0;
+    nextExceptionPositionIndex_ = 0;
+    if (exceptionValues_ != nullptr) {
+      exceptionValues_->reset();
+    }
+  }
+
+  /// Advances sequential decoding by `rowCount` rows.
+  void skip(uint32_t rowCount) final {
+    NIMBLE_CHECK_LE(
+        rowCount,
+        this->rowCount() - row_,
+        "Cannot skip beyond MainlyConstantV2 row count.");
+    const auto rowEnd = row_ + rowCount;
+    const auto beginIndex = nextExceptionPositionIndex_;
+    advanceExceptionPositionIndex(rowEnd);
+    const auto numExceptions = nextExceptionPositionIndex_ - beginIndex;
+    if (numExceptions != 0) {
+      NIMBLE_CHECK_NOT_NULL(exceptionValues_);
+      exceptionValues_->skip(numExceptions);
+    }
+    row_ = rowEnd;
+  }
+
+  /// Decodes `rowCount` sequential rows into `buffer` and advances state.
+  void materialize(uint32_t rowCount, void* buffer) final {
+    NIMBLE_CHECK_LE(
+        rowCount,
+        this->rowCount() - row_,
+        "Cannot materialize beyond MainlyConstantV2 row count.");
+    const auto rowBegin = row_;
+    const auto rowEnd = row_ + rowCount;
+    auto* output = static_cast<physicalType*>(buffer);
+    velox::simd::simdFill(output, commonValue_, rowCount);
+
+    const auto beginIndex = nextExceptionPositionIndex_;
+    advanceExceptionPositionIndex(rowEnd);
+    const auto numExceptions = nextExceptionPositionIndex_ - beginIndex;
+    if (numExceptions != 0) {
+      NIMBLE_CHECK_NOT_NULL(exceptionValues_);
+      exceptionValuesBuffer_.resize(numExceptions);
+      exceptionValues_->materialize(
+          numExceptions, exceptionValuesBuffer_.data());
+      for (uint32_t i = 0; i < numExceptions; ++i) {
+        output[exceptionPositions_[beginIndex + i] - rowBegin] =
+            exceptionValuesBuffer_[i];
+      }
+    }
+
+    row_ = rowEnd;
+  }
+
+  /// Reads selected rows through the standard decoder visitor interface.
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
+    detail::readWithVisitorSlow(
+        visitor,
+        params,
+        [&](auto toSkip) { skip(toSkip); },
+        [&] {
+          physicalType value;
+          materialize(1, &value);
+          return value;
+        });
+  }
+
+  /// Encodes values using one common value and two exception child streams.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    if constexpr (
+        !isNumericType<physicalType>() || isBoolType<physicalType>()) {
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "MainlyConstantV2 encoding only supports non-bool numeric data.");
+    }
+    if (values.empty()) {
+      NIMBLE_INCOMPATIBLE_ENCODING("MainlyConstantV2 cannot be empty.");
+    }
+    NIMBLE_CHECK_LE(values.size(), std::numeric_limits<uint32_t>::max());
+
+    const auto commonElement =
+        findCommonValue(selection.statistics().uniqueCounts().value());
+    const auto commonValue = commonElement->first;
+    const auto numExceptions = values.size() - commonElement->second;
+
+    auto* pool = &buffer.getMemoryPool();
+    Vector<uint32_t> exceptionPositions{pool};
+    exceptionPositions.reserve(numExceptions);
+    Vector<physicalType> exceptionValues{pool};
+    exceptionValues.reserve(numExceptions);
+    for (uint32_t i = 0; i < values.size(); ++i) {
+      if (values[i] != commonValue) {
+        exceptionPositions.push_back(i);
+        exceptionValues.push_back(values[i]);
+      }
+    }
+
+    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+    const auto serializedExceptionPositions = exceptionPositions.empty()
+        ? std::string_view{}
+        : selection.template encodeNested<uint32_t>(
+              EncodingIdentifiers::MainlyConstantV2::ExceptionPositions,
+              exceptionPositions,
+              scopedBuffer.get(),
+              options);
+    const auto serializedExceptionValues = exceptionValues.empty()
+        ? std::string_view{}
+        : selection.template encodeNested<physicalType>(
+              EncodingIdentifiers::MainlyConstantV2::ExceptionValues,
+              exceptionValues,
+              scopedBuffer.get(),
+              options);
+
+    NIMBLE_CHECK_LE(
+        serializedExceptionPositions.size(),
+        std::numeric_limits<uint32_t>::max(),
+        "MainlyConstantV2 positions child is too large.");
+    NIMBLE_CHECK_LE(
+        serializedExceptionValues.size(),
+        std::numeric_limits<uint32_t>::max(),
+        "MainlyConstantV2 values child is too large.");
+    const uint64_t encodingSize =
+        Encoding::serializePrefixSize(
+            values.size(), options.useVarintRowCount) +
+        sizeof(physicalType) + sizeof(uint32_t) +
+        serializedExceptionPositions.size() + sizeof(uint32_t) +
+        serializedExceptionValues.size();
+    NIMBLE_CHECK_LE(
+        encodingSize,
+        std::numeric_limits<uint32_t>::max(),
+        "MainlyConstantV2 stream is too large.");
+
+    char* reserved = buffer.reserve(encodingSize);
+    char* cursor = reserved;
+    Encoding::serializePrefix(
+        EncodingType::MainlyConstantV2,
+        TypeTraits<T>::dataType,
+        values.size(),
+        options.useVarintRowCount,
+        cursor);
+    encoding::write<physicalType>(commonValue, cursor);
+    encoding::writeString(serializedExceptionPositions, cursor);
+    encoding::writeString(serializedExceptionValues, cursor);
+    NIMBLE_DCHECK_EQ(
+        cursor - reserved, encodingSize, "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
+  /// Estimates the encoded size for the supplied value statistics.
+  static std::optional<uint64_t> estimateSize(
+      uint64_t rowCount,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {}) {
+    if (rowCount == 0 || !statistics.uniqueCounts().has_value()) {
+      return std::nullopt;
+    }
+    const auto commonElement =
+        findCommonValue(statistics.uniqueCounts().value());
+    const auto numExceptions = rowCount - commonElement->second;
+
+    return estimatePositionLayoutSize(
+        rowCount, numExceptions, statistics, options);
+  }
+
+  /// Returns a human-readable summary of the decoded stream state.
+  std::string debugString(int offset) const final {
+    return fmt::format(
+        "{}{}<{}> rowCount={} commonValue={} exceptionPositions={}",
+        std::string(offset, ' '),
+        toString(this->encodingType()),
+        toString(this->dataType()),
+        this->rowCount(),
+        commonValue_,
+        exceptionPositions_.size());
+  }
+
+ private:
+  // Estimates the direct-position layout using fixed-bit-width child streams.
+  static std::optional<uint64_t> estimatePositionLayoutSize(
+      uint64_t rowCount,
+      uint64_t numExceptions,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    const auto positionsSize = numExceptions == 0
+        ? 0
+        : FixedBitWidthEncoding<uint32_t>::estimateSize(
+              numExceptions, 0, rowCount - 1, options);
+    const auto exceptionValuesSize = numExceptions == 0
+        ? 0
+        : FixedBitWidthEncoding<physicalType>::estimateSize(
+              numExceptions, statistics.min(), statistics.max(), options);
+
+    return EncodingPrefix::serializedSize(
+               static_cast<uint32_t>(rowCount), options.useVarintRowCount) +
+        sizeof(physicalType) + 2 * sizeof(uint32_t) + positionsSize +
+        exceptionValuesSize;
+  }
+
+  // Selects the most frequent value and breaks ties by the smaller value.
+  template <typename UniqueCounts>
+  static auto findCommonValue(const UniqueCounts& uniqueCounts) {
+    return std::max_element(
+        uniqueCounts.cbegin(),
+        uniqueCounts.cend(),
+        [](const auto& left, const auto& right) {
+          if (left.second != right.second) {
+            return left.second < right.second;
+          }
+          return left.first > right.first;
+        });
+  }
+
+  // Advances to the first exception position at or after `rowEnd`.
+  void advanceExceptionPositionIndex(uint32_t rowEnd) {
+    while (nextExceptionPositionIndex_ < exceptionPositions_.size() &&
+           exceptionPositions_[nextExceptionPositionIndex_] < rowEnd) {
+      ++nextExceptionPositionIndex_;
+    }
+  }
+
+  // Value used for rows without an exception.
+  physicalType commonValue_;
+
+  // Strictly increasing row positions for exception values.
+  Vector<uint32_t> exceptionPositions_;
+
+  // Index of the next exception position in sequential decoding state.
+  uint32_t nextExceptionPositionIndex_{0};
+
+  // Nested encoding for exception values, absent when all rows are common.
+  std::unique_ptr<Encoding> exceptionValues_;
+
+  // Reusable decode buffer for exception values.
+  Vector<physicalType> exceptionValuesBuffer_;
+
+  // Next row in sequential decoding state.
+  uint32_t row_{0};
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -30,6 +30,7 @@
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h"
 #include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/PFOREncoding.h"
 #include "velox/dwio/nimble/encodings/PrefixEncoding.h"
@@ -128,6 +129,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::MainlyConstant: {
       RETURN_ENCODING_BY_NON_BOOL_TYPE(MainlyConstantEncoding, dataType);
+    }
+    case EncodingType::MainlyConstantV2: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(MainlyConstantV2Encoding, dataType);
     }
     case EncodingType::Prefix: {
       NIMBLE_CHECK_EQ(
@@ -365,6 +369,14 @@ std::string_view EncodingFactory::encode(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "MainlyConstant encoding should not be selected for bool data types.");
+    }
+    case EncodingType::MainlyConstantV2: {
+      if constexpr (isNumericType<physicalType>() && !isBoolType<T>()) {
+        return MainlyConstantV2Encoding<T>::encode(
+            selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "MainlyConstantV2 encoding should not be selected for non-numeric or bool data types.");
     }
     case EncodingType::SparseBool: {
       if constexpr (std::is_same<T, bool>::value) {

--- a/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -307,6 +307,35 @@ EncodingLayout EncodingLayoutCapture::capture(
           EncodingLayoutCapture::capture({pos, otherValuesBytes}, options));
       break;
     }
+    case EncodingType::MainlyConstantV2: {
+      children.reserve(2);
+
+      NIMBLE_CHECK_FILE(
+          encoding.size() >= prefixSize, "Truncated MainlyConstantV2 prefix.");
+      const char* cursor = encoding.data() + prefixSize;
+      const char* const end = encoding.end();
+      const auto dataType =
+          encoding::peek<uint8_t, DataType>(encoding.data() + 1);
+      NIMBLE_CHECK_FILE(
+          static_cast<size_t>(end - cursor) >=
+              detail::dataTypeSize(dataType) + sizeof(uint32_t),
+          "Truncated MainlyConstantV2 layout header.");
+      cursor += detail::dataTypeSize(dataType);
+
+      const uint32_t exceptionPositionsBytes = encoding::readUint32(cursor);
+      NIMBLE_CHECK_FILE(
+          static_cast<size_t>(end - cursor) >=
+              static_cast<size_t>(exceptionPositionsBytes) + sizeof(uint32_t),
+          "Truncated MainlyConstantV2 positions child.");
+      captureChild(children, cursor, exceptionPositionsBytes, options);
+
+      const uint32_t exceptionValuesBytes = encoding::readUint32(cursor);
+      NIMBLE_CHECK_FILE(
+          static_cast<size_t>(end - cursor) == exceptionValuesBytes,
+          "Invalid MainlyConstantV2 values child size.");
+      captureChild(children, cursor, exceptionValuesBytes, options);
+      break;
+    }
     case EncodingType::Dictionary: {
       children.reserve(2);
       const char* pos = encoding.data() + prefixSize;

--- a/velox/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/velox/dwio/nimble/encodings/common/EncodingUtils.h
@@ -25,6 +25,7 @@
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h"
 #include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/PFOREncoding.h"
 #include "velox/dwio/nimble/encodings/PrefixEncoding.h"
@@ -141,6 +142,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<ConstantEncoding<T>&>(encoding));
     case EncodingType::MainlyConstant:
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
+    case EncodingType::MainlyConstantV2:
+      if constexpr (isNumericType<T>() && !isBoolType<T>()) {
+        return f(static_cast<MainlyConstantV2Encoding<T>&>(encoding));
+      }
+      NIMBLE_UNREACHABLE(
+          "MainlyConstantV2 encoding only supports non-boolean numeric data types, got {}.",
+          encoding.dataType());
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
     case EncodingType::DeltaBlock:

--- a/velox/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/velox/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -34,6 +34,15 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier OtherValues = 1;
   };
 
+  /// Identifies the direct position and value child streams for
+  /// MainlyConstantV2.
+  struct MainlyConstantV2 {
+    /// Stores row positions for values that differ from the common value.
+    static constexpr NestedEncodingIdentifier ExceptionPositions = 0;
+    /// Stores values corresponding to ExceptionPositions.
+    static constexpr NestedEncodingIdentifier ExceptionValues = 1;
+  };
+
   struct Nullable {
     static constexpr NestedEncodingIdentifier Data = 0;
     static constexpr NestedEncodingIdentifier Nulls = 1;

--- a/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -170,6 +170,7 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       EncodingType::DeltaBlock,
       EncodingType::Fsst,
       EncodingType::Huffman,
+      EncodingType::MainlyConstantV2,
   };
 }
 

--- a/velox/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/velox/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -29,6 +29,7 @@
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h"
 #include "velox/dwio/nimble/encodings/PFOREncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
 #include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -95,6 +96,10 @@ struct EncodingSizeEstimation {
         // candidate. MainlyConstantEncoding::estimateSize already supports
         // usePerBlockStats + blockSize params.
         return MainlyConstantEncoding<T>::estimateSize(
+            entryCount, statistics, options);
+      }
+      case EncodingType::MainlyConstantV2: {
+        return MainlyConstantV2Encoding<T>::estimateSize(
             entryCount, statistics, options);
       }
       case EncodingType::Trivial: {

--- a/velox/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(
   ForEncodingTest.cpp
   FrequencyPartitionEncodingTest.cpp
   MainlyConstantEncodingTest.cpp
+  MainlyConstantV2EncodingTest.cpp
   MainlyConstantEncodingViewTest.cpp
   NullableEncodingTest.cpp
   OpenZLCompressorTest.cpp

--- a/velox/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -452,6 +452,25 @@ TEST(EncodingLayoutTests, mainlyConst) {
   testCapture<uint32_t>(captureTest, {1, 1, 1, 1, 5, 1});
 }
 
+TEST(EncodingLayoutTests, mainlyConstantV2) {
+  nimble::EncodingLayout expected{
+      nimble::EncodingType::MainlyConstantV2,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
+  testSerialization(expected);
+  testCapture<uint32_t>(expected, {1, 1, 1, 1, 5, 1});
+}
+
 TEST(EncodingLayoutTests, dictionary) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::Dictionary,

--- a/velox/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -35,6 +35,7 @@
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h"
 #include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
 #include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -246,6 +247,12 @@ template <typename T>
 struct EncodingTypeTraits<nimble::MainlyConstantEncoding<T>> {
   static constexpr inline nimble::EncodingType encodingType =
       nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::MainlyConstantV2Encoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::MainlyConstantV2;
 };
 
 template <typename T>
@@ -469,6 +476,12 @@ struct EncodingTypeGetter<nimble::MainlyConstantEncoding<T>> {
 };
 
 template <typename T>
+struct EncodingTypeGetter<nimble::MainlyConstantV2Encoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::MainlyConstantV2;
+};
+
+template <typename T>
 struct EncodingTypeGetter<nimble::RLEEncoding<T>> {
   static constexpr nimble::EncodingType value = nimble::EncodingType::RLE;
 };
@@ -564,6 +577,7 @@ using TestTypes = ::testing::Types<
     NUMERIC_TYPES(nimble::FixedBitWidthEncoding),
     NON_BOOL_TYPES(nimble::DictionaryEncoding),
     NON_BOOL_TYPES(nimble::MainlyConstantEncoding),
+    NUMERIC_TYPES(nimble::MainlyConstantV2Encoding),
     ALL_TYPES(nimble::TrivialEncoding),
     ALL_TYPES(nimble::RLEEncoding),
     ALL_TYPES(nimble::ConstantEncoding)>;

--- a/velox/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
@@ -62,6 +62,7 @@ TEST_F(EncodingViewTest, supportsEncodingViewMatchesViewableEncodingSet) {
       nimble::EncodingType::SubIntSplit,
       nimble::EncodingType::FrequencyPartition,
       nimble::EncodingType::Fsst,
+      nimble::EncodingType::MainlyConstantV2,
       nimble::EncodingType::SharedDictionary};
   for (const auto encodingType : unsupportedEncodings) {
     SCOPED_TRACE(fmt::format("encodingType={}", encodingType));

--- a/velox/dwio/nimble/encodings/tests/MainlyConstantV2EncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/MainlyConstantV2EncodingTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/tests/TestUtils.h"
+
+using namespace facebook;
+using testing::ElementsAreArray;
+
+namespace {
+
+class MainlyConstantV2EncodingTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  nimble::Vector<int64_t> makeValues(std::initializer_list<int64_t> values) {
+    nimble::Vector<int64_t> result{pool_.get()};
+    result.insert(result.end(), values.begin(), values.end());
+    return result;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(MainlyConstantV2EncodingTest, roundTripAndSequentialState) {
+  const auto values = makeValues({9, 7, 7, 11, 7, 7, 7, 13});
+
+  for (const bool useVarintRowCount : {false, true}) {
+    SCOPED_TRACE(
+        testing::Message() << "useVarintRowCount=" << useVarintRowCount);
+    nimble::Buffer buffer{*pool_};
+    const nimble::Encoding::Options options{
+        .useVarintRowCount = useVarintRowCount};
+    auto encoding = nimble::test::
+        Encoder<nimble::MainlyConstantV2Encoding<int64_t>>::createEncoding(
+            buffer,
+            values,
+            [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    nimble::Vector<int64_t> decoded{pool_.get(), values.size()};
+    encoding->materialize(values.size(), decoded.data());
+    EXPECT_THAT(decoded, ElementsAreArray(values));
+
+    encoding->reset();
+    encoding->skip(2);
+    nimble::Vector<int64_t> middle{pool_.get(), 4};
+    encoding->materialize(middle.size(), middle.data());
+    EXPECT_THAT(middle, testing::ElementsAre(7, 11, 7, 7));
+
+    encoding->reset();
+    nimble::Vector<int64_t> first{pool_.get(), 3};
+    encoding->materialize(first.size(), first.data());
+    EXPECT_THAT(first, testing::ElementsAre(9, 7, 7));
+    nimble::Vector<int64_t> second{pool_.get(), 5};
+    encoding->materialize(second.size(), second.data());
+    EXPECT_THAT(second, testing::ElementsAre(11, 7, 7, 7, 13));
+  }
+}
+
+TEST_F(MainlyConstantV2EncodingTest, allCommonHasNoChildren) {
+  const auto values = makeValues({7, 7, 7, 7});
+  nimble::Buffer buffer{*pool_};
+  const auto encoded =
+      nimble::test::Encoder<nimble::MainlyConstantV2Encoding<int64_t>>::encode(
+          buffer, values);
+
+  const auto layout = nimble::EncodingLayoutCapture::capture(
+      encoded, nimble::Encoding::Options{});
+  EXPECT_EQ(layout.encodingType(), nimble::EncodingType::MainlyConstantV2);
+  EXPECT_EQ(layout.childrenCount(), 2);
+  EXPECT_FALSE(layout.child(0).has_value());
+  EXPECT_FALSE(layout.child(1).has_value());
+
+  auto encoding = nimble::EncodingFactory{}.create(
+      *pool_, encoded, [](uint32_t /*totalLength*/) -> void* {
+        return nullptr;
+      });
+  nimble::Vector<int64_t> decoded{pool_.get(), values.size()};
+  encoding->materialize(values.size(), decoded.data());
+  EXPECT_THAT(decoded, ElementsAreArray(values));
+}
+
+TEST_F(MainlyConstantV2EncodingTest, rejectsEmptyInput) {
+  nimble::Vector<int64_t> values{pool_.get()};
+  nimble::Buffer buffer{*pool_};
+
+  NIMBLE_ASSERT_THROW(
+      (nimble::test::Encoder<nimble::MainlyConstantV2Encoding<int64_t>>::encode(
+          buffer, values)),
+      "MainlyConstantV2 cannot be empty");
+}
+
+TEST_F(MainlyConstantV2EncodingTest, rejectsMismatchedPositionsType) {
+  const auto values = makeValues({7, 7, 9, 7});
+  nimble::Buffer buffer{*pool_};
+  const auto encoded =
+      nimble::test::Encoder<nimble::MainlyConstantV2Encoding<int64_t>>::encode(
+          buffer, values);
+  std::string malformed{encoded};
+  const auto positionsOffset = nimble::EncodingPrefix::prefixSize(
+                                   malformed, /*useVarintRowCount=*/false) +
+      sizeof(int64_t) + sizeof(uint32_t);
+  malformed[positionsOffset + 1] = static_cast<char>(nimble::DataType::Int32);
+
+  NIMBLE_ASSERT_THROW(
+      nimble::EncodingFactory{}.create(
+          *pool_,
+          malformed,
+          [](uint32_t /*totalLength*/) -> void* { return nullptr; }),
+      "positions child must use Uint32");
+}
+
+TEST_F(MainlyConstantV2EncodingTest, rejectsReadPastEnd) {
+  const auto values = makeValues({7, 7, 9, 7});
+  nimble::Buffer buffer{*pool_};
+  auto encoding =
+      nimble::test::Encoder<nimble::MainlyConstantV2Encoding<int64_t>>::
+          createEncoding(buffer, values, [](uint32_t /*totalLength*/) -> void* {
+            return nullptr;
+          });
+  nimble::Vector<int64_t> decoded{pool_.get(), values.size() + 1};
+
+  NIMBLE_ASSERT_THROW(
+      encoding->materialize(decoded.size(), decoded.data()),
+      "Cannot materialize beyond MainlyConstantV2 row count");
+}
+
+} // namespace

--- a/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -1871,6 +1871,62 @@ TEST_P(ReadWithVisitorTest, encodingLevelMainlyConstantAlwaysTrueDense) {
   }
 }
 
+TEST_P(ReadWithVisitorTest, encodingLevelMainlyConstantV2RangeDense) {
+  constexpr int kRows = 200;
+  std::vector<int64_t> data(kRows, 42);
+  data[20] = 7;
+  data[80] = 13;
+  data[120] = 19;
+  data[180] = 53;
+
+  auto input = makeRowVector({makeFlatVector<int64_t>(data)});
+  auto rowType = asRowType(input->type());
+  auto context = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(10, 50, false));
+  auto root = buildReader(*context, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowNumbers(kRows);
+  std::iota(rowNumbers.begin(), rowNumbers.end(), 0);
+  RowSet rows(rowNumbers.data(), rowNumbers.size());
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  const EncodingLayout layout{
+      EncodingType::MainlyConstantV2,
+      {},
+      CompressionType::Uncompressed,
+      {TrivialEnc{}, TrivialEnc{}}};
+  auto encoding =
+      createFromCustomLayout<int64_t>(layout, data, *pool(), buffer);
+
+  common::BigintRange filter(10, 50, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows - 2);
+  const auto values = getValues<int64_t>(reader);
+  EXPECT_EQ(values[79], 13);
+  EXPECT_EQ(values[119], 19);
+}
+
 // ---------------------------------------------------------------------------
 // 8. MainlyConstantEncoding
 // 8. MainlyConstantEncoding<int64_t> + AlwaysTrue + dense + SLOW PATH

--- a/velox/dwio/nimble/encodings/tests/TestUtils.h
+++ b/velox/dwio/nimble/encodings/tests/TestUtils.h
@@ -29,6 +29,7 @@
 #include "velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/MainlyConstantV2Encoding.h"
 #include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/PFOREncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
@@ -112,6 +113,12 @@ template <typename T>
 struct EncodingTypeTraits<nimble::MainlyConstantEncoding<T>> {
   static constexpr inline nimble::EncodingType encodingType =
       nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::MainlyConstantV2Encoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::MainlyConstantV2;
 };
 
 template <typename T>

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -148,6 +148,7 @@ bool isNumericCompatible(EncodingType encodingType) {
   switch (encodingType) {
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
+    case EncodingType::MainlyConstantV2:
     case EncodingType::Trivial:
     case EncodingType::FixedBitWidth:
     case EncodingType::Dictionary:

--- a/velox/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/velox/dwio/nimble/tools/EncodingUtilities.cpp
@@ -63,6 +63,7 @@ void extractCompressionType(
     case EncodingType::DeltaBlock:
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
+    case EncodingType::MainlyConstantV2:
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::Fsst:
@@ -308,6 +309,47 @@ void traverseEncodings(
           "OtherValues",
           useVarintRowCount,
           visitor);
+      break;
+    }
+    case EncodingType::MainlyConstantV2: {
+      NIMBLE_CHECK_LE(dataOffset, stream.size());
+      const auto commonValueSize = detail::dataTypeSize(dataType);
+      NIMBLE_CHECK_GE(
+          stream.size() - dataOffset,
+          static_cast<size_t>(commonValueSize) + sizeof(uint32_t),
+          "Truncated MainlyConstantV2 header.");
+      const char* cursor = stream.data() + dataOffset;
+      const char* const end = stream.end();
+      cursor += commonValueSize;
+      const uint32_t exceptionPositionsBytes = encoding::readUint32(cursor);
+      NIMBLE_CHECK_GE(
+          static_cast<size_t>(end - cursor),
+          static_cast<size_t>(exceptionPositionsBytes) + sizeof(uint32_t),
+          "Truncated MainlyConstantV2 positions child.");
+      if (exceptionPositionsBytes != 0) {
+        traverseEncodings(
+            {cursor, exceptionPositionsBytes},
+            level + 1,
+            0,
+            "ExceptionPositions",
+            useVarintRowCount,
+            visitor);
+      }
+      cursor += exceptionPositionsBytes;
+      const uint32_t exceptionValuesBytes = encoding::readUint32(cursor);
+      NIMBLE_CHECK_EQ(
+          static_cast<size_t>(end - cursor),
+          exceptionValuesBytes,
+          "Invalid MainlyConstantV2 values child size.");
+      if (exceptionValuesBytes != 0) {
+        traverseEncodings(
+            {cursor, exceptionValuesBytes},
+            level + 1,
+            1,
+            "ExceptionValues",
+            useVarintRowCount,
+            visitor);
+      }
       break;
     }
     case EncodingType::Dictionary: {

--- a/velox/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/velox/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -1000,6 +1000,8 @@ std::string getEncodingLayoutLabel(
       identifierNames{
           {nimble::EncodingType::Dictionary, {"Alphabet", "Indices"}},
           {nimble::EncodingType::MainlyConstant, {"IsCommon", "OtherValues"}},
+          {nimble::EncodingType::MainlyConstantV2,
+           {"ExceptionPositions", "ExceptionValues"}},
           {nimble::EncodingType::Nullable, {"Data", "Nulls"}},
           {nimble::EncodingType::RLE, {"RunLengths", "RunValues"}},
           {nimble::EncodingType::SparseBool, {"Indices"}},

--- a/velox/dwio/nimble/tools/encoding/EncodingEvaluation.cpp
+++ b/velox/dwio/nimble/tools/encoding/EncodingEvaluation.cpp
@@ -51,6 +51,7 @@ uint8_t nestedChildrenCount(nimble::EncodingType encodingType) {
     case nimble::EncodingType::RLE:
     case nimble::EncodingType::Dictionary:
     case nimble::EncodingType::MainlyConstant:
+    case nimble::EncodingType::MainlyConstantV2:
     case nimble::EncodingType::PFOR:
       return 2;
     case nimble::EncodingType::SparseBool:

--- a/velox/dwio/nimble/tools/encoding/tests/EncodingEvaluationTest.cpp
+++ b/velox/dwio/nimble/tools/encoding/tests/EncodingEvaluationTest.cpp
@@ -80,6 +80,28 @@ TEST_F(EncodingEvaluationTest, evaluateCandidatesReturnsResultsForCompatible) {
   EXPECT_GT(results[1]->encodedBytes, 0u);
 }
 
+TEST_F(EncodingEvaluationTest, evaluatesMainlyConstantV2WithNestedChildren) {
+  const std::vector<velox::VectorPtr> vectors{vectorMaker_->flatVector<int64_t>(
+      1'024,
+      [](velox::vector_size_t row) { return row % 100 == 0 ? row : 42; })};
+  const auto candidates = buildEncodingCandidates({
+      nimble::EncodingType::Trivial,
+      nimble::EncodingType::MainlyConstantV2,
+  });
+
+  EvaluationOptions options;
+  options.iterations = 1;
+
+  const auto results =
+      evaluateCandidates(vectors, candidates, options, pool_.get());
+
+  ASSERT_EQ(results.size(), 2u);
+  ASSERT_TRUE(results[0].has_value());
+  ASSERT_TRUE(results[1].has_value());
+  EXPECT_EQ(results[1]->type, nimble::EncodingType::MainlyConstantV2);
+  EXPECT_GT(results[1]->encodedBytes, 0u);
+}
+
 TEST_F(EncodingEvaluationTest, evaluateCandidatesReturnsNulloptOnIncompatible) {
   const std::vector<velox::VectorPtr> vectors{makeVariedColumn(1'024)};
   const auto candidates = buildEncodingCandidates({


### PR DESCRIPTION
Summary:
Adds an experimental numeric encoding that stores one common value plus direct exception positions and values. It remains outside the production default candidate set.

MainlyConstantV2 is an experiment-only encoding for sparse-non-common MainlyConstant-like streams. It is not added to the production default candidate list and only appears when benchmark/eval explicitly enables it.

Current DataFM evidence supports a conservative initial gate around nonCommonRate below 5%. The broader 5%-10% range still needs more workload validation before becoming a default rule.

Differential Revision: D118060848


