### PR TITLE
perf(nimble): Vectorize the ALP encode transform and grid search

### DIFF
--- a/velox/dwio/nimble/encodings/ALPEncoding.h
+++ b/velox/dwio/nimble/encodings/ALPEncoding.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <folly/CPortability.h>
+#include <xsimd/xsimd.hpp>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -247,21 +249,49 @@ class ALPEncoding final
         /*size=*/0, pool, options.bufferPool};
     ScopedVector<physicalType> exceptionValues{
         /*size=*/0, pool, options.bufferPool};
-    const auto [exponent, factor] = findBestExponentFactor(
+    const auto [exponent, factor] = findBestExponentFactorByCount(
         std::span<const cppDataType>{
             logicalValues.data(), logicalValues.size()});
 
-    for (uint32_t i = 0; i < rowCount; ++i) {
-      if (!canRepresentExactly(logicalValues[i], values[i], exponent, factor)) {
+    const double exponentMultiplier = kPow10Double[exponent];
+    const double factorMultiplier = kPow10Double[factor];
+    alignas(64) uint64_t zigZagLanes[kBatchSize];
+    alignas(64) bool okLanes[kBatchSize];
+
+    uint32_t i = 0;
+    for (; i + kBatchSize <= rowCount; i += kBatchSize) {
+      batchTransform(
+          logicalValues.data() + i,
+          values.data() + i,
+          exponentMultiplier,
+          factorMultiplier,
+          zigZagLanes,
+          okLanes);
+      for (std::size_t k = 0; k < kBatchSize; ++k) {
+        const uint32_t position = i + static_cast<uint32_t>(k);
+        if (!okLanes[k]) {
+          encodedValues[position] = 0;
+          exceptionPositions.push_back(position);
+          exceptionValues.push_back(values[position]);
+          continue;
+        }
+        encodedValues[position] = zigZagLanes[k];
+      }
+    }
+    for (; i < rowCount; ++i) {
+      uint64_t zigZag = 0;
+      if (!scalarTransformOne(
+              logicalValues[i],
+              values[i],
+              exponentMultiplier,
+              factorMultiplier,
+              zigZag)) {
         encodedValues[i] = 0;
         exceptionPositions.push_back(i);
         exceptionValues.push_back(values[i]);
         continue;
       }
-
-      const auto encoded =
-          encodeValue(static_cast<double>(logicalValues[i]), exponent, factor);
-      encodedValues[i] = velox::ZigZag::encode(encoded);
+      encodedValues[i] = zigZag;
     }
 
     const uint32_t exceptionCount = exceptionPositions.size();
@@ -462,7 +492,7 @@ class ALPEncoding final
       logicalValues.push_back(detail::alp::toLogical<cppDataType>(value));
     }
 
-    const auto [exponent, factor] = findBestExponentFactor(
+    const auto [exponent, factor] = findBestExponentFactorByCount(
         std::span<const cppDataType>{
             logicalValues.data(), logicalValues.size()});
 
@@ -649,10 +679,36 @@ class ALPEncoding final
   // Largest exponent and factor values backed by kPow10Double.
   static constexpr int kMaxExponent{23};
   static constexpr int kMaxFactor{23};
+  // int64_t bounds represented in double. The positive bound is exclusive:
+  // INT64_MAX itself rounds to 2^63 when converted to double.
+  static constexpr double kInt64MinAsDouble{-0x1p63};
+  static constexpr double kInt64MaxExclusiveAsDouble{0x1p63};
   // ALP-specific control word following the standard Encoding prefix.
   static constexpr uint32_t kHeaderSize{3};
   // Sample up to this many values to find the best (exponent, factor) pair.
   static constexpr uint32_t kSampleSize{1024};
+
+  static bool
+  tryRoundToInt64(double scaled, double factorMultiplier, int64_t& result) {
+    if (!(scaled >= kInt64MinAsDouble &&
+          scaled <= kInt64MaxExclusiveAsDouble)) {
+      return false;
+    }
+
+    const double factored = scaled / factorMultiplier;
+    // ALP factors are powers of ten and therefore >= 1. In that hot path the
+    // inclusive scaled bound already proves that division cannot exceed the
+    // int64 domain, except for +2^63 / 1. Keep a defensive range check for
+    // non-ALP callers of the public transform helper.
+    if ((factorMultiplier == 1.0 && scaled == kInt64MaxExclusiveAsDouble) ||
+        (!(factorMultiplier >= 1.0) &&
+         !(factored >= kInt64MinAsDouble &&
+           factored < kInt64MaxExclusiveAsDouble))) {
+      return false;
+    }
+    result = std::llround(factored);
+    return true;
+  }
 
   // Checks whether the selected ALP transform can encode the value without an
   // exception.
@@ -664,15 +720,10 @@ class ALPEncoding final
     const double exponentMultiplier = kPow10Double[exponent];
     const double factorMultiplier = kPow10Double[factor];
     const double scaled = static_cast<double>(value) * exponentMultiplier;
-    if (!std::isfinite(scaled)) {
+    int64_t factored;
+    if (!tryRoundToInt64(scaled, factorMultiplier, factored)) {
       return false;
     }
-    if (scaled < static_cast<double>(std::numeric_limits<int64_t>::min()) ||
-        scaled > static_cast<double>(std::numeric_limits<int64_t>::max())) {
-      return false;
-    }
-    const int64_t factored =
-        static_cast<int64_t>(std::llround(scaled / factorMultiplier));
     const double restored =
         static_cast<double>(factored) * factorMultiplier / exponentMultiplier;
 
@@ -680,27 +731,181 @@ class ALPEncoding final
                static_cast<cppDataType>(restored)) == physicalValue;
   }
 
+ public:
+  // Number of doubles processed per vectorized step.
+  static constexpr std::size_t kBatchSize = xsimd::batch<double>::size;
+
+  /// Applies the ALP transform to a single value, merging the representability
+  /// check and the integer encoding into one pass so scaled/factored/restored
+  /// are each computed once. Writes the ZigZag-encoded result to `zigZagOut`
+  /// and returns true iff the value is exactly representable under
+  /// (exponent, factor). Byte-identical to canRepresentExactly() followed by
+  /// encodeValue() and ZigZag::encode() whenever it returns true.
+  static bool scalarTransformOne(
+      cppDataType logical,
+      physicalType physical,
+      double exponentMultiplier,
+      double factorMultiplier,
+      uint64_t& zigZagOut) {
+    const double scaled = static_cast<double>(logical) * exponentMultiplier;
+    int64_t factored;
+    if (!tryRoundToInt64(scaled, factorMultiplier, factored)) {
+      return false;
+    }
+    const double restored =
+        static_cast<double>(factored) * factorMultiplier / exponentMultiplier;
+    if (detail::alp::toPhysical<cppDataType>(
+            static_cast<cppDataType>(restored)) != physical) {
+      return false;
+    }
+    zigZagOut = velox::ZigZag::encode(factored);
+    return true;
+  }
+
+  /// Applies scalarTransformOne() to exactly kBatchSize consecutive values,
+  /// computing the multiply, divide, round, and range mask in xsimd and
+  /// falling back to per-lane scalar code for the int64 conversion, inverse
+  /// transform, physical-byte equality check, and ZigZag encoding.
+  ///
+  /// Writes kBatchSize lanes starting at `outZigZag` and sets outMask[i] to
+  /// true iff lane i is exactly representable; lanes whose mask is false hold
+  /// an undefined value in `outZigZag`. Callers handle trailing values that do
+  /// not fill a batch via scalarTransformOne().
+  static void batchTransform(
+      const cppDataType* logicals,
+      const physicalType* physicals,
+      double exponentMultiplier,
+      double factorMultiplier,
+      uint64_t* outZigZag,
+      bool* outMask) {
+    using BatchD = xsimd::batch<double>;
+
+    // Widen to double for float inputs so all lanes share the same rounding
+    // domain as std::round(double).
+    alignas(64) double lanes[kBatchSize];
+    for (std::size_t i = 0; i < kBatchSize; ++i) {
+      lanes[i] = static_cast<double>(logicals[i]);
+    }
+    const auto x = BatchD::load_aligned(lanes);
+    const auto scaled = x * BatchD(exponentMultiplier);
+
+    // xsimd::round() implements round-half-away-from-zero, matching
+    // std::llround() for finite in-range values. The trunc(x + copysign(0.5,
+    // x)) emulation is deliberately avoided: near 2^52..2^53 a double's ULP
+    // reaches 1.0, so adding 0.5 rounds in floating point and diverges from
+    // std::llround(). batchTransformMatchesScalar locks this in.
+    const auto factored = scaled / BatchD(factorMultiplier);
+    const auto rounded = xsimd::round(factored);
+
+    // Comparisons reject NaN and infinities as well. ALP factors are >= 1, so
+    // an inclusive scaled bound proves that the quotient is in range except
+    // for +2^63 / 1. Select '<' for that one case without adding two quotient
+    // comparisons to every hot batch. Retain a defensive fallback for callers
+    // that pass a non-ALP factor.
+    const auto lowBound = BatchD(kInt64MinAsDouble);
+    const auto highBound = BatchD(kInt64MaxExclusiveAsDouble);
+    auto safeMask = (scaled >= lowBound) &
+        (factorMultiplier == 1.0 ? scaled < highBound : scaled <= highBound);
+    if (!(factorMultiplier >= 1.0)) {
+      safeMask = safeMask & ((factored >= lowBound) & (factored < highBound));
+    }
+
+    alignas(64) double roundedLanes[kBatchSize];
+    rounded.store_aligned(roundedLanes);
+
+    // Materialize the mask as per-lane 1.0/0.0 doubles so it can be read back
+    // lane by lane. Storing an xsimd::batch_bool directly varies by
+    // architecture; going through select keeps this portable across AVX-2,
+    // AVX-512, and NEON.
+    alignas(64) double safeLanes[kBatchSize];
+    xsimd::select(safeMask, BatchD(1.0), BatchD(0.0)).store_aligned(safeLanes);
+
+    for (std::size_t i = 0; i < kBatchSize; ++i) {
+      if (safeLanes[i] == 0.0) {
+        outMask[i] = false;
+        continue;
+      }
+      // Restore through int64 rather than staying in the floating-point
+      // domain, mirroring the scalar path: an FP-only restore would preserve
+      // -0.0 and near-boundary rounding artifacts that the int64 cast
+      // collapses.
+      const int64_t factored = static_cast<int64_t>(roundedLanes[i]);
+      const double restored =
+          static_cast<double>(factored) * factorMultiplier / exponentMultiplier;
+      if (detail::alp::toPhysical<cppDataType>(
+              static_cast<cppDataType>(restored)) != physicals[i]) {
+        outMask[i] = false;
+        continue;
+      }
+      outMask[i] = true;
+      outZigZag[i] = velox::ZigZag::encode(factored);
+    }
+  }
+
+ private:
+  // Counts the values exactly representable under (exponent, factor), routing
+  // through the vectorized transform with a scalar tail. Kept out of line
+  // because the candidate grid calls it a few hundred times, so a single
+  // shared body keeps the caller small.
+  FOLLY_NOINLINE static uint32_t countRepresentable(
+      std::span<const cppDataType> logicalValues,
+      const physicalType* physicals,
+      int exponent,
+      int factor) {
+    const double exponentMultiplier = kPow10Double[exponent];
+    const double factorMultiplier = kPow10Double[factor];
+    const uint64_t sampleSize = logicalValues.size();
+    uint32_t representableCount = 0;
+
+    alignas(64) uint64_t zigZagLanes[kBatchSize];
+    alignas(64) bool okLanes[kBatchSize];
+
+    uint64_t i = 0;
+    for (; i + kBatchSize <= sampleSize; i += kBatchSize) {
+      batchTransform(
+          logicalValues.data() + i,
+          physicals + i,
+          exponentMultiplier,
+          factorMultiplier,
+          zigZagLanes,
+          okLanes);
+      for (std::size_t k = 0; k < kBatchSize; ++k) {
+        representableCount += okLanes[k] ? 1 : 0;
+      }
+    }
+    for (; i < sampleSize; ++i) {
+      uint64_t zigZag = 0;
+      if (scalarTransformOne(
+              logicalValues[i],
+              physicals[i],
+              exponentMultiplier,
+              factorMultiplier,
+              zigZag)) {
+        ++representableCount;
+      }
+    }
+    return representableCount;
+  }
+
   // Selects the sampled (exponent, factor) pair that preserves the most values.
-  static std::pair<uint8_t, uint8_t> findBestExponentFactor(
+  static std::pair<uint8_t, uint8_t> findBestExponentFactorByCount(
       std::span<const cppDataType> values) {
     const uint32_t sampleSize =
         std::min(static_cast<uint32_t>(values.size()), kSampleSize);
+    const auto sample = values.subspan(0, sampleSize);
+    // Free: physicalType has the same width as cppDataType, and the cast is
+    // exactly what toPhysical does per value.
+    const physicalType* physicals =
+        EncodingPhysicalType<cppDataType>::asEncodingPhysicalTypeSpan(sample)
+            .data();
 
     uint8_t bestExponent = 0;
     uint8_t bestFactor = 0;
     uint32_t bestRepresentableCount = 0;
 
     for (int e = 0; e <= kMaxExponent; ++e) {
-      uint32_t countNoFactor = 0;
-      for (uint32_t i = 0; i < sampleSize; ++i) {
-        if (canRepresentExactly(
-                values[i],
-                detail::alp::toPhysical<cppDataType>(values[i]),
-                e,
-                /*factor=*/0)) {
-          ++countNoFactor;
-        }
-      }
+      const uint32_t countNoFactor =
+          countRepresentable(sample, physicals, e, /*factor=*/0);
       if (countNoFactor > bestRepresentableCount) {
         bestRepresentableCount = countNoFactor;
         bestExponent = static_cast<uint8_t>(e);
@@ -711,16 +916,8 @@ class ALPEncoding final
       }
 
       for (int f = 1; f <= std::min(e, kMaxFactor); ++f) {
-        uint32_t countWithFactor = 0;
-        for (uint32_t i = 0; i < sampleSize; ++i) {
-          if (canRepresentExactly(
-                  values[i],
-                  detail::alp::toPhysical<cppDataType>(values[i]),
-                  e,
-                  f)) {
-            ++countWithFactor;
-          }
-        }
+        const uint32_t countWithFactor =
+            countRepresentable(sample, physicals, e, f);
         if (countWithFactor > bestRepresentableCount) {
           bestRepresentableCount = countWithFactor;
           bestExponent = static_cast<uint8_t>(e);

--- a/velox/dwio/nimble/encodings/benchmarks/ALPEncodingBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/ALPEncodingBenchmark.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <random>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+DEFINE_uint32(
+    rows,
+    65'536,
+    "Values per dataset; use --bm_regex to select cases.");
+
+namespace {
+
+using facebook::nimble::ALPEncoding;
+using facebook::nimble::Buffer;
+using facebook::nimble::EncodingFactory;
+using facebook::nimble::EncodingType;
+using facebook::nimble::ManualEncodingSelectionPolicy;
+using facebook::nimble::TypeTraits;
+using facebook::nimble::benchmarks::benchmarkPool;
+using facebook::nimble::benchmarks::nullFactory;
+namespace alp = facebook::nimble::detail::alp;
+
+constexpr uint64_t kSeed = 0x51ED0FF1CEULL;
+
+template <typename FloatType, typename Generator>
+std::vector<FloatType> makeValues(Generator generator) {
+  std::mt19937_64 random(kSeed);
+  std::vector<FloatType> values;
+  values.reserve(FLAGS_rows);
+  for (uint32_t row = 0; row < FLAGS_rows; ++row) {
+    values.push_back(generator(random));
+  }
+  return values;
+}
+
+template <typename FloatType>
+std::vector<FloatType> makeSensorValues(double outlierRate) {
+  std::uniform_int_distribution<int32_t> clean(0, 99'999);
+  std::uniform_int_distribution<int64_t> outlier(
+      5'000'000'000LL, 9'999'999'999LL);
+  std::uniform_real_distribution<double> probability(0.0, 1.0);
+  return makeValues<FloatType>([&](auto& random) {
+    return probability(random) < outlierRate
+        ? static_cast<FloatType>(outlier(random)) /
+            static_cast<FloatType>(1'000'000)
+        : static_cast<FloatType>(clean(random)) / static_cast<FloatType>(1'000);
+  });
+}
+
+struct GridResult {
+  uint8_t exponent{0};
+  uint8_t factor{0};
+  uint32_t representable{0};
+
+  bool operator==(const GridResult&) const = default;
+};
+
+template <typename FloatType>
+class AlpBenchmarkFixture {
+ public:
+  using Alp = ALPEncoding<FloatType>;
+  using PhysicalType = typename TypeTraits<FloatType>::physicalType;
+
+  AlpBenchmarkFixture(
+      const std::string& name,
+      std::vector<FloatType> values,
+      uint8_t exponent)
+      : values_{std::move(values)},
+        physicals_(values_.size()),
+        zigZag_(values_.size()),
+        mask_(values_.size()),
+        output_(values_.size()),
+        exponent_{exponent} {
+    for (size_t row = 0; row < values_.size(); ++row) {
+      physicals_[row] = alp::toPhysical<FloatType>(values_[row]);
+    }
+
+    const auto scalarCount = runTransform<false>();
+    const auto scalarZigZag = zigZag_;
+    const auto scalarMask = mask_;
+    CHECK_EQ(runTransform<true>(), scalarCount);
+    CHECK(scalarZigZag == zigZag_);
+    CHECK(scalarMask == mask_);
+
+    const auto scalarGrid = runGrid<false>();
+    const auto batchGrid = runGrid<true>();
+    CHECK(scalarGrid == batchGrid);
+
+    Buffer buffer{*benchmarkPool()};
+    encoded_ = std::string{encode(buffer)};
+    auto encoding =
+        EncodingFactory{}.create(*benchmarkPool(), encoded_, nullFactory());
+    if (encoding->encodingType() == EncodingType::ALP) {
+      const char* position = encoded_.data() + encoding->dataOffset();
+      const auto header = alp::readHeader(position);
+      CHECK_EQ(header.exponent, batchGrid.exponent);
+      CHECK_EQ(header.factor, batchGrid.factor);
+    }
+
+    decode();
+    for (size_t row = 0; row < values_.size(); ++row) {
+      CHECK_EQ(alp::toPhysical<FloatType>(output_[row]), physicals_[row]);
+    }
+
+    fmt::print(
+        "{}: rows={} transform=({},0) exceptions={:.2f}% "
+        "grid=({},{}) encoding={} bytes={} encoded/raw={:.4f}\n",
+        name,
+        values_.size(),
+        exponent_,
+        100.0 * (values_.size() - scalarCount) / values_.size(),
+        batchGrid.exponent,
+        batchGrid.factor,
+        facebook::nimble::toString(encoding->encodingType()),
+        encoded_.size(),
+        static_cast<double>(encoded_.size()) /
+            (values_.size() * sizeof(FloatType)));
+  }
+
+  template <bool useBatch>
+  uint32_t runTransform() {
+    const auto count = transform<useBatch, true>(values_.size(), exponent_, 0);
+    folly::doNotOptimizeAway(zigZag_.data());
+    folly::doNotOptimizeAway(mask_.data());
+    return count;
+  }
+
+  template <bool useBatch>
+  GridResult runGrid() {
+    folly::doNotOptimizeAway(values_.data());
+    const auto sampleSize = Alp::estimateSampleSize(values_.size());
+    GridResult best;
+    for (uint8_t exponent = 0; exponent < Alp::kPow10Double.size();
+         ++exponent) {
+      for (uint8_t factor = 0; factor <= exponent; ++factor) {
+        const auto count =
+            transform<useBatch, false>(sampleSize, exponent, factor);
+        if (count > best.representable) {
+          best = {exponent, factor, count};
+        }
+        if (best.representable == sampleSize) {
+          return best;
+        }
+      }
+    }
+    return best;
+  }
+
+  std::string_view encode(Buffer& buffer) const {
+    auto policy = std::make_unique<ManualEncodingSelectionPolicy<FloatType>>(
+        std::vector<std::pair<EncodingType, float>>{
+            {EncodingType::ALP, 1.0},
+            {EncodingType::Trivial, 1.0},
+            {EncodingType::FixedBitWidth, 1.0}},
+        std::nullopt,
+        std::nullopt);
+    return EncodingFactory::encode<FloatType>(
+        std::move(policy), std::span<const FloatType>{values_}, buffer);
+  }
+
+  void decode() {
+    auto encoding =
+        EncodingFactory{}.create(*benchmarkPool(), encoded_, nullFactory());
+    encoding->materialize(values_.size(), output_.data());
+    folly::doNotOptimizeAway(output_.data());
+  }
+
+ private:
+  template <bool useBatch, bool materialize>
+  FOLLY_NOINLINE uint32_t
+  transform(size_t size, uint8_t exponent, uint8_t factor) {
+    const double exponentMultiplier = Alp::kPow10Double[exponent];
+    const double factorMultiplier = Alp::kPow10Double[factor];
+    uint32_t representableCount = 0;
+    auto record = [&](size_t row, bool representable, uint64_t zigZag) {
+      representableCount += representable;
+      if constexpr (materialize) {
+        mask_[row] = representable;
+        zigZag_[row] = zigZag;
+      }
+    };
+
+    size_t row = 0;
+    if constexpr (useBatch) {
+      constexpr auto kBatchSize = Alp::kBatchSize;
+      alignas(64) uint64_t zigZagLanes[kBatchSize];
+      alignas(64) bool maskLanes[kBatchSize];
+      for (; row + kBatchSize <= size; row += kBatchSize) {
+        Alp::batchTransform(
+            values_.data() + row,
+            physicals_.data() + row,
+            exponentMultiplier,
+            factorMultiplier,
+            zigZagLanes,
+            maskLanes);
+        for (size_t lane = 0; lane < kBatchSize; ++lane) {
+          record(
+              row + lane,
+              maskLanes[lane],
+              maskLanes[lane] ? zigZagLanes[lane] : 0);
+        }
+      }
+    }
+    for (; row < size; ++row) {
+      uint64_t zigZag = 0;
+      const bool representable = Alp::scalarTransformOne(
+          values_[row],
+          physicals_[row],
+          exponentMultiplier,
+          factorMultiplier,
+          zigZag);
+      record(row, representable, zigZag);
+    }
+    return representableCount;
+  }
+
+  std::vector<FloatType> values_;
+  std::vector<PhysicalType> physicals_;
+  std::vector<uint64_t> zigZag_;
+  std::vector<uint8_t> mask_;
+  std::vector<FloatType> output_;
+  uint8_t exponent_;
+  std::string encoded_;
+};
+
+template <typename FloatType>
+void registerDataset(
+    const std::string& dataset,
+    std::vector<FloatType> values,
+    uint8_t exponent) {
+  const auto name = fmt::format(
+      "{}_{}", std::is_same_v<FloatType, float> ? "Float" : "Double", dataset);
+  auto fixture = std::make_shared<AlpBenchmarkFixture<FloatType>>(
+      name, std::move(values), exponent);
+
+  folly::addBenchmark(
+      __FILE__, fmt::format("TransformScalar_{}", name), [fixture] {
+        folly::doNotOptimizeAway(fixture->template runTransform<false>());
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("%TransformBatch_{}", name), [fixture] {
+        folly::doNotOptimizeAway(fixture->template runTransform<true>());
+        return 1;
+      });
+  folly::addBenchmark(__FILE__, fmt::format("GridScalar_{}", name), [fixture] {
+    folly::doNotOptimizeAway(fixture->template runGrid<false>());
+    return 1;
+  });
+  folly::addBenchmark(__FILE__, fmt::format("%GridBatch_{}", name), [fixture] {
+    folly::doNotOptimizeAway(fixture->template runGrid<true>());
+    return 1;
+  });
+  folly::addBenchmark(__FILE__, fmt::format("Encode_{}", name), [fixture] {
+    Buffer buffer{*benchmarkPool()};
+    folly::doNotOptimizeAway(fixture->encode(buffer));
+    return 1;
+  });
+  folly::addBenchmark(__FILE__, fmt::format("Decode_{}", name), [fixture] {
+    fixture->decode();
+    return 1;
+  });
+}
+
+template <typename FloatType>
+void registerDatasets() {
+  std::uniform_int_distribution<int32_t> integers(-1'000'000, 1'000'000);
+  registerDataset(
+      "Integers",
+      makeValues<FloatType>([&](auto& random) {
+        return static_cast<FloatType>(integers(random));
+      }),
+      0);
+
+  std::uniform_int_distribution<int32_t> cents(0, 999'999);
+  registerDataset(
+      "TwoDecimal",
+      makeValues<FloatType>([&](auto& random) {
+        return static_cast<FloatType>(cents(random)) /
+            static_cast<FloatType>(100);
+      }),
+      2);
+
+  std::normal_distribution<double> prices(500.0, 120.0);
+  registerDataset(
+      "Prices",
+      makeValues<FloatType>([&](auto& random) {
+        const auto rounded = std::llround(std::abs(prices(random)) * 100.0);
+        return static_cast<FloatType>(rounded) / static_cast<FloatType>(100);
+      }),
+      2);
+
+  std::uniform_int_distribution<int64_t> seconds(
+      1'700'000'000LL, 1'800'000'000LL);
+  std::uniform_int_distribution<int32_t> milliseconds(0, 999);
+  registerDataset(
+      "Timestamps",
+      makeValues<FloatType>([&](auto& random) {
+        const auto value = seconds(random) * 1'000LL + milliseconds(random);
+        return static_cast<FloatType>(value) / static_cast<FloatType>(1'000);
+      }),
+      3);
+
+  const std::array<double, 8> palette{
+      0.1234, 1.5000, 2.7182, 3.1415, 42.0000, 100.9999, 999.0001, 12.3456};
+  std::uniform_int_distribution<uint32_t> pick(0, palette.size() - 1);
+  registerDataset(
+      "LowCardinality",
+      makeValues<FloatType>([&](auto& random) {
+        return static_cast<FloatType>(palette[pick(random)]);
+      }),
+      4);
+
+  registerDataset("Sensor2Percent", makeSensorValues<FloatType>(0.02), 3);
+  registerDataset(
+      "MixedPrecision30Percent", makeSensorValues<FloatType>(0.30), 3);
+
+  std::uniform_real_distribution<double> chaotic(-1e6, 1e6);
+  registerDataset(
+      "Chaotic",
+      makeValues<FloatType>([&](auto& random) {
+        return static_cast<FloatType>(chaotic(random));
+      }),
+      2);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const folly::Init init{&argc, &argv};
+  CHECK_GT(FLAGS_rows, 0);
+  facebook::velox::memory::MemoryManager::initialize({});
+  fmt::print(
+      "Transform/encode/decode times are per {} rows; grid times are per "
+      "{}-value sample. Relative rows compare batch with scalar.\n",
+      FLAGS_rows,
+      ALPEncoding<double>::estimateSampleSize(FLAGS_rows));
+  registerDatasets<double>();
+  registerDatasets<float>();
+  folly::runBenchmarks();
+}

--- a/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -165,6 +165,18 @@ if(VELOX_ENABLE_BENCHMARKS)
     Folly::folly
     velox_memory
   )
+
+  add_executable(nimble_alp_encoding_benchmark ALPEncodingBenchmark.cpp)
+
+  target_link_libraries(
+    nimble_alp_encoding_benchmark
+    nimble_encodings
+    nimble_common
+    Folly::follybenchmark
+    Folly::folly
+    velox_memory
+    fmt::fmt
+  )
 endif()
 
 if(NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS)

--- a/velox/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/dwio/nimble/tools/EncodingUtilities.h"
 
 #include <array>
+#include <cmath>
 #include <limits>
 #include <random>
 #include <string_view>
@@ -340,6 +341,186 @@ void expectInterleavedMaterializeAndSkip(
       EXPECT_TRUE(
           nimble::NimbleCompare<D>::equals(output[i], values[target + i]));
     }
+  }
+}
+
+// batchTransform (xsimd) must produce lane-by-lane byte-identical output to
+// the scalar path (scalarTransformOne). This is the correctness contract that
+// lets the encode loop and the selection grid route through the vectorized
+// helper without changing encoded bytes.
+//
+// Covers:
+//   * pathological finite inputs (0, +/-0, denormals, huge, tiny)
+//   * non-finite inputs (NaN, +/-Inf)
+//   * out-of-int64-range scaled values
+//   * halfway cases where round-half-away-from-zero rules matter
+//   * randomized fuzz over a moderately-sized sample
+// for every (exponent, factor) pair in the search grid.
+TYPED_TEST(ALPEncodingTest, batchTransformMatchesScalar) {
+  using D = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<D>::physicalType;
+  using Alp = nimble::ALPEncoding<D>;
+
+  // Pathological + edge-case inputs. Chosen so at least one lane in each
+  // batch tickles: NaN, +/-Inf, +/-0, subnormal, huge, tiny, and negatives
+  // of half-values. Padded to a multiple of kBatchSize so we cover the
+  // full-batch path (the scalar tail is separately covered by the fuzz
+  // block below).
+  std::vector<D> edge{
+      D{0.0},
+      -D{0.0},
+      D{0.5},
+      -D{0.5},
+      D{1.25},
+      -D{1.25},
+      D{2.5},
+      -D{2.5},
+      D{1e-6},
+      -D{1e-6},
+      std::numeric_limits<D>::min(),
+      std::numeric_limits<D>::denorm_min(),
+      D{1e6},
+      -D{1e6},
+      D{1.234567},
+      -D{7.654321},
+      std::numeric_limits<D>::infinity(),
+      -std::numeric_limits<D>::infinity(),
+      std::numeric_limits<D>::quiet_NaN(),
+      -std::numeric_limits<D>::quiet_NaN(),
+      D{9.2233720368547758e18}, // ~int64::max as double
+      -D{9.2233720368547758e18},
+      D{1e30}, // Overflows int64 after any positive exponent.
+      -D{1e30},
+  };
+  // Pad to a multiple of kBatchSize by repeating a benign representable value.
+  while (edge.size() % Alp::kBatchSize != 0) {
+    edge.push_back(D{1.0});
+  }
+
+  // Randomized fuzz block: 4096 samples across [-1e6, 1e6], mostly two-decimal
+  // to keep exception counts realistic. Same seed for reproducibility.
+  std::mt19937_64 rng(0xA1FDA1FD01D3B0FDULL);
+  std::uniform_int_distribution<int64_t> centDist(-100'000'000, 100'000'000);
+  std::vector<D> fuzz;
+  fuzz.reserve(4096);
+  for (int i = 0; i < 4096; ++i) {
+    fuzz.push_back(static_cast<D>(centDist(rng)) / static_cast<D>(100));
+  }
+
+  auto checkSpan = [&](const std::vector<D>& logicals, int e, int f) {
+    std::vector<PhysicalType> physicals;
+    physicals.reserve(logicals.size());
+    for (const auto value : logicals) {
+      physicals.push_back(nimble::detail::alp::toPhysical<D>(value));
+    }
+    const double exponentMultiplier = Alp::kPow10Double[e];
+    const double factorMultiplier = Alp::kPow10Double[f];
+
+    const std::size_t batches = logicals.size() / Alp::kBatchSize;
+    for (std::size_t b = 0; b < batches; ++b) {
+      const std::size_t base = b * Alp::kBatchSize;
+      // Upper-bounded by any real kBatchSize the build produces.
+      std::array<uint64_t, 64> batchZigZag{};
+      std::array<bool, 64> batchOk{};
+      Alp::batchTransform(
+          logicals.data() + base,
+          physicals.data() + base,
+          exponentMultiplier,
+          factorMultiplier,
+          batchZigZag.data(),
+          batchOk.data());
+      for (std::size_t k = 0; k < Alp::kBatchSize; ++k) {
+        uint64_t scalarZigZag = 0;
+        const bool scalarOk = Alp::scalarTransformOne(
+            logicals[base + k],
+            physicals[base + k],
+            exponentMultiplier,
+            factorMultiplier,
+            scalarZigZag);
+        EXPECT_EQ(batchOk[k], scalarOk)
+            << "mask mismatch at lane " << (base + k) << " (e=" << e
+            << ", f=" << f << ", value=" << +logicals[base + k] << ")";
+        if (scalarOk) {
+          EXPECT_EQ(batchZigZag[k], scalarZigZag)
+              << "zigzag mismatch at lane " << (base + k) << " (e=" << e
+              << ", f=" << f << ", value=" << +logicals[base + k] << ")";
+        }
+      }
+    }
+  };
+
+  // Enumerate the complete (exponent, factor) grid walked by production
+  // selection. Only combinations with f <= e are ever considered.
+  constexpr int kMaxExponent = 23;
+  for (int e = 0; e <= kMaxExponent; ++e) {
+    for (int f = 0; f <= e; ++f) {
+      checkSpan(edge, e, f);
+      checkSpan(fuzz, e, f);
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, int64BoundariesAndScalarTail) {
+  using D = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<D>;
+
+  const auto expectTransform = [](D value,
+                                  double exponentMultiplier,
+                                  double factorMultiplier,
+                                  bool expected) {
+    uint64_t zigZag = 0;
+    EXPECT_EQ(
+        Alp::scalarTransformOne(
+            value,
+            nimble::detail::alp::toPhysical<D>(value),
+            exponentMultiplier,
+            factorMultiplier,
+            zigZag),
+        expected)
+        << "value=" << value << " exponentMultiplier=" << exponentMultiplier
+        << " factorMultiplier=" << factorMultiplier;
+  };
+
+  const D positiveBound = static_cast<D>(0x1p63);
+  const D negativeBound = -positiveBound;
+  expectTransform(positiveBound, 1.0, 1.0, false);
+  expectTransform(negativeBound, 1.0, 1.0, true);
+  expectTransform(std::nextafter(positiveBound, D{0}), 1.0, 1.0, true);
+  expectTransform(
+      std::nextafter(negativeBound, -std::numeric_limits<D>::infinity()),
+      1.0,
+      1.0,
+      false);
+
+  if constexpr (std::is_same_v<D, double>) {
+    // scaled is exactly +2^63, but the factor division brings the integer
+    // conversion back into range. The scaled upper bound must stay inclusive.
+    expectTransform(0x1p63 / 10.0, 10.0, 10.0, true);
+  }
+
+  // Exercise both production loops with one full SIMD batch followed by the
+  // scalar tail. Keeping +2^63 in the last position specifically covers the
+  // former out-of-range llround in both selection and final encoding.
+  nimble::Vector<D> values{this->pool_.get(), Alp::kBatchSize + 1};
+  values.fill(D{1.25});
+  values.back() = positiveBound;
+
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto serialized = encodeWithLayout<D>(
+      *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
+
+  const char* pos = serialized.data() +
+      nimble::EncodingPrefix::prefixSize(serialized, options.useVarintRowCount);
+  EXPECT_TRUE(nimble::detail::alp::readHeader(pos).hasExceptions);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding =
+      createEncoding(this->pool_.get(), serialized, options, stringBuffers);
+  nimble::Vector<D> decoded{this->pool_.get(), values.size()};
+  encoding->materialize(values.size(), decoded.data());
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(decoded[i], values[i]));
   }
 }
 

--- a/velox/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(nimble_encoding_layout_test_helper nimble_encodings)
 
 add_executable(
   nimble_encodings_tests
+  ALPEncodingTest.cpp
   ALPEncodingViewTest.cpp
   BufferedEncodingTest.cpp
   BlockBitPackingEncodingViewTest.cpp


### PR DESCRIPTION
This PR vectorizes Nimble ALP’s encode path and exponent/factor search using xsimd. The SIMD kernel performs scaling, division, rounding, and range checks in batches, while exact
  restoration checks, ZigZag encoding, and exception handling remain per lane. The serialized format and decode path are unchanged.

It also fixes the +2^63 floating-point-to-int64_t undefined behavior by applying an exclusive upper bound before conversion. Regression coverage includes the complete exponent/factor
  grid, integer boundary cases, SIMD/scalar equivalence, and scalar-tail handling.

Compared with origin/main, end-to-end encode throughput improves by 1.34× geometrically averaged across the tested datasets: 1.45× for double and 1.25× for float. Encoded sizes are
  identical, and decode performance is unchanged. The full Nimble encoding test suite, UBSan boundary checks, clang-format, and CMake formatting all pass.
