### PR TITLE
refactor: Use `.data()`/`.size()` instead of `string_view` iterators as `const char*` (#18809)

### DIFF
--- a/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -327,7 +327,8 @@ class BlockBitPackingEncoding final
     NIMBLE_CHECK_GT(source.lastBlockRows, 0);
     NIMBLE_CHECK_LE(source.lastBlockRows, source.blockSize);
 
-    source.packedData = {pos, static_cast<size_t>(encoded.end() - pos)};
+    source.packedData = {
+        pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)};
     return source;
   }
 

--- a/velox/dwio/nimble/encodings/ConstantEncoding.cpp
+++ b/velox/dwio/nimble/encodings/ConstantEncoding.cpp
@@ -26,9 +26,10 @@ ConstantEncoding<std::string_view>::ConstantEncoding(
     : ConstantEncodingBase<std::string_view>(pool, data, options) {
   const char* pos = data.data() + this->dataOffset();
   value_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
+  NIMBLE_CHECK(
+      pos == data.data() + data.size(), "Unexpected constant encoding end");
   auto stringBuffer = static_cast<char*>(stringBufferFactory(value_.size()));
-  std::memcpy(stringBuffer, value_.begin(), value_.size());
+  std::memcpy(stringBuffer, value_.data(), value_.size());
   value_ = std::string_view{stringBuffer, value_.size()};
 }
 

--- a/velox/dwio/nimble/encodings/ConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/ConstantEncoding.h
@@ -319,7 +319,8 @@ ConstantEncoding<T>::ConstantEncoding(
     : ConstantEncodingBase<T>(pool, data, options) {
   const char* pos = data.data() + this->dataOffset();
   this->value_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected constant encoding end");
+  NIMBLE_CHECK_EQ(
+      pos, data.data() + data.size(), "Unexpected constant encoding end");
 }
 
 // Specialization for bool to override materializeBoolsAsBits
@@ -337,7 +338,8 @@ class ConstantEncoding<bool> final : public ConstantEncodingBase<bool> {
       : ConstantEncodingBase<bool>(pool, data, options) {
     const char* pos = data.data() + this->dataOffset();
     this->value_ = encoding::read<physicalType>(pos);
-    NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected constant encoding end");
+    NIMBLE_CHECK_EQ(
+        pos, data.data() + data.size(), "Unexpected constant encoding end");
   }
 
   void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)

--- a/velox/dwio/nimble/encodings/DeltaEncoding.h
+++ b/velox/dwio/nimble/encodings/DeltaEncoding.h
@@ -144,7 +144,7 @@ DeltaEncoding<T>::DeltaEncoding(
   pos += isRestatementsOffset;
   isRestatements_ = EncodingFactory().create(
       pool,
-      {pos, static_cast<size_t>(data.end() - pos)},
+      {pos, static_cast<size_t>(data.data() + data.size() - pos)},
       std::move(stringBufferFactory),
       options);
 }

--- a/velox/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/DictionaryEncoding.h
@@ -208,7 +208,7 @@ DictionaryEncoding<T>::DictionaryEncoding(
   pos += alphabetSize;
   indicesEncoding_ = EncodingFactory().create(
       *this->pool_,
-      {pos, static_cast<size_t>(data.end() - pos)},
+      {pos, static_cast<size_t>(data.data() + data.size() - pos)},
       stringBufferFactory,
       options);
 }
@@ -507,7 +507,8 @@ std::string_view DictionaryEncoding<T>::slice(
   const uint32_t alphabetSize = encoding::readUint32(pos);
   const std::string_view alphabet{pos, alphabetSize};
   pos += alphabetSize;
-  const std::string_view indices{pos, static_cast<size_t>(encoded.end() - pos)};
+  const std::string_view indices{
+      pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)};
 
   auto* pool = &buffer.getMemoryPool();
   ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};

--- a/velox/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/velox/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -163,14 +163,14 @@ FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
         pool,
         compressionType,
         DataType::Undefined,
-        {pos, static_cast<size_t>(data.end() - pos)},
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)},
         options.decompressCounter(),
         options.bufferPool);
     fixedBitArray_ = FixedBitArray{
         {uncompressedData_->as<char>(), uncompressedData_->size()}, bitWidth_};
   } else {
-    fixedBitArray_ =
-        FixedBitArray{{pos, static_cast<size_t>(data.end() - pos)}, bitWidth_};
+    fixedBitArray_ = FixedBitArray{
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)}, bitWidth_};
   }
 }
 
@@ -434,7 +434,8 @@ std::string_view FixedBitWidthEncoding<T>::slice(
 
   velox::BufferPtr uncompressed;
   std::string_view packedData{
-      sourcePos, static_cast<size_t>(encoded.end() - sourcePos)};
+      sourcePos,
+      static_cast<size_t>(encoded.data() + encoded.size() - sourcePos)};
   if (sourceCompressionType != CompressionType::Uncompressed) {
     uncompressed = Compression::uncompress(
         buffer.getMemoryPool(),

--- a/velox/dwio/nimble/encodings/MainlyConstantEncoding.cpp
+++ b/velox/dwio/nimble/encodings/MainlyConstantEncoding.cpp
@@ -34,7 +34,9 @@ MainlyConstantEncoding<std::string_view>::MainlyConstantEncoding(
       *this->pool_, {pos, otherValuesBytes}, stringBufferFactory, options);
   pos += otherValuesBytes;
   commonValue_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
+  NIMBLE_CHECK(
+      pos == data.data() + data.size(),
+      "Unexpected mainly constant encoding end");
   auto stringBuffer =
       static_cast<char*>(stringBufferFactory(commonValue_.size()));
   std::memcpy(stringBuffer, commonValue_.data(), commonValue_.size());

--- a/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -738,7 +738,7 @@ class MainlyConstantEncodingBase
     const std::string_view otherValues{pos, otherValuesSize};
     pos += otherValuesSize;
     const std::string_view commonValue{
-        pos, static_cast<size_t>(encoded.end() - pos)};
+        pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)};
 
     auto* pool = &buffer.getMemoryPool();
     ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
@@ -906,7 +906,9 @@ MainlyConstantEncoding<T>::MainlyConstantEncoding(
       *this->pool_, {pos, otherValuesBytes}, stringBufferFactory, options);
   pos += otherValuesBytes;
   this->commonValue_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
+  NIMBLE_CHECK(
+      pos == data.data() + data.size(),
+      "Unexpected mainly constant encoding end");
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/NullableEncoding.h
+++ b/velox/dwio/nimble/encodings/NullableEncoding.h
@@ -174,7 +174,7 @@ NullableEncoding<T>::NullableEncoding(
   pos += nonNullsBytes;
   nulls_ = EncodingFactory().create(
       *this->pool_,
-      {pos, static_cast<size_t>(data.end() - pos)},
+      {pos, static_cast<size_t>(data.data() + data.size() - pos)},
       stringBufferFactory,
       options);
   NIMBLE_DCHECK_EQ(
@@ -505,7 +505,7 @@ std::string_view NullableEncoding<T>::slice(
   const uint32_t valuesSize = encoding::readUint32(pos);
   const std::string_view values{pos, valuesSize};
   pos += valuesSize;
-  const std::string_view nulls{pos, encoded.end()};
+  const std::string_view nulls{pos, encoded.data() + encoded.size()};
 
   const auto [nonNullOffset, nonNullCount] =
       countNonNullsForSlice(nulls, offset, length, buffer, options);

--- a/velox/dwio/nimble/encodings/PFOREncoding.h
+++ b/velox/dwio/nimble/encodings/PFOREncoding.h
@@ -303,11 +303,12 @@ PFOREncoding<T>::PFOREncoding(
       const size_t bitpackedSize =
           FixedBitArray::bufferSize(this->rowCount_, baseBitWidth_);
       NIMBLE_CHECK_GE(
-          static_cast<size_t>(data.end() - pos),
+          static_cast<size_t>(data.data() + data.size() - pos),
           bitpackedSize,
           "Pfor bitpacked region underruns wire data.");
       fixedBitArray_ = FixedBitArray{
-          {pos, static_cast<size_t>(data.end() - pos)}, baseBitWidth_};
+          {pos, static_cast<size_t>(data.data() + data.size() - pos)},
+          baseBitWidth_};
     }
   }
   reset();
@@ -627,7 +628,7 @@ std::string_view PFOREncoding<T>::slice(
   const std::string_view exceptionValues{readPos, exceptionValuesSize};
   readPos += exceptionValuesSize;
   const std::string_view packedData{
-      readPos, static_cast<size_t>(encoded.end() - readPos)};
+      readPos, static_cast<size_t>(encoded.data() + encoded.size() - readPos)};
 
   ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   const auto exceptionSlice = sliceExceptions(

--- a/velox/dwio/nimble/encodings/RLEEncoding.cpp
+++ b/velox/dwio/nimble/encodings/RLEEncoding.cpp
@@ -48,7 +48,7 @@ RLEEncoding<bool>::RLEEncoding(
       internal::RLEEncodingBase<bool, RLEEncoding<bool>>::getValuesStart());
   NIMBLE_CHECK(
       (internal::RLEEncodingBase<bool, RLEEncoding<bool>>::getValuesStart() +
-       1) == data.end(),
+       1) == data.data() + data.size(),
       "Unexpected run length encoding end");
   internal::RLEEncodingBase<bool, RLEEncoding<bool>>::reset();
 }

--- a/velox/dwio/nimble/encodings/RLEEncoding.h
+++ b/velox/dwio/nimble/encodings/RLEEncoding.h
@@ -246,7 +246,7 @@ class RLEEncodingBase
     const std::string_view runLengthsData{pos, runLengthsSize};
     pos += runLengthsSize;
     const std::string_view runValuesData{
-        pos, static_cast<size_t>(encoded.end() - pos)};
+        pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)};
 
     auto slicedRuns =
         sliceRuns(runLengthsData, offset, length, buffer, options);
@@ -867,7 +867,7 @@ RLEEncoding<T>::RLEEncoding(
   auto valuesView = std::string_view{
       internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart(),
       static_cast<size_t>(
-          data.end() -
+          data.data() + data.size() -
           internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())};
   valuesEncoding_ =
       EncodingFactory().create(pool, valuesView, stringBufferFactory, options);

--- a/velox/dwio/nimble/encodings/SentinelEncoding.h
+++ b/velox/dwio/nimble/encodings/SentinelEncoding.h
@@ -114,7 +114,8 @@ SentinelEncoding<T>::SentinelEncoding(
   sentineledData_ = deserializeEncoding(this->pool_, {pos, sentineledBytes});
   pos += sentineledBytes;
   sentinelValue_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected sentinel encoding end");
+  NIMBLE_CHECK(
+      pos == data.data() + data.size(), "Unexpected sentinel encoding end");
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/SimdForBitpackEncoding.h
+++ b/velox/dwio/nimble/encodings/SimdForBitpackEncoding.h
@@ -299,7 +299,8 @@ std::string_view SimdForBitpackEncoding<T>::validateEncodedPrefix(
       encoded.size() >= EncodingPrefix::kRowCountOffset,
       "Truncated SimdForBitpack prefix.");
   const char* cursor = encoded.data() + EncodingPrefix::kRowCountOffset;
-  readPrefixRowCount(cursor, encoded.end(), options.useVarintRowCount);
+  readPrefixRowCount(
+      cursor, encoded.data() + encoded.size(), options.useVarintRowCount);
   return encoded;
 }
 
@@ -351,7 +352,7 @@ SimdForBitpackEncoding<T>::parseHeader(
   validateEncodedPrefix(encoded, options);
   Header header;
   const char* cursor = encoded.data() + EncodingPrefix::kRowCountOffset;
-  const char* const encodedEnd = encoded.end();
+  const char* const encodedEnd = encoded.data() + encoded.size();
   header.rowCount =
       readPrefixRowCount(cursor, encodedEnd, options.useVarintRowCount);
   NIMBLE_CHECK_FILE(

--- a/velox/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/velox/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -271,7 +271,7 @@ std::string_view SparseBoolEncoding::encodeWithSlicedIndices(
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
   const auto sparseValue = encoding::readChar(readPos);
   const std::string_view encodedIndices{
-      readPos, static_cast<size_t>(encoded.end() - readPos)};
+      readPos, static_cast<size_t>(encoded.data() + encoded.size() - readPos)};
 
   const auto serializedIndices =
       EncodingFactory::encodeWithCapturedLayout<uint32_t>(

--- a/velox/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/velox/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -40,7 +40,8 @@ StringPayload readStringPayload(std::string_view encoded, uint32_t dataOffset) {
   return {
       .compressionType = compressionType,
       .lengths = lengths,
-      .blob = {pos, static_cast<size_t>(encoded.end() - pos)}};
+      .blob = {
+          pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)}};
 }
 
 void writeStringHeader(
@@ -302,7 +303,7 @@ TrivialEncoding<bool>::TrivialEncoding(
         pool,
         compressionType,
         DataType::Undefined,
-        {bitmap_, static_cast<size_t>(data.end() - bitmap_)},
+        {bitmap_, static_cast<size_t>(data.data() + data.size() - bitmap_)},
         options.decompressCounter(),
         options.bufferPool);
     bitmap_ = uncompressed_->as<char>();
@@ -313,7 +314,7 @@ TrivialEncoding<bool>::TrivialEncoding(
   } else {
     NIMBLE_CHECK_EQ(
         bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),
-        data.end(),
+        data.data() + data.size(),
         "Unexpected trivial encoding end");
   }
 }
@@ -447,7 +448,8 @@ std::string_view TrivialEncoding<bool>::slice(
       buffer.getMemoryPool(),
       compressionType,
       DataType::Undefined,
-      {sourcePos, static_cast<size_t>(encoded.end() - sourcePos)},
+      {sourcePos,
+       static_cast<size_t>(encoded.data() + encoded.size() - sourcePos)},
       options);
   sourcePos = sourceData.data;
 

--- a/velox/dwio/nimble/encodings/TrivialEncoding.h
+++ b/velox/dwio/nimble/encodings/TrivialEncoding.h
@@ -277,7 +277,7 @@ TrivialEncoding<T>::TrivialEncoding(
   } else {
     NIMBLE_CHECK_EQ(
         reinterpret_cast<const char*>(values_ + this->rowCount()),
-        data.end(),
+        data.data() + data.size(),
         "Unexpected trivial encoding end");
   }
 }
@@ -353,7 +353,8 @@ std::string_view TrivialEncoding<T>::slice(
         buffer.getMemoryPool(),
         compressionType,
         TypeTraits<T>::dataType,
-        {sourcePos, static_cast<size_t>(encoded.end() - sourcePos)},
+        {sourcePos,
+         static_cast<size_t>(encoded.data() + encoded.size() - sourcePos)},
         options.decompressCounter(),
         options.bufferPool);
     sourcePos = uncompressed->template as<char>();

--- a/velox/dwio/nimble/encodings/legacy/ConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/ConstantEncoding.h
@@ -76,7 +76,8 @@ ConstantEncoding<T>::ConstantEncoding(
     : TypedEncoding<T, physicalType>(memoryPool, data) {
   const char* pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   value_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
+  NIMBLE_CHECK(
+      pos == data.data() + data.size(), "Unexpected constant encoding end");
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/legacy/DeltaEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/DeltaEncoding.h
@@ -124,7 +124,7 @@ DeltaEncoding<T>::DeltaEncoding(
   pos += isRestatementsOffset;
   isRestatements_ = factory.create(
       memoryPool,
-      {pos, static_cast<size_t>(data.end() - pos)},
+      {pos, static_cast<size_t>(data.data() + data.size() - pos)},
       stringBufferFactory,
       Encoding::Options{});
 }

--- a/velox/dwio/nimble/encodings/legacy/DictionaryEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/DictionaryEncoding.h
@@ -105,7 +105,7 @@ DictionaryEncoding<T>::DictionaryEncoding(
   pos += alphabetSize;
   indicesEncoding_ = factory.create(
       *this->pool_,
-      {pos, static_cast<size_t>(data.end() - pos)},
+      {pos, static_cast<size_t>(data.data() + data.size() - pos)},
       stringBufferFactory,
       Encoding::Options{});
 }

--- a/velox/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -99,13 +99,13 @@ FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
         pool,
         compressionType,
         TypeTraits<physicalType>::dataType,
-        {pos, static_cast<size_t>(data.end() - pos)},
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)},
         /*decompressCounter=*/nullptr);
     fixedBitArray_ = FixedBitArray{
         {uncompressedData_->as<char>(), uncompressedData_->size()}, bitWidth_};
   } else {
-    fixedBitArray_ =
-        FixedBitArray{{pos, static_cast<size_t>(data.end() - pos)}, bitWidth_};
+    fixedBitArray_ = FixedBitArray{
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)}, bitWidth_};
   }
 }
 

--- a/velox/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
@@ -131,7 +131,9 @@ MainlyConstantEncoding<T>::MainlyConstantEncoding(
       Encoding::Options{});
   pos += otherValuesBytes;
   commonValue_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
+  NIMBLE_CHECK(
+      pos == data.data() + data.size(),
+      "Unexpected mainly constant encoding end");
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/legacy/NullableEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/NullableEncoding.h
@@ -110,7 +110,7 @@ NullableEncoding<T>::NullableEncoding(
   pos += nonNullsBytes;
   nulls_ = factory.create(
       *this->pool_,
-      {pos, static_cast<size_t>(data.end() - pos)},
+      {pos, static_cast<size_t>(data.data() + data.size() - pos)},
       stringBufferFactory,
       Encoding::Options{});
   NIMBLE_DCHECK_EQ(

--- a/velox/dwio/nimble/encodings/legacy/RLEEncoding.cpp
+++ b/velox/dwio/nimble/encodings/legacy/RLEEncoding.cpp
@@ -29,7 +29,7 @@ RLEEncoding<bool>::RLEEncoding(
       internal::RLEEncodingBase<bool, RLEEncoding<bool>>::getValuesStart());
   NIMBLE_CHECK(
       (internal::RLEEncodingBase<bool, RLEEncoding<bool>>::getValuesStart() +
-       1) == data.end(),
+       1) == data.data() + data.size(),
       "Unexpected run length encoding end");
   internal::RLEEncodingBase<bool, RLEEncoding<bool>>::reset();
 }

--- a/velox/dwio/nimble/encodings/legacy/RLEEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/RLEEncoding.h
@@ -304,7 +304,7 @@ RLEEncoding<T>::RLEEncoding(
           memoryPool,
           {internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart(),
            static_cast<size_t>(
-               data.end() -
+               data.data() + data.size() -
                internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())},
           stringBufferFactory,
           Encoding::Options{})} {

--- a/velox/dwio/nimble/encodings/legacy/SentinelEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/SentinelEncoding.h
@@ -114,7 +114,8 @@ SentinelEncoding<T>::SentinelEncoding(
       deserializeEncoding(this->memoryPool_, {pos, sentineledBytes});
   pos += sentineledBytes;
   sentinelValue_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected sentinel encoding end");
+  NIMBLE_CHECK(
+      pos == data.data() + data.size(), "Unexpected sentinel encoding end");
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
+++ b/velox/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
@@ -38,7 +38,7 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
         pool,
         dataCompressionType,
         DataType::String,
-        {blob_, static_cast<size_t>(data.end() - blob_)},
+        {blob_, static_cast<size_t>(data.data() + data.size() - blob_)},
         /*decompressCounter=*/nullptr);
     blob_ = dataUncompressed_->as<char>();
     uncompressedDataBytes_ = dataUncompressed_->size();
@@ -149,7 +149,7 @@ TrivialEncoding<bool>::TrivialEncoding(
         pool,
         compressionType,
         DataType::Undefined,
-        {bitmap_, static_cast<size_t>(data.end() - bitmap_)},
+        {bitmap_, static_cast<size_t>(data.data() + data.size() - bitmap_)},
         /*decompressCounter=*/nullptr);
     bitmap_ = uncompressed_->as<char>();
     NIMBLE_CHECK_EQ(
@@ -159,7 +159,7 @@ TrivialEncoding<bool>::TrivialEncoding(
   } else {
     NIMBLE_CHECK_EQ(
         bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),
-        data.end(),
+        data.data() + data.size(),
         "Unexpected trivial encoding end");
   }
 }

--- a/velox/dwio/nimble/encodings/legacy/TrivialEncoding.h
+++ b/velox/dwio/nimble/encodings/legacy/TrivialEncoding.h
@@ -209,7 +209,7 @@ TrivialEncoding<T>::TrivialEncoding(
   } else {
     NIMBLE_CHECK_EQ(
         reinterpret_cast<const char*>(values_ + this->rowCount()),
-        data.end(),
+        data.data() + data.size(),
         "Unexpected trivial encoding end");
   }
 }

--- a/velox/dwio/nimble/encodings/views/DictionaryEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/DictionaryEncodingView.h
@@ -39,7 +39,9 @@ class DictionaryEncodingView final : public TypedEncodingView<T> {
     NIMBLE_CHECK_NOT_NULL(alphabet_);
     pos += alphabetSize;
     indices_ = detail::createTypedEncodingView<uint32_t>(
-        {pos, static_cast<size_t>(data.end() - pos)}, this->pool_, options);
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)},
+        this->pool_,
+        options);
     NIMBLE_CHECK_NOT_NULL(indices_);
   }
 

--- a/velox/dwio/nimble/encodings/views/FOREncodingView.h
+++ b/velox/dwio/nimble/encodings/views/FOREncodingView.h
@@ -101,7 +101,7 @@ class FOREncodingView final : public TypedEncodingView<T> {
     const auto packedDataSize = varint::readVarint32(&pos);
     packedData_ = pos;
     pos += packedDataSize;
-    NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected FOR view end.");
+    NIMBLE_CHECK_EQ(pos, data.data() + data.size(), "Unexpected FOR view end.");
   }
 
   ~FOREncodingView() override {

--- a/velox/dwio/nimble/encodings/views/FixedBitWidthEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/FixedBitWidthEncodingView.h
@@ -44,7 +44,7 @@ class FixedBitWidthEncodingView final : public TypedEncodingView<T> {
     baseline_ = encoding::read<physicalType>(pos);
     bitWidth_ = static_cast<uint32_t>(encoding::readChar(pos));
     fixedBitArray_ = FixedBitArray{
-        {pos, static_cast<size_t>(data.end() - pos)},
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)},
         static_cast<int>(bitWidth_)};
   }
 

--- a/velox/dwio/nimble/encodings/views/HuffmanEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/HuffmanEncodingView.h
@@ -96,7 +96,7 @@ class HuffmanEncodingView final : public TypedEncodingView<T> {
     }
     bitstreamBytes_ = varint::readVarint32(&pos);
     bitstream_ = reinterpret_cast<const uint8_t*>(pos);
-    NIMBLE_CHECK_EQ(pos + bitstreamBytes_, data.end());
+    NIMBLE_CHECK_EQ(pos + bitstreamBytes_, data.data() + data.size());
   }
 
   ~HuffmanEncodingView() override {

--- a/velox/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
@@ -54,7 +54,8 @@ class MainlyConstantEncodingView final : public TypedEncodingView<T> {
     pos += otherValuesSize;
 
     commonValue_ = encoding::read<physicalType>(pos);
-    NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected MainlyConstant view end.");
+    NIMBLE_CHECK_EQ(
+        pos, data.data() + data.size(), "Unexpected MainlyConstant view end.");
 
     uint32_t otherValueCount = 0;
     otherValueIndices_.resize(this->rowCount_);

--- a/velox/dwio/nimble/encodings/views/RLEEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/RLEEncodingView.h
@@ -53,7 +53,9 @@ class RLEEncodingView final : public TypedEncodingView<T> {
 
     pos += runLengthsSize;
     values_ = detail::createTypedEncodingView<T>(
-        {pos, static_cast<size_t>(data.end() - pos)}, this->pool_, options);
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)},
+        this->pool_,
+        options);
     NIMBLE_CHECK_NOT_NULL(values_);
   }
 
@@ -121,7 +123,7 @@ class RLEEncodingView<bool> final : public TypedEncodingView<bool> {
     NIMBLE_CHECK_EQ(end, this->rowCount_);
 
     pos += runLengthsSize;
-    NIMBLE_CHECK_EQ(pos + sizeof(bool), data.end());
+    NIMBLE_CHECK_EQ(pos + sizeof(bool), data.data() + data.size());
     initialValue_ = *reinterpret_cast<const bool*>(pos);
   }
 

--- a/velox/dwio/nimble/encodings/views/SparseBoolEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/SparseBoolEncodingView.h
@@ -33,7 +33,9 @@ class SparseBoolEncodingView final : public TypedEncodingView<bool> {
     const char* pos = data.data() + this->dataOffset_;
     sparseValue_ = static_cast<bool>(encoding::readChar(pos));
     indices_ = detail::createTypedEncodingView<uint32_t>(
-        {pos, static_cast<size_t>(data.end() - pos)}, pool, options);
+        {pos, static_cast<size_t>(data.data() + data.size() - pos)},
+        pool,
+        options);
     NIMBLE_CHECK_NOT_NULL(indices_);
     NIMBLE_CHECK_GT(indices_->rowCount(), 0);
     NIMBLE_CHECK_EQ(

--- a/velox/dwio/nimble/serializer/StreamData.cpp
+++ b/velox/dwio/nimble/serializer/StreamData.cpp
@@ -113,8 +113,8 @@ void StreamData::init(std::string_view data) {
     end_ = nullptr;
     return;
   }
-  pos_ = data.begin();
-  end_ = data.end();
+  pos_ = data.data();
+  end_ = data.data() + data.size();
   if (encodingEnabled_) {
     prepareForDecoding({pos_, end_});
   } else {

--- a/velox/dwio/nimble/serializer/StreamDataParser.cpp
+++ b/velox/dwio/nimble/serializer/StreamDataParser.cpp
@@ -354,7 +354,7 @@ Buffer& StreamDataParser::ensureStrippedStreamBuffer() {
 
 uint32_t StreamDataParser::initialize(std::string_view data) {
   pos_ = data.data();
-  end_ = data.end();
+  end_ = data.data() + data.size();
   auto header = readSerializationHeader(pos_, end_, options_.hasHeader);
   version_ = header.version;
   requiresNullBarrier_ = header.flags.requiresNullBarrier;

--- a/velox/dwio/nimble/serializer/StreamSlicer.cpp
+++ b/velox/dwio/nimble/serializer/StreamSlicer.cpp
@@ -110,10 +110,10 @@ std::string_view nullableNullsStream(
   const auto valuesSize = encoding::readUint32(pos);
   NIMBLE_CHECK_LE(
       valuesSize,
-      static_cast<size_t>(encoded.end() - pos),
+      static_cast<size_t>(encoded.data() + encoded.size() - pos),
       "Nullable values child exceeds encoding size");
   pos += valuesSize;
-  return {pos, encoded.end()};
+  return {pos, encoded.data() + encoded.size()};
 }
 
 uint32_t maxStreamOffset(const StreamDescriptor& descriptor) {


### PR DESCRIPTION
Summary:

## Context

fbcode is migrating from libstdc++ to libc++ for better performance, access to newer C++ features, and stronger safety guarantees. Some code that compiled under libstdc++ relies on non-standard extensions, implicit conversions, or header inclusion side effects that libc++ does not provide.

## Problem

libstdc++ implements `std::string_view::iterator` as a plain `const char*`, so code could freely mix `sv.begin()`/`sv.end()` with raw `const char*` cursors. libc++ implements it as the wrapper class `__wrap_iter<const char*>`, which has no implicit conversion to `const char*`. Nimble's encoding readers parse the wire format with a `const char* pos` cursor and compare or subtract it against `data.end()`/`encoded.end()`, which now fails to compile:

```
error: invalid operands to binary expression ('const_iterator' (aka '__wrap_iter<const char *>') and 'const char *')
  437 |       sourcePos, static_cast<size_t>(encoded.end() - sourcePos)};
```

```
error: invalid operands to binary expression ('const char *' and 'const_iterator' (aka '__wrap_iter<const char *>'))
  278 |     NIMBLE_CHECK_EQ(
  279 |         reinterpret_cast<const char*>(values_ + this->rowCount()),
  280 |         data.end(),
```

The same pattern appears throughout `encodings/` (including `legacy/` and `views/`) and `serializer/`, so fixing only the two headers named in the build failure would just surface the rest on the next run.

## Fix

Replace every `string_view` iterator that is used as a raw pointer with the equivalent pointer expression: `sv.end()` becomes `sv.data() + sv.size()` and `sv.begin()` becomes `sv.data()`. Under libstdc++ these were already the same value, so this is a no-op at runtime and preserves the existing bounds checks exactly. Iterator uses over `Vector<T>`, `std::vector`, and `std::span` are left untouched — only the pointer-mixing `string_view` sites are changed.

Reviewed By: yuxuanchen1997

Differential Revision: D117942391
