### PR TITLE
fix(rpc): Cap the backend error copied into every batch row

### DIFF
--- a/velox/exec/rpc/BackendErrorSummary.cpp
+++ b/velox/exec/rpc/BackendErrorSummary.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/BackendErrorSummary.h"
+
+#include <algorithm>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec::rpc {
+
+namespace {
+
+// Appended whenever any of the backend text was dropped, so a reader knows the
+// row is showing a summary and the full text is in the logs.
+constexpr std::string_view kElisionMarker = "... (truncated)";
+
+constexpr std::string_view kWhitespace = " \t\n\r\f\v";
+
+// Drops the whitespace around a backend message. Leading whitespace is what
+// makes the first line empty, and a lone trailing newline is not text worth
+// telling the reader was dropped.
+std::string_view trimWhitespace(std::string_view text) {
+  const auto begin = text.find_first_not_of(kWhitespace);
+  if (begin == std::string_view::npos) {
+    return {};
+  }
+  return text.substr(begin, text.find_last_not_of(kWhitespace) + 1 - begin);
+}
+
+// Backs 'length' off to a UTF-8 sequence boundary. Presto reads this text as a
+// UTF-8 VARCHAR, and a backend message echoing prompt text is not necessarily
+// ASCII, so cutting on a raw byte index can leave half a character in the
+// column.
+size_t utf8SafeLength(std::string_view text, size_t length) {
+  if (length >= text.size()) {
+    return text.size();
+  }
+  while (length > 0 &&
+         (static_cast<unsigned char>(text[length]) & 0xC0) == 0x80) {
+    --length;
+  }
+  return length;
+}
+
+} // namespace
+
+std::string summarizeBackendError(std::string_view rawError, size_t maxLength) {
+  VELOX_CHECK_GT(
+      maxLength,
+      kElisionMarker.size(),
+      "Backend error cap must leave room for the elision marker");
+
+  // Trim first: a message that leads with a newline has an empty first line,
+  // which would leave the row carrying the marker and nothing else, and a
+  // message that ends with one has nothing dropped worth marking.
+  const std::string_view trimmed = trimWhitespace(rawError);
+
+  // Servers put their stack frames on their own lines, so the first newline is
+  // the boundary between the sentence worth keeping and the trace. A backend
+  // that appends frames to the message instead leaves no boundary; the cap
+  // below is what bounds the row in that case.
+  const std::string_view firstLine = trimmed.substr(0, trimmed.find('\n'));
+
+  if (firstLine.size() == trimmed.size() && firstLine.size() <= maxLength) {
+    return std::string(firstLine);
+  }
+  // The marker is appended below, so the kept text has to leave room for it or
+  // the result overruns 'maxLength'. The VELOX_CHECK_GT above makes the
+  // subtraction safe.
+  const auto kept = utf8SafeLength(
+      firstLine, std::min(firstLine.size(), maxLength - kElisionMarker.size()));
+  return std::string(firstLine.substr(0, kept)) + std::string(kElisionMarker);
+}
+
+std::vector<facebook::velox::rpc::RPCResponse> makeBatchErrorResponses(
+    size_t numRows,
+    std::string_view errorPrefix,
+    std::string_view rawError) {
+  std::vector<facebook::velox::rpc::RPCResponse> responses(numRows);
+  const std::string rowError = std::string(errorPrefix) +
+      summarizeBackendError(rawError, kMaxBackendErrorBytes);
+  for (auto& response : responses) {
+    response.error = rowError;
+    response.errorKind = facebook::velox::rpc::RPCErrorKind::kBackendError;
+  }
+  return responses;
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/BackendErrorSummary.h
+++ b/velox/exec/rpc/BackendErrorSummary.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "velox/common/rpc/RPCTypes.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// Upper bound, in bytes, on how much of a backend's error text is kept in one
+/// row's error message. The prefix naming the failing path is added on top of
+/// it.
+constexpr size_t kMaxBackendErrorBytes{256};
+
+/// Reduces a backend error message to the single line worth showing per row:
+/// the text before the first newline, capped at 'maxLength' bytes including
+/// the elision marker that is appended whenever anything was dropped.
+/// Surrounding whitespace is dropped first, so a message that leads with a
+/// newline still yields its first real line. The cut is backed off to a UTF-8
+/// sequence boundary, so the result can be shorter than 'maxLength'.
+///
+/// A backend whose thrift method declares no `throws` clause surfaces a
+/// rejection as an untyped TApplicationException, and its message is the
+/// server's one useful sentence followed by the server-side stack trace: one
+/// measured MetaGen rejection ran to 5,665 characters over 51 lines. A
+/// whole-batch failure copies that message into every row, so without a cap it
+/// lands in the output column and is allocated once per row.
+std::string summarizeBackendError(std::string_view rawError, size_t maxLength);
+
+/// Builds one errored response per row for a whole-batch failure, each
+/// carrying 'errorPrefix' followed by the summarized backend text. Summarizing
+/// once, before the fan-out, is what keeps the dropped trace from being
+/// allocated per row. rowId is left at its default because callers stamp batch
+/// positions differently.
+std::vector<facebook::velox::rpc::RPCResponse> makeBatchErrorResponses(
+    size_t numRows,
+    std::string_view errorPrefix,
+    std::string_view rawError);
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/CMakeLists.txt
+++ b/velox/exec/rpc/CMakeLists.txt
@@ -18,6 +18,10 @@ velox_add_library(velox_rpc_error_classification HEADERS RpcErrorClassification.
 
 velox_link_libraries(velox_rpc_error_classification Folly::folly FBThrift::thriftcpp2)
 
+velox_add_library(velox_backend_error_summary BackendErrorSummary.cpp HEADERS BackendErrorSummary.h)
+
+velox_link_libraries(velox_backend_error_summary velox_rpc_types velox_common_base)
+
 velox_add_library(
   velox_rpc_state
   CongestionController.cpp
@@ -44,6 +48,7 @@ velox_add_library(velox_rpc_operator RPCOperator.cpp HEADERS RPCOperator.h)
 
 velox_link_libraries(
   velox_rpc_operator
+  velox_backend_error_summary
   velox_rpc_state
   velox_rpc_rate_limiter
   velox_async_rpc_function

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -20,12 +20,20 @@
 
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
+#include "velox/exec/rpc/BackendErrorSummary.h"
 #include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
 
 #define RPC_OP_LOG(severity) LOG(severity) << "[RPC_OP] "
 #define RPC_OP_VLOG(level) VLOG(level) << "[RPC_OP] "
 
 namespace facebook::velox::exec::rpc {
+
+namespace {
+
+// Identifies the operator-level batch fan-out as the source of a row's error.
+constexpr std::string_view kBatchErrorPrefix = "[RPC_BATCH] batch error: ";
+
+} // namespace
 
 RPCOperator::RPCOperator(
     int32_t operatorId,
@@ -358,14 +366,16 @@ std::vector<RPCResponse> degradeBatchFailureToRowErrors(
   // since evaluateCongestion reads a batch failure as overload.
   RPC_OP_LOG(ERROR) << "RPC batch failed, " << rowIds.size()
                     << " rows will carry a per-row error: " << error.what();
-  std::vector<RPCResponse> errored(rowIds.size());
-  for (size_t i = 0; i < rowIds.size(); ++i) {
+  // Summarize once here rather than copying a server-side stack trace into
+  // every row: the backend text is the same for all of them, and at batch
+  // sizes in the thousands the duplication dominates the output. The
+  // untruncated text stays in the log line above.
+  auto errored = makeBatchErrorResponses(
+      rowIds.size(), kBatchErrorPrefix, error.what().toStdString());
+  for (size_t i = 0; i < errored.size(); ++i) {
     // Batch-position rowId, so the scatter stamps global ids the same way it
     // does on the success path.
     errored[i].rowId = static_cast<int64_t>(i);
-    errored[i].error =
-        std::string("[RPC_BATCH] batch error: ") + error.what().toStdString();
-    errored[i].errorKind = velox::rpc::RPCErrorKind::kBackendError;
   }
   return errored;
 }

--- a/velox/exec/rpc/tests/BackendErrorSummaryTest.cpp
+++ b/velox/exec/rpc/tests/BackendErrorSummaryTest.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Unit tests for the backend error summary shared by every whole-batch
+/// failure fan-out (the RPC operator, the MetaGen batch client, and the
+/// embedding batch path).
+///
+/// A backend whose thrift method declares no `throws` clause reports a
+/// rejection as an untyped TApplicationException whose message is one useful
+/// sentence followed by the server's stack trace. Copying that into every row
+/// of a failed batch puts thousands of characters of trace in the output
+/// column and allocates one copy per row.
+
+#include "velox/exec/rpc/BackendErrorSummary.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace facebook::velox::exec::rpc {
+namespace {
+
+// The prefix a caller puts in front of the summarized backend text.
+const std::string kErrorPrefix = "[RPC_BATCH] batch error: ";
+
+// The one useful sentence a rejected MetaGen batch produces. 107 characters,
+// matching the first line of the payload measured on the fleet.
+const std::string kBackendSentence =
+    "apache::thrift::TApplicationException: you must supply a metagen key in "
+    "the auth token field of the request";
+
+// Builds a payload shaped like the measured backend rejection: the sentence
+// followed by 50 stack frames, each starting at the beginning of its own line
+// (51 lines in total). The frames are NOT separated from the message by a
+// space, so a " #0 " marker never appears — the newline is the only boundary.
+// NOTE: the payload's SIZE is load-bearing, not incidental.
+// dropsServerTraceFromEveryRow asserts it exceeds 5,000 bytes, and that
+// assertion lives far enough below this loop that the coupling is invisible
+// here. Shortening the frame path drops the payload under the floor: a
+// cosmetic rename to "/service/handler.php" once took it to 2,847 bytes.
+std::string makeServerTracePayload() {
+  std::string payload = kBackendSentence;
+  for (int frame = 0; frame < 50; ++frame) {
+    payload += "\n#" + std::to_string(frame) +
+        " /service/flib/backend/metagen/"
+        "TBackendAsyncHandlerBatchRequestCompletion.php(" +
+        std::to_string(100 + frame) + "): batchRequestCompletion()";
+  }
+  return payload;
+}
+
+TEST(BackendErrorSummaryTest, dropsServerTraceFromEveryRow) {
+  const std::string rawError = makeServerTracePayload();
+  // The fixture is the shape the fan-out has to survive: one sentence, then
+  // thousands of characters of trace.
+  ASSERT_GT(rawError.size(), 5'000u);
+
+  const auto responses = makeBatchErrorResponses(4, kErrorPrefix, rawError);
+
+  ASSERT_THAT(responses, testing::SizeIs(4));
+  for (const auto& response : responses) {
+    ASSERT_TRUE(response.hasError());
+    EXPECT_EQ(response.errorKind, velox::rpc::RPCErrorKind::kBackendError);
+    // The sentence survives; not one frame of the trace does.
+    EXPECT_THAT(*response.error, testing::HasSubstr(kBackendSentence));
+    EXPECT_THAT(*response.error, testing::Not(testing::HasSubstr(".php")));
+    EXPECT_THAT(*response.error, testing::Not(testing::HasSubstr("#0")));
+    EXPECT_LE(
+        response.error->size() - kErrorPrefix.size(), kMaxBackendErrorBytes);
+  }
+  // Every row carries the same summarized text.
+  EXPECT_EQ(*responses.front().error, *responses.back().error);
+}
+
+TEST(BackendErrorSummaryTest, shortErrorPassedThroughUnchanged) {
+  const std::string rawError = "connection reset by peer";
+  const auto responses = makeBatchErrorResponses(1, kErrorPrefix, rawError);
+
+  ASSERT_THAT(responses, testing::SizeIs(1));
+  ASSERT_TRUE(responses[0].hasError());
+  EXPECT_EQ(*responses[0].error, kErrorPrefix + rawError);
+}
+
+TEST(BackendErrorSummaryTest, trailingNewlineIsNotCalledTruncation) {
+  // Nothing was dropped but the newline the backend ended its message with.
+  // Marking the row truncated would send a reader to the log for text that is
+  // not there, which is what makes the marker worth trusting elsewhere.
+  const auto responses =
+      makeBatchErrorResponses(1, kErrorPrefix, "connection reset by peer\n");
+
+  ASSERT_THAT(responses, testing::SizeIs(1));
+  ASSERT_TRUE(responses[0].hasError());
+  EXPECT_EQ(*responses[0].error, kErrorPrefix + "connection reset by peer");
+}
+
+TEST(BackendErrorSummaryTest, leadingNewlineKeepsTheFirstRealLine) {
+  // A message that opens with a newline has an empty first line, so cutting at
+  // it would leave the row carrying the prefix and the marker and no
+  // diagnostic text at all.
+  const auto responses = makeBatchErrorResponses(
+      1,
+      kErrorPrefix,
+      "\n" + kBackendSentence + "\n#0 handler.php(100): call()");
+
+  ASSERT_THAT(responses, testing::SizeIs(1));
+  ASSERT_TRUE(responses[0].hasError());
+  EXPECT_THAT(*responses[0].error, testing::HasSubstr(kBackendSentence));
+  EXPECT_THAT(*responses[0].error, testing::Not(testing::HasSubstr(".php")));
+}
+
+TEST(BackendErrorSummaryTest, truncationDoesNotSplitAMultibyteCharacter) {
+  // A backend that echoes the rejected prompt back is not restricted to ASCII,
+  // and the row lands in a UTF-8 VARCHAR column. The cap below falls between
+  // the two bytes of the 'e' with an acute accent, which a byte-index cut
+  // would leave half of in the column.
+  const std::string rawError = "prompt rejected: café is not a model";
+  ASSERT_EQ(rawError.find("é"), 20u);
+  ASSERT_GT(rawError.size(), 36u);
+
+  // 36 - 15 marker bytes cuts at byte 21, the trailing byte of the accent.
+  EXPECT_EQ(
+      summarizeBackendError(rawError, 36),
+      "prompt rejected: caf... (truncated)");
+}
+
+TEST(BackendErrorSummaryTest, resultNeverExceedsTheRequestedCap) {
+  // The elision marker is appended after the cut, so the kept text has to
+  // leave room for it. Computing the cut against the full cap instead reads
+  // as correct and overruns by the length of the marker on every truncated
+  // row, which is the one thing this function exists to bound.
+  for (const size_t maxLength : {16UL, 32UL, 64UL, 256UL}) {
+    EXPECT_LE(
+        summarizeBackendError(std::string(4'000, 'x'), maxLength).size(),
+        maxLength);
+  }
+}
+
+TEST(BackendErrorSummaryTest, capsSingleLineErrorWithNoNewline) {
+  // No newline to cut at, so the hard cap is the only thing that can bound it.
+  const std::string rawError(4'000, 'x');
+  const auto responses = makeBatchErrorResponses(1, kErrorPrefix, rawError);
+
+  ASSERT_THAT(responses, testing::SizeIs(1));
+  ASSERT_TRUE(responses[0].hasError());
+  const std::string& error = *responses[0].error;
+  ASSERT_THAT(error, testing::StartsWith(kErrorPrefix));
+  EXPECT_THAT(error, testing::HasSubstr("truncated"));
+  EXPECT_LE(error.size() - kErrorPrefix.size(), kMaxBackendErrorBytes);
+}
+
+TEST(BackendErrorSummaryTest, capsTraceAppendedToTheSameLine) {
+  // A backend that appends its frames to the message instead of starting a new
+  // line leaves no newline to cut at. Nothing tries to recognize a frame
+  // marker; the cap alone has to bound the row.
+  std::string rawError = kBackendSentence;
+  for (int frame = 0; frame < 50; ++frame) {
+    rawError += " #" + std::to_string(frame) + " handler.php(100): call()";
+  }
+  const auto responses = makeBatchErrorResponses(1, kErrorPrefix, rawError);
+
+  ASSERT_THAT(responses, testing::SizeIs(1));
+  ASSERT_TRUE(responses[0].hasError());
+  EXPECT_LE(
+      responses[0].error->size() - kErrorPrefix.size(), kMaxBackendErrorBytes);
+}
+
+TEST(BackendErrorSummaryTest, capIsTheCallerSuppliedLength) {
+  // Both inputs are longer than the cap, so both go through the cap rather
+  // than the unchanged-passthrough branch, and the result fills the caller's
+  // budget exactly.
+  const std::string rawError(200, 'x');
+
+  EXPECT_EQ(summarizeBackendError(rawError, 32).size(), 32u);
+  EXPECT_EQ(summarizeBackendError(rawError, 100).size(), 100u);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/CMakeLists.txt
+++ b/velox/exec/rpc/tests/CMakeLists.txt
@@ -104,10 +104,24 @@ target_link_libraries(
 
 add_test(NAME velox_rpc_error_classification_test COMMAND velox_rpc_error_classification_test)
 
+add_executable(velox_backend_error_summary_test BackendErrorSummaryTest.cpp)
+
+target_link_libraries(
+  velox_backend_error_summary_test
+  velox_backend_error_summary
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main
+  Folly::folly
+)
+
+add_test(NAME velox_backend_error_summary_test COMMAND velox_backend_error_summary_test)
+
 add_executable(velox_rpc_operator_test RPCOperatorTest.cpp Main.cpp)
 
 target_link_libraries(
   velox_rpc_operator_test
+  velox_backend_error_summary
   velox_demo_batch_rpc_function
   velox_demo_rpc_function
   velox_rpc_plan_node_translator

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -24,6 +24,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/rpc/BackendErrorSummary.h"
 #include "velox/exec/rpc/RPCOperator.h"
 #include "velox/exec/rpc/RPCPlanNodeTranslator.h"
 #include "velox/exec/rpc/RPCRateLimiter.h"
@@ -44,6 +45,57 @@
 namespace facebook::velox::exec::rpc {
 
 using namespace facebook::velox::exec::test;
+
+// The one useful sentence of a measured backend rejection, and the prefix the
+// operator puts in front of it.
+const std::string kBackendSentence =
+    "apache::thrift::TApplicationException: you must supply a metagen key in "
+    "the auth token field of the request";
+const std::string kOperatorErrorPrefix = "[RPC_BATCH] batch error: ";
+
+// Fails the whole batch the way a real backend rejection arrives — one
+// sentence followed by a server-side stack trace — and writes each row's error
+// text into the output column, which is what meta_ai_on_error='error_message'
+// does and where an untruncated trace would land.
+class TraceFailingBatchRPCFunction : public DemoBatchRPCFunction {
+ public:
+  TraceFailingBatchRPCFunction() : DemoBatchRPCFunction() {}
+
+  static std::string backendMessage() {
+    std::string message = kBackendSentence;
+    for (int frame = 0; frame < 50; ++frame) {
+      message += "\n#" + std::to_string(frame) +
+          " /www/flib/gen_ai/metagen/"
+          "TMetaGenAsyncHandlerBatchDialogCompletion.php(" +
+          std::to_string(100 + frame) + "): batchDialogCompletion()";
+    }
+    return message;
+  }
+
+  folly::SemiFuture<std::vector<RPCResponse>> flushBatch(
+      int32_t maxRows) override {
+    // Drain through the base so the accumulated rows are consumed and
+    // noMoreInput() terminates, then fail the flush future.
+    DemoBatchRPCFunction::flushBatch(maxRows);
+    return folly::makeSemiFuture<std::vector<RPCResponse>>(
+        std::runtime_error(backendMessage()));
+  }
+
+  VectorPtr buildOutput(
+      const std::vector<RPCResponse>& responses,
+      memory::MemoryPool* pool) const override {
+    auto result = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), static_cast<vector_size_t>(responses.size()), pool);
+    for (size_t i = 0; i < responses.size(); ++i) {
+      // set() copies, so a StringView over the response's own storage is safe.
+      const std::string& text = responses[i].error.value_or("");
+      result->set(
+          static_cast<vector_size_t>(i),
+          StringView(text.data(), static_cast<int32_t>(text.size())));
+    }
+    return result;
+  }
+};
 
 class RPCOperatorTest : public OperatorTestBase {
  protected:
@@ -87,6 +139,9 @@ class RPCOperatorTest : public OperatorTestBase {
               /*failWholeBatch=*/true,
               /*failOnError=*/true);
         });
+    AsyncRPCFunctionRegistry::registerFunction(
+        "demo_batch_rpc_whole_fail_trace",
+        []() { return std::make_shared<TraceFailingBatchRPCFunction>(); });
     // Returns fewer responses than rows (function-contract violation): the
     // operator's scatter must hard-fail on the count mismatch.
     AsyncRPCFunctionRegistry::registerFunction(
@@ -711,6 +766,34 @@ TEST_F(RPCOperatorTest, batchWholeBatchFailureDegradesToNull) {
   for (vector_size_t i = 0; i < result->size(); ++i) {
     EXPECT_TRUE(results->isNullAt(i))
         << "row " << i << " should degrade to NULL on whole-batch failure";
+  }
+}
+
+// A whole-batch failure fans one backend message out to every row. The message
+// is the server's sentence followed by its stack trace, so the operator has to
+// summarize it before the fan-out — otherwise every cell carries thousands of
+// characters of trace and the trace is allocated once per row.
+TEST_F(RPCOperatorTest, batchWholeBatchFailureSummarizesBackendError) {
+  auto input =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"a", "b", "c"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_whole_fail_trace");
+
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 3);
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    const std::string cell = results->valueAt(i).str();
+    EXPECT_NE(cell.find(kBackendSentence), std::string::npos)
+        << "row " << i << " should keep the backend's leading sentence";
+    EXPECT_EQ(cell.find(".php"), std::string::npos)
+        << "row " << i << " should not carry a stack frame";
+    EXPECT_LE(cell.size(), kOperatorErrorPrefix.size() + kMaxBackendErrorBytes)
+        << "row " << i << " exceeds the backend error cap";
   }
 }
 


### PR DESCRIPTION
Summary:
A failed MetaGen batch call copies the backend's full stack trace into the error column of every output row. An 8-row query returned 8 identical 5,690-character cells. Each error is now summarized where it is produced, down to what precedes the first newline and capped at 256 bytes; the untruncated text still goes to the log.

The batch thrift methods declare no `throws` clause, so a rejection arrives as an untyped `TApplicationException` carrying the server's raw text. The IDL gap on the batch methods is what makes this path untyped; transport-level failures (ServiceRouter, connection, overload) are untyped regardless of the IDL and are handled separately.

Three things worth knowing before reviewing:
- The column and the thrown failure read the same `RPCResponse::error` field, so under `meta_ai_on_error=fail` the thrown query error is capped too. The backtrace then reaches only the worker log, which is harder for a Presto user to get at than a query error. The actionable sentence survives, so this is the intended trade, not a side effect.
- This reduces total bytes ~38x (5,690 -> 147 per row). One string is still allocated per row, so it stays O(rows) allocations -- do not cite it as an allocator-pressure fix. (Allocation count does drop, roughly by half: the pre-fix code built the string inside the per-row loop.)
- It caps the three BATCH fan-outs and the per-input failure reason in the results loop. Other uncapped producers remain -- the largest measured is `MetaGenTransport.cpp:319-322` at 83 failed queries in 7 days, p50 5,685 chars, a longer median than the case fixed here. There are ~8 more (the timeout arm just above it, `MetaGenRPCClient.cpp:276/293/352/374/415`, `RPCState.cpp:203`). Tracked as a follow-up; different producers, different paths.

Differential Revision: D118374563


