### PR TITLE
refactor(hashbuild): Extract the build side accumulation of HashBuild into JoinTableBuilder

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3238,6 +3238,18 @@ inline bool isCountingJoin(JoinType joinType) {
   return isCountingAntiJoin(joinType) || isCountingLeftSemiFilterJoin(joinType);
 }
 
+/// Indicates if a join with 'joinType' can drop the build side rows with a
+/// duplicate join key. 'withFilter' is true if the join has an extra filter.
+/// Left semi and anti join with no extra filter only need to know whether there
+/// is a match, hence there is no need to store entries with duplicate keys.
+/// Counting joins always deduplicate and track counts.
+inline bool canDropDuplicates(JoinType joinType, bool withFilter) {
+  return isCountingJoin(joinType) ||
+      (!withFilter &&
+       (isLeftSemiFilterJoin(joinType) || isLeftSemiProjectJoin(joinType) ||
+        isAntiJoin(joinType)));
+}
+
 /// Returns true if the join type is "probe-only", meaning the output includes
 /// only columns from the probe side (plus possibly a mark column).
 inline bool isProbeOnlyJoin(JoinType joinType) {
@@ -3408,12 +3420,7 @@ class AbstractJoinNode : public PlanNode {
   /// For left semi and anti join, it is not necessary to store duplicate rows.
   /// For counting joins, duplicates are folded into a per-key count.
   bool canDropDuplicates() const {
-    // Left semi and anti join with no extra filter only needs to know whether
-    // there is a match. Hence, no need to store entries with duplicate keys.
-    // Counting joins always deduplicate and track counts.
-    return isCountingJoin() ||
-        (!filter() &&
-         (isLeftSemiFilterJoin() || isLeftSemiProjectJoin() || isAntiJoin()));
+    return core::canDropDuplicates(joinType_, filter() != nullptr);
   }
 
   const std::vector<FieldAccessTypedExprPtr>& leftKeys() const {

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -52,6 +52,7 @@ velox_add_library(
   IndexLookupJoin.cpp
   IndexLookupJoinBridge.cpp
   JoinBridge.cpp
+  JoinTableBuilder.cpp
   Limit.cpp
   LocalPartition.cpp
   LocalPlanner.cpp
@@ -156,6 +157,7 @@ velox_add_library(
   IndexLookupJoin.h
   IndexLookupJoinBridge.h
   JoinBridge.h
+  JoinTableBuilder.h
   Limit.h
   LocalPartition.h
   LocalPlanner.h

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -67,58 +67,48 @@ HashBuild::HashBuild(
       nullAware_{joinNode_->isNullAware()},
       nullAsValue_{joinNode_->isNullAsValue()},
       needProbedFlagSpill_{needRightSideJoin(joinType_)},
-      dropDuplicates_(joinNode_->canDropDuplicates()),
-      vectorHasherMaxNumDistinct_(
-          driverCtx->queryConfig().joinBuildVectorHasherMaxNumDistinct()),
-      abandonHashBuildDedupMinRows_(
-          driverCtx->queryConfig().abandonHashBuildDedupMinRows()),
-      abandonHashBuildDedupMinPct_(
-          driverCtx->queryConfig().abandonHashBuildDedupMinPct()),
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
-          planNodeId())),
-      keyChannelMap_(joinNode_->rightKeys().size()) {
+          planNodeId())) {
   VELOX_CHECK(pool()->trackUsage());
   VELOX_CHECK_NOT_NULL(joinBridge_);
 
   joinBridge_->addBuilder();
 
-  const auto& inputType = joinNode_->sources()[1]->outputType();
-
-  const auto numKeys = joinNode_->rightKeys().size();
-  keyChannels_.reserve(numKeys);
-
-  for (int i = 0; i < numKeys; ++i) {
-    auto& key = joinNode_->rightKeys()[i];
-    auto channel = exprToChannel(key.get(), inputType);
-    keyChannelMap_[channel] = i;
-    keyChannels_.emplace_back(channel);
-  }
-
-  // Identify the non-key build side columns and make a decoder for each.
-  const int32_t numDependents = inputType->size() - numKeys;
-  if (!dropDuplicates_) {
-    if (numDependents > 0) {
-      // Number of join keys (numKeys) may be less then number of input columns
-      // (inputType->size()). In this case numDependents is negative and cannot
-      // be used to call 'reserve'. This happens when we join different probe
-      // side keys with the same build side key: SELECT * FROM t LEFT JOIN u ON
-      // t.k1 = u.k AND t.k2 = u.k.
-      dependentChannels_.reserve(numDependents);
-      decoders_.reserve(numDependents);
-    }
-
-    for (auto i = 0; i < inputType->size(); ++i) {
-      if (keyChannelMap_.find(i) == keyChannelMap_.end()) {
-        dependentChannels_.emplace_back(i);
-        decoders_.emplace_back(std::make_unique<DecodedVector>());
-      }
-    }
-  }
-
-  tableType_ = hashJoinTableType(joinNode_);
+  setupTableBuilder();
 
   stateCleared_ = false;
+}
+
+void HashBuild::setupTableBuilder() {
+  const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
+
+  JoinTableBuilder::Options options;
+  options.joinType = joinType_;
+  options.nullAware = nullAware_;
+  options.nullAsValue = nullAsValue_;
+  options.withFilter = joinNode_->filter() != nullptr;
+  options.inputType = joinNode_->sources()[1]->outputType();
+  options.joinKeys = joinNode_->rightKeys();
+  options.minTableRowsForParallelJoinBuild =
+      queryConfig.minTableRowsForParallelJoinBuild();
+  options.vectorHasherMaxNumDistinct =
+      queryConfig.joinBuildVectorHasherMaxNumDistinct();
+  options.abandonHashBuildDedupMinRows =
+      queryConfig.abandonHashBuildDedupMinRows();
+  options.abandonHashBuildDedupMinPct =
+      queryConfig.abandonHashBuildDedupMinPct();
+  options.bloomFilterPushdownMaxSize =
+      queryConfig.hashProbeBloomFilterPushdownMaxSize();
+  options.onDedupAbandoned = [this]() {
+    // The hash table is no longer directly constructed in addInput. The data
+    // that was previously inserted into the hash table is already in the
+    // RowContainer.
+    addRuntimeStat(
+        std::string(HashBuild::kAbandonBuildNoDupHash), RuntimeCounter(1));
+  };
+
+  tableBuilder_ = std::make_unique<JoinTableBuilder>(std::move(options));
 }
 
 void HashBuild::initialize() {
@@ -130,12 +120,8 @@ void HashBuild::initialize() {
 
   // Set up table and spiller now that cache state is initialized.
   // This ensures tableMemoryPool() returns the cache's tablePool when enabled.
-  setupTable();
+  tableBuilder_->initialize(tableMemoryPool(), pool(), analyzeAntiJoinFilter());
   setupSpiller();
-
-  if (isAntiJoin(joinType_) && joinNode_->filter()) {
-    setupFilterForAntiJoins(keyChannelMap_);
-  }
 }
 
 bool HashBuild::setupCachedHashTable() {
@@ -209,7 +195,7 @@ void HashBuild::maybeSetHashTableInCache(
     return;
   }
   auto* cache = HashTableCache::instance();
-  cache->put(cacheKey(), table, joinHasNullKeys_);
+  cache->put(cacheKey(), table, tableBuilder_->joinHasNullKeys());
 }
 
 bool HashBuild::receivedCachedHashTable() {
@@ -236,76 +222,6 @@ bool HashBuild::receivedCachedHashTable() {
   return true;
 }
 
-void HashBuild::setupTable() {
-  VELOX_CHECK_NULL(table_);
-
-  const auto numKeys = keyChannels_.size();
-  std::vector<std::unique_ptr<VectorHasher>> keyHashers;
-  keyHashers.reserve(numKeys);
-  for (vector_size_t i = 0; i < numKeys; ++i) {
-    keyHashers.emplace_back(
-        VectorHasher::create(tableType_->childAt(i), keyChannels_[i]));
-  }
-
-  const auto numDependents = tableType_->size() - numKeys;
-  std::vector<TypePtr> dependentTypes;
-  dependentTypes.reserve(numDependents);
-  for (int i = numKeys; i < tableType_->size(); ++i) {
-    dependentTypes.emplace_back(tableType_->childAt(i));
-  }
-  auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
-      joinNode_->isRightSemiProjectJoin() || joinNode_->isRightAntiJoin()) {
-    // Do not ignore null keys. kRightAnti must retain null keys: a null-keyed
-    // build row never matches and is always returned.
-    table_ = HashTable<false>::createForJoin(
-        std::move(keyHashers),
-        dependentTypes,
-        true, // allowDuplicates
-        true, // hasProbedFlag
-        false, // hasCountFlag
-        queryConfig.minTableRowsForParallelJoinBuild(),
-        tableMemoryPool());
-  } else {
-    // Right semi join needs to tag build rows that were probed.
-    const bool needProbedFlag = joinNode_->isRightSemiFilterJoin();
-    const bool hasCountFlag = joinNode_->isCountingJoin();
-    if (nullAsValue_ || isLeftNullAwareJoinWithFilter(joinNode_)) {
-      // We need to check null key rows in build side in case of null-aware anti
-      // or left semi project join with filter set.
-      table_ = HashTable<false>::createForJoin(
-          std::move(keyHashers),
-          dependentTypes,
-          !dropDuplicates_, // allowDuplicates
-          needProbedFlag, // hasProbedFlag
-          hasCountFlag,
-          queryConfig.minTableRowsForParallelJoinBuild(),
-          tableMemoryPool());
-    } else {
-      // Ignore null keys
-      table_ = HashTable<true>::createForJoin(
-          std::move(keyHashers),
-          dependentTypes,
-          !dropDuplicates_, // allowDuplicates
-          needProbedFlag, // hasProbedFlag
-          hasCountFlag,
-          queryConfig.minTableRowsForParallelJoinBuild(),
-          tableMemoryPool(),
-          queryConfig.hashProbeBloomFilterPushdownMaxSize());
-    }
-  }
-  analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
-  if (abandonHashBuildDedupMinPct_ == 0 && !joinNode_->isCountingJoin()) {
-    // Building a HashTable without duplicates is disabled if
-    // abandonBuildNoDupHashMinPct_ is 0. Counting joins always require dedup.
-    abandonHashBuildDedup_ = true;
-    table_->setAllowDuplicates(true);
-    return;
-  }
-  // Only create HashLookup when dedup is enabled.
-  lookup_ = std::make_unique<HashLookup>(table_->hashers(), pool());
-}
-
 void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   VELOX_CHECK_NULL(spiller_);
   VELOX_CHECK_NULL(spillInputReader_);
@@ -314,7 +230,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
     return;
   }
   if (spillType_ == nullptr) {
-    spillType_ = hashJoinTableSpillType(tableType_, joinType_);
+    spillType_ = hashJoinTableSpillType(tableBuilder_->tableType(), joinType_);
     if (needProbedFlagSpill_) {
       spillProbedFlagChannel_ = spillType_->size() - 1;
       VELOX_CHECK_NULL(spillProbedFlagVector_);
@@ -361,7 +277,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   spiller_ = std::make_unique<HashBuildSpiller>(
       joinType_,
       restoringPartitionId_,
-      table_->rows(),
+      tableBuilder_->table()->rows(),
       spillType_,
       HashBitRange(
           startPartitionBit, startPartitionBit + config->numPartitionBits),
@@ -380,63 +296,53 @@ bool HashBuild::isInputFromSpill() const {
 }
 
 RowTypePtr HashBuild::inputType() const {
-  return isInputFromSpill() ? tableType_
+  return isInputFromSpill() ? tableBuilder_->tableType()
                             : joinNode_->sources()[1]->outputType();
 }
 
-void HashBuild::setupFilterForAntiJoins(
-    const folly::F14FastMap<column_index_t, column_index_t>& keyChannelMap) {
-  VELOX_DCHECK(
-      std::is_sorted(dependentChannels_.begin(), dependentChannels_.end()));
+JoinTableBuilder::AntiJoinFilterInfo HashBuild::analyzeAntiJoinFilter() {
+  JoinTableBuilder::AntiJoinFilterInfo filterInfo;
+  if (!isAntiJoin(joinType_) || joinNode_->filter() == nullptr) {
+    return filterInfo;
+  }
 
   ExprSet exprs({joinNode_->filter()}, operatorCtx_->execCtx());
   VELOX_DCHECK_EQ(exprs.exprs().size(), 1);
   const auto& expr = exprs.expr(0);
-  filterPropagatesNulls_ = expr->propagatesNulls();
-  if (filterPropagatesNulls_) {
-    const auto inputType = joinNode_->sources()[1]->outputType();
-    for (const auto& field : expr->distinctFields()) {
-      const auto index = inputType->getChildIdxIfExists(field->field());
-      if (!index.has_value()) {
-        continue;
-      }
-      auto keyIter = keyChannelMap.find(*index);
-      if (keyIter != keyChannelMap.end()) {
-        keyFilterChannels_.push_back(keyIter->second);
-      } else {
-        auto dependentIter = std::lower_bound(
-            dependentChannels_.begin(), dependentChannels_.end(), *index);
-        VELOX_DCHECK(
-            dependentIter != dependentChannels_.end() &&
-            *dependentIter == *index);
-        dependentFilterChannels_.push_back(
-            dependentIter - dependentChannels_.begin());
-      }
-    }
+  filterInfo.propagatesNulls = expr->propagatesNulls();
+  if (!filterInfo.propagatesNulls) {
+    return filterInfo;
   }
+
+  const auto& inputType = joinNode_->sources()[1]->outputType();
+  for (const auto& field : expr->distinctFields()) {
+    const auto index = inputType->getChildIdxIfExists(field->field());
+    if (!index.has_value()) {
+      continue;
+    }
+    filterInfo.inputChannels.push_back(*index);
+  }
+  std::sort(filterInfo.inputChannels.begin(), filterInfo.inputChannels.end());
+  return filterInfo;
 }
 
-void HashBuild::removeInputRowsForAntiJoinFilter() {
-  bool changed = false;
-  auto* rawActiveRows = activeRows_.asMutableRange().bits();
-  auto removeNulls = [&](DecodedVector& decoded) {
-    if (decoded.mayHaveNulls()) {
-      changed = true;
-      // NOTE: the true value of a raw null bit indicates non-null so we AND
-      // 'rawActiveRows' with the raw bit.
-      bits::andBits(
-          rawActiveRows, decoded.nulls(&activeRows_), 0, activeRows_.end());
-    }
-  };
-  for (auto channel : keyFilterChannels_) {
-    removeNulls(table_->hashers()[channel]->decodedVector());
+void HashBuild::updateNullKeysStats() {
+  // Update statistics for null keys in join operator.
+  // We use the active rows to store which rows have some null keys,
+  // and reset it after using it.
+  auto& activeRows = tableBuilder_->activeRows();
+  auto lockedStats = stats_.wlock();
+  deselectRowsWithNulls(tableBuilder_->hashers(), activeRows);
+  lockedStats->numNullKeys += activeRows.size() - activeRows.countSelected();
+  activeRows.setAll();
+}
+
+const FlatVector<bool>* HashBuild::spillProbedFlags(
+    const RowVectorPtr& input) const {
+  if (!isInputFromSpill() || !needProbedFlagSpill_) {
+    return nullptr;
   }
-  for (auto channel : dependentFilterChannels_) {
-    removeNulls(*decoders_[channel]);
-  }
-  if (changed) {
-    activeRows_.updateBounds();
-  }
+  return input->childAt(spillProbedFlagChannel_)->asFlatVector<bool>();
 }
 
 void HashBuild::addInput(RowVectorPtr input) {
@@ -450,151 +356,26 @@ void HashBuild::addInput(RowVectorPtr input) {
 
   TestValue::adjust("facebook::velox::exec::HashBuild::addInput", this);
 
-  activeRows_.resize(input->size());
-  activeRows_.setAll();
+  tableBuilder_->decodeKeys(input);
 
-  auto& hashers = table_->hashers();
-
-  for (auto i = 0; i < hashers.size(); ++i) {
-    auto key = input->childAt(hashers[i]->channel())->loadedVector();
-    hashers[i]->decode(*key, activeRows_);
-  }
-
-  // Update statistics for null keys in join operator.
-  // We use activeRows_ to store which rows have some null keys,
-  // and reset it after using it.
-  // Only process when input is not spilled, to avoid overcounting.
+  // Only update the null keys stats when input is not spilled, to avoid
+  // overcounting.
   if (!isInputFromSpill()) {
-    auto lockedStats = stats_.wlock();
-    deselectRowsWithNulls(hashers, activeRows_);
-    lockedStats->numNullKeys +=
-        activeRows_.size() - activeRows_.countSelected();
-    activeRows_.setAll();
+    updateNullKeysStats();
   }
 
-  if (!isRightJoin(joinType_) && !isFullJoin(joinType_) &&
-      !isRightSemiProjectJoin(joinType_) && !isRightAntiJoin(joinType_) &&
-      !nullAsValue_ && !isLeftNullAwareJoinWithFilter(joinNode_)) {
-    deselectRowsWithNulls(hashers, activeRows_);
-    if (nullAware_ && !joinHasNullKeys_ &&
-        activeRows_.countSelected() < input->size()) {
-      joinHasNullKeys_ = true;
-    }
-  } else if (nullAware_ && !joinHasNullKeys_) {
-    for (auto& hasher : hashers) {
-      auto& decoded = hasher->decodedVector();
-      if (decoded.mayHaveNulls()) {
-        auto* nulls = decoded.nulls(&activeRows_);
-        if (nulls && bits::countNulls(nulls, 0, activeRows_.end()) > 0) {
-          joinHasNullKeys_ = true;
-          break;
-        }
-      }
-    }
-  }
-
-  for (auto i = 0; i < dependentChannels_.size(); ++i) {
-    decoders_[i]->decode(
-        *input->childAt(dependentChannels_[i])->loadedVector(), activeRows_);
-  }
-
-  if (isAntiJoin(joinType_) && joinNode_->filter()) {
-    if (filterPropagatesNulls_) {
-      removeInputRowsForAntiJoinFilter();
-    }
-  } else if (isAntiJoin(joinType_) && nullAware_ && joinHasNullKeys_) {
+  if (!tableBuilder_->processNullKeys()) {
     // Null-aware anti join with no extra filter returns no rows if build side
     // has nulls in join keys. Hence, we can stop processing on first null.
     noMoreInput();
     return;
   }
 
+  tableBuilder_->decodeDependents(input);
+
   spillInput(input);
-  if (!activeRows_.hasSelections()) {
-    return;
-  }
 
-  if (dropDuplicates_ && !abandonHashBuildDedup_) {
-    // Counting joins must not abandon dedup — accurate counts are required.
-    const bool abandonEarly = !joinNode_->isCountingJoin() &&
-        abandonHashBuildDedupEarly(table_->numDistinct());
-    if (!abandonEarly) {
-      numHashInputRows_ += activeRows_.countSelected();
-      table_->prepareForGroupProbe(
-          *lookup_,
-          input,
-          activeRows_,
-          BaseHashTable::kNoSpillInputStartPartitionBit);
-      if (lookup_->rows.empty()) {
-        return;
-      }
-      table_->groupProbe(
-          *lookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
-
-      // For counting joins, increment the count for duplicate rows.
-      // New rows are initialized with count = 1 by initializeRow.
-      // Increment count for all rows, then decrement for new rows to
-      // correct the over-counting.
-      if (joinNode_->isCountingJoin()) {
-        auto* rows = table_->rows();
-        for (auto row : lookup_->rows) {
-          rows->incrementCount(lookup_->hits[row]);
-        }
-        for (auto newRow : lookup_->newGroups) {
-          rows->decrementCount(lookup_->hits[newRow]);
-        }
-      }
-      return;
-    }
-    abandonHashBuildDedup();
-  }
-
-  if (analyzeKeys_ && hashes_.size() < activeRows_.end()) {
-    hashes_.resize(activeRows_.end());
-  }
-
-  // As long as analyzeKeys is true, we keep running the keys through
-  // the Vectorhashers so that we get a possible mapping of the keys
-  // to small ints for array or normalized key. When mayUseValueIds is
-  // false for the first time we stop. We do not retain the value ids
-  // since the final ones will only be known after all data is
-  // received.
-  for (auto& hasher : hashers) {
-    // TODO: Load only for active rows, except if right/full outer join.
-    if (analyzeKeys_) {
-      hasher->computeValueIds(activeRows_, hashes_);
-      analyzeKeys_ = hasher->mayUseValueIds();
-    }
-  }
-  auto rows = table_->rows();
-  auto nextOffset = rows->nextOffset();
-  FlatVector<bool>* spillProbedFlagVector{nullptr};
-  if (isInputFromSpill() && needProbedFlagSpill_) {
-    spillProbedFlagVector =
-        input->childAt(spillProbedFlagChannel_)->asFlatVector<bool>();
-  }
-
-  activeRows_.applyToSelected([&](auto rowIndex) {
-    char* newRow = rows->newRow();
-    if (nextOffset) {
-      *reinterpret_cast<char**>(newRow + nextOffset) = nullptr;
-    }
-    // Store the columns for each row in sequence. At probe time
-    // strings of the row will probably be in consecutive places, so
-    // reading one will prime the cache for the next.
-    for (auto i = 0; i < hashers.size(); ++i) {
-      rows->store(hashers[i]->decodedVector(), rowIndex, newRow, i);
-    }
-    for (auto i = 0; i < dependentChannels_.size(); ++i) {
-      rows->store(*decoders_[i], rowIndex, newRow, i + hashers.size());
-    }
-    if (spillProbedFlagVector != nullptr) {
-      VELOX_CHECK(!spillProbedFlagVector->isNullAt(rowIndex));
-      if (spillProbedFlagVector->valueAt(rowIndex)) {
-        rows->setProbedFlag(&newRow, 1);
-      }
-    }
-  });
+  tableBuilder_->insertRows(input, spillProbedFlags(input));
 }
 
 void HashBuild::ensureInputFits(RowVectorPtr& input) {
@@ -610,7 +391,7 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
   // is already sufficient reservations.
   VELOX_CHECK(canSpill());
 
-  auto* rows = table_->rows();
+  auto* rows = tableBuilder_->table()->rows();
   const auto numRows = rows->numRows();
 
   auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
@@ -630,7 +411,8 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
   const auto minReservationBytes =
       currentUsage * spillConfig_->minSpillableReservationPct / 100;
   const auto availableReservationBytes = pool()->availableReservation();
-  const auto tableIncrementBytes = table_->hashTableSizeIncrease(input->size());
+  const auto tableIncrementBytes =
+      tableBuilder_->table()->hashTableSizeIncrease(input->size());
   const int64_t flatBytes = input->estimateFlatSize();
   const auto rowContainerIncrementBytes = numRows == 0
       ? flatBytes * 2
@@ -686,10 +468,11 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
 }
 
 void HashBuild::spillInput(const RowVectorPtr& input) {
-  VELOX_CHECK_EQ(input->size(), activeRows_.size());
+  auto& activeRows = tableBuilder_->activeRows();
+  VELOX_CHECK_EQ(input->size(), activeRows.size());
 
   if (!canSpill() || spiller_ == nullptr || !spiller_->spillTriggered() ||
-      !activeRows_.hasSelections()) {
+      !activeRows.hasSelections()) {
     return;
   }
 
@@ -700,10 +483,10 @@ void HashBuild::spillInput(const RowVectorPtr& input) {
   vector_size_t numSpillInputs = 0;
   for (auto row = 0; row < numInput; ++row) {
     const auto partition = spillPartitions_[row];
-    if (FOLLY_UNLIKELY(!activeRows_.isValid(row))) {
+    if (FOLLY_UNLIKELY(!activeRows.isValid(row))) {
       continue;
     }
-    activeRows_.setValid(row, false);
+    activeRows.setValid(row, false);
     ++numSpillInputs;
     rawSpillInputIndicesBuffers_[partition][numSpillInputs_[partition]++] = row;
   }
@@ -724,7 +507,7 @@ void HashBuild::spillInput(const RowVectorPtr& input) {
     VELOX_CHECK(
         spiller_->state().isPartitionSpilled(SpillPartitionId(partition)));
   }
-  activeRows_.updateBounds();
+  activeRows.updateBounds();
 }
 
 void HashBuild::maybeSetupSpillChildVectors(const RowVectorPtr& input) {
@@ -732,10 +515,10 @@ void HashBuild::maybeSetupSpillChildVectors(const RowVectorPtr& input) {
     return;
   }
   int32_t spillChannel = 0;
-  for (const auto& channel : keyChannels_) {
+  for (const auto& channel : tableBuilder_->keyChannels()) {
     spillChildVectors_[spillChannel++] = input->childAt(channel);
   }
-  for (const auto& channel : dependentChannels_) {
+  for (const auto& channel : tableBuilder_->dependentChannels()) {
     spillChildVectors_[spillChannel++] = input->childAt(channel);
   }
   if (needProbedFlagSpill_) {
@@ -761,22 +544,23 @@ void HashBuild::prepareInputIndicesBuffers(vector_size_t numInput) {
 }
 
 void HashBuild::computeSpillPartitions(const RowVectorPtr& input) {
-  if (hashes_.size() < activeRows_.end()) {
-    hashes_.resize(activeRows_.end());
+  auto& activeRows = tableBuilder_->activeRows();
+  if (spillHashes_.size() < activeRows.end()) {
+    spillHashes_.resize(activeRows.end());
   }
-  const auto& hashers = table_->hashers();
+  const auto& hashers = tableBuilder_->hashers();
   for (auto i = 0; i < hashers.size(); ++i) {
     auto& hasher = hashers[i];
     if (hasher->channel() != kConstantChannel) {
-      hashers[i]->hash(activeRows_, i > 0, hashes_);
+      hashers[i]->hash(activeRows, i > 0, spillHashes_);
     } else {
-      hashers[i]->hashPrecomputed(activeRows_, i > 0, hashes_);
+      hashers[i]->hashPrecomputed(activeRows, i > 0, spillHashes_);
     }
   }
 
   spillPartitions_.resize(input->size());
-  activeRows_.applyToSelected([&](int32_t row) {
-    spillPartitions_[row] = spiller_->hashBits().partition(hashes_[row]);
+  activeRows.applyToSelected([&](int32_t row) {
+    spillPartitions_[row] = spiller_->hashBits().partition(spillHashes_[row]);
   });
 }
 
@@ -837,7 +621,8 @@ bool HashBuild::finishHashBuild() {
       // cached table). Nothing to contribute — finish immediately. Clear the
       // future since allPeersFinished() set it but we don't need to wait.
       VELOX_CHECK_NULL(
-          table_, "Waiter task should not have built a partial hash table");
+          tableBuilder_->table(),
+          "Waiter task should not have built a partial hash table");
       future_ = folly::SemiFuture<folly::Unit>::makeEmpty();
       setState(State::kFinish);
     } else {
@@ -863,7 +648,7 @@ bool HashBuild::finishHashBuild() {
     return true;
   }
 
-  if (joinHasNullKeys_ && isAntiJoin(joinType_) && nullAware_ &&
+  if (tableBuilder_->joinHasNullKeys() && isAntiJoin(joinType_) && nullAware_ &&
       !joinNode_->filter()) {
     joinBridge_->setAntiJoinHasNullKeys();
     return true;
@@ -874,14 +659,14 @@ bool HashBuild::finishHashBuild() {
   uint64_t numRows{0};
   {
     std::lock_guard<std::mutex> l(mutex_);
-    numRows += table_->rows()->numRows();
+    numRows += tableBuilder_->table()->rows()->numRows();
   }
   for (auto& peer : peers) {
     auto op = peer->findOperator(planNodeId());
     HashBuild* build = dynamic_cast<HashBuild*>(op);
     VELOX_CHECK_NOT_NULL(build);
-    if (build->joinHasNullKeys_) {
-      joinHasNullKeys_ = true;
+    if (build->tableBuilder_->joinHasNullKeys()) {
+      tableBuilder_->setJoinHasNullKeys(true);
       if (isAntiJoin(joinType_) && nullAware_ && !joinNode_->filter()) {
         joinBridge_->setAntiJoinHasNullKeys();
         return true;
@@ -893,7 +678,7 @@ bool HashBuild::finishHashBuild() {
           !build->stateCleared_,
           "Internal state for a peer is empty. It might have already"
           " been closed.");
-      numRows += build->table_->rows()->numRows();
+      numRows += build->tableBuilder_->table()->rows()->numRows();
     }
     otherBuilds.push_back(build);
   }
@@ -912,8 +697,8 @@ bool HashBuild::finishHashBuild() {
           "Internal state for a peer is empty. It might have already"
           " been closed.");
       build->stateCleared_ = true;
-      VELOX_CHECK_NOT_NULL(build->table_);
-      otherTables.push_back(std::move(build->table_));
+      VELOX_CHECK_NOT_NULL(build->tableBuilder_->table());
+      otherTables.push_back(build->tableBuilder_->takeTable());
       spiller = std::move(build->spiller_);
     }
     if (spiller != nullptr) {
@@ -941,12 +726,12 @@ bool HashBuild::finishHashBuild() {
   CpuWallTiming timing;
   {
     CpuWallTimer cpuWallTimer{timing};
-    table_->prepareJoinTable(
+    tableBuilder_->table()->prepareJoinTable(
         std::move(otherTables),
         isInputFromSpill() ? spillConfig()->startPartitionBit
                            : BaseHashTable::kNoSpillInputStartPartitionBit,
-        vectorHasherMaxNumDistinct_,
-        dropDuplicates_,
+        tableBuilder_->vectorHasherMaxNumDistinct(),
+        tableBuilder_->dropDuplicates(),
         allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
                                : nullptr);
   }
@@ -978,12 +763,12 @@ bool HashBuild::finishHashBuild() {
   }
 
   // For hash table caching: the last driver caches the merged table.
-  std::shared_ptr<BaseHashTable> table = std::move(table_);
+  std::shared_ptr<BaseHashTable> table = tableBuilder_->takeTable();
   maybeSetHashTableInCache(table);
   joinBridge_->setHashTable(
       table,
       std::move(spillPartitions),
-      joinHasNullKeys_,
+      tableBuilder_->joinHasNullKeys(),
       std::move(tableSpillFunc));
 
   if (canSpill()) {
@@ -1014,7 +799,7 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
   //
   // TODO: make this query configurable.
   const uint64_t memoryBytesToReserve =
-      table_->estimateHashTableSize(numRows) * 1.1;
+      tableBuilder_->table()->estimateHashTableSize(numRows) * 1.1;
   {
     Operator::ReclaimableSectionGuard guard(this);
     if (pool()->maybeReserve(memoryBytesToReserve)) {
@@ -1061,23 +846,13 @@ void HashBuild::setupSpillInput(HashJoinBridge::SpillInput spillInput) {
     return;
   }
 
-  table_.reset();
   spiller_.reset();
   spillInputReader_.reset();
   restoringPartitionId_.reset();
 
-  // Reset the key and dependent channels as the spilled data columns have
-  // already been ordered.
-  std::iota(keyChannels_.begin(), keyChannels_.end(), 0);
-  std::iota(
-      dependentChannels_.begin(),
-      dependentChannels_.end(),
-      keyChannels_.size());
-
-  setupTable();
+  tableBuilder_->resetForSpillInput();
   setupSpiller(spillInput.spillPartition.get());
   stateCleared_ = false;
-  numHashInputRows_ = 0;
 
   // Start to process spill input.
   processSpillInput();
@@ -1102,12 +877,13 @@ void HashBuild::processSpillInput() {
 
 void HashBuild::addRuntimeStats() {
   // Report range sizes and number of distinct values for the join keys.
-  const auto& hashers = table_->hashers();
+  const auto& hashers = tableBuilder_->table()->hashers();
   uint64_t asRange{0};
   uint64_t asDistinct{0};
   auto lockedStats = stats_.wlock();
 
-  for (const auto& timing : table_->parallelJoinBuildStats().partitionTimings) {
+  for (const auto& timing :
+       tableBuilder_->table()->parallelJoinBuildStats().partitionTimings) {
     lockedStats->getOutputTiming.add(timing);
     lockedStats->addRuntimeStat(
         std::string(BaseHashTable::kParallelJoinPartitionWallNanos),
@@ -1117,7 +893,8 @@ void HashBuild::addRuntimeStats() {
         RuntimeCounter(timing.cpuNanos, RuntimeCounter::Unit::kNanos));
   }
 
-  for (const auto& timing : table_->parallelJoinBuildStats().buildTimings) {
+  for (const auto& timing :
+       tableBuilder_->table()->parallelJoinBuildStats().buildTimings) {
     lockedStats->getOutputTiming.add(timing);
     lockedStats->addRuntimeStat(
         std::string(BaseHashTable::kParallelJoinBuildWallNanos),
@@ -1127,8 +904,9 @@ void HashBuild::addRuntimeStats() {
         RuntimeCounter(timing.cpuNanos, RuntimeCounter::Unit::kNanos));
   }
 
-  for (const auto& timing :
-       table_->parallelJoinBuildStats().bloomFilterPartitionTimings) {
+  for (const auto& timing : tableBuilder_->table()
+                                ->parallelJoinBuildStats()
+                                .bloomFilterPartitionTimings) {
     lockedStats->getOutputTiming.add(timing);
     if (timing.wallNanos > 0) {
       lockedStats->addRuntimeStat(
@@ -1143,8 +921,9 @@ void HashBuild::addRuntimeStats() {
     }
   }
 
-  for (const auto& timing :
-       table_->parallelJoinBuildStats().bloomFilterBuildTimings) {
+  for (const auto& timing : tableBuilder_->table()
+                                ->parallelJoinBuildStats()
+                                .bloomFilterBuildTimings) {
     lockedStats->getOutputTiming.add(timing);
     if (timing.wallNanos > 0) {
       lockedStats->addRuntimeStat(
@@ -1170,7 +949,7 @@ void HashBuild::addRuntimeStats() {
     }
   }
 
-  table_->addRuntimeStats(lockedStats->runtimeStats);
+  tableBuilder_->table()->addRuntimeStats(lockedStats->runtimeStats);
 
   // Add max spilling level stats if spilling has been triggered.
   if (spiller_ != nullptr && spiller_->spillTriggered()) {
@@ -1183,7 +962,7 @@ void HashBuild::addRuntimeStats() {
   lockedStats->addRuntimeStat(
       std::string(BaseHashTable::kVectorHasherMergeCpuNanos),
       RuntimeCounter(
-          table_->vectorHasherMergeTiming().cpuNanos,
+          tableBuilder_->table()->vectorHasherMergeTiming().cpuNanos,
           RuntimeCounter::Unit::kNanos));
 }
 
@@ -1402,7 +1181,7 @@ void HashBuild::reclaim(
 
   for (auto* op : operators) {
     HashBuild* buildOp = static_cast<HashBuild*>(op);
-    buildOp->table_->clear(true);
+    buildOp->tableBuilder_->table()->clear(true);
     buildOp->pool()->release();
   }
 }
@@ -1426,7 +1205,7 @@ bool HashBuild::nonReclaimableState() const {
   // 1) the hash table has been built by the last build thread (indicated by
   //    state_)
   // 2) the last build operator has transferred ownership of 'this operator's
-  //    internal state (table_ and spiller_) to itself.
+  //    internal state (the build table and spiller_) to itself.
   // 3) it has completed spilling before reaching either of the previous
   //    two states.
   return ((state_ != State::kRunning) && (state_ != State::kWaitForBuild) &&
@@ -1449,7 +1228,7 @@ void HashBuild::close() {
     stateCleared_ = true;
     joinBridge_.reset();
     spiller_.reset();
-    table_.reset();
+    tableBuilder_->clearTable();
   }
 
   // Release the entry here rather than at operator destruction:
@@ -1523,23 +1302,6 @@ void HashBuildSpiller::extractSpill(
     container_->extractProbedFlags(
         rows.data(), rows.size(), false, false, result->childAt(types.size()));
   }
-}
-
-bool HashBuild::abandonHashBuildDedupEarly(int64_t numDistinct) const {
-  VELOX_CHECK(dropDuplicates_);
-  return numHashInputRows_ > abandonHashBuildDedupMinRows_ &&
-      100 * numDistinct / numHashInputRows_ >= abandonHashBuildDedupMinPct_;
-}
-
-void HashBuild::abandonHashBuildDedup() {
-  // The hash table is no longer directly constructed in addInput. The data
-  // that was previously inserted into the hash table is already in the
-  // RowContainer.
-  addRuntimeStat(
-      std::string(HashBuild::kAbandonBuildNoDupHash), RuntimeCounter(1));
-  abandonHashBuildDedup_ = true;
-  table_->setAllowDuplicates(true);
-  lookup_.reset();
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -20,6 +20,7 @@
 #include "velox/exec/HashJoinBridge.h"
 #include "velox/exec/HashTable.h"
 #include "velox/exec/HashTableCache.h"
+#include "velox/exec/JoinTableBuilder.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/Spill.h"
 #include "velox/exec/Spiller.h"
@@ -99,7 +100,7 @@ class HashBuild final : public Operator {
   }
 
   const std::vector<column_index_t>& dependentChannels() const {
-    return dependentChannels_;
+    return tableBuilder_->dependentChannels();
   }
 
   const std::shared_ptr<HashJoinBridge>& joinBridge() const {
@@ -121,8 +122,9 @@ class HashBuild final : public Operator {
     return cacheEntry_->builderTaskId == taskId();
   }
 
-  // Invoked to set up hash table to build.
-  void setupTable();
+  // Creates the join table builder. Called from the constructor as the key and
+  // the dependent channels it resolves are used before 'initialize()'.
+  void setupTableBuilder();
 
   // Sets up hash table caching if enabled. Returns true if the cached table
   // is already available or if this operator should wait for another task
@@ -222,31 +224,22 @@ class HashBuild final : public Operator {
   // Invoked to process data from spill input reader on restoring.
   void processSpillInput();
 
-  // Set up for null-aware and regular anti-join with filter processing.
-  void setupFilterForAntiJoins(
-      const folly::F14FastMap<column_index_t, column_index_t>& keyChannelMap);
+  // Compiles the join filter of an anti join to find out if it is null
+  // propagating and which build side columns it references.
+  JoinTableBuilder::AntiJoinFilterInfo analyzeAntiJoinFilter();
 
-  // Invoked when preparing for null-aware and regular anti join with
-  // null-propagating filter. The function deselects the input rows which have
-  // any null in the filter input columns. This is an optimization for
-  // null-aware and regular anti join processing at the probe side as any probe
-  // matches with the deselected rows can't pass the null-propagating filter and
-  // will be added to the joined output.
-  void removeInputRowsForAntiJoinFilter();
+  // Updates the null keys stats from the keys decoded by the table builder.
+  void updateNullKeysStats();
+
+  // Sets the probed flag vector to restore when the input comes from a spilled
+  // table, nullptr otherwise.
+  const FlatVector<bool>* spillProbedFlags(const RowVectorPtr& input) const;
 
   void addRuntimeStats();
 
   // Indicates if this hash build operator is under non-reclaimable state or
   // not.
   bool nonReclaimableState() const;
-
-  // True if we have enough rows and not enough duplicate join keys, i.e. more
-  // than 'abandonHashBuildDedupMinRows_' rows and more than
-  // 'abandonHashBuildDedupMinPct_' % of rows are unique.
-  bool abandonHashBuildDedupEarly(int64_t numDistinct) const;
-
-  // Invoked to abandon build deduped hash table.
-  void abandonHashBuildDedup();
 
   // Returns true if this operator is using a cached hash table.
   // When enabled, the hash table is built once and cached for reuse
@@ -284,22 +277,6 @@ class HashBuild final : public Operator {
   // not.
   const bool needProbedFlagSpill_;
 
-  // Indicates whether drop duplicate rows. Rows containing duplicate keys
-  // can be removed for left semi and anti join.
-  const bool dropDuplicates_;
-
-  // Maximum number of distinct values to keep when merging vector hashers
-  const size_t vectorHasherMaxNumDistinct_;
-
-  // Minimum number of rows to see before deciding to give up build no
-  // duplicates hash table.
-  const int32_t abandonHashBuildDedupMinRows_;
-
-  // Min unique rows pct for give up build deduped hash table. If more
-  // than this many rows are unique, build hash table in addInput phase is not
-  // worthwhile.
-  const int32_t abandonHashBuildDedupMinPct_;
-
   std::shared_ptr<HashJoinBridge> joinBridge_;
 
   tsan_atomic<bool> exceededMaxSpillLevelLimit_{false};
@@ -316,58 +293,29 @@ class HashBuild final : public Operator {
   // Retrieved from HashTableCache.
   std::shared_ptr<HashTableCacheEntry> cacheEntry_;
 
-  // The row type used for hash table build and disk spilling.
-  RowTypePtr tableType_;
+  // Accumulates the build input into the hash table. Holds the state and the
+  // logic shared with the non-operator build side users.
+  std::unique_ptr<JoinTableBuilder> tableBuilder_;
 
-  // Used to serialize access to internal state including 'table_' and
-  // 'spiller_'. This is only required when variables are accessed
-  // concurrently, that is, when a thread tries to close the operator while
-  // another thread is building the hash table. Refer to 'close()' and
+  // Used to serialize access to internal state including the table of
+  // 'tableBuilder_' and 'spiller_'. This is only required when variables are
+  // accessed concurrently, that is, when a thread tries to close the operator
+  // while another thread is building the hash table. Refer to 'close()' and
   // finishHashBuild()' for more details.
   std::mutex mutex_;
 
-  // Indicates if the intermediate state ('table_' and 'spiller_') has
-  // been cleared. This can happen either when the operator is closed or when
-  // the last hash build operator transfers ownership of them to itself while
-  // building the final hash table.
+  // Indicates if the intermediate state (the table of 'tableBuilder_' and
+  // 'spiller_') has been cleared. This can happen either when the operator is
+  // closed or when the last hash build operator transfers ownership of them to
+  // itself while building the final hash table.
   bool stateCleared_{false};
-
-  // Container for the rows being accumulated.
-  std::unique_ptr<BaseHashTable> table_;
-
-  // Used for building hash table while adding input rows.
-  std::unique_ptr<HashLookup> lookup_;
-
-  // Key channels in 'input_'
-  std::vector<column_index_t> keyChannels_;
-
-  // Non-key channels in 'input_'.
-  std::vector<column_index_t> dependentChannels_;
-
-  // Corresponds 1:1 to 'dependentChannels_'.
-  std::vector<std::unique_ptr<DecodedVector>> decoders_;
 
   // Future for synchronizing with other Drivers of the same pipeline. All build
   // Drivers must be completed before making the hash table.
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 
-  // True if we are considering use of normalized keys or array hash tables. Set
-  // to false when the dataset is no longer suitable.
-  bool analyzeKeys_;
-
-  // Temporary space for hash numbers.
-  raw_vector<uint64_t> hashes_;
-
-  // Set of active rows during addInput().
-  SelectivityVector activeRows_;
-
-  // True if this is a build side of an anti or left semi project join and has
-  // at least one entry with null join keys.
-  bool joinHasNullKeys_{false};
-
-  // Whether to abandon building a HashTable without duplicates in HashBuild
-  // addInput phase for left semi/anti join.
-  bool abandonHashBuildDedup_{false};
+  // Temporary space for the hash numbers of the input spill partitioning.
+  raw_vector<uint64_t> spillHashes_;
 
   // The type used to spill hash table which might attach a boolean column to
   // record the probed flag if 'needProbedFlagSpill_' is true.
@@ -399,21 +347,6 @@ class HashBuild final : public Operator {
   std::vector<BufferPtr> spillInputIndicesBuffers_;
   std::vector<vector_size_t*> rawSpillInputIndicesBuffers_;
   std::vector<VectorPtr> spillChildVectors_;
-
-  // Indicates whether the filter is null-propagating.
-  bool filterPropagatesNulls_{false};
-
-  // Indices of key columns used by the filter in build side table.
-  std::vector<column_index_t> keyFilterChannels_;
-  // Indices of dependent columns used by the filter in 'decoders_'.
-  std::vector<column_index_t> dependentFilterChannels_;
-
-  // Maps key channel in 'input_' to channel in key.
-  folly::F14FastMap<column_index_t, column_index_t> keyChannelMap_;
-
-  // Count the number of hash table input rows for building deduped
-  // hash table. It will not be updated after abandonBuildNoDupHash_ is true.
-  int64_t numHashInputRows_ = 0;
 };
 
 inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {

--- a/velox/exec/JoinTableBuilder.cpp
+++ b/velox/exec/JoinTableBuilder.cpp
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/JoinTableBuilder.h"
+
+#include <algorithm>
+#include <numeric>
+
+#include "velox/exec/HashJoinBridge.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/OperatorUtils.h"
+
+namespace facebook::velox::exec {
+
+JoinTableBuilder::JoinTableBuilder(Options options)
+    : options_(std::move(options)),
+      dropDuplicates_(
+          core::canDropDuplicates(options_.joinType, options_.withFilter)),
+      keyChannelMap_(options_.joinKeys.size()) {
+  VELOX_CHECK_NOT_NULL(options_.inputType);
+
+  const auto numKeys = options_.joinKeys.size();
+  keyChannels_.reserve(numKeys);
+  for (auto i = 0; i < numKeys; ++i) {
+    const auto channel =
+        exprToChannel(options_.joinKeys[i].get(), options_.inputType);
+    keyChannelMap_[channel] = i;
+    keyChannels_.emplace_back(channel);
+  }
+
+  // Identify the non-key build side columns and make a decoder for each.
+  if (!dropDuplicates_) {
+    const int32_t numDependents = options_.inputType->size() - numKeys;
+    if (numDependents > 0) {
+      // Number of join keys (numKeys) may be less then number of input columns
+      // (inputType->size()). In this case numDependents is negative and cannot
+      // be used to call 'reserve'. This happens when we join different probe
+      // side keys with the same build side key: SELECT * FROM t LEFT JOIN u ON
+      // t.k1 = u.k AND t.k2 = u.k.
+      dependentChannels_.reserve(numDependents);
+      decoders_.reserve(numDependents);
+    }
+    for (auto i = 0; i < options_.inputType->size(); ++i) {
+      if (keyChannelMap_.find(i) == keyChannelMap_.end()) {
+        dependentChannels_.emplace_back(i);
+        decoders_.emplace_back(std::make_unique<DecodedVector>());
+      }
+    }
+  }
+
+  tableType_ =
+      hashJoinTableType(options_.joinKeys, options_.inputType, dropDuplicates_);
+}
+
+void JoinTableBuilder::initialize(
+    memory::MemoryPool* tablePool,
+    memory::MemoryPool* auxiliaryPool,
+    const AntiJoinFilterInfo& filterInfo) {
+  VELOX_CHECK_NOT_NULL(tablePool);
+  VELOX_CHECK_NOT_NULL(auxiliaryPool);
+  VELOX_CHECK_NULL(tablePool_, "JoinTableBuilder is already initialized");
+
+  tablePool_ = tablePool;
+  auxiliaryPool_ = auxiliaryPool;
+  filterPropagatesNulls_ = filterInfo.propagatesNulls;
+
+  setupTable();
+
+  if (isAntiJoin(options_.joinType) && options_.withFilter &&
+      filterPropagatesNulls_) {
+    setupFilterChannels(filterInfo);
+  }
+}
+
+void JoinTableBuilder::setupTable() {
+  VELOX_CHECK_NOT_NULL(tablePool_, "JoinTableBuilder is not initialized");
+  VELOX_CHECK_NULL(table_);
+
+  const auto numKeys = keyChannels_.size();
+  std::vector<std::unique_ptr<VectorHasher>> keyHashers;
+  keyHashers.reserve(numKeys);
+  for (auto i = 0; i < numKeys; ++i) {
+    keyHashers.emplace_back(
+        VectorHasher::create(tableType_->childAt(i), keyChannels_[i]));
+  }
+
+  const auto numDependents = tableType_->size() - numKeys;
+  std::vector<TypePtr> dependentTypes;
+  dependentTypes.reserve(numDependents);
+  for (auto i = numKeys; i < tableType_->size(); ++i) {
+    dependentTypes.emplace_back(tableType_->childAt(i));
+  }
+
+  const auto joinType = options_.joinType;
+  if (isRightJoin(joinType) || isFullJoin(joinType) ||
+      isRightSemiProjectJoin(joinType) || isRightAntiJoin(joinType)) {
+    // Do not ignore null keys. kRightAnti must retain null keys: a null-keyed
+    // build row never matches and is always returned.
+    table_ = HashTable<false>::createForJoin(
+        std::move(keyHashers),
+        dependentTypes,
+        true, // allowDuplicates
+        true, // hasProbedFlag
+        false, // hasCountFlag
+        options_.minTableRowsForParallelJoinBuild,
+        tablePool_);
+  } else {
+    // Right semi join needs to tag build rows that were probed.
+    const bool needProbedFlag = isRightSemiFilterJoin(joinType);
+    const bool hasCountFlag = core::isCountingJoin(joinType);
+    if (options_.nullAsValue ||
+        isLeftNullAwareJoinWithFilter(
+            joinType, options_.nullAware, options_.withFilter)) {
+      // We need to check null key rows in build side in case of null-aware anti
+      // or left semi project join with filter set.
+      table_ = HashTable<false>::createForJoin(
+          std::move(keyHashers),
+          dependentTypes,
+          !dropDuplicates_, // allowDuplicates
+          needProbedFlag, // hasProbedFlag
+          hasCountFlag,
+          options_.minTableRowsForParallelJoinBuild,
+          tablePool_);
+    } else {
+      // Ignore null keys
+      table_ = HashTable<true>::createForJoin(
+          std::move(keyHashers),
+          dependentTypes,
+          !dropDuplicates_, // allowDuplicates
+          needProbedFlag, // hasProbedFlag
+          hasCountFlag,
+          options_.minTableRowsForParallelJoinBuild,
+          tablePool_,
+          options_.bloomFilterPushdownMaxSize);
+    }
+  }
+  analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
+
+  if (options_.abandonHashBuildDedupMinPct == 0 &&
+      !core::isCountingJoin(joinType)) {
+    // Building a HashTable without duplicates is disabled if
+    // abandonHashBuildDedupMinPct is 0. Counting joins always require dedup.
+    abandonHashBuildDedup_ = true;
+    table_->setAllowDuplicates(true);
+    return;
+  }
+  // Only create HashLookup when dedup is enabled.
+  lookup_ = std::make_unique<HashLookup>(table_->hashers(), auxiliaryPool_);
+}
+
+void JoinTableBuilder::resetForSpillInput() {
+  table_.reset();
+  lookup_.reset();
+
+  // Reset the key and dependent channels as the spilled data columns have
+  // already been ordered.
+  std::iota(keyChannels_.begin(), keyChannels_.end(), 0);
+  std::iota(
+      dependentChannels_.begin(),
+      dependentChannels_.end(),
+      keyChannels_.size());
+
+  setupTable();
+  numHashInputRows_ = 0;
+}
+
+void JoinTableBuilder::setupFilterChannels(
+    const AntiJoinFilterInfo& filterInfo) {
+  VELOX_DCHECK(
+      std::is_sorted(dependentChannels_.begin(), dependentChannels_.end()));
+  VELOX_DCHECK(
+      std::is_sorted(
+          filterInfo.inputChannels.begin(), filterInfo.inputChannels.end()));
+
+  for (const auto channel : filterInfo.inputChannels) {
+    const auto keyIter = keyChannelMap_.find(channel);
+    if (keyIter != keyChannelMap_.end()) {
+      keyFilterChannels_.push_back(keyIter->second);
+      continue;
+    }
+    const auto dependentIter = std::lower_bound(
+        dependentChannels_.begin(), dependentChannels_.end(), channel);
+    if (dependentIter == dependentChannels_.end() ||
+        *dependentIter != channel) {
+      // Not a build side column, e.g. a probe side column referenced by the
+      // filter.
+      continue;
+    }
+    dependentFilterChannels_.push_back(
+        dependentIter - dependentChannels_.begin());
+  }
+}
+
+void JoinTableBuilder::removeInputRowsForAntiJoinFilter() {
+  bool changed = false;
+  auto* rawActiveRows = activeRows_.asMutableRange().bits();
+  auto removeNulls = [&](DecodedVector& decoded) {
+    if (decoded.mayHaveNulls()) {
+      changed = true;
+      // NOTE: the true value of a raw null bit indicates non-null so we AND
+      // 'rawActiveRows' with the raw bit.
+      bits::andBits(
+          rawActiveRows, decoded.nulls(&activeRows_), 0, activeRows_.end());
+    }
+  };
+  for (const auto channel : keyFilterChannels_) {
+    removeNulls(table_->hashers()[channel]->decodedVector());
+  }
+  for (const auto channel : dependentFilterChannels_) {
+    removeNulls(*decoders_[channel]);
+  }
+  if (changed) {
+    activeRows_.updateBounds();
+  }
+}
+
+bool JoinTableBuilder::abandonHashBuildDedupEarly(int64_t numDistinct) const {
+  VELOX_CHECK(dropDuplicates_);
+  return numHashInputRows_ > options_.abandonHashBuildDedupMinRows &&
+      100 * numDistinct / numHashInputRows_ >=
+      options_.abandonHashBuildDedupMinPct;
+}
+
+void JoinTableBuilder::abandonHashBuildDedup() {
+  // The hash table is no longer directly constructed in addInput. The data
+  // that was previously inserted into the hash table is already in the
+  // RowContainer.
+  if (options_.onDedupAbandoned != nullptr) {
+    options_.onDedupAbandoned();
+  }
+  abandonHashBuildDedup_ = true;
+  table_->setAllowDuplicates(true);
+  lookup_.reset();
+}
+
+bool JoinTableBuilder::addInput(const RowVectorPtr& input) {
+  decodeKeys(input);
+  if (!processNullKeys()) {
+    return false;
+  }
+  decodeDependents(input);
+  insertRows(input);
+  return true;
+}
+
+void JoinTableBuilder::decodeKeys(const RowVectorPtr& input) {
+  VELOX_CHECK_NOT_NULL(table_, "JoinTableBuilder is not initialized");
+
+  activeRows_.resize(input->size());
+  activeRows_.setAll();
+
+  auto& hashers = table_->hashers();
+  for (auto i = 0; i < hashers.size(); ++i) {
+    auto* key = input->childAt(hashers[i]->channel())->loadedVector();
+    hashers[i]->decode(*key, activeRows_);
+  }
+}
+
+bool JoinTableBuilder::processNullKeys() {
+  const auto joinType = options_.joinType;
+  auto& hashers = table_->hashers();
+
+  if (!isRightJoin(joinType) && !isFullJoin(joinType) &&
+      !isRightSemiProjectJoin(joinType) && !isRightAntiJoin(joinType) &&
+      !options_.nullAsValue &&
+      !isLeftNullAwareJoinWithFilter(
+          joinType, options_.nullAware, options_.withFilter)) {
+    const auto numInput = activeRows_.size();
+    deselectRowsWithNulls(hashers, activeRows_);
+    if (options_.nullAware && !joinHasNullKeys_ &&
+        activeRows_.countSelected() < numInput) {
+      joinHasNullKeys_ = true;
+    }
+  } else if (options_.nullAware && !joinHasNullKeys_) {
+    for (auto& hasher : hashers) {
+      auto& decoded = hasher->decodedVector();
+      if (decoded.mayHaveNulls()) {
+        auto* nulls = decoded.nulls(&activeRows_);
+        if (nulls && bits::countNulls(nulls, 0, activeRows_.end()) > 0) {
+          joinHasNullKeys_ = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // Null-aware anti join with no extra filter returns no rows if build side
+  // has nulls in join keys. Hence, we can stop processing on first null.
+  return !(
+      isAntiJoin(joinType) && options_.nullAware && joinHasNullKeys_ &&
+      !options_.withFilter);
+}
+
+void JoinTableBuilder::decodeDependents(const RowVectorPtr& input) {
+  for (auto i = 0; i < dependentChannels_.size(); ++i) {
+    decoders_[i]->decode(
+        *input->childAt(dependentChannels_[i])->loadedVector(), activeRows_);
+  }
+
+  if (isAntiJoin(options_.joinType) && options_.withFilter &&
+      filterPropagatesNulls_) {
+    removeInputRowsForAntiJoinFilter();
+  }
+}
+
+void JoinTableBuilder::insertRows(
+    const RowVectorPtr& input,
+    const FlatVector<bool>* spillProbedFlags) {
+  if (!activeRows_.hasSelections()) {
+    return;
+  }
+
+  if (dropDuplicates_ && !abandonHashBuildDedup_) {
+    // Counting joins must not abandon dedup - accurate counts are required.
+    VELOX_CHECK_NOT_NULL(lookup_);
+    const bool abandonEarly = !core::isCountingJoin(options_.joinType) &&
+        abandonHashBuildDedupEarly(table_->numDistinct());
+    if (!abandonEarly) {
+      numHashInputRows_ += activeRows_.countSelected();
+      table_->prepareForGroupProbe(
+          *lookup_,
+          input,
+          activeRows_,
+          BaseHashTable::kNoSpillInputStartPartitionBit);
+      if (lookup_->rows.empty()) {
+        return;
+      }
+      table_->groupProbe(
+          *lookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
+
+      // For counting joins, increment the count for duplicate rows.
+      // New rows are initialized with count = 1 by initializeRow.
+      // Increment count for all rows, then decrement for new rows to
+      // correct the over-counting.
+      if (core::isCountingJoin(options_.joinType)) {
+        auto* rows = table_->rows();
+        for (const auto row : lookup_->rows) {
+          rows->incrementCount(lookup_->hits[row]);
+        }
+        for (const auto newRow : lookup_->newGroups) {
+          rows->decrementCount(lookup_->hits[newRow]);
+        }
+      }
+      return;
+    }
+    abandonHashBuildDedup();
+  }
+
+  if (analyzeKeys_ && hashes_.size() < activeRows_.end()) {
+    hashes_.resize(activeRows_.end());
+  }
+
+  // As long as analyzeKeys is true, we keep running the keys through
+  // the Vectorhashers so that we get a possible mapping of the keys
+  // to small ints for array or normalized key. When mayUseValueIds is
+  // false for the first time we stop. We do not retain the value ids
+  // since the final ones will only be known after all data is
+  // received.
+  auto& hashers = table_->hashers();
+  for (auto& hasher : hashers) {
+    // TODO: Load only for active rows, except if right/full outer join.
+    if (analyzeKeys_) {
+      hasher->computeValueIds(activeRows_, hashes_);
+      analyzeKeys_ = hasher->mayUseValueIds();
+    }
+  }
+
+  auto* rows = table_->rows();
+  const auto nextOffset = rows->nextOffset();
+  activeRows_.applyToSelected([&](auto rowIndex) {
+    char* newRow = rows->newRow();
+    if (nextOffset) {
+      *reinterpret_cast<char**>(newRow + nextOffset) = nullptr;
+    }
+    // Store the columns for each row in sequence. At probe time
+    // strings of the row will probably be in consecutive places, so
+    // reading one will prime the cache for the next.
+    for (auto i = 0; i < hashers.size(); ++i) {
+      rows->store(hashers[i]->decodedVector(), rowIndex, newRow, i);
+    }
+    for (auto i = 0; i < dependentChannels_.size(); ++i) {
+      rows->store(*decoders_[i], rowIndex, newRow, i + hashers.size());
+    }
+    if (spillProbedFlags != nullptr) {
+      VELOX_CHECK(!spillProbedFlags->isNullAt(rowIndex));
+      if (spillProbedFlags->valueAt(rowIndex)) {
+        rows->setProbedFlag(&newRow, 1);
+      }
+    }
+  });
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/JoinTableBuilder.cpp
+++ b/velox/exec/JoinTableBuilder.cpp
@@ -43,13 +43,13 @@ JoinTableBuilder::JoinTableBuilder(Options options)
 
   // Identify the non-key build side columns and make a decoder for each.
   if (!dropDuplicates_) {
+    // The number of join keys (numKeys) may be greater than the number of
+    // input columns (inputType->size()), which makes 'numDependents' negative
+    // and unusable for 'reserve'. This happens when we join different probe
+    // side keys with the same build side key: SELECT * FROM t LEFT JOIN u ON
+    // t.k1 = u.k AND t.k2 = u.k.
     const int32_t numDependents = options_.inputType->size() - numKeys;
     if (numDependents > 0) {
-      // Number of join keys (numKeys) may be less then number of input columns
-      // (inputType->size()). In this case numDependents is negative and cannot
-      // be used to call 'reserve'. This happens when we join different probe
-      // side keys with the same build side key: SELECT * FROM t LEFT JOIN u ON
-      // t.k1 = u.k AND t.k2 = u.k.
       dependentChannels_.reserve(numDependents);
       decoders_.reserve(numDependents);
     }
@@ -175,6 +175,30 @@ void JoinTableBuilder::resetForSpillInput() {
 
   setupTable();
   numHashInputRows_ = 0;
+  phase_ = Phase::kIdle;
+}
+
+void JoinTableBuilder::advancePhase(Phase required, Phase next) {
+  const auto name = [](Phase phase) -> std::string_view {
+    switch (phase) {
+      case Phase::kIdle:
+        return "none";
+      case Phase::kKeysDecoded:
+        return "decodeKeys()";
+      case Phase::kNullKeysProcessed:
+        return "processNullKeys()";
+      case Phase::kDependentsDecoded:
+        return "decodeDependents()";
+    }
+    VELOX_UNREACHABLE();
+  };
+  VELOX_CHECK(
+      phase_ == required,
+      "The phases of JoinTableBuilder::addInput() must be called in order. "
+      "Last completed phase should be {}, but it is {}",
+      name(required),
+      name(phase_));
+  phase_ = next;
 }
 
 void JoinTableBuilder::setupFilterChannels(
@@ -258,6 +282,8 @@ bool JoinTableBuilder::addInput(const RowVectorPtr& input) {
 
 void JoinTableBuilder::decodeKeys(const RowVectorPtr& input) {
   VELOX_CHECK_NOT_NULL(table_, "JoinTableBuilder is not initialized");
+  // A new input starts the sequence over, whatever the previous one reached.
+  phase_ = Phase::kKeysDecoded;
 
   activeRows_.resize(input->size());
   activeRows_.setAll();
@@ -270,6 +296,8 @@ void JoinTableBuilder::decodeKeys(const RowVectorPtr& input) {
 }
 
 bool JoinTableBuilder::processNullKeys() {
+  advancePhase(Phase::kKeysDecoded, Phase::kNullKeysProcessed);
+
   const auto joinType = options_.joinType;
   auto& hashers = table_->hashers();
 
@@ -305,6 +333,8 @@ bool JoinTableBuilder::processNullKeys() {
 }
 
 void JoinTableBuilder::decodeDependents(const RowVectorPtr& input) {
+  advancePhase(Phase::kNullKeysProcessed, Phase::kDependentsDecoded);
+
   for (auto i = 0; i < dependentChannels_.size(); ++i) {
     decoders_[i]->decode(
         *input->childAt(dependentChannels_[i])->loadedVector(), activeRows_);
@@ -319,6 +349,8 @@ void JoinTableBuilder::decodeDependents(const RowVectorPtr& input) {
 void JoinTableBuilder::insertRows(
     const RowVectorPtr& input,
     const FlatVector<bool>* spillProbedFlags) {
+  advancePhase(Phase::kDependentsDecoded, Phase::kIdle);
+
   if (!activeRows_.hasSelections()) {
     return;
   }

--- a/velox/exec/JoinTableBuilder.h
+++ b/velox/exec/JoinTableBuilder.h
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+
+#include "velox/exec/HashTable.h"
+#include "velox/exec/VectorHasher.h"
+
+namespace facebook::velox::exec {
+
+/// Accumulates build side input into a join hash table.
+///
+/// This holds the state and the logic which is shared between the 'HashBuild'
+/// operator and the users which build a join table outside of a Velox driver,
+/// e.g. Gluten builds the broadcast build side directly from a set of vectors.
+/// Hence it knows nothing about plan nodes, drivers, spilling, stats or the
+/// hash table cache: the owner drives it and plugs its own processing in
+/// between the 'addInput()' phases.
+///
+/// Not thread safe. One instance accumulates the input of one build thread.
+/// Tables built by multiple instances are merged with
+/// 'BaseHashTable::prepareJoinTable()'.
+class JoinTableBuilder {
+ public:
+  struct Options {
+    core::JoinType joinType;
+
+    bool nullAware{false};
+
+    bool nullAsValue{false};
+
+    /// True if the join has an extra filter, i.e. 'HashJoinNode::filter()' is
+    /// set.
+    bool withFilter{false};
+
+    /// The type of the vectors passed to 'addInput()'. Note that this is the
+    /// build source type, which is not necessarily 'tableType()'.
+    RowTypePtr inputType;
+
+    /// The build side join keys, resolved against 'inputType'.
+    std::vector<core::FieldAccessTypedExprPtr> joinKeys;
+
+    /// See the query config options of the same name.
+    uint32_t minTableRowsForParallelJoinBuild{1'000};
+    uint32_t vectorHasherMaxNumDistinct{1'000'000};
+    int32_t abandonHashBuildDedupMinRows{100'000};
+    int32_t abandonHashBuildDedupMinPct{0};
+    int64_t bloomFilterPushdownMaxSize{0};
+
+    /// Invoked at most once when the build of a deduplicated hash table is
+    /// abandoned while processing input. Not invoked if dedup was disabled by
+    /// 'abandonHashBuildDedupMinPct' being zero. Used by 'HashBuild' to record
+    /// a runtime stat.
+    std::function<void()> onDedupAbandoned{nullptr};
+  };
+
+  /// Describes the join filter of an anti join. Only used to skip the build
+  /// rows which can never pass a null propagating filter.
+  struct AntiJoinFilterInfo {
+    /// True if the join filter is null propagating, e.g.
+    /// 'exec::Expr::propagatesNulls()'.
+    bool propagatesNulls{false};
+
+    /// Channels in 'Options::inputType' of the build side columns referenced by
+    /// the filter. Must be sorted. Channels which are not build side columns
+    /// are ignored.
+    std::vector<column_index_t> inputChannels;
+  };
+
+  explicit JoinTableBuilder(Options options);
+
+  /// Creates the hash table. Must be called once before 'addInput()'. This is
+  /// separate from the constructor as neither the pools nor the compiled filter
+  /// are necessarily known at construction time, see 'HashBuild::initialize()'.
+  /// 'tablePool' is used by the hash table and its row container,
+  /// 'auxiliaryPool' by the transient state of the build, e.g. the hash lookup.
+  /// They can be the same pool.
+  void initialize(
+      memory::MemoryPool* tablePool,
+      memory::MemoryPool* auxiliaryPool,
+      const AntiJoinFilterInfo& filterInfo);
+
+  void initialize(
+      memory::MemoryPool* tablePool,
+      memory::MemoryPool* auxiliaryPool) {
+    initialize(tablePool, auxiliaryPool, AntiJoinFilterInfo{});
+  }
+
+  /// Accumulates 'input' into the table. Returns false if the build can stop
+  /// early, i.e. this is a null-aware anti join without a filter and 'input'
+  /// has a null join key, in which case the join returns no rows.
+  ///
+  /// This is the composition of the four phases below and is meant for the
+  /// owners which have nothing to do in between.
+  bool addInput(const RowVectorPtr& input);
+
+  /// The phases of 'addInput()'. Decodes the join keys of 'input' into the
+  /// hashers and resets 'activeRows()' to all the rows of 'input'.
+  void decodeKeys(const RowVectorPtr& input);
+
+  /// Deselects the rows of 'activeRows()' with a null join key unless the join
+  /// needs to retain them, and tracks whether the build side has null keys.
+  /// Returns false if the build can stop early, see 'addInput()'.
+  bool processNullKeys();
+
+  /// Decodes the non-key columns of 'input' and, for an anti join with a null
+  /// propagating filter, deselects the rows with a null in a filter column.
+  void decodeDependents(const RowVectorPtr& input);
+
+  /// Inserts the rows still selected in 'activeRows()' into the table, either
+  /// by deduplicating them into the hash table or by appending them to the row
+  /// container. 'spillProbedFlags', if set, carries the probed flag of each row
+  /// restored from a spilled table.
+  void insertRows(
+      const RowVectorPtr& input,
+      const FlatVector<bool>* spillProbedFlags = nullptr);
+
+  /// Clears the table and re-creates an empty one. Used when restoring
+  /// previously spilled data: the columns of the spilled input are already
+  /// ordered as 'tableType()', hence the key and dependent channels are reset
+  /// to their identity mapping.
+  void resetForSpillInput();
+
+  /// Frees the table. The builder can not be used afterwards unless
+  /// 'resetForSpillInput()' is called.
+  void clearTable() {
+    table_.reset();
+    lookup_.reset();
+  }
+
+  BaseHashTable* table() const {
+    return table_.get();
+  }
+
+  /// Transfers the ownership of the table out of the builder.
+  std::unique_ptr<BaseHashTable> takeTable() {
+    lookup_.reset();
+    return std::move(table_);
+  }
+
+  /// Replaces the table, e.g. with one restored from a serialized image.
+  void setTable(std::unique_ptr<BaseHashTable> table) {
+    lookup_.reset();
+    table_ = std::move(table);
+  }
+
+  const std::vector<std::unique_ptr<VectorHasher>>& hashers() const {
+    return table_->hashers();
+  }
+
+  /// The rows of the last 'input' which are still being processed. Exposed as
+  /// the owner may deselect rows in between the 'addInput()' phases, e.g.
+  /// 'HashBuild' deselects the rows it spills.
+  SelectivityVector& activeRows() {
+    return activeRows_;
+  }
+
+  /// The row type of the hash table, which is also the type used to spill it.
+  const RowTypePtr& tableType() const {
+    return tableType_;
+  }
+
+  const std::vector<column_index_t>& keyChannels() const {
+    return keyChannels_;
+  }
+
+  const std::vector<column_index_t>& dependentChannels() const {
+    return dependentChannels_;
+  }
+
+  bool dropDuplicates() const {
+    return dropDuplicates_;
+  }
+
+  /// True if the build of the deduplicated hash table has been abandoned.
+  bool dedupAbandoned() const {
+    return abandonHashBuildDedup_;
+  }
+
+  /// True if this is the build side of an anti or left semi project join and
+  /// has at least one entry with null join keys.
+  bool joinHasNullKeys() const {
+    return joinHasNullKeys_;
+  }
+
+  void setJoinHasNullKeys(bool joinHasNullKeys) {
+    joinHasNullKeys_ = joinHasNullKeys;
+  }
+
+  core::JoinType joinType() const {
+    return options_.joinType;
+  }
+
+  uint32_t vectorHasherMaxNumDistinct() const {
+    return options_.vectorHasherMaxNumDistinct;
+  }
+
+ private:
+  // Invoked to set up the hash table to build.
+  void setupTable();
+
+  // Maps the filter input channels to the key and the dependent channels of
+  // the table. Set up for null-aware and regular anti join with a
+  // null-propagating filter.
+  void setupFilterChannels(const AntiJoinFilterInfo& filterInfo);
+
+  // Invoked when preparing for null-aware and regular anti join with a
+  // null-propagating filter. The function deselects the input rows which have
+  // any null in the filter input columns. This is an optimization for
+  // null-aware and regular anti join processing at the probe side as any probe
+  // matches with the deselected rows can't pass the null-propagating filter
+  // and will be added to the joined output.
+  void removeInputRowsForAntiJoinFilter();
+
+  // True if we have enough rows and not enough duplicate join keys, i.e. more
+  // than 'abandonHashBuildDedupMinRows' rows and more than
+  // 'abandonHashBuildDedupMinPct' % of rows are unique.
+  bool abandonHashBuildDedupEarly(int64_t numDistinct) const;
+
+  // Invoked to abandon the build of the deduped hash table.
+  void abandonHashBuildDedup();
+
+  const Options options_;
+
+  // Indicates whether to drop duplicate rows. Rows containing duplicate keys
+  // can be removed for left semi and anti join.
+  const bool dropDuplicates_;
+
+  memory::MemoryPool* tablePool_{nullptr};
+  memory::MemoryPool* auxiliaryPool_{nullptr};
+
+  // Indicates whether the join filter is null-propagating.
+  bool filterPropagatesNulls_{false};
+
+  // The row type used for the hash table build and the disk spilling.
+  RowTypePtr tableType_;
+
+  // Container for the rows being accumulated.
+  std::unique_ptr<BaseHashTable> table_;
+
+  // Used for building the hash table while adding input rows.
+  std::unique_ptr<HashLookup> lookup_;
+
+  // Key channels in the input.
+  std::vector<column_index_t> keyChannels_;
+
+  // Non-key channels in the input.
+  std::vector<column_index_t> dependentChannels_;
+
+  // Corresponds 1:1 to 'dependentChannels_'.
+  std::vector<std::unique_ptr<DecodedVector>> decoders_;
+
+  // Maps a key channel in the input to a channel in the key.
+  folly::F14FastMap<column_index_t, column_index_t> keyChannelMap_;
+
+  // Indices of the key columns used by the filter in the build side table.
+  std::vector<column_index_t> keyFilterChannels_;
+
+  // Indices of the dependent columns used by the filter in 'decoders_'.
+  std::vector<column_index_t> dependentFilterChannels_;
+
+  // True if we are considering use of normalized keys or array hash tables.
+  // Set to false when the dataset is no longer suitable.
+  bool analyzeKeys_{false};
+
+  // Temporary space for hash numbers.
+  raw_vector<uint64_t> hashes_;
+
+  // Set of active rows during 'addInput()'.
+  SelectivityVector activeRows_;
+
+  bool joinHasNullKeys_{false};
+
+  // Whether to abandon building a hash table without duplicates while adding
+  // input for left semi/anti join.
+  bool abandonHashBuildDedup_{false};
+
+  // Counts the number of hash table input rows for building the deduped hash
+  // table. It is not updated after 'abandonHashBuildDedup_' is true.
+  int64_t numHashInputRows_{0};
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/JoinTableBuilder.h
+++ b/velox/exec/JoinTableBuilder.h
@@ -108,8 +108,16 @@ class JoinTableBuilder {
   /// owners which have nothing to do in between.
   bool addInput(const RowVectorPtr& input);
 
-  /// The phases of 'addInput()'. Decodes the join keys of 'input' into the
-  /// hashers and resets 'activeRows()' to all the rows of 'input'.
+  /// The phases of 'addInput()'. Each one consumes the state the previous one
+  /// leaves behind, so they must be called once per input and in this order:
+  /// 'decodeKeys()', 'processNullKeys()', 'decodeDependents()',
+  /// 'insertRows()'. Skipping one, or calling one twice, throws.
+  /// 'decodeKeys()' starts a new input and is therefore accepted at any point,
+  /// which is what lets the owner abandon an input half way, e.g. after
+  /// 'processNullKeys()' returned false.
+  ///
+  /// Decodes the join keys of 'input' into the hashers and resets
+  /// 'activeRows()' to all the rows of 'input'.
   void decodeKeys(const RowVectorPtr& input);
 
   /// Deselects the rows of 'activeRows()' with a null join key unless the join
@@ -150,12 +158,6 @@ class JoinTableBuilder {
   std::unique_ptr<BaseHashTable> takeTable() {
     lookup_.reset();
     return std::move(table_);
-  }
-
-  /// Replaces the table, e.g. with one restored from a serialized image.
-  void setTable(std::unique_ptr<BaseHashTable> table) {
-    lookup_.reset();
-    table_ = std::move(table);
   }
 
   const std::vector<std::unique_ptr<VectorHasher>>& hashers() const {
@@ -210,6 +212,19 @@ class JoinTableBuilder {
   }
 
  private:
+  // How far the current input has moved through the phases of 'addInput()'.
+  enum class Phase {
+    // Before the first 'decodeKeys()' and after 'insertRows()'.
+    kIdle,
+    kKeysDecoded,
+    kNullKeysProcessed,
+    kDependentsDecoded,
+  };
+
+  // Checks that the current input has completed 'required' and records that it
+  // has now completed 'next'.
+  void advancePhase(Phase required, Phase next);
+
   // Invoked to set up the hash table to build.
   void setupTable();
 
@@ -292,6 +307,9 @@ class JoinTableBuilder {
   // Counts the number of hash table input rows for building the deduped hash
   // table. It is not updated after 'abandonHashBuildDedup_' is true.
   int64_t numHashInputRows_{0};
+
+  // Where the input being processed has got to. Reset by 'decodeKeys()'.
+  Phase phase_{Phase::kIdle};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ set(
   OrderByTest.cpp
   HashTableCacheTest.cpp
   HashTableTest.cpp
+  JoinTableBuilderTest.cpp
   RowNumberTest.cpp
   UnnestTest.cpp
   PlanNodeSerdeTest.cpp

--- a/velox/exec/tests/JoinTableBuilderTest.cpp
+++ b/velox/exec/tests/JoinTableBuilderTest.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/JoinTableBuilder.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class JoinTableBuilderTest : public testing::Test,
+                             public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  // Options for a build side of 'k BIGINT, v VARCHAR' joined on 'k'.
+  JoinTableBuilder::Options makeOptions(core::JoinType joinType) const {
+    JoinTableBuilder::Options options;
+    options.joinType = joinType;
+    options.inputType = ROW({"k", "v"}, {BIGINT(), VARCHAR()});
+    options.joinKeys = {
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "k"),
+    };
+    return options;
+  }
+
+  RowVectorPtr makeInput() {
+    return makeRowVector(
+        {makeFlatVector<int64_t>({1, 2, 3}),
+         makeFlatVector<std::string>({"a", "b", "c"})});
+  }
+};
+
+TEST_F(JoinTableBuilderTest, addInput) {
+  JoinTableBuilder builder(makeOptions(core::JoinType::kInner));
+  builder.initialize(pool(), pool());
+
+  EXPECT_THAT(builder.keyChannels(), testing::ElementsAre(0));
+  EXPECT_THAT(builder.dependentChannels(), testing::ElementsAre(1));
+  EXPECT_FALSE(builder.dropDuplicates());
+
+  const auto input = makeInput();
+  ASSERT_TRUE(builder.addInput(input));
+  ASSERT_TRUE(builder.addInput(input));
+  EXPECT_EQ(builder.table()->rows()->numRows(), 2 * input->size());
+  EXPECT_FALSE(builder.joinHasNullKeys());
+
+  // The table the builder hands over is a usable join build side. A join build
+  // counts every row, duplicate keys included.
+  auto table = builder.takeTable();
+  table->prepareJoinTable(
+      {},
+      BaseHashTable::kNoSpillInputStartPartitionBit,
+      builder.vectorHasherMaxNumDistinct());
+  EXPECT_EQ(table->numDistinct(), 2 * input->size());
+}
+
+TEST_F(JoinTableBuilderTest, phasesMustRunInOrder) {
+  JoinTableBuilder builder(makeOptions(core::JoinType::kInner));
+  builder.initialize(pool(), pool());
+  const auto input = makeInput();
+
+  // No input has been decoded yet, so every phase but the first is rejected.
+  VELOX_ASSERT_THROW(builder.processNullKeys(), "must be called in order");
+  VELOX_ASSERT_THROW(
+      builder.decodeDependents(input), "must be called in order");
+  VELOX_ASSERT_THROW(builder.insertRows(input), "must be called in order");
+
+  builder.decodeKeys(input);
+  VELOX_ASSERT_THROW(builder.insertRows(input), "must be called in order");
+
+  // A rejected phase leaves the sequence where it was, and decodeKeys() starts
+  // it over, so the input can still be processed.
+  builder.decodeKeys(input);
+  ASSERT_TRUE(builder.processNullKeys());
+  VELOX_ASSERT_THROW(builder.insertRows(input), "must be called in order");
+  builder.decodeDependents(input);
+  builder.insertRows(input);
+  EXPECT_EQ(builder.table()->rows()->numRows(), input->size());
+
+  // The input has been consumed, so inserting it again is rejected rather than
+  // silently duplicating its rows.
+  VELOX_ASSERT_THROW(builder.insertRows(input), "must be called in order");
+  EXPECT_EQ(builder.table()->rows()->numRows(), input->size());
+}
+
+TEST_F(JoinTableBuilderTest, nullAwareAntiJoinStopsOnNullKey) {
+  auto options = makeOptions(core::JoinType::kAnti);
+  options.nullAware = true;
+  JoinTableBuilder builder(std::move(options));
+  builder.initialize(pool(), pool());
+
+  const auto input = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, std::nullopt}),
+       makeFlatVector<std::string>({"a", "b"})});
+
+  // A null build side key makes the join return no rows, so the build can stop.
+  EXPECT_FALSE(builder.addInput(input));
+  EXPECT_TRUE(builder.joinHasNullKeys());
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Part of https://github.com/facebookincubator/velox/issues/18321

`HashBuild` mixes two concerns: the operator-level machinery (driver state machine, join bridge, spilling, memory reservation, stats, table cache) and the actual work of accumulating build side vectors into a join hash table (resolving key/dependent channels, creating the table, decoding keys, null handling, dedup, storing rows).

Only the first concern needs a driver. The second one is useful on its own, and users that build a join table outside of a Velox driver currently have to copy it. Gluten, for example, builds the broadcast build side directly from a set of vectors on the driver side, and carries a ~150 line copy of `HashBuild::setupTable()`, `HashBuild::addInput()` and the anti-join filter/dedup helpers. That copy has already drifted from Velox (wrong `dropDuplicates` for counting joins, an inverted condition in `abandonHashBuildDedup()`), which is exactly the kind of bug this split avoids.

## Changes

Adds `velox/exec/JoinTableBuilder.{h,cpp}`: accumulates build side input into a join hash table, with no dependency on `Operator`, `HashJoinNode`, `DriverCtx`, `QueryConfig`, spilling or stats. It is configured with a plain `Options` struct and driven by its owner:

```

// All in one, for owners that have nothing to do in between.
bool addInput(const RowVectorPtr& input);   // false: null-aware anti join can stop early

// The phases of addInput(), for owners that do.
void decodeKeys(const RowVectorPtr& input);
bool processNullKeys();
void decodeDependents(const RowVectorPtr& input);
void insertRows(const RowVectorPtr& input, const FlatVector<bool>* spillProbedFlags = nullptr);

Moved out of HashBuild verbatim: setupTable(), the key/dependent channel resolution
and tableType_ computation, the filter channel mapping and
removeInputRowsForAntiJoinFilter(), abandonHashBuildDedupEarly(),
abandonHashBuildDedup(), and the body of addInput(). 15 members and 5 methods are
replaced by a single tableBuilder_.

HashBuild keeps everything operator specific and plugs it in at the phase boundaries:

tableBuilder_->decodeKeys(input);
if (!isInputFromSpill()) {
  updateNullKeysStats();
}
if (!tableBuilder_->processNullKeys()) {
  noMoreInput();
  return;
}
tableBuilder_->decodeDependents(input);
spillInput(input);
tableBuilder_->insertRows(input, spillProbedFlags(input));
```
