### PR TITLE
fix(dwio): Exclude prefetch reads from query thread IO wait

### DIFF
--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -158,9 +158,12 @@ class IoStatistics {
   // or for an in-progress read-ahead to finish.
   IoCounter queryThreadIoLatencyUs_;
 
-  // Breakdown of queryThreadIoLatencyUs_ by I/O type:
+  // IO latency by type. Does not add up to queryThreadIoLatencyUs_ - a read
+  // issued by the prefetch thread is included in the metrics below but does not
+  // block the query thread and thus does not contribute to
+  // queryThreadIoLatencyUs_.
 
-  // Time spent waiting for remote storage reads (S3, HDFS, etc.)
+  // Time spent reading from remote storage (S3, HDFS, etc.)
   IoCounter storageReadLatencyUs_;
 
   // Time spent waiting for SSD cache reads

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -417,7 +417,6 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
   ioStatistics_->read().increment(size + overread);
   ioStatistics_->incRawBytesRead(size);
   ioStatistics_->incTotalScanTimeNs(static_cast<int64_t>(usecs * 1'000));
-  ioStatistics_->queryThreadIoLatencyUs().increment(usecs);
   ioStatistics_->storageReadLatencyUs().increment(usecs);
   ioStatistics_->incRawOverreadBytes(overread);
   if (prefetch) {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -18,6 +18,7 @@
 
 #include <fmt/ranges.h>
 #include <folly/OperationCancelled.h>
+#include <folly/ScopeGuard.h>
 #include <folly/synchronization/Baton.h>
 #include <folly/synchronization/EventCount.h>
 #include <folly/synchronization/Latch.h>
@@ -30,6 +31,7 @@
 #include "velox/common/file/File.h"
 #include "velox/common/file/tests/FaultyFile.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
+#include "velox/common/file/tests/FaultyFileSystemOperations.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TestValue.h"
@@ -162,6 +164,101 @@ TEST_F(TableScanTest, directBufferInputRawInputBytes) {
       rawInputBytes + overreadBytes);
   ASSERT_GT(getTableScanRuntimeStats(task)["totalScanTime"].sum, 0);
   ASSERT_GT(getTableScanRuntimeStats(task)["ioWaitWallNanos"].sum, 0);
+}
+
+TEST_F(TableScanTest, directBufferInputInlineCoalescedLoadIoWait) {
+  // Fuzzed rather than sequential, so the data does not compress down to a
+  // read too short to time.
+  VectorFuzzer::Options fuzzerOptions;
+  fuzzerOptions.vectorSize = 2'000;
+  fuzzerOptions.nullRatio = 0;
+  VectorFuzzer fuzzer(fuzzerOptions, pool_.get());
+  const auto tableType =
+      ROW({"c0", "c1", "c2", "c3"}, {BIGINT(), BIGINT(), BIGINT(), BIGINT()});
+  constexpr int kNumBatches = 5;
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(kNumBatches);
+  for (int i = 0; i < kNumBatches; ++i) {
+    vectors.push_back(fuzzer.fuzzInputRow(tableType));
+  }
+  auto filePath = TempFilePath::create(/*enableFaultInjection=*/true);
+  createDuckDbTable(vectors);
+  writeToFile(filePath->tempFilePath(), vectors);
+
+  // Slow every read down so IO dominates the scan. That makes the operator's
+  // own wall time a tight bound on how long it can have been blocked.
+  constexpr uint64_t kReadDelayUs = 50'000;
+  faultyFileSystem()->setFileInjectionDelay(
+      kReadDelayUs,
+      {FaultFileOperation::Type::kRead, FaultFileOperation::Type::kReadv});
+  SCOPE_EXIT {
+    faultyFileSystem()->clearFileFaultInjections();
+  };
+
+  gflags::FlagSaver gflagSaver;
+  // Make every data stream eligible for coalescing, so the scan goes through
+  // DirectCoalescedLoad rather than the standalone loadSync() path.
+  FLAGS_cache_prefetch_min_pct = 0;
+
+  // Without an IO executor the coalesced loads stay kPlanned and the query
+  // thread runs them inline from DirectInputStream::loadPosition(). Disable
+  // whole-file preload too, which would serve the data with no coalesced load.
+  connector::ConnectorRegistry::global().erase(kHiveConnectorId);
+  connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector(
+      kHiveConnectorId,
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>{
+              {connector::hive::HiveConfig::kFilePreloadThreshold, "0"}}),
+      /*ioExecutor=*/nullptr);
+  connector::ConnectorRegistry::global().insert(
+      hiveConnector->connectorId(), hiveConnector);
+
+  auto plan =
+      PlanBuilder(pool_.get())
+          .startTableScan()
+          .outputType(ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), BIGINT()}))
+          .endTableScan()
+          .planNode();
+
+  std::unordered_map<std::string, std::string> config;
+  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
+      connectorConfigs = {};
+  // Create query ctx without cache to read through direct buffer input.
+  auto queryCtx = core::QueryCtx::create(
+      executor_.get(),
+      core::QueryConfig(std::move(config)),
+      connectorConfigs,
+      /*cache=*/nullptr);
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .splits(makeHiveConnectorSplits({filePath}))
+                  .queryCtx(queryCtx)
+                  .assertResults("SELECT c0, c1, c2 FROM tmp");
+
+  const auto scanStats = getTableScanStats(task);
+  const auto& stats = scanStats.customStats;
+  // Nothing prefetched, so the query thread read every coalesced load itself.
+  ASSERT_EQ(stats.count("numPrefetch"), 0);
+  // Both timers ran, so the comparisons below are not vacuous.
+  ASSERT_GT(stats.at("coalescedStorageLoadWallNanos").sum, 0);
+  ASSERT_GT(stats.at("storageReadWallNanos").sum, 0);
+
+  // Every read happened on the driver thread inside getOutput(), so the thread
+  // cannot have been blocked for longer than the operator ran. Timing an
+  // inline coalesced load twice pushes the reported wait past that.
+  EXPECT_LE(
+      stats.at("ioWaitWallNanos").sum, scanStats.getOutputTiming.wallNanos);
+
+  // An inline coalesced load is timed into coalescedStorageLoadWallNanos by
+  // loadPosition() and into storageReadWallNanos by loadData(). The query
+  // thread waited out one of those intervals, not both, so its wait has to
+  // come in strictly under their sum.
+  EXPECT_LT(
+      stats.at("ioWaitWallNanos").sum,
+      stats.at("coalescedStorageLoadWallNanos").sum +
+          stats.at("storageReadWallNanos").sum);
 }
 
 DEBUG_ONLY_TEST_F(TableScanTest, pendingCoalescedIoWhenTaskFailed) {


### PR DESCRIPTION
Summary: `DirectCoalescedLoad::loadData` increments `queryThreadIoLatencyUs`, but it runs on whichever thread performs the read. For a read-ahead that is the prefetch executor, so the scan reports time no query thread spent waiting. For an inline load, `DirectInputStream::loadPosition` has already timed the same read, so it is double counted. Drop the increment. `storageReadLatencyUs` keeps it, so the read still counts as storage time.

Differential Revision: D118211460


