### PR TITLE
feat(vector): Expose if DecodedVector buffers are borrowed or owned (#18795)

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -288,9 +288,28 @@ void DecodedVector::applyDictionaryWrapper(
   });
 }
 
+bool DecodedVector::ownsNulls(const SelectivityVector* rows) {
+  const auto* bits = nulls(rows);
+  return bits != nullptr && !copiedNulls_.empty() &&
+      bits == copiedNulls_.data();
+}
+
+bool DecodedVector::ownsIndices() const {
+  // Before indices() has run there is no pointer yet, so answer for the one it
+  // would produce rather than for the absence of one.
+  return indices_ == nullptr ? wouldCopyIndices() : !indicesNotCopied();
+}
+
+bool DecodedVector::wouldCopyIndices() const {
+  if (isConstantMapping_) {
+    return size_ > zeroIndices().size() || constantIndex_ != 0;
+  }
+  return isIdentityMapping_ && size_ > consecutiveIndices().size();
+}
+
 void DecodedVector::fillInIndices() const {
   if (isConstantMapping_) {
-    if (size_ > zeroIndices().size() || constantIndex_ != 0) {
+    if (wouldCopyIndices()) {
       copiedIndices_.resize(size_);
       std::fill(copiedIndices_.begin(), copiedIndices_.end(), constantIndex_);
       indices_ = copiedIndices_.data();
@@ -300,7 +319,7 @@ void DecodedVector::fillInIndices() const {
     return;
   }
   if (isIdentityMapping_) {
-    if (size_ > consecutiveIndices().size()) {
+    if (wouldCopyIndices()) {
       copiedIndices_.resize(size_);
       std::iota(copiedIndices_.begin(), copiedIndices_.end(), 0);
       indices_ = &copiedIndices_[0];

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -150,6 +150,33 @@ class DecodedVector {
     return hasExtraNulls_;
   }
 
+  /// Returns true if nulls() returns storage owned by this DecodedVector.
+  ///
+  /// Owned storage is overwritten by the next decode() and freed when this
+  /// object is destroyed. When this returns false the pointer outlives this
+  /// DecodedVector, because it belongs to the decoded vector itself, so a
+  /// caller building a longer-lived view over it may borrow it rather than
+  /// copy it.
+  ///
+  /// Materializes the bitmap if that has not happened yet, so the answer never
+  /// depends on call order. That costs nothing a caller does not already owe:
+  /// nulls() caches its result, and the one path that does real work -- the
+  /// gather into top-level row order -- only runs when there are nulls to
+  /// gather, which is when the caller wanted the bitmap anyway.
+  ///
+  /// Pass the same 'rows' as decode(), exactly as for nulls().
+  bool ownsNulls(const SelectivityVector* rows = nullptr);
+
+  /// Returns true if indices() returns storage owned by this DecodedVector,
+  /// with the same lifetime and borrowing rules as ownsNulls().
+  ///
+  /// A single dictionary wrapping is adopted by pointer rather than composed,
+  /// so it reports false and can be borrowed. Composing two or more wrappings
+  /// materializes indices here and reports true. A flat or constant input
+  /// materializes on first access to indices(); this answers for that result
+  /// without forcing it.
+  bool ownsIndices() const;
+
   /// Returns the mapping from top-level rows to rows in the base vector or
   /// data() buffer.
   ///
@@ -446,9 +473,15 @@ class DecodedVector {
   static const std::vector<vector_size_t>& zeroIndices();
 
   bool indicesNotCopied() const {
-    return copiedIndices_.empty() || indices_ < copiedIndices_.data() ||
-        indices_ >= &copiedIndices_.back();
+    return copiedIndices_.empty() || indices_ != copiedIndices_.data();
   }
+
+  // Whether fillInIndices() would materialize into copiedIndices_ rather than
+  // hand back one of the shared static arrays. Only meaningful before
+  // indices() has run. Consulted by ownsIndices(), so a caller can ask whether
+  // it may borrow without paying for the materialization, and by
+  // fillInIndices() itself, so the rule lives in one place.
+  bool wouldCopyIndices() const;
 
   bool nullsNotCopied() const {
     return copiedNulls_.empty() || nulls_ != copiedNulls_.data();

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -651,6 +651,106 @@ TEST_F(DecodedVectorTest, dictionary) {
       1000, [](vector_size_t i) { return std::make_shared<int>(i % 5); });
 }
 
+TEST_F(DecodedVectorTest, ownsIndices) {
+  auto base = makeFlatVector<int64_t>({10, 20, 30});
+  auto reversed = makeIndices(3, [](auto row) { return 2 - row; });
+
+  // A single wrapping is adopted by pointer, so the caller may borrow it.
+  auto oneLevel = BaseVector::wrapInDictionary(nullptr, reversed, 3, base);
+  DecodedVector decoded(*oneLevel);
+  EXPECT_EQ(decoded.indices(), reversed->as<vector_size_t>());
+  EXPECT_FALSE(decoded.ownsIndices());
+
+  // Composing a second wrapping materializes indices here instead.
+  auto identity = makeIndices(3, [](auto row) { return row; });
+  auto twoLevels = BaseVector::wrapInDictionary(nullptr, identity, 3, oneLevel);
+  decoded.decode(*twoLevels);
+  EXPECT_NE(decoded.indices(), identity->as<vector_size_t>());
+  EXPECT_TRUE(decoded.ownsIndices());
+}
+
+TEST_F(DecodedVectorTest, ownsIndicesSingleRow) {
+  // One row is where a range-based ownership check goes wrong, because the
+  // buffer's first and last element share an address. indices_ only ever
+  // points at the start of copiedIndices_ or somewhere else entirely, so the
+  // check is an equality and the size cannot matter. This pins that.
+  auto base = makeFlatVector<int64_t>({10});
+  auto indices = makeIndices(1, [](auto) { return 0; });
+  auto oneLevel = BaseVector::wrapInDictionary(nullptr, indices, 1, base);
+  auto twoLevels = BaseVector::wrapInDictionary(nullptr, indices, 1, oneLevel);
+
+  DecodedVector decoded(*twoLevels);
+  ASSERT_EQ(decoded.indices()[0], 0);
+  EXPECT_TRUE(decoded.ownsIndices());
+}
+
+TEST_F(DecodedVectorTest, ownsIndicesBeforeIndicesIsCalled) {
+  // A caller deciding whether it may borrow should not have to allocate to
+  // find out, and for a flat input indices() allocates. The answer must
+  // therefore be available before it runs, and agree with it afterwards.
+  auto small = makeFlatVector<int64_t>(100, [](auto row) { return row; });
+  DecodedVector decoded(*small);
+  EXPECT_FALSE(decoded.ownsIndices());
+  EXPECT_EQ(decoded.indices()[7], 7);
+  EXPECT_FALSE(decoded.ownsIndices());
+
+  // Past the shared array's 10'000 entries there is nothing to hand back, so
+  // indices() has to materialize and the answer flips.
+  auto large = makeFlatVector<int64_t>(20'000, [](auto row) { return row; });
+  DecodedVector decodedLarge(*large);
+  EXPECT_TRUE(decodedLarge.ownsIndices());
+  EXPECT_EQ(decodedLarge.indices()[19'999], 19'999);
+  EXPECT_TRUE(decodedLarge.ownsIndices());
+}
+
+TEST_F(DecodedVectorTest, ownsNullsDoesNotDependOnCallOrder) {
+  // Asking first must give the same answer as asking after, or a caller that
+  // checks before fetching gets told a decoder-owned bitmap is borrowable.
+  auto base = makeNullableFlatVector<int64_t>({1, std::nullopt, 3});
+  auto reversed = makeIndices(3, [](auto row) { return 2 - row; });
+  auto dictionary = BaseVector::wrapInDictionary(nullptr, reversed, 3, base);
+
+  DecodedVector asked(*dictionary);
+  EXPECT_TRUE(asked.ownsNulls());
+  EXPECT_TRUE(asked.ownsNulls());
+
+  DecodedVector fetched(*dictionary);
+  ASSERT_NE(fetched.nulls(), nullptr);
+  EXPECT_TRUE(fetched.ownsNulls());
+
+  // And the null-free case answers without materializing anything, which is
+  // what lets a caller ask unconditionally.
+  auto noNulls = makeFlatVector<int64_t>({1, 2, 3});
+  DecodedVector clean(*noNulls);
+  EXPECT_FALSE(clean.ownsNulls());
+  EXPECT_EQ(clean.nulls(), nullptr);
+}
+
+TEST_F(DecodedVectorTest, ownsNulls) {
+  // Flat nulls are the vector's own bitmap, so they can be borrowed.
+  auto flat = makeNullableFlatVector<int64_t>({1, std::nullopt, 3});
+  DecodedVector decoded(*flat);
+  ASSERT_NE(decoded.nulls(), nullptr);
+  EXPECT_FALSE(decoded.ownsNulls());
+  EXPECT_EQ(decoded.nulls(), flat->rawNulls());
+
+  // Reading a null-bearing base through a dictionary gathers the bits into
+  // top-level row order, which is storage this DecodedVector owns -- even
+  // though the wrapping added no nulls of its own.
+  auto reversed = makeIndices(3, [](auto row) { return 2 - row; });
+  auto dictionary = BaseVector::wrapInDictionary(nullptr, reversed, 3, flat);
+  decoded.decode(*dictionary);
+  ASSERT_NE(decoded.nulls(), nullptr);
+  EXPECT_TRUE(decoded.ownsNulls());
+  EXPECT_NE(decoded.nulls(), flat->rawNulls());
+
+  // No nulls at all is neither owned nor borrowed.
+  auto noNulls = makeFlatVector<int64_t>({1, 2, 3});
+  decoded.decode(*noNulls);
+  ASSERT_EQ(decoded.nulls(), nullptr);
+  EXPECT_FALSE(decoded.ownsNulls());
+}
+
 TEST_F(DecodedVectorTest, valueAtOpaqueDoesNotCopy) {
   using TOpaque = std::shared_ptr<void>;
   constexpr vector_size_t size = 100;


### PR DESCRIPTION
Summary:

A caller building a view that must outlive a `DecodedVector` cannot tell whether `indices()` and `nulls()` point at storage the decoder owns, which the next `decode()` overwrites and destruction frees. It has to copy both defensively, even though a single dictionary wrapping is adopted by pointer and could be borrowed. `ownsIndices()` and `ownsNulls()` answer the question, so the copy happens only where it is needed.

The two reach the answer differently, deliberately. `ownsNulls()` materializes the bitmap if that has not happened yet, so its answer never depends on call order; that costs nothing a caller does not already owe, because `nulls()` caches and its one expensive path runs only when there are nulls to gather. `ownsIndices()` instead reports on the pointer `indices()` would produce, without producing it, because for a flat or constant input `indices()` builds an identity array that such a caller went out of its way not to ask for.

Also simplifies the ownership check for indices. It compared the pointer against a range, but `indices_` is only ever the start of `copiedIndices_` or a buffer outside it, so an equality says the same thing. The range form additionally got a one-row buffer wrong, since its first and last element share an address -- harmless where it was used, but not once callers can read the result.

Reviewed By: Yuhta

Differential Revision: D118298348


