### PR TITLE
fix(exec): Finish grouped tasks without split groups (#18780)

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1875,6 +1875,8 @@ void Task::noMoreSplitsForGroup(
 void Task::noMoreSplits(const core::PlanNodeId& planNodeId) {
   std::vector<ContinuePromise> splitPromises;
   bool allFinished;
+  std::shared_ptr<OutputBufferManager> outputBufferManager;
+  std::optional<uint32_t> numOutputDrivers;
   std::shared_ptr<InMemoryExchangeClient> exchangeClient;
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
@@ -1917,10 +1919,21 @@ void Task::noMoreSplits(const core::PlanNodeId& planNodeId) {
     }
 
     allFinished = checkNoMoreSplitGroupsLocked();
+    if (isGroupedExecution() && numDriversPerSplitGroup_ != 0 &&
+        allNodesReceivedNoMoreSplitsMessageLocked() &&
+        groupedPartitionedOutput_) {
+      outputBufferManager = bufferManager_.lock();
+      numOutputDrivers =
+          numDriversInPartitionedOutput_ * seenSplitGroups_.size();
+    }
 
     if (!isRunningLocked()) {
       exchangeClient = getExchangeClientLocked(planNodeId);
     }
+  }
+
+  if (outputBufferManager != nullptr) {
+    outputBufferManager->updateNumDrivers(taskId(), *numOutputDrivers);
   }
 
   for (auto& promise : splitPromises) {
@@ -2147,13 +2160,6 @@ bool Task::checkNoMoreSplitGroupsLocked() {
       allNodesReceivedNoMoreSplitsMessageLocked()) {
     numTotalDrivers_ = seenSplitGroups_.size() * numDriversPerSplitGroup_ +
         numDriversUngrouped_;
-    if (groupedPartitionedOutput_) {
-      if (auto manager = bufferManager_.lock()) {
-        manager->updateNumDrivers(
-            taskId(), numDriversInPartitionedOutput_ * seenSplitGroups_.size());
-      }
-    }
-
     return checkIfFinishedLocked();
   }
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axiom/pull/1814

Grouped execution could hang when a fixed task received no split groups. `Task::noMoreSplits()` reduced its partitioned-output driver count to zero while holding the task mutex, and the synchronous output-buffer completion callback tried to reacquire that mutex.

Move output-buffer driver-count updates outside the task lock. LocalRunner now aggregates statistics from tasks whose pipelines have no operators, which is the expected shape for an empty fixed task.

Differential Revision: D118221440
