### PR TITLE
feat: Add no-op runtime stat writer (#18773)

### DIFF
--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -115,6 +115,9 @@ class BaseRuntimeStatWriter {
   }
 };
 
+/// Discards every metric written to it.
+class NoopRuntimeStatWriter : public BaseRuntimeStatWriter {};
+
 /// Setting a concrete runtime stats writer on the thread will ensure that any
 /// code can add runtime counters to the current Operator running on that
 /// thread.

--- a/velox/common/base/tests/RuntimeMetricsTest.cpp
+++ b/velox/common/base/tests/RuntimeMetricsTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/RuntimeMetrics.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "velox/common/base/ConcurrentRuntimeStatWriter.h"
 #include "velox/common/base/VeloxException.h"
@@ -176,6 +177,21 @@ TEST_F(SetThreadLocalRuntimeStatTest, noWriter) {
   RuntimeMetric metric(RuntimeCounter::Unit::kNanos);
   metric.addValue(42);
   setThreadLocalRuntimeStat("test.nowriter", metric);
+}
+
+TEST_F(SetThreadLocalRuntimeStatTest, noopWriter) {
+  ConcurrentRuntimeStatWriter collector;
+  RuntimeStatWriterScopeGuard collecting(&collector);
+
+  {
+    NoopRuntimeStatWriter noop;
+    RuntimeStatWriterScopeGuard discarding(&noop);
+    addThreadLocalRuntimeStat("test.noop", RuntimeCounter(1));
+  }
+  EXPECT_THAT(collector.runtimeStats(), testing::IsEmpty());
+
+  addThreadLocalRuntimeStat("test.after", RuntimeCounter(1));
+  EXPECT_EQ(collector.runtimeStats().count("test.after"), 1);
 }
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:

 An API that returns a BaseRuntimeStatWriter& cannot signal "do not record" the way the thread-local writer does with setThreadLocalRunTimeStatWriter(nullptr). A reference must refer to an object.

This adds NoopRuntimeStatWriter next to the base class for reference-returning APIs to return.

Reviewed By: mbasmanova

Differential Revision: D118160689


