### PR TITLE
feat(nimble): Collect user metadata at close via a provider (#18777)

### DIFF
--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -1063,6 +1063,99 @@ TEST_F(WriterTest, exceptionOnClose) {
   }
 }
 
+TEST_F(WriterTest, metadataProviderWrittenAtClose) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vector = vectorMaker.rowVector(
+      {"col0"}, {vectorMaker.flatVector<int32_t>({1, 2, 3})});
+
+  nimble::WriterOptions options;
+  // Drop the seeded defaults so this also covers a file whose only metadata
+  // arrives late, which the writer used to skip serializing altogether.
+  options.metadata.clear();
+  options.metadataProvider = [] {
+    return std::unordered_map<std::string, std::string>{{"key 1", "value 1"}};
+  };
+
+  std::string file;
+  nimble::Writer writer(
+      vector->type(),
+      std::make_unique<velox::InMemoryWriteFile>(&file),
+      *rootPool_,
+      std::move(options));
+  writer.write(vector);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
+  const std::map<std::string, std::string> expected{{"key 1", "value 1"}};
+  EXPECT_EQ(reader.metadata(), expected);
+}
+
+TEST_F(WriterTest, metadataProviderOverridesOptionsMetadata) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vector = vectorMaker.rowVector(
+      {"col0"}, {vectorMaker.flatVector<int32_t>({1, 2, 3})});
+
+  nimble::WriterOptions options;
+  options.metadata = {{"key 1", "value 1"}, {"key 2", "value 2"}};
+  options.metadataProvider = [] {
+    return std::unordered_map<std::string, std::string>{
+        {"key 2", "late value 2"}, {"key 3", "value 3"}};
+  };
+
+  std::string file;
+  nimble::Writer writer(
+      vector->type(),
+      std::make_unique<velox::InMemoryWriteFile>(&file),
+      *rootPool_,
+      std::move(options));
+  writer.write(vector);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
+  const std::map<std::string, std::string> expected{
+      {"key 1", "value 1"}, {"key 2", "late value 2"}, {"key 3", "value 3"}};
+  EXPECT_EQ(reader.metadata(), expected);
+}
+
+TEST_F(WriterTest, metadataProviderObservesEveryWrittenRow) {
+  // The whole point of the hook: the provider runs late enough to report a
+  // value that is only final once the caller has written its last row.
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vector = vectorMaker.rowVector(
+      {"col0"}, {vectorMaker.flatVector<int32_t>({1, 2, 3})});
+
+  uint32_t rowsWritten = 0;
+  uint32_t providerCalls = 0;
+
+  nimble::WriterOptions options;
+  options.metadata.clear();
+  options.metadataProvider = [&] {
+    ++providerCalls;
+    return std::unordered_map<std::string, std::string>{
+        {"rows", folly::to<std::string>(rowsWritten)}};
+  };
+
+  std::string file;
+  nimble::Writer writer(
+      vector->type(),
+      std::make_unique<velox::InMemoryWriteFile>(&file),
+      *rootPool_,
+      std::move(options));
+  for (int batch = 0; batch < 2; ++batch) {
+    writer.write(vector);
+    rowsWritten += vector->size();
+  }
+  writer.close();
+
+  EXPECT_EQ(providerCalls, 1);
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  nimble::BatchReader reader(readFile.get(), *leafPool_);
+  const std::map<std::string, std::string> expected{{"rows", "6"}};
+  EXPECT_EQ(reader.metadata(), expected);
+}
+
 TEST_F(WriterTest, emptyFileNoSchema) {
   const uint32_t batchSize = 10;
   auto type = velox::ROW({{"simple", velox::INTEGER()}});

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -2148,24 +2148,37 @@ velox::VectorPtr Writer::storedDataInput(const velox::VectorPtr& input) const {
 }
 
 void Writer::writeMetadata() {
-  if (context_->options().metadata.empty()) {
+  const auto& optionsMetadata = context_->options().metadata;
+  const auto& metadataProvider = context_->options().metadataProvider;
+  // Called here rather than at open so it observes the finished file.
+  const auto providedMetadata = metadataProvider
+      ? metadataProvider()
+      : std::unordered_map<std::string, std::string>{};
+  if (optionsMetadata.empty() && providedMetadata.empty()) {
     return;
   }
-  auto& metadata = context_->options().metadata;
-  auto it = metadata.cbegin();
-  flatbuffers::FlatBufferBuilder builder(kInitialSchemaSectionSize);
-  auto entries =
-      builder.CreateVector<flatbuffers::Offset<serialization::MetadataEntry>>(
-          metadata.size(), [&builder, &it](size_t /* i */) {
-            auto entry = serialization::CreateMetadataEntry(
-                builder,
-                builder.CreateString(it->first),
-                builder.CreateString(it->second));
-            ++it;
-            return entry;
-          });
 
-  builder.Finish(serialization::CreateMetadata(builder, entries));
+  flatbuffers::FlatBufferBuilder builder(kInitialSchemaSectionSize);
+  std::vector<flatbuffers::Offset<serialization::MetadataEntry>> entries;
+  entries.reserve(optionsMetadata.size() + providedMetadata.size());
+  const auto appendEntry = [&builder, &entries](
+                               const auto& key, const auto& value) {
+    entries.push_back(
+        serialization::CreateMetadataEntry(
+            builder, builder.CreateString(key), builder.CreateString(value)));
+  };
+  for (const auto& [key, value] : optionsMetadata) {
+    // Skip the keys the provider overrode, so each key appears once.
+    if (!providedMetadata.contains(key)) {
+      appendEntry(key, value);
+    }
+  }
+  for (const auto& [key, value] : providedMetadata) {
+    appendEntry(key, value);
+  }
+
+  builder.Finish(
+      serialization::CreateMetadata(builder, builder.CreateVector(entries)));
   tabletWriter_->writeOptionalSection(
       std::string(kMetadataSection),
       {reinterpret_cast<const char*>(builder.GetBufferPointer()),

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -291,7 +291,8 @@ class Writer : public velox::dwio::common::Writer {
   void updateIoStatistics();
 
   // Writes caller-supplied key/value metadata into the optional metadata
-  // section.
+  // section, merging whatever `options.metadataProvider` returns over
+  // `options.metadata`.
   void writeMetadata();
   // Writes the column statistics section, using the vectorized representation
   // when enabled and the legacy raw-size section otherwise.

--- a/velox/dwio/nimble/writer/WriterOptions.h
+++ b/velox/dwio/nimble/writer/WriterOptions.h
@@ -67,6 +67,15 @@ struct WriterOptions {
   std::unordered_map<std::string, std::string> metadata =
       detail::defaultMetadata();
 
+  /// Supplies user metadata that is only known once every row has been
+  /// written, for callers whose value is not final when the writer opens.
+  /// Invoked once from close(), after the last stripe is written and before
+  /// the metadata section is serialized, so it observes the finished file.
+  /// Entries it returns win over `metadata` on a key collision, including
+  /// over the defaults seeded above. Throwing from it fails close().
+  std::function<std::unordered_map<std::string, std::string>()>
+      metadataProvider{};
+
   /// Shared dictionary encoding settings.
   /// EXPERIMENTAL: Shared dictionary encoding is not production-ready. Do not
   /// enable for production tables without consulting the Nimble team (oncall:


### PR DESCRIPTION
Summary:

Nimble accepted user metadata only through `WriterOptions::metadata`, which
the caller must fill in before the writer opens the file. A caller whose
value is not final until the last row is ingested — a row count, a checksum,
a max timestamp — had nowhere to put it.

Add `WriterOptions::metadataProvider`, a callback the writer invokes once
from `close()`, after the last stripe is written and before the metadata
section is serialized, so it observes the finished file. Entries it returns
are merged over `WriterOptions::metadata`; on a key collision the provider
wins, including over the defaults `WriterOptions` seeds.

The format already permitted this. The metadata section is serialized in
`Writer::close()`, which reads the map at that moment rather than at open.
The only thing missing was a way in: `WriterContext` holds its
`WriterOptions` by const value and exposes no mutator.

A provider rather than a `Writer::addMetadata(key, value)` mutator, per
review. The writer pulls when it needs the value instead of the caller
pushing before a deadline, which keeps the writer free of a second metadata
map and removes the ordering hazard — there is no longer a call that can
arrive after `close()` has consumed the section. It also matches the other
extension points on `WriterOptions`, which are already callbacks
(`flushPolicyFactory`, `bufferPolicyFactory`, `reclaimerFactory`).

Reviewed By: xiaoxmeng

Differential Revision: D118197998
