### PR TITLE
fix(HashTableCache): Give each entry its own leaf pool (#18788)

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1451,6 +1451,15 @@ void HashBuild::close() {
     spiller_.reset();
     table_.reset();
   }
+
+  // Release the entry here rather than at operator destruction:
+  // Driver::closeOperators() closes every operator but never destroys
+  // 'operators_', so a failed build's leaf pool would otherwise stay attached
+  // to the shared query pool until the Driver goes away. Keep this after
+  // 'table_' is reset, whose allocations live in that pool, and outside
+  // 'mutex_' -- dropping the last reference destroys the pool, which takes the
+  // parent's lock via MemoryPool::dropChild().
+  cacheEntry_.reset();
 }
 
 HashBuildSpiller::HashBuildSpiller(

--- a/velox/exec/HashTableCache.cpp
+++ b/velox/exec/HashTableCache.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<HashTableCacheEntry> HashTableCache::get(
         taskId,
         // Add memory reclaimer that is not reclaimable.
         queryPool->addLeafChild(
-            fmt::format("cached_table_{}", key),
+            fmt::format("cached_table_{}_{}", key, tablePoolId_++),
             /* threadsafe */ true,
             exec::MemoryReclaimer::create()));
     tables_.insert({key, entry});

--- a/velox/exec/HashTableCache.h
+++ b/velox/exec/HashTableCache.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -40,6 +41,10 @@ struct HashTableCacheEntry {
 
   const std::string cacheKey;
   const std::string builderTaskId;
+  /// Leaf pool the cached table is allocated from. Immutable for the entry's
+  /// lifetime: drop() removes the entry rather than emptying it, so readers
+  /// need no synchronisation. The pool is destroyed once the cache and every
+  /// operator holding this entry have released it.
   const std::shared_ptr<memory::MemoryPool> tablePool;
   std::shared_ptr<BaseHashTable> table;
   bool hasNullKeys{false};
@@ -95,6 +100,12 @@ class HashTableCache {
 
   std::mutex lock_;
   std::unordered_map<std::string, std::shared_ptr<HashTableCacheEntry>> tables_;
+
+  // Distinguishes the leaf pool names of successive entries for one key. Every
+  // task of a query shares its query pool, so an entry created after a previous
+  // one for the same key was dropped would otherwise ask for a leaf child name
+  // that the previous pool still holds, and addLeafChild() rejects duplicates.
+  std::atomic_uint64_t tablePoolId_{0};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/HashTableCacheTest.cpp
+++ b/velox/exec/tests/HashTableCacheTest.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/Memory.h"
@@ -53,6 +55,18 @@ class HashTableCacheTest : public testing::Test {
   // Helper to track keys for cleanup.
   void trackKey(const std::string& key) {
     createdKeys_.push_back(key);
+  }
+
+  // Number of cached-table leaf pools still attached to the query pool.
+  int numCachedTablePools() const {
+    int numPools{0};
+    queryCtx_->pool()->visitChildren([&](memory::MemoryPool* child) {
+      if (child->name().rfind("cached_table_", 0) == 0) {
+        ++numPools;
+      }
+      return true;
+    });
+    return numPools;
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -214,6 +228,65 @@ TEST_F(HashTableCacheTest, drop) {
 
   // Cleanup.
   cache->drop(key);
+}
+
+TEST_F(HashTableCacheTest, repeatedBuilderFailuresGetDistinctPools) {
+  // Successive tasks of one query share a query pool, so repeated failed builds
+  // of the same key all create leaf pools under it. A failed builder holds its
+  // entry past drop() -- Driver::close() calls closeOperators() but never
+  // destroys operators_ -- so the previous pool is still attached when the next
+  // entry is created, and addLeafChild() aborts on a duplicate name.
+  auto* cache = HashTableCache::instance();
+  const std::string key = "queryRetry:node1";
+  constexpr int kNumFailures = 5;
+
+  // Held across the whole loop, standing in for the failed builders' operators.
+  std::vector<std::shared_ptr<HashTableCacheEntry>> failedEntries;
+  std::set<std::string> poolNames;
+  for (int i = 0; i < kNumFailures; ++i) {
+    ContinueFuture future = ContinueFuture::makeEmpty();
+    auto entry =
+        cache->get(key, fmt::format("task{}", i), queryCtx_.get(), &future);
+    ASSERT_NE(entry->tablePool, nullptr);
+    poolNames.insert(entry->tablePool->name());
+    cache->drop(key);
+    failedEntries.push_back(std::move(entry));
+  }
+
+  EXPECT_EQ(poolNames.size(), kNumFailures);
+
+  // Each pool lives exactly as long as the operators that hold its entry, which
+  // is what HashBuild::close() bounds by releasing 'cacheEntry_'.
+  failedEntries.clear();
+  EXPECT_EQ(numCachedTablePools(), 0);
+}
+
+TEST_F(HashTableCacheTest, tablePoolStaysUsableAfterItsEntryIsDropped) {
+  // HashBuild allocates 'table_' from tableMemoryPool() and destroys it in
+  // close(), where drop() also runs -- and a peer driver of the same builder
+  // task can run drop() earlier still. Dropping an entry must therefore leave
+  // the pool intact for whoever still holds it; 'tablePool' is const so that
+  // this needs no synchronisation between the two.
+  auto* cache = HashTableCache::instance();
+  const std::string key = "queryOutlive:node1";
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto entry = cache->get(key, "task1", queryCtx_.get(), &future);
+  ASSERT_NE(entry->tablePool, nullptr);
+  auto tablePool = entry->tablePool;
+  auto table = makeTestJoinHashTable(tablePool.get());
+  ASSERT_GT(tablePool->usedBytes(), 0);
+
+  cache->drop(key);
+
+  EXPECT_NE(entry->tablePool, nullptr);
+  EXPECT_GT(tablePool->usedBytes(), 0);
+  EXPECT_EQ(numCachedTablePools(), 1);
+
+  table.reset();
+  tablePool.reset();
+  entry.reset();
+  EXPECT_EQ(numCachedTablePools(), 0);
 }
 
 TEST_F(HashTableCacheTest, concurrentWaiters) {


### PR DESCRIPTION
Summary:

A broadcast hash join with `useHashTableCache` set aborts the worker when a build fails and another task then runs the same join on that worker:

```
children_.count(name) == 0 (1 vs. 0) Leaf child memory pool
cached_table_<queryId>:<planNodeId> already exists in <queryId>_0
```

Every task of a query shares one query memory pool, and `get()` named the cached table's leaf child after the cache key alone. A failed builder's pool outlives its entry: `drop()` erases the map entry, but every operator that called `get()` still holds that entry, and `Driver::close()` only closes operators -- it never destroys them. So the next task asks `addLeafChild()` for a name that is still taken.

`get()` now appends a process-wide counter to the pool name, so successive entries for one key get distinct children and the collision cannot happen. On its own that would only trade the abort for accumulation, since each failed build would leave another pool attached to the query pool for the rest of the query. `HashBuild::close()` therefore releases `cacheEntry_` instead of leaving it to operator destruction, which bounds every pool's lifetime by the task that created it.

Ownership is what makes this safe rather than a second lifetime bug. `HashBuild` takes its own reference to the leaf pool during initialization and releases it in `close()` after `table_`, which allocates from it. `HashTableCacheEntry::tablePool` stays `const` and is never emptied in place, so a peer driver running `drop()` cannot pull the pool out from under a table still being torn down, and readers of the entry need no synchronisation against the dropper.

Waiters parked on a failed build are still woken and still fail, as today. Letting a waiter take over the build is a larger change and is deliberately not attempted here.

Reviewed By: shrinidhijoshi

Differential Revision: D117552585


