### PR TITLE
fix(iceberg): Do not read timestamp default values as localtime

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -1134,8 +1134,8 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
                 columnType,
                 it->second->initialDefaultValue().value(),
                 connectorQueryCtx_->memoryPool(),
-                readTimestampAsLocalTime,
-                false));
+                /*isLocalTimestamp=*/false,
+                /*isDaysSinceEpoch=*/false));
           } else {
             // Fall back to NULL if no default value.
             VELOX_CHECK_NOT_NULL(

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -811,12 +811,7 @@ TEST_F(IcebergReadTest, addColumnWithDefaultAllTypes) {
             Timestamp(1705314600, 0)})})};
 
   assertDefaultValues(
-      newRowType,
-      newRowType,
-      assignments,
-      dataVectors,
-      expectedVectors,
-      {{HiveConfig::kReadTimestampPartitionValueAsLocalTimeSession, "false"}});
+      newRowType, newRowType, assignments, dataVectors, expectedVectors);
 }
 
 TEST_F(IcebergReadTest, addColumnWithInvalidDefault) {


### PR DESCRIPTION
We are trying to read the initial default values for timestamp in local time zone. This is incorrect since default values represent UTC instant. This fix is required for https://github.com/prestodb/presto/pull/28380 