### PR TITLE
fix(SfmSketch): Debias randomized merge (#18790)

### DIFF
--- a/velox/functions/lib/sfm/SfmSketch.cpp
+++ b/velox/functions/lib/sfm/SfmSketch.cpp
@@ -146,9 +146,8 @@ void SfmSketch::mergeWith(const SfmSketch& other) {
     for (int32_t i = 0; i < numBits; i++) {
       const double bit1 = bits::isBitSet(rawBits_, i) ? 1.0 : 0.0;
       const double bit2 = bits::isBitSet(other.rawBits_, i) ? 1.0 : 0.0;
-      const double x =
-          1 - 2 * p - normalizer * (1 - p1 - bit1) * (1 - p2 - bit2);
-      double probability = p + normalizer * x;
+      double probability =
+          1 - p - normalizer * (1 - p1 - bit1) * (1 - p2 - bit2);
       probability = std::min(1.0, std::max(0.0, probability));
 
       bits::setBit(

--- a/velox/functions/lib/sfm/tests/SfmSketchTest.cpp
+++ b/velox/functions/lib/sfm/tests/SfmSketchTest.cpp
@@ -113,6 +113,43 @@ TEST_F(SfmSketchTest, merge) {
   ASSERT_TRUE(a.privacyEnabled());
 }
 
+TEST_F(SfmSketchTest, mergePrivatePrivate) {
+  // Private-private merges should be unbiased: merging two disjoint
+  // private sketches should estimate the union cardinality. Average over
+  // multiple runs with different seeds to reduce variance.
+  auto testPrivateMerge = [&](double epsilon,
+                              int32_t numPerSketch,
+                              double relativeTolerance) {
+    const int32_t totalCardinality = numPerSketch * 2;
+    static constexpr int32_t kNumRuns = 10;
+    double sumEstimates{0};
+    for (int32_t run = 0; run < kNumRuns; ++run) {
+      SfmSketch firstSketch(&allocator_, 42 + run * 2);
+      SfmSketch secondSketch(&allocator_, 43 + run * 2);
+      firstSketch.initialize(numBuckets_, precision_);
+      secondSketch.initialize(numBuckets_, precision_);
+      for (int32_t i = 0; i < numPerSketch; ++i) {
+        firstSketch.add(i);
+        secondSketch.add(numPerSketch + i);
+      }
+      firstSketch.enablePrivacy(epsilon);
+      secondSketch.enablePrivacy(epsilon);
+      firstSketch.mergeWith(secondSketch);
+      sumEstimates += static_cast<double>(firstSketch.cardinality());
+    }
+    const double averageEstimate = sumEstimates / kNumRuns;
+    ASSERT_NEAR(
+        averageEstimate, totalCardinality, totalCardinality * relativeTolerance)
+        << "epsilon=" << epsilon << " numPerSketch=" << numPerSketch;
+  };
+
+  // Tolerances are ~6x the theoretical standard error of the 10-run average
+  // (see Eq. 2 of https://arxiv.org/pdf/2302.02056.pdf).
+  testPrivateMerge(1.0, 10'000, 0.10);
+  testPrivateMerge(2.0, 10'000, 0.04);
+  testPrivateMerge(5.0, 10'000, 0.02);
+}
+
 TEST_F(SfmSketchTest, cardinality) {
   SfmSketch sketch(&allocator_, 3);
   VELOX_ASSERT_THROW(sketch.cardinality(), "Sketch is not initialized.");
@@ -319,4 +356,5 @@ TEST_F(SfmSketchTest, javaSerializationCompatibility) {
   // Test that the deserialized sketch is the same as the original.
   ASSERT_EQ(sketch.cardinality(), 927499);
 }
+
 } // namespace facebook::velox::functions::sfm


### PR DESCRIPTION
Summary:

A small typo in the formula used for `SfmSketch` merges resulted in excess 1-bits in merged sketches, when both input sketches were noisy. This resulted in upward-biased cardinality estimates that were particularly notable at epsilon < 1. A simple correction to the formula yields unbiased sketches.

Reviewed By: DanielTing, natashasehgal

Differential Revision: D118353470


