### PR TITLE
fix: Fix naming violations in ScopedArbitrationParticipant

### DIFF
--- a/velox/common/memory/ArbitrationParticipant.cpp
+++ b/velox/common/memory/ArbitrationParticipant.cpp
@@ -399,11 +399,10 @@ std::string ArbitrationParticipant::Stats::toString() const {
 }
 
 ScopedArbitrationParticipant::ScopedArbitrationParticipant(
-    std::shared_ptr<ArbitrationParticipant> ArbitrationParticipant,
+    std::shared_ptr<ArbitrationParticipant> participant,
     std::shared_ptr<MemoryPool> pool)
-    : ArbitrationParticipant_(std::move(ArbitrationParticipant)),
-      pool_(std::move(pool)) {
-  VELOX_CHECK_NOT_NULL(ArbitrationParticipant_);
+    : participant_(std::move(participant)), pool_(std::move(pool)) {
+  VELOX_CHECK_NOT_NULL(participant_);
   VELOX_CHECK_NOT_NULL(pool_);
 }
 

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -371,27 +371,27 @@ class ArbitrationParticipant
 class ScopedArbitrationParticipant {
  public:
   ScopedArbitrationParticipant(
-      std::shared_ptr<ArbitrationParticipant> ArbitrationParticipant,
+      std::shared_ptr<ArbitrationParticipant> participant,
       std::shared_ptr<MemoryPool> pool);
 
   ArbitrationParticipant* operator->() const {
-    return ArbitrationParticipant_.get();
+    return participant_.get();
   }
 
   ArbitrationParticipant& operator*() const {
-    return *ArbitrationParticipant_;
+    return *participant_;
   }
 
   ArbitrationParticipant& operator()() const {
-    return *ArbitrationParticipant_;
+    return *participant_;
   }
 
   ArbitrationParticipant* get() const {
-    return ArbitrationParticipant_.get();
+    return participant_.get();
   }
 
  private:
-  std::shared_ptr<ArbitrationParticipant> ArbitrationParticipant_;
+  std::shared_ptr<ArbitrationParticipant> participant_;
   std::shared_ptr<MemoryPool> pool_;
 };
 


### PR DESCRIPTION
`ScopedArbitrationParticipant` names its private member  
`ArbitrationParticipant_` and the constructor parameter  
`ArbitrationParticipant`. Both use PascalCase, violating the camelCase naming  
convention for members and parameters, and the parameter shadows the class  
name.  

Rename the member to `participant_` and the constructor parameter to  
`participant`, matching the existing naming for this type in the codebase.  