### PR TITLE
fix(exec): Only retain clustered input when no group spans batches (#18789)

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -182,12 +182,15 @@ class Aggregate {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) = 0;
 
-  /// Called by aggregation operator to set whether the input data is eligible
-  /// for clustered input optimization.  This is turned off, in cases for
-  /// example if the input rows from same group are not contiguous, or the
-  /// aggregate is sorted or distinct.
-  void setClusteredInput(bool value) {
-    clusteredInput_ = value;
+  /// Called by aggregation operator to set whether an accumulator may keep a
+  /// reference to the input vector rather than copying the value out of it.
+  /// This requires both that the input rows from same group are contiguous and
+  /// that no group spans batches, so each reference is dropped when the group's
+  /// output is produced. Without the latter a group stays open across batches
+  /// and the references pin every input batch that contributed a group. Also
+  /// turned off if the aggregate is sorted or distinct.
+  void setCanRetainInput(bool value) {
+    canRetainInput_ = value;
   }
 
   /// Whether the function itself supports clustered input optimization.
@@ -519,7 +522,7 @@ class Aggregate {
 
   bool validateIntermediateInputs_ = false;
 
-  bool clusteredInput_ = false;
+  bool canRetainInput_ = false;
 };
 
 using AggregateFunctionFactory = std::function<std::unique_ptr<Aggregate>(

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -101,12 +101,15 @@ void StreamingAggregation::initialize() {
     }
   }
 
-  if (isRawInput(step_)) {
+  // Retaining a reference to the input instead of copying is only bounded when
+  // no group spans batches, since the reference is dropped once the group's
+  // output is produced. Otherwise leave it off, which is the default.
+  if (isRawInput(step_) && noGroupsSpanBatches_) {
     for (column_index_t i = 0; i < aggregates_.size(); ++i) {
       if (aggregates_[i].sortingKeys.empty() && !aggregates_[i].distinct) {
         // Must be set before we initialize row container, because it could
         // change the type and size of accumulator.
-        aggregates_[i].function->setClusteredInput(true);
+        aggregates_[i].function->setCanRetainInput(true);
       }
     }
   }

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -166,7 +166,7 @@ class NonNumericArbitrary : public exec::Aggregate {
       : exec::Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
-    return clusteredInput_ ? sizeof(ClusteredNonNumericAccumulator)
+    return canRetainInput_ ? sizeof(ClusteredNonNumericAccumulator)
                            : sizeof(SingleValueAccumulator);
   }
 
@@ -178,7 +178,7 @@ class NonNumericArbitrary : public exec::Aggregate {
       override {
     VELOX_CHECK_NOT_NULL(result);
     (*result)->resize(numGroups);
-    if (clusteredInput_) {
+    if (canRetainInput_) {
       bool singleSource{true};
       VectorPtr* currentSource = nullptr;
       VELOX_DCHECK(copyRanges_.empty());
@@ -266,7 +266,7 @@ class NonNumericArbitrary : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
-    VELOX_CHECK(!clusteredInput_);
+    VELOX_CHECK(!canRetainInput_);
     decoded_.decode(*args[0], rows, true);
     if (decoded_.isConstantMapping() && decoded_.isNullAt(rows.begin())) {
       // nothing to do; all values are nulls
@@ -287,7 +287,7 @@ class NonNumericArbitrary : public exec::Aggregate {
   }
 
   bool supportsAddRawClusteredInput() const override {
-    return clusteredInput_;
+    return canRetainInput_;
   }
 
   void addRawClusteredInput(
@@ -295,7 +295,7 @@ class NonNumericArbitrary : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       const folly::Range<const vector_size_t*>& groupBoundaries) override {
-    VELOX_CHECK(clusteredInput_);
+    VELOX_CHECK(canRetainInput_);
     // Since we're going through the process of decoding anyway, store the base
     // so that downstream operators don't need to.
     const auto base = decoded_.decodeAndGetBase(args[0]);
@@ -343,7 +343,7 @@ class NonNumericArbitrary : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
-    VELOX_CHECK(!clusteredInput_);
+    VELOX_CHECK(!canRetainInput_);
     auto* accumulator = value<SingleValueAccumulator>(group);
     if (accumulator->hasValue()) {
       return;
@@ -382,7 +382,7 @@ class NonNumericArbitrary : public exec::Aggregate {
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     for (auto i : indices) {
-      if (clusteredInput_) {
+      if (canRetainInput_) {
         new (groups[i] + offset_) ClusteredNonNumericAccumulator();
       } else {
         new (groups[i] + offset_) SingleValueAccumulator();
@@ -393,7 +393,7 @@ class NonNumericArbitrary : public exec::Aggregate {
   void destroyInternal(folly::Range<char**> groups) override {
     for (auto group : groups) {
       if (isInitialized(group)) {
-        if (clusteredInput_) {
+        if (canRetainInput_) {
           auto* accumulator = value<ClusteredNonNumericAccumulator>(group);
           std::destroy_at(accumulator);
         } else {

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -48,7 +48,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       : Aggregate(resultType), ignoreNulls_(ignoreNulls) {}
 
   int32_t accumulatorFixedWidthSize() const override {
-    return clusteredInput_ ? sizeof(ClusteredAccumulator)
+    return canRetainInput_ ? sizeof(ClusteredAccumulator)
                            : sizeof(ArrayAccumulator);
   }
 
@@ -128,7 +128,7 @@ class ArrayAggAggregate : public exec::Aggregate {
     elements->resize(numElements);
 
     vector_size_t arrayOffset = 0;
-    if (clusteredInput_) {
+    if (canRetainInput_) {
       bool singleSource{true};
       VectorPtr* currentSource{nullptr};
       bool contiguousElementsPerGroup = true;
@@ -259,7 +259,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
-    VELOX_CHECK(!clusteredInput_);
+    VELOX_CHECK(!canRetainInput_);
     decodedElements_.decode(*args[0], rows);
     rows.applyToSelected([&](vector_size_t row) {
       if (ignoreNulls_ && decodedElements_.isNullAt(row)) {
@@ -273,7 +273,7 @@ class ArrayAggAggregate : public exec::Aggregate {
   }
 
   bool supportsAddRawClusteredInput() const override {
-    return clusteredInput_;
+    return canRetainInput_;
   }
 
   void addRawClusteredInput(
@@ -281,7 +281,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       const folly::Range<const vector_size_t*>& groupBoundaries) override {
-    VELOX_CHECK(clusteredInput_);
+    VELOX_CHECK(canRetainInput_);
     decodedElements_.decode(*args[0]);
     vector_size_t groupStart = 0;
     auto forEachAccumulator = [&](auto func) {
@@ -347,7 +347,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
-    VELOX_CHECK(!clusteredInput_);
+    VELOX_CHECK(!canRetainInput_);
     auto& values = value<ArrayAccumulator>(group)->elements;
 
     decodedElements_.decode(*args[0], rows);
@@ -365,7 +365,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
-    VELOX_CHECK(!clusteredInput_);
+    VELOX_CHECK(!canRetainInput_);
     decodedIntermediate_.decode(*args[0], rows);
     auto arrayVector = decodedIntermediate_.base()->as<ArrayVector>();
 
@@ -388,7 +388,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     for (auto index : indices) {
-      if (clusteredInput_) {
+      if (canRetainInput_) {
         new (groups[index] + offset_) ClusteredAccumulator();
       } else {
         new (groups[index] + offset_) ArrayAccumulator();
@@ -399,7 +399,7 @@ class ArrayAggAggregate : public exec::Aggregate {
   void destroyInternal(folly::Range<char**> groups) override {
     for (auto group : groups) {
       if (isInitialized(group)) {
-        if (clusteredInput_) {
+        if (canRetainInput_) {
           auto* accumulator = value<ClusteredAccumulator>(group);
           std::destroy_at(accumulator);
         } else {
@@ -412,7 +412,7 @@ class ArrayAggAggregate : public exec::Aggregate {
  private:
   vector_size_t countElements(char** groups, int32_t numGroups) const {
     vector_size_t size = 0;
-    if (clusteredInput_) {
+    if (canRetainInput_) {
       for (int32_t i = 0; i < numGroups; ++i) {
         auto* accumulator = value<ClusteredAccumulator>(groups[i]);
         for (auto& source : accumulator->sources) {

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -38,7 +38,8 @@ class ArbitraryTest : public AggregationTestBase {
   //   second = (possibly encoded) data fed to Velox.
   // When both are the same vector the caller can return {v, v}.
   void testClusteredInput(
-      std::function<std::pair<RowVectorPtr, RowVectorPtr>(int batchSize, int i)>
+      const std::function<
+          std::pair<RowVectorPtr, RowVectorPtr>(int batchSize, int i)>&
           makeBatch) {
     constexpr int kSize = 1000;
     for (int batchRows : {kSize, 13}) {
@@ -51,16 +52,32 @@ class ArbitraryTest : public AggregationTestBase {
         encodedData.push_back(encoded);
       }
       createDuckDbTable(flatData);
+      // A single batch cannot have a group spanning batches, so the
+      // clustered-input fast path is available and gets covered. With 13-row
+      // batches the 17-row groups straddle batch boundaries, so it must stay
+      // off and the copying fallback is covered instead.
+      const bool noGroupsSpanBatches = batchRows >= kSize;
       for (bool mask : {false, true}) {
         auto builder = PlanBuilder().values(encodedData);
         std::string expected;
         if (mask) {
-          builder.partialStreamingAggregation(
-              {"c0"}, {"arbitrary(c1)"}, {"c2"});
+          builder.streamingAggregation(
+              {"c0"},
+              {"arbitrary(c1)"},
+              {"c2"},
+              core::AggregationNode::Step::kPartial,
+              /*ignoreNullKeys=*/false,
+              noGroupsSpanBatches);
           expected =
               "select c0, first(c1) filter (where c2 and c1 is not null) from tmp group by 1";
         } else {
-          builder.partialStreamingAggregation({"c0"}, {"arbitrary(c1)"});
+          builder.streamingAggregation(
+              {"c0"},
+              {"arbitrary(c1)"},
+              {},
+              core::AggregationNode::Step::kPartial,
+              /*ignoreNullKeys=*/false,
+              noGroupsSpanBatches);
           expected =
               "select c0, first(c1) filter (where c1 is not null) from tmp group by 1";
         }
@@ -661,9 +678,17 @@ TEST_F(ArbitraryTest, clusteredInputDirectVectorAssign) {
 
   createDuckDbTable(data);
 
+  // Single batch, so no group spans batches and the clustered-input fast path
+  // this test is about stays enabled.
   auto plan = PlanBuilder()
                   .values(data)
-                  .partialStreamingAggregation({"c0"}, {"arbitrary(c1)"})
+                  .streamingAggregation(
+                      {"c0"},
+                      {"arbitrary(c1)"},
+                      {},
+                      core::AggregationNode::Step::kPartial,
+                      /*ignoreNullKeys=*/false,
+                      /*noGroupsSpanBatches=*/true)
                   .finalAggregation()
                   .planNode();
 
@@ -675,6 +700,67 @@ TEST_F(ArbitraryTest, clusteredInputDirectVectorAssign) {
 
 // Also verify the direct vector assign path with multiple batches where the
 // source vector size may differ from numGroups (exercises the slice fallback).
+// The clustered-input fast path keeps a reference to the whole input vector
+// rather than copying the chosen value out of it. That is only bounded when a
+// group cannot span batches, because the reference is dropped once the group's
+// output is produced. When groups do span batches, every batch that contributed
+// a group stays pinned until extractValues, so peak memory grows with the input
+// instead of with the accumulators.
+//
+// The projection matters: it materializes each batch inside the query's pool,
+// so retained batches show up in peakBytes. Reading straight from values()
+// would allocate them in the test's pool and hide the retention.
+TEST_F(ArbitraryTest, clusteredInputNotRetainedWhenGroupsSpanBatches) {
+  constexpr int kNumBatches = 100;
+  constexpr int kBatchRows = 64;
+  constexpr int kPayloadBytes = 4'096;
+  // Coprime with kBatchRows so groups straddle batch boundaries.
+  constexpr int kGroupRows = 17;
+
+  std::vector<RowVectorPtr> data;
+  data.reserve(kNumBatches);
+  for (int batch = 0; batch < kNumBatches; ++batch) {
+    data.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            kBatchRows,
+            [&](auto row) { return (batch * kBatchRows + row) / kGroupRows; }),
+        makeFlatVector<std::string>(
+            kBatchRows,
+            [&](auto /*row*/) { return std::string(kPayloadBytes, 'x'); }),
+    }));
+  }
+
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .project({"c0", "concat(c1, '') as c1"})
+                  .streamingAggregation(
+                      {"c0"},
+                      {"arbitrary(c1)"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      /*ignoreNullKeys=*/false,
+                      /*noGroupsSpanBatches=*/false)
+                  .planNode();
+
+  auto queryPool = memory::memoryManager()->addRootPool(
+      "clusteredInputNotRetainedWhenGroupsSpanBatches",
+      memory::kMaxMemory,
+      exec::MemoryReclaimer::create());
+  auto queryCtx = core::QueryCtx::create(
+      executor_.get(), core::QueryConfig{{}}, {}, {}, std::move(queryPool));
+  auto result = AssertQueryBuilder(plan).queryCtx(queryCtx).copyResults(pool());
+  ASSERT_EQ(
+      result->size(), (kNumBatches * kBatchRows + kGroupRows - 1) / kGroupRows);
+
+  // Retaining every batch would keep roughly the whole input resident. A
+  // copying accumulator holds one payload per group, which is far smaller.
+  constexpr int64_t kInputBytes =
+      static_cast<int64_t>(kNumBatches) * kBatchRows * kPayloadBytes;
+  EXPECT_LT(queryCtx->pool()->peakBytes(), kInputBytes / 4)
+      << "peak " << queryCtx->pool()->peakBytes() << " of input " << kInputBytes
+      << " suggests input batches are being pinned by the accumulators";
+}
+
 TEST_F(ArbitraryTest, clusteredInputSliceFallback) {
   // Use a larger batch size than the number of groups so that the source
   // vector size exceeds numGroups, exercising the existing slice path.
@@ -689,9 +775,17 @@ TEST_F(ArbitraryTest, clusteredInputSliceFallback) {
 
   createDuckDbTable(data);
 
+  // Single batch, so no group spans batches and the clustered-input slice path
+  // this test is about stays enabled.
   auto plan = PlanBuilder()
                   .values(data)
-                  .partialStreamingAggregation({"c0"}, {"arbitrary(c1)"})
+                  .streamingAggregation(
+                      {"c0"},
+                      {"arbitrary(c1)"},
+                      {},
+                      core::AggregationNode::Step::kPartial,
+                      /*ignoreNullKeys=*/false,
+                      /*noGroupsSpanBatches=*/true)
                   .finalAggregation()
                   .planNode();
 

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -573,15 +573,32 @@ TEST_F(ArrayAggTest, clusteredInput) {
       }));
     }
     createDuckDbTable(data);
+    // A single batch cannot have a group spanning batches, so the
+    // clustered-input fast path is available and gets covered. With 13-row
+    // batches the 17-row groups straddle batch boundaries, so it must stay off
+    // and the copying fallback is covered instead.
+    const bool noGroupsSpanBatches = batchRows >= kSize;
     for (bool mask : {false, true}) {
       auto builder = PlanBuilder().values(data);
       std::string expected;
       if (mask) {
-        builder.partialStreamingAggregation({"c0"}, {"array_agg(c1)"}, {"c2"});
+        builder.streamingAggregation(
+            {"c0"},
+            {"array_agg(c1)"},
+            {"c2"},
+            core::AggregationNode::Step::kPartial,
+            /*ignoreNullKeys=*/false,
+            noGroupsSpanBatches);
         expected =
             "select c0, array_agg(c1) filter (where c2) from tmp group by 1";
       } else {
-        builder.partialStreamingAggregation({"c0"}, {"array_agg(c1)"});
+        builder.streamingAggregation(
+            {"c0"},
+            {"array_agg(c1)"},
+            {},
+            core::AggregationNode::Step::kPartial,
+            /*ignoreNullKeys=*/false,
+            noGroupsSpanBatches);
         expected = "select c0, array_agg(c1) from tmp group by 1";
       }
       auto plan = builder.finalAggregation().planNode();
@@ -601,6 +618,72 @@ TEST_F(ArrayAggTest, clusteredInput) {
       }
     }
   }
+}
+
+// The clustered-input fast path stores a reference to the whole argument
+// vector rather than copying the selected values out of it, so a group pins
+// every batch it drew from until extractValues runs. That is only bounded when
+// a group cannot span batches, because the reference is dropped once the
+// group's output is produced.
+//
+// The mask is what makes the two paths distinguishable. Without it array_agg
+// keeps every value anyway, so copying costs as much as retaining. Selecting
+// one row per batch leaves the copying accumulator holding kNumBatches
+// payloads while retention would pin all of them in full.
+//
+// The projection matters: it materializes each batch inside the query's pool,
+// so retained batches show up in peakBytes. Reading straight from values()
+// would allocate them in the test's pool and hide the retention.
+TEST_F(ArrayAggTest, clusteredInputNotRetainedWhenGroupsSpanBatches) {
+  constexpr int kNumBatches = 100;
+  constexpr int kBatchRows = 64;
+  constexpr int kPayloadBytes = 4'096;
+  // Coprime with kBatchRows so groups straddle batch boundaries.
+  constexpr int kGroupRows = 17;
+
+  std::vector<RowVectorPtr> data;
+  data.reserve(kNumBatches);
+  for (int batch = 0; batch < kNumBatches; ++batch) {
+    data.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            kBatchRows,
+            [&](auto row) { return (batch * kBatchRows + row) / kGroupRows; }),
+        makeFlatVector<std::string>(
+            kBatchRows,
+            [&](auto /*row*/) { return std::string(kPayloadBytes, 'x'); }),
+        makeFlatVector<bool>(kBatchRows, [&](auto row) { return row == 0; }),
+    }));
+  }
+
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .project({"c0", "concat(c1, '') as c1", "c2"})
+                  .streamingAggregation(
+                      {"c0"},
+                      {"array_agg(c1)"},
+                      {"c2"},
+                      core::AggregationNode::Step::kSingle,
+                      /*ignoreNullKeys=*/false,
+                      /*noGroupsSpanBatches=*/false)
+                  .planNode();
+
+  auto queryPool = memory::memoryManager()->addRootPool(
+      "clusteredInputNotRetainedWhenGroupsSpanBatches",
+      memory::kMaxMemory,
+      exec::MemoryReclaimer::create());
+  auto queryCtx = core::QueryCtx::create(
+      executor_.get(), core::QueryConfig{{}}, {}, {}, std::move(queryPool));
+  auto result = AssertQueryBuilder(plan).queryCtx(queryCtx).copyResults(pool());
+  ASSERT_EQ(
+      result->size(), (kNumBatches * kBatchRows + kGroupRows - 1) / kGroupRows);
+
+  // Retaining every batch would keep roughly the whole input resident. The
+  // copying accumulator holds only the masked rows, which is far smaller.
+  constexpr int64_t kInputBytes =
+      static_cast<int64_t>(kNumBatches) * kBatchRows * kPayloadBytes;
+  EXPECT_LT(queryCtx->pool()->peakBytes(), kInputBytes / 4)
+      << "peak " << queryCtx->pool()->peakBytes() << " of input " << kInputBytes
+      << " suggests input batches are being pinned by the accumulators";
 }
 
 TEST_F(ArrayAggTest, maskedRows) {


### PR DESCRIPTION
Summary:

`StreamingAggregation::initialize()` enabled the clustered-input optimization for every
raw-input, non-sorted, non-distinct aggregate:

```cpp
if (aggregates_[i].sortingKeys.empty() && !aggregates_[i].distinct) {
  aggregates_[i].function->setClusteredInput(true);
}
```

For non-numeric `arbitrary` (and `array_agg`) that flag switches the accumulator from
`SingleValueAccumulator`, which serializes the value into the `HashStringAllocator`, to
`ClusteredNonNumericAccumulator`, which keeps a reference instead:

```cpp
struct ClusteredNonNumericAccumulator {
  VectorPtr vector;
  vector_size_t index;
};
...
accumulator->vector = base;   // the whole base input vector
```

https://github.com/facebookincubator/velox/pull/12975 introduced that fast path together with `streaming_aggregation_eager_flush`,
described in its summary as what "allows us to minimize the memory used by accumulators" --
flush as soon as results are available so the references are dropped promptly. That config
now has no readers anywhere in the codebase and is marked `TODO: Remove after dependencies
are cleaned up`, so the optimization is left without the bound it was designed against.

When a group can span batches the references accumulate: each group pins the entire base
vector of the batch it was first seen in, including every column and every row, until
`extractValues` runs. Nothing observes this. The bytes belong to the upstream operator's
pool, `RowContainer::estimateRowSize()` measures only the row arena and the
`HashStringAllocator` so `outputDueToBatchBytes` never fires, and `StreamingAggregation`
passes no spill config so `canReclaim()` is false.

`noGroupsSpanBatches` is exactly the property the optimization needs, so gate on it.
`setClusteredInput` becomes `setCanRetainInput`, named for the invariant the accumulators
actually depend on, and the operator supplies all three preconditions in one place. Callers
can no longer set one condition and forget the other.

Reviewed By: kgpai

Differential Revision: D118337112


