### PR TITLE
feat(sparksql): Support null handling configuration at registration for collect_list

### DIFF
--- a/velox/functions/sparksql/aggregates/CollectListAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectListAggregate.cpp
@@ -28,7 +28,10 @@ namespace facebook::velox::functions::aggregate::sparksql {
 using functions::sparksql::SparkQueryConfig;
 
 namespace {
-class CollectListAggregate {
+// Fix null handling at registration time to support varying null handing
+// contracts.
+template <bool PinIgnoreNulls>
+class CollectListAggregateBase {
  public:
   using InputType = Row<Generic<T1>>;
 
@@ -53,7 +56,11 @@ class CollectListAggregate {
       const std::vector<TypePtr>& /*argTypes*/,
       const TypePtr& /*resultType*/,
       const core::QueryConfig& config) {
-    ignoreNulls_ = SparkQueryConfig{config}.collectListIgnoreNulls();
+    if constexpr (PinIgnoreNulls) {
+      ignoreNulls_ = true;
+    } else {
+      ignoreNulls_ = SparkQueryConfig{config}.collectListIgnoreNulls();
+    }
   }
 
   struct AccumulatorType {
@@ -61,7 +68,7 @@ class CollectListAggregate {
 
     explicit AccumulatorType(
         HashStringAllocator* /*allocator*/,
-        CollectListAggregate* fn)
+        CollectListAggregateBase* fn)
         : elements_{}, ignoreNulls_(fn->ignoreNulls_) {}
 
     static constexpr bool is_fixed_size_ = false;
@@ -120,7 +127,10 @@ class CollectListAggregate {
 
 } // namespace
 
-void registerCollectListAggregate(
+namespace {
+
+template <bool PinIgnoreNulls>
+void registerCollectListAggregateImpl(
     const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
@@ -142,10 +152,27 @@ void registerCollectListAggregate(
         const std::string& name = names.front();
         VELOX_CHECK_EQ(
             argTypes.size(), 1, "{} takes at most one argument", name);
-        return std::make_unique<SimpleAggregateAdapter<CollectListAggregate>>(
+        return std::make_unique<
+            SimpleAggregateAdapter<CollectListAggregateBase<PinIgnoreNulls>>>(
             step, argTypes, resultType, &config);
       },
       withCompanionFunctions,
       overwrite);
+}
+
+} // namespace
+
+void registerCollectListAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite,
+    bool pinIgnoreNulls) {
+  if (pinIgnoreNulls) {
+    registerCollectListAggregateImpl</*PinIgnoreNulls=*/true>(
+        names, withCompanionFunctions, overwrite);
+  } else {
+    registerCollectListAggregateImpl</*PinIgnoreNulls=*/false>(
+        names, withCompanionFunctions, overwrite);
+  }
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/CollectListAggregate.h
+++ b/velox/functions/sparksql/aggregates/CollectListAggregate.h
@@ -26,9 +26,13 @@ namespace facebook::velox::functions::aggregate::sparksql {
 /// @param withCompanionFunctions Also register companion functions.
 /// @param overwrite Whether to overwrite existing entry in the function
 /// registry.
+/// @param pinIgnoreNulls When true, null inputs are always ignored and the
+/// collect_list.ignore_nulls session config is not consulted. Use for a name
+/// whose contract fixes null handling and must not follow session config.
 void registerCollectListAggregate(
     const std::vector<std::string>& names,
     bool withCompanionFunctions,
-    bool overwrite);
+    bool overwrite,
+    bool pinIgnoreNulls);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -71,7 +71,10 @@ void registerAggregateFunctions(
   registerCentralMomentsAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectSetAggAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectListAggregate(
-      {prefix + "collect_list"}, withCompanionFunctions, overwrite);
+      {prefix + "collect_list"},
+      withCompanionFunctions,
+      overwrite,
+      /*pinIgnoreNulls=*/false);
   registerRegrReplacementAggregate(prefix, withCompanionFunctions, overwrite);
   registerModeAggregate(prefix, withCompanionFunctions, overwrite);
   registerVarianceAggregate(prefix, withCompanionFunctions, overwrite);


### PR DESCRIPTION
Summary: Refactor Spark function collect_list to support varying null contracts. ANSI always drops nulls while Hive defaults to config settings. Rather than writing two near identical implementations, let's templatize the function to configure at registration time.

Differential Revision: D117915833


