### PR TITLE
fix(sparksql): Make make_date ANSI-aware

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -201,14 +201,24 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: make_date(year, month, day) -> date
 
+    *(ANSI compliant)*
+
     Returns the date from year, month and day fields.
     ``year``, ``month`` and ``day`` must be ``INTEGER``.
-    Returns NULL if inputs are not valid.
 
     The valid inputs need to meet the following conditions,
     ``month`` need to be from 1 (January) to 12 (December).
     ``day`` need to be from 1 to 31, and matches the number of days in each month.
     days of ``year-month-day - 1970-01-01`` need to be in the range of INTEGER type.
+
+    When ``spark.ansi_enabled`` is true, invalid inputs throw an error;
+    otherwise the function returns NULL. NULL inputs always return NULL
+    regardless of ANSI mode. ::
+
+        SELECT make_date(1920, 1, 25); -- 1920-01-25
+        SELECT make_date(null, 1, 25); -- NULL
+        SELECT make_date(2021, 13, 1); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+        SELECT make_date(2023, 2, 29); -- NULL (ANSI OFF) / ERROR (ANSI ON)
 
 .. spark:function:: make_timestamp(year, month, day, hour, minute, second[, timezone]) -> timestamp
 

--- a/velox/functions/sparksql/AnsiMode.h
+++ b/velox/functions/sparksql/AnsiMode.h
@@ -24,6 +24,24 @@
 
 namespace facebook::velox::functions::sparksql {
 
+/// Throws a user error formatted from 'formatString' and 'args' when
+/// 'ansiEnabled' is true; does nothing otherwise. Use when the caller
+/// signals NULL via its own bool/Status return, not std::optional (see
+/// nullOrUserFail() below for that case).
+///
+/// Error messages should follow Velox convention: static description first,
+/// runtime values at the end of the format string.
+template <typename... Args>
+void ansiUserFail(
+    bool ansiEnabled,
+    fmt::format_string<Args...> formatString,
+    Args&&... args) {
+  if (FOLLY_UNLIKELY(ansiEnabled)) {
+    VELOX_USER_FAIL(
+        "{}", fmt::format(formatString, std::forward<Args>(args)...));
+  }
+}
+
 /// Returns std::nullopt when ANSI mode is disabled; throws a user error
 /// formatted from 'formatString' and 'args' when enabled. Use at validation
 /// sites in Spark functions that return NULL on invalid input unless ANSI mode
@@ -34,18 +52,12 @@ namespace facebook::velox::functions::sparksql {
 ///         ansiEnabled, "Invalid value for hour, must be in [0, 24): {}",
 ///         hour);
 ///   }
-///
-/// Error messages should follow Velox convention: static description first,
-/// runtime values at the end of the format string.
 template <typename... Args>
 std::nullopt_t nullOrUserFail(
     bool ansiEnabled,
     fmt::format_string<Args...> formatString,
     Args&&... args) {
-  if (FOLLY_UNLIKELY(ansiEnabled)) {
-    VELOX_USER_FAIL(
-        "{}", fmt::format(formatString, std::forward<Args>(args)...));
-  }
+  ansiUserFail(ansiEnabled, formatString, std::forward<Args>(args)...);
   return std::nullopt;
 }
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -20,6 +20,7 @@
 
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
+#include "velox/functions/sparksql/AnsiMode.h"
 #include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/TimestampUtils.h"
 #include "velox/type/TimestampConversion.h"
@@ -486,6 +487,15 @@ template <typename T>
 struct MakeDateFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const int32_t* /*year*/,
+      const int32_t* /*month*/,
+      const int32_t* /*day*/) {
+    ansiEnabled_ = SparkQueryConfig{config}.ansiEnabled();
+  }
+
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Date>& result,
       const int32_t year,
@@ -493,15 +503,20 @@ struct MakeDateFunction {
       const int32_t day) {
     Expected<int64_t> expected = util::daysSinceEpochFromDate(year, month, day);
     if (expected.hasError()) {
+      ansiUserFail(ansiEnabled_, "{}", expected.error().message());
       return false;
     }
     int64_t daysSinceEpoch = expected.value();
+    // Not the DateTimeException failOnError catches in Spark -- always throws.
     if (daysSinceEpoch != static_cast<int32_t>(daysSinceEpoch)) {
-      return false;
+      VELOX_USER_FAIL("Date out of range: {}-{}-{}", year, month, day);
     }
     result = daysSinceEpoch;
     return true;
   }
+
+ private:
+  bool ansiEnabled_ = false;
 };
 
 template <typename T>

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -59,6 +59,12 @@ class DateTimeFunctionsTest : public SparkFunctionBaseTest {
     });
   }
 
+  void enableAnsiMode() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"},
+    });
+  }
+
   template <typename TOutput, typename TValue>
   std::optional<TOutput> evaluateDateFuncOnce(
       const std::string& expr,
@@ -387,8 +393,11 @@ TEST_F(DateTimeFunctionsTest, makeDate) {
 
   EXPECT_EQ(makeDate(kMax, 12, 15), std::nullopt);
 
+  // Day-count overflow always throws, not gated by ANSI.
   constexpr const int32_t kJodaMaxYear{292278994};
-  EXPECT_EQ(makeDate(kJodaMaxYear - 10, 12, 15), std::nullopt);
+  VELOX_ASSERT_USER_THROW(
+      makeDate(kJodaMaxYear - 10, 12, 15),
+      fmt::format("Date out of range: {}-12-15", kJodaMaxYear - 10));
 
   EXPECT_EQ(makeDate(2021, 13, 1), std::nullopt);
   EXPECT_EQ(makeDate(2022, 3, 35), std::nullopt);
@@ -398,6 +407,59 @@ TEST_F(DateTimeFunctionsTest, makeDate) {
 
   EXPECT_EQ(makeDate(2023, 2, 29), std::nullopt);
   EXPECT_EQ(makeDate(2023, 3, 29), parseDate("2023-03-29"));
+}
+
+TEST_F(DateTimeFunctionsTest, makeDateAnsiErrors) {
+  enableAnsiMode();
+
+  const auto makeDate = [&](std::optional<int32_t> year,
+                            std::optional<int32_t> month,
+                            std::optional<int32_t> day) {
+    return evaluateOnce<int32_t>("make_date(c0, c1, c2)", year, month, day);
+  };
+
+  // Valid inputs are unaffected by ANSI mode.
+  EXPECT_EQ(makeDate(1920, 1, 25), parseDate("1920-01-25"));
+  EXPECT_EQ(makeDate(-10, 1, 30), parseDate("-0010-01-30"));
+  EXPECT_EQ(makeDate(2023, 3, 31), parseDate("2023-03-31"));
+  EXPECT_EQ(makeDate(2023, 3, 29), parseDate("2023-03-29"));
+
+  // Under ANSI mode, invalid inputs throw instead of returning NULL.
+  constexpr const int32_t kJodaMaxYear{292278994};
+  VELOX_ASSERT_USER_THROW(
+      makeDate(kMax, 12, 15), "Date out of range: 2147483647-12-15");
+  VELOX_ASSERT_USER_THROW(
+      makeDate(kJodaMaxYear - 10, 12, 15),
+      fmt::format("Date out of range: {}-12-15", kJodaMaxYear - 10));
+  VELOX_ASSERT_USER_THROW(
+      makeDate(2021, 13, 1), "Date out of range: 2021-13-1");
+  VELOX_ASSERT_USER_THROW(
+      makeDate(2022, 3, 35), "Date out of range: 2022-3-35");
+  VELOX_ASSERT_USER_THROW(
+      makeDate(2023, 4, 31), "Date out of range: 2023-4-31");
+  VELOX_ASSERT_USER_THROW(
+      makeDate(2023, 2, 29), "Date out of range: 2023-2-29");
+}
+
+TEST_F(DateTimeFunctionsTest, tryMakeDateAnsi) {
+  enableAnsiMode();
+
+  // The generic TRY special form swallows the ANSI error and returns NULL,
+  // regardless of the ANSI setting.
+  EXPECT_EQ(
+      evaluateOnce<int32_t>(
+          "try(make_date(c0, c1, c2))",
+          std::optional<int32_t>(2021),
+          std::optional<int32_t>(13),
+          std::optional<int32_t>(1)),
+      std::nullopt);
+  EXPECT_EQ(
+      evaluateOnce<int32_t>(
+          "try(make_date(c0, c1, c2))",
+          std::optional<int32_t>(2023),
+          std::optional<int32_t>(3),
+          std::optional<int32_t>(31)),
+      parseDate("2023-03-31"));
 }
 
 TEST_F(DateTimeFunctionsTest, lastDay) {


### PR DESCRIPTION
Adds ANSI-mode support for `make_date`. When ANSI is enabled, an invalid year, month, or day throws an error instead of returning NULL.

Issue: https://github.com/apache/incubator-gluten/issues/10134