### PR TITLE
refactor(vector): Make `forEachEntry` const in map concat sources (#18792)

### DIFF
--- a/velox/vector/MapConcat.cpp
+++ b/velox/vector/MapConcat.cpp
@@ -42,7 +42,7 @@ class UpdateMapRow {
   }
 
   template <typename F>
-  void forEachEntry(F&& func) {
+  void forEachEntry(F&& func) const {
     for (auto& [_, source] : values_) {
       func(source);
     }
@@ -78,7 +78,7 @@ class UpdateMapRow<void> {
   }
 
   template <typename F>
-  void forEachEntry(F&& func) {
+  void forEachEntry(F&& func) const {
     for (auto& [_, source] : references_) {
       func(source);
     }


### PR DESCRIPTION
Summary:

`UpdateSource` and `Reference` in `MapConcat.cpp` each expose a `forEachEntry` that only reads the entries it walks, but both were non-const, so neither could be called through a const reference to the row. Marking them const widens where they can be used without changing behavior. The single caller passes its parameter by value, so the entries it receives are unaffected.

Differential Revision: D118363448


