### PR TITLE
fix(nimble): Avoid nested parallel decode deadlock (#18796)

### DIFF
--- a/velox/dwio/nimble/serializer/Deserializer.cpp
+++ b/velox/dwio/nimble/serializer/Deserializer.cpp
@@ -17,6 +17,7 @@
 #include "folly/Likely.h"
 #include "folly/ScopeGuard.h"
 #include "folly/container/F14Set.h"
+#include "folly/coro/BlockingWait.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -106,8 +107,8 @@ bool checkColumnProjectionSubfield(
   return false;
 }
 
-// One reader operation. Executed as `reader_->skip(numRows)` when
-// `skip == true`, or `reader_->next(numRows, ...)` when `skip == false`.
+// One reader operation. Executed as `reader_->co_skip(numRows)` when
+// `skip == true`, or `reader_->co_next(numRows, ...)` when `skip == false`.
 struct DecodeOp {
   bool skip;
   uint32_t numRows;
@@ -235,7 +236,7 @@ FieldReaderParams Deserializer::createFieldReaderParams() const {
   params.flatMapFeatureSelector = flatMapFeatureSelector_;
   params.decodeExecutor = options_.decodeExecutor;
   params.maxDecodeParallelism = options_.maxDecodeParallelism;
-  params.minStreamsPerDecodeUnit = options_.minStreamsPerDecodeUnit;
+  params.minStreamsPerDecodeTask = options_.minStreamsPerDecodeTask;
   if (options_.outputType == nullptr) {
     return params;
   }
@@ -567,11 +568,11 @@ void Deserializer::decodeRun(DecodeRun& run, velox::VectorPtr& output) const {
   const auto ops = buildDecodeOps(runRanges_);
   for (const auto& op : ops) {
     if (op.skip) {
-      reader_->skip(op.numRows);
+      folly::coro::blockingWait(reader_->co_skip(op.numRows));
       continue;
     }
     velox::VectorPtr decoded;
-    reader_->next(op.numRows, decoded, nullptr);
+    folly::coro::blockingWait(reader_->co_next(op.numRows, decoded, nullptr));
     decoded = projectOutput(std::move(decoded));
     appendToOutput(std::move(decoded), output);
   }

--- a/velox/dwio/nimble/serializer/Deserializer.h
+++ b/velox/dwio/nimble/serializer/Deserializer.h
@@ -114,7 +114,7 @@ class Deserializer {
   ///   for each i: deserialize(data[i]).slice(rowRanges[i].startRow,
   ///                                          rowRanges[i].numRows())
   /// concatenated, but rows outside each range are never materialized —
-  /// they are skipped via the FieldReader's `skip()` primitive. Note this
+  /// they are skipped via the FieldReader's `co_skip()` primitive. Note this
   /// equivalence holds under the relative interpretation: the single-batch
   /// `deserialize` already applies the header window, so slicing its output
   /// is the same as narrowing within that window.

--- a/velox/dwio/nimble/serializer/Options.h
+++ b/velox/dwio/nimble/serializer/Options.h
@@ -300,14 +300,16 @@ struct DeserializerOptions {
   /// When nullptr (default), child reads are performed sequentially.
   folly::Executor* decodeExecutor{nullptr};
 
-  /// Maximum number of parallel coroutine tasks for child field decoding.
-  /// Children are grouped into this many batches, each decoded sequentially
-  /// within a single coroutine task. 0 disables parallel decoding.
+  /// Maximum number of parallel coroutine tasks scheduled by each field
+  /// reader. Children are grouped into this many batches, each decoded
+  /// sequentially within a single coroutine task. This is a per-reader limit;
+  /// the executor bounds the number of tasks that run concurrently across the
+  /// reader tree. 0 disables parallel decoding.
   uint32_t maxDecodeParallelism{0};
 
   /// Minimum number of child streams per parallel decode task. Ensures each
   /// coroutine task has enough work to amortize threading overhead.
-  uint32_t minStreamsPerDecodeUnit{1};
+  uint32_t minStreamsPerDecodeTask{1};
 };
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <numeric>
 #include <optional>
 #include <string_view>
@@ -6322,21 +6323,21 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeRow) {
 
   struct ParallelDecodeParam {
     uint32_t maxDecodeParallelism;
-    uint32_t minStreamsPerDecodeUnit;
+    uint32_t minStreamsPerDecodeTask;
     uint32_t expectedTaskCount;
 
     std::string debugString() const {
       return fmt::format(
           "maxParallel={}, minStreams={}, expectedTasks={}",
           maxDecodeParallelism,
-          minStreamsPerDecodeUnit,
+          minStreamsPerDecodeTask,
           expectedTaskCount);
     }
   };
 
   // 8 children: test different parallelism combinations.
-  // parallelDecodeEnabled requires numChildren >= minStreamsPerDecodeUnit * 2,
-  // so all test cases must satisfy 8 >= minStreams * 2.
+  // Parallel decode requires numChildren >= minStreamsPerDecodeTask * 2, so
+  // all test cases must satisfy 8 >= minStreams * 2.
   const std::vector<ParallelDecodeParam> testCases = {
       {2, 1, 2}, // 2 tasks, 4 children each
       {4, 1, 4}, // 4 tasks, 2 children each
@@ -6354,7 +6355,7 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeRow) {
     auto opts = deserializerOptions();
     opts.decodeExecutor = &executor;
     opts.maxDecodeParallelism = testCase.maxDecodeParallelism;
-    opts.minStreamsPerDecodeUnit = testCase.minStreamsPerDecodeUnit;
+    opts.minStreamsPerDecodeTask = testCase.minStreamsPerDecodeTask;
 
     Deserializer deserializer{schema, pool_.get(), opts};
 
@@ -6382,6 +6383,94 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeRow) {
       EXPECT_EQ(taskCount, testCase.expectedTaskCount);
     }
   }
+}
+
+DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeNestedRows) {
+  velox::common::testutil::TestValue::enable();
+
+  const auto nestedType = velox::ROW({
+      {"integer", velox::BIGINT()},
+      {"floating_point", velox::DOUBLE()},
+  });
+  const auto type = velox::ROW({
+      {"left", nestedType},
+      {"right", nestedType},
+  });
+  velox::VectorFuzzer fuzzer({.vectorSize = 50, .nullRatio = 0}, pool_.get());
+  const auto input = fuzzer.fuzzInputRow(
+      std::dynamic_pointer_cast<const velox::RowType>(type));
+
+  Serializer serializer{
+      SerializerOptions{.version = version()}, type, pool_.get()};
+  const auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+  const auto schema =
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+
+  folly::CPUThreadPoolExecutor executor{2};
+  auto options = deserializerOptions();
+  options.decodeExecutor = &executor;
+  options.maxDecodeParallelism = 2;
+
+  std::atomic_uint32_t parallelDecodeCount{0};
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::RowFieldReader::co_next",
+      std::function<void(const uint32_t*)>(
+          [&](const uint32_t*) { ++parallelDecodeCount; }));
+
+  Deserializer deserializer{schema, pool_.get(), options};
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t row = 0; row < output->size(); ++row) {
+    EXPECT_TRUE(output->equalValueAt(input.get(), row, row));
+  }
+  EXPECT_EQ(parallelDecodeCount, 3);
+}
+
+DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeNestedRowsInArrays) {
+  velox::common::testutil::TestValue::enable();
+
+  const auto nestedType = velox::ROW({
+      {"integer", velox::BIGINT()},
+      {"floatingPoint", velox::DOUBLE()},
+  });
+  const auto type = velox::ROW({
+      {"left", velox::ARRAY(nestedType)},
+      {"right", velox::ARRAY(nestedType)},
+  });
+  velox::VectorFuzzer fuzzer({.vectorSize = 50, .nullRatio = 0}, pool_.get());
+  const auto input = fuzzer.fuzzInputRow(
+      std::dynamic_pointer_cast<const velox::RowType>(type));
+
+  Serializer serializer{
+      SerializerOptions{.version = version()}, type, pool_.get()};
+  const auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+  const auto schema =
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+
+  folly::CPUThreadPoolExecutor executor{2};
+  auto options = deserializerOptions();
+  options.decodeExecutor = &executor;
+  options.maxDecodeParallelism = 2;
+
+  std::atomic_uint32_t numParallelRowDecodes{0};
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::RowFieldReader::co_next",
+      std::function<void(const uint32_t*)>(
+          [&](const uint32_t*) { ++numParallelRowDecodes; }));
+
+  Deserializer deserializer{schema, pool_.get(), options};
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t row = 0; row < output->size(); ++row) {
+    EXPECT_TRUE(output->equalValueAt(input.get(), row, row));
+  }
+  EXPECT_EQ(numParallelRowDecodes, 3);
 }
 
 // Verifies that parallel decode is triggered for StructFlatMapFieldReader
@@ -6472,25 +6561,25 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeFlatMapAsStruct) {
 
   struct ParallelDecodeParam {
     uint32_t maxDecodeParallelism;
-    uint32_t minStreamsPerDecodeUnit;
+    uint32_t minStreamsPerDecodeTask;
     // Expected task count for the StructFlatMapFieldReader (8 keys).
     uint32_t expectedFlatMapTaskCount;
     // Whether parallel decode is expected for the Row (2 children: id +
-    // features). Depends on whether 2 >= minStreamsPerDecodeUnit * 2.
+    // features). Depends on whether 2 >= minStreamsPerDecodeTask * 2.
     bool rowParallelExpected;
 
     std::string debugString() const {
       return fmt::format(
           "maxParallel={}, minStreams={}, expectedFlatMapTasks={}, rowParallel={}",
           maxDecodeParallelism,
-          minStreamsPerDecodeUnit,
+          minStreamsPerDecodeTask,
           expectedFlatMapTaskCount,
           rowParallelExpected);
     }
   };
 
   // 8 flatmap keys -> 8 children in StructFlatMapFieldReader.
-  // parallelDecodeEnabled requires numChildren >= minStreamsPerDecodeUnit * 2.
+  // Parallel decode requires numChildren >= minStreamsPerDecodeTask * 2.
   const std::vector<ParallelDecodeParam> testCases = {
       {2, 1, 2, true},
       {4, 1, 4, true},
@@ -6507,7 +6596,7 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeFlatMapAsStruct) {
     opts.outputType = outputType;
     opts.decodeExecutor = &executor;
     opts.maxDecodeParallelism = testCase.maxDecodeParallelism;
-    opts.minStreamsPerDecodeUnit = testCase.minStreamsPerDecodeUnit;
+    opts.minStreamsPerDecodeTask = testCase.minStreamsPerDecodeTask;
 
     Deserializer deserializer{schema, pool_.get(), opts};
 
@@ -6650,7 +6739,7 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeSkippedFewKeys) {
   opts.outputType = outputType;
   opts.decodeExecutor = &executor;
   opts.maxDecodeParallelism = 4;
-  opts.minStreamsPerDecodeUnit = 1;
+  opts.minStreamsPerDecodeTask = 1;
 
   Deserializer deserializer{schema, pool_.get(), opts};
 
@@ -6753,7 +6842,7 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeDisabled) {
     auto opts = deserializerOptions();
     opts.decodeExecutor = testCase.hasExecutor ? &executor : nullptr;
     opts.maxDecodeParallelism = testCase.maxDecodeParallelism;
-    opts.minStreamsPerDecodeUnit = 1;
+    opts.minStreamsPerDecodeTask = 1;
 
     Deserializer deserializer{schema, pool_.get(), opts};
 
@@ -6890,7 +6979,7 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeDisabledFlatMap) {
     opts.outputType = outputType;
     opts.decodeExecutor = testCase.hasExecutor ? &executor : nullptr;
     opts.maxDecodeParallelism = testCase.maxDecodeParallelism;
-    opts.minStreamsPerDecodeUnit = 1;
+    opts.minStreamsPerDecodeTask = 1;
 
     Deserializer deserializer{schema, pool_.get(), opts};
 

--- a/velox/dwio/nimble/velox/BatchReader.cpp
+++ b/velox/dwio/nimble/velox/BatchReader.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include "fmt/core.h"
 #include "folly/container/F14Map.h"
+#include "folly/coro/BlockingWait.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/common/OnDemandUnitLoader.h"
 #include "velox/dwio/common/UnitLoader.h"
@@ -526,7 +527,7 @@ bool BatchReader::next(uint64_t rowCount, velox::VectorPtr& result) {
   }
   unitLoader_->onRead(
       getUnitIndex(loadedStripe_.value()), getCurrentRowInStripe(), rowsToRead);
-  rootReader_->next(rowsToRead, result);
+  folly::coro::blockingWait(rootReader_->co_next(rowsToRead, result));
   if (barrier_) {
     // Wait for all reader tasks to complete.
     barrier_->waitAll();
@@ -654,7 +655,7 @@ void BatchReader::skipInCurrentStripe(uint64_t rowsToSkip) {
   rowsRemainingInStripe_ -= rowsToSkip;
   unitLoader_->onSeek(
       getUnitIndex(loadedStripe_.value()), getCurrentRowInStripe());
-  rootReader_->skip(rowsToSkip);
+  folly::coro::blockingWait(rootReader_->co_skip(rowsToSkip));
 }
 
 BatchReader::~BatchReader() = default;

--- a/velox/dwio/nimble/velox/FieldReader.cpp
+++ b/velox/dwio/nimble/velox/FieldReader.cpp
@@ -27,9 +27,8 @@
 #include "velox/dwio/nimble/encodings/legacy/TrivialEncoding.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
 
-#include <folly/coro/BlockingWait.h>
+#include <folly/Conv.h>
 #include <folly/coro/Collect.h>
-#include <folly/coro/Invoke.h>
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/FlatMapHelper.h"
 #include "velox/vector/ComplexVector.h"
@@ -295,14 +294,17 @@ class NullColumnReader final : public FieldReader {
     return std::optional<std::pair<uint32_t, uint64_t>>({0, 0});
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
     ensureNullConstant(type_, scatterCount(count, scatterBitmap), output);
+    co_return;
   }
 
-  void skip(uint32_t /* count */) final {}
+  folly::coro::Task<void> co_skip(uint32_t /*count*/) final {
+    co_return;
+  }
 };
 
 class NullFieldReaderFactory final : public FieldReaderFactory {
@@ -451,7 +453,7 @@ class ScalarFieldReader final
         {rowCount, totalBytes / rowCount});
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
@@ -545,10 +547,12 @@ class ScalarFieldReader final
         upcastWithNulls();
       }
     }
+    co_return;
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     decoder_->skip(count);
+    co_return;
   }
 };
 
@@ -671,7 +675,7 @@ class StringFieldReader final : public FieldReader {
                                {rowCount, totalBytes / rowCount});
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
@@ -709,10 +713,12 @@ class StringFieldReader final : public FieldReader {
     }
     // Use shared ownership of the buffers
     vector->setStringBuffers(std::move(stringBuffers));
+    co_return;
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     decoder_->skip(count);
+    co_return;
   }
 
  private:
@@ -777,7 +783,7 @@ class LegacyStringFieldReader final : public FieldReader {
                                {rowCount, totalBytes / rowCount});
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
@@ -841,10 +847,12 @@ class LegacyStringFieldReader final : public FieldReader {
       }
     }
     vector->setStringBuffers({data});
+    co_return;
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     decoder_->skip(count);
+    co_return;
   }
 
  private:
@@ -918,7 +926,7 @@ class TimestampMicroNanoFieldReader final : public FieldReader {
         {rowCount, totalBytes / rowCount});
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
@@ -964,9 +972,10 @@ class TimestampMicroNanoFieldReader final : public FieldReader {
         }
       }
     }
+    co_return;
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     std::array<int64_t, kSkipBatchSize> microsBuffer{};
     std::array<char, nullBytes(kSkipBatchSize)> nulls{};
     uint32_t nonNullCount = 0;
@@ -986,6 +995,7 @@ class TimestampMicroNanoFieldReader final : public FieldReader {
     if (nonNullCount > 0) {
       nanosDecoder_->skip(nonNullCount);
     }
+    co_return;
   }
 
   void reset() final {
@@ -1208,26 +1218,25 @@ class ArrayFieldReader final : public MultiValueFieldReader {
     }
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
-    auto childrenRows = this->template loadOffsets<velox::ArrayVector>(
+    const auto childrenRows = this->template loadOffsets<velox::ArrayVector>(
         count, output, scatterBitmap);
 
-    // As the fields are aligned by lengths decoder so no need to pass scatter
-    // to elements
-    elementsReader_->next(
+    co_await elementsReader_->co_next(
         childrenRows,
         static_cast<velox::ArrayVector&>(*output).elements(),
-        /* scatterBitmap */ nullptr);
+        /*scatterBitmap=*/nullptr);
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     auto childrenCount = this->skipLengths(count);
     if (childrenCount > 0) {
-      elementsReader_->skip(childrenCount);
+      co_await elementsReader_->co_skip(childrenCount);
     }
+    co_return;
   }
 
   void reset() final {
@@ -1291,7 +1300,7 @@ class ArrayWithOffsetsFieldReader final : public MultiValueFieldReader {
     return std::nullopt;
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
@@ -1367,20 +1376,20 @@ class ArrayWithOffsetsFieldReader final : public MultiValueFieldReader {
 
     if (cached_ && cachedLazyLoad_) {
       if (cachedLocally) {
-        elementsReader_->next(
+        co_await elementsReader_->co_next(
             cachedLazyChildrenRows_,
             static_cast<velox::ArrayVector&>(*cachedValue_).elements(),
-            /* scatterBitmap */ nullptr);
+            /*scatterBitmap=*/nullptr);
       } else {
-        elementsReader_->skip(cachedLazyChildrenRows_);
+        co_await elementsReader_->co_skip(cachedLazyChildrenRows_);
       }
       cachedLazyLoad_ = false;
     }
 
-    elementsReader_->next(
+    co_await elementsReader_->co_next(
         childrenRows,
         static_cast<velox::ArrayVector&>(*dictionaryValues).elements(),
-        /* scatterBitmap */ nullptr);
+        /*scatterBitmap=*/nullptr);
 
     if (cachedLocally) {
       auto vector = static_cast<velox::ArrayVector*>(dictionaryValues.get());
@@ -1481,9 +1490,10 @@ class ArrayWithOffsetsFieldReader final : public MultiValueFieldReader {
         }
       }
     }
+    co_return;
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     // read the offsets/indices which is one value per rowCount
     // and filter out deduped arrays to be read
     std::array<OffsetType, kSkipBatchSize> indices;
@@ -1516,12 +1526,10 @@ class ArrayWithOffsetsFieldReader final : public MultiValueFieldReader {
             cached_ && cachedLazyLoad_ ? cachedLazyChildrenRows_ : 0;
         childrenRows += this->skipLengths(dedupCount - 1);
         if (childrenRows > 0) {
-          elementsReader_->skip(childrenRows);
+          co_await elementsReader_->co_skip(childrenRows);
         }
 
-        /// cache the last child
-
-        // get the index for this last element which must be non-null
+        // Get the index for the last child, which must be non-null.
         cachedIndex_ =
             indices[findLastBit(batchedRowCount, hasNulls, nullsPtr)];
         cached_ = true;
@@ -1534,6 +1542,7 @@ class ArrayWithOffsetsFieldReader final : public MultiValueFieldReader {
 
       count -= batchedRowCount;
     }
+    co_return;
   }
 
   void reset() final {
@@ -1697,7 +1706,7 @@ class SlidingWindowMapFieldReader final : public FieldReader {
     return std::nullopt;
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) override {
@@ -1763,14 +1772,16 @@ class SlidingWindowMapFieldReader final : public FieldReader {
 
     // Return early if everything is null
     if (nonNullCount == 0) {
-      return;
+      co_return;
     }
 
     bool hasNulls = nonNullCount != rowCount;
     // Read the lengths
-    uint32_t lengthBuffer[nonNullCount];
+    Vector<uint32_t> lengthBuffer{pool_};
+    lengthBuffer.resize(nonNullCount);
     std::vector<velox::BufferPtr> lengthStringBuffers;
-    lengthsDecoder_->next(nonNullCount, lengthBuffer, lengthStringBuffers);
+    lengthsDecoder_->next(
+        nonNullCount, lengthBuffer.data(), lengthStringBuffers);
 
     // Convert the offsets and lengths to a list of unique offsets and lengths
     // and update the indices to be 0-based indices
@@ -1871,14 +1882,14 @@ class SlidingWindowMapFieldReader final : public FieldReader {
     }
 
     if (childrenRows > 0) {
-      keysReader_->next(
+      co_await keysReader_->co_next(
           childrenRows,
           map->mapKeys(),
-          /* scatterBitmap */ nullptr);
-      valuesReader_->next(
+          /*scatterBitmap=*/nullptr);
+      co_await valuesReader_->co_next(
           childrenRows,
           map->mapValues(),
-          /* scatterBitmap */ nullptr);
+          /*scatterBitmap=*/nullptr);
     }
 
     currentOffset_ = endOffset;
@@ -1951,11 +1962,12 @@ class SlidingWindowMapFieldReader final : public FieldReader {
       // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
       cacheOffset_ = deduplicatedOffsets.back();
     }
+    co_return;
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     if (count == 0) {
-      return;
+      co_return;
     }
 
     // @lint-ignore CLANGTIDY cppcoreguidelines-pro-type-member-init
@@ -2065,51 +2077,49 @@ class SlidingWindowMapFieldReader final : public FieldReader {
     }
 
     if (childrenSkip == 0) {
-      return;
+      co_return;
     }
 
     childrenSkip -= lastLength;
 
     if (childrenSkip > 0) {
-      keysReader_->skip(childrenSkip);
-      valuesReader_->skip(childrenSkip);
+      co_await keysReader_->co_skip(childrenSkip);
+      co_await valuesReader_->co_skip(childrenSkip);
     }
 
     if (lastLength == 0) {
-      return;
+      co_return;
     }
 
     auto& cachedMap = static_cast<velox::MapVector&>(*cachedMap_);
     cachedMap_->resize(1);
     cacheOffset_ = lastOffset;
     currentOffset_ += lastLength;
-    keysReader_->next(
-        lastLength,
-        cachedMap.mapKeys(),
-        /* scatterBitmap */ nullptr);
-    valuesReader_->next(
-        lastLength,
-        cachedMap.mapValues(),
-        /* scatterBitmap */ nullptr);
+    co_await keysReader_->co_next(
+        lastLength, cachedMap.mapKeys(), /*scatterBitmap=*/nullptr);
+    co_await valuesReader_->co_next(
+        lastLength, cachedMap.mapValues(), /*scatterBitmap=*/nullptr);
 
     cachedMap.mutableOffsets(1)->template asMutable<uint32_t>()[0] = 0;
     cachedMap.mutableSizes(1)->template asMutable<uint32_t>()[0] = lastLength;
+    co_return;
   }
 
   // Move the cursor of key and value readers to the given offset
-  void seek(uint32_t offset) {
+  folly::coro::Task<void> co_seek(uint32_t offset) {
     if (offset == currentOffset_) {
-      return;
+      co_return;
     } else if (offset < currentOffset_) {
       keysReader_->reset();
       valuesReader_->reset();
-      keysReader_->skip(offset);
-      valuesReader_->skip(offset);
+      co_await keysReader_->co_skip(offset);
+      co_await valuesReader_->co_skip(offset);
     } else {
-      keysReader_->skip(offset - currentOffset_);
-      valuesReader_->skip(offset - currentOffset_);
+      co_await keysReader_->co_skip(offset - currentOffset_);
+      co_await valuesReader_->co_skip(offset - currentOffset_);
     }
     currentOffset_ = offset;
+    co_return;
   }
 
   void reset() final {
@@ -2224,28 +2234,27 @@ class MapFieldReader final : public MultiValueFieldReader {
                                {rowCount, totalBytes / rowCount});
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
-    auto childrenRows = this->template loadOffsets<velox::MapVector>(
+    const auto childrenRows = this->template loadOffsets<velox::MapVector>(
         count, output, scatterBitmap);
 
-    // As the field is aligned by lengths decoder then no need to pass
-    // scatterBitmap to keys and values
     auto& mapVector = static_cast<velox::MapVector&>(*output);
-    keysReader_->next(
-        childrenRows, mapVector.mapKeys(), /* scatterBitmap */ nullptr);
-    valuesReader_->next(
-        childrenRows, mapVector.mapValues(), /* scatterBitmap */ nullptr);
+    co_await keysReader_->co_next(
+        childrenRows, mapVector.mapKeys(), /*scatterBitmap=*/nullptr);
+    co_await valuesReader_->co_next(
+        childrenRows, mapVector.mapValues(), /*scatterBitmap=*/nullptr);
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     auto childrenCount = this->skipLengths(count);
     if (childrenCount > 0) {
-      keysReader_->skip(childrenCount);
-      valuesReader_->skip(childrenCount);
+      co_await keysReader_->co_skip(childrenCount);
+      co_await valuesReader_->co_skip(childrenCount);
     }
+    co_return;
   }
 
   void reset() final {
@@ -2417,30 +2426,6 @@ class RowFieldReader final : public FieldReader {
                                {rowCount, totalBytes / rowCount});
   }
 
-  void next(
-      uint32_t count,
-      velox::VectorPtr& output,
-      const velox::bits::Bitmap* scatterBitmap) final {
-    if (parallelDecodeEnabled(childrenReaders_.size())) {
-      folly::coro::blockingWait(co_next(count, output, scatterBitmap));
-      return;
-    }
-    const auto outputContext = prepareOutput(count, output, scatterBitmap);
-    velox::bits::Bitmap bitmap{
-        outputContext.scatterNullBits, outputContext.rowCount};
-    auto* bitmapPtr =
-        outputContext.scatterNullBits != nullptr ? &bitmap : nullptr;
-    for (uint32_t i = 0; i < childrenReaders_.size(); ++i) {
-      auto& reader = childrenReaders_[i];
-      if (reader != nullptr) {
-        reader->next(
-            outputContext.selectedNonNullCount,
-            outputContext.vector->childAt(i),
-            bitmapPtr);
-      }
-    }
-  }
-
   folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
@@ -2460,30 +2445,37 @@ class RowFieldReader final : public FieldReader {
       co_return;
     }
 
-    const uint32_t taskCount =
-        computeParallelDecodeTaskCount(nonNullChildren.size());
-    velox::common::testutil::TestValue::adjust(
-        "facebook::nimble::RowFieldReader::co_next",
-        const_cast<uint32_t*>(&taskCount));
-
-    const uint32_t childrenPerTask = nonNullChildren.size() / taskCount;
-    const uint32_t numRemainderChildren = nonNullChildren.size() % taskCount;
-
-    // Decodes children in [startIdx, endIdx) synchronously.
+    // Decodes children in [startIdx, endIdx).
     auto decodeRange = [this, &outputContext, &nonNullChildren](
-                           uint32_t startIdx, uint32_t endIdx) {
+                           uint32_t startIdx,
+                           uint32_t endIdx) -> folly::coro::Task<void> {
       velox::bits::Bitmap bitmap{
           outputContext.scatterNullBits, outputContext.rowCount};
       auto* bitmapPtr =
           outputContext.scatterNullBits != nullptr ? &bitmap : nullptr;
       for (uint32_t idx = startIdx; idx < endIdx; ++idx) {
         const auto i = nonNullChildren[idx];
-        childrenReaders_[i]->next(
+        co_await childrenReaders_[i]->co_next(
             outputContext.selectedNonNullCount,
             outputContext.vector->childAt(i),
             bitmapPtr);
       }
+      co_return;
     };
+
+    const auto numChildren = folly::to<uint32_t>(nonNullChildren.size());
+    const uint32_t taskCount = decodeTaskCount(numChildren);
+    if (taskCount <= 1) {
+      co_await decodeRange(0, numChildren);
+      co_return;
+    }
+
+    velox::common::testutil::TestValue::adjust(
+        "facebook::nimble::RowFieldReader::co_next",
+        const_cast<uint32_t*>(&taskCount));
+
+    const uint32_t childrenPerTask = numChildren / taskCount;
+    const uint32_t numRemainderChildren = numChildren % taskCount;
 
     // First 'numRemainderChildren' tasks get one extra child each.
     std::vector<folly::coro::TaskWithExecutor<void>> tasks;
@@ -2494,20 +2486,14 @@ class RowFieldReader final : public FieldReader {
           (task < numRemainderChildren ? 1 : 0);
       tasks.emplace_back(
           folly::coro::co_withExecutor(
-              decodeExecutor_,
-              folly::coro::co_invoke(
-                  [&decodeRange, nextChildIdx, endChildIdx]()
-                      -> folly::coro::Task<void> {
-                    decodeRange(nextChildIdx, endChildIdx);
-                    co_return;
-                  })));
+              decodeExecutor_, decodeRange(nextChildIdx, endChildIdx)));
       nextChildIdx = endChildIdx;
     }
 
     co_await folly::coro::collectAllRange(std::move(tasks));
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     uint32_t childRowCount = count;
     if constexpr (hasNull) {
       std::array<bool, kSkipBatchSize> buffer{};
@@ -2522,10 +2508,11 @@ class RowFieldReader final : public FieldReader {
     if (childRowCount > 0) {
       for (auto& reader : childrenReaders_) {
         if (reader) {
-          reader->skip(childRowCount);
+          co_await reader->co_skip(childRowCount);
         }
       }
     }
+    co_return;
   }
 
   void reset() final {
@@ -2631,7 +2618,7 @@ class RowFieldReaderFactory final : public FieldReaderFactory {
       : FieldReaderFactory{std::move(veloxType), type, pool},
         decodeExecutor_{params.decodeExecutor},
         maxDecodeParallelism_{params.maxDecodeParallelism},
-        minStreamsPerDecodeUnit_{params.minStreamsPerDecodeUnit},
+        minStreamsPerDecodeTask_{params.minStreamsPerDecodeTask},
         children_{std::move(children)},
         boolBuffer_{pool_} {}
 
@@ -2650,7 +2637,7 @@ class RowFieldReaderFactory final : public FieldReaderFactory {
     }
 
     const FieldReader::Options options{
-        decodeExecutor_, maxDecodeParallelism_, minStreamsPerDecodeUnit_};
+        decodeExecutor_, maxDecodeParallelism_, minStreamsPerDecodeTask_};
     if (!nulls) {
       return std::make_unique<RowFieldReader<false>>(
           veloxType_,
@@ -2673,7 +2660,7 @@ class RowFieldReaderFactory final : public FieldReaderFactory {
  private:
   folly::Executor* const decodeExecutor_;
   const uint32_t maxDecodeParallelism_;
-  const uint32_t minStreamsPerDecodeUnit_;
+  const uint32_t minStreamsPerDecodeTask_;
   std::vector<std::unique_ptr<FieldReaderFactory>> children_;
   Vector<bool> boolBuffer_;
 };
@@ -2696,7 +2683,7 @@ class FlatMapKeyNode {
 
   ~FlatMapKeyNode() = default;
 
-  void readAsChild(
+  folly::coro::Task<void> co_readAsChild(
       velox::VectorPtr& vector,
       uint32_t numValues,
       uint32_t nonNullValues,
@@ -2708,8 +2695,9 @@ class FlatMapKeyNode {
     const auto nonNullCount =
         mergeNulls(numValues, nonNullValues, mapNulls, *mergedNulls);
     velox::bits::Bitmap bitmap{mergedNulls->data(), numValues};
-    valueReader_->next(nonNullCount, vector, &bitmap);
+    co_await valueReader_->co_next(nonNullCount, vector, &bitmap);
     NIMBLE_DCHECK_EQ(numValues, vector->size(), "Items not loaded");
+    co_return;
   }
 
   uint32_t readInMapData(uint32_t numValues) {
@@ -2725,16 +2713,19 @@ class FlatMapKeyNode {
     return numValues_;
   }
 
-  void loadValues(velox::VectorPtr& values) {
-    valueReader_->next(numValues_, values, /*scatterBitmap=*/nullptr);
+  folly::coro::Task<void> co_loadValues(velox::VectorPtr& values) {
+    co_await valueReader_->co_next(
+        numValues_, values, /*scatterBitmap=*/nullptr);
     NIMBLE_DCHECK_EQ(numValues_, values->size(), "Items not loaded");
+    co_return;
   }
 
-  void skip(uint32_t numValues) {
+  folly::coro::Task<void> co_skip(uint32_t numValues) {
     auto numItems = readInMapData(numValues);
     if (numItems > 0) {
-      valueReader_->skip(numItems);
+      co_await valueReader_->co_skip(numItems);
     }
+    co_return;
   }
 
   const velox::dwio::common::flatmap::KeyValue<T>& key() const {
@@ -2835,7 +2826,7 @@ class FlatMapFieldReaderBase : public FieldReader {
     }
   }
 
-  void skip(uint32_t count) final {
+  folly::coro::Task<void> co_skip(uint32_t count) final {
     uint32_t nonNullCount = count;
 
     if constexpr (hasNull) {
@@ -2851,10 +2842,11 @@ class FlatMapFieldReaderBase : public FieldReader {
     if (nonNullCount > 0) {
       for (auto& node : keyNodes_) {
         if (node) {
-          node->skip(nonNullCount);
+          co_await node->co_skip(nonNullCount);
         }
       }
     }
+    co_return;
   }
 
   void reset() final {
@@ -3057,33 +3049,6 @@ class StructFlatMapFieldReader : public FlatMapFieldReaderBase<T, hasNull> {
                                {rowCount, totalBytes / rowCount});
   }
 
-  void next(
-      uint32_t rowCount,
-      velox::VectorPtr& output,
-      const velox::bits::Bitmap* scatterBitmap) final {
-    NIMBLE_CHECK_NULL(scatterBitmap, "unexpected scatterBitmap");
-    if (this->parallelDecodeEnabled(this->keyNodes_.size())) {
-      folly::coro::blockingWait(co_next(rowCount, output, scatterBitmap));
-      return;
-    }
-    const auto outputContext = prepareOutput(rowCount, output);
-    for (uint32_t i = 0; i < this->keyNodes_.size(); ++i) {
-      if (this->keyNodes_[i] == nullptr) {
-        this->ensureNullConstant(
-            this->type_->childAt(i),
-            rowCount,
-            outputContext.vector->childAt(i));
-      } else {
-        this->keyNodes_[i]->readAsChild(
-            outputContext.vector->childAt(i),
-            rowCount,
-            outputContext.nonNullCount,
-            this->boolBuffer_,
-            &mergedNulls_);
-      }
-    }
-  }
-
   folly::coro::Task<void> co_next(
       uint32_t rowCount,
       velox::VectorPtr& output,
@@ -3110,27 +3075,34 @@ class StructFlatMapFieldReader : public FlatMapFieldReaderBase<T, hasNull> {
       co_return;
     }
 
-    const uint32_t taskCount =
-        this->computeParallelDecodeTaskCount(nonNullChildren.size());
-    velox::common::testutil::TestValue::adjust(
-        "facebook::nimble::StructFlatMapFieldReader::co_next",
-        const_cast<uint32_t*>(&taskCount));
-
-    const uint32_t childrenPerTask = nonNullChildren.size() / taskCount;
-    const uint32_t numRemainderChildren = nonNullChildren.size() % taskCount;
-
     // Decodes children in [startIdx, endIdx).
     auto decodeRange = [this, rowCount, &outputContext, &nonNullChildren](
-                           uint32_t startIdx, uint32_t endIdx) {
+                           uint32_t startIdx,
+                           uint32_t endIdx) -> folly::coro::Task<void> {
       for (uint32_t idx = startIdx; idx < endIdx; ++idx) {
         const auto i = nonNullChildren[idx];
-        this->keyNodes_[i]->readAsChild(
+        co_await this->keyNodes_[i]->co_readAsChild(
             outputContext.vector->childAt(i),
             rowCount,
             outputContext.nonNullCount,
             this->boolBuffer_);
       }
+      co_return;
     };
+
+    const auto numChildren = folly::to<uint32_t>(nonNullChildren.size());
+    const uint32_t taskCount = this->decodeTaskCount(numChildren);
+    if (taskCount <= 1) {
+      co_await decodeRange(0, numChildren);
+      co_return;
+    }
+
+    velox::common::testutil::TestValue::adjust(
+        "facebook::nimble::StructFlatMapFieldReader::co_next",
+        const_cast<uint32_t*>(&taskCount));
+
+    const uint32_t childrenPerTask = numChildren / taskCount;
+    const uint32_t numRemainderChildren = numChildren % taskCount;
 
     // First 'numRemainderChildren' tasks get one extra child each.
     std::vector<folly::coro::TaskWithExecutor<void>> tasks;
@@ -3141,13 +3113,7 @@ class StructFlatMapFieldReader : public FlatMapFieldReaderBase<T, hasNull> {
           (task < numRemainderChildren ? 1 : 0);
       tasks.emplace_back(
           folly::coro::co_withExecutor(
-              this->decodeExecutor_,
-              folly::coro::co_invoke(
-                  [&decodeRange, nextChildIdx, endChildIdx]()
-                      -> folly::coro::Task<void> {
-                    decodeRange(nextChildIdx, endChildIdx);
-                    co_return;
-                  })));
+              this->decodeExecutor_, decodeRange(nextChildIdx, endChildIdx)));
       nextChildIdx = endChildIdx;
     }
 
@@ -3197,7 +3163,7 @@ class StructFlatMapFieldReaderFactory final
             pool),
         decodeExecutor_{params.decodeExecutor},
         maxDecodeParallelism_{params.maxDecodeParallelism},
-        minStreamsPerDecodeUnit_{params.minStreamsPerDecodeUnit},
+        minStreamsPerDecodeTask_{params.minStreamsPerDecodeTask},
         mergedNulls_{this->pool_} {
     NIMBLE_CHECK(this->nimbleType_->isFlatMap(), "Type should be a flat map.");
   }
@@ -3206,7 +3172,7 @@ class StructFlatMapFieldReaderFactory final
       const folly::F14FastMap<offset_size, std::unique_ptr<Decoder>>& decoders)
       final {
     const FieldReader::Options options{
-        decodeExecutor_, maxDecodeParallelism_, minStreamsPerDecodeUnit_};
+        decodeExecutor_, maxDecodeParallelism_, minStreamsPerDecodeTask_};
     return this->template createFlatMapReader<ReaderType, true>(
         decoders, mergedNulls_, options);
   }
@@ -3214,7 +3180,7 @@ class StructFlatMapFieldReaderFactory final
  private:
   folly::Executor* const decodeExecutor_;
   const uint32_t maxDecodeParallelism_;
-  const uint32_t minStreamsPerDecodeUnit_;
+  const uint32_t minStreamsPerDecodeTask_;
   Vector<char> mergedNulls_;
 };
 
@@ -3340,7 +3306,7 @@ class MergedFlatMapFieldReader final
                                {rowCount, totalBytes / rowCount});
   }
 
-  void next(
+  folly::coro::Task<void> co_next(
       uint32_t rowCount,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap) final {
@@ -3407,7 +3373,7 @@ class MergedFlatMapFieldReader final
     // values, bypassing copyRangesImpl's incremental resize.
     nodeValues_.resize(nodes_.size());
     for (size_t j = 0; j < nodes_.size(); ++j) {
-      nodes_[j]->loadValues(nodeValues_[j]);
+      co_await nodes_[j]->co_loadValues(nodeValues_[j]);
     }
 
     auto* offsetsPtr = offsets->asMutable<velox::vector_size_t>();
@@ -3464,6 +3430,7 @@ class MergedFlatMapFieldReader final
 
     // Reset the updated value vector to result
     vector->setKeysAndValues(std::move(keysVector), std::move(valuesVector));
+    co_return;
   }
 
  private:
@@ -4168,17 +4135,19 @@ FieldReader::FieldReader(
       decoder_{decoder},
       decodeExecutor_{options.decodeExecutor},
       maxDecodeParallelism_{options.maxDecodeParallelism},
-      minStreamsPerDecodeUnit_{options.minStreamsPerDecodeUnit} {}
+      minStreamsPerDecodeTask_{options.minStreamsPerDecodeTask} {}
 
-uint32_t FieldReader::computeParallelDecodeTaskCount(
-    uint32_t numStreamChildren) const {
-  if (numStreamChildren == 0) {
+uint32_t FieldReader::decodeTaskCount(uint32_t numChildren) const {
+  if (numChildren == 0) {
     return 0;
   }
+  if (decodeExecutor_ == nullptr) {
+    return 1;
+  }
   const uint32_t maxByStreams =
-      numStreamChildren / std::max(1u, minStreamsPerDecodeUnit_);
+      numChildren / std::max(1u, minStreamsPerDecodeTask_);
   return std::clamp(
-      std::min(maxDecodeParallelism_, maxByStreams), 1u, numStreamChildren);
+      std::min(maxDecodeParallelism_, maxByStreams), 1u, numChildren);
 }
 
 void FieldReader::ensureNullConstant(

--- a/velox/dwio/nimble/velox/FieldReader.h
+++ b/velox/dwio/nimble/velox/FieldReader.h
@@ -60,14 +60,16 @@ struct FieldReaderParams {
   /// Executor for parallel decoding of child fields.
   folly::Executor* decodeExecutor{nullptr};
 
-  /// Maximum number of parallel coroutine tasks for child field decoding.
-  /// Children are grouped into this many batches, each decoded sequentially
-  /// within a single coroutine task. 0 disables parallel decoding.
+  /// Maximum number of parallel coroutine tasks scheduled by each field
+  /// reader. Children are grouped into this many batches, each decoded
+  /// sequentially within a single coroutine task. This is a per-reader limit;
+  /// the executor bounds the number of tasks that run concurrently across the
+  /// reader tree. 0 disables parallel decoding.
   uint32_t maxDecodeParallelism{0};
 
   /// Minimum number of child streams per parallel decode task. Ensures each
   /// coroutine task has enough work to amortize threading overhead.
-  uint32_t minStreamsPerDecodeUnit{1};
+  uint32_t minStreamsPerDecodeTask{1};
 };
 
 class FieldReader {
@@ -75,7 +77,7 @@ class FieldReader {
   struct Options {
     folly::Executor* decodeExecutor{nullptr};
     uint32_t maxDecodeParallelism{0};
-    uint32_t minStreamsPerDecodeUnit{1};
+    uint32_t minStreamsPerDecodeTask{1};
   };
 
   FieldReader(
@@ -101,28 +103,19 @@ class FieldReader {
   virtual std::optional<std::pair<uint32_t, uint64_t>> estimatedRowSize()
       const = 0;
 
-  /// Place the next 'count' rows of data into the passed in output vector.
+  /// Places the next 'count' rows of data into the passed output vector.
+  /// Parent readers co_await child readers, allowing nested decoding to yield
+  /// executor threads instead of blocking them.
   ///
   /// NOTE: scatterBitmap is not for external selectivity. External callers must
-  /// leave scatterBitmap nullptr
-  virtual void next(
+  /// leave scatterBitmap nullptr.
+  virtual folly::coro::Task<void> co_next(
       uint32_t count,
       velox::VectorPtr& output,
       const velox::bits::Bitmap* scatterBitmap = nullptr) = 0;
 
-  /// Coroutine version of next(). Used for parallel decoding: parent readers
-  /// co_await children's co_next() via collectAllRange, yielding their thread
-  /// back to the executor. This prevents deadlock from nested parallelism.
-  /// Default implementation wraps the synchronous next() call.
-  virtual folly::coro::Task<void> co_next(
-      uint32_t count,
-      velox::VectorPtr& output,
-      const velox::bits::Bitmap* scatterBitmap = nullptr) {
-    next(count, output, scatterBitmap);
-    co_return;
-  }
-
-  virtual void skip(uint32_t count) = 0;
+  /// Advances past count rows without materializing output.
+  virtual folly::coro::Task<void> co_skip(uint32_t count) = 0;
 
   /// Called at the end of stripe
   virtual void reset();
@@ -137,23 +130,16 @@ class FieldReader {
       uint32_t count,
       velox::VectorPtr& output) const;
 
-  // Computes the number of parallel decode tasks based on max parallelism and
-  // minimum streams per task. The result is clamped to [1, numStreamChildren].
-  uint32_t computeParallelDecodeTaskCount(uint32_t numStreamChildren) const;
-
-  // Returns true if child fields should be decoded in parallel.
-  // Requires at least 2 parallel tasks to justify coroutine/executor overhead.
-  bool parallelDecodeEnabled(uint32_t numChildren) const {
-    return decodeExecutor_ != nullptr &&
-        computeParallelDecodeTaskCount(numChildren) > 1;
-  }
+  // Returns the number of decode tasks. A single task keeps decoding on the
+  // current executor; multiple tasks enable parallel child decoding.
+  uint32_t decodeTaskCount(uint32_t numChildren) const;
 
   velox::memory::MemoryPool* const pool_;
   const velox::TypePtr type_;
   Decoder* const decoder_;
   folly::Executor* const decodeExecutor_;
   const uint32_t maxDecodeParallelism_;
-  const uint32_t minStreamsPerDecodeUnit_;
+  const uint32_t minStreamsPerDecodeTask_;
 };
 
 class FieldReaderFactory {


### PR DESCRIPTION
Summary:

Nested parallel decoding could deadlock when executor workers entered synchronous child readers and waited for more work scheduled on the same pool. `FieldReader` now exposes coroutine-native `co_next()` and `co_skip()` APIs, and composite readers propagate both operations with `co_await`. Synchronous waits remain only at the `Deserializer` and `VeloxReader` entry points.

The existing lazy cache behavior in `ArrayWithOffsetsFieldReader` is preserved. `SlidingWindowMapFieldReader::co_skip()` can directly await child decoding, so it no longer needs the temporary lazy-cache workaround.

`maxDecodeParallelism` remains a per-reader-node task limit; the executor bounds concurrently running work across the recursive reader tree. A shared tree-wide task budget and nested scalar-stream-weighted planning are intentionally separate scheduling changes.

The Unicorn scan benchmark uses process-wide CPU timing, defaults to four streams per decode task, prints profile links, downloads missing source SSTs from `manifold://rexdb_benchmark_samples/tree/unicorn/`, and documents the complete users, ig-media, and posts configuration matrix.

Reviewed By: tanjialiang, zacw7

Differential Revision: D118040121


