### PR TITLE
feat: Add API for registering operator-aggregated runtime metrics

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -14,13 +14,29 @@
  * limitations under the License.
  */
 
-#include <folly/ThreadLocal.h>
+#include <mutex>
+#include <unordered_set>
 
+#include <folly/ThreadLocal.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/base/SuccinctPrinter.h"
 
 namespace facebook::velox {
+
+namespace {
+
+struct RuntimeMetricAggregationRegistry {
+  std::mutex mutex;
+  std::unordered_set<std::string> names;
+};
+
+RuntimeMetricAggregationRegistry& runtimeMetricAggregationRegistry() {
+  static RuntimeMetricAggregationRegistry registry;
+  return registry;
+}
+
+} // namespace
 
 void RuntimeMetric::addValue(int64_t value) {
   sum += value;
@@ -32,6 +48,24 @@ void RuntimeMetric::addValue(int64_t value) {
 void RuntimeMetric::aggregate() {
   count = std::min(count, static_cast<uint64_t>(1));
   min = max = sum;
+}
+
+void registerRuntimeMetricForOperatorAggregation(std::string name) {
+  auto& registry = runtimeMetricAggregationRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  registry.names.insert(std::move(name));
+}
+
+void unregisterRuntimeMetricForOperatorAggregation(std::string_view name) {
+  auto& registry = runtimeMetricAggregationRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  registry.names.erase(std::string(name));
+}
+
+bool isRuntimeMetricAggregatedPerOperator(std::string_view name) {
+  auto& registry = runtimeMetricAggregationRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  return registry.names.contains(std::string(name));
 }
 
 void RuntimeMetric::merge(const RuntimeCounter& value) {

--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/SuccinctPrinter.h"
 
 #include <folly/Synchronized.h>
@@ -29,6 +29,39 @@ folly::Synchronized<folly::F14FastSet<std::string>>&
 operatorAggregatedMetrics() {
   static folly::Synchronized<folly::F14FastSet<std::string>> registry;
   return registry;
+}
+
+const folly::F14FastSet<std::string>& defaultOperatorAggregatedMetrics() {
+  static const folly::F14FastSet<std::string> metrics{
+      "cacheWaitWallNanos",
+      "coalescedSsdLoadWallNanos",
+      "coalescedStorageLoadWallNanos",
+      "dataSourceAddSplitWallNanos",
+      "dataSourceLazyCpuNanos",
+      "dataSourceLazyWallNanos",
+      "dataSourceLazyInputBytes",
+      "dataSourceReadWallNanos",
+      "driverCpuTimeNanos",
+      "flushTimes",
+      "ioWaitWallNanos",
+      "prefetchBytes",
+      "preloadSplitPrepareTimeNanos",
+      "preloadedSplits",
+      "ramReadBytes",
+      "readyPreloadedSplits",
+      "rpcCongestionWindowFinal",
+      "rpcPeakInFlight",
+      "rpcBaselineRttNanos",
+      "rpcRttMinWallNanos",
+      "rpcRttMaxWallNanos",
+      "rpcStreamingMode",
+      "queuedWallNanos",
+      "storageReadWallNanos",
+      "storageReadBytes",
+      "ssdCacheReadWallNanos",
+      "waitForPreloadSplitNanos",
+  };
+  return metrics;
 }
 
 } // namespace
@@ -46,18 +79,39 @@ void RuntimeMetric::aggregate() {
 }
 
 void OperatorAggregatedMetrics::add(std::string name) {
-  operatorAggregatedMetrics().withWLock(
-      [&](auto& metrics) { metrics.insert(std::move(name)); });
+  VELOX_CHECK(
+      !defaultOperatorAggregatedMetrics().contains(name),
+      "Metric is built in for operator aggregation: {}",
+      name);
+  operatorAggregatedMetrics().withWLock([&](auto& metrics) {
+    const auto inserted = metrics.insert(name).second;
+    VELOX_CHECK(
+        inserted,
+        "Metric is already registered for operator aggregation: {}",
+        name);
+  });
 }
 
-void OperatorAggregatedMetrics::remove(std::string_view name) {
-  operatorAggregatedMetrics().withWLock(
-      [&](auto& metrics) { metrics.erase(std::string(name)); });
+void OperatorAggregatedMetrics::remove(const std::string& name) {
+  VELOX_CHECK(
+      !defaultOperatorAggregatedMetrics().contains(name),
+      "Metric is built in for operator aggregation: {}",
+      name);
+  operatorAggregatedMetrics().withWLock([&](auto& metrics) {
+    VELOX_CHECK_EQ(
+        metrics.erase(name),
+        1,
+        "Metric is not registered for operator aggregation: {}",
+        name);
+  });
 }
 
-bool OperatorAggregatedMetrics::contains(std::string_view name) {
+bool OperatorAggregatedMetrics::contains(const std::string& name) {
+  if (defaultOperatorAggregatedMetrics().contains(name)) {
+    return true;
+  }
   return operatorAggregatedMetrics().withRLock(
-      [&](const auto& metrics) { return metrics.contains(std::string(name)); });
+      [&](const auto& metrics) { return metrics.contains(name); });
 }
 
 void RuntimeMetric::merge(const RuntimeCounter& value) {

--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -14,25 +14,20 @@
  * limitations under the License.
  */
 
-#include <mutex>
-#include <unordered_set>
-
-#include <folly/ThreadLocal.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/base/SuccinctPrinter.h"
+
+#include <folly/Synchronized.h>
+#include <folly/container/F14Set.h>
 
 namespace facebook::velox {
 
 namespace {
 
-struct RuntimeMetricAggregationRegistry {
-  std::mutex mutex;
-  std::unordered_set<std::string> names;
-};
-
-RuntimeMetricAggregationRegistry& runtimeMetricAggregationRegistry() {
-  static RuntimeMetricAggregationRegistry registry;
+folly::Synchronized<folly::F14FastSet<std::string>>&
+operatorAggregatedMetrics() {
+  static folly::Synchronized<folly::F14FastSet<std::string>> registry;
   return registry;
 }
 
@@ -50,22 +45,19 @@ void RuntimeMetric::aggregate() {
   min = max = sum;
 }
 
-void registerRuntimeMetricForOperatorAggregation(std::string name) {
-  auto& registry = runtimeMetricAggregationRegistry();
-  std::lock_guard<std::mutex> lock(registry.mutex);
-  registry.names.insert(std::move(name));
+void OperatorAggregatedMetrics::add(std::string name) {
+  operatorAggregatedMetrics().withWLock(
+      [&](auto& metrics) { metrics.insert(std::move(name)); });
 }
 
-void unregisterRuntimeMetricForOperatorAggregation(std::string_view name) {
-  auto& registry = runtimeMetricAggregationRegistry();
-  std::lock_guard<std::mutex> lock(registry.mutex);
-  registry.names.erase(std::string(name));
+void OperatorAggregatedMetrics::remove(std::string_view name) {
+  operatorAggregatedMetrics().withWLock(
+      [&](auto& metrics) { metrics.erase(std::string(name)); });
 }
 
-bool isRuntimeMetricAggregatedPerOperator(std::string_view name) {
-  auto& registry = runtimeMetricAggregationRegistry();
-  std::lock_guard<std::mutex> lock(registry.mutex);
-  return registry.names.contains(std::string(name));
+bool OperatorAggregatedMetrics::contains(std::string_view name) {
+  return operatorAggregatedMetrics().withRLock(
+      [&](const auto& metrics) { return metrics.contains(std::string(name)); });
 }
 
 void RuntimeMetric::merge(const RuntimeCounter& value) {

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -82,6 +82,16 @@ struct RuntimeMetric {
   std::string toString() const;
 };
 
+/// Registers a runtime metric to be aggregated per operator. Registration is
+/// idempotent.
+void registerRuntimeMetricForOperatorAggregation(std::string name);
+
+/// Removes a runtime metric from per-operator aggregation.
+void unregisterRuntimeMetricForOperatorAggregation(std::string_view name);
+
+/// Returns true if 'name' is registered for per-operator aggregation.
+bool isRuntimeMetricAggregatedPerOperator(std::string_view name);
+
 /// Simple interface to implement writing of runtime stats to Velox Operator
 /// stats.
 /// Inherit a concrete class from this to implement your writing.

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -82,15 +82,18 @@ struct RuntimeMetric {
   std::string toString() const;
 };
 
-/// Registers a runtime metric to be aggregated per operator. Registration is
-/// idempotent.
-void registerRuntimeMetricForOperatorAggregation(std::string name);
+/// Process-global registry of runtime metrics aggregated per operator.
+class OperatorAggregatedMetrics {
+ public:
+  /// Adds a metric name. Registration is idempotent.
+  static void add(std::string name);
 
-/// Removes a runtime metric from per-operator aggregation.
-void unregisterRuntimeMetricForOperatorAggregation(std::string_view name);
+  /// Removes a metric name.
+  static void remove(std::string_view name);
 
-/// Returns true if 'name' is registered for per-operator aggregation.
-bool isRuntimeMetricAggregatedPerOperator(std::string_view name);
+  /// Returns true if 'name' is registered.
+  static bool contains(std::string_view name);
+};
 
 /// Simple interface to implement writing of runtime stats to Velox Operator
 /// stats.

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -82,17 +82,17 @@ struct RuntimeMetric {
   std::string toString() const;
 };
 
-/// Process-global registry of runtime metrics aggregated per operator.
+/// Process-global set of runtime metrics aggregated per operator.
 class OperatorAggregatedMetrics {
  public:
-  /// Adds a metric name. Registration is idempotent.
+  /// Adds a metric name in addition to the built-in names. Throws if present.
   static void add(std::string name);
 
-  /// Removes a metric name.
-  static void remove(std::string_view name);
+  /// Removes a dynamically added metric name. Throws if absent.
+  static void remove(const std::string& name);
 
-  /// Returns true if 'name' is registered.
-  static bool contains(std::string_view name);
+  /// Returns true if 'name' is built in or dynamically added.
+  static bool contains(const std::string& name);
 };
 
 /// Simple interface to implement writing of runtime stats to Velox Operator

--- a/velox/dwio/common/Statistics.cpp
+++ b/velox/dwio/common/Statistics.cpp
@@ -345,8 +345,7 @@ RuntimeStats::toRuntimeMetricMap() const {
   }
   for (const auto& [format, metrics] : formatSpecificStats) {
     for (const auto& [name, metric] : metrics) {
-      result.emplace(
-          fmt::format("{}.{}", FileFormatName::toName(format), name), metric);
+      result.emplace(formatMetricName(format, name), metric);
     }
   }
   for (const auto& [nodeId, statsByFormat] : columnStats) {
@@ -360,5 +359,11 @@ RuntimeStats::toRuntimeMetricMap() const {
     }
   }
   return result;
+}
+
+std::string RuntimeStats::formatMetricName(
+    FileFormat format,
+    std::string_view name) {
+  return fmt::format("{}.{}", FileFormatName::toName(format), name);
 }
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -604,6 +604,9 @@ struct RuntimeStats {
   /// Merges one split's format-specific and per-column statistics.
   void mergeFrom(const SplitStats& split);
 
+  /// Returns the exported name of a format-specific runtime metric.
+  static std::string formatMetricName(FileFormat format, std::string_view name);
+
   // Exports collected counters as runtime metrics.
   std::unordered_map<std::string, RuntimeMetric> toRuntimeMetricMap() const;
 };

--- a/velox/dwio/parquet/RegisterParquetReader.cpp
+++ b/velox/dwio/parquet/RegisterParquetReader.cpp
@@ -15,20 +15,39 @@
  */
 
 #ifdef VELOX_ENABLE_PARQUET
+#include "velox/common/base/RuntimeMetrics.h" // @manual
+#include "velox/dwio/parquet/common/ParquetRuntimeStats.h" // @manual
 #include "velox/dwio/parquet/reader/ParquetReader.h" // @manual
 #endif
 
 namespace facebook::velox::parquet {
 
+#ifdef VELOX_ENABLE_PARQUET
+namespace {
+
+std::string parquetRuntimeMetricName(std::string_view name) {
+  return fmt::format(
+      "{}.{}",
+      dwio::common::FileFormatName::toName(dwio::common::FileFormat::PARQUET),
+      name);
+}
+
+} // namespace
+#endif
+
 void registerParquetReaderFactory() {
 #ifdef VELOX_ENABLE_PARQUET
   dwio::common::registerReaderFactory(std::make_shared<ParquetReaderFactory>());
+  registerRuntimeMetricForOperatorAggregation(
+      parquetRuntimeMetricName(ParquetRuntimeStats::kPageLoadTimeNs));
 #endif
 }
 
 void unregisterParquetReaderFactory() {
 #ifdef VELOX_ENABLE_PARQUET
   dwio::common::unregisterReaderFactory(dwio::common::FileFormat::PARQUET);
+  unregisterRuntimeMetricForOperatorAggregation(
+      parquetRuntimeMetricName(ParquetRuntimeStats::kPageLoadTimeNs));
 #endif
 }
 

--- a/velox/dwio/parquet/RegisterParquetReader.cpp
+++ b/velox/dwio/parquet/RegisterParquetReader.cpp
@@ -16,38 +16,30 @@
 
 #ifdef VELOX_ENABLE_PARQUET
 #include "velox/common/base/RuntimeMetrics.h" // @manual
+#include "velox/dwio/common/Statistics.h" // @manual
 #include "velox/dwio/parquet/common/ParquetRuntimeStats.h" // @manual
 #include "velox/dwio/parquet/reader/ParquetReader.h" // @manual
 #endif
 
 namespace facebook::velox::parquet {
 
-#ifdef VELOX_ENABLE_PARQUET
-namespace {
-
-std::string parquetRuntimeMetricName(std::string_view name) {
-  return fmt::format(
-      "{}.{}",
-      dwio::common::FileFormatName::toName(dwio::common::FileFormat::PARQUET),
-      name);
-}
-
-} // namespace
-#endif
-
 void registerParquetReaderFactory() {
 #ifdef VELOX_ENABLE_PARQUET
   dwio::common::registerReaderFactory(std::make_shared<ParquetReaderFactory>());
-  registerRuntimeMetricForOperatorAggregation(
-      parquetRuntimeMetricName(ParquetRuntimeStats::kPageLoadTimeNs));
+  OperatorAggregatedMetrics::add(
+      dwio::common::RuntimeStats::formatMetricName(
+          dwio::common::FileFormat::PARQUET,
+          ParquetRuntimeStats::kPageLoadTimeNs));
 #endif
 }
 
 void unregisterParquetReaderFactory() {
 #ifdef VELOX_ENABLE_PARQUET
   dwio::common::unregisterReaderFactory(dwio::common::FileFormat::PARQUET);
-  unregisterRuntimeMetricForOperatorAggregation(
-      parquetRuntimeMetricName(ParquetRuntimeStats::kPageLoadTimeNs));
+  OperatorAggregatedMetrics::remove(
+      dwio::common::RuntimeStats::formatMetricName(
+          dwio::common::FileFormat::PARQUET,
+          ParquetRuntimeStats::kPageLoadTimeNs));
 #endif
 }
 

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -154,9 +154,9 @@ bool shouldAggregateRuntimeMetric(const std::string& name) {
       "storageReadBytes",
       "ssdCacheReadWallNanos",
       "waitForPreloadSplitNanos",
-      "parquet.pageLoadTimeNanos",
   };
-  if (metricNames.contains(name)) {
+  if (metricNames.contains(name) ||
+      isRuntimeMetricAggregatedPerOperator(name)) {
     return true;
   }
 

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -126,36 +126,7 @@ void gatherCopy(
 // We want to aggregate some operator runtime metrics per operator rather than
 // per event. This function returns true for such metrics.
 bool shouldAggregateRuntimeMetric(const std::string& name) {
-  static const folly::F14FastSet<std::string> metricNames{
-      "cacheWaitWallNanos",
-      "coalescedSsdLoadWallNanos",
-      "coalescedStorageLoadWallNanos",
-      "dataSourceAddSplitWallNanos",
-      "dataSourceLazyCpuNanos",
-      "dataSourceLazyWallNanos",
-      "dataSourceLazyInputBytes",
-      "dataSourceReadWallNanos",
-      "driverCpuTimeNanos",
-      "flushTimes",
-      "ioWaitWallNanos",
-      "prefetchBytes",
-      "preloadSplitPrepareTimeNanos",
-      "preloadedSplits",
-      "ramReadBytes",
-      "readyPreloadedSplits",
-      "rpcCongestionWindowFinal",
-      "rpcPeakInFlight",
-      "rpcBaselineRttNanos",
-      "rpcRttMinWallNanos",
-      "rpcRttMaxWallNanos",
-      "rpcStreamingMode",
-      "queuedWallNanos",
-      "storageReadWallNanos",
-      "storageReadBytes",
-      "ssdCacheReadWallNanos",
-      "waitForPreloadSplitNanos",
-  };
-  if (metricNames.contains(name) || OperatorAggregatedMetrics::contains(name)) {
+  if (OperatorAggregatedMetrics::contains(name)) {
     return true;
   }
 

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -155,8 +155,7 @@ bool shouldAggregateRuntimeMetric(const std::string& name) {
       "ssdCacheReadWallNanos",
       "waitForPreloadSplitNanos",
   };
-  if (metricNames.contains(name) ||
-      isRuntimeMetricAggregatedPerOperator(name)) {
+  if (metricNames.contains(name) || OperatorAggregatedMetrics::contains(name)) {
     return true;
   }
 

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -616,6 +616,25 @@ TEST_F(OperatorUtilsTest, setOperatorRuntimeStats) {
   ASSERT_EQ(stats[std::string(statsName)].min, 100);
 }
 
+TEST_F(OperatorUtilsTest, registeredRuntimeMetricAggregation) {
+  constexpr std::string_view kMetricName = "registeredMetric";
+  registerRuntimeMetricForOperatorAggregation(std::string(kMetricName));
+
+  std::unordered_map<std::string, RuntimeMetric> stats;
+  auto& metric =
+      stats.emplace(std::string(kMetricName), RuntimeMetric{}).first->second;
+  metric.addValue(10);
+  metric.addValue(20);
+  aggregateOperatorRuntimeStats(stats);
+
+  EXPECT_EQ(metric.sum, 30);
+  EXPECT_EQ(metric.count, 1);
+  EXPECT_EQ(metric.min, 30);
+  EXPECT_EQ(metric.max, 30);
+
+  unregisterRuntimeMetricForOperatorAggregation(kMetricName);
+}
+
 TEST_F(OperatorUtilsTest, initializeRowNumberMapping) {
   BufferPtr mapping;
   auto rawMapping = initializeRowNumberMapping(mapping, 10, pool());

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -616,9 +616,9 @@ TEST_F(OperatorUtilsTest, setOperatorRuntimeStats) {
   ASSERT_EQ(stats[std::string(statsName)].min, 100);
 }
 
-TEST_F(OperatorUtilsTest, registeredRuntimeMetricAggregation) {
+TEST_F(OperatorUtilsTest, operatorAggregatedMetrics) {
   constexpr std::string_view kMetricName = "registeredMetric";
-  registerRuntimeMetricForOperatorAggregation(std::string(kMetricName));
+  OperatorAggregatedMetrics::add(std::string(kMetricName));
 
   std::unordered_map<std::string, RuntimeMetric> stats;
   auto& metric =
@@ -632,7 +632,7 @@ TEST_F(OperatorUtilsTest, registeredRuntimeMetricAggregation) {
   EXPECT_EQ(metric.min, 30);
   EXPECT_EQ(metric.max, 30);
 
-  unregisterRuntimeMetricForOperatorAggregation(kMetricName);
+  OperatorAggregatedMetrics::remove(kMetricName);
 }
 
 TEST_F(OperatorUtilsTest, initializeRowNumberMapping) {

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -617,12 +617,20 @@ TEST_F(OperatorUtilsTest, setOperatorRuntimeStats) {
 }
 
 TEST_F(OperatorUtilsTest, operatorAggregatedMetrics) {
-  constexpr std::string_view kMetricName = "registeredMetric";
-  OperatorAggregatedMetrics::add(std::string(kMetricName));
+  EXPECT_TRUE(OperatorAggregatedMetrics::contains("storageReadBytes"));
+  EXPECT_THROW(
+      OperatorAggregatedMetrics::add("storageReadBytes"), VeloxException);
+  EXPECT_THROW(
+      OperatorAggregatedMetrics::remove("storageReadBytes"), VeloxException);
+  EXPECT_THROW(
+      OperatorAggregatedMetrics::remove("unregisteredMetric"), VeloxException);
+
+  const std::string kMetricName = "registeredMetric";
+  OperatorAggregatedMetrics::add(kMetricName);
+  EXPECT_THROW(OperatorAggregatedMetrics::add(kMetricName), VeloxException);
 
   std::unordered_map<std::string, RuntimeMetric> stats;
-  auto& metric =
-      stats.emplace(std::string(kMetricName), RuntimeMetric{}).first->second;
+  auto& metric = stats.emplace(kMetricName, RuntimeMetric{}).first->second;
   metric.addValue(10);
   metric.addValue(20);
   aggregateOperatorRuntimeStats(stats);
@@ -633,6 +641,7 @@ TEST_F(OperatorUtilsTest, operatorAggregatedMetrics) {
   EXPECT_EQ(metric.max, 30);
 
   OperatorAggregatedMetrics::remove(kMetricName);
+  EXPECT_THROW(OperatorAggregatedMetrics::remove(kMetricName), VeloxException);
 }
 
 TEST_F(OperatorUtilsTest, initializeRowNumberMapping) {


### PR DESCRIPTION
The patch adds APIs to register / unregister operator-aggregated runtime metrics, and refactor the current format-specific metric registration accordingly.

This is to address review comment https://github.com/facebookincubator/velox/pull/18063#pullrequestreview-5067077881.