### PR TITLE
perf(nimble): Collect string min/max in a single pass (#18760)

### DIFF
--- a/velox/dwio/nimble/common/StatsUtil.h
+++ b/velox/dwio/nimble/common/StatsUtil.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <optional>
 #include <span>
+#include <string_view>
 #include <type_traits>
 
 #include "velox/common/base/SimdUtil.h"
@@ -39,6 +40,10 @@ constexpr bool kIntegralMinMaxType = std::is_integral_v<std::remove_cv_t<T>> &&
 template <typename T>
 constexpr bool kFloatingPointMinMaxType =
     std::is_floating_point_v<std::remove_cv_t<T>>;
+
+template <typename T>
+constexpr bool kStringMinMaxType =
+    std::is_same_v<std::remove_cv_t<T>, std::string_view>;
 
 template <typename T>
 std::enable_if_t<kIntegralMinMaxType<T>, MinMax<std::remove_cv_t<T>>>
@@ -105,6 +110,32 @@ findMinMax(std::span<T> values) {
   }
 
   return MinMax<Value>{
+      .min = minValue,
+      .max = maxValue,
+  };
+}
+
+/// Returns bounds as views into 'values'; copy them before the buffer is
+/// recycled. Branches instead of calling std::min and std::max unconditionally
+/// because string comparison is not free, and a value below the running minimum
+/// cannot also be above the running maximum.
+template <typename T>
+  requires(kStringMinMaxType<T>)
+MinMax<std::remove_cv_t<T>> findMinMax(std::span<T> values) {
+  using Value = std::remove_cv_t<T>;
+
+  Value minValue{values.front()};
+  Value maxValue{values.front()};
+
+  for (const Value value : values) {
+    if (value < minValue) {
+      minValue = value;
+    } else if (value > maxValue) {
+      maxValue = value;
+    }
+  }
+
+  return {
       .min = minValue,
       .max = maxValue,
   };

--- a/velox/dwio/nimble/common/tests/StatsUtilTest.cpp
+++ b/velox/dwio/nimble/common/tests/StatsUtilTest.cpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <optional>
 #include <span>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -74,6 +75,34 @@ TEST(StatsUtilTest, findMinMaxHandlesIntegralTypes) {
   unsignedValues[211] = std::numeric_limits<uint64_t>::max();
   expectIntegralMinMax<uint64_t>(
       0, std::numeric_limits<uint64_t>::max(), unsignedValues);
+}
+
+TEST(StatsUtilTest, findMinMaxHandlesStringViews) {
+  using namespace std::string_view_literals;
+
+  // Bounds trail the first value, so seeding from values.front() and skipping
+  // the max check when a value lowers the min must still find both.
+  std::vector<std::string_view> values = {"mmm"sv, "aaa"sv, "zzz"sv, "qqq"sv};
+  auto minMax = findMinMax(std::span<std::string_view>(values));
+  EXPECT_EQ(minMax.min, "aaa"sv);
+  EXPECT_EQ(minMax.max, "zzz"sv);
+
+  // Ordering is by bytes and length, not NUL termination.
+  std::vector<std::string_view> withNuls = {"a\0a"sv, "a\0"sv, "a\0z"sv};
+  minMax = findMinMax(std::span<std::string_view>(withNuls));
+  EXPECT_EQ(minMax.min, "a\0"sv);
+  EXPECT_EQ(minMax.max, "a\0z"sv);
+
+  std::vector<std::string_view> single = {"only"sv};
+  minMax = findMinMax(std::span<std::string_view>(single));
+  EXPECT_EQ(minMax.min, "only"sv);
+  EXPECT_EQ(minMax.max, "only"sv);
+
+  // The returned bounds are views into the input, not copies.
+  std::vector<std::string_view> aliased = {"beta"sv, "alpha"sv};
+  minMax = findMinMax(std::span<std::string_view>(aliased));
+  EXPECT_EQ(minMax.min.data(), aliased[1].data());
+  EXPECT_EQ(minMax.max.data(), aliased[0].data());
 }
 
 TEST(StatsUtilTest, findMinMaxHandlesFloatingPointTypes) {

--- a/velox/dwio/nimble/velox/stats/ColumnStatistics.cpp
+++ b/velox/dwio/nimble/velox/stats/ColumnStatistics.cpp
@@ -466,22 +466,32 @@ StringStatistics* StringStatisticsCollector::stringStats() {
 }
 
 void StringStatisticsCollector::addValues(std::span<std::string_view> values) {
-  if (!values.empty()) {
-    auto* stats = stringStats();
-    if (UNLIKELY(!stats->min_.has_value())) {
-      stats->min_ = std::string(values.front());
-    }
-    if (UNLIKELY(!stats->max_.has_value())) {
-      stats->max_ = std::string(values.front());
-    }
+  if (values.empty()) {
+    return;
+  }
+  uint64_t logicalSize{0};
+  for (const auto& value : values) {
+    logicalSize += value.size();
+  }
 
-    for (const auto& value : values) {
-      addLogicalSize(value.size());
-      stats->min_ = stats->min_ > value ? std::make_optional(std::string(value))
-                                        : stats->min_;
-      stats->max_ = stats->max_ < value ? std::make_optional(std::string(value))
-                                        : stats->max_;
-    }
+  // Adding once per batch is equivalent: every override is additive.
+  addLogicalSize(logicalSize);
+
+  auto* stats = stringStats();
+
+  // findMinMax returns views into the writer's value stream, which is recycled
+  // per stripe. Assign rather than construct so a monotonic column reuses the
+  // capacity it already has.
+  const auto minMax = findMinMax(values);
+  if (!stats->min_.has_value()) {
+    stats->min_.emplace(minMax.min);
+  } else if (minMax.min < *stats->min_) {
+    stats->min_->assign(minMax.min);
+  }
+  if (!stats->max_.has_value()) {
+    stats->max_.emplace(minMax.max);
+  } else if (minMax.max > *stats->max_) {
+    stats->max_->assign(minMax.max);
   }
 }
 

--- a/velox/dwio/nimble/velox/stats/benchmarks/ColumnStatisticsBenchmark.cpp
+++ b/velox/dwio/nimble/velox/stats/benchmarks/ColumnStatisticsBenchmark.cpp
@@ -19,7 +19,11 @@
 #include <limits>
 #include <optional>
 #include <span>
+#include <string>
+#include <string_view>
 #include <vector>
+
+#include <fmt/format.h>
 
 #include <folly/Benchmark.h>
 #include <folly/Portability.h>
@@ -41,6 +45,12 @@ struct LegacyFloatingPointStatistics {
   uint64_t logicalSize{0};
   std::optional<double> min;
   std::optional<double> max;
+};
+
+struct LegacyStringStatistics {
+  uint64_t logicalSize{0};
+  std::optional<std::string> min;
+  std::optional<std::string> max;
 };
 
 template <typename T>
@@ -95,6 +105,88 @@ std::vector<T>& floatingPointValues() {
   static auto* values =
       new std::vector<T>(makeFloatingPointValues<T>(NumValues));
   return *values;
+}
+
+// Ascending input is the shape the batched scan targets: under the legacy
+// implementation every value advanced the maximum and allocated a string, while
+// random input allocates only on the occasional new extreme.
+enum class StringOrder { kRandom, kAscending };
+
+std::vector<std::string> makeStringValues(size_t numValues, StringOrder order) {
+  std::vector<std::string> values;
+  values.reserve(numValues);
+
+  for (size_t i = 0; i < numValues; ++i) {
+    const auto mixed =
+        order == StringOrder::kAscending ? i : (i * 1'103'515'245 + 12'345);
+    values.push_back(
+        fmt::format("{:016x}_padding_to_a_realistic_width", mixed));
+  }
+  return values;
+}
+
+template <StringOrder Order, size_t NumValues>
+std::vector<std::string_view>& stringValues() {
+  static auto* owned =
+      new std::vector<std::string>(makeStringValues(NumValues, Order));
+  static auto* views =
+      new std::vector<std::string_view>(owned->begin(), owned->end());
+  return *views;
+}
+
+// Mirrors StringStatisticsCollector::addValues before the batched scan: the
+// ternary reassigns the accumulator on every value, so a non-advancing value
+// still copy-assigns the optional and an advancing one allocates.
+FOLLY_NOINLINE void legacyAddStringValues(
+    LegacyStringStatistics& stats,
+    std::span<std::string_view> values) {
+  if (values.empty()) {
+    return;
+  }
+
+  if (!stats.min.has_value()) {
+    stats.min = std::string(values.front());
+  }
+  if (!stats.max.has_value()) {
+    stats.max = std::string(values.front());
+  }
+
+  for (const auto& value : values) {
+    stats.logicalSize += value.size();
+    stats.min =
+        stats.min > value ? std::make_optional(std::string(value)) : stats.min;
+    stats.max =
+        stats.max < value ? std::make_optional(std::string(value)) : stats.max;
+  }
+}
+
+template <StringOrder Order, size_t NumValues>
+void legacyStringOptionalBenchmark(unsigned int iters) {
+  auto& input = stringValues<Order, NumValues>();
+  LegacyStringStatistics stats;
+
+  while (iters--) {
+    legacyAddStringValues(stats, std::span<std::string_view>(input));
+  }
+
+  folly::doNotOptimizeAway(stats.logicalSize);
+  folly::doNotOptimizeAway(stats.min);
+  folly::doNotOptimizeAway(stats.max);
+}
+
+template <StringOrder Order, size_t NumValues>
+void currentStringCollectorBenchmark(unsigned int iters) {
+  auto& input = stringValues<Order, NumValues>();
+  StringStatisticsCollector collector;
+
+  while (iters--) {
+    collector.addValues(std::span<std::string_view>(input));
+  }
+
+  auto* stats = collector.getStatsView()->as<StringStatistics>();
+  folly::doNotOptimizeAway(stats->getLogicalSize());
+  folly::doNotOptimizeAway(stats->getMin());
+  folly::doNotOptimizeAway(stats->getMax());
 }
 
 template <typename T>
@@ -224,6 +316,15 @@ void currentFloatingPointCollectorBenchmark(unsigned int iters) {
   }                                                                    \
   BENCHMARK_DRAW_LINE()
 
+#define STRING_STATS_BENCHMARKS(order, name, numValues)                    \
+  BENCHMARK(legacyStringOptional_##name##_##numValues, iters) {            \
+    legacyStringOptionalBenchmark<order, numValues>(iters);                \
+  }                                                                        \
+  BENCHMARK_RELATIVE(currentStringCollector_##name##_##numValues, iters) { \
+    currentStringCollectorBenchmark<order, numValues>(iters);              \
+  }                                                                        \
+  BENCHMARK_DRAW_LINE()
+
 INTEGRAL_STATS_BENCHMARKS(int8_t, int8, 128);
 INTEGRAL_STATS_BENCHMARKS(int8_t, int8, 8192);
 INTEGRAL_STATS_BENCHMARKS(int16_t, int16, 128);
@@ -236,6 +337,10 @@ FLOATING_POINT_STATS_BENCHMARKS(float, float, 128);
 FLOATING_POINT_STATS_BENCHMARKS(float, float, 8192);
 FLOATING_POINT_STATS_BENCHMARKS(double, double, 128);
 FLOATING_POINT_STATS_BENCHMARKS(double, double, 8192);
+STRING_STATS_BENCHMARKS(StringOrder::kRandom, random, 128);
+STRING_STATS_BENCHMARKS(StringOrder::kRandom, random, 8192);
+STRING_STATS_BENCHMARKS(StringOrder::kAscending, ascending, 128);
+STRING_STATS_BENCHMARKS(StringOrder::kAscending, ascending, 8192);
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);

--- a/velox/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
+++ b/velox/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
@@ -16,6 +16,8 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <optional>
+#include <random>
 #include <span>
 #include <vector>
 
@@ -785,6 +787,189 @@ TEST_F(StatisticsCollectorTests, stringMinMaxAfterAddCounts) {
   EXPECT_EQ(stats->getMin().value(), "apple");
   ASSERT_TRUE(stats->getMax().has_value());
   EXPECT_EQ(stats->getMax().value(), "cherry");
+}
+
+// The batch scan tracks bounds as views and materializes at most two strings
+// per call, so a caller's buffer must not be aliased after addValues returns
+// and repeated calls must still accumulate a file-wide min/max. Ascending and
+// descending input are the two orders that previously allocated on every value.
+TEST_F(StatisticsCollectorTests, stringMinMaxAcrossBatchesDoesNotAliasInput) {
+  StringStatisticsCollector collector;
+  {
+    // Ascending, then let the source buffer die before the next batch.
+    std::vector<std::string> owned = {"aaa", "bbb", "ccc", "ddd"};
+    std::vector<std::string_view> views(owned.begin(), owned.end());
+    collector.addValues(std::span<std::string_view>(views));
+  }
+  {
+    // Descending, disjoint range below the current min.
+    std::vector<std::string> owned = {"a99", "a55", "a11"};
+    std::vector<std::string_view> views(owned.begin(), owned.end());
+    collector.addValues(std::span<std::string_view>(views));
+  }
+  {
+    // Entirely inside the current bounds: neither bound may move.
+    std::vector<std::string> owned = {"bzz", "czz"};
+    std::vector<std::string_view> views(owned.begin(), owned.end());
+    collector.addValues(std::span<std::string_view>(views));
+  }
+  auto* stats = collector.getStatsView()->as<StringStatistics>();
+  ASSERT_NE(stats, nullptr);
+  ASSERT_TRUE(stats->getMin().has_value());
+  ASSERT_TRUE(stats->getMax().has_value());
+  EXPECT_EQ(stats->getMin().value(), "a11");
+  EXPECT_EQ(stats->getMax().value(), "ddd");
+  EXPECT_EQ(
+      dynamic_cast<StatisticsCollector&>(collector).getLogicalSize(),
+      12 + 9 + 6);
+}
+
+// The scan seeds both bounds from the first value and skips the maximum check
+// whenever a value advances the minimum. Cover the orders where that shortcut
+// could drop a bound: the extremes trailing the first value, and each extreme
+// arriving in a separate batch.
+TEST_F(StatisticsCollectorTests, stringMinMaxWhenFirstValueIsNeitherBound) {
+  StringStatisticsCollector collector;
+  std::vector<std::string_view> middleFirst = {"mmm", "aaa", "zzz"};
+  collector.addValues(std::span<std::string_view>(middleFirst));
+
+  auto* stats = collector.getStatsView()->as<StringStatistics>();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->getMin().value(), "aaa");
+  EXPECT_EQ(stats->getMax().value(), "zzz");
+
+  // A single-value batch that widens only the maximum.
+  std::vector<std::string_view> single = {"zzzz"};
+  collector.addValues(std::span<std::string_view>(single));
+  EXPECT_EQ(stats->getMin().value(), "aaa");
+  EXPECT_EQ(stats->getMax().value(), "zzzz");
+
+  // The empty string sorts below every other value.
+  std::vector<std::string_view> withEmpty = {"qqq", ""};
+  collector.addValues(std::span<std::string_view>(withEmpty));
+  EXPECT_EQ(stats->getMin().value(), "");
+  EXPECT_EQ(stats->getMax().value(), "zzzz");
+
+  EXPECT_EQ(
+      dynamic_cast<StatisticsCollector&>(collector).getLogicalSize(),
+      9 + 4 + 3);
+}
+
+// Pins the batched scan against a trivial reference over randomized input:
+// arbitrary bytes, mixed lengths, duplicates, empty strings, and batch
+// boundaries that fall anywhere relative to the extremes. Any divergence in the
+// bound-tracking shortcut shows up here rather than as a wrong file footer.
+TEST_F(
+    StatisticsCollectorTests,
+    stringMinMaxMatchesReferenceOverRandomBatches) {
+  std::mt19937 rng{20260830};
+  std::uniform_int_distribution<size_t> lengthDist{0, 12};
+  std::uniform_int_distribution<int> byteDist{0, 255};
+  std::uniform_int_distribution<size_t> batchDist{1, 40};
+
+  for (int trial = 0; trial < 200; ++trial) {
+    StringStatisticsCollector collector;
+    std::optional<std::string> expectedMin;
+    std::optional<std::string> expectedMax;
+    uint64_t expectedLogicalSize{0};
+
+    const size_t numBatches = batchDist(rng);
+    for (size_t batch = 0; batch < numBatches; ++batch) {
+      std::vector<std::string> owned;
+      const size_t batchSize = batchDist(rng);
+      owned.reserve(batchSize);
+      for (size_t i = 0; i < batchSize; ++i) {
+        std::string value(lengthDist(rng), '\0');
+        for (auto& byte : value) {
+          byte = static_cast<char>(byteDist(rng));
+        }
+        owned.push_back(std::move(value));
+      }
+
+      for (const auto& value : owned) {
+        expectedLogicalSize += value.size();
+        if (!expectedMin.has_value() || value < *expectedMin) {
+          expectedMin = value;
+        }
+        if (!expectedMax.has_value() || value > *expectedMax) {
+          expectedMax = value;
+        }
+      }
+
+      std::vector<std::string_view> views(owned.begin(), owned.end());
+      collector.addValues(std::span<std::string_view>(views));
+    }
+
+    auto* stats = collector.getStatsView()->as<StringStatistics>();
+    ASSERT_NE(stats, nullptr);
+    EXPECT_EQ(stats->getMin(), expectedMin) << "trial " << trial;
+    EXPECT_EQ(stats->getMax(), expectedMax) << "trial " << trial;
+    EXPECT_EQ(
+        dynamic_cast<StatisticsCollector&>(collector).getLogicalSize(),
+        expectedLogicalSize)
+        << "trial " << trial;
+  }
+}
+
+// varchar columns carry arbitrary bytes, so bounds must be ordered and stored
+// by length rather than by NUL termination.
+TEST_F(StatisticsCollectorTests, stringMinMaxHandlesEmbeddedNulBytes) {
+  using namespace std::string_view_literals;
+  StringStatisticsCollector collector;
+
+  // "a\0a" sorts above "a\0" purely on length, and both would collapse to "a"
+  // under NUL-terminated comparison.
+  std::vector<std::string_view> values = {"a\0a"sv, "a\0"sv, "a\0z"sv};
+  collector.addValues(std::span<std::string_view>(values));
+
+  auto* stats = collector.getStatsView()->as<StringStatistics>();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->getMin().value(), "a\0"sv);
+  EXPECT_EQ(stats->getMax().value(), "a\0z"sv);
+  EXPECT_EQ(stats->getMin().value().size(), 2);
+  EXPECT_EQ(stats->getMax().value().size(), 3);
+  EXPECT_EQ(
+      dynamic_cast<StatisticsCollector&>(collector).getLogicalSize(),
+      3 + 2 + 3);
+}
+
+// An empty batch must leave the accumulator untouched rather than reading
+// values.front().
+TEST_F(StatisticsCollectorTests, stringMinMaxEmptyBatchIsANoOp) {
+  StringStatisticsCollector collector;
+  std::vector<std::string_view> empty;
+  collector.addValues(std::span<std::string_view>(empty));
+
+  auto* stats = collector.getStatsView()->as<StringStatistics>();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_FALSE(stats->getMin().has_value());
+  EXPECT_FALSE(stats->getMax().has_value());
+  EXPECT_EQ(dynamic_cast<StatisticsCollector&>(collector).getLogicalSize(), 0);
+
+  std::vector<std::string_view> populated = {"kkk"};
+  collector.addValues(std::span<std::string_view>(populated));
+  collector.addValues(std::span<std::string_view>(empty));
+  EXPECT_EQ(stats->getMin().value(), "kkk");
+  EXPECT_EQ(stats->getMax().value(), "kkk");
+  EXPECT_EQ(dynamic_cast<StatisticsCollector&>(collector).getLogicalSize(), 3);
+}
+
+// A shorter bound assigned over a longer one must not leave the previous
+// contents behind, which is the failure mode of reusing the buffer.
+TEST_F(
+    StatisticsCollectorTests,
+    stringMinMaxShrinkingBoundsDoNotRetainOldBytes) {
+  StringStatisticsCollector collector;
+  std::vector<std::string_view> wide = {"bbbbbbbbbb", "yyyyyyyyyy"};
+  collector.addValues(std::span<std::string_view>(wide));
+
+  std::vector<std::string_view> narrow = {"a", "z"};
+  collector.addValues(std::span<std::string_view>(narrow));
+
+  auto* stats = collector.getStatsView()->as<StringStatistics>();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->getMin().value(), "a");
+  EXPECT_EQ(stats->getMax().value(), "z");
 }
 
 TEST_F(StatisticsCollectorTests, stringStatisticsCollectorMerge) {


### PR DESCRIPTION
Summary:

__**Problem**__

`StringStatisticsCollector::addValues` updated both bounds once per value:

    stats->min_ = stats->min_ > value
        ? std::make_optional(std::string(value)) : stats->min_;

The winning branch allocates a `std::string`, but the losing branch is not free
either: it assigns the optional to itself, which copy-assigns the string it
already holds. So the cost is paid on every row, not only on rows that move a
bound. The benchmark shows this directly, with legacy timings coming out the
same for random and ascending input. If advancing values were the cost,
ascending would be far worse.

`addLogicalSize` was also called once per value, and it is virtual.

The integral and floating-point collectors already avoid all of this by calling
a single `findMinMax` per batch. The string collector was the odd one out.

__**Fix**__

Add a `std::string_view` overload of `findMinMax` in `common/StatsUtil.h`
alongside the existing integral and floating-point ones, and have the string
collector use it. It returns the two bounds as views, so nothing is allocated
while scanning.

The collector then materializes at most two strings, only when the batch widens
the accumulated range, and assigns into the existing buffers so a monotonic
column reuses capacity rather than allocating each time a bound advances.
Logical size is summed locally and added once; every `addLogicalSize` override
is additive, so this is equivalent.

Stats values are unchanged, so file output is byte-identical.

Reviewed By: xiaoxmeng

Differential Revision: D117972961


