### PR TITLE
feat(functions): Dispatch map_concat to flatMapConcat (#18814)

### DIFF
--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/lib/MapConcat.h"
 #include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/vector/FlatMapConcat.h"
 #include "velox/vector/MapConcat.h"
 
 namespace facebook::velox::functions {
@@ -88,7 +89,10 @@ class MapConcatFunction : public exec::VectorFunction {
           ctx->queryConfig().throwExceptionOnDuplicateMapKeys();
     }
 
-    auto merged = mapConcat(context.pool(), outputType, inputs, rows, config);
+    const VectorPtr merged = allInputsAreFlatMap(inputs)
+        ? VectorPtr(
+              flatMapConcat(context.pool(), outputType, inputs, rows, config))
+        : mapConcat(context.pool(), outputType, inputs, rows, config);
     context.moveOrCopyResult(merged, rows, result);
   }
 

--- a/velox/functions/lib/tests/MapConcatTest.cpp
+++ b/velox/functions/lib/tests/MapConcatTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/functions/lib/MapConcat.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
@@ -316,6 +317,44 @@ TEST_F(MapConcatTest, nullEntry) {
   auto result = evaluate<MapVector>("map_concat_empty_nulls(c0, c1)", rows);
   ASSERT_EQ(result->size(), 1);
   EXPECT_EQ(result->sizeAt(0), 0);
+}
+
+TEST_F(MapConcatTest, flatMapInputs) {
+  auto map1 = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+      {{1, 11}},
+  });
+  auto map2 = makeFlatMapVector<int64_t, int64_t>({
+      {{2, 20}},
+      {{2, 21}},
+  });
+
+  auto result = evaluate<FlatMapVector>(
+      "map_concat(c0, c1)", makeRowVector({map1, map2}));
+
+  auto expected = VectorTestBase::makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{1, 11}, {2, 21}},
+  });
+  ASSERT_EQ(result->size(), expected->size());
+  for (vector_size_t i = 0; i < expected->size(); ++i) {
+    ASSERT_TRUE(expected->equalValueAt(result.get(), i, i))
+        << "at " << i << ": expected " << expected->toString(i) << ", got "
+        << result->toString(i);
+  }
+}
+
+TEST_F(MapConcatTest, mixedMapAndFlatMapInputs) {
+  auto flatMap = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+  });
+  auto map = VectorTestBase::makeMapVector<int64_t, int64_t>({
+      {{2, 20}},
+  });
+
+  VELOX_ASSERT_THROW(
+      evaluate("map_concat(c0, c1)", makeRowVector({flatMap, map})),
+      "Wrong type cast expected");
 }
 
 TEST_F(MapConcatTest, unknownType) {

--- a/velox/vector/FlatMapConcat.cpp
+++ b/velox/vector/FlatMapConcat.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/FlatMapConcat.h"
+
+#include <algorithm>
+
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/VectorMap.h"
+
+namespace facebook::velox {
+namespace {
+
+void checkFlatMapInputsSupported(std::span<DecodedVector* const> inputs) {
+  if (!std::ranges::all_of(inputs, [](const DecodedVector* input) {
+        return input->isIdentityMapping();
+      })) {
+    VELOX_NYI(
+        "flatMapConcat does not support encodings over FlatMapVector inputs.");
+  }
+}
+
+struct OutputChannels {
+  std::vector<VectorValueSetEntry> keys;
+  std::vector<VectorPtr> mapValues;
+  std::vector<BufferPtr> inMaps;
+
+  void reserve(vector_size_t numKeys) {
+    keys.reserve(numKeys);
+    mapValues.reserve(numKeys);
+    inMaps.reserve(numKeys);
+  }
+
+  void push(VectorValueSetEntry key, VectorPtr values, BufferPtr inMap) {
+    keys.push_back(key);
+    mapValues.push_back(std::move(values));
+    inMaps.push_back(std::move(inMap));
+  }
+};
+
+vector_size_t totalNumDistinctKeys(std::span<DecodedVector* const> inputs) {
+  vector_size_t numKeys = 0;
+  for (auto* input : inputs) {
+    numKeys += input->base()->asUnchecked<FlatMapVector>()->numDistinctKeys();
+  }
+  return numKeys;
+}
+
+BufferPtr concatNulls(
+    memory::MemoryPool* pool,
+    std::span<DecodedVector* const> inputs,
+    const SelectivityVector& rows,
+    const MapConcatConfig& config) {
+  if (config.emptyForNull) {
+    return nullptr;
+  }
+
+  const auto numRows = rows.end();
+  BufferPtr newNulls;
+  for (auto* input : inputs) {
+    const auto* nulls = input->nulls(&rows);
+    if (!nulls) {
+      continue;
+    }
+    if (!newNulls) {
+      newNulls = allocateNulls(numRows, pool);
+      bits::copyBits(nulls, 0, newNulls->asMutable<uint64_t>(), 0, numRows);
+    } else {
+      bits::andBits(newNulls->asMutable<uint64_t>(), nulls, 0, numRows);
+    }
+  }
+  return newNulls;
+}
+
+BufferPtr buildRowMask(
+    memory::MemoryPool* pool,
+    const SelectivityVector& rows,
+    const BufferPtr& nulls) {
+  if (rows.isAllSelected() && !nulls) {
+    return nullptr;
+  }
+
+  const auto numRows = rows.end();
+  auto mask = allocateNulls(numRows, pool, bits::kNotNull);
+  auto* rawMask = mask->asMutable<uint64_t>();
+  if (!rows.isAllSelected()) {
+    bits::andBits(rawMask, rows.asRange().bits(), 0, numRows);
+  }
+  if (nulls) {
+    bits::andBits(rawMask, nulls->as<uint64_t>(), 0, numRows);
+  }
+  return mask;
+}
+
+BufferPtr safeGetInMap(const FlatMapVector* flatMap, column_index_t channel) {
+  return flatMap->rawInMapsAt(channel) ? flatMap->inMapsAt(channel) : nullptr;
+}
+
+// A null 'sourceInMap' means the key is in every row, so masking one has to
+// start from all ones rather than skip.
+BufferPtr buildInMap(
+    memory::MemoryPool* pool,
+    const BufferPtr& sourceInMap,
+    const BufferPtr& mask,
+    const uint64_t* inputNulls,
+    vector_size_t numRows) {
+  if (!mask && !inputNulls) {
+    return sourceInMap;
+  }
+
+  auto inMap = AlignedBuffer::allocate<bool>(numRows, pool, false);
+  auto* rawInMap = inMap->asMutable<uint64_t>();
+  if (sourceInMap) {
+    bits::copyBits(sourceInMap->as<uint64_t>(), 0, rawInMap, 0, numRows);
+  } else {
+    bits::fillBits(rawInMap, 0, numRows, true);
+  }
+  if (mask) {
+    bits::andBits(rawInMap, mask->as<uint64_t>(), 0, numRows);
+  }
+  if (inputNulls) {
+    bits::andBits(rawInMap, inputNulls, 0, numRows);
+  }
+  return inMap;
+}
+
+OutputChannels collectOutputChannels(
+    memory::MemoryPool* pool,
+    std::span<DecodedVector* const> inputs,
+    const SelectivityVector& rows,
+    const BufferPtr& mask,
+    bool emptyForNull,
+    vector_size_t numRows) {
+  const auto numKeys = totalNumDistinctKeys(inputs);
+
+  OutputChannels channels;
+  channels.reserve(numKeys);
+
+  VectorValueSet seen;
+  seen.reserve(numKeys);
+
+  for (auto* input : inputs) {
+    const auto* inputNulls = emptyForNull ? input->nulls(&rows) : nullptr;
+    const auto* flatMap = input->base()->asUnchecked<FlatMapVector>();
+    const auto& keys = flatMap->distinctKeys();
+    for (vector_size_t channel = 0; channel < flatMap->numDistinctKeys();
+         ++channel) {
+      const VectorValueSetEntry key{keys.get(), channel};
+      if (!seen.insert(key).second) {
+        VELOX_NYI(
+            "Currently flatMapConcat does not support duplicate keys across "
+            "inputs: {}",
+            keys->toString(channel));
+      }
+      channels.push(
+          key,
+          flatMap->mapValuesAt(channel),
+          buildInMap(
+              pool, safeGetInMap(flatMap, channel), mask, inputNulls, numRows));
+    }
+  }
+  return channels;
+}
+
+VectorPtr buildDistinctKeys(
+    memory::MemoryPool* pool,
+    const TypePtr& keyType,
+    const std::vector<VectorValueSetEntry>& keys) {
+  const auto numKeys = static_cast<vector_size_t>(keys.size());
+  auto distinctKeys = BaseVector::create(keyType, numKeys, pool);
+  for (vector_size_t key = 0; key < numKeys; ++key) {
+    distinctKeys->copy(keys[key].vector, key, keys[key].index, 1);
+  }
+  return distinctKeys;
+}
+
+} // namespace
+
+bool allInputsAreFlatMap(std::span<DecodedVector* const> inputs) {
+  return !inputs.empty() &&
+      std::ranges::all_of(inputs, [](const DecodedVector* input) {
+        return input->base()->encoding() == VectorEncoding::Simple::FLAT_MAP;
+      });
+}
+
+FlatMapVectorPtr flatMapConcat(
+    memory::MemoryPool* pool,
+    const TypePtr& outputType,
+    std::span<DecodedVector* const> inputs,
+    const SelectivityVector& rows,
+    const MapConcatConfig& config) {
+  VELOX_CHECK_GT(inputs.size(), 0);
+  checkFlatMapInputsSupported(inputs);
+
+  const auto numRows = rows.end();
+  auto newNulls = concatNulls(pool, inputs, rows, config);
+  const auto mask = buildRowMask(pool, rows, newNulls);
+  auto channels = collectOutputChannels(
+      pool, inputs, rows, mask, config.emptyForNull, numRows);
+  auto distinctKeys =
+      buildDistinctKeys(pool, outputType->asMap().keyType(), channels.keys);
+
+  return std::make_shared<FlatMapVector>(
+      pool,
+      outputType,
+      std::move(newNulls),
+      numRows,
+      std::move(distinctKeys),
+      std::move(channels.mapValues),
+      std::move(channels.inMaps));
+}
+
+} // namespace facebook::velox

--- a/velox/vector/FlatMapConcat.h
+++ b/velox/vector/FlatMapConcat.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <span>
+
+#include "velox/vector/FlatMapVector.h"
+#include "velox/vector/MapConcat.h"
+
+namespace facebook::velox {
+
+/// Returns true when every input is flat map encoded. Returns false for no
+/// inputs.
+bool allInputsAreFlatMap(std::span<DecodedVector* const> inputs);
+
+/// Merges vectors into a single FlatMapVector.
+/// Inputs:
+///   - Expect all flatmap encoded Velox vector. Throw otherwises.
+/// Duplicated key handling:
+///   - Currently throw if there is any key duplication.
+
+FlatMapVectorPtr flatMapConcat(
+    memory::MemoryPool* pool,
+    const TypePtr& outputType,
+    std::span<DecodedVector* const> inputs,
+    const SelectivityVector& rows,
+    const MapConcatConfig& config);
+
+} // namespace facebook::velox

--- a/velox/vector/tests/FlatMapConcatTest.cpp
+++ b/velox/vector/tests/FlatMapConcatTest.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/FlatMapConcat.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox {
+namespace {
+
+// Owns the DecodedVectors for as long as the pointers handed to the concat are
+// in use.
+struct Decoded {
+  std::vector<std::unique_ptr<DecodedVector>> owners;
+  std::vector<DecodedVector*> pointers;
+};
+
+class FlatMapConcatTest : public testing::Test,
+                          public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  Decoded decode(const std::vector<VectorPtr>& inputs) {
+    Decoded decoded;
+    decoded.owners.reserve(inputs.size());
+    decoded.pointers.reserve(inputs.size());
+    for (const auto& input : inputs) {
+      decoded.owners.push_back(std::make_unique<DecodedVector>(*input));
+      decoded.pointers.push_back(decoded.owners.back().get());
+    }
+    return decoded;
+  }
+
+  FlatMapVectorPtr concat(
+      const std::vector<VectorPtr>& inputs,
+      const SelectivityVector& rows,
+      const MapConcatConfig& config = {}) {
+    auto decoded = decode(inputs);
+    return flatMapConcat(
+        pool(), inputs[0]->type(), decoded.pointers, rows, config);
+  }
+};
+
+TEST_F(FlatMapConcatTest, flatMapEncoded) {
+  // One row each, one entry each, disjoint keys: {1->10} + {2->20}.
+  auto map1 = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+  });
+  auto map2 = makeFlatMapVector<int64_t, int64_t>({
+      {{2, 20}},
+  });
+
+  SelectivityVector rows(1);
+  auto result = concat({map1, map2}, rows);
+
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+  });
+  ASSERT_TRUE(expected->equalValueAt(result.get(), 0, 0))
+      << "expected " << expected->toString(0) << ", got "
+      << result->toString(0);
+}
+
+TEST_F(FlatMapConcatTest, flatMapEncodedWithoutInMaps) {
+  auto map = std::make_shared<FlatMapVector>(
+      pool(),
+      MAP(BIGINT(), BIGINT()),
+      nullptr,
+      1,
+      makeFlatVector<int64_t>({1}),
+      std::vector<VectorPtr>{makeFlatVector<int64_t>({10})},
+      std::vector<BufferPtr>{}); // Empty in-map vector means all keys exist.
+  ASSERT_TRUE(map->inMaps().empty());
+
+  SelectivityVector rows(1);
+  auto result = concat({map}, rows);
+
+  ASSERT_TRUE(map->equalValueAt(result.get(), 0, 0));
+}
+
+TEST_F(FlatMapConcatTest, flatMapEncodedPartialRowsAndNulls) {
+  auto map1 = makeNullableFlatMapVector<int64_t, int64_t>({
+      {{{1, 10}}},
+      std::nullopt,
+      {{{1, 30}}},
+      {{{1, 40}}},
+  });
+  auto map2 = makeNullableFlatMapVector<int64_t, int64_t>({
+      {{{2, 20}}},
+      {{{2, 21}}},
+      {{{2, 31}}},
+      {{{2, 41}}},
+  });
+
+  // Select 0, 1, 3 -- row 2 unselected, row 1 null in map1.
+  SelectivityVector rows(4, false);
+  rows.setValid(0, true);
+  rows.setValid(1, true);
+  rows.setValid(3, true);
+  rows.updateBounds();
+
+  auto result = concat({map1, map2}, rows);
+  auto* flatMap = result->as<FlatMapVector>();
+  ASSERT_NE(flatMap, nullptr);
+  ASSERT_EQ(flatMap->size(), 4);
+
+  EXPECT_FALSE(flatMap->isNullAt(0));
+  EXPECT_EQ(flatMap->sizeAt(0), 2);
+  EXPECT_TRUE(flatMap->isNullAt(1)); // null propagated from map1
+  EXPECT_EQ(flatMap->sizeAt(2), 0); // unselected -> size 0
+  EXPECT_EQ(flatMap->sizeAt(3), 2);
+
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {},
+      {},
+      {{1, 40}, {2, 41}},
+  });
+  for (int i : {0, 3}) {
+    EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+        << "at " << i << ": expected " << expected->toString(i) << ", got "
+        << result->toString(i);
+  }
+}
+
+TEST_F(FlatMapConcatTest, emptyForNullMasksNullInputChannels) {
+  auto map1 = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+      {{1, 11}},
+  });
+  auto map2 = makeFlatMapVector<int64_t, int64_t>({
+      {{2, 20}},
+      {{2, 21}},
+  });
+
+  // Parent nulls do not guarantee that child in-map bits are cleared.
+  map1->setNull(1, true);
+  map2->setNull(0, true);
+  ASSERT_TRUE(map1->isInMap(0, 1));
+  ASSERT_TRUE(map2->isInMap(0, 0));
+
+  SelectivityVector rows(2);
+  auto result = concat({map1, map2}, rows, {.emptyForNull = true});
+
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 10}},
+      {{2, 21}},
+  });
+  for (vector_size_t row = 0; row < 2; ++row) {
+    EXPECT_EQ(result->sizeAt(row), 1);
+    EXPECT_TRUE(expected->equalValueAt(result.get(), row, row))
+        << "at " << row << ": expected " << expected->toString(row) << ", got "
+        << result->toString(row);
+  }
+}
+
+TEST_F(FlatMapConcatTest, flatMapEncodedDuplicateKeys) {
+  // Key 1 is in both inputs.  Merging shared keys is not implemented yet.
+  auto map1 = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+  });
+  auto map2 = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 100}},
+  });
+
+  SelectivityVector rows(1);
+  VELOX_ASSERT_THROW(
+      concat({map1, map2}, rows), "duplicate keys across inputs");
+}
+
+TEST_F(FlatMapConcatTest, allInputsAreFlatMapFalseForEmptyInputs) {
+  const std::vector<DecodedVector*> inputs;
+  EXPECT_FALSE(allInputsAreFlatMap(inputs));
+}
+
+TEST_F(FlatMapConcatTest, allInputsAreFlatMapTrueForFlatMaps) {
+  auto first = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+  });
+  auto second = makeFlatMapVector<int64_t, int64_t>({
+      {{2, 20}},
+  });
+
+  auto decoded = decode({first, second});
+  EXPECT_TRUE(allInputsAreFlatMap(decoded.pointers));
+}
+
+TEST_F(FlatMapConcatTest, allInputsAreFlatMapFalseForMapVectors) {
+  auto first = makeMapVector<int64_t, int64_t>({
+      {{1, 10}},
+  });
+  auto second = makeMapVector<int64_t, int64_t>({
+      {{2, 20}},
+  });
+
+  auto decoded = decode({first, second});
+  EXPECT_FALSE(allInputsAreFlatMap(decoded.pointers));
+}
+
+TEST_F(FlatMapConcatTest, allInputsAreFlatMapFalseForMixedEncodings) {
+  auto flatMap = makeFlatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+  });
+  auto map = makeMapVector<int64_t, int64_t>({
+      {{2, 20}},
+  });
+
+  auto decoded = decode({flatMap, map});
+  EXPECT_FALSE(allInputsAreFlatMap(decoded.pointers));
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:

`map_concat` on flat map encoded columns failed with `Wrong type cast expected MapVector, but got FlatMapVector`. `MapConcatFunction::apply` now classifies its inputs with `allInputsAreFlatMap` and calls `flatMapConcat` when every one of them is flat map encoded, so the result stays flat map encoded instead of being materialized as a `MapVector`.

Mixing the two encodings across arguments throws, replacing the `asChecked` cast failure with a message that names the limitation.

Differential Revision: D118491973


