### PR TITLE
fix(nimble): Resolve EncodingFactory({}) ambiguity in Fsst test

### DIFF
--- a/velox/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
@@ -143,7 +143,7 @@ class FsstEncodingTest : public ::testing::Test {
       static_cast<void>(FsstEncoding::lengthsEncoding(malformed));
     });
     expectMalformed("constructor", [&] {
-      static_cast<void>(EncodingFactory({}).create(
+      static_cast<void>(EncodingFactory().create(
           *pool_, malformed, createStringBufferFactory()));
     });
     expectMalformed("slice", [&] {
@@ -862,7 +862,7 @@ TEST_F(FsstEncodingTest, resetReusesMultipleStringBufferPages) {
   std::vector<velox::BufferPtr> pages;
   uint64_t allocatedBytes{0};
   auto encoding =
-      EncodingFactory({}).create(*pool_, encoded, [&](uint32_t bytes) -> void* {
+      EncodingFactory().create(*pool_, encoded, [&](uint32_t bytes) -> void* {
         allocatedBytes += bytes;
         auto& page = pages.emplace_back(
             velox::AlignedBuffer::allocate<char>(bytes, pool_.get()));


### PR DESCRIPTION
`FsstEncodingTest.cpp` fails to compile under GCC 12 with:

    error: call of overloaded 'EncodingFactory(<brace-enclosed initializer list>)' is ambiguous

`Encoding::Options` is an aggregate, so `{}` is a valid initializer for both the options constructor and the implicit copy constructor, and neither is a better match. Use `EncodingFactory()` at the two call sites, matching how every other caller in the tree constructs a default factory.