### PR TITLE
feat(vector): Add BaseVector::unsafeSetPool for future allocations

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -181,6 +181,15 @@ class BaseVector {
     return pool_;
   }
 
+  /// Changes the pool used by this vector node for future allocations without
+  /// transferring or copying existing buffers or changing child vectors. The
+  /// caller must ensure that existing allocations remain valid and that
+  /// 'pool' outlives this vector.
+  void unsafeSetPool(velox::memory::MemoryPool* pool) {
+    VELOX_CHECK_NOT_NULL(pool);
+    pool_ = pool;
+  }
+
   virtual bool isNullAt(vector_size_t idx) const {
     VELOX_DCHECK_GE(idx, 0, "Index must not be negative");
     VELOX_DCHECK_LT(idx, length_, "Index is too large");

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -4338,6 +4338,41 @@ TEST_F(VectorTest, estimateFlatSize) {
   arrayVector->prepareForReuse();
 }
 
+TEST_F(VectorTest, unsafeSetPoolDoesNotTransferBuffersOrChildren) {
+  auto sourceRoot = memory::memoryManager()->addRootPool("source");
+  auto sourcePool = sourceRoot->addLeafChild("source leaf");
+  auto destinationRoot = memory::memoryManager()->addRootPool("destination");
+  auto destinationPool = destinationRoot->addLeafChild("destination leaf");
+
+  test::VectorMaker maker{sourcePool.get()};
+  auto child = maker.flatVector<int64_t>({1, 2});
+  auto vector = std::make_shared<RowVector>(
+      sourcePool.get(),
+      ROW({"c0"}, {BIGINT()}),
+      allocateNulls(2, sourcePool.get()),
+      2,
+      std::vector<VectorPtr>{child});
+
+  const auto nulls = vector->nulls();
+  const auto values = child->values();
+  vector->unsafeSetPool(destinationPool.get());
+
+  EXPECT_EQ(vector->pool(), destinationPool.get());
+  EXPECT_EQ(vector->nulls(), nulls);
+  EXPECT_EQ(vector->nulls()->pool(), sourcePool.get());
+  EXPECT_EQ(vector->childAt(0), child);
+  EXPECT_EQ(child->pool(), sourcePool.get());
+  EXPECT_EQ(child->values(), values);
+  EXPECT_EQ(child->values()->pool(), sourcePool.get());
+
+  // Holding a reference makes the existing nulls buffer non-unique, forcing
+  // appendNulls() to allocate a replacement from the reset pool.
+  vector->appendNulls(1);
+  EXPECT_EQ(vector->nulls()->pool(), destinationPool.get());
+  EXPECT_EQ(nulls->pool(), sourcePool.get());
+  EXPECT_EQ(child->pool(), sourcePool.get());
+}
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(VectorTest, transferOrCopyTo) {


### PR DESCRIPTION
Summary:
Why

The intention is to separate a vector node allocation context from ownership of the storage already reachable from that node.

A BaseVector contains both:

* existing buffers and child vectors, which may have different owners and lifetimes; and
* pool_, which the node consults when it needs to allocate in the future.

BaseVector::transferOrCopyTo() handles the common case where the whole vector graph is moving to a new pool: it moves or copies existing buffers and recursively processes children. Some callers have a narrower need. They have already made each existing allocation safe by retaining it or transferring it according to its actual owner, and only need future allocations by one vector node to use a longer-lived pool.

Concrete examples

* A deferred or lazy vector is created with pool A and handed to a longer-lived consumer using pool B before it is materialized. There may be no value buffer to transfer at handoff time. When materialization happens later, the vector consults pool() to create its result, so the node must use B even though there was no existing allocation to move.
* A RowVector created with pool A can borrow a null bitmap from a long-lived pool C and contain a child vector owned elsewhere. Retargeting the row node to B should not move or copy the borrowed null bitmap and should not recurse into the child. Their identities, pools, and lifetimes are independent of where the row node allocates next.
* If that RowVector later needs to replace a shared null bitmap through copy-on-write, the original shared bitmap should remain in C while the replacement is allocated from B.

What changes

Add BaseVector::unsafeSetPool() to change only the current node pool pointer. It deliberately does not transfer or copy existing buffers, recurse into children, or extend the lifetime of anything already allocated.

This operation is unsafe because the vector can temporarily refer to allocations from several pools. The caller must ensure that every existing allocation remains alive independently and that the new pool outlives the vector. The name makes these obligations explicit and distinguishes this node-only operation from transferOrCopyTo().

Testing

The unit test builds a RowVector and child in a source pool, captures their buffers and identities, and switches only the row node to a destination pool. It verifies that the original null buffer, child, and child values remain unchanged in the source pool. It then holds the old null buffer to force appendNulls() to allocate a copy-on-write replacement and verifies that only the replacement comes from the destination pool.

Differential Revision: D118318398


