### PR TITLE
fix(sparksql): Respect ANSI mode in unix_timestamp/to_unix_timestamp datetime parsing

### DIFF
--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -155,13 +155,14 @@ struct UnixTimestampParseFunction {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const arg_type<Varchar>* /*input*/) {
+    const SparkQueryConfig sparkConfig{config};
     auto formatter = detail::getDateTimeFormatter(
         kDefaultFormat_,
-        SparkQueryConfig{config}.legacyDateFormatter()
-            ? DateTimeFormatterType::STRICT_SIMPLE
-            : DateTimeFormatterType::JODA);
+        sparkConfig.legacyDateFormatter() ? DateTimeFormatterType::STRICT_SIMPLE
+                                          : DateTimeFormatterType::JODA);
     VELOX_CHECK(!formatter.hasError(), "Default format should always be valid");
     format_ = formatter.value();
+    ansiEnabled_ = sparkConfig.ansiEnabled();
     setTimezone(config);
   }
 
@@ -169,8 +170,13 @@ struct UnixTimestampParseFunction {
       int64_t& result,
       const arg_type<Varchar>& input) {
     auto dateTimeResult = format_->parse(std::string_view(input));
-    // Return null if could not parse.
+    // Could not parse the input. Under ANSI mode Spark fails on invalid input;
+    // otherwise the result is null.
     if (dateTimeResult.hasError()) {
+      if (ansiEnabled_) {
+        VELOX_USER_FAIL(
+            "Could not parse '{}' to unix timestamp.", std::string_view(input));
+      }
       return false;
     }
     toGMTWithGapCorrection(
@@ -196,6 +202,10 @@ struct UnixTimestampParseFunction {
   constexpr static std::string_view kDefaultFormat_{"yyyy-MM-dd HH:mm:ss"};
   std::shared_ptr<DateTimeFormatter> format_;
   const tz::TimeZone* sessionTimeZone_{tz::locateZone(0)}; // fallback to GMT.
+  // Whether ANSI-compliant behavior is enabled. When true, parse failures
+  // raise a user error instead of returning null, matching Spark's
+  // failOnError behavior.
+  bool ansiEnabled_{false};
 };
 
 template <typename T>
@@ -210,7 +220,9 @@ struct UnixTimestampParseWithFormatFunction
       const core::QueryConfig& config,
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* format) {
-    legacyFormatter_ = SparkQueryConfig{config}.legacyDateFormatter();
+    const SparkQueryConfig sparkConfig{config};
+    legacyFormatter_ = sparkConfig.legacyDateFormatter();
+    this->ansiEnabled_ = sparkConfig.ansiEnabled();
     if (format != nullptr) {
       auto formatter = detail::getDateTimeFormatter(
           std::string_view(format->data(), format->size()),
@@ -230,6 +242,7 @@ struct UnixTimestampParseWithFormatFunction
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const arg_type<Date>* /*input*/) {
+    this->ansiEnabled_ = SparkQueryConfig{config}.ansiEnabled();
     this->setTimezone(config);
   }
 
@@ -254,8 +267,14 @@ struct UnixTimestampParseWithFormatFunction
     }
     auto dateTimeResult =
         this->format_->parse(std::string_view(input.data(), input.size()));
-    // parsing error returns null
+    // Could not parse the input. Under ANSI mode Spark fails on invalid input;
+    // otherwise the result is null.
     if (dateTimeResult.hasError()) {
+      if (this->ansiEnabled_) {
+        VELOX_USER_FAIL(
+            "Could not parse '{}' to unix timestamp.",
+            std::string_view(input.data(), input.size()));
+      }
       return false;
     }
     toGMTWithGapCorrection(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -59,6 +59,12 @@ class DateTimeFunctionsTest : public SparkFunctionBaseTest {
     });
   }
 
+  void enableAnsi() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"},
+    });
+  }
+
   template <typename TOutput, typename TValue>
   std::optional<TOutput> evaluateDateFuncOnce(
       const std::string& expr,
@@ -374,6 +380,67 @@ TEST_F(DateTimeFunctionsTest, toUnixTimestamp) {
 
   // to_unix_timestamp does not provide an overoaded without any parameters.
   EXPECT_THROW(evaluateOnce<int64_t>("to_unix_timestamp()"), VeloxUserError);
+}
+
+// When ANSI mode is enabled, unix_timestamp/to_unix_timestamp fail on invalid
+// input instead of returning null, matching Spark's failOnError behavior.
+TEST_F(DateTimeFunctionsTest, unixTimestampAnsi) {
+  const auto unixTimestamp = [&](std::optional<StringView> dateStr) {
+    return evaluateOnce<int64_t>("unix_timestamp(c0)", dateStr);
+  };
+  const auto unixTimestampWithFormat =
+      [&](std::optional<StringView> dateStr,
+          std::optional<StringView> formatStr) {
+        return evaluateOnce<int64_t>(
+            "unix_timestamp(c0, c1)", dateStr, formatStr);
+      };
+  const auto toUnixTimestamp = [&](std::optional<StringView> dateStr) {
+    return evaluateOnce<int64_t>("to_unix_timestamp(c0)", dateStr);
+  };
+
+  enableAnsi();
+
+  // Valid input still parses successfully.
+  EXPECT_EQ(0, unixTimestamp("1970-01-01 00:00:00"));
+  EXPECT_EQ(0, unixTimestampWithFormat("1970-01-01", "yyyy-MM-dd"));
+  EXPECT_EQ(0, toUnixTimestamp("1970-01-01 00:00:00"));
+
+  // Null input is still propagated as null (not an error).
+  EXPECT_EQ(std::nullopt, unixTimestamp(std::nullopt));
+
+  // Invalid input fails under ANSI mode.
+  VELOX_ASSERT_USER_THROW(
+      unixTimestamp("1970-01-01"),
+      "Could not parse '1970-01-01' to unix timestamp.");
+  VELOX_ASSERT_USER_THROW(
+      unixTimestamp("malformed input"),
+      "Could not parse 'malformed input' to unix timestamp.");
+  VELOX_ASSERT_USER_THROW(
+      unixTimestamp(""), "Could not parse '' to unix timestamp.");
+  VELOX_ASSERT_USER_THROW(
+      unixTimestampWithFormat("malformed input", "yyyy-MM-dd"),
+      "Could not parse 'malformed input' to unix timestamp.");
+  VELOX_ASSERT_USER_THROW(
+      toUnixTimestamp("malformed input"),
+      "Could not parse 'malformed input' to unix timestamp.");
+
+  // Invalid format still returns null (not gated by ANSI, matching the
+  // existing non-ANSI behavior).
+  EXPECT_EQ(
+      std::nullopt,
+      unixTimestampWithFormat(
+          "2022-12-12 asd 07:45:31", "yyyy-MM-dd 'asd HH:mm:ss"));
+
+  // Same behavior with the legacy formatter (set both configs together since
+  // overriding replaces the whole config map).
+  queryCtx_->testingOverrideConfigUnsafe({
+      {SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"},
+      {SparkQueryConfig::qualify(SparkQueryConfig::kLegacyDateFormatter),
+       "true"},
+  });
+  VELOX_ASSERT_USER_THROW(
+      unixTimestamp("malformed input"),
+      "Could not parse 'malformed input' to unix timestamp.");
 }
 
 TEST_F(DateTimeFunctionsTest, makeDate) {


### PR DESCRIPTION
Spark uses `failOnError` in a base class to affect the parsing behavior. `failOnError` is initialized with Spark ANSI config. See code link below.
https://github.com/apache/spark/blob/9e0bea0c104a558d798706675a9bb47612a0575b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L1882