### PR TITLE
perf(nimble): Slice RLE run ranges structurally instead of re-encoding

### DIFF
--- a/velox/dwio/nimble/encodings/RLEEncoding.h
+++ b/velox/dwio/nimble/encodings/RLEEncoding.h
@@ -26,6 +26,7 @@
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/BufferedEncoding.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
@@ -256,8 +257,22 @@ class RLEEncodingBase
         buffer,
         options);
 
+    // sliceRuns() may keep the boundary runs whole to avoid re-encoding the
+    // run-length list, in which case the runs cover more rows than requested
+    // and a SliceEncoding trims the remainder at decode time.
+    const auto encodedRows = slicedRuns.encodedRows;
+    NIMBLE_CHECK_LE(
+        static_cast<uint64_t>(slicedRuns.leadingSkipRows) + length,
+        encodedRows,
+        "RLE run slice does not cover the requested rows.");
+    // The invariant above forces the two deferred-shape signals to move
+    // together: leadingSkipRows>0 implies encodedRows>length, and vice-versa,
+    // so a single comparison decides whether a SliceEncoding wrapper is
+    // needed to trim what the kept-whole boundary runs added.
+    const bool needsSliceWrapper = encodedRows != length;
+
     const auto prefixSize =
-        EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+        EncodingPrefix::serializedSize(encodedRows, options.useVarintRowCount);
     const auto encodingSize = prefixSize + sizeof(uint32_t) +
         slicedRuns.encodedLengths.size() + slicedRunValues.size();
     char* reserved = buffer.reserve(encodingSize);
@@ -265,13 +280,21 @@ class RLEEncodingBase
     EncodingPrefix::serialize(
         EncodingType::RLE,
         TypeTraits<T>::dataType,
-        length,
+        encodedRows,
         options.useVarintRowCount,
         output);
     encoding::writeString(slicedRuns.encodedLengths, output);
     encoding::writeBytes(slicedRunValues, output);
     NIMBLE_CHECK_EQ(output - reserved, encodingSize, "Encoding size mismatch.");
-    return std::string_view{reserved, encodingSize};
+    if (!needsSliceWrapper) {
+      return std::string_view{reserved, encodingSize};
+    }
+    return SliceEncoding<T>::wrap(
+        {reserved, encodingSize},
+        slicedRuns.leadingSkipRows,
+        length,
+        buffer,
+        options);
   }
 
   const char* getValuesStart() const {
@@ -322,8 +345,25 @@ class RLEEncodingBase
     // Run-value child range matching encodedLengths.
     uint32_t runValueOffset{0};
     uint32_t runValueCount{0};
+    // Row count written into the emitted RLE's prefix. Equal to the requested
+    // length when the range is run-aligned; larger when the boundary runs
+    // were kept whole to avoid re-encoding the length list.
+    uint32_t encodedRows{0};
+    // Rows to drop from the front of the emitted RLE to reach the requested
+    // slice start. Non-zero, or encodedRows above the requested length, means
+    // the caller must wrap the result in a SliceEncoding so the consumer
+    // trims what the lengths did not.
+    uint32_t leadingSkipRows{0};
   };
 
+  // Locates the run range that covers `[offset, offset+length)`, keeps the
+  // boundary runs whole, and structurally slices the run-length list.
+  //
+  // Trimming boundary run lengths to match `length` exactly would force the
+  // length list back through `encodeWithCapturedLayout`; the wrapper the
+  // caller adds on any overhang costs a few bytes forever but skips that
+  // pipeline every time. A run-aligned range has zero overhang, so the caller
+  // returns the inner RLE unwrapped.
   static RLESliceRuns sliceRuns(
       std::string_view encodedRunLengths,
       uint32_t offset,
@@ -338,8 +378,6 @@ class RLEEncodingBase
         runCount, 0, "Cannot slice a non-empty range from empty RLE runs.");
     auto* pool = &buffer.getMemoryPool();
 
-    RLESliceRuns result;
-
     EncodingFactory encodingFactory{options};
     auto runLengthsEncoding = encodingFactory.create(
         *pool, encodedRunLengths, [](uint32_t /* totalLength */) -> void* {
@@ -353,8 +391,7 @@ class RLEEncodingBase
     const auto maxRunLengthChunkSize =
         std::min({runCount, length, kRunLengthChunkSize});
     Vector<uint32_t> runLengths{pool, maxRunLengthChunkSize};
-    Vector<uint32_t> slicedRunLengths{pool};
-    slicedRunLengths.reserve(length);
+    RLESliceRuns result;
     uint32_t row{0};
     for (uint32_t run = 0; run < runCount;) {
       const auto chunkSize =
@@ -376,7 +413,6 @@ class RLEEncodingBase
         }
         lastRunEnd = runEnd;
         ++result.runValueCount;
-        slicedRunLengths.push_back(runLengths[i]);
       }
       if (row >= end) {
         break;
@@ -387,40 +423,16 @@ class RLEEncodingBase
         result.runValueCount,
         0,
         "Could not find RLE runs for a non-empty row range.");
-    NIMBLE_CHECK_EQ(
-        slicedRunLengths.size(),
-        result.runValueCount,
-        "Sliced RLE run length count mismatch.");
 
-    if (firstRunStart < offset || lastRunEnd > end) {
-      slicedRunLengths[0] -= offset - firstRunStart;
-      slicedRunLengths[result.runValueCount - 1] -= lastRunEnd - end;
-      result.encodedLengths = encodeRunLengthsSlice(
-          encodedRunLengths, slicedRunLengths, buffer, options);
-    } else {
-      result.encodedLengths = EncodingFactory::slice(
-          encodedRunLengths,
-          result.runValueOffset,
-          result.runValueCount,
-          buffer,
-          options);
-    }
-    return result;
-  }
-
-  static std::string_view encodeRunLengthsSlice(
-      std::string_view encodedRunLengths,
-      std::span<const uint32_t> runLengths,
-      Buffer& buffer,
-      const Encoding::Options& options) {
-    NIMBLE_CHECK_GT(
-        runLengths.size(), 0, "Cannot encode empty RLE run-length slice.");
-    return EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+    result.encodedRows = lastRunEnd - firstRunStart;
+    result.leadingSkipRows = offset - firstRunStart;
+    result.encodedLengths = EncodingFactory::slice(
         encodedRunLengths,
-        runLengths,
+        result.runValueOffset,
+        result.runValueCount,
         buffer,
-        options,
-        "Captured RLE run-length layout");
+        options);
+    return result;
   }
 };
 

--- a/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
@@ -270,6 +270,18 @@ class EncodingSliceTest : public ::testing::Test {
         expectedEncodingType = nimble::EncodingType::Constant;
       }
     }
+    if constexpr (std::is_same_v<EncodingType, nimble::RLEEncoding<T>>) {
+      // A range that starts or ends inside a run keeps the boundary runs whole
+      // and comes back wrapped.
+      const auto end = offset + length;
+      const bool startsMidRun =
+          offset > 0 && values[offset] == values[offset - 1];
+      const bool endsMidRun =
+          end < values.size() && values[end] == values[end - 1];
+      if (startsMidRun || endsMidRun) {
+        expectedEncodingType = nimble::EncodingType::Slice;
+      }
+    }
 
     EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
     EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
@@ -533,12 +545,15 @@ TEST_F(EncodingSliceTest, materializesConstantRangeWithoutWrapper) {
 }
 
 TEST_F(EncodingSliceTest, materializesRleRangeWithoutWrapper) {
+  // Runs are [0,2) [2,5) [5,7); rows [2,7) are run-aligned, so the run lengths
+  // need no trimming and the slice stays a plain RLE. The mid-run case, which
+  // does come back wrapped, is covered by the deferred RLE tests.
   const auto values = makeVector<int32_t>({10, 10, 11, 11, 11, 12, 12});
   const auto encoded =
       nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
           *buffer_, values);
 
-  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/5);
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/5);
   EXPECT_NE(sliced.data(), encoded.data());
 
   auto encoding = createEncoding(sliced);
@@ -550,7 +565,7 @@ TEST_F(EncodingSliceTest, materializesRleRangeWithoutWrapper) {
   nimble::Vector<int32_t> output{pool_.get(), 5};
   encoding->materialize(5, output.data());
 
-  const std::vector<int32_t> expected{10, 11, 11, 11, 12};
+  const std::vector<int32_t> expected{11, 11, 11, 12, 12};
   EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
 }
 

--- a/velox/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/common/tests/NimbleCompare.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingType.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
@@ -327,49 +328,66 @@ TYPED_TEST(RleEncodingTest, slice) {
           nimble::CompressionType::Uncompressed,
           options);
 
+  // Runs are [0,3) [3,5) [5,8) [8,10). A range that starts or ends inside a
+  // run keeps the boundary runs whole and comes back wrapped in a
+  // SliceEncoding; only run-aligned ranges stay a plain RLE.
   struct Range {
     const char* name;
     uint32_t offset;
     uint32_t length;
+    nimble::EncodingType expectedType;
   };
   for (const auto range :
        {Range{/*name=*/"allRunsNoPartial",
               /*offset=*/0,
-              /*length=*/10},
+              /*length=*/10,
+              nimble::EncodingType::RLE},
         Range{/*name=*/"singleRunNoPartial",
               /*offset=*/0,
-              /*length=*/3},
+              /*length=*/3,
+              nimble::EncodingType::RLE},
         Range{/*name=*/"middleRunsNoPartial",
               /*offset=*/3,
-              /*length=*/5},
-        Range{/*name=*/"lastRunNoPartial", /*offset=*/8, /*length=*/2},
+              /*length=*/5,
+              nimble::EncodingType::RLE},
+        Range{/*name=*/"lastRunNoPartial",
+              /*offset=*/8,
+              /*length=*/2,
+              nimble::EncodingType::RLE},
         Range{/*name=*/"firstRunPartialLastExact",
               /*offset=*/1,
-              /*length=*/7},
+              /*length=*/7,
+              nimble::EncodingType::Slice},
         Range{/*name=*/"firstExactLastRunPartial",
               /*offset=*/3,
-              /*length=*/4},
-        Range{/*name=*/"bothPartialSameRun", /*offset=*/1, /*length=*/1},
+              /*length=*/4,
+              nimble::EncodingType::Slice},
+        Range{/*name=*/"bothPartialSameRun",
+              /*offset=*/1,
+              /*length=*/1,
+              nimble::EncodingType::Slice},
         Range{/*name=*/"bothPartialWithInteriorRun",
               /*offset=*/1,
-              /*length=*/5}}) {
+              /*length=*/5,
+              nimble::EncodingType::Slice}}) {
     SCOPED_TRACE(
         testing::Message() << "case=" << range.name << ", offset="
                            << range.offset << ", length=" << range.length);
     nimble::Buffer sliceBuffer{*this->pool_};
     const auto sliced = nimble::RLEEncoding<DataType>::slice(
         encoded, range.offset, range.length, sliceBuffer, options);
-    nimble::RLEEncoding<DataType> encoding{
-        *this->pool_,
-        sliced,
-        [](uint32_t /*totalLength*/) -> void* { return nullptr; },
-        options};
+    // Built through the factory rather than as an RLEEncoding directly: a
+    // deferred slice comes back as a SliceEncoding wrapping the RLE.
+    auto encoding = nimble::EncodingFactory{options}.create(
+        *this->pool_, sliced, [](uint32_t /*totalLength*/) -> void* {
+          return nullptr;
+        });
 
-    EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::RLE);
-    EXPECT_EQ(encoding.dataType(), nimble::TypeTraits<DataType>::dataType);
-    EXPECT_EQ(encoding.rowCount(), range.length);
+    EXPECT_EQ(encoding->encodingType(), range.expectedType);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<DataType>::dataType);
+    EXPECT_EQ(encoding->rowCount(), range.length);
     nimble::Vector<DataType> result(this->pool_.get(), range.length);
-    encoding.materialize(range.length, result.data());
+    encoding->materialize(range.length, result.data());
     for (uint32_t i = 0; i < range.length; ++i) {
       EXPECT_TRUE(
           nimble::NimbleCompare<DataType>::equals(

--- a/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -59,6 +59,12 @@ class SliceEncodingTest : public ::testing::Test {
         });
   }
 
+  std::string_view
+  slice(std::string_view encoded, uint32_t offset, uint32_t length) {
+    return nimble::EncodingFactory::slice(
+        encoded, offset, length, *buffer_, nimble::Encoding::Options{});
+  }
+
   template <typename T>
   std::vector<T> materialize(nimble::Encoding& encoding, uint32_t rowCount) {
     nimble::Vector<T> output{pool_.get(), rowCount};
@@ -166,6 +172,106 @@ TEST_F(SliceEncodingTest, wrapsBoolRle) {
   EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
   EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
   EXPECT_FALSE(velox::bits::isBitSet(&bits, 3));
+}
+
+// --- Deferred RLE run slicing ---------------------------------------------
+//
+// A slice that starts or ends mid-run keeps the boundary runs whole and wraps
+// the result, instead of trimming the two boundary lengths and re-encoding.
+
+TEST_F(SliceEncodingTest, deferredRleMatchesSourceRows) {
+  // 5 runs: 10x3, 11x2, 12x4, 13x1, 14x3 over 13 rows. Sweep every non-empty
+  // range so aligned, mid-run, single-run and full-range cases are all covered
+  // and each must reproduce the source rows exactly.
+  const auto values =
+      makeVector<int32_t>({10, 10, 10, 11, 11, 12, 12, 12, 12, 13, 14, 14, 14});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  for (uint32_t offset = 0; offset < values.size(); ++offset) {
+    for (uint32_t length = 1; offset + length <= values.size(); ++length) {
+      const std::vector<int32_t> expected(
+          values.begin() + offset, values.begin() + offset + length);
+
+      auto encoding = createEncoding(slice(encoded, offset, length));
+      ASSERT_EQ(encoding->rowCount(), length)
+          << "offset=" << offset << " length=" << length;
+      nimble::Vector<int32_t> output{pool_.get(), length};
+      encoding->materialize(length, output.data());
+      ASSERT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected)
+          << "offset=" << offset << " length=" << length;
+    }
+  }
+}
+
+TEST_F(SliceEncodingTest, deferredRleWrapsOnlyWhenMidRun) {
+  // Runs: 10x3 [0,3), 11x2 [3,5), 12x4 [5,9), 13x1 [9,10). The length-1 run
+  // covers the aligned single-run edge case; the 10x3 run covers the mid-run
+  // subcases (front only, back only, both boundaries in the same run).
+  const auto values =
+      makeVector<int32_t>({10, 10, 10, 11, 11, 12, 12, 12, 12, 13});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  struct Case {
+    const char* name;
+    uint32_t offset;
+    uint32_t length;
+    nimble::EncodingType expectedType;
+  };
+  for (const auto& testCase : {
+           Case{"alignedSingleRun", 3, 2, nimble::EncodingType::RLE},
+           Case{"alignedMultiRun", 3, 6, nimble::EncodingType::RLE},
+           Case{"alignedSingleRowRun", 9, 1, nimble::EncodingType::RLE},
+           Case{"alignedFullRange", 0, 10, nimble::EncodingType::RLE},
+           Case{"midRunAcrossRuns", 4, 3, nimble::EncodingType::Slice},
+           Case{
+               "midRunInsideSingleRunFrontAndBack",
+               1,
+               1,
+               nimble::EncodingType::Slice},
+           Case{
+               "midRunInsideSingleRunBackOnly",
+               0,
+               2,
+               nimble::EncodingType::Slice},
+           Case{
+               "midRunInsideSingleRunFrontOnly",
+               1,
+               2,
+               nimble::EncodingType::Slice},
+       }) {
+    SCOPED_TRACE(testCase.name);
+    auto encoding =
+        createEncoding(slice(encoded, testCase.offset, testCase.length));
+    EXPECT_EQ(encoding->encodingType(), testCase.expectedType);
+    EXPECT_EQ(encoding->rowCount(), testCase.length);
+  }
+}
+
+TEST_F(SliceEncodingTest, deferredRleHandlesBool) {
+  // Bool RLE is the FlatMap in-map and null-stream case, and the one the
+  // MainlyConstant isCommon child hits.
+  const auto values =
+      makeVector<bool>({false, false, true, true, true, false, true, true});
+  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+      *buffer_, values);
+
+  for (uint32_t offset = 0; offset < values.size(); ++offset) {
+    for (uint32_t length = 1; offset + length <= values.size(); ++length) {
+      auto encoding = createEncoding(slice(encoded, offset, length));
+      ASSERT_EQ(encoding->rowCount(), length);
+
+      uint64_t bits{0};
+      encoding->materializeBoolsAsBits(length, &bits, /*begin=*/0);
+      for (uint32_t i = 0; i < length; ++i) {
+        ASSERT_EQ(velox::bits::isBitSet(&bits, i), values[offset + i])
+            << "offset=" << offset << " length=" << length << " row=" << i;
+      }
+    }
+  }
 }
 
 TEST_F(SliceEncodingTest, boolSkipIsRelativeToSlice) {


### PR DESCRIPTION
Summary:

An RLE slice whose row range starts or ends mid-run cannot reuse the source's
run-length bytes if we trim the boundary runs to match: the two changed
integers force the whole length list through `encodeWithCapturedLayout`, which
captures the source layout, builds `Statistics` over the list, runs selection
and encodes. `perf` on `fb_public_sparse` shows that as the tail of both hot
slicing stacks -- the direct one through `RLEEncodingBase::slice`, and the
nested one where `MainlyConstant`'s `isCommon` child is itself a bool RLE.

The run VALUES have no such problem: a run's value does not change when the
run is clipped, so they are already sliced structurally by run index.

This makes the lengths structural too. Keep the boundary runs whole, slice the
length list by run index like the values, and record how many rows to drop
from the front in a `SliceEncoding` wrapper. The tail needs nothing: the
wrapper's row count stops the reader before the last run's overhang.

The re-encode path is removed entirely; every mid-run slice goes through the
wrapper regardless of how many runs are touched. The single-run mid-run case
used to be handled by trimming a 1-element length list -- which was cheaper
than a multi-element re-encode but still had to run the pipeline. Sending it
through the wrapper too costs a small header and one extra decode layer on
that specific case, in exchange for `sliceRuns` losing its trim branch,
`slicedRunLengths` scratch vector and the `encodeRunLengthsSlice`/
`encodeWithCapturedLayout` call site.

Applied unconditionally -- there is no flag. `RLEEncoding::slice()` returns a
`SliceEncoding`-wrapped result whenever the range starts or ends mid-run, so
every reader of a sliced stream has to understand `SliceEncoding` (added in
D116084507).

That changes an existing contract, so two pre-existing tests moved with it.
Both asserted that slicing an RLE always yields an RLE, which now holds only
for run-aligned ranges: `RleEncodingTest.slice` builds through
`EncodingFactory` and states the expected type per case, and
`EncodingSliceTest.materializesRleRangeWithoutWrapper` moved to a run-aligned
range, with the mid-run case covered by the deferred RLE tests.

Reviewed By: xiaoxmeng

Differential Revision: D116338105


