### PR TITLE
perf(nimble): Plan and scan only the stripes that carry ranges

### DIFF
--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -244,7 +244,7 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
 
 void NimbleIndexProjector::setResumeKey(
     uint32_t requestIndex,
-    uint32_t stripeOffset,
+    uint32_t resolvedStripeIndex,
     uint32_t readEndRow,
     bool partialRead) {
   if (ctx_.resumeKeys[requestIndex].has_value()) {
@@ -254,9 +254,17 @@ void NimbleIndexProjector::setResumeKey(
   // the next stripe. A request occupies one contiguous stripe span, so
   // "continues" can only mean the immediately-next stripe -- no scan needed.
   bool hasMore = partialRead;
-  const uint32_t nextStripe = stripeOffset + 1;
-  if (!hasMore && nextStripe < ctx_.stripeRanges.numStripes) {
-    const auto ranges = ctx_.stripeRanges.getRanges(nextStripe);
+  const auto& resolvedStripes = ctx_.stripeRanges.resolvedStripes;
+  const uint32_t nextResolvedStripeIndex = resolvedStripeIndex + 1;
+  // Only the immediately-next stripe can continue the request, so skip the
+  // scan when the next resolved stripe is not adjacent. Requests cover one
+  // contiguous stripe run, so a non-adjacent successor could never hold this
+  // request anyway -- the adjacency test just avoids scanning its ranges to
+  // find that out.
+  if (!hasMore && nextResolvedStripeIndex < resolvedStripes.size() &&
+      resolvedStripes[nextResolvedStripeIndex] ==
+          resolvedStripes[resolvedStripeIndex] + 1) {
+    const auto ranges = ctx_.stripeRanges.getRanges(nextResolvedStripeIndex);
     hasMore = std::any_of(ranges.begin(), ranges.end(), [&](const auto& range) {
       return range.requestIndex == requestIndex;
     });
@@ -265,7 +273,7 @@ void NimbleIndexProjector::setResumeKey(
   // the clip point for a mid-stripe cut, or this stripe's end (== the next
   // stripe's start) for a boundary cap.
   if (hasMore) {
-    const uint32_t stripeIndex = ctx_.stripeRanges.startStripe + stripeOffset;
+    const uint32_t stripeIndex = resolvedStripes[resolvedStripeIndex];
     const auto stripeStartRow =
         static_cast<uint32_t>(tablet_->stripeStartRow(stripeIndex));
     ctx_.resumeKeys[requestIndex] =
@@ -283,21 +291,29 @@ void NimbleIndexProjector::prepareStripes() {
   rowsPerRequest.assign(ctx_.numRequests, 0);
   ctx_.hasStripeRanges.assign(ctx_.numRequests, false);
   ctx_.resumeKeys.assign(ctx_.numRequests, std::nullopt);
-  ctx_.plan.stripeIndices.reserve(ctx_.stripeRanges.numStripes);
-  ctx_.plan.numRows.reserve(ctx_.stripeRanges.numStripes);
-  ctx_.plan.requiresNullBarriers.reserve(ctx_.stripeRanges.numStripes);
-  ctx_.plan.numStreams.reserve(ctx_.stripeRanges.numStripes);
-  ctx_.plan.projectedBytes.reserve(ctx_.stripeRanges.numStripes);
-  ctx_.plan.stripeFileOffsets.reserve(ctx_.stripeRanges.numStripes);
-  ctx_.plan.stripeRangeOffsets.reserve(ctx_.stripeRanges.numStripes + 1);
+  // Reserve against the number of stripes that carry ranges, not the min..max
+  // span: the CSR is now indexed by position in resolvedStripes, so the span
+  // is an over-estimate whenever the requested stripes are sparse.
+  const auto numResolvedStripes =
+      static_cast<uint32_t>(ctx_.stripeRanges.resolvedStripes.size());
+  ctx_.plan.stripeIndices.reserve(numResolvedStripes);
+  ctx_.plan.numRows.reserve(numResolvedStripes);
+  ctx_.plan.requiresNullBarriers.reserve(numResolvedStripes);
+  ctx_.plan.numStreams.reserve(numResolvedStripes);
+  ctx_.plan.projectedBytes.reserve(numResolvedStripes);
+  ctx_.plan.stripeFileOffsets.reserve(numResolvedStripes);
+  ctx_.plan.stripeRangeOffsets.reserve(numResolvedStripes + 1);
   ctx_.plan.projectedStreams.reserve(
-      static_cast<size_t>(ctx_.stripeRanges.numStripes) *
+      static_cast<size_t>(numResolvedStripes) *
       projection_->streamOffsets.size());
   ctx_.plan.stripeRanges.reserve(ctx_.stripeRanges.ranges.size());
 
-  for (uint32_t offset = 0; offset < ctx_.stripeRanges.numStripes; ++offset) {
-    auto spanRanges = ctx_.stripeRanges.getRanges(offset);
-    const uint32_t stripeIndex = ctx_.stripeRanges.startStripe + offset;
+  for (uint32_t resolvedStripeIndex = 0;
+       resolvedStripeIndex < numResolvedStripes;
+       ++resolvedStripeIndex) {
+    auto spanRanges = ctx_.stripeRanges.getRanges(resolvedStripeIndex);
+    const uint32_t stripeIndex =
+        ctx_.stripeRanges.resolvedStripes[resolvedStripeIndex];
 
     const auto rangeOffset = ctx_.plan.stripeRanges.size();
     uint32_t numStripeRanges{0};
@@ -337,7 +353,10 @@ void NimbleIndexProjector::prepareStripes() {
       // exactly on this stripe's end), record where it resumes.
       if (needResumeKey && rowsPerRequest[requestIndex] >= maxRowsPerRequest) {
         setResumeKey(
-            requestIndex, offset, stripeRange.rowRange.endRow, partialRead);
+            requestIndex,
+            resolvedStripeIndex,
+            stripeRange.rowRange.endRow,
+            partialRead);
       }
       ctx_.hasStripeRanges[requestIndex] = true;
       ctx_.plan.stripeRanges.push_back(stripeRange);
@@ -398,6 +417,7 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.packedStripes.clear();
   ctx_.stripePackRanges.clear();
   ctx_.rowsPerRequest.clear();
+  ctx_.resolvedStripesScratch.clear();
   ctx_.sliceCounts.clear();
   ctx_.emittedSlices.clear();
   ctx_.sliceOutputBuffer.reset();
@@ -434,8 +454,6 @@ void NimbleIndexProjector::lookupStripes() {
     RowRange rowRange;
   };
 
-  uint32_t minStripe = numStripes_;
-  uint32_t maxStripe = 0;
   std::vector<ResolvedRequest> resolvedRequests;
   resolvedRequests.reserve(ctx_.numRequests);
   for (uint32_t requestIndex = 0; requestIndex < ctx_.numRequests;
@@ -454,41 +472,58 @@ void NimbleIndexProjector::lookupStripes() {
     NIMBLE_CHECK_LT(startStripe, endStripe);
 
     resolvedRequests.push_back({requestIndex, startStripe, endStripe, range});
-    minStripe = std::min(minStripe, startStripe);
-    maxStripe = std::max(maxStripe, endStripe);
   }
 
   if (resolvedRequests.empty()) {
     return;
   }
 
-  ctx_.stripeRanges.startStripe = minStripe;
-  ctx_.stripeRanges.numStripes = maxStripe - minStripe;
-
-  // Build CSR layout with write-cursor pattern: count entries per stripe,
-  // prefix-sum into offsets, then fill entries by index.
-  ctx_.stripeRanges.offsets.assign(ctx_.stripeRanges.numStripes + 1, 0);
+  // Collect one entry per (request, stripe) pair, then group. Everything here
+  // is O(entries) -- a few hundred -- where a span-indexed CSR would zero-fill
+  // and prefix-sum the whole min..max stripe span, which for scattered probes
+  // is three orders of magnitude larger than the number of stripes with
+  // ranges.
+  auto& scratch = ctx_.resolvedStripesScratch;
+  scratch.clear();
   for (const auto& request : resolvedRequests) {
     for (uint32_t stripe = request.startStripe; stripe < request.endStripe;
          ++stripe) {
-      ++ctx_.stripeRanges.offsets[stripe - minStripe + 1];
+      scratch.push_back(
+          {stripe,
+           StripeRange{
+               request.requestIndex,
+               stripeRowRange(stripe, request.rowRange)}});
     }
   }
-  for (uint32_t i = 1; i <= ctx_.stripeRanges.numStripes; ++i) {
-    ctx_.stripeRanges.offsets[i] += ctx_.stripeRanges.offsets[i - 1];
-  }
+  // Ordering on (stripe, request) is a total order, so an unstable sort still
+  // leaves the ranges within a stripe in request order, matching the
+  // write-cursor fill this replaces.
+  std::sort(
+      scratch.begin(), scratch.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.tabletStripeIndex != rhs.tabletStripeIndex) {
+          return lhs.tabletStripeIndex < rhs.tabletStripeIndex;
+        }
+        return lhs.range.requestIndex < rhs.range.requestIndex;
+      });
 
-  const auto numRanges = ctx_.stripeRanges.offsets.back();
-  ctx_.stripeRanges.ranges.resize(numRanges);
-  auto writeCursors = ctx_.stripeRanges.offsets;
-  for (const auto& request : resolvedRequests) {
-    for (uint32_t stripe = request.startStripe; stripe < request.endStripe;
-         ++stripe) {
-      const auto stripeOffset = stripe - minStripe;
-      ctx_.stripeRanges.ranges[writeCursors[stripeOffset]++] = StripeRange{
-          request.requestIndex, stripeRowRange(stripe, request.rowRange)};
+  auto& stripeRanges = ctx_.stripeRanges;
+  stripeRanges.ranges.reserve(scratch.size());
+  stripeRanges.offsets.push_back(0);
+  for (size_t i = 0; i < scratch.size(); ++i) {
+    if (i == 0) {
+      stripeRanges.resolvedStripes.push_back(scratch[i].tabletStripeIndex);
+    } else if (
+        scratch[i].tabletStripeIndex != scratch[i - 1].tabletStripeIndex) {
+      stripeRanges.offsets.push_back(static_cast<uint32_t>(i));
+      stripeRanges.resolvedStripes.push_back(scratch[i].tabletStripeIndex);
     }
+    stripeRanges.ranges.push_back(scratch[i].range);
   }
+  stripeRanges.offsets.push_back(static_cast<uint32_t>(scratch.size()));
+  NIMBLE_CHECK_EQ(
+      stripeRanges.offsets.size(),
+      stripeRanges.resolvedStripes.size() + 1,
+      "Stripe range offsets must have one entry per resolved stripe plus one");
 }
 
 void NimbleIndexProjector::loadStripes() {
@@ -981,9 +1016,13 @@ void NimbleIndexProjector::setResumeKeys(Result& result) {
   const auto stripeRanges = plannedStripeRanges(lastStripeOffset);
 
   // No next stripe in the range map — all mapped requests end at this stripe.
+  // resolvedStripes is ascending, so the successor is found by binary search;
+  // a miss means the next stripe carries no ranges and nothing continues.
   const auto nextStripe = stripeIndex + 1;
-  if (nextStripe >=
-      ctx_.stripeRanges.startStripe + ctx_.stripeRanges.numStripes) {
+  const auto& resolvedStripes = ctx_.stripeRanges.resolvedStripes;
+  const auto nextStripeIt = std::lower_bound(
+      resolvedStripes.begin(), resolvedStripes.end(), nextStripe);
+  if (nextStripeIt == resolvedStripes.end() || *nextStripeIt != nextStripe) {
     return;
   }
 
@@ -996,8 +1035,8 @@ void NimbleIndexProjector::setResumeKeys(Result& result) {
   }
 
   auto resumeKey = clusterIndex_->keyAtRow(nextStripeStartRow);
-  const auto nextRanges =
-      ctx_.stripeRanges.getRanges(nextStripe - ctx_.stripeRanges.startStripe);
+  const auto nextRanges = ctx_.stripeRanges.getRanges(
+      static_cast<uint32_t>(nextStripeIt - resolvedStripes.begin()));
 
   for (const auto& request : stripeRanges) {
     auto& response = result.responses[request.requestIndex];

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -230,27 +230,37 @@ class NimbleIndexProjector {
   };
 
   // CSR (compressed sparse row) layout mapping stripes to request row ranges.
-  // All StripeRange entries are stored in a single flat vector (`entries`),
+  // All StripeRange entries are stored in a single flat vector (`ranges`),
   // with `offsets[i]` marking where stripe i's entries begin.
   struct StripeRanges {
-    uint32_t startStripe{0};
-    uint32_t numStripes{0};
-    // Flat storage of all per-stripe row ranges, grouped by stripe.
+    // Ascending tablet stripe indices that carry ranges. Everything else here
+    // is indexed by POSITION IN THIS VECTOR -- a "resolved stripe index" --
+    // not by tablet stripe index. Each request covers one contiguous stripe
+    // run, but the requests together only pin down an outer envelope, and for
+    // scattered lookups that envelope is far wider than the set of stripes
+    // that actually carry ranges -- 148k stripes between the first and last
+    // against ~250 that hold anything, for 128 random probes. Indexing by
+    // tablet stripe index would make the tables here scale with the envelope
+    // rather than with the work.
+    std::vector<uint32_t> resolvedStripes;
+    // Flat storage of all per-stripe row ranges, grouped by resolved stripe
+    // index.
     std::vector<StripeRange> ranges;
-    // offsets[i] = start index in ranges for stripe i (relative to
-    // startStripe). Size = numStripes + 1.
+    // offsets[i] = start index in ranges for resolvedStripes[i].
+    // Size = resolvedStripes.size() + 1.
     std::vector<uint32_t> offsets;
 
-    std::span<const StripeRange> getRanges(uint32_t stripeIndex) const {
-      NIMBLE_CHECK_LT(stripeIndex, numStripes);
+    /// @param resolvedStripeIndex Index into resolvedStripes, NOT a tablet
+    /// stripe index.
+    std::span<const StripeRange> getRanges(uint32_t resolvedStripeIndex) const {
+      NIMBLE_CHECK_LT(resolvedStripeIndex, resolvedStripes.size());
       return {
-          ranges.data() + offsets[stripeIndex],
-          offsets[stripeIndex + 1] - offsets[stripeIndex]};
+          ranges.data() + offsets[resolvedStripeIndex],
+          offsets[resolvedStripeIndex + 1] - offsets[resolvedStripeIndex]};
     }
 
     void clear() {
-      startStripe = 0;
-      numStripes = 0;
+      resolvedStripes.clear();
       ranges.clear();
       offsets.clear();
     }
@@ -311,17 +321,18 @@ class NimbleIndexProjector {
   RowRange stripeRowRangeToPack(size_t stripeOffset) const;
 
   // Records the resume key for a request that reached its maxRowsPerRequest cap
-  // in the stripe at `stripeOffset` (index relative to
-  // stripeRanges.startStripe, not an absolute stripe index). `readEndRow` is
+  // in the stripe at `resolvedStripeIndex` (an index into
+  // stripeRanges.resolvedStripes, not a tablet stripe index). `readEndRow` is
   // the request's stripe-relative end row after clipping. When `partialRead` is
   // true the cap fell inside the stripe, so the key is the row-precise key at
   // `readEndRow`; otherwise the cap landed on the stripe boundary and the key
   // resumes from the next stripe still holding this request. The stripe's
-  // absolute start row is derived from `stripeOffset`. Idempotent (no-op once a
-  // key is recorded); callers gate on Options::needResumeKey.
+  // absolute start row is derived from `resolvedStripeIndex`.
+  // Idempotent (no-op once a key is recorded); callers gate on
+  // Options::needResumeKey.
   void setResumeKey(
       uint32_t requestIndex,
-      uint32_t stripeOffset,
+      uint32_t resolvedStripeIndex,
       uint32_t readEndRow,
       bool partialRead);
 
@@ -429,6 +440,15 @@ class NimbleIndexProjector {
   // Reused across stripes; its raw input format is fixed by the tablet.
   const std::unique_ptr<serde::StreamSlicer> streamSlicer_;
 
+  // One range tagged with the tablet stripe it falls in, before grouping.
+  // Sorting a vector of these on (tabletStripeIndex, range.requestIndex) is
+  // what produces the CSR grouping; the second key keeps each stripe's ranges
+  // in request order, which the grouped layout preserves.
+  struct ResolvedStripe {
+    uint32_t tabletStripeIndex{};
+    StripeRange range;
+  };
+
   // Per-project() call state. Set by initRequest(), populated through the
   // pipeline (lookupStripes → prepareStripes → loadStripes → processStripes),
   // and reset on return.
@@ -461,6 +481,11 @@ class NimbleIndexProjector {
     std::vector<RowRange> stripePackRanges;
     // Reusable per-request vectors.
     std::vector<uint64_t> rowsPerRequest;
+    // Stripes resolved from the cluster index, collected before grouping into
+    // StripeRanges and reused across project() calls to keep the build
+    // alloc-free. Holds one entry per (request, stripe) pair, so a stripe
+    // repeats once per request that lands in it.
+    std::vector<ResolvedStripe> resolvedStripesScratch;
     std::vector<size_t> sliceCounts;
     std::vector<size_t> emittedSlices;
     // Shared arena for all sliced stream bytes produced by one project() call.

--- a/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -4747,6 +4747,128 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestStripeAlignedSetsResumeKeys) {
   }
 }
 
+TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestResumeKeyWithStripeGap) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows; stripe s holds keys [s*100, s*100+100).
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Request 0 covers stripes 3-5, request 1 covers stripe 9, so the resolved
+  // stripe list is {3, 4, 5, 9}. No resolved stripe index equals its tablet
+  // stripe index here, so confusing the two is observable rather than benign.
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 300, 550);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 900, 1000);
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  NimbleIndexProjector::Options options;
+  options.maxRowsPerRequest = 100;
+  options.needResumeKey = true;
+  auto result = projector->project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 2);
+  // Only the two stripes each request was capped in get planned; stripes 4-5
+  // hold nothing once request 0 is at its cap.
+  EXPECT_EQ(projector->stats().numReadStripes, 2);
+
+  // Request 0 caps on stripe 3's boundary and continues into stripe 4, which
+  // is adjacent and still holds it, so it resumes.
+  const auto& capped = result.responses[0];
+  ASSERT_EQ(capped.slices.size(), 1);
+  EXPECT_EQ(readEmbeddedRowRange(capped.slices[0]).numRows(), 100);
+  ASSERT_TRUE(capped.resumeKey.has_value());
+  EXPECT_EQ(readEmbeddedResumeKey(capped.slices[0]), capped.resumeKey);
+
+  // Request 1 caps on stripe 9's boundary, which is the last resolved stripe.
+  // Nothing follows it in the resolved list, so it is fully satisfied.
+  {
+    const auto& response = result.responses[1];
+    ASSERT_EQ(response.slices.size(), 1);
+    EXPECT_EQ(readEmbeddedRowRange(response.slices[0]).numRows(), 100);
+    EXPECT_FALSE(response.resumeKey.has_value());
+  }
+
+  // The resume key must name stripe 3's start plus the 100 rows already
+  // returned -- key 400 -- not the start of the stripe that shares request 0's
+  // resolved stripe index. Resuming returns the remaining 150 rows.
+  auto resumed = createProjector(subfields);
+  NimbleIndexProjector::Request resumeRequest;
+  resumeRequest.keyBounds = {velox::serializer::EncodedKeyBounds{
+      .lowerKey = capped.resumeKey.value(), .upperKey = bounds0.upperKey}};
+  auto resumeResult = resumed->project(resumeRequest, {});
+
+  ASSERT_EQ(resumeResult.responses.size(), 1);
+  uint64_t resumedRows = 0;
+  for (const auto& slice : resumeResult.responses[0].slices) {
+    resumedRows += readEmbeddedRowRange(slice).numRows();
+  }
+  EXPECT_EQ(resumedRows, 150);
+}
+
+TEST_P(NimbleIndexProjectorTest, truncationResumeKeyWithStripeGap) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows; stripe s holds keys [s*100, s*100+100).
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Request 0 covers stripe 0, request 1 covers stripes 5-8, so the resolved
+  // stripe list is {0, 5, 6, 7, 8}. Truncation stops on stripe 5, whose
+  // successor stripe 6 sits at resolved stripe index 2 -- far from the tablet
+  // stripe index the pre-compaction layout would have used.
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 0, 100);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 500, 900);
+
+  auto projector = createProjector(subfields);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  NimbleIndexProjector::Options options;
+  // Soft limit: stripe 0 (100 rows) is under it, stripe 5 crosses it.
+  options.maxRows = 150;
+  options.needResumeKey = true;
+  auto result = projector->project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 2);
+  EXPECT_EQ(projector->stats().numReadStripes, 2);
+
+  // Request 0 ends inside stripe 0, so truncation leaves it complete.
+  {
+    const auto& response = result.responses[0];
+    ASSERT_EQ(response.slices.size(), 1);
+    EXPECT_EQ(readEmbeddedRowRange(response.slices[0]).numRows(), 100);
+    EXPECT_FALSE(response.resumeKey.has_value());
+  }
+
+  // Request 1 was cut at stripe 5 and still holds stripes 6-8, so it resumes.
+  const auto& truncated = result.responses[1];
+  ASSERT_EQ(truncated.slices.size(), 1);
+  EXPECT_EQ(readEmbeddedRowRange(truncated.slices[0]).numRows(), 100);
+  ASSERT_TRUE(truncated.resumeKey.has_value());
+  EXPECT_EQ(readEmbeddedResumeKey(truncated.slices[0]), truncated.resumeKey);
+
+  // Resuming from that key returns exactly the rows the gap-aware lookup said
+  // were left: stripes 6-8, keys 600-899.
+  auto resumed = createProjector(subfields);
+  NimbleIndexProjector::Request resumeRequest;
+  resumeRequest.keyBounds = {velox::serializer::EncodedKeyBounds{
+      .lowerKey = truncated.resumeKey.value(), .upperKey = bounds1.upperKey}};
+  NimbleIndexProjector::Options resumeOptions;
+  resumeOptions.needResumeKey = true;
+  auto resumeResult = resumed->project(resumeRequest, resumeOptions);
+
+  ASSERT_EQ(resumeResult.responses.size(), 1);
+  uint64_t resumedRows = 0;
+  for (const auto& slice : resumeResult.responses[0].slices) {
+    resumedRows += readEmbeddedRowRange(slice).numRows();
+  }
+  EXPECT_EQ(resumedRows, 300);
+  EXPECT_FALSE(resumeResult.responses[0].resumeKey.has_value());
+}
+
 TEST_P(NimbleIndexProjectorTest, needResumeKeyGatesResumeKey) {
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
   // 10 stripes x 100 rows.


### PR DESCRIPTION
Summary:

Combines two previously separate experimental changes (D116070897 and
D116373155) into one, rebased onto current master. Both attack the same
inefficiency from opposite ends: the projector sizes and walks its per-stripe
structures over the `min..max` tablet stripe span, while the requests in a
batch typically touch a small, sparse subset of that span.

- `lookupStripes()` builds the stripe-range CSR over the touched stripes only.
  Previously it allocated an offsets table of `maxStripe - minStripe + 1` and
  prefix-summed the whole thing; it now collects `(stripe, range)` pairs,
  stable-sorts by stripe, and walks once, so both the allocation and the
  prefix sum are O(touched) instead of O(span).
- `prepareStripes()` walks only the stripes that carry ranges, and the flat
  `ScanPlan` vectors reserve against the touched count rather than the span.
- Resume-key handling is re-expressed in terms of an index into
  `touchedStripes`; the truncation path binary-searches it to find the
  successor stripe.

This is the same optimization D117409371 implements independently. Landing
either one makes the other redundant -- this diff exists so the two
implementations can be measured against a common master baseline.

Reviewed By: xiaoxmeng

Differential Revision: D117929272


