### PR TITLE
feat(nimble): Restricted extension to SubIntSplit Cost Model Selection

### DIFF
--- a/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -166,6 +166,55 @@ class BlockBitPackingEncoding final
         metadataSize + packedSize;
   }
 
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+  /// Statistics-only overload for general encoding selection (e.g. as a
+  /// SubIntSplit segment candidate), where only `Statistics<physicalType>` --
+  /// not the raw values -- is available. Without raw values, true per-block
+  /// locality can't be observed; this approximates a "typical" per-block bit
+  /// width as the ~50%-coverage point of `statistics.bucketCounts()` (median
+  /// bit width of value - min), analogous to how PFOREncoding's
+  /// `selectBaseBitWidth` picks a 90%-coverage baseline. This is a coarser
+  /// approximation than the span-based overload above.
+  static uint64_t estimateSize(
+      uint64_t rowCount,
+      const Statistics<physicalType>& statistics,
+      uint16_t blockSize = kBlockBitPackingBlockSize) {
+    if (rowCount == 0) {
+      return EncodingPrefix::kFixedPrefixSize;
+    }
+    const auto& bucketCounts = statistics.bucketCounts();
+    const auto fullRange =
+        static_cast<physicalType>(statistics.max() - statistics.min());
+    const uint8_t maxBitWidth =
+        static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+
+    constexpr double kCoverageThreshold = 0.5;
+    const uint64_t threshold = static_cast<uint64_t>(
+        static_cast<double>(rowCount) * kCoverageThreshold);
+    uint8_t typicalBitWidth = maxBitWidth;
+    uint64_t cumulative = 0;
+    for (size_t k = 0; k < bucketCounts.size(); ++k) {
+      cumulative += bucketCounts[k];
+      if (cumulative >= threshold) {
+        typicalBitWidth = std::min<uint8_t>(
+            static_cast<uint8_t>(std::min<size_t>((k + 1) * 7, 64)),
+            maxBitWidth);
+        break;
+      }
+    }
+
+    const uint32_t numBlocks =
+        velox::bits::divRoundUp(static_cast<uint32_t>(rowCount), blockSize);
+    const uint64_t packedSize =
+        FixedBitArray::bufferSize(rowCount, typicalBitWidth);
+    const uint64_t metadataSize = kMetadataHeaderSize +
+        TrivialEncoding<physicalType>::estimateSize(numBlocks) +
+        TrivialEncoding<uint8_t>::estimateSize(numBlocks) +
+        TrivialEncoding<uint32_t>::estimateSize(numBlocks);
+    return EncodingPrefix::kFixedPrefixSize + metadataSize + packedSize;
+  }
+#endif
+
   std::string debugString(int offset) const final;
 
  private:

--- a/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -209,7 +209,8 @@ class BlockBitPackingEncoding final
         FixedBitArray::bufferSize(rowCount, typicalBitWidth);
     const auto baselinesSize =
         TrivialEncoding<physicalType>::estimateSize(numBlocks);
-    const auto bitWidthsSize = TrivialEncoding<uint8_t>::estimateSize(numBlocks);
+    const auto bitWidthsSize =
+        TrivialEncoding<uint8_t>::estimateSize(numBlocks);
     const auto offsetsSize = TrivialEncoding<uint32_t>::estimateSize(numBlocks);
     const auto firstBlockRows =
         std::min<uint32_t>(blockSize, static_cast<uint32_t>(rowCount));

--- a/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -207,10 +207,20 @@ class BlockBitPackingEncoding final
         velox::bits::divRoundUp(static_cast<uint32_t>(rowCount), blockSize);
     const uint64_t packedSize =
         FixedBitArray::bufferSize(rowCount, typicalBitWidth);
-    const uint64_t metadataSize = kMetadataHeaderSize +
-        TrivialEncoding<physicalType>::estimateSize(numBlocks) +
-        TrivialEncoding<uint8_t>::estimateSize(numBlocks) +
-        TrivialEncoding<uint32_t>::estimateSize(numBlocks);
+    const auto baselinesSize =
+        TrivialEncoding<physicalType>::estimateSize(numBlocks);
+    const auto bitWidthsSize = TrivialEncoding<uint8_t>::estimateSize(numBlocks);
+    const auto offsetsSize = TrivialEncoding<uint32_t>::estimateSize(numBlocks);
+    const auto firstBlockRows =
+        std::min<uint32_t>(blockSize, static_cast<uint32_t>(rowCount));
+    const uint64_t metadataSize = headerSize(
+                                      blockSize,
+                                      numBlocks,
+                                      static_cast<uint32_t>(baselinesSize),
+                                      static_cast<uint32_t>(bitWidthsSize),
+                                      static_cast<uint32_t>(offsetsSize),
+                                      firstBlockRows) +
+        baselinesSize + bitWidthsSize + offsetsSize;
     return EncodingPrefix::kFixedPrefixSize + metadataSize + packedSize;
   }
 #endif

--- a/velox/dwio/nimble/encodings/DeltaEncoding.h
+++ b/velox/dwio/nimble/encodings/DeltaEncoding.h
@@ -24,6 +24,7 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/FixedBitArray.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
@@ -97,6 +98,50 @@ class DeltaEncoding final
       std::span<const physicalType> values,
       Buffer& buffer,
       const Encoding::Options& options = {});
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+  /// Statistics-only size estimate for general encoding selection (e.g. as a
+  /// SubIntSplit segment candidate), where only `Statistics<physicalType>` --
+  /// not the raw values -- is available. Without raw values, the true
+  /// monotonic-step pattern can't be observed; this assumes a single leading
+  /// restatement and an average step size of range / (rowCount - 1) -- the
+  /// typical step for a column whose values are roughly evenly spread across
+  /// [min, max] in row order. This is a coarse approximation: non-monotonic
+  /// columns (which need many restatements) will be underestimated.
+  static uint64_t estimateSize(
+      uint64_t rowCount,
+      const Statistics<physicalType>& statistics) {
+    if (rowCount == 0) {
+      return EncodingPrefix::kFixedPrefixSize;
+    }
+    const auto fullRange =
+        static_cast<uint64_t>(statistics.max() - statistics.min());
+    const double avgAbsDelta = rowCount > 1
+        ? static_cast<double>(fullRange) / static_cast<double>(rowCount - 1)
+        : 0.0;
+    const uint8_t deltaBitWidth = avgAbsDelta < 1.0
+        ? uint8_t{0}
+        : static_cast<uint8_t>(
+              velox::bits::bitsRequired(static_cast<uint64_t>(avgAbsDelta)));
+
+    const uint64_t deltasSize =
+        FixedBitArray::bufferSize(rowCount, deltaBitWidth);
+    // Assume a single leading restatement (best case; non-monotonic columns
+    // need more, but Statistics<T> doesn't expose monotonicity).
+    const uint64_t restatementsSize = sizeof(physicalType);
+    const uint64_t isRestatementsSize = velox::bits::nbytes(rowCount);
+
+    // Each of the three nested sub-streams has its own ~7-byte header
+    // (prefix(6) + compressionType(1)).
+    constexpr uint64_t kNestedHeaderSize = 7;
+    // Outer prefix(6) + two 4-byte relative offsets.
+    constexpr uint64_t kOuterHeaderSize = EncodingPrefix::kFixedPrefixSize + 8;
+
+    return kOuterHeaderSize + (kNestedHeaderSize + deltasSize) +
+        (kNestedHeaderSize + restatementsSize) +
+        (kNestedHeaderSize + isRestatementsSize);
+  }
+#endif
 
  private:
   // Ensures isRestatementsBitmap_ has capacity for rowCount bits and

--- a/velox/dwio/nimble/encodings/ForEncoding.h
+++ b/velox/dwio/nimble/encodings/ForEncoding.h
@@ -135,8 +135,8 @@ class ForEncoding final
     // (compressionType + frameSize + numFrames + enableBitOffsets = 10),
     // plus each of the four sub-streams' 4-byte size prefix.
     constexpr uint64_t kForSpecificFixedFieldsSize = 10;
-    return EncodingPrefix::kFixedPrefixSize + kForSpecificFixedFieldsSize +
-        4 + bitWidthsSize + 4 + referencesSize + 4 + bitOffsetsSize + 4 +
+    return EncodingPrefix::kFixedPrefixSize + kForSpecificFixedFieldsSize + 4 +
+        bitWidthsSize + 4 + referencesSize + 4 + bitOffsetsSize + 4 +
         packedSize;
   }
 #endif

--- a/velox/dwio/nimble/encodings/ForEncoding.h
+++ b/velox/dwio/nimble/encodings/ForEncoding.h
@@ -34,7 +34,6 @@
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "velox/dwio/nimble/encodings/common/EncodingType.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
-#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 // Frame of Reference encoding. Divides data into fixed-size frames, storing
 // a reference value per frame and bit-packing the exceptions (value - ref).

--- a/velox/dwio/nimble/encodings/ForEncoding.h
+++ b/velox/dwio/nimble/encodings/ForEncoding.h
@@ -92,6 +92,55 @@ class ForEncoding final
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+  /// Statistics-only size estimate for general encoding selection (e.g. as a
+  /// SubIntSplit segment candidate), where only `Statistics<physicalType>` --
+  /// not the raw values -- is available. The local (per-frame) bit width is
+  /// estimated from the average step size scaled to the frame size -- a
+  /// random-walk heuristic where the local range over a frame of
+  /// `kFrameSize` steps grows roughly with avgAbsDelta -- capped by the
+  /// overall range. Per-frame metadata streams are estimated as Trivial,
+  /// matching encode()'s frame size of 128.
+  static uint64_t estimateSize(
+      uint64_t rowCount,
+      const Statistics<physicalType>& statistics) {
+    if (rowCount == 0) {
+      return EncodingPrefix::kFixedPrefixSize;
+    }
+    constexpr uint32_t kFrameSize = 128;
+    const auto numFrames =
+        static_cast<uint32_t>(velox::bits::divRoundUp(rowCount, kFrameSize));
+
+    const auto fullRange =
+        static_cast<uint64_t>(statistics.max() - statistics.min());
+    const double avgAbsDelta = rowCount > 1
+        ? static_cast<double>(fullRange) / static_cast<double>(rowCount - 1)
+        : 0.0;
+    const double localRange = std::min(
+        static_cast<double>(fullRange),
+        avgAbsDelta * static_cast<double>(kFrameSize) / 2.0);
+    const uint8_t localBits = localRange < 1.0
+        ? uint8_t{0}
+        : static_cast<uint8_t>(
+              velox::bits::bitsRequired(static_cast<uint64_t>(localRange)));
+
+    const uint64_t packedSize = FixedBitArray::bufferSize(rowCount, localBits);
+    const uint64_t bitWidthsSize =
+        TrivialEncoding<uint8_t>::estimateSize(numFrames);
+    const uint64_t referencesSize =
+        TrivialEncoding<physicalType>::estimateSize(numFrames);
+    const uint64_t bitOffsetsSize =
+        TrivialEncoding<uint64_t>::estimateSize(numFrames);
+
+    // EncodingPrefix::kFixedPrefixSize(6) + FOR-specific fixed fields
+    // (compressionType + frameSize + numFrames + enableBitOffsets = 10),
+    // plus each of the four sub-streams' 4-byte size prefix.
+    return EncodingPrefix::kFixedPrefixSize +
+        (kPrefixSize - Encoding::kPrefixSize) + 4 + bitWidthsSize + 4 +
+        referencesSize + 4 + bitOffsetsSize + 4 + packedSize;
+  }
+#endif
+
   std::string debugString(int offset) const final;
 
  private:

--- a/velox/dwio/nimble/encodings/ForEncoding.h
+++ b/velox/dwio/nimble/encodings/ForEncoding.h
@@ -135,9 +135,10 @@ class ForEncoding final
     // EncodingPrefix::kFixedPrefixSize(6) + FOR-specific fixed fields
     // (compressionType + frameSize + numFrames + enableBitOffsets = 10),
     // plus each of the four sub-streams' 4-byte size prefix.
-    return EncodingPrefix::kFixedPrefixSize +
-        (kPrefixSize - Encoding::kPrefixSize) + 4 + bitWidthsSize + 4 +
-        referencesSize + 4 + bitOffsetsSize + 4 + packedSize;
+    constexpr uint64_t kForSpecificFixedFieldsSize = 10;
+    return EncodingPrefix::kFixedPrefixSize + kForSpecificFixedFieldsSize +
+        4 + bitWidthsSize + 4 + referencesSize + 4 + bitOffsetsSize + 4 +
+        packedSize;
   }
 #endif
 

--- a/velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h
+++ b/velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h
@@ -122,6 +122,39 @@ class FrequencyPartitionEncoding
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+  // Statistics-only size estimate for encoding selection. Uses
+  // consecutiveRepeatCount as a proxy for top-tier coverage (high repetition
+  // → values concentrate in the 1-bit tier → cheaper FPE). Assumes
+  // PerTierBitmaps index (2 index bits/value) since that is what
+  // SubIntSplitEncoding overrides for segment children.
+  static uint64_t estimateSize(
+      uint64_t rowCount,
+      const Statistics<physicalType>& statistics) {
+    if (rowCount == 0) {
+      return Encoding::kPrefixSize;
+    }
+    const double n = static_cast<double>(rowCount);
+    const double repeatFraction = (rowCount > 1)
+        ? static_cast<double>(statistics.consecutiveRepeatCount()) /
+              static_cast<double>(rowCount - 1)
+        : 0.0;
+    constexpr double kFallbackBitsPerValue =
+        static_cast<double>(sizeof(physicalType) * 8u);
+    const double tier0Frac = repeatFraction;
+    const double fallbackFrac = 1.0 - tier0Frac;
+    // Key cost: top-tier values get 1-bit codes, remainder get full-width.
+    const double keyCostBytes =
+        (tier0Frac * n * 1.0 + fallbackFrac * n * kFallbackBitsPerValue) /
+        8.0;
+    // PerTierBitmaps index: 2 tiers × 1 bit/value/tier.
+    const double indexBytes = 2.0 * n / 8.0;
+    // Tier sub-stream headers + outer encoding prefix.
+    constexpr double kOverheadBytes = 6.0 + 4.0 + 4.0 + 4.0 + 4.0 * 7.0;
+    return static_cast<uint64_t>(kOverheadBytes + keyCostBytes + indexBytes);
+  }
+#endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
   std::string debugString(int offset) const final;
   uint32_t getTierForRow(uint32_t rowIndex) const;
 

--- a/velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h
+++ b/velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h
@@ -139,7 +139,7 @@ class FrequencyPartitionEncoding
     const double n = static_cast<double>(rowCount);
     const double repeatFraction = (rowCount > 1)
         ? static_cast<double>(statistics.consecutiveRepeatCount()) /
-              static_cast<double>(rowCount - 1)
+            static_cast<double>(rowCount - 1)
         : 0.0;
     constexpr double kFallbackBitsPerValue =
         static_cast<double>(sizeof(physicalType) * 8u);
@@ -147,8 +147,7 @@ class FrequencyPartitionEncoding
     const double fallbackFrac = 1.0 - tier0Frac;
     // Key cost: top-tier values get 1-bit codes, remainder get full-width.
     const double keyCostBytes =
-        (tier0Frac * n * 1.0 + fallbackFrac * n * kFallbackBitsPerValue) /
-        8.0;
+        (tier0Frac * n * 1.0 + fallbackFrac * n * kFallbackBitsPerValue) / 8.0;
 
     // Number of tiers encode() would create, mirroring its keyBitOptions loop.
     const uint64_t uniqueCount = statistics.uniqueCounts().has_value()

--- a/velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h
+++ b/velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h
@@ -125,9 +125,11 @@ class FrequencyPartitionEncoding
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
   // Statistics-only size estimate for encoding selection. Uses
   // consecutiveRepeatCount as a proxy for top-tier coverage (high repetition
-  // → values concentrate in the 1-bit tier → cheaper FPE). Assumes
-  // PerTierBitmaps index (2 index bits/value) since that is what
-  // SubIntSplitEncoding overrides for segment children.
+  // → values concentrate in the 1-bit tier → cheaper FPE). Assumes a
+  // PerTierBitmaps index sized for the number of tiers `encode()` would
+  // actually create for the observed unique count (see getCapacity/
+  // keyBitOptions above) -- a fixed 2-tier assumption undercounts the index
+  // whenever uniqueCount exceeds the 2-tier capacity of 6.
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<physicalType>& statistics) {
@@ -147,11 +149,34 @@ class FrequencyPartitionEncoding
     const double keyCostBytes =
         (tier0Frac * n * 1.0 + fallbackFrac * n * kFallbackBitsPerValue) /
         8.0;
-    // PerTierBitmaps index: 2 tiers × 1 bit/value/tier.
-    const double indexBytes = 2.0 * n / 8.0;
-    // Tier sub-stream headers + outer encoding prefix.
-    constexpr double kOverheadBytes = 6.0 + 4.0 + 4.0 + 4.0 + 4.0 * 7.0;
-    return static_cast<uint64_t>(kOverheadBytes + keyCostBytes + indexBytes);
+
+    // Number of tiers encode() would create, mirroring its keyBitOptions loop.
+    const uint64_t uniqueCount = statistics.uniqueCounts().has_value()
+        ? statistics.uniqueCounts().value().size()
+        : uint64_t{1};
+    constexpr uint32_t keyBitOptions[] = {1, 2, 4, 8, 16, 32};
+    constexpr uint32_t maxKeyBits = getMaxKeyBits();
+    uint64_t assigned = 0;
+    uint32_t numTiers = 0;
+    for (uint32_t keyBits : keyBitOptions) {
+      if (keyBits > maxKeyBits || assigned >= uniqueCount) {
+        break;
+      }
+      ++numTiers;
+      assigned += getCapacity(keyBits);
+    }
+    numTiers = std::max(numTiers, 1u);
+
+    // PerTierBitmaps index: one N-bit bitmap per active tier, plus a 4-byte
+    // bitmapByteCount prefix per tier (see the "Index payload layout
+    // (PerTierBitmaps)" comment above).
+    const double bitmapBits = std::ceil(n / 64.0) * 64.0 + 32.0;
+    const double indexBytes = static_cast<double>(numTiers) * bitmapBits / 8.0;
+    // One dictionary + one key stream per active tier, each a nested
+    // sub-encoding with a ~7-byte header, plus the outer encoding prefix.
+    const double overheadBytes =
+        6.0 + 4.0 + 4.0 + static_cast<double>(numTiers) * 2.0 * 7.0;
+    return static_cast<uint64_t>(overheadBytes + keyCostBytes + indexBytes);
   }
 #endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -25,9 +25,12 @@
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
+#include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitMetrics.h"
+#include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/selection/Statistics.h"
 
 // Per-segment cost models for SubIntSplitEncoding's DP selector.
@@ -124,6 +127,11 @@ inline double constantCostBits(
 // MainlyConstant: store one dominant value, a SparseBool mask marking the
 // exception rows, and the exception values as a FixedBitWidth child. Effective
 // when one value dominates the segment (say >=50%).
+// Delegates the otherValues and isCommon sub-costs directly to
+// FixedBitWidthEncoding::estimateSize / SparseBoolEncoding::estimateSize --
+// the same calls MainlyConstantEncoding::estimateSize itself makes (see
+// MainlyConstantEncoding.h) -- instead of a separate hand-rolled formula, so
+// the two estimators cannot drift apart.
 // Required: DominantValue, MinMax
 inline double mainlyConstantCostBits(
     const SegmentMetrics& m,
@@ -139,38 +147,48 @@ inline double mainlyConstantCostBits(
   }
 
   const double storageBits = static_cast<double>(storageWidthBits(bitWidth));
-  const double storageBytes = storageBits / 8.0;
-  const size_t uncommonCount =
-      m.dominantCount >= numValues ? 0 : numValues - m.dominantCount;
+  const auto rowCount = static_cast<uint64_t>(numValues);
+  const uint64_t uncommonCount =
+      m.dominantCount >= numValues ? 0 : rowCount - m.dominantCount;
 
   // Outer: prefix(6) + two child-size fields(4 each) + the common value.
   const double outerBits = (6.0 + 4.0 + 4.0) * 8.0 + storageBits;
 
-  // otherValues: FixedBitWidth over the uncommon values (observed range),
-  // packed bits rounded up to a byte boundary.
-  const uint8_t rangeWidth =
-      m.range == 0 ? uint8_t{0} : static_cast<uint8_t>(std::bit_width(m.range));
-  const uint8_t packedBits = static_cast<uint8_t>(
-      (std::min<uint8_t>(static_cast<uint8_t>(bitWidth), rangeWidth) + 7u) &
-      ~7u);
+  uint64_t otherValuesBytes;
+  switch (storageWidthBits(bitWidth)) {
+    case 8:
+      otherValuesBytes = FixedBitWidthEncoding<uint8_t>::estimateSize(
+          uncommonCount, m.min, m.max, Encoding::Options{});
+      break;
+    case 16:
+      otherValuesBytes = FixedBitWidthEncoding<uint16_t>::estimateSize(
+          uncommonCount, m.min, m.max, Encoding::Options{});
+      break;
+    case 32:
+      otherValuesBytes = FixedBitWidthEncoding<uint32_t>::estimateSize(
+          uncommonCount, m.min, m.max, Encoding::Options{});
+      break;
+    default:
+      otherValuesBytes = FixedBitWidthEncoding<uint64_t>::estimateSize(
+          uncommonCount, m.min, m.max, Encoding::Options{});
+      break;
+  }
 
-  const double otherHeaderBits = (7.0 + storageBytes + 1.0) * 8.0;
-  const double otherValuesBits = otherHeaderBits +
-      static_cast<double>(packedBits) * static_cast<double>(uncommonCount);
+  const uint64_t isCommonBytes =
+      SparseBoolEncoding::estimateSize(rowCount, uncommonCount, Encoding::Options{});
 
-  const uint32_t indexWidth =
-      numValues <= 1 ? 1u : static_cast<uint32_t>(std::bit_width(numValues));
-  const double roundedIndexBits = static_cast<double>((indexWidth + 7u) & ~7u);
-  // SparseBool: prefix(6) + tag(1) + FixedBitWidth header(7 + uint32 baseline +
-  // 1)
-  const double sparseHeaderBits = (6.0 + 1.0 + 7.0 + 4.0 + 1.0) * 8.0;
-  const double isCommonBits = sparseHeaderBits +
-      roundedIndexBits * static_cast<double>(uncommonCount + 1);
-
-  return outerBits + otherValuesBits + isCommonBits;
+  return outerBits + static_cast<double>(otherValuesBytes) * 8.0 +
+      static_cast<double>(isCommonBytes) * 8.0;
 }
 
 // Dictionary: unique value table + bit-packed indices.
+// Delegates both nested streams directly to the same estimators
+// DictionaryEncoding::estimateSize uses (see DictionaryEncoding.h): the
+// indices stream via FixedBitWidthEncoding<uint32_t>::estimateSize(rowCount,
+// 0, uniqueCount-1), and the alphabet via
+// min(TrivialEncoding, FixedBitWidthEncoding)::estimateSize(uniqueCount, min,
+// max). Only the numeric path is modeled; SIS operates on raw uint64_t
+// bit-range slices, never strings.
 // Uses observed uniqueCount directly (no HLL blending). Directionally correct
 // for the DP's purposes.
 // Required: UniqueCount, MinMax
@@ -181,26 +199,45 @@ inline double dictionaryCostBits(
   if (m.uniqueCount == 0 || numValues == 0) {
     return 0.0;
   }
-  const size_t uniques = m.uniqueCount;
-  const uint8_t valueBits = storageWidthBits(bitWidth);
-  const double dictBits =
-      static_cast<double>(uniques) * static_cast<double>(valueBits);
-  // Index width: ceil(log2(uniques)), clamped to 32
-  const uint32_t indexWidth = (uniques <= 1)
-      ? 1u
-      : std::min(32u, static_cast<uint32_t>(std::bit_width(uniques - 1)));
-  // Bit-packed indices rounded up to byte boundary
-  const double roundedIndexBits = static_cast<double>((indexWidth + 7u) & ~7u);
-  const double indexBits = roundedIndexBits * static_cast<double>(numValues);
-  // prefix(6) + alphabetSize(4) + nested header overhead (~15 bytes)
-  const double headerBits = (6.0 + 4.0 + 15.0) * 8.0;
+  const uint64_t uniques = static_cast<uint64_t>(m.uniqueCount);
+  const auto rowCount = static_cast<uint64_t>(numValues);
+  const Encoding::Options options{};
 
-  // Penalise when index width ≥ value width (dictionary doesn't compress).
-  const double penalty = (indexWidth >= valueBits)
-      ? 1.0 + 0.15 * (static_cast<double>(indexWidth) / valueBits - 1.0)
-      : 1.0;
+  const uint64_t indicesBytes = FixedBitWidthEncoding<uint32_t>::estimateSize(
+      rowCount, /*minValue=*/0, uniques - 1, options);
 
-  return headerBits + penalty * (dictBits + indexBits);
+  uint64_t alphabetBytes;
+  switch (storageWidthBits(bitWidth)) {
+    case 8:
+      alphabetBytes = std::min(
+          TrivialEncoding<uint8_t>::estimateSize(uniques),
+          FixedBitWidthEncoding<uint8_t>::estimateSize(
+              uniques, m.min, m.max, options));
+      break;
+    case 16:
+      alphabetBytes = std::min(
+          TrivialEncoding<uint16_t>::estimateSize(uniques),
+          FixedBitWidthEncoding<uint16_t>::estimateSize(
+              uniques, m.min, m.max, options));
+      break;
+    case 32:
+      alphabetBytes = std::min(
+          TrivialEncoding<uint32_t>::estimateSize(uniques),
+          FixedBitWidthEncoding<uint32_t>::estimateSize(
+              uniques, m.min, m.max, options));
+      break;
+    default:
+      alphabetBytes = std::min(
+          TrivialEncoding<uint64_t>::estimateSize(uniques),
+          FixedBitWidthEncoding<uint64_t>::estimateSize(
+              uniques, m.min, m.max, options));
+      break;
+  }
+
+  // Outer: prefix(6) + alphabetSize(4), matching DictionaryEncoding's layout.
+  const double outerBits = (6.0 + 4.0) * 8.0;
+  return outerBits + static_cast<double>(alphabetBytes) * 8.0 +
+      static_cast<double>(indicesBytes) * 8.0;
 }
 
 // RLE: run values + bit-packed run lengths.
@@ -442,12 +479,14 @@ inline double deltaCostBits(
     return std::numeric_limits<double>::infinity();
   }
 
-  const double avgAbsDelta = static_cast<double>(m.sumAbsDelta) /
-      static_cast<double>(numValues - 1);
-  const uint8_t deltaBitWidth = avgAbsDelta < 1.0
+  // Sized to the largest kept (non-decreasing) delta, not the average: a
+  // fixed-width packed array must cover every value it stores, and a
+  // right-skewed delta distribution makes the average a severe
+  // underestimate of the width actually required (see SegmentMetrics::
+  // maxDelta). Matches FixedBitWidthEncoding's own exact-bits sizing.
+  const uint8_t deltaBitWidth = m.maxDelta == 0
       ? uint8_t{0}
-      : static_cast<uint8_t>(
-            std::bit_width(static_cast<uint64_t>(avgAbsDelta)));
+      : static_cast<uint8_t>(std::bit_width(m.maxDelta));
   // Round up to byte boundary, matching nested encodings' FixedBitWidth-style
   // packing.
   const uint8_t roundedDeltaBits = (deltaBitWidth + 7u) & ~7u;
@@ -521,6 +560,29 @@ forCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
       packedBits;
 }
 
+// Number of PerTierBitmaps tiers FrequencyPartitionEncoding::encode would
+// create for `uniqueCount` distinct values, mirroring its tier-capacity table
+// (FrequencyPartitionEncoding.h: keyBitOptions = {1,2,4,8,16,32} bits with
+// capacities 2/4/16/256/65280/~4.29B). Each tier created needs its own N-bit
+// bitmap in the index payload (FrequencyPartitionEncoding.h's "Index payload
+// layout (PerTierBitmaps)"), so this directly drives indexBits below.
+// Assuming a fixed 2 tiers regardless of uniqueCount -- rather than the 3-5
+// tiers typical for a segment near the 1024-unique cap -- was the single
+// largest source of FPE's cost underestimate.
+inline uint32_t frequencyPartitionNumTiers(uint64_t uniqueCount) noexcept {
+  constexpr uint64_t kCapacities[] = {2, 4, 16, 256, 65280, 4294901760ull};
+  uint64_t assigned = 0;
+  uint32_t tiers = 0;
+  for (uint64_t capacity : kCapacities) {
+    if (assigned >= uniqueCount) {
+      break;
+    }
+    ++tiers;
+    assigned += capacity;
+  }
+  return std::max(tiers, 1u);
+}
+
 // FrequencyPartition: tier-based dictionary encoding where the top-K
 // most-frequent values are stored with narrow (1/2-bit) keys. Requires an
 // indexed mode (PerTierBitmaps) that preserves original row order; without an
@@ -551,12 +613,17 @@ inline double frequencyPartitionCostBits(
       tier1Coverage * n * 2.0 +
       fallbackCoverage * n * static_cast<double>(storageWidthBits(bitWidth));
 
-  // PerTierBitmaps index: ~1 bit per value per active tier (2 tiers assumed).
-  const double indexBits = 2.0 * n;
+  // PerTierBitmaps index: one N-bit bitmap per active tier (4-byte
+  // bitmapByteCount prefix + numValues bits rounded to a 64-bit word), not a
+  // fixed 2 tiers -- see frequencyPartitionNumTiers.
+  const uint32_t numTiers = frequencyPartitionNumTiers(m.uniqueCount);
+  const double bitmapBits = std::ceil(n / 64.0) * 64.0 + 32.0;
+  const double indexBits = static_cast<double>(numTiers) * bitmapBits;
 
-  // ~2 tier dictionaries + 2 key streams, each a nested sub-encoding with a
-  // ~7-byte header.
-  constexpr double kTierOverheadBits = 4.0 * 7.0 * 8.0;
+  // One dictionary + one key stream per active tier, each a nested
+  // sub-encoding with a ~7-byte header.
+  const double kTierOverheadBits =
+      static_cast<double>(numTiers) * 2.0 * 7.0 * 8.0;
 
   // Outer prefix + numPartitions + nested partitionOffsets/partitionSizes.
   constexpr double kOuterHeaderBits = (6.0 + 4.0 + 4.0 + 4.0 + 2.0 * 7.0) * 8.0;

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -65,8 +65,8 @@ inline constexpr uint8_t storageWidthBits(int bw) noexcept {
 // Union of MetricFlags needed across all cost models below.
 inline MetricFlags allCostModelRequiredFlags() noexcept {
   return MetricFlag::MinMax | MetricFlag::RunStats | MetricFlag::UniqueCount |
-      MetricFlag::DominantValue | MetricFlag::BitWidthHistogram | MetricFlag::DeltaStats |
-      MetricFlag::FrequencyTiers;
+      MetricFlag::DominantValue | MetricFlag::BitWidthHistogram |
+      MetricFlag::DeltaStats | MetricFlag::FrequencyTiers;
 }
 
 // Trivial: store each value at its native storage width.
@@ -174,8 +174,8 @@ inline double mainlyConstantCostBits(
       break;
   }
 
-  const uint64_t isCommonBytes =
-      SparseBoolEncoding::estimateSize(rowCount, uncommonCount, Encoding::Options{});
+  const uint64_t isCommonBytes = SparseBoolEncoding::estimateSize(
+      rowCount, uncommonCount, Encoding::Options{});
 
   return outerBits + static_cast<double>(otherValuesBytes) * 8.0 +
       static_cast<double>(isCommonBytes) * 8.0;
@@ -313,15 +313,11 @@ inline double simdForBitpackCostBits(
       break;
     case 16:
       bytes = SimdForBitpackEncoding<uint16_t>::estimateSize(
-          rowCount,
-          static_cast<uint16_t>(m.min),
-          static_cast<uint16_t>(m.max));
+          rowCount, static_cast<uint16_t>(m.min), static_cast<uint16_t>(m.max));
       break;
     case 32:
       bytes = SimdForBitpackEncoding<uint32_t>::estimateSize(
-          rowCount,
-          static_cast<uint32_t>(m.min),
-          static_cast<uint32_t>(m.max));
+          rowCount, static_cast<uint32_t>(m.min), static_cast<uint32_t>(m.max));
       break;
     default:
       bytes = SimdForBitpackEncoding<uint64_t>::estimateSize(
@@ -381,9 +377,8 @@ pforCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
   const double positionsBits = numExceptions == 0
       ? 0.0
       : kNestedHeaderBits + static_cast<double>(numExceptions) * 32.0;
-  const double valuesBits = numExceptions == 0
-      ? 0.0
-      : kNestedHeaderBits +
+  const double valuesBits = numExceptions == 0 ? 0.0
+                                               : kNestedHeaderBits +
           static_cast<double>(numExceptions) *
               static_cast<double>(storageWidthBits(bitWidth));
 
@@ -452,8 +447,8 @@ inline double deltaBlockCostBits(
     return 0.0;
   }
   const std::span<const uint64_t> values(segValues.data(), numValues);
-  const auto bytes = DeltaBlockEncoding<uint64_t>::estimateSize(
-      values, options);
+  const auto bytes =
+      DeltaBlockEncoding<uint64_t>::estimateSize(values, options);
   if (!bytes.has_value()) {
     return std::numeric_limits<double>::infinity();
   }
@@ -515,8 +510,7 @@ inline double deltaCostBits(
           Encoding::Options{})) *
       8.0;
 
-  return kOuterHeaderBits + deltasBits + restatementsBits +
-      isRestatementsBits;
+  return kOuterHeaderBits + deltasBits + restatementsBits + isRestatementsBits;
 }
 
 // FOR (Frame of Reference): fixed-size frames, each bit-packed against a
@@ -535,16 +529,14 @@ forCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
       static_cast<uint32_t>((numValues + kForFrameSize - 1) / kForFrameSize);
 
   const double avgAbsDelta = numValues > 1
-      ? static_cast<double>(m.sumAbsDelta) /
-          static_cast<double>(numValues - 1)
+      ? static_cast<double>(m.sumAbsDelta) / static_cast<double>(numValues - 1)
       : 0.0;
   const double localRange = std::min(
       static_cast<double>(m.range),
       avgAbsDelta * static_cast<double>(kForFrameSize) / 2.0);
   const uint8_t localBits = localRange < 1.0
       ? uint8_t{0}
-      : static_cast<uint8_t>(
-            std::bit_width(static_cast<uint64_t>(localRange)));
+      : static_cast<uint8_t>(std::bit_width(static_cast<uint64_t>(localRange)));
 
   // prefix(6) + compressionType(1) + frameSize(4) + numFrames(4) +
   // enableBitOffsets(1)
@@ -614,8 +606,7 @@ inline double frequencyPartitionCostBits(
       std::max(0.0, m.topKCoverage[3] - m.topKCoverage[1]); // next → 2-bit
   const double fallbackCoverage = std::max(0.0, 1.0 - m.topKCoverage[3]);
 
-  const double keyCostBits = tier0Coverage * n * 1.0 +
-      tier1Coverage * n * 2.0 +
+  const double keyCostBits = tier0Coverage * n * 1.0 + tier1Coverage * n * 2.0 +
       fallbackCoverage * n * static_cast<double>(storageWidthBits(bitWidth));
 
   // PerTierBitmaps index: one N-bit bitmap per active tier (4-byte
@@ -689,8 +680,7 @@ inline double bestCostBits(
       m.uniqueCount <= HuffmanEncoding<uint64_t>::kMaxSymbols) {
     consider(huffmanCostBits(segValues, numValues), EncodingType::Huffman);
   }
-  consider(
-      deltaBlockCostBits(segValues, numValues), EncodingType::DeltaBlock);
+  consider(deltaBlockCostBits(segValues, numValues), EncodingType::DeltaBlock);
   return best;
 }
 

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -487,9 +487,6 @@ inline double deltaCostBits(
   const uint8_t deltaBitWidth = m.maxDelta == 0
       ? uint8_t{0}
       : static_cast<uint8_t>(std::bit_width(m.maxDelta));
-  // Round up to byte boundary, matching nested encodings' FixedBitWidth-style
-  // packing.
-  const uint8_t roundedDeltaBits = (deltaBitWidth + 7u) & ~7u;
 
   const double restatementFraction = 1.0 - monotonicFraction;
   // At least one restatement (the leading value) is always present.
@@ -503,12 +500,20 @@ inline double deltaCostBits(
   constexpr double kOuterHeaderBits = (6.0 + 4.0 + 4.0) * 8.0;
 
   const double deltasBits = kNestedHeaderBits +
-      static_cast<double>(numValues) * static_cast<double>(roundedDeltaBits);
+      static_cast<double>(numValues) * static_cast<double>(deltaBitWidth);
   const double restatementsBits = kNestedHeaderBits +
       numRestatements * static_cast<double>(storageWidthBits(bitWidth));
-  // isRestatements is a bool stream, bit-packed to ~1 bit/value.
+  // isRestatements is a bool stream that is true only at restatement
+  // positions -- nested-encoded, so delegate to SparseBoolEncoding's own
+  // estimator (as the MainlyConstant/Dictionary fixes above do) instead of
+  // charging a flat 1 bit/value, which drastically overestimates when
+  // restatements are rare (the common case for mostly-monotonic data).
   const double isRestatementsBits =
-      kNestedHeaderBits + static_cast<double>(numValues);
+      static_cast<double>(SparseBoolEncoding::estimateSize(
+          static_cast<uint64_t>(numValues),
+          static_cast<uint64_t>(numRestatements),
+          Encoding::Options{})) *
+      8.0;
 
   return kOuterHeaderBits + deltasBits + restatementsBits +
       isRestatementsBits;

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -363,9 +363,12 @@ inline double blockBitPackingCostBits(
   if (numValues == 0) {
     return 0.0;
   }
-  const uint64_t bytes =
+  const auto bytes =
       BlockBitPackingEncoding<uint64_t>::estimateSize(segValues, blockSize);
-  return static_cast<double>(bytes) * 8.0;
+  if (!bytes.has_value()) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return static_cast<double>(bytes.value()) * 8.0;
 }
 
 // Delta: positive-delta encoding with restatements for non-monotonic steps.

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -59,7 +59,8 @@ inline constexpr uint8_t storageWidthBits(int bw) noexcept {
 // Union of MetricFlags needed across all cost models below.
 inline MetricFlags allCostModelRequiredFlags() noexcept {
   return MetricFlag::MinMax | MetricFlag::RunStats | MetricFlag::UniqueCount |
-      MetricFlag::DominantValue | MetricFlag::BitWidthHistogram | MetricFlag::DeltaStats;
+      MetricFlag::DominantValue | MetricFlag::BitWidthHistogram | MetricFlag::DeltaStats |
+      MetricFlag::FrequencyTiers;
 }
 
 // Trivial: store each value at its native storage width.
@@ -465,6 +466,49 @@ forCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
       packedBits;
 }
 
+// FrequencyPartition: tier-based dictionary encoding where the top-K
+// most-frequent values are stored with narrow (1/2-bit) keys. Requires an
+// indexed mode (PerTierBitmaps) that preserves original row order; without an
+// index, materialize() would desync sibling SubIntSplit segments.
+// Returns infinity when the unique count is unknown, capped, or > 1024
+// (FPE's overhead dominates for high-cardinality segments).
+// Required: UniqueCount, FrequencyTiers (topKCoverage populated)
+inline double frequencyPartitionCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (numValues == 0 || m.uniqueCount == 0 || m.uniqueCountCapped ||
+      m.uniqueCount > 1024) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  const double n = static_cast<double>(numValues);
+
+  // Tier 0 (1-bit keys, capacity 2): top-2 most frequent values.
+  // Tier 1 (2-bit keys, capacity 4): next tier up to top-8 (proxy).
+  // Remainder: fallback at full storage width.
+  const double tier0Coverage = m.topKCoverage[1]; // top-2 values → 1-bit keys
+  const double tier1Coverage =
+      std::max(0.0, m.topKCoverage[3] - m.topKCoverage[1]); // next → 2-bit
+  const double fallbackCoverage = std::max(0.0, 1.0 - m.topKCoverage[3]);
+
+  const double keyCostBits = tier0Coverage * n * 1.0 +
+      tier1Coverage * n * 2.0 +
+      fallbackCoverage * n * static_cast<double>(storageWidthBits(bitWidth));
+
+  // PerTierBitmaps index: ~1 bit per value per active tier (2 tiers assumed).
+  const double indexBits = 2.0 * n;
+
+  // ~2 tier dictionaries + 2 key streams, each a nested sub-encoding with a
+  // ~7-byte header.
+  constexpr double kTierOverheadBits = 4.0 * 7.0 * 8.0;
+
+  // Outer prefix + numPartitions + nested partitionOffsets/partitionSizes.
+  constexpr double kOuterHeaderBits = (6.0 + 4.0 + 4.0 + 4.0 + 2.0 * 7.0) * 8.0;
+
+  return kOuterHeaderBits + keyCostBits + indexBits + kTierOverheadBits;
+}
+
 // Evaluate all cost models and return the minimum cost in bits.
 // Also sets `bestEncoding` to the winning EncodingType.
 inline double bestCostBits(
@@ -506,6 +550,12 @@ inline double bestCostBits(
       EncodingType::BlockBitPacking);
   consider(deltaCostBits(m, numValues, bitWidth), EncodingType::Delta);
   consider(forCostBits(m, numValues, bitWidth), EncodingType::FOR);
+  // FrequencyPartition is only viable for low-cardinality segments.
+  if (m.uniqueCount > 0 && !m.uniqueCountCapped && m.uniqueCount <= 1024) {
+    consider(
+        frequencyPartitionCostBits(m, numValues, bitWidth),
+        EncodingType::FrequencyPartition);
+  }
   return best;
 }
 

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -20,8 +20,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <vector>
 
 #include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitMetrics.h"
 
 // Per-segment cost models for SubIntSplitEncoding's DP selector.
@@ -56,7 +59,7 @@ inline constexpr uint8_t storageWidthBits(int bw) noexcept {
 // Union of MetricFlags needed across all cost models below.
 inline MetricFlags allCostModelRequiredFlags() noexcept {
   return MetricFlag::MinMax | MetricFlag::RunStats | MetricFlag::UniqueCount |
-      MetricFlag::DominantValue;
+      MetricFlag::DominantValue | MetricFlag::BitWidthHistogram;
 }
 
 // Trivial: store each value at its native storage width.
@@ -251,12 +254,126 @@ inline double varintCostBits(
       static_cast<double>(varintBytes) * 8.0 * static_cast<double>(numValues);
 }
 
+// SimdForBitpack: SIMD-friendly bit-packing of the observed [min, max] range.
+// Required: MinMax
+inline double simdForBitpackCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  const auto rowCount = static_cast<uint64_t>(numValues);
+  uint64_t bytes;
+  switch (storageWidthBits(bitWidth)) {
+    case 8:
+      bytes = SimdForBitpackEncoding<uint8_t>::estimateSize(
+          rowCount, static_cast<uint8_t>(m.min), static_cast<uint8_t>(m.max));
+      break;
+    case 16:
+      bytes = SimdForBitpackEncoding<uint16_t>::estimateSize(
+          rowCount,
+          static_cast<uint16_t>(m.min),
+          static_cast<uint16_t>(m.max));
+      break;
+    case 32:
+      bytes = SimdForBitpackEncoding<uint32_t>::estimateSize(
+          rowCount,
+          static_cast<uint32_t>(m.min),
+          static_cast<uint32_t>(m.max));
+      break;
+    default:
+      bytes = SimdForBitpackEncoding<uint64_t>::estimateSize(
+          rowCount, m.min, m.max);
+      break;
+  }
+  return static_cast<double>(bytes) * 8.0;
+}
+
+// PFOR: bit-packed "base" region sized to cover ~90% of values (by observed
+// bit width), plus exception side-channels (positions + residual values) for
+// the remainder. Mirrors PFOREncoding<T>::selectBaseBitWidth /
+// PFOREncoding<T>::estimateSize, but operates on `m.bitWidthBuckets` directly
+// instead of constructing a real Statistics<T>.
+// Required: BitWidthHistogram
+inline double
+pforCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  if (bitWidth < 4) {
+    // PFOR's fixed per-segment header (baseline + baseBitWidth +
+    // numExceptions) dominates for very narrow segments.
+    return std::numeric_limits<double>::infinity();
+  }
+
+  constexpr double kCoverageThreshold = 0.9;
+  const uint64_t threshold = static_cast<uint64_t>(
+      static_cast<double>(numValues) * kCoverageThreshold);
+
+  uint8_t baseBitWidth = static_cast<uint8_t>(bitWidth);
+  uint64_t numExceptions = 0;
+  uint64_t cumulative = 0;
+  for (size_t k = 0; k < m.bitWidthBuckets.size(); ++k) {
+    cumulative += m.bitWidthBuckets[k];
+    if (cumulative >= threshold) {
+      const uint8_t bucketEndBitWidth =
+          static_cast<uint8_t>(std::min<size_t>((k + 1) * 7, 64));
+      baseBitWidth =
+          std::min<uint8_t>(bucketEndBitWidth, static_cast<uint8_t>(bitWidth));
+      numExceptions = static_cast<uint64_t>(numValues) - cumulative;
+      break;
+    }
+  }
+
+  const double storageBytes =
+      static_cast<double>(storageWidthBits(bitWidth)) / 8.0;
+  // prefix(6) + baseline(storageBytes) + baseBitWidth(1) + numExceptions(4)
+  const double headerBits = (6.0 + storageBytes + 1.0 + 4.0) * 8.0;
+  const double baseValuesBits =
+      static_cast<double>(baseBitWidth) * static_cast<double>(numValues);
+
+  // Exception side-channels are nested encodings; approximate as Trivial
+  // sub-encodings (prefix(6) + 1 + raw values), as PFOREncoding::estimateSize
+  // does.
+  constexpr double kNestedHeaderBits = 7.0 * 8.0;
+  const double positionsBits = numExceptions == 0
+      ? 0.0
+      : kNestedHeaderBits + static_cast<double>(numExceptions) * 32.0;
+  const double valuesBits = numExceptions == 0
+      ? 0.0
+      : kNestedHeaderBits +
+          static_cast<double>(numExceptions) *
+              static_cast<double>(storageWidthBits(bitWidth));
+
+  return headerBits + baseValuesBits + positionsBits + valuesBits;
+}
+
+// BlockBitPacking: per-block bit-packing with local baselines/widths.
+// Calls the encoding's own estimateSize directly on the raw sample (always
+// instantiated at uint64_t, regardless of `bitWidth` -- this overestimates
+// per-block metadata for narrower sections, but keeps the DP directionally
+// correct without per-width sample copies).
+// Required: none beyond `segValues` itself.
+inline double blockBitPackingCostBits(
+    const std::vector<uint64_t>& segValues,
+    size_t numValues,
+    uint16_t blockSize = kBlockBitPackingBlockSize) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  const uint64_t bytes =
+      BlockBitPackingEncoding<uint64_t>::estimateSize(segValues, blockSize);
+  return static_cast<double>(bytes) * 8.0;
+}
+
 // Evaluate all cost models and return the minimum cost in bits.
 // Also sets `bestEncoding` to the winning EncodingType.
 inline double bestCostBits(
     const SegmentMetrics& m,
     size_t numValues,
     int bitWidth,
+    const std::vector<uint64_t>& segValues,
     EncodingType& bestEncoding) noexcept {
   double best = std::numeric_limits<double>::infinity();
   auto consider = [&](double cost, EncodingType type) noexcept {
@@ -282,6 +399,13 @@ inline double bestCostBits(
     consider(
         dictionaryCostBits(m, numValues, bitWidth), EncodingType::Dictionary);
   }
+  consider(
+      simdForBitpackCostBits(m, numValues, bitWidth),
+      EncodingType::SimdForBitpack);
+  consider(pforCostBits(m, numValues, bitWidth), EncodingType::PFOR);
+  consider(
+      blockBitPackingCostBits(segValues, numValues),
+      EncodingType::BlockBitPacking);
   return best;
 }
 

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -24,8 +24,11 @@
 
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitMetrics.h"
+#include "velox/dwio/nimble/encodings/selection/Statistics.h"
 
 // Per-segment cost models for SubIntSplitEncoding's DP selector.
 //
@@ -371,6 +374,55 @@ inline double blockBitPackingCostBits(
   return static_cast<double>(bytes.value()) * 8.0;
 }
 
+// Huffman: canonical Huffman coding over the observed value alphabet.
+// Delegates to HuffmanEncoding<uint64_t>::estimateSize directly (rather than
+// approximating from SegmentMetrics) since the exact per-symbol code length
+// depends on the full frequency distribution, which SegmentMetrics does not
+// retain. Only evaluated when the segment's cardinality is low enough for
+// Huffman to apply (see the `bestCostBits` guard below), keeping the
+// Statistics<uint64_t>::create() cost bounded.
+// Required: none beyond `segValues` itself.
+inline double huffmanCostBits(
+    const std::vector<uint64_t>& segValues,
+    size_t numValues) noexcept {
+  if (numValues < 2) {
+    return std::numeric_limits<double>::infinity();
+  }
+  const std::span<const uint64_t> values(segValues.data(), numValues);
+  const auto statistics = Statistics<uint64_t>::create(values);
+  const auto bytes = HuffmanEncoding<uint64_t>::estimateSize(
+      values, statistics, Encoding::Options{});
+  if (!bytes.has_value()) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return static_cast<double>(bytes.value()) * 8.0;
+}
+
+// DeltaBlock: fixed-size blocks, each storing a base value plus bit-packed
+// non-decreasing deltas from that base. Delegates directly to
+// DeltaBlockEncoding<uint64_t>::estimateSize on the raw sample, mirroring
+// blockBitPackingCostBits -- DeltaBlockEncoding's own estimator is already
+// exact (it walks real block boundaries), so approximating from
+// SegmentMetrics would only lose precision. Returns infinity for any block
+// containing a decrease, matching DeltaBlockEncoding's non-decreasing-only
+// design.
+// Required: none beyond `segValues` itself.
+inline double deltaBlockCostBits(
+    const std::vector<uint64_t>& segValues,
+    size_t numValues,
+    const Encoding::Options& options = {}) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  const std::span<const uint64_t> values(segValues.data(), numValues);
+  const auto bytes = DeltaBlockEncoding<uint64_t>::estimateSize(
+      values, options);
+  if (!bytes.has_value()) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return static_cast<double>(bytes.value()) * 8.0;
+}
+
 // Delta: positive-delta encoding with restatements for non-monotonic steps.
 // Infinity unless at least 90% of consecutive steps are non-decreasing
 // (matches DeltaEncoding's positive-delta-only design — frequent decreases
@@ -559,6 +611,14 @@ inline double bestCostBits(
         frequencyPartitionCostBits(m, numValues, bitWidth),
         EncodingType::FrequencyPartition);
   }
+  // Huffman is only viable within its supported alphabet size; skip the
+  // Statistics<uint64_t>::create() call entirely otherwise.
+  if (m.uniqueCount > 0 && !m.uniqueCountCapped &&
+      m.uniqueCount <= HuffmanEncoding<uint64_t>::kMaxSymbols) {
+    consider(huffmanCostBits(segValues, numValues), EncodingType::Huffman);
+  }
+  consider(
+      deltaBlockCostBits(segValues, numValues), EncodingType::DeltaBlock);
   return best;
 }
 

--- a/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -59,7 +59,7 @@ inline constexpr uint8_t storageWidthBits(int bw) noexcept {
 // Union of MetricFlags needed across all cost models below.
 inline MetricFlags allCostModelRequiredFlags() noexcept {
   return MetricFlag::MinMax | MetricFlag::RunStats | MetricFlag::UniqueCount |
-      MetricFlag::DominantValue | MetricFlag::BitWidthHistogram;
+      MetricFlag::DominantValue | MetricFlag::BitWidthHistogram | MetricFlag::DeltaStats;
 }
 
 // Trivial: store each value at its native storage width.
@@ -367,6 +367,104 @@ inline double blockBitPackingCostBits(
   return static_cast<double>(bytes) * 8.0;
 }
 
+// Delta: positive-delta encoding with restatements for non-monotonic steps.
+// Infinity unless at least 90% of consecutive steps are non-decreasing
+// (matches DeltaEncoding's positive-delta-only design — frequent decreases
+// force expensive restatements).
+// Required: DeltaStats
+inline double deltaCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (numValues < 2) {
+    return std::numeric_limits<double>::infinity();
+  }
+  const double monotonicFraction = static_cast<double>(m.monotonicCount) /
+      static_cast<double>(numValues - 1);
+  constexpr double kMonotonicThreshold = 0.9;
+  if (monotonicFraction < kMonotonicThreshold) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  const double avgAbsDelta = static_cast<double>(m.sumAbsDelta) /
+      static_cast<double>(numValues - 1);
+  const uint8_t deltaBitWidth = avgAbsDelta < 1.0
+      ? uint8_t{0}
+      : static_cast<uint8_t>(
+            std::bit_width(static_cast<uint64_t>(avgAbsDelta)));
+  // Round up to byte boundary, matching nested encodings' FixedBitWidth-style
+  // packing.
+  const uint8_t roundedDeltaBits = (deltaBitWidth + 7u) & ~7u;
+
+  const double restatementFraction = 1.0 - monotonicFraction;
+  // At least one restatement (the leading value) is always present.
+  const double numRestatements =
+      std::max(1.0, restatementFraction * static_cast<double>(numValues));
+
+  // Three nested sub-encodings (deltas, restatements, isRestatements), each
+  // with its own ~7-byte header, plus the outer prefix(6) + two 4-byte
+  // relative offsets.
+  constexpr double kNestedHeaderBits = 7.0 * 8.0;
+  constexpr double kOuterHeaderBits = (6.0 + 4.0 + 4.0) * 8.0;
+
+  const double deltasBits = kNestedHeaderBits +
+      static_cast<double>(numValues) * static_cast<double>(roundedDeltaBits);
+  const double restatementsBits = kNestedHeaderBits +
+      numRestatements * static_cast<double>(storageWidthBits(bitWidth));
+  // isRestatements is a bool stream, bit-packed to ~1 bit/value.
+  const double isRestatementsBits =
+      kNestedHeaderBits + static_cast<double>(numValues);
+
+  return kOuterHeaderBits + deltasBits + restatementsBits +
+      isRestatementsBits;
+}
+
+// FOR (Frame of Reference): fixed-size frames, each bit-packed against a
+// local minimum (reference). The local bit width is estimated from the
+// average step size scaled to the frame size -- a random-walk heuristic
+// where the local range over a frame of `kForFrameSize` steps grows roughly
+// with avgAbsDelta -- capped by the segment's overall range.
+// Required: MinMax, DeltaStats
+inline double
+forCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  constexpr uint32_t kForFrameSize = 128;
+  const uint32_t numFrames =
+      static_cast<uint32_t>((numValues + kForFrameSize - 1) / kForFrameSize);
+
+  const double avgAbsDelta = numValues > 1
+      ? static_cast<double>(m.sumAbsDelta) /
+          static_cast<double>(numValues - 1)
+      : 0.0;
+  const double localRange = std::min(
+      static_cast<double>(m.range),
+      avgAbsDelta * static_cast<double>(kForFrameSize) / 2.0);
+  const uint8_t localBits = localRange < 1.0
+      ? uint8_t{0}
+      : static_cast<uint8_t>(
+            std::bit_width(static_cast<uint64_t>(localRange)));
+
+  // prefix(6) + compressionType(1) + frameSize(4) + numFrames(4) +
+  // enableBitOffsets(1)
+  constexpr double kOuterHeaderBits = (6.0 + 1.0 + 4.0 + 4.0 + 1.0) * 8.0;
+  // Per-frame metadata streams (bitWidths, references, bitOffsets), each a
+  // nested encoding with its own ~7-byte header.
+  constexpr double kNestedHeaderBits = 7.0 * 8.0;
+  const double bitWidthsBits =
+      kNestedHeaderBits + static_cast<double>(numFrames) * 8.0;
+  const double referencesBits = kNestedHeaderBits +
+      static_cast<double>(numFrames) *
+          static_cast<double>(storageWidthBits(bitWidth));
+  const double bitOffsetsBits =
+      kNestedHeaderBits + static_cast<double>(numFrames) * 64.0;
+  const double packedBits = static_cast<double>(numValues) * localBits;
+
+  return kOuterHeaderBits + bitWidthsBits + referencesBits + bitOffsetsBits +
+      packedBits;
+}
+
 // Evaluate all cost models and return the minimum cost in bits.
 // Also sets `bestEncoding` to the winning EncodingType.
 inline double bestCostBits(
@@ -406,6 +504,8 @@ inline double bestCostBits(
   consider(
       blockBitPackingCostBits(segValues, numValues),
       EncodingType::BlockBitPacking);
+  consider(deltaCostBits(m, numValues, bitWidth), EncodingType::Delta);
+  consider(forCostBits(m, numValues, bitWidth), EncodingType::FOR);
   return best;
 }
 

--- a/velox/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -779,6 +779,12 @@ std::string_view SubIntSplitEncoding<T>::encode(
   // width, so the decode path is unaffected.
   Encoding::Options sectionOptions = options;
   sectionOptions.fixedBitWidthUseExactBits = true;
+  // FrequencyPartitionEncoding with NoIndex (options.frequencyPartitionIndex
+  // == 0) outputs values in tier-reordered order, which would desync this
+  // segment from sibling segments at decode time. Override to PerTierBitmaps
+  // (1) so materialize() preserves original row order for all sub-encodings
+  // that read this field.
+  sectionOptions.frequencyPartitionIndex = 1u; // FreqPartIndexType::PerTierBitmaps
 
   for (uint8_t s = 0; s < splitCount; ++s) {
     const auto& seg = segments[s];

--- a/velox/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -133,8 +133,9 @@ class SubIntSplitEncoding
     if (rangeBits > (kTypeWidthBits * 3) / 4) {
       return std::nullopt;
     }
-    const uint64_t fbwEstimate = FixedBitWidthEncoding<physicalType>::
-        estimateSize(rowCount, statistics, options);
+    const uint64_t fbwEstimate =
+        FixedBitWidthEncoding<physicalType>::estimateSize(
+            rowCount, statistics, options);
     // Outer prefix(6) + compressionType(2) + up to 4 sections' worth of
     // per-section prefix(6) + relative offset(8) overhead.
     constexpr uint64_t kOverheadBytes = 6u + 2u + 4u * 6u + 4u * 8u;
@@ -816,7 +817,8 @@ std::string_view SubIntSplitEncoding<T>::encode(
   // segment from sibling segments at decode time. Override to PerTierBitmaps
   // (1) so materialize() preserves original row order for all sub-encodings
   // that read this field.
-  sectionOptions.frequencyPartitionIndex = 1u; // FreqPartIndexType::PerTierBitmaps
+  sectionOptions.frequencyPartitionIndex =
+      1u; // FreqPartIndexType::PerTierBitmaps
 
   for (uint8_t s = 0; s < splitCount; ++s) {
     const auto& seg = segments[s];

--- a/velox/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -23,12 +23,14 @@
 #include <string_view>
 #include <vector>
 
+#include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/DecoderUtil.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitConfig.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitSampler.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitSelector.h"
@@ -110,6 +112,36 @@ class SubIntSplitEncoding
       std::span<const physicalType> values,
       Buffer& buffer,
       const Encoding::Options& options = {});
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+  /// Statistics-only size estimate for general encoding selection, where
+  /// only `Statistics<physicalType>` -- not the raw values -- is available.
+  /// Approximates the split-section layout as a single FixedBitWidth-packed
+  /// stream over the full value range, discounted by 10% for the bit
+  /// savings sectioning typically achieves, plus a fixed per-section header
+  /// overhead (assumes the default 4-section split). Returns nullopt when
+  /// the value range is too wide for sectioning to be worthwhile, so
+  /// encoding selection skips it instead of picking a poor split.
+  static std::optional<uint64_t> estimateSize(
+      uint64_t rowCount,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    constexpr uint64_t kTypeWidthBits =
+        static_cast<uint64_t>(sizeof(physicalType)) * 8u;
+    const uint64_t rangeBits =
+        velox::bits::bitsRequired(statistics.max() - statistics.min());
+    if (rangeBits > (kTypeWidthBits * 3) / 4) {
+      return std::nullopt;
+    }
+    const uint64_t fbwEstimate = FixedBitWidthEncoding<physicalType>::
+        estimateSize(rowCount, statistics, options);
+    // Outer prefix(6) + compressionType(2) + up to 4 sections' worth of
+    // per-section prefix(6) + relative offset(8) overhead.
+    constexpr uint64_t kOverheadBytes = 6u + 2u + 4u * 6u + 4u * 8u;
+    return static_cast<uint64_t>(static_cast<double>(fbwEstimate) * 0.90) +
+        kOverheadBytes;
+  }
+#endif
 
   std::string debugString(int offset) const final;
 

--- a/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -41,7 +41,7 @@ enum class MetricFlag : uint32_t {
   UniqueCount = 1u << 2, // uniqueCount (raw, capped)
   DominantValue = 1u << 3, // dominantCount (most-frequent value's frequency)
   BitWidthHistogram = 1u << 4, // bitWidthBuckets
-  DeltaStats = 1u << 5, // sumAbsDelta, monotonicCount
+  DeltaStats = 1u << 5, // sumAbsDelta, monotonicCount, maxDelta
   FrequencyTiers = 1u << 6, // topKCoverage (requires UniqueCount)
   All = (1u << 7) - 1,
 };
@@ -86,6 +86,13 @@ struct SegmentMetrics {
   // average step size and the monotonic-non-decreasing fraction.
   uint64_t sumAbsDelta{0};
   size_t monotonicCount{0};
+
+  // Max of (v[i] - v[i-1]) over non-decreasing pairs only -- i.e. the largest
+  // delta DeltaEncoding would actually have to bit-pack (decreasing pairs are
+  // restated, not delta-encoded). A fixed-width packed array must be sized to
+  // this max, not the average; using the average alone underestimates the
+  // required bit width whenever the delta distribution is right-skewed.
+  uint64_t maxDelta{0};
 
   // Cumulative fraction of values covered by the top-1/2/4/8 most-frequent
   // distinct values. Only valid when FrequencyTiers was requested AND
@@ -187,6 +194,7 @@ class MetricCollector {
         out.sumAbsDelta += (v >= prev) ? (v - prev) : (prev - v);
         if (v >= prev) {
           ++out.monotonicCount;
+          out.maxDelta = std::max(out.maxDelta, v - prev);
         }
       }
       prev = v;

--- a/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <array>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -37,7 +39,8 @@ enum class MetricFlag : uint32_t {
   RunStats = 1u << 1, // runCount, avgRunLength
   UniqueCount = 1u << 2, // uniqueCount (raw, capped)
   DominantValue = 1u << 3, // dominantCount (most-frequent value's frequency)
-  All = (1u << 4) - 1,
+  BitWidthHistogram = 1u << 4, // bitWidthBuckets
+  All = (1u << 5) - 1,
 };
 using MetricFlags = uint32_t;
 
@@ -66,6 +69,13 @@ struct SegmentMetrics {
 
   size_t runCount{0};
   double avgRunLength{0.0};
+
+  // bitWidthBuckets[i] counts values v with bit_width(v) in [7*i, 7*i+6],
+  // for i in [0, 8]; bucket 9 catches bit_width(v) >= 63. Approximates
+  // PFOREncoding<T>::selectBaseBitWidth's bit_width(v - min) histogram using
+  // bit_width(v) directly (segment values are already small bit-slices, so
+  // `min` is usually close to 0). See PFOREncoding.h's selectBaseBitWidth.
+  std::array<uint32_t, 10> bitWidthBuckets{};
 };
 
 // Single-pass metric collector for extracted bit-range values.
@@ -81,6 +91,11 @@ class MetricCollector {
   static constexpr size_t kUniqueCountCap = 1
       << 14; // 16K cap (lighter than full HLL)
 
+  // Maps bit_width(v) to a bucket index in [0, 9], grouping every 7 bits.
+  static constexpr size_t bitWidthBucket(uint64_t v) noexcept {
+    return std::min<size_t>(static_cast<size_t>(std::bit_width(v)) / 7, 9);
+  }
+
   SegmentMetrics compute(
       const std::vector<uint64_t>& values,
       MetricFlags flags = static_cast<MetricFlags>(MetricFlag::All)) {
@@ -90,6 +105,7 @@ class MetricCollector {
     const bool doDominant = hasFlag(flags, MetricFlag::DominantValue);
     // Unique count and dominant value share a single frequency map pass.
     const bool doFreq = doUniq || doDominant;
+    const bool doHist = hasFlag(flags, MetricFlag::BitWidthHistogram);
 
     SegmentMetrics out;
     const size_t n = values.size();
@@ -104,6 +120,9 @@ class MetricCollector {
     }
     if (doRun) {
       out.runCount = 1;
+    }
+    if (doHist) {
+      ++out.bitWidthBuckets[bitWidthBucket(v0)];
     }
 
     bool capped = false;
@@ -138,6 +157,9 @@ class MetricCollector {
         if (inserted && freqMap_.size() > kUniqueCountCap) {
           capped = true;
         }
+      }
+      if (doHist) {
+        ++out.bitWidthBuckets[bitWidthBucket(v)];
       }
       prev = v;
     }

--- a/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -129,8 +129,7 @@ class MetricCollector {
     const bool doDominant = hasFlag(flags, MetricFlag::DominantValue);
     const bool doFreqTiers = hasFlag(flags, MetricFlag::FrequencyTiers);
     // FrequencyTiers requires frequency counts, which subsumes UniqueCount.
-    const bool doUniq =
-        hasFlag(flags, MetricFlag::UniqueCount) || doFreqTiers;
+    const bool doUniq = hasFlag(flags, MetricFlag::UniqueCount) || doFreqTiers;
     // Unique count and dominant value share a single frequency map pass.
     const bool doFreq = doUniq || doDominant;
     const bool doHist = hasFlag(flags, MetricFlag::BitWidthHistogram);

--- a/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <cstddef>
@@ -41,7 +42,8 @@ enum class MetricFlag : uint32_t {
   DominantValue = 1u << 3, // dominantCount (most-frequent value's frequency)
   BitWidthHistogram = 1u << 4, // bitWidthBuckets
   DeltaStats = 1u << 5, // sumAbsDelta, monotonicCount
-  All = (1u << 6) - 1,
+  FrequencyTiers = 1u << 6, // topKCoverage (requires UniqueCount)
+  All = (1u << 7) - 1,
 };
 using MetricFlags = uint32_t;
 
@@ -84,6 +86,14 @@ struct SegmentMetrics {
   // average step size and the monotonic-non-decreasing fraction.
   uint64_t sumAbsDelta{0};
   size_t monotonicCount{0};
+
+  // Cumulative fraction of values covered by the top-1/2/4/8 most-frequent
+  // distinct values. Only valid when FrequencyTiers was requested AND
+  // uniqueCountCapped == false (i.e. uniqueCount <= kUniqueCountCap).
+  // topKCoverage[0] = fraction for top-1, [1] = top-2, [2] = top-4,
+  // [3] = top-8. Used by frequencyPartitionCostBits to estimate tier encoding
+  // gains.
+  std::array<double, 4> topKCoverage{};
 };
 
 // Single-pass metric collector for extracted bit-range values.
@@ -109,8 +119,11 @@ class MetricCollector {
       MetricFlags flags = static_cast<MetricFlags>(MetricFlag::All)) {
     const bool doMin = hasFlag(flags, MetricFlag::MinMax);
     const bool doRun = hasFlag(flags, MetricFlag::RunStats);
-    const bool doUniq = hasFlag(flags, MetricFlag::UniqueCount);
     const bool doDominant = hasFlag(flags, MetricFlag::DominantValue);
+    const bool doFreqTiers = hasFlag(flags, MetricFlag::FrequencyTiers);
+    // FrequencyTiers requires frequency counts, which subsumes UniqueCount.
+    const bool doUniq =
+        hasFlag(flags, MetricFlag::UniqueCount) || doFreqTiers;
     // Unique count and dominant value share a single frequency map pass.
     const bool doFreq = doUniq || doDominant;
     const bool doHist = hasFlag(flags, MetricFlag::BitWidthHistogram);
@@ -193,6 +206,33 @@ class MetricCollector {
     if (doDominant) {
       out.dominantCount = maxCount;
       out.dominantCountCapped = capped;
+    }
+    if (doFreqTiers && !capped) {
+      // Extract frequency values, sort descending, then compute cumulative
+      // coverage fractions for top {1, 2, 4, 8} distinct values.
+      std::vector<uint32_t> freqs;
+      freqs.reserve(freqMap_.size());
+      for (const auto& [val, cnt] : freqMap_) {
+        freqs.push_back(cnt);
+      }
+      std::sort(freqs.begin(), freqs.end(), std::greater<uint32_t>());
+
+      constexpr size_t kTopKs[4] = {1, 2, 4, 8};
+      const double dn = static_cast<double>(n);
+      uint64_t cumFreq = 0;
+      size_t ki = 0;
+      for (size_t fi = 0; fi < freqs.size() && ki < 4; ++fi) {
+        cumFreq += freqs[fi];
+        while (ki < 4 && fi + 1 >= kTopKs[ki]) {
+          out.topKCoverage[ki] = static_cast<double>(cumFreq) / dn;
+          ++ki;
+        }
+      }
+      // Fill remaining slots if fewer distinct values than topK thresholds.
+      while (ki < 4) {
+        out.topKCoverage[ki] = static_cast<double>(cumFreq) / dn;
+        ++ki;
+      }
     }
 
     return out;

--- a/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -40,7 +40,8 @@ enum class MetricFlag : uint32_t {
   UniqueCount = 1u << 2, // uniqueCount (raw, capped)
   DominantValue = 1u << 3, // dominantCount (most-frequent value's frequency)
   BitWidthHistogram = 1u << 4, // bitWidthBuckets
-  All = (1u << 5) - 1,
+  DeltaStats = 1u << 5, // sumAbsDelta, monotonicCount
+  All = (1u << 6) - 1,
 };
 using MetricFlags = uint32_t;
 
@@ -76,6 +77,13 @@ struct SegmentMetrics {
   // bit_width(v) directly (segment values are already small bit-slices, so
   // `min` is usually close to 0). See PFOREncoding.h's selectBaseBitWidth.
   std::array<uint32_t, 10> bitWidthBuckets{};
+
+  // Sum of |v[i] - v[i-1]| over consecutive pairs, and the count of pairs
+  // where v[i] >= v[i-1] (non-decreasing, i.e. encodable as a positive delta
+  // without a restatement). Used by deltaCostBits/forCostBits to estimate the
+  // average step size and the monotonic-non-decreasing fraction.
+  uint64_t sumAbsDelta{0};
+  size_t monotonicCount{0};
 };
 
 // Single-pass metric collector for extracted bit-range values.
@@ -106,6 +114,7 @@ class MetricCollector {
     // Unique count and dominant value share a single frequency map pass.
     const bool doFreq = doUniq || doDominant;
     const bool doHist = hasFlag(flags, MetricFlag::BitWidthHistogram);
+    const bool doDelta = hasFlag(flags, MetricFlag::DeltaStats);
 
     SegmentMetrics out;
     const size_t n = values.size();
@@ -160,6 +169,12 @@ class MetricCollector {
       }
       if (doHist) {
         ++out.bitWidthBuckets[bitWidthBucket(v)];
+      }
+      if (doDelta) {
+        out.sumAbsDelta += (v >= prev) ? (v - prev) : (prev - v);
+        if (v >= prev) {
+          ++out.monotonicCount;
+        }
       }
       prev = v;
     }

--- a/velox/dwio/nimble/encodings/SubIntSplitSelector.h
+++ b/velox/dwio/nimble/encodings/SubIntSplitSelector.h
@@ -110,8 +110,8 @@ struct SelectorResult {
 // produces estimates in the right units.
 //
 // `costFn` scores a single segment: given (metrics, numValues, bitWidth,
-// outBestEncoding), return the per-sample cost in bits and write the best
-// encoding into the output parameter.  Defaults to `bestCostBits`.
+// segValues, outBestEncoding), return the per-sample cost in bits and write
+// the best encoding into the output parameter.  Defaults to `bestCostBits`.
 template <typename CostFn>
 inline SelectorResult selectSplitsImpl(
     const std::vector<uint64_t>& samples,
@@ -149,7 +149,7 @@ inline SelectorResult selectSplitsImpl(
 
       EncodingType bestEnc = EncodingType::Trivial;
       const double perSampleCost =
-          costFn(metrics, numSamples, bitWidth, bestEnc);
+          costFn(metrics, numSamples, bitWidth, segValues, bestEnc);
 
       const double fullCost = perSampleCost * static_cast<double>(fullCount) /
           static_cast<double>(numSamples);

--- a/velox/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -76,7 +76,10 @@ add_executable(
 )
 
 if(NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS)
-  target_sources(nimble_encodings_tests PRIVATE SubIntSplitEncodingTest.cpp)
+  target_sources(
+    nimble_encodings_tests
+    PRIVATE SubIntSplitEncodingTest.cpp SubIntSplitCostModelsTest.cpp
+  )
 endif()
 
 add_test(nimble_encodings_tests nimble_encodings_tests)

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -103,6 +103,37 @@ std::vector<uint64_t> makeAlternatingValues() {
   return values;
 }
 
+// 1024 values with a Zipfian frequency distribution, interleaved to avoid
+// monotonic ordering (keeps Delta cost at infinity). Layout:
+//   value 0: 512 occurrences (dominant — wins top-2 tier, topKCoverage[1] high)
+//   value 1: 256 occurrences
+//   value 2: 128 occurrences
+//   value 3: 64 occurrences
+//   values 4..67: 1 occurrence each (sparse fallback)
+// Interleaving (0,j) pairs ensures monotonicCount / (n-1) ≈ 0.5 < 0.9, so
+// Delta returns infinity and FrequencyPartition can win.
+std::vector<uint64_t> makeZipfianValues() {
+  std::vector<uint64_t> values;
+  values.reserve(1024);
+  auto push = [&](uint64_t a, uint64_t b, int count) {
+    for (int i = 0; i < count; ++i) {
+      values.push_back(a);
+      values.push_back(b);
+    }
+  };
+  push(0, 1, 256); // 512 values: 256× each of 0 and 1
+  push(0, 2, 128); // 256 values: 128× each of 0 and 2
+  push(0, 3, 64);  // 128 values: 64× each of 0 and 3
+  for (uint64_t j = 4; j < 36; ++j) {
+    push(0, j, 1); // 64 values: 1× each of 0 and j
+  }
+  for (uint64_t j = 36; j < 68; ++j) {
+    push(0, j, 1); // 64 values: 1× each of 0 and j
+  }
+  // Total: 512 + 256 + 128 + 64 + 64 = 1024
+  return values;
+}
+
 } // namespace
 
 TEST(SubIntSplitCostModelsTest, PforBeatsFixedBitWidthForBaselinePlusOutliers) {
@@ -251,6 +282,40 @@ TEST(
 
   EXPECT_TRUE(std::isfinite(best));
   EXPECT_EQ(bestEncoding, EncodingType::FOR);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    FrequencyPartitionCostBitsFiniteForZipfianData) {
+  const std::vector<uint64_t> values = makeZipfianValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  // Values 0..67 require 7 bits; FPE should be finite and beat fixed-bit-width
+  // thanks to the skewed distribution (value 0 covers 50% of entries).
+  constexpr int kBitWidth = 7; // bit_width(67) == 7
+  const double fpeCost = frequencyPartitionCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isfinite(fpeCost));
+  EXPECT_GT(fpeCost, 0.0);
+  EXPECT_LT(fpeCost, fixedBitWidth);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsSelectsFrequencyPartitionForZipfianData) {
+  const std::vector<uint64_t> values = makeZipfianValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 7; // bit_width(67) == 7
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::FrequencyPartition);
 }
 
 #endif

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -134,6 +134,26 @@ std::vector<uint64_t> makeZipfianValues() {
   return values;
 }
 
+// 1000 values: 900 zeros (90% dominant) interleaved with 100 distinct values
+// in [128, 227]. Pattern: 9 zeros then one non-zero, repeated 100 times. The
+// 90% dominance makes MainlyConstant's exception-list representation (~2760
+// bits) cheaper than RLE (~5008 bits, 200 runs), FrequencyPartition (~4139
+// bits, 101 uniques), and all others. Non-monotonic enough to keep Delta from
+// also being cheap: monotonicFraction ≈ 900/999 ≈ 0.9009 passes Delta's 0.9
+// threshold but the large average delta (≈35.5) drives Delta's cost to ~10073
+// bits — well above MainlyConstant.
+std::vector<uint64_t> makeMainlyConstantValues() {
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 100; ++i) {
+    for (int z = 0; z < 9; ++z) {
+      values.push_back(0);
+    }
+    values.push_back(static_cast<uint64_t>(128 + i)); // 128..227
+  }
+  return values;
+}
+
 } // namespace
 
 TEST(SubIntSplitCostModelsTest, PforBeatsFixedBitWidthForBaselinePlusOutliers) {
@@ -316,6 +336,40 @@ TEST(
 
   EXPECT_TRUE(std::isfinite(best));
   EXPECT_EQ(bestEncoding, EncodingType::FrequencyPartition);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    MainlyConstantCostBitsFiniteForDominantData) {
+  const std::vector<uint64_t> values = makeMainlyConstantValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  // bit_width(227) == 8; MainlyConstant should be finite and beat FixedBitWidth
+  // (~8072 bits) at this dominance level (900/1000 = 90% dominant value).
+  constexpr int kBitWidth = 8;
+  const double mc = mainlyConstantCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isfinite(mc));
+  EXPECT_GT(mc, 0.0);
+  EXPECT_LT(mc, fixedBitWidth);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsSelectsMainlyConstantForDominantData) {
+  const std::vector<uint64_t> values = makeMainlyConstantValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 8; // bit_width(227) == 8
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::MainlyConstant);
 }
 
 #endif

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -64,6 +64,45 @@ std::vector<uint64_t> makeBlockClusteredValues() {
   return values;
 }
 
+// 1000 values: v[i] = i, a strictly monotonically increasing sequence with
+// constant step size 1 (bit_width(999) == 10). FOR's small per-frame
+// (128-value) local range (~64, 7 bits) beats Delta's byte-rounded 8-bit-
+// per-delta cost and PFOR/SimdForBitpack/BlockBitPacking/FixedBitWidth's
+// full 10-bit packing.
+std::vector<uint64_t> makeForFriendlyValues() {
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 1000; ++i) {
+    values.push_back(static_cast<uint64_t>(i));
+  }
+  return values;
+}
+
+// 1000 values: v[i] = i * 20, a strictly monotonically increasing sequence
+// with constant step size 20 but a wide overall range (~19980, bit_width ==
+// 15). Delta's byte-rounded 8-bit-per-delta cost beats FOR's per-frame local
+// range estimate (~1280, 11 bits) and FixedBitWidth/PFOR/SimdForBitpack/
+// BlockBitPacking's full 15-bit packing.
+std::vector<uint64_t> makeDeltaFriendlyValues() {
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 1000; ++i) {
+    values.push_back(static_cast<uint64_t>(i) * 20);
+  }
+  return values;
+}
+
+// 1000 values alternating between 0 and 1000. Half of all consecutive steps
+// are decreases, well below Delta's 90% monotonic-non-decreasing threshold.
+std::vector<uint64_t> makeAlternatingValues() {
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 1000; ++i) {
+    values.push_back((i % 2 == 0) ? uint64_t{0} : uint64_t{1000});
+  }
+  return values;
+}
+
 } // namespace
 
 TEST(SubIntSplitCostModelsTest, PforBeatsFixedBitWidthForBaselinePlusOutliers) {
@@ -141,6 +180,77 @@ TEST(
 
   EXPECT_TRUE(std::isfinite(best));
   EXPECT_EQ(bestEncoding, EncodingType::BlockBitPacking);
+}
+
+TEST(SubIntSplitCostModelsTest, DeltaCostBitsFiniteForMonotonicData) {
+  const std::vector<uint64_t> values = makeDeltaFriendlyValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 15; // bit_width(19980) == 15
+  const double delta = deltaCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isfinite(delta));
+  EXPECT_GT(delta, 0.0);
+  EXPECT_LT(delta, fixedBitWidth);
+}
+
+TEST(SubIntSplitCostModelsTest, DeltaCostBitsInfiniteForNonMonotonicData) {
+  const std::vector<uint64_t> values = makeAlternatingValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 10; // bit_width(1000) == 10
+  const double delta = deltaCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isinf(delta));
+}
+
+TEST(SubIntSplitCostModelsTest, ForCostBitsFiniteAndPositive) {
+  const std::vector<uint64_t> values = makeForFriendlyValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 10; // bit_width(999) == 10
+  const double forCost = forCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isfinite(forCost));
+  EXPECT_GT(forCost, 0.0);
+  EXPECT_LT(forCost, fixedBitWidth);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsSelectsDeltaForWideRangeConstantStepData) {
+  const std::vector<uint64_t> values = makeDeltaFriendlyValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 15; // bit_width(19980) == 15
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::Delta);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsSelectsForForUnitStepMonotonicData) {
+  const std::vector<uint64_t> values = makeForFriendlyValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 10; // bit_width(999) == 10
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::FOR);
 }
 
 #endif

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -168,6 +168,66 @@ TEST(SubIntSplitCostModelsTest, PforBeatsFixedBitWidthForBaselinePlusOutliers) {
   EXPECT_LT(pfor, fixedBitWidth);
 }
 
+TEST(SubIntSplitCostModelsTest, HuffmanIsFiniteAndCheaperThanPforForLowCardinalityBaselinePlusOutliers) {
+  // Same data as makePforFriendlyValues: 17 distinct values total (16
+  // baseline + 1 outlier). Huffman's exact per-symbol code length beats
+  // PFOR's fixed-base-bit-width approximation for this small an alphabet.
+  const std::vector<uint64_t> values = makePforFriendlyValues();
+  MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 16;
+  const double huffman = huffmanCostBits(values, values.size());
+  const double pfor = pforCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isfinite(huffman));
+  EXPECT_GT(huffman, 0.0);
+  EXPECT_LT(huffman, pfor);
+}
+
+TEST(SubIntSplitCostModelsTest, HuffmanCostBitsInfiniteWhenAlphabetTooLarge) {
+  // Every value distinct and count > HuffmanEncoding<uint64_t>::kMaxSymbols
+  // (4096): HuffmanEncoding::estimateSize returns nullopt past this cap.
+  std::vector<uint64_t> values;
+  values.reserve(HuffmanEncoding<uint64_t>::kMaxSymbols + 1);
+  for (uint32_t i = 0; i <= HuffmanEncoding<uint64_t>::kMaxSymbols; ++i) {
+    values.push_back(static_cast<uint64_t>(i));
+  }
+
+  const double huffman = huffmanCostBits(values, values.size());
+
+  EXPECT_TRUE(std::isinf(huffman));
+}
+
+TEST(SubIntSplitCostModelsTest, DeltaBlockIsFiniteAndCheaperThanDeltaForConstantStepData) {
+  const std::vector<uint64_t> values = makeDeltaFriendlyValues();
+  MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 15; // bit_width(19980) == 15
+  const double deltaBlock = deltaBlockCostBits(values, values.size());
+  const double delta = deltaCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isfinite(deltaBlock));
+  EXPECT_GT(deltaBlock, 0.0);
+  EXPECT_LT(deltaBlock, delta);
+}
+
+TEST(SubIntSplitCostModelsTest, DeltaBlockCostBitsInfiniteWhenBlockContainsADecrease) {
+  // A single decrease within a deltaBlockSize (default 256) window makes the
+  // whole block ineligible for DeltaBlock's non-decreasing-only design.
+  std::vector<uint64_t> values;
+  values.reserve(300);
+  for (uint64_t i = 0; i < 300; ++i) {
+    values.push_back(i);
+  }
+  values[10] = 0; // introduces a decrease within the first 256-value block.
+
+  const double deltaBlock = deltaBlockCostBits(values, values.size());
+
+  EXPECT_TRUE(std::isinf(deltaBlock));
+}
+
 TEST(
     SubIntSplitCostModelsTest,
     BlockBitPackingBeatsFixedBitWidthForLocallyClusteredData) {
@@ -203,7 +263,12 @@ TEST(SubIntSplitCostModelsTest, SimdForBitpackIsFiniteAndCheaperThanTrivial) {
   EXPECT_LT(simdForBitpack, trivial);
 }
 
-TEST(SubIntSplitCostModelsTest, BestCostBitsSelectsPforForBaselinePlusOutliers) {
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsSelectsHuffmanForLowCardinalityBaselinePlusOutliers) {
+  // Same 17-distinct-value data PFOR was originally tuned for: now that
+  // Huffman is a candidate, its exact per-symbol code length beats PFOR's
+  // fixed-base-bit-width approximation for this small an alphabet.
   const std::vector<uint64_t> values = makePforFriendlyValues();
   MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
@@ -214,7 +279,40 @@ TEST(SubIntSplitCostModelsTest, BestCostBitsSelectsPforForBaselinePlusOutliers) 
       bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
 
   EXPECT_TRUE(std::isfinite(best));
-  EXPECT_EQ(bestEncoding, EncodingType::PFOR);
+  EXPECT_EQ(bestEncoding, EncodingType::Huffman);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsDoesNotUseHuffmanForHighCardinalityBaselinePlusOutliers) {
+  // Widen the baseline from 16 to 200 distinct values (bit_width <= 8),
+  // still well under HuffmanEncoding's kMaxSymbols cap, with a near-uniform
+  // frequency distribution across a wider alphabet -- Huffman's per-symbol
+  // savings shrink relative to Dictionary, which packs each of the 210
+  // unique values (200 baseline + 10 distinct-looking outliers folded into
+  // the same 16-bit alphabet) into an 8-bit index, cheaper than the
+  // segment's native 16-bit width (driven up by the rare 65535 outliers).
+  // Values are multiplicatively permuted (rather than a plain i % 200
+  // sawtooth) to avoid accidentally producing long monotonic runs that would
+  // let Delta win instead.
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 990; ++i) {
+    values.push_back(static_cast<uint64_t>((i * 37) % 200));
+  }
+  for (int i = 0; i < 10; ++i) {
+    values.push_back(65535);
+  }
+  MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 16;
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::Dictionary);
 }
 
 TEST(
@@ -274,7 +372,10 @@ TEST(SubIntSplitCostModelsTest, ForCostBitsFiniteAndPositive) {
 
 TEST(
     SubIntSplitCostModelsTest,
-    BestCostBitsSelectsDeltaForWideRangeConstantStepData) {
+    BestCostBitsSelectsDeltaBlockForWideRangeConstantStepData) {
+  // Strictly increasing, no decreases anywhere in the stream, so every
+  // deltaBlockSize block is eligible for DeltaBlock -- its exact per-block
+  // bit-packed deltas beat Delta's byte-rounded per-value cost.
   const std::vector<uint64_t> values = makeDeltaFriendlyValues();
   MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
@@ -285,13 +386,41 @@ TEST(
       bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
 
   EXPECT_TRUE(std::isfinite(best));
-  EXPECT_EQ(bestEncoding, EncodingType::Delta);
+  EXPECT_EQ(bestEncoding, EncodingType::DeltaBlock);
 }
 
 TEST(
     SubIntSplitCostModelsTest,
-    BestCostBitsSelectsForForUnitStepMonotonicData) {
+    BestCostBitsSelectsDeltaBlockForUnitStepMonotonicData) {
+  // Strictly increasing with step 1: DeltaBlock's per-block bit-packing of
+  // (mostly) zero-width deltas beats FOR's per-frame local-range estimate.
   const std::vector<uint64_t> values = makeForFriendlyValues();
+  MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 10; // bit_width(999) == 10
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::DeltaBlock);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsSelectsForForMonotonicDataWithADecrease) {
+  // Same step-1 growth as makeForFriendlyValues, but with a single decrease
+  // inside the first deltaBlockSize (256) block, which disqualifies that
+  // block -- and therefore the whole segment -- from DeltaBlock. FOR's
+  // per-frame (128-value) local-range packing still handles the isolated
+  // decrease cheaply and remains the best candidate.
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 1000; ++i) {
+    values.push_back(static_cast<uint64_t>(i));
+  }
+  values[10] = 0;
   MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -66,9 +66,8 @@ std::vector<uint64_t> makeBlockClusteredValues() {
 
 // 1000 values: v[i] = i, a strictly monotonically increasing sequence with
 // constant step size 1 (bit_width(999) == 10). FOR's small per-frame
-// (128-value) local range (~64, 7 bits) beats Delta's byte-rounded 8-bit-
-// per-delta cost and PFOR/SimdForBitpack/BlockBitPacking/FixedBitWidth's
-// full 10-bit packing.
+// (128-value) local range (~64, 7 bits) beats PFOR/SimdForBitpack/
+// BlockBitPacking/FixedBitWidth's full 10-bit packing.
 std::vector<uint64_t> makeForFriendlyValues() {
   std::vector<uint64_t> values;
   values.reserve(1000);
@@ -78,16 +77,19 @@ std::vector<uint64_t> makeForFriendlyValues() {
   return values;
 }
 
-// 1000 values: v[i] = i * 20, a strictly monotonically increasing sequence
-// with constant step size 20 but a wide overall range (~19980, bit_width ==
-// 15). Delta's byte-rounded 8-bit-per-delta cost beats FOR's per-frame local
-// range estimate (~1280, 11 bits) and FixedBitWidth/PFOR/SimdForBitpack/
-// BlockBitPacking's full 15-bit packing.
+// 1000 values: v[i] = i * 200'000, a strictly monotonically increasing
+// sequence with constant step size 200'000 but a wide overall range
+// (~199'800'000, bit_width == 28). Delta's exact-bit deltaBitWidth ==
+// bit_width(200'000) == 18 beats FixedBitWidth/PFOR/SimdForBitpack/
+// BlockBitPacking's full 28-bit packing, but DeltaBlock still wins overall:
+// its per-block residuals collapse to a single repeated value (constant
+// step), needing ~0 bits per block regardless of the step's magnitude, while
+// Delta's flat per-value cost keeps scaling with deltaBitWidth.
 std::vector<uint64_t> makeDeltaFriendlyValues() {
   std::vector<uint64_t> values;
   values.reserve(1000);
   for (int i = 0; i < 1000; ++i) {
-    values.push_back(static_cast<uint64_t>(i) * 20);
+    values.push_back(static_cast<uint64_t>(i) * 200'000);
   }
   return values;
 }
@@ -204,7 +206,7 @@ TEST(SubIntSplitCostModelsTest, DeltaBlockIsFiniteAndCheaperThanDeltaForConstant
   MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
-  constexpr int kBitWidth = 15; // bit_width(19980) == 15
+  constexpr int kBitWidth = 28; // bit_width(199800000) == 28
   const double deltaBlock = deltaBlockCostBits(values, values.size());
   const double delta = deltaCostBits(m, values.size(), kBitWidth);
 
@@ -336,7 +338,7 @@ TEST(SubIntSplitCostModelsTest, DeltaCostBitsFiniteForMonotonicData) {
   MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
-  constexpr int kBitWidth = 15; // bit_width(19980) == 15
+  constexpr int kBitWidth = 28; // bit_width(199800000) == 28
   const double delta = deltaCostBits(m, values.size(), kBitWidth);
   const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
 
@@ -374,13 +376,15 @@ TEST(
     SubIntSplitCostModelsTest,
     BestCostBitsSelectsDeltaBlockForWideRangeConstantStepData) {
   // Strictly increasing, no decreases anywhere in the stream, so every
-  // deltaBlockSize block is eligible for DeltaBlock -- its exact per-block
-  // bit-packed deltas beat Delta's byte-rounded per-value cost.
+  // deltaBlockSize block is eligible for DeltaBlock. Its per-block residuals
+  // collapse to a single repeated value (constant step) and cost ~0 bits per
+  // block regardless of the step's magnitude, while Delta's flat per-value
+  // cost keeps scaling with the (now exact, not byte-rounded) deltaBitWidth.
   const std::vector<uint64_t> values = makeDeltaFriendlyValues();
   MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
-  constexpr int kBitWidth = 15; // bit_width(19980) == 15
+  constexpr int kBitWidth = 28; // bit_width(199800000) == 28
   EncodingType bestEncoding = EncodingType::Trivial;
   const double best =
       bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
@@ -409,12 +413,15 @@ TEST(
 
 TEST(
     SubIntSplitCostModelsTest,
-    BestCostBitsSelectsForForMonotonicDataWithADecrease) {
+    BestCostBitsSelectsDeltaForMonotonicDataWithADecrease) {
   // Same step-1 growth as makeForFriendlyValues, but with a single decrease
   // inside the first deltaBlockSize (256) block, which disqualifies that
-  // block -- and therefore the whole segment -- from DeltaBlock. FOR's
-  // per-frame (128-value) local-range packing still handles the isolated
-  // decrease cheaply and remains the best candidate.
+  // block -- and therefore the whole segment -- from DeltaBlock. Delta pays
+  // one restatement plus a single wider (11-bit) delta at the point the
+  // sequence resumes; with deltaBitWidth sized exactly (not byte-rounded)
+  // and the mostly-false isRestatements stream delegated to
+  // SparseBoolEncoding's estimator, that's now cheaper than FOR's per-frame
+  // local-range packing.
   std::vector<uint64_t> values;
   values.reserve(1000);
   for (int i = 0; i < 1000; ++i) {
@@ -430,7 +437,7 @@ TEST(
       bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
 
   EXPECT_TRUE(std::isfinite(best));
-  EXPECT_EQ(bestEncoding, EncodingType::FOR);
+  EXPECT_EQ(bestEncoding, EncodingType::Delta);
 }
 
 TEST(

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -125,7 +125,7 @@ std::vector<uint64_t> makeZipfianValues() {
   };
   push(0, 1, 256); // 512 values: 256× each of 0 and 1
   push(0, 2, 128); // 256 values: 128× each of 0 and 2
-  push(0, 3, 64);  // 128 values: 64× each of 0 and 3
+  push(0, 3, 64); // 128 values: 64× each of 0 and 3
   for (uint64_t j = 4; j < 36; ++j) {
     push(0, j, 1); // 64 values: 1× each of 0 and j
   }
@@ -161,22 +161,27 @@ std::vector<uint64_t> makeMainlyConstantValues() {
 TEST(SubIntSplitCostModelsTest, PforBeatsFixedBitWidthForBaselinePlusOutliers) {
   const std::vector<uint64_t> values = makePforFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 16;
   const double pfor = pforCostBits(m, values.size(), kBitWidth);
-  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth =
+      fixedBitWidthCostBits(m, values.size(), kBitWidth);
 
   EXPECT_LT(pfor, fixedBitWidth);
 }
 
-TEST(SubIntSplitCostModelsTest, HuffmanIsFiniteAndCheaperThanPforForLowCardinalityBaselinePlusOutliers) {
+TEST(
+    SubIntSplitCostModelsTest,
+    HuffmanIsFiniteAndCheaperThanPforForLowCardinalityBaselinePlusOutliers) {
   // Same data as makePforFriendlyValues: 17 distinct values total (16
   // baseline + 1 outlier). Huffman's exact per-symbol code length beats
   // PFOR's fixed-base-bit-width approximation for this small an alphabet.
   const std::vector<uint64_t> values = makePforFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 16;
   const double huffman = huffmanCostBits(values, values.size());
@@ -201,10 +206,13 @@ TEST(SubIntSplitCostModelsTest, HuffmanCostBitsInfiniteWhenAlphabetTooLarge) {
   EXPECT_TRUE(std::isinf(huffman));
 }
 
-TEST(SubIntSplitCostModelsTest, DeltaBlockIsFiniteAndCheaperThanDeltaForConstantStepData) {
+TEST(
+    SubIntSplitCostModelsTest,
+    DeltaBlockIsFiniteAndCheaperThanDeltaForConstantStepData) {
   const std::vector<uint64_t> values = makeDeltaFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 28; // bit_width(199800000) == 28
   const double deltaBlock = deltaBlockCostBits(values, values.size());
@@ -215,7 +223,9 @@ TEST(SubIntSplitCostModelsTest, DeltaBlockIsFiniteAndCheaperThanDeltaForConstant
   EXPECT_LT(deltaBlock, delta);
 }
 
-TEST(SubIntSplitCostModelsTest, DeltaBlockCostBitsInfiniteWhenBlockContainsADecrease) {
+TEST(
+    SubIntSplitCostModelsTest,
+    DeltaBlockCostBitsInfiniteWhenBlockContainsADecrease) {
   // A single decrease within a deltaBlockSize (default 256) window makes the
   // whole block ineligible for DeltaBlock's non-decreasing-only design.
   std::vector<uint64_t> values;
@@ -235,11 +245,13 @@ TEST(
     BlockBitPackingBeatsFixedBitWidthForLocallyClusteredData) {
   const std::vector<uint64_t> values = makeBlockClusteredValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 20; // bit_width(750015) == 20
   const double blockBitPacking = blockBitPackingCostBits(values, values.size());
-  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth =
+      fixedBitWidthCostBits(m, values.size(), kBitWidth);
 
   EXPECT_LT(blockBitPacking, fixedBitWidth);
 }
@@ -254,10 +266,12 @@ TEST(SubIntSplitCostModelsTest, SimdForBitpackIsFiniteAndCheaperThanTrivial) {
     values.push_back(static_cast<uint64_t>(i % 64)); // bit_width <= 6
   }
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 8;
-  const double simdForBitpack = simdForBitpackCostBits(m, values.size(), kBitWidth);
+  const double simdForBitpack =
+      simdForBitpackCostBits(m, values.size(), kBitWidth);
   const double trivial = trivialCostBits(m, values.size(), kBitWidth);
 
   EXPECT_TRUE(std::isfinite(simdForBitpack));
@@ -273,7 +287,8 @@ TEST(
   // fixed-base-bit-width approximation for this small an alphabet.
   const std::vector<uint64_t> values = makePforFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 16;
   EncodingType bestEncoding = EncodingType::Trivial;
@@ -306,7 +321,8 @@ TEST(
     values.push_back(65535);
   }
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 16;
   EncodingType bestEncoding = EncodingType::Trivial;
@@ -322,7 +338,8 @@ TEST(
     BestCostBitsSelectsBlockBitPackingForLocallyClusteredData) {
   const std::vector<uint64_t> values = makeBlockClusteredValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 20;
   EncodingType bestEncoding = EncodingType::Trivial;
@@ -336,11 +353,13 @@ TEST(
 TEST(SubIntSplitCostModelsTest, DeltaCostBitsFiniteForMonotonicData) {
   const std::vector<uint64_t> values = makeDeltaFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 28; // bit_width(199800000) == 28
   const double delta = deltaCostBits(m, values.size(), kBitWidth);
-  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth =
+      fixedBitWidthCostBits(m, values.size(), kBitWidth);
 
   EXPECT_TRUE(std::isfinite(delta));
   EXPECT_GT(delta, 0.0);
@@ -350,7 +369,8 @@ TEST(SubIntSplitCostModelsTest, DeltaCostBitsFiniteForMonotonicData) {
 TEST(SubIntSplitCostModelsTest, DeltaCostBitsInfiniteForNonMonotonicData) {
   const std::vector<uint64_t> values = makeAlternatingValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 10; // bit_width(1000) == 10
   const double delta = deltaCostBits(m, values.size(), kBitWidth);
@@ -361,11 +381,13 @@ TEST(SubIntSplitCostModelsTest, DeltaCostBitsInfiniteForNonMonotonicData) {
 TEST(SubIntSplitCostModelsTest, ForCostBitsFiniteAndPositive) {
   const std::vector<uint64_t> values = makeForFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 10; // bit_width(999) == 10
   const double forCost = forCostBits(m, values.size(), kBitWidth);
-  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth =
+      fixedBitWidthCostBits(m, values.size(), kBitWidth);
 
   EXPECT_TRUE(std::isfinite(forCost));
   EXPECT_GT(forCost, 0.0);
@@ -382,7 +404,8 @@ TEST(
   // cost keeps scaling with the (now exact, not byte-rounded) deltaBitWidth.
   const std::vector<uint64_t> values = makeDeltaFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 28; // bit_width(199800000) == 28
   EncodingType bestEncoding = EncodingType::Trivial;
@@ -400,7 +423,8 @@ TEST(
   // (mostly) zero-width deltas beats FOR's per-frame local-range estimate.
   const std::vector<uint64_t> values = makeForFriendlyValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 10; // bit_width(999) == 10
   EncodingType bestEncoding = EncodingType::Trivial;
@@ -429,7 +453,8 @@ TEST(
   }
   values[10] = 0;
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 10; // bit_width(999) == 10
   EncodingType bestEncoding = EncodingType::Trivial;
@@ -445,13 +470,16 @@ TEST(
     FrequencyPartitionCostBitsFiniteForZipfianData) {
   const std::vector<uint64_t> values = makeZipfianValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   // Values 0..67 require 7 bits; FPE should be finite and beat fixed-bit-width
   // thanks to the skewed distribution (value 0 covers 50% of entries).
   constexpr int kBitWidth = 7; // bit_width(67) == 7
-  const double fpeCost = frequencyPartitionCostBits(m, values.size(), kBitWidth);
-  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+  const double fpeCost =
+      frequencyPartitionCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth =
+      fixedBitWidthCostBits(m, values.size(), kBitWidth);
 
   EXPECT_TRUE(std::isfinite(fpeCost));
   EXPECT_GT(fpeCost, 0.0);
@@ -463,7 +491,8 @@ TEST(
     BestCostBitsSelectsFrequencyPartitionForZipfianData) {
   const std::vector<uint64_t> values = makeZipfianValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 7; // bit_width(67) == 7
   EncodingType bestEncoding = EncodingType::Trivial;
@@ -474,18 +503,18 @@ TEST(
   EXPECT_EQ(bestEncoding, EncodingType::FrequencyPartition);
 }
 
-TEST(
-    SubIntSplitCostModelsTest,
-    MainlyConstantCostBitsFiniteForDominantData) {
+TEST(SubIntSplitCostModelsTest, MainlyConstantCostBitsFiniteForDominantData) {
   const std::vector<uint64_t> values = makeMainlyConstantValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   // bit_width(227) == 8; MainlyConstant should be finite and beat FixedBitWidth
   // (~8072 bits) at this dominance level (900/1000 = 90% dominant value).
   constexpr int kBitWidth = 8;
   const double mc = mainlyConstantCostBits(m, values.size(), kBitWidth);
-  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth =
+      fixedBitWidthCostBits(m, values.size(), kBitWidth);
 
   EXPECT_TRUE(std::isfinite(mc));
   EXPECT_GT(mc, 0.0);
@@ -497,7 +526,8 @@ TEST(
     BestCostBitsSelectsMainlyConstantForDominantData) {
   const std::vector<uint64_t> values = makeMainlyConstantValues();
   MetricCollector collector;
-  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+  const SegmentMetrics m =
+      collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 8; // bit_width(227) == 8
   EncodingType bestEncoding = EncodingType::Trivial;

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "velox/dwio/nimble/encodings/SubIntSplitCostModels.h"
+#include "velox/dwio/nimble/encodings/SubIntSplitMetrics.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::detail::subintsplit;
+
+namespace {
+
+// 1000 values: 990 small values (bit_width <= 4, only 16 distinct) and 10
+// "exception" values requiring the full 16-bit segment width. Models a
+// column where the vast majority of values fit a narrow baseline and a rare
+// few outliers require the full range. The 1% outlier rate keeps PFOR's
+// exception side-channels cheap, while the low baseline cardinality (17
+// distinct values total) would make Dictionary's per-value index overhead
+// (rounded to a byte) more expensive than PFOR's 7-bit base region.
+std::vector<uint64_t> makePforFriendlyValues() {
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 990; ++i) {
+    values.push_back(static_cast<uint64_t>(i % 16)); // bit_width <= 4
+  }
+  for (int i = 0; i < 10; ++i) {
+    values.push_back(65535); // bit_width == 16
+  }
+  return values;
+}
+
+// 4096 values laid out as 4 blocks of 1024. Each block is locally clustered
+// to a narrow 4-bit range, but the blocks' baselines are spread across a
+// globally wide ~20-bit range.
+std::vector<uint64_t> makeBlockClusteredValues() {
+  std::vector<uint64_t> values;
+  values.reserve(4096);
+  for (int block = 0; block < 4; ++block) {
+    const uint64_t base = static_cast<uint64_t>(block) * 250000;
+    for (int i = 0; i < 1024; ++i) {
+      values.push_back(base + static_cast<uint64_t>(i % 16));
+    }
+  }
+  return values;
+}
+
+} // namespace
+
+TEST(SubIntSplitCostModelsTest, PforBeatsFixedBitWidthForBaselinePlusOutliers) {
+  const std::vector<uint64_t> values = makePforFriendlyValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 16;
+  const double pfor = pforCostBits(m, values.size(), kBitWidth);
+  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_LT(pfor, fixedBitWidth);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BlockBitPackingBeatsFixedBitWidthForLocallyClusteredData) {
+  const std::vector<uint64_t> values = makeBlockClusteredValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 20; // bit_width(750015) == 20
+  const double blockBitPacking = blockBitPackingCostBits(values, values.size());
+  const double fixedBitWidth = fixedBitWidthCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_LT(blockBitPacking, fixedBitWidth);
+}
+
+TEST(SubIntSplitCostModelsTest, SimdForBitpackIsFiniteAndCheaperThanTrivial) {
+  // Values span [0, 63] (bit_width <= 6), narrower than the 8-bit segment
+  // width below, so SimdForBitpack's tight 6-bit packing beats Trivial's
+  // full 8-bit-per-value storage despite group-padding/header overhead.
+  std::vector<uint64_t> values;
+  values.reserve(1000);
+  for (int i = 0; i < 1000; ++i) {
+    values.push_back(static_cast<uint64_t>(i % 64)); // bit_width <= 6
+  }
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 8;
+  const double simdForBitpack = simdForBitpackCostBits(m, values.size(), kBitWidth);
+  const double trivial = trivialCostBits(m, values.size(), kBitWidth);
+
+  EXPECT_TRUE(std::isfinite(simdForBitpack));
+  EXPECT_GT(simdForBitpack, 0.0);
+  EXPECT_LT(simdForBitpack, trivial);
+}
+
+TEST(SubIntSplitCostModelsTest, BestCostBitsSelectsPforForBaselinePlusOutliers) {
+  const std::vector<uint64_t> values = makePforFriendlyValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 16;
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::PFOR);
+}
+
+TEST(
+    SubIntSplitCostModelsTest,
+    BestCostBitsSelectsBlockBitPackingForLocallyClusteredData) {
+  const std::vector<uint64_t> values = makeBlockClusteredValues();
+  const MetricCollector collector;
+  const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
+
+  constexpr int kBitWidth = 20;
+  EncodingType bestEncoding = EncodingType::Trivial;
+  const double best =
+      bestCostBits(m, values.size(), kBitWidth, values, bestEncoding);
+
+  EXPECT_TRUE(std::isfinite(best));
+  EXPECT_EQ(bestEncoding, EncodingType::BlockBitPacking);
+}
+
+#endif

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitCostModelsTest.cpp
@@ -158,7 +158,7 @@ std::vector<uint64_t> makeMainlyConstantValues() {
 
 TEST(SubIntSplitCostModelsTest, PforBeatsFixedBitWidthForBaselinePlusOutliers) {
   const std::vector<uint64_t> values = makePforFriendlyValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 16;
@@ -172,7 +172,7 @@ TEST(
     SubIntSplitCostModelsTest,
     BlockBitPackingBeatsFixedBitWidthForLocallyClusteredData) {
   const std::vector<uint64_t> values = makeBlockClusteredValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 20; // bit_width(750015) == 20
@@ -191,7 +191,7 @@ TEST(SubIntSplitCostModelsTest, SimdForBitpackIsFiniteAndCheaperThanTrivial) {
   for (int i = 0; i < 1000; ++i) {
     values.push_back(static_cast<uint64_t>(i % 64)); // bit_width <= 6
   }
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 8;
@@ -205,7 +205,7 @@ TEST(SubIntSplitCostModelsTest, SimdForBitpackIsFiniteAndCheaperThanTrivial) {
 
 TEST(SubIntSplitCostModelsTest, BestCostBitsSelectsPforForBaselinePlusOutliers) {
   const std::vector<uint64_t> values = makePforFriendlyValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 16;
@@ -221,7 +221,7 @@ TEST(
     SubIntSplitCostModelsTest,
     BestCostBitsSelectsBlockBitPackingForLocallyClusteredData) {
   const std::vector<uint64_t> values = makeBlockClusteredValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 20;
@@ -235,7 +235,7 @@ TEST(
 
 TEST(SubIntSplitCostModelsTest, DeltaCostBitsFiniteForMonotonicData) {
   const std::vector<uint64_t> values = makeDeltaFriendlyValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 15; // bit_width(19980) == 15
@@ -249,7 +249,7 @@ TEST(SubIntSplitCostModelsTest, DeltaCostBitsFiniteForMonotonicData) {
 
 TEST(SubIntSplitCostModelsTest, DeltaCostBitsInfiniteForNonMonotonicData) {
   const std::vector<uint64_t> values = makeAlternatingValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 10; // bit_width(1000) == 10
@@ -260,7 +260,7 @@ TEST(SubIntSplitCostModelsTest, DeltaCostBitsInfiniteForNonMonotonicData) {
 
 TEST(SubIntSplitCostModelsTest, ForCostBitsFiniteAndPositive) {
   const std::vector<uint64_t> values = makeForFriendlyValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 10; // bit_width(999) == 10
@@ -276,7 +276,7 @@ TEST(
     SubIntSplitCostModelsTest,
     BestCostBitsSelectsDeltaForWideRangeConstantStepData) {
   const std::vector<uint64_t> values = makeDeltaFriendlyValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 15; // bit_width(19980) == 15
@@ -292,7 +292,7 @@ TEST(
     SubIntSplitCostModelsTest,
     BestCostBitsSelectsForForUnitStepMonotonicData) {
   const std::vector<uint64_t> values = makeForFriendlyValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 10; // bit_width(999) == 10
@@ -308,7 +308,7 @@ TEST(
     SubIntSplitCostModelsTest,
     FrequencyPartitionCostBitsFiniteForZipfianData) {
   const std::vector<uint64_t> values = makeZipfianValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   // Values 0..67 require 7 bits; FPE should be finite and beat fixed-bit-width
@@ -326,7 +326,7 @@ TEST(
     SubIntSplitCostModelsTest,
     BestCostBitsSelectsFrequencyPartitionForZipfianData) {
   const std::vector<uint64_t> values = makeZipfianValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 7; // bit_width(67) == 7
@@ -342,7 +342,7 @@ TEST(
     SubIntSplitCostModelsTest,
     MainlyConstantCostBitsFiniteForDominantData) {
   const std::vector<uint64_t> values = makeMainlyConstantValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   // bit_width(227) == 8; MainlyConstant should be finite and beat FixedBitWidth
@@ -360,7 +360,7 @@ TEST(
     SubIntSplitCostModelsTest,
     BestCostBitsSelectsMainlyConstantForDominantData) {
   const std::vector<uint64_t> values = makeMainlyConstantValues();
-  const MetricCollector collector;
+  MetricCollector collector;
   const SegmentMetrics m = collector.compute(values, allCostModelRequiredFlags());
 
   constexpr int kBitWidth = 8; // bit_width(227) == 8

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -149,6 +149,58 @@ std::string_view encodeWithNonRecursiveSubIntSplit(
       std::make_unique<NonRecursiveSubIntSplitPolicy<T>>(), values, buffer);
 }
 
+// Like NonRecursiveSubIntSplitPolicy, but its createImpl() delegates to
+// ManualEncodingSelectionPolicy<T>::createImpl() (passing through
+// EncodingType::SubIntSplit), exercising the real
+// EncodingType::SubIntSplit special case there, which extends the segment's
+// candidate list with PFOR / SimdForBitpack / BlockBitPacking.
+template <typename T>
+class ExtendedSubIntSplitPolicy final
+    : public nimble::EncodingSelectionPolicy<T> {
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
+ public:
+  nimble::EncodingSelectionResult select(
+      std::span<const physicalType> /* values */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = nimble::EncodingType::SubIntSplit};
+  }
+
+  nimble::EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /* values */,
+      std::span<const bool> /* nulls */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = nimble::EncodingType::Nullable};
+  }
+
+  std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
+      nimble::EncodingType encodingType,
+      nimble::NestedEncodingIdentifier identifier,
+      nimble::DataType type) override {
+    auto readFactors =
+        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    readFactors.erase(
+        std::remove_if(
+            readFactors.begin(),
+            readFactors.end(),
+            [](const auto& factor) {
+              return factor.first == nimble::EncodingType::SubIntSplit;
+            }),
+        readFactors.end());
+    nimble::ManualEncodingSelectionPolicy<T> delegate{
+        std::move(readFactors), std::nullopt, std::nullopt};
+    return delegate.createImpl(encodingType, identifier, type);
+  }
+};
+
+template <typename T>
+std::string_view encodeWithExtendedSubIntSplit(
+    const std::vector<T>& values,
+    nimble::Buffer& buffer) {
+  return nimble::EncodingFactory::encode<T>(
+      std::make_unique<ExtendedSubIntSplitPolicy<T>>(), values, buffer);
+}
+
 template <typename T>
 std::string_view encodeWithReplayLayout(
     const nimble::EncodingLayout& layout,
@@ -411,6 +463,63 @@ TEST(SubIntSplitEncodingTests, fullWidthSingleSectionRoundTrip) {
       nimble::detail::subintsplit::serializeSplitBoundaries(segments));
 
   const auto decoded = decodeAll<uint64_t>(encoded, *pool);
+  expectBitwiseEqual(values, decoded);
+}
+
+TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren) {
+  nimble::ManualEncodingSelectionPolicy<uint64_t> policy{
+      nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      std::nullopt,
+      std::nullopt};
+
+  auto containsType =
+      [](const std::vector<std::pair<nimble::EncodingType, float>>& factors,
+         nimble::EncodingType type) {
+        return std::any_of(
+            factors.begin(), factors.end(), [type](const auto& pair) {
+              return pair.first == type;
+            });
+      };
+
+  // Direct children of a SubIntSplit node get the extended candidate list.
+  auto subIntSplitChild = policy.createImpl(
+      nimble::EncodingType::SubIntSplit, 0, nimble::DataType::Uint64);
+  auto* subIntSplitChildPolicy =
+      dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint64_t>*>(
+          subIntSplitChild.get());
+  ASSERT_NE(subIntSplitChildPolicy, nullptr);
+  const auto& extendedFactors = subIntSplitChildPolicy->readFactors();
+  EXPECT_TRUE(containsType(extendedFactors, nimble::EncodingType::PFOR));
+  EXPECT_TRUE(
+      containsType(extendedFactors, nimble::EncodingType::SimdForBitpack));
+  EXPECT_TRUE(
+      containsType(extendedFactors, nimble::EncodingType::BlockBitPacking));
+
+  // Children of a non-SubIntSplit node do not get the extended list.
+  auto pforChild = policy.createImpl(
+      nimble::EncodingType::PFOR, 0, nimble::DataType::Uint64);
+  auto* pforChildPolicy =
+      dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint64_t>*>(
+          pforChild.get());
+  ASSERT_NE(pforChildPolicy, nullptr);
+  const auto& unextendedFactors = pforChildPolicy->readFactors();
+  EXPECT_FALSE(containsType(unextendedFactors, nimble::EncodingType::PFOR));
+  EXPECT_FALSE(
+      containsType(unextendedFactors, nimble::EncodingType::SimdForBitpack));
+  EXPECT_FALSE(
+      containsType(unextendedFactors, nimble::EncodingType::BlockBitPacking));
+}
+
+TYPED_TEST(SubIntSplitEncodingTest, ExtendedCandidatesRoundTrip) {
+  using T = TypeParam;
+  const auto values = makeStructuredValues<T>();
+
+  const auto encoded =
+      encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
+  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
+
+  const auto decoded = decodeAll<T>(encoded, *this->pool_);
   expectBitwiseEqual(values, decoded);
 }
 

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -551,13 +551,14 @@ TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren
       };
 
   // Direct children of a SubIntSplit node get the extended candidate list.
-  auto subIntSplitChild = policy.createImpl(
-      nimble::EncodingType::SubIntSplit, 0, nimble::DataType::Uint64);
+  auto subIntSplitChild =
+      policy.create<uint64_t>(nimble::EncodingType::SubIntSplit, 0);
   auto* subIntSplitChildPolicy =
       dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint64_t>*>(
           subIntSplitChild.get());
   ASSERT_NE(subIntSplitChildPolicy, nullptr);
-  const auto& extendedFactors = subIntSplitChildPolicy->readFactors();
+  const auto& extendedFactors =
+      subIntSplitChildPolicy->candidateEncodingReadFactors();
   EXPECT_TRUE(containsType(extendedFactors, nimble::EncodingType::PFOR));
   EXPECT_TRUE(
       containsType(extendedFactors, nimble::EncodingType::SimdForBitpack));
@@ -569,13 +570,13 @@ TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren
       containsType(extendedFactors, nimble::EncodingType::FrequencyPartition));
 
   // Children of a non-SubIntSplit node do not get the extended list.
-  auto pforChild = policy.createImpl(
-      nimble::EncodingType::PFOR, 0, nimble::DataType::Uint64);
+  auto pforChild = policy.create<uint64_t>(nimble::EncodingType::PFOR, 0);
   auto* pforChildPolicy =
       dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint64_t>*>(
           pforChild.get());
   ASSERT_NE(pforChildPolicy, nullptr);
-  const auto& unextendedFactors = pforChildPolicy->readFactors();
+  const auto& unextendedFactors =
+      pforChildPolicy->candidateEncodingReadFactors();
   EXPECT_FALSE(containsType(unextendedFactors, nimble::EncodingType::PFOR));
   EXPECT_FALSE(
       containsType(unextendedFactors, nimble::EncodingType::SimdForBitpack));
@@ -593,7 +594,8 @@ TYPED_TEST(SubIntSplitEncodingTest, ExtendedCandidatesRoundTrip) {
 
   const auto encoded =
       encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
-  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  const auto captured = nimble::EncodingLayoutCapture::capture(
+      encoded, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
 
   const auto decoded = decodeAll<T>(encoded, *this->pool_);
@@ -611,7 +613,8 @@ TYPED_TEST(SubIntSplitEncodingTest, WideRangeMonotonicRoundTrip) {
 
   const auto encoded =
       encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
-  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  const auto captured = nimble::EncodingLayoutCapture::capture(
+      encoded, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
 
   const auto decoded = decodeAll<T>(encoded, *this->pool_);
@@ -635,7 +638,8 @@ TYPED_TEST(SubIntSplitEncodingTest, ZipfianRoundTrip) {
 
   const auto encoded =
       encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
-  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  const auto captured = nimble::EncodingLayoutCapture::capture(
+      encoded, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
 
   const auto decoded = decodeAll<T>(encoded, *this->pool_);

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -62,6 +62,37 @@ std::vector<T> makeStructuredValues() {
   return values;
 }
 
+// 300 values with a constant high prefix and a low-cardinality, non-monotonic
+// low section (cycling through 5 distinct values). Unlike
+// makeStructuredValues's unit-step low section -- which plain Delta already
+// encodes optimally as a single, unsplit stream -- this low section is not
+// monotonic, so encoding the full value directly is comparatively expensive
+// and splitting off the constant high prefix (leaving a cheap
+// Dictionary/MainlyConstant-friendly low segment) is unambiguously smaller.
+// Used to exercise SubIntSplit's multi-segment capture/replay path
+// independent of any single candidate's cost-model tuning.
+template <typename T>
+std::vector<T> makeStructuredValuesWithLowCardinalityNoise() {
+  std::vector<T> values;
+  values.reserve(300);
+
+  UnsignedPhysicalType<T> prefix{};
+  if constexpr (sizeof(PhysicalType<T>) == 4) {
+    prefix = static_cast<UnsignedPhysicalType<T>>(0x12340000u);
+  } else {
+    prefix = static_cast<UnsignedPhysicalType<T>>(0x1234567890000000ULL);
+  }
+
+  constexpr UnsignedPhysicalType<T> kLowValues[] = {3, 7, 1, 9, 3, 3, 5, 3};
+  for (size_t i = 0; i < 300; ++i) {
+    const auto bits = static_cast<UnsignedPhysicalType<T>>(
+        prefix + kLowValues[i % 8]);
+    values.push_back(std::bit_cast<T>(bits));
+  }
+
+  return values;
+}
+
 // 300 values whose unsigned physical representation is strictly
 // monotonically increasing with a constant, wide step (so consecutive
 // values' low-order bit-range segments are also roughly monotonic with a
@@ -407,7 +438,7 @@ TYPED_TEST_CASE(SubIntSplitEncodingTest, SubIntSplitEncodingTypes);
 
 TYPED_TEST(SubIntSplitEncodingTest, recomputeRoundTripAndReplay) {
   using T = TypeParam;
-  const auto values = makeStructuredValues<T>();
+  const auto values = makeStructuredValuesWithLowCardinalityNoise<T>();
 
   const auto encoded =
       encodeWithNonRecursiveSubIntSplit<T>(values, *this->buffer_);

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -222,14 +222,16 @@ class ExtendedSubIntSplitPolicy final
  public:
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::SubIntSplit};
   }
 
   nimble::EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::Nullable};
   }
 
@@ -237,8 +239,8 @@ class ExtendedSubIntSplitPolicy final
       nimble::EncodingType encodingType,
       nimble::NestedEncodingIdentifier identifier,
       nimble::DataType type) override {
-    auto readFactors =
-        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    auto readFactors = nimble::ManualEncodingSelectionPolicyFactory::
+        defaultEncodingReadFactors();
     readFactors.erase(
         std::remove_if(
             readFactors.begin(),
@@ -528,7 +530,8 @@ TEST(SubIntSplitEncodingTests, fullWidthSingleSectionRoundTrip) {
 
 TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren) {
   nimble::ManualEncodingSelectionPolicy<uint64_t> policy{
-      nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      nimble::ManualEncodingSelectionPolicyFactory::
+          defaultEncodingReadFactors(),
       std::nullopt,
       std::nullopt};
 

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -85,8 +85,8 @@ std::vector<T> makeStructuredValuesWithLowCardinalityNoise() {
 
   constexpr UnsignedPhysicalType<T> kLowValues[] = {3, 7, 1, 9, 3, 3, 5, 3};
   for (size_t i = 0; i < 300; ++i) {
-    const auto bits = static_cast<UnsignedPhysicalType<T>>(
-        prefix + kLowValues[i % 8]);
+    const auto bits =
+        static_cast<UnsignedPhysicalType<T>>(prefix + kLowValues[i % 8]);
     values.push_back(std::bit_cast<T>(bits));
   }
 
@@ -142,7 +142,7 @@ std::vector<T> makeZipfianValues() {
   };
   push(0, 1, 256); // 512 values
   push(0, 2, 128); // 256 values
-  push(0, 3, 64);  // 128 values
+  push(0, 3, 64); // 128 values
   for (uint64_t j = 4; j < 36; ++j) {
     push(0, j, 1); // 64 values
   }
@@ -565,7 +565,9 @@ TEST(SubIntSplitEncodingTests, fullWidthSingleSectionRoundTrip) {
   expectBitwiseEqual(values, decoded);
 }
 
-TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren) {
+TEST(
+    SubIntSplitEncodingTests,
+    CreateImplExtendsCandidatesForSubIntSplitChildren) {
   nimble::ManualEncodingSelectionPolicy<uint64_t> policy{
       nimble::ManualEncodingSelectionPolicyFactory::
           defaultEncodingReadFactors(),
@@ -623,8 +625,7 @@ TYPED_TEST(SubIntSplitEncodingTest, ExtendedCandidatesRoundTrip) {
   using T = TypeParam;
   const auto values = makeStructuredValues<T>();
 
-  const auto encoded =
-      encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
+  const auto encoded = encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
   const auto captured = nimble::EncodingLayoutCapture::capture(
       encoded, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
@@ -642,8 +643,7 @@ TYPED_TEST(SubIntSplitEncodingTest, WideRangeMonotonicRoundTrip) {
   using T = TypeParam;
   const auto values = makeWideRangeMonotonicValues<T>();
 
-  const auto encoded =
-      encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
+  const auto encoded = encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
   const auto captured = nimble::EncodingLayoutCapture::capture(
       encoded, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
@@ -667,8 +667,7 @@ TYPED_TEST(SubIntSplitEncodingTest, ZipfianRoundTrip) {
   using T = TypeParam;
   const auto values = makeZipfianValues<T>();
 
-  const auto encoded =
-      encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
+  const auto encoded = encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
   const auto captured = nimble::EncodingLayoutCapture::capture(
       encoded, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -216,10 +216,19 @@ std::string_view encodeWithNonRecursiveSubIntSplit(
 // candidate list with PFOR / SimdForBitpack / BlockBitPacking.
 template <typename T>
 class ExtendedSubIntSplitPolicy final
-    : public nimble::EncodingSelectionPolicy<T> {
+    : public nimble::ManualEncodingSelectionPolicy<T> {
   using physicalType = typename nimble::TypeTraits<T>::physicalType;
 
  public:
+  // ManualEncodingSelectionPolicy::createImpl() is protected, so its
+  // special-cased SubIntSplit child candidates can only be exercised by
+  // inheriting it (rather than delegating to a sibling instance).
+  ExtendedSubIntSplitPolicy()
+      : nimble::ManualEncodingSelectionPolicy<T>(
+            filteredReadFactors(),
+            std::nullopt,
+            std::nullopt) {}
+
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
       const nimble::Statistics<physicalType>& /* statistics */,
@@ -235,10 +244,9 @@ class ExtendedSubIntSplitPolicy final
     return {.encodingType = nimble::EncodingType::Nullable};
   }
 
-  std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
-      nimble::EncodingType encodingType,
-      nimble::NestedEncodingIdentifier identifier,
-      nimble::DataType type) override {
+ private:
+  static std::vector<std::pair<nimble::EncodingType, float>>
+  filteredReadFactors() {
     auto readFactors = nimble::ManualEncodingSelectionPolicyFactory::
         defaultEncodingReadFactors();
     readFactors.erase(
@@ -249,9 +257,7 @@ class ExtendedSubIntSplitPolicy final
               return factor.first == nimble::EncodingType::SubIntSplit;
             }),
         readFactors.end());
-    nimble::ManualEncodingSelectionPolicy<T> delegate{
-        std::move(readFactors), std::nullopt, std::nullopt};
-    return delegate.createImpl(encodingType, identifier, type);
+    return readFactors;
   }
 };
 

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -92,6 +92,36 @@ std::vector<T> makeWideRangeMonotonicValues() {
   return values;
 }
 
+// Typed Zipfian generator for SubIntSplitEncodingTest. Values 0..67 are small
+// enough to fit in any physicalType; bit_cast is used so the round-trip stays
+// bit-exact regardless of the logical type (int32_t, float, etc.).
+// Interleaved (0, j) pairs give monotonicCount ≈ 50%, keeping Delta cost
+// infinite so FrequencyPartition can win the DP cost model.
+template <typename T>
+std::vector<T> makeZipfianValues() {
+  std::vector<T> values;
+  values.reserve(1024);
+  auto push = [&](uint64_t a, uint64_t b, int count) {
+    for (int i = 0; i < count; ++i) {
+      values.push_back(
+          std::bit_cast<T>(static_cast<UnsignedPhysicalType<T>>(a)));
+      values.push_back(
+          std::bit_cast<T>(static_cast<UnsignedPhysicalType<T>>(b)));
+    }
+  };
+  push(0, 1, 256); // 512 values
+  push(0, 2, 128); // 256 values
+  push(0, 3, 64);  // 128 values
+  for (uint64_t j = 4; j < 36; ++j) {
+    push(0, j, 1); // 64 values
+  }
+  for (uint64_t j = 36; j < 68; ++j) {
+    push(0, j, 1); // 64 values
+  }
+  // Total: 512 + 256 + 128 + 64 + 64 = 1024
+  return values;
+}
+
 template <typename T>
 std::vector<nimble::detail::subintsplit::SegmentPlan> makePreserveSegments() {
   if constexpr (sizeof(PhysicalType<T>) == 4) {
@@ -526,6 +556,8 @@ TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren
       containsType(extendedFactors, nimble::EncodingType::BlockBitPacking));
   EXPECT_TRUE(containsType(extendedFactors, nimble::EncodingType::Delta));
   EXPECT_TRUE(containsType(extendedFactors, nimble::EncodingType::FOR));
+  EXPECT_TRUE(
+      containsType(extendedFactors, nimble::EncodingType::FrequencyPartition));
 
   // Children of a non-SubIntSplit node do not get the extended list.
   auto pforChild = policy.createImpl(
@@ -542,6 +574,8 @@ TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren
       containsType(unextendedFactors, nimble::EncodingType::BlockBitPacking));
   EXPECT_FALSE(containsType(unextendedFactors, nimble::EncodingType::Delta));
   EXPECT_FALSE(containsType(unextendedFactors, nimble::EncodingType::FOR));
+  EXPECT_FALSE(containsType(
+      unextendedFactors, nimble::EncodingType::FrequencyPartition));
 }
 
 TYPED_TEST(SubIntSplitEncodingTest, ExtendedCandidatesRoundTrip) {
@@ -576,6 +610,30 @@ TYPED_TEST(SubIntSplitEncodingTest, WideRangeMonotonicRoundTrip) {
 
   // Bounded size: the recursive candidate set must not blow up the encoding
   // beyond a small multiple of the raw data size.
+  const size_t rawSize = values.size() * sizeof(T);
+  EXPECT_LE(encoded.size(), rawSize * 4 + 1024);
+}
+
+// Zipfian-distributed data (FrequencyPartition as SubIntSplit segment
+// candidate, Phase C): a column with a dominant value (50% frequency) and a
+// long tail should round-trip bit-exactly through SubIntSplit with the
+// extended candidate set. The encoding size bound verifies that the
+// PerTierBitmaps index override in SubIntSplitEncoding::encode() does not
+// inflate the output beyond a reasonable multiple of the raw data.
+TYPED_TEST(SubIntSplitEncodingTest, ZipfianRoundTrip) {
+  using T = TypeParam;
+  const auto values = makeZipfianValues<T>();
+
+  const auto encoded =
+      encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
+  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
+
+  const auto decoded = decodeAll<T>(encoded, *this->pool_);
+  expectBitwiseEqual(values, decoded);
+
+  // Bounded size: FrequencyPartition with PerTierBitmaps adds index overhead
+  // but should still compress better than storing raw values.
   const size_t rawSize = values.size() * sizeof(T);
   EXPECT_LE(encoded.size(), rawSize * 4 + 1024);
 }

--- a/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -62,6 +62,36 @@ std::vector<T> makeStructuredValues() {
   return values;
 }
 
+// 300 values whose unsigned physical representation is strictly
+// monotonically increasing with a constant, wide step (so consecutive
+// values' low-order bit-range segments are also roughly monotonic with a
+// constant step). This is the data shape the Delta/FOR cost models
+// (SubIntSplitCostModelsTest.cpp's makeDeltaFriendlyValues/
+// makeForFriendlyValues) favor, exercised here end-to-end through the real
+// SubIntSplit segment-selection pipeline (B.4's extended candidate list).
+template <typename T>
+std::vector<T> makeWideRangeMonotonicValues() {
+  std::vector<T> values;
+  values.reserve(300);
+
+  UnsignedPhysicalType<T> base{};
+  UnsignedPhysicalType<T> step{};
+  if constexpr (sizeof(PhysicalType<T>) == 4) {
+    base = static_cast<UnsignedPhysicalType<T>>(0x10000000u);
+    step = static_cast<UnsignedPhysicalType<T>>(0x00010000u);
+  } else {
+    base = static_cast<UnsignedPhysicalType<T>>(0x1000000000000000ULL);
+    step = static_cast<UnsignedPhysicalType<T>>(0x0000000100000000ULL);
+  }
+
+  for (UnsignedPhysicalType<T> i = 0; i < 300; ++i) {
+    const auto bits = static_cast<UnsignedPhysicalType<T>>(base + i * step);
+    values.push_back(std::bit_cast<T>(bits));
+  }
+
+  return values;
+}
+
 template <typename T>
 std::vector<nimble::detail::subintsplit::SegmentPlan> makePreserveSegments() {
   if constexpr (sizeof(PhysicalType<T>) == 4) {
@@ -494,6 +524,8 @@ TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren
       containsType(extendedFactors, nimble::EncodingType::SimdForBitpack));
   EXPECT_TRUE(
       containsType(extendedFactors, nimble::EncodingType::BlockBitPacking));
+  EXPECT_TRUE(containsType(extendedFactors, nimble::EncodingType::Delta));
+  EXPECT_TRUE(containsType(extendedFactors, nimble::EncodingType::FOR));
 
   // Children of a non-SubIntSplit node do not get the extended list.
   auto pforChild = policy.createImpl(
@@ -508,6 +540,8 @@ TEST(SubIntSplitEncodingTests, CreateImplExtendsCandidatesForSubIntSplitChildren
       containsType(unextendedFactors, nimble::EncodingType::SimdForBitpack));
   EXPECT_FALSE(
       containsType(unextendedFactors, nimble::EncodingType::BlockBitPacking));
+  EXPECT_FALSE(containsType(unextendedFactors, nimble::EncodingType::Delta));
+  EXPECT_FALSE(containsType(unextendedFactors, nimble::EncodingType::FOR));
 }
 
 TYPED_TEST(SubIntSplitEncodingTest, ExtendedCandidatesRoundTrip) {
@@ -521,6 +555,29 @@ TYPED_TEST(SubIntSplitEncodingTest, ExtendedCandidatesRoundTrip) {
 
   const auto decoded = decodeAll<T>(encoded, *this->pool_);
   expectBitwiseEqual(values, decoded);
+}
+
+// Recursion-sanity test for Delta/FOR as SubIntSplit segment candidates
+// (B.4): a wide-range, constant-step monotonic column should round-trip
+// bit-exactly and produce a bounded encoding size, regardless of which
+// candidate (Delta, FOR, or another) each segment's encodeNested ends up
+// selecting.
+TYPED_TEST(SubIntSplitEncodingTest, WideRangeMonotonicRoundTrip) {
+  using T = TypeParam;
+  const auto values = makeWideRangeMonotonicValues<T>();
+
+  const auto encoded =
+      encodeWithExtendedSubIntSplit<T>(values, *this->buffer_);
+  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
+
+  const auto decoded = decodeAll<T>(encoded, *this->pool_);
+  expectBitwiseEqual(values, decoded);
+
+  // Bounded size: the recursive candidate set must not blow up the encoding
+  // beyond a small multiple of the raw data size.
+  const size_t rawSize = values.size() * sizeof(T);
+  EXPECT_LE(encoded.size(), rawSize * 4 + 1024);
 }
 
 #endif


### PR DESCRIPTION
## Summary

Migrates [facebookincubator/nimble#880](https://github.com/facebookincubator/nimble/pull/880) to this repo following Nimble's move into Velox ([#18468](https://github.com/facebookincubator/velox/pull/18468)). Also separates SubIntSplit cost model changes from SubIntSplit selection integration changes from closed PR #18578.

- Extends `SubIntSplit`'s cost-model-based segment selection to consider `BlockBitPacking`, PFOR, SIMDBitpacking, Delta, FOR, and FreqPart as candidate segment encodings, each backed by a statistics-only `estimateSize` overload usable without materializing raw values.
- Extends tracked segment metrics (bit-width histogram, monotonic counter, absolute delta) and `SubIntSplitCostModels` to score these candidates.
- Adds Huffman and DeltaBlock cost models for segment selection.
- Extends `ManualEncodingSelectionPolicy` and the `SubIntSplitEncoding`/`SubIntSplitCostModels` test suites to cover the new candidates.

## Preliminary Cost Model Accuracy Results

Manual spot-check comparing each cost model's predicted size against the real `encode()`-produced size on representative synthetic patterns:

| Encoding | Predicted vs. actual | Notes | Updated Predicted vs. actual | New Notes
|---|---|---|---|---|
| DeltaBlock | **0% error** | Exact as it delegates directly to `DeltaBlockEncoding::estimateSize`'s real block-boundary walk | N/A | Not touched
| Huffman | **+5% to +18%** | Conservative overestimate, directionally correct, never selection-flipping | N/A | Not touched
| Constant, Trivial, Varint, PFOR | 0% to -7% | Accurate | N/A | Not touched
| FOR | -11% | Underestimate | N/A | Not touched
| MainlyConstant | +32% | Overestimate | +4.7% | Accurate (See below for changes)
| RLE | -36% | Underestimate | N/A | Not touched
| FixedBitWidth | -37% | Underestimate | N/A | Not touched
| Delta | -46% | Underestimate | +24.6% | Overestimate (See below for changes)
| Dictionary | **-74%** | Underestimate | +3.2% | Accurate (See below for changes)
| FrequencyPartition | **-87%** | Underestimate | +29.7% | Overestimate (See below for changes)

Dictionary and FrequencyPartition could both be improved further through the exact bit cost introduced by [facebookincubator/nimble#1023](https://github.com/facebookincubator/nimble/pull/1023) which has not been closed nor migrated to the velox repo yet.

Additionally, further refinement of these cost models is best done through the cost model accuracy microbenchmark driver being introduced by #18577 .

## Refinements and Selection-Time Preliminary Results

### Estimation-accuracy results Notes

**Per-encoding notes:**
- **MainlyConstant, Dictionary**: close to the canonical estimator's accuracy floor now as both delegate directly to `FixedBitWidthEncoding`/`SparseBoolEncoding`/`TrivialEncoding::estimateSize`.
- **Delta**: two residual gaps remain: (1) neither the SIS proxy nor the canonical `DeltaEncoding::estimateSize` model that the `deltas` sub-stream is itself nested-selected (e.g. a low-cardinality delta distribution might pick Dictionary instead of FixedBitWidth); (2) same for the `restatements` stream if restatement *values* (not just positions) are low-cardinality/repeating.
- **FrequencyPartition**: still overestimates by ~30% even after the tier-count fix; likely the same tier-occupancy-proxy gap flagged earlier (`topKCoverage` top-1/2/4/8 buckets vs. the real tier boundaries at capacities 2/4/16/256/...) along with exact bit cost not being accounted for.

### Selection-time preliminary results

Measured with the stacked integration draft PR applied on top of this branch as nimble_subint_split_benchmark's CMake target isn't registered on this branch alone.

Encode-time impact of adding Huffman / DeltaBlock / FrequencyPartition as DP
candidates (`NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS` off vs on), measured with
`nimble_subint_split_benchmark` (`SubIntSplitBenchmark.cpp`). **Single run per
config, not averaged across repetitions** so treat as directional, not final.

- Sample size: 100,000 synthetic `uint64_t` values per data pattern (`kNumElements`, `BenchmarkUtils.h`)
- Patterns: 7 (bit-structured, random, narrow, constant, mainly-constant, low-cardinality)
- Build: `VELOX_BUILD_MINIMAL_WITH_DWIO=ON`, Debug, scoped local build

#### Results

| Pattern | Before (candidates off, 7 total) | After (+Huffman/DeltaBlock/FPE, 10 total) | Δ time |
|---|---:|---:|---:|
| BitStructured16 | 2.64 s | 3.13 s | **+18.6%** |
| BitStructured32 | 5.08 s | 5.89 s | **+15.9%** |
| Random | 7.05 s | 7.85 s | **+11.3%** |
| Narrow16bit | 2.63 s | 3.10 s | **+17.9%** |
| Constant | 1.38 s | 1.38 s | +0.0% |
| MainlyConstant | 2.41 s | 2.37 s | -1.7% (noise) |
| LowCardinality1024 | 1.58 s | 1.61 s | +1.9% |

**Takeaway:** patterns where the extra candidates are actually evaluated by
the DP (BitStructured*, Random, Narrow16bit) see a consistent **~12-19%**
encode-time increase. Patterns that short-circuit early via existing guards
(Constant, MainlyConstant, LowCardinality1024) show no meaningful change.

#### Possible shortcuts to reduce encode/selection time

- **Branch-and-bound pruning**: compute a cheap lower bound per candidate
  (e.g. header-only cost) before doing the full formula, and skip candidates
  whose lower bound already exceeds the current best.
- **Tighten existing cardinality/coverage guards**: FPE's `uniqueCount > 1024`
  and Huffman's low-cardinality gate already skip expensive candidates for
  unfavourable data, so consider adding similar cheap pre-checks for
  DeltaBlock/PFOR before the DP evaluates them per bit-range.
- **Memoise `SegmentMetrics` across overlapping bit-ranges**: the DP's
  `O(kBits^2)` grid currently recomputes stats per bit-range from scratch;
  overlapping ranges could share partial sums (e.g. prefix-sum style) instead
  of a fresh `MetricCollector::compute()` pass each time.
- **Parallelize the grid search**: the `O(kBits^2)` cost evaluations across
  bit-range candidates are independent and could be evaluated concurrently.