### PR TITLE
perf(nimble): Slice BlockBitPacking partial blocks structurally instead of repacking

### DIFF
--- a/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -34,6 +34,7 @@
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/compression/Compression.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
@@ -270,23 +271,6 @@ class BlockBitPackingEncoding final
     return std::min(trivialSize, fixedBitWidthSize);
   }
 
-  struct BlockSliceInfo {
-    // Source block that contributes rows to this output block.
-    uint32_t blockIndex{0};
-    // Byte offset of the source block payload, adjusted for raw partial blocks.
-    uint32_t packedOffset{0};
-    // First row copied from the source block.
-    uint32_t rowOffset{0};
-    // Bytes written for this output block.
-    uint32_t packedSize{0};
-    // Rows written for this output block.
-    uint32_t rowCount{0};
-    // Output bit width; zero also represents constant blocks.
-    uint8_t bitWidth{0};
-    // True when the payload is copied as raw physical values.
-    bool skipEncoding{false};
-  };
-
   // Parsed stream metadata. lastBlockRows is derived from rowCount and the
   // first-block override; it is not serialized.
   struct Header {
@@ -469,13 +453,25 @@ class BlockBitPackingEncoding final
     return static_cast<uint32_t>(FixedBitArray::bufferSize(rowCount, bitWidth));
   }
 
-  static void writeBlockSlicesPayload(
-      const Header& header,
+  // Writes a BlockBitPacking encoding that covers the source's blocks
+  // [firstBlock, firstBlock + numBlocks) whole -- baselines / bit widths
+  // structurally sliced, block offsets rebased and re-encoded, packed payload
+  // memcpy'd verbatim from the source.
+  //
+  // `rowCount` is the row count written into the emitted encoding's prefix.
+  // slice() passes the request length for block-aligned requests -- the
+  // emitted encoding is the final output. For mid-block requests it passes
+  // the sum of touched block row counts (larger than the request), and then
+  // wraps the result in a SliceEncoding whose leadingSkipRows and length
+  // trim the boundary-block overhang at decode time.
+  static std::string_view sliceBlockRange(
+      const Header& source,
       std::string_view packedData,
-      std::span<const BlockSliceInfo> blockSlices,
-      std::span<const uint32_t> sliceOffsets,
-      uint32_t totalPackedSize,
-      char*& pos);
+      uint32_t rowCount,
+      uint32_t firstBlock,
+      uint32_t numBlocks,
+      Buffer& buffer,
+      const Encoding::Options& options);
 
   // Reads a single decoded value at the given absolute row index.
   physicalType readSingleValue(uint32_t row) const;
@@ -603,69 +599,6 @@ BlockBitPackingEncoding<T>::makeBlockInfo(
       start,
       count,
       false};
-}
-
-template <typename T>
-void BlockBitPackingEncoding<T>::writeBlockSlicesPayload(
-    const Header& header,
-    std::string_view packedData,
-    std::span<const BlockSliceInfo> blockSlices,
-    std::span<const uint32_t> sliceOffsets,
-    uint32_t totalPackedSize,
-    char*& pos) {
-  std::memset(pos, 0, totalPackedSize);
-  uint32_t dataOffset{0};
-  const auto needsBitCopy = [&](const BlockSliceInfo& blockSlice) {
-    return !blockSlice.skipEncoding && blockSlice.bitWidth != 0 &&
-        (blockSlice.rowOffset != 0 ||
-         blockSlice.rowCount != blockRowCount(header, blockSlice.blockIndex));
-  };
-  const auto copyBlockBitsRange = [&](uint32_t blockIndex) {
-    const auto& blockSlice = blockSlices[blockIndex];
-
-    const auto sourceBitOffset =
-        static_cast<uint64_t>(blockSlice.rowOffset) * blockSlice.bitWidth;
-    const auto sliceBits =
-        static_cast<uint64_t>(blockSlice.rowCount) * blockSlice.bitWidth;
-    encoding::copyPackedBits(
-        packedData.substr(blockSlice.packedOffset),
-        sourceBitOffset,
-        sliceBits,
-        pos + dataOffset);
-    dataOffset += blockSlice.packedSize;
-  };
-
-  const auto numBlocks = static_cast<uint32_t>(blockSlices.size());
-  const bool firstNeedsBitCopy = needsBitCopy(blockSlices[0]);
-  const bool lastNeedsBitCopy =
-      numBlocks > 1 && needsBitCopy(blockSlices[numBlocks - 1]);
-  if (firstNeedsBitCopy) {
-    copyBlockBitsRange(/*blockIndex=*/0);
-  }
-
-  uint32_t packedBegin = firstNeedsBitCopy ? 1 : 0;
-  const uint32_t packedEnd = lastNeedsBitCopy ? numBlocks - 1 : numBlocks;
-  // Constant blocks have rows but no packed payload (bit width 0). They still
-  // participate in slice offsets, but cannot anchor the source byte range for
-  // the coalesced copy.
-  while (packedBegin < packedEnd && blockSlices[packedBegin].packedSize == 0) {
-    ++packedBegin;
-  }
-  if (packedBegin < packedEnd) {
-    NIMBLE_CHECK_EQ(dataOffset, sliceOffsets[packedBegin]);
-    const auto packedEndOffset = sliceOffsets[packedEnd];
-    const auto packedBytes = packedEndOffset - sliceOffsets[packedBegin];
-    std::memcpy(
-        pos + dataOffset,
-        packedData.data() + blockSlices[packedBegin].packedOffset,
-        packedBytes);
-    dataOffset += packedBytes;
-  }
-
-  if (lastNeedsBitCopy) {
-    copyBlockBitsRange(numBlocks - 1);
-  }
-  pos += totalPackedSize;
 }
 
 template <typename T>
@@ -1288,9 +1221,44 @@ std::string_view BlockBitPackingEncoding<T>::slice(
       kMaxBlockCount,
       "Row count too large for BlockBitPacking encoding.");
 
+  // Write a BlockBitPacking that covers the touched source blocks whole. When
+  // the request lines up with block boundaries this is the final output; when
+  // either boundary is mid-block, the output covers more rows than requested
+  // and a SliceEncoding wrapper trims the overhang at decode time. Boundary
+  // blocks are copied byte-for-byte either way -- no per-value bit-shift work.
+  const auto startRow = blockRowOffset(source, firstBlock);
+  const auto endRow =
+      blockRowOffset(source, lastBlock) + blockRowCount(source, lastBlock);
+  const auto encodedRows = endRow - startRow;
+  const auto skipLeadingRows = offset - startRow;
+
+  const auto encodedBlockRange = sliceBlockRange(
+      source, packedData, encodedRows, firstBlock, numBlocks, buffer, options);
+  if (encodedRows == length) {
+    return encodedBlockRange;
+  }
+  return SliceEncoding<T>::wrap(
+      encodedBlockRange, skipLeadingRows, length, buffer, options);
+}
+
+template <typename T>
+std::string_view BlockBitPackingEncoding<T>::sliceBlockRange(
+    const Header& source,
+    std::string_view packedData,
+    uint32_t rowCount,
+    uint32_t firstBlock,
+    uint32_t numBlocks,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  auto* pool = &buffer.getMemoryPool();
+
+  // Read the touched blocks' per-block byte offsets, then rebase them so the
+  // first is at 0 (positions in the output's own packedData). The rebase
+  // happens in place -- the source values are only needed to derive the
+  // payload byte range below, which is captured first.
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   ScopedVector<uint32_t> blockOffsets{
       static_cast<uint64_t>(numBlocks) + 1, pool, options.bufferPool};
-  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   readBlockOffsets(
       source,
       firstBlock,
@@ -1299,60 +1267,27 @@ std::string_view BlockBitPackingEncoding<T>::slice(
       blockOffsets,
       scopedBuffer.get(),
       options);
-
-  const auto getPackedSize = [&](uint32_t blockIndex) {
-    const auto blockOffset = blockIndex - firstBlock;
-    return blockOffsets[blockOffset + 1] - blockOffsets[blockOffset];
-  };
-  ScopedVector<uint8_t> bitWidths{numBlocks, pool, options.bufferPool};
-  readMetadataRange(
-      source.encodedBitWidths,
-      firstBlock,
-      numBlocks,
-      bitWidths,
-      scopedBuffer.get(),
-      options);
-  const auto getBlockBitWidth = [&](uint32_t blockIndex) {
-    return bitWidths[blockIndex - firstBlock];
-  };
-
-  ScopedVector<BlockSliceInfo> blockSlices{numBlocks, pool, options.bufferPool};
-  ScopedVector<uint32_t> sliceOffsets{
-      static_cast<uint64_t>(numBlocks) + 1, pool, options.bufferPool};
-  uint32_t totalPackedSize{0};
-  uint32_t curRow{offset};
-  const auto endRow = offset + length;
-  for (uint16_t sliceIndex = 0; sliceIndex < numBlocks; ++sliceIndex) {
-    const auto position = blockPosition(source, curRow);
-    const auto blockIndex = position.blockIndex;
-    NIMBLE_CHECK_EQ(blockIndex, firstBlock + sliceIndex);
-    const auto rowOffset = position.rowOffset;
-    const auto rowCount =
-        std::min<uint32_t>(endRow - curRow, position.rowCount - rowOffset);
-    const auto fullBlock = rowOffset == 0 && rowCount == position.rowCount;
-    const auto bitWidth = fullBlock ? uint8_t{0} : getBlockBitWidth(blockIndex);
-    const auto skipEncoding = bitWidth == kRawBlockBitWidth;
-    const uint32_t packedOffsetAdjustment = skipEncoding
-        ? static_cast<uint32_t>(rowOffset * sizeof(physicalType))
-        : uint32_t{0};
-    blockSlices[sliceIndex] = {
-        .blockIndex = blockIndex,
-        .packedOffset =
-            blockOffsets[blockIndex - firstBlock] + packedOffsetAdjustment,
-        .rowOffset = rowOffset,
-        .packedSize = fullBlock
-            ? getPackedSize(blockIndex)
-            : BlockBitPackingEncoding::getPackedSize(rowCount, bitWidth),
-        .rowCount = rowCount,
-        .bitWidth = skipEncoding ? uint8_t{0} : bitWidth,
-        .skipEncoding = skipEncoding};
-    sliceOffsets[sliceIndex] = totalPackedSize;
-    totalPackedSize += blockSlices[sliceIndex].packedSize;
-    curRow += rowCount;
+  const uint32_t sourcePayloadStart = blockOffsets[0];
+  const uint32_t packedPayloadSize =
+      blockOffsets[numBlocks] - sourcePayloadStart;
+  for (uint32_t i = 0; i < numBlocks; ++i) {
+    blockOffsets[i] -= sourcePayloadStart;
   }
-  sliceOffsets[numBlocks] = totalPackedSize;
-  NIMBLE_CHECK_EQ(curRow, endRow);
+  // TODO: An OffsetEncoding wrapper that carries a constant delta over an
+  // inner encoding could replace this re-encode with a structural slice -- the
+  // rebase becomes "wrap the source offsets and record -sourcePayloadStart".
+  // Same shape would let FixedBitWidth / PFOR skip their own baseline
+  // re-encodes on slice too; worth a look if the offset re-encode ever shows
+  // up on a profile.
+  const auto encodedOffsets =
+      EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+          source.encodedBlockOffsets,
+          std::span<const uint32_t>{blockOffsets.data(), numBlocks},
+          scopedBuffer.get(),
+          options,
+          "Captured BlockBitPacking offset layout");
 
+  // Structurally slice the metadata sub-encodings -- values are unchanged.
   const auto encodedBaselines = EncodingFactory::slice(
       source.encodedBaselines,
       firstBlock,
@@ -1365,15 +1300,8 @@ std::string_view BlockBitPackingEncoding<T>::slice(
       numBlocks,
       scopedBuffer.get(),
       options);
-  const auto encodedOffsets =
-      EncodingFactory::encodeWithCapturedLayout<uint32_t>(
-          source.encodedBlockOffsets,
-          std::span<const uint32_t>{sliceOffsets.data(), numBlocks},
-          scopedBuffer.get(),
-          options,
-          "Captured BlockBitPacking offset layout");
 
-  const auto firstBlockRows = blockSlices[0].rowCount;
+  const auto firstBlockRows = blockRowCount(source, firstBlock);
   const uint32_t headerSize = BlockBitPackingEncoding<T>::headerSize(
       source.blockSize,
       numBlocks,
@@ -1382,18 +1310,18 @@ std::string_view BlockBitPackingEncoding<T>::slice(
       static_cast<uint32_t>(encodedOffsets.size()),
       firstBlockRows);
   const uint32_t encodingSize = Encoding::serializePrefixSize(
-                                    length, options.useVarintRowCount) +
+                                    rowCount, options.useVarintRowCount) +
       headerSize +
       static_cast<uint32_t>(encodedBaselines.size() + encodedBitWidths.size() +
                             encodedOffsets.size()) +
-      totalPackedSize;
+      packedPayloadSize;
 
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
       EncodingType::BlockBitPacking,
       TypeTraits<T>::dataType,
-      length,
+      rowCount,
       options.useVarintRowCount,
       pos);
   encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
@@ -1404,15 +1332,12 @@ std::string_view BlockBitPackingEncoding<T>::slice(
   encoding::writeVarintString(encodedOffsets, pos);
   varint::writeVarint(firstBlockRows, &pos);
 
-  writeBlockSlicesPayload(
-      source,
-      packedData,
-      std::span<const BlockSliceInfo>{blockSlices.data(), blockSlices.size()},
-      std::span<const uint32_t>{sliceOffsets.data(), sliceOffsets.size()},
-      totalPackedSize,
-      pos);
-
-  NIMBLE_CHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+  // Touched blocks are contiguous in the source's packedData, so a single
+  // memcpy carries the payload -- constant blocks contribute 0 bytes, raw
+  // blocks are wholesale, bit-packed blocks are byte-copied as-is.
+  std::memcpy(pos, packedData.data() + sourcePayloadStart, packedPayloadSize);
+  pos += packedPayloadSize;
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/velox/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
@@ -302,9 +302,14 @@ TEST_F(BlockBitPackingEncodingTest, compressionRoundTrip) {
 TEST_F(BlockBitPackingEncodingTest, slice) {
   using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
   constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+  // Ranges whose boundaries sit inside a block come back wrapped in a
+  // SliceEncoding; ranges that hit block boundaries stay a plain
+  // BlockBitPacking. The last range covers exactly the partial trailing block
+  // (137 rows).
   struct Range {
     uint32_t offset;
     uint32_t length;
+    nimble::EncodingType expectedType;
   };
 
   std::vector<uint32_t> input(blockSize * 3 + 137);
@@ -322,11 +327,18 @@ TEST_F(BlockBitPackingEncodingTest, slice) {
   const auto encoded = nimble::test::Encoder<Enc>::encode(*buffer_, values);
 
   for (const auto range :
-       {Range{/*offset=*/0, /*length=*/128},
-        Range{/*offset=*/blockSize - 13, /*length=*/64},
-        Range{/*offset=*/blockSize + 17, /*length=*/blockSize + 29},
+       {Range{/*offset=*/0,
+              /*length=*/128,
+              nimble::EncodingType::Slice},
+        Range{/*offset=*/blockSize - 13,
+              /*length=*/64,
+              nimble::EncodingType::Slice},
+        Range{/*offset=*/blockSize + 17,
+              /*length=*/blockSize + 29,
+              nimble::EncodingType::Slice},
         Range{/*offset=*/static_cast<uint32_t>(input.size() - 137),
-              /*length=*/137}}) {
+              /*length=*/137,
+              nimble::EncodingType::BlockBitPacking}}) {
     SCOPED_TRACE(
         testing::Message() << "offset=" << range.offset
                            << " length=" << range.length);
@@ -334,14 +346,10 @@ TEST_F(BlockBitPackingEncodingTest, slice) {
     const auto sliced = nimble::EncodingFactory::slice(
         encoded, range.offset, range.length, sliceBuffer);
 
-    EXPECT_EQ(
-        nimble::EncodingPrefix::encodingType(sliced),
-        nimble::EncodingType::BlockBitPacking);
-    EXPECT_EQ(
-        nimble::EncodingPrefix::readRowCount(sliced, /*useVarint=*/false),
-        range.length);
+    EXPECT_EQ(nimble::EncodingPrefix::encodingType(sliced), range.expectedType);
 
     auto encoding = nimble::EncodingFactory{}.create(*pool_, sliced, nullptr);
+    EXPECT_EQ(encoding->rowCount(), range.length);
     std::vector<uint32_t> output(range.length);
     encoding->materialize(range.length, output.data());
     const std::vector<uint32_t> expected{
@@ -489,8 +497,11 @@ TEST_F(BlockBitPackingEncodingTest, sliceCompressedSource) {
   const auto encoded = nimble::test::Encoder<Enc>::encode(
       *buffer_, values, nimble::CompressionType::Zstd);
 
-  constexpr uint32_t kOffset{31};
-  constexpr uint32_t kLength{blockSize + 7};
+  // Block-aligned so the slice stays a plain BlockBitPacking rather than
+  // coming back wrapped in a SliceEncoding -- the compression-type byte read
+  // below is only meaningful at the BlockBitPacking header offset.
+  constexpr uint32_t kOffset{0};
+  constexpr uint32_t kLength{blockSize};
   nimble::Buffer sliceBuffer{*pool_};
   const auto sliced =
       nimble::EncodingFactory::slice(encoded, kOffset, kLength, sliceBuffer);

--- a/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
@@ -282,6 +282,16 @@ class EncodingSliceTest : public ::testing::Test {
         expectedEncodingType = nimble::EncodingType::Slice;
       }
     }
+    if constexpr (std::is_same_v<
+                      EncodingType,
+                      nimble::BlockBitPackingEncoding<T>>) {
+      // A range whose boundary sits inside a block keeps the boundary blocks
+      // whole and comes back wrapped. This test's sources fit in one block, so
+      // any range that isn't the full source is mid-block.
+      if (offset > 0 || offset + length < values.size()) {
+        expectedEncodingType = nimble::EncodingType::Slice;
+      }
+    }
 
     EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
     EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
@@ -361,9 +371,17 @@ TYPED_TEST(EncodingSliceTypedTest, materializesRange) {
   constexpr uint32_t offset{1};
   constexpr uint32_t length{3};
 
+  // BlockBitPacking with default blockSize (1024) fits the 6-value source in
+  // one block, so this mid-block range comes back wrapped in a SliceEncoding.
+  auto expectedType = nimble::test::Encoder<EncodingType>::encodingType();
+  if constexpr (std::is_same_v<
+                    EncodingType,
+                    nimble::BlockBitPackingEncoding<uint32_t>>) {
+    expectedType = nimble::EncodingType::Slice;
+  }
   this->template expectSliceMaterializes<EncodingType>(
       nimble::toString(nimble::test::Encoder<EncodingType>::encodingType()),
-      nimble::test::Encoder<EncodingType>::encodingType(),
+      expectedType,
       values,
       offset,
       length);

--- a/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
@@ -53,7 +54,16 @@ class SliceEncodingTest : public ::testing::Test {
   }
 
   std::unique_ptr<nimble::Encoding> createEncoding(std::string_view encoded) {
-    return nimble::EncodingFactory{}.create(
+    return createEncoding(encoded, nimble::Encoding::Options{});
+  }
+
+  // Reads the encoded blob with the given options. Matches the options used
+  // at write time -- required when useVarintRowCount is set, otherwise the
+  // outer prefix parses wrong and any nested construction cascades.
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      std::string_view encoded,
+      const nimble::Encoding::Options& options) {
+    return nimble::EncodingFactory{options}.create(
         *pool_, encoded, [](uint32_t /*totalLength*/) -> void* {
           return nullptr;
         });
@@ -61,8 +71,19 @@ class SliceEncodingTest : public ::testing::Test {
 
   std::string_view
   slice(std::string_view encoded, uint32_t offset, uint32_t length) {
+    return slice(encoded, offset, length, nimble::Encoding::Options{});
+  }
+
+  // Slices the encoded blob with the given options. Matches the options used
+  // at write time -- required when a per-encoding option (e.g.
+  // useVarintRowCount) must be honoured through the factory dispatch.
+  std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      const nimble::Encoding::Options& options) {
     return nimble::EncodingFactory::slice(
-        encoded, offset, length, *buffer_, nimble::Encoding::Options{});
+        encoded, offset, length, *buffer_, options);
   }
 
   template <typename T>
@@ -290,6 +311,272 @@ TEST_F(SliceEncodingTest, boolSkipIsRelativeToSlice) {
   encoding->materializeBoolsAsBits(/*rowCount=*/2, &bits, /*begin=*/0);
   EXPECT_TRUE(velox::bits::isBitSet(&bits, 0));
   EXPECT_FALSE(velox::bits::isBitSet(&bits, 1));
+}
+
+// --- Deferred BlockBitPacking partial-block slicing ----------------------
+//
+// A slice that starts or ends inside a block keeps the boundary blocks whole
+// and wraps the result, instead of unpack+re-packing the partial rows into
+// byte-aligned slots.
+
+// Builds a BlockBitPacking source with several blocks whose bit widths vary --
+// two normal blocks, one constant block (bitWidth == 0), and one raw block
+// (bitWidth == kRawBlockBitWidth). blockSize is 8 so tests cover both aligned
+// and misaligned boundaries across every mode.
+nimble::Vector<int32_t> makeBlockBitPackingSource(
+    velox::memory::MemoryPool* pool) {
+  nimble::Vector<int32_t> values{pool};
+  // Block 0: narrow range [1000..1007], bit-packed at bitWidth=3.
+  for (int32_t i = 0; i < 8; ++i) {
+    values.push_back(1000 + i);
+  }
+  // Block 1: constant 5 -> bitWidth == 0.
+  for (int32_t i = 0; i < 8; ++i) {
+    values.push_back(5);
+  }
+  // Block 2: full 32-bit range -> raw block (bitWidth == 255).
+  for (int32_t i = 0; i < 8; ++i) {
+    values.push_back(
+        i == 3 ? std::numeric_limits<int32_t>::max()
+               : (i == 5 ? std::numeric_limits<int32_t>::min() : i * 100));
+  }
+  // Block 3: narrow again, bit-packed.
+  for (int32_t i = 0; i < 8; ++i) {
+    values.push_back(2000 + i);
+  }
+  return values;
+}
+
+TEST_F(SliceEncodingTest, deferredBlockBitPackingMatchesSourceRows) {
+  const auto values = makeBlockBitPackingSource(pool_.get());
+  // blockSize=8, four blocks -- sweep every non-empty range so aligned,
+  // partial-front, partial-back and single-block-interior cases are all
+  // covered against a raw block, a constant block, and two bit-packed ones.
+  nimble::Encoding::Options writeOptions{.blockBitPackingBlockSize = 8};
+  const auto encoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<int32_t>>::encode(
+          *buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          writeOptions);
+
+  for (uint32_t offset = 0; offset < values.size(); ++offset) {
+    for (uint32_t length = 1; offset + length <= values.size(); ++length) {
+      const std::vector<int32_t> expected(
+          values.begin() + offset, values.begin() + offset + length);
+
+      auto encoding = createEncoding(slice(encoded, offset, length));
+      ASSERT_EQ(encoding->rowCount(), length)
+          << "offset=" << offset << " length=" << length;
+      nimble::Vector<int32_t> output{pool_.get(), length};
+      encoding->materialize(length, output.data());
+      ASSERT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected)
+          << "offset=" << offset << " length=" << length;
+    }
+  }
+}
+
+TEST_F(SliceEncodingTest, deferredBlockBitPackingWrapsOnlyWhenPartial) {
+  // Four blocks of 8 rows each. Block-aligned slices come back as a plain
+  // BlockBitPacking; any partial boundary -- front, back, both, or a
+  // single-block interior -- comes back wrapped in a SliceEncoding.
+  const auto values = makeBlockBitPackingSource(pool_.get());
+  nimble::Encoding::Options writeOptions{.blockBitPackingBlockSize = 8};
+  const auto encoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<int32_t>>::encode(
+          *buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          writeOptions);
+
+  struct Case {
+    const char* name;
+    uint32_t offset;
+    uint32_t length;
+    nimble::EncodingType expectedType;
+  };
+  for (const auto& testCase : {
+           Case{
+               "alignedSingleBlock",
+               8,
+               8,
+               nimble::EncodingType::BlockBitPacking},
+           Case{
+               "alignedMultiBlock",
+               8,
+               16,
+               nimble::EncodingType::BlockBitPacking},
+           Case{
+               "alignedFullSource",
+               0,
+               32,
+               nimble::EncodingType::BlockBitPacking},
+           Case{"partialFrontOnly", 3, 5, nimble::EncodingType::Slice},
+           Case{"partialBackOnly", 0, 5, nimble::EncodingType::Slice},
+           Case{"partialAcrossBlocks", 10, 10, nimble::EncodingType::Slice},
+           Case{"partialInsideSingleBlock", 1, 3, nimble::EncodingType::Slice},
+       }) {
+    SCOPED_TRACE(testCase.name);
+    auto encoding =
+        createEncoding(slice(encoded, testCase.offset, testCase.length));
+    EXPECT_EQ(encoding->encodingType(), testCase.expectedType);
+    EXPECT_EQ(encoding->rowCount(), testCase.length);
+  }
+}
+
+TEST_F(SliceEncodingTest, deferredBlockBitPackingWrapperTrimsToLength) {
+  const auto values = makeBlockBitPackingSource(pool_.get());
+  nimble::Encoding::Options writeOptions{.blockBitPackingBlockSize = 8};
+  const auto encoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<int32_t>>::encode(
+          *buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          writeOptions);
+
+  // Partial slice starting mid-block: the wrapped BlockBitPacking covers 2
+  // full blocks (block 0 + block 1 = 16 rows) and the wrapper trims to
+  // length=10.
+  auto partial = createEncoding(slice(encoded, 3, 10));
+  EXPECT_EQ(partial->rowCount(), 10);
+
+  const std::vector<int32_t> expected(
+      values.begin() + 3, values.begin() + 3 + 10);
+  nimble::Vector<int32_t> out{pool_.get(), 10};
+  partial->materialize(10, out.data());
+  EXPECT_EQ(std::vector<int32_t>(out.begin(), out.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, deferredBlockBitPackingHandlesInt64) {
+  // Same shape as the int32 test above; the write path is templated over
+  // the physical type, so exercise the 8-byte payload memcpy too.
+  nimble::Vector<int64_t> values{pool_.get()};
+  for (int64_t i = 0; i < 8; ++i) {
+    values.push_back(int64_t{1'000'000'000} + i); // bit-packed narrow range
+  }
+  for (int64_t i = 0; i < 8; ++i) {
+    values.push_back(int64_t{-42}); // constant, bitWidth == 0
+  }
+  for (int64_t i = 0; i < 8; ++i) {
+    values.push_back(
+        i == 3 ? std::numeric_limits<int64_t>::max()
+               : (i == 5 ? std::numeric_limits<int64_t>::min()
+                         : int64_t{1} << (16 + i))); // raw, bitWidth == 255
+  }
+  nimble::Encoding::Options writeOptions{.blockBitPackingBlockSize = 8};
+  const auto encoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<int64_t>>::encode(
+          *buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          writeOptions);
+
+  for (uint32_t offset = 0; offset < values.size(); ++offset) {
+    for (uint32_t length = 1; offset + length <= values.size(); ++length) {
+      const std::vector<int64_t> expected(
+          values.begin() + offset, values.begin() + offset + length);
+      auto deferred = createEncoding(slice(encoded, offset, length));
+      ASSERT_EQ(deferred->rowCount(), length)
+          << "offset=" << offset << " length=" << length;
+      nimble::Vector<int64_t> out{pool_.get(), length};
+      deferred->materialize(length, out.data());
+      ASSERT_EQ(std::vector<int64_t>(out.begin(), out.end()), expected)
+          << "offset=" << offset << " length=" << length;
+    }
+  }
+}
+
+TEST_F(SliceEncodingTest, deferredBlockBitPackingHandlesPartialLastBlock) {
+  // 30 rows with blockSize=8 -> four blocks, the last with only 6 rows.
+  // Sweep exercises blockRowCount(source, source.numBlocks-1) < blockSize
+  // -- the partial last block's row count must propagate into the wrapped
+  // encoding's rowCount when a slice touches it.
+  nimble::Vector<int32_t> values{pool_.get()};
+  for (int32_t i = 0; i < 30; ++i) {
+    values.push_back(500 + i);
+  }
+  nimble::Encoding::Options writeOptions{.blockBitPackingBlockSize = 8};
+  const auto encoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<int32_t>>::encode(
+          *buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          writeOptions);
+
+  for (uint32_t offset = 0; offset < values.size(); ++offset) {
+    for (uint32_t length = 1; offset + length <= values.size(); ++length) {
+      const std::vector<int32_t> expected(
+          values.begin() + offset, values.begin() + offset + length);
+      auto deferred = createEncoding(slice(encoded, offset, length));
+      ASSERT_EQ(deferred->rowCount(), length)
+          << "offset=" << offset << " length=" << length;
+      nimble::Vector<int32_t> out{pool_.get(), length};
+      deferred->materialize(length, out.data());
+      ASSERT_EQ(std::vector<int32_t>(out.begin(), out.end()), expected)
+          << "offset=" << offset << " length=" << length;
+    }
+  }
+}
+
+TEST_F(SliceEncodingTest, deferredBlockBitPackingHandlesShortSource) {
+  // Source shorter than one block -> source.firstBlockRows < blockSize and
+  // source.numBlocks == 1. Verifies the write path propagates a partial
+  // firstBlockRows into the emitted encoding's header field verbatim.
+  nimble::Vector<int32_t> values{pool_.get()};
+  for (int32_t i = 0; i < 6; ++i) {
+    values.push_back(7000 + i);
+  }
+  nimble::Encoding::Options writeOptions{.blockBitPackingBlockSize = 8};
+  const auto encoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<int32_t>>::encode(
+          *buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          writeOptions);
+
+  for (uint32_t offset = 0; offset < values.size(); ++offset) {
+    for (uint32_t length = 1; offset + length <= values.size(); ++length) {
+      const std::vector<int32_t> expected(
+          values.begin() + offset, values.begin() + offset + length);
+      auto deferred = createEncoding(slice(encoded, offset, length));
+      ASSERT_EQ(deferred->rowCount(), length)
+          << "offset=" << offset << " length=" << length;
+      nimble::Vector<int32_t> out{pool_.get(), length};
+      deferred->materialize(length, out.data());
+      ASSERT_EQ(std::vector<int32_t>(out.begin(), out.end()), expected)
+          << "offset=" << offset << " length=" << length;
+    }
+  }
+}
+
+TEST_F(SliceEncodingTest, deferredBlockBitPackingHandlesVarintRowCount) {
+  // Production StreamSlicer sets useVarintRowCount=true; the write path
+  // stamps the emitted encoding's prefix with the flag, so exercise that.
+  const auto values = makeBlockBitPackingSource(pool_.get());
+  nimble::Encoding::Options writeOptions{
+      .useVarintRowCount = true, .blockBitPackingBlockSize = 8};
+  const auto encoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<int32_t>>::encode(
+          *buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          writeOptions);
+
+  const nimble::Encoding::Options varintOptions{.useVarintRowCount = true};
+  for (uint32_t offset = 0; offset < values.size(); ++offset) {
+    for (uint32_t length = 1; offset + length <= values.size(); ++length) {
+      const std::vector<int32_t> expected(
+          values.begin() + offset, values.begin() + offset + length);
+      auto deferred = createEncoding(
+          slice(encoded, offset, length, varintOptions), varintOptions);
+      ASSERT_EQ(deferred->rowCount(), length)
+          << "offset=" << offset << " length=" << length;
+      nimble::Vector<int32_t> out{pool_.get(), length};
+      deferred->materialize(length, out.data());
+      ASSERT_EQ(std::vector<int32_t>(out.begin(), out.end()), expected)
+          << "offset=" << offset << " length=" << length;
+    }
+  }
 }
 
 TEST_F(SliceEncodingTest, resetReturnsToSliceStart) {


### PR DESCRIPTION
Summary:
Same shape as D116338105 for RLE, applied to BlockBitPacking: when a slice
starts or ends inside a block, keep the boundary blocks whole, carry their
packed payload verbatim, and wrap the result in a `SliceEncoding` that trims
the row range at decode time.

The cost the deferred path skips is the per-value bit-shift work when the
first or last touched block is bit-packed: today's `slice()` unpacks the
partial-row bit fields from mid-byte positions in the source and re-packs
them at bit 0 of the output. Structurally the inner encoding covers those
blocks in full and the wrapper's `skip()` steps over the unwanted prefix at
decode time, so no per-value work happens at write.

Applied unconditionally -- there is no flag. Block-aligned slices stay on the
existing eager path (which for them is essentially a memcpy over full blocks
with no repacking, and comes back as a plain `BlockBitPacking` with no
wrapper); only mid-block slices go through the structural path.

The inner BlockBitPacking encoding built for the wrap has:
- prefix `rowCount` = sum of rows across touched blocks (larger than
  `length` when either boundary is partial)
- `blockSize` inherited from source
- `firstBlockRows` = source's `firstBlock`'s row count (so its own block-0
  divmod layout keeps working)
- `baselines` / `bitWidths` structurally sliced from the source (nested
  `EncodingFactory::slice`, cheap -- same as eager)
- `blockOffsets` rebased to start at 0, re-encoded with the source's
  captured layout (matches eager for parity; could be tightened to a
  Trivial-only policy in a follow-up)
- payload = single `memcpy` of the source's packed byte range for the
  touched blocks; raw blocks (`bitWidth == 255`) and constant blocks
  (`bitWidth == 0`) work unchanged because the byte range is copied
  wholesale

Because the output contract changes for mid-block slices, three pre-existing
tests moved with it: `BlockBitPackingEncodingTest.slice` states the expected
type per range (aligned → BlockBitPacking, mid-block → Slice);
`BlockBitPackingEncodingTest.sliceCompressedSource` uses a block-aligned range
so its compression-type byte assertion stays meaningful; and
`EncodingSliceTypedTest`'s type-shape check gained a BlockBitPacking carve-out
matching the existing RLE one.

Reviewed By: xiaoxmeng

Differential Revision: D117309777


