### PR TITLE
fix(nimble): Reject shared dictionary encoding in the index projector

### DIFF
--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -220,6 +220,15 @@ NimbleIndexProjector::NimbleIndexProjector(
       clusterIndex_, "NimbleIndexProjector requires a tablet with an index");
   NIMBLE_CHECK_GT(numStripes_, 0, "NimbleIndexProjector requires stripes");
 
+  // Rejects the whole file rather than only the projected streams: no cheap
+  // per-stream binding query exists for file and external scopes, and
+  // resolving an alphabet just to test for one would decode it.
+  if (tablet_->hasStripeDictionaries() ||
+      tablet_->hasFileOrExternalDictionaries()) {
+    NIMBLE_UNSUPPORTED(
+        "NimbleIndexProjector does not support shared dictionary encoding");
+  }
+
   NIMBLE_CHECK_EQ(
       projection_->streamOffsets.size(),
       projection_->rowOrFlatMapNullStreams.size(),

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -74,6 +74,12 @@ using Subfield = velox::common::Subfield;
 ///       // cut-short response) the resume key embedded in the header.
 ///     }
 ///   }
+///
+/// Shared dictionary encoding is not supported. The output carries projected
+/// stream bytes only and has nowhere to put the alphabet a shared dictionary
+/// stream decodes against, so create() rejects any tablet that records shared
+/// dictionaries.
+///
 /// NOTE: NimbleIndexProjector is not thread-safe. Each thread must use its
 /// own instance.
 class NimbleIndexProjector {

--- a/velox/dwio/nimble/velox/index/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/index/tests/CMakeLists.txt
@@ -23,6 +23,9 @@ target_link_libraries(
   nimble_serializer
   nimble_stream_data_writer
   nimble_velox_common
+  nimble_shared_dictionary_test_utils
+  nimble_velox_shared_dictionary_config
+  nimble_encodings
   nimble_writer
   nimble_velox_selective
   nimble_velox_schema_utils

--- a/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -22,6 +22,7 @@
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/common/tests/TestUtils.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/index/ClusterIndexConfig.h"
 #include "velox/dwio/nimble/serializer/Deserializer.h"
 #include "velox/dwio/nimble/serializer/SerializationHeader.h"
@@ -33,7 +34,9 @@
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaUtils.h"
+#include "velox/dwio/nimble/velox/SharedDictionaryConfig.h"
 #include "velox/dwio/nimble/velox/tests/SchemaUtils.h"
+#include "velox/dwio/nimble/velox/tests/SharedDictionaryTestUtils.h"
 #include "velox/dwio/nimble/writer/Writer.h"
 
 #include "folly/Random.h"
@@ -211,9 +214,6 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
       CompressionType chunkCompressionType = CompressionType::Uncompressed,
       bool skipConstantFlatMapInMapStreams = false,
       bool enableChunking = true) {
-    sinkData_.clear();
-    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
-
     WriterOptions options;
     options.enableChunking = enableChunking;
     options.flatMapColumns = flatMapColumns;
@@ -225,15 +225,7 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
         .acceptRatio = 10.0f,
     };
     options.skipConstantFlatMapInMapStreams = skipConstantFlatMapInMapStreams;
-    options.clusterIndexConfig =
-        ClusterIndexConfigBuilder{}
-            .withKeyColumns(indexColumns)
-            .withSortOrders(
-                std::vector<SortOrder>(
-                    indexColumns.size(), SortOrder{.ascending = true}))
-            .withEnforceKeyOrder(true)
-            .withNoDuplicateKey(true)
-            .build();
+    options.clusterIndexConfig = makeClusterIndexConfig(indexColumns);
 
     options.flushPolicyFactory = [stripeSize]() {
       return std::make_unique<LambdaFlushPolicy>(
@@ -242,6 +234,29 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
             return progress.stripeRawSize >= stripeSize;
           });
     };
+    writeBatches(batches, std::move(options));
+  }
+
+  // Returns an ascending, duplicate-free cluster index over `indexColumns`.
+  static std::shared_ptr<const index::IndexConfig> makeClusterIndexConfig(
+      const std::vector<std::string>& indexColumns) {
+    return ClusterIndexConfigBuilder{}
+        .withKeyColumns(indexColumns)
+        .withSortOrders(
+            std::vector<SortOrder>(
+                indexColumns.size(), SortOrder{.ascending = true}))
+        .withEnforceKeyOrder(true)
+        .withNoDuplicateKey(true)
+        .build();
+  }
+
+  // Writes `batches` into sinkData_ under `options` and drops the readers
+  // holding the previous file.
+  void writeBatches(
+      const std::vector<RowVectorPtr>& batches,
+      WriterOptions options) {
+    sinkData_.clear();
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
     auto rowType = asRowType(batches[0]->type());
     Writer writer(
         rowType, std::move(writeFile), *rootPool_, std::move(options));
@@ -5362,6 +5377,62 @@ TEST_P(NimbleIndexProjectorTest, requiresIoStats) {
             /*setMetadataIoStats=*/testCase.setMetadataIoStats,
             /*setIndexIoStats=*/testCase.setIndexIoStats),
         testCase.expectedMessage);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, rejectsSharedDictionaryEncoding) {
+  constexpr uint32_t kDictionaryId{7};
+  constexpr velox::vector_size_t kNumRows{2'000};
+  const std::vector<int32_t> alphabet{0, 10, 20, 30};
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(
+           kNumRows, [](auto row) { return row; }),
+       vectorMaker_->flatVector<int32_t>(kNumRows, [&](auto row) {
+         return alphabet[row % alphabet.size()];
+       })});
+
+  // Stripe scope lands in the catalog's stripe references while File and
+  // External land in its file and external references, so the two halves of
+  // the guard are exercised separately.
+  for (const auto scope :
+       {SharedDictionaryScope::Stripe,
+        SharedDictionaryScope::File,
+        SharedDictionaryScope::External}) {
+    SCOPED_TRACE(
+        fmt::format("scope={}", SharedDictionaryScopeName::toName(scope)));
+    SharedDictionaryConfig dictionary{.scope = scope};
+    if (scope != SharedDictionaryScope::Stripe) {
+      // Stripe scope derives the id from its auxiliary alphabet stream and
+      // rejects a caller-assigned one.
+      dictionary.dictionaryId = kDictionaryId;
+    }
+
+    WriterOptions options;
+    options.clusterIndexConfig = makeClusterIndexConfig({"key"});
+    options.experimentalSharedDictionaryEncoding =
+        SharedDictionaryEncodingConfig::builder()
+            .addColumnDictionary("value", std::move(dictionary))
+            .build();
+    if (scope == SharedDictionaryScope::External) {
+      // An external alphabet is supplied rather than built from the data, so
+      // it has to already hold every value written above.
+      options.experimentalSharedDictionaryEncoding.externalResolver =
+          std::make_shared<SharedDictionaryTestResolver>(
+              std::vector<SharedDictionaryTestDictionary>{
+                  {kDictionaryId, alphabet}},
+              leafPool_.get());
+    }
+    // The catalog only records a dictionary the writer actually used, so steer
+    // encoding selection to the shared-dictionary path.
+    configureSharedDictionarySelectionPolicy(options);
+    writeBatches({batch}, std::move(options));
+
+    std::vector<Subfield> subfields;
+    subfields.emplace_back("value");
+    NIMBLE_ASSERT_THROW(
+        createProjector(subfields),
+        "NimbleIndexProjector does not support shared dictionary encoding");
   }
 }
 


### PR DESCRIPTION
Summary:
`NimbleIndexProjector` has no support for shared dictionary encoding, and
nothing stopped it from being handed a file that uses it.

A `SharedDictionary` stream decodes against an alphabet held elsewhere -- in
another stripe stream, in a file section, or in an external provider. The
projector's output format has nowhere to carry that alphabet: `packFullStripe`
copies the projected stream bytes verbatim and the kTablet trailer only
describes `projection_->streamOffsets` slots, so a projected index stream would
reach the `Deserializer` with no way to resolve its values. The partial-stripe
path fails differently -- `StreamSlicer::streamEncodingOptions` never populates
`Encoding::Options::sharedDictionaryAlphabet`, so
`SharedDictionaryEncoding<T>::slice` trips its own `NIMBLE_CHECK_NOT_NULL`
somewhere deep in packing.

Fail fast at construction instead. `TabletReader::hasStripeDictionaries()` and
`hasFileOrExternalDictionaries()` are O(1) reads off the already-parsed
`columnar.dictionaries` catalog and together cover all three scopes, so the
check costs nothing on the common path.

The guard rejects the whole file rather than only the projected streams. There
is no cheap per-stream binding query for File and External scopes --
`resolveDictionaryAlphabet` decodes the alphabet to answer -- and shared
dictionary encoding is still opt-in behind
`WriterOptions::experimentalSharedDictionaryEncoding`, so nothing in production
reads such a file through the projector today.

Scoped to `NimbleIndexProjector` on purpose. `serde::Projector` has the same
structural gap -- it also copies stream bytes with nowhere to put an alphabet
-- but nothing can currently hand it those bytes: `serde::Serializer` has no
selection policy that offers SharedDictionary, `EncodingFactory::encode`
requires writer-provided indices that only the file `Writer` supplies, and
`EncodingSliceFactory` converts shared dictionaries to local `Dictionary`
encodings when slicing. A guard there would be dead code on the Rodos
projection hot path, so it is left out.

Reviewed By: xiaoxmeng

Differential Revision: D118242040


