### PR TITLE
misc(nimble): Delete the write-only flat map value stream offset collector (#18818)

### DIFF
--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -600,10 +600,6 @@ class WriterStreamContext : public StreamContext {
     isInMapStream_ = value;
   }
 
-  void setFlatMapValueStreamOffsets(std::vector<offset_size> offsets) {
-    flatMapValueStreamOffsets_ = std::move(offsets);
-  }
-
   // The layout to replay for this stream: overlaid from the EncodingLayoutTree
   // at setup, or captured from this stream's first encode when
   // encoding-selection caching is enabled. Empty until one of those populates
@@ -641,10 +637,6 @@ class WriterStreamContext : public StreamContext {
  private:
   bool isNullStream_{false};
   bool isInMapStream_{false};
-  // Value stream descriptor offsets for this in-map stream's flat-map field.
-  // Empty for non in-map streams and flat-map values with no reader-visible
-  // value stream.
-  std::vector<offset_size> flatMapValueStreamOffsets_;
   std::optional<EncodingLayout> encoding_;
   std::optional<SharedDictionaryConfig> sharedDictionaryConfig_;
   mutable std::unique_ptr<SharedDictionaryWriter> sharedDictionaryWriter_;
@@ -1247,63 +1239,6 @@ void findNodeIds(
   }
 }
 
-void collectFlatMapValueStreamOffsets(
-    const TypeBuilder& type,
-    std::vector<offset_size>& offsets) {
-  switch (type.kind()) {
-    case Kind::Scalar:
-      offsets.push_back(type.asScalar().scalarDescriptor().offset());
-      return;
-    case Kind::TimestampMicroNano:
-      offsets.push_back(
-          type.asTimestampMicroNano().microsDescriptor().offset());
-      offsets.push_back(type.asTimestampMicroNano().nanosDescriptor().offset());
-      return;
-    case Kind::Array:
-      offsets.push_back(type.asArray().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asArray().elements(), offsets);
-      return;
-    case Kind::ArrayWithOffsets:
-      offsets.push_back(type.asArrayWithOffsets().offsetsDescriptor().offset());
-      offsets.push_back(type.asArrayWithOffsets().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asArrayWithOffsets().elements(), offsets);
-      return;
-    case Kind::Map:
-      offsets.push_back(type.asMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(type.asMap().values(), offsets);
-      return;
-    case Kind::SlidingWindowMap:
-      offsets.push_back(type.asSlidingWindowMap().offsetsDescriptor().offset());
-      offsets.push_back(type.asSlidingWindowMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().values(), offsets);
-      return;
-    case Kind::Row: {
-      const auto& row = type.asRow();
-      offsets.push_back(row.nullsDescriptor().offset());
-      for (size_t i = 0; i < row.childrenCount(); ++i) {
-        collectFlatMapValueStreamOffsets(row.childAt(i), offsets);
-      }
-      return;
-    }
-    case Kind::FlatMap: {
-      const auto& flatMap = type.asFlatMap();
-      offsets.push_back(flatMap.nullsDescriptor().offset());
-      for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-        offsets.push_back(flatMap.inMapDescriptorAt(i).offset());
-        collectFlatMapValueStreamOffsets(flatMap.childAt(i), offsets);
-      }
-      return;
-    }
-    default:
-      NIMBLE_UNREACHABLE("Unsupported type kind {}", type.kind());
-  }
-}
-
 FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodingsForFlatMap(
     const EncodingLayoutTree& encodingLayoutTree) {
   FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodings;
@@ -1737,9 +1672,6 @@ void configureAddedFlatMapField(
   auto& inMapContext = streamContext(
       flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1));
   inMapContext.setIsInMapStream(true);
-  std::vector<offset_size> valueStreamOffsets;
-  collectFlatMapValueStreamOffsets(fieldType, valueStreamOffsets);
-  inMapContext.setFlatMapValueStreamOffsets(std::move(valueStreamOffsets));
 
   auto* flatMapContext = flatmap.context<FlatmapEncodingLayoutContext>();
   if (flatMapContext == nullptr) {


### PR DESCRIPTION
Summary:

`collectFlatMapValueStreamOffsets()` is called -- exactly once, from
`configureAddedFlatMapField()` -- but its result is never read. The chain is
write-only: the collector fills a vector, `setFlatMapValueStreamOffsets()`
stores it into `flatMapValueStreamOffsets_`, and nothing ever consults the
member. There is no getter. Its two sibling fields, `isNullStream_` and
`isInMapStream_`, each have one.

Four pieces go, all in `Writer.cpp`: the call site (`:1747-1749`), the
recursive collector (`:1257-1312`), the setter (`:610-612`), and the member
(`:651-654`). The line count is dominated by the collector, which is a single
walk with a case per `Kind`.

They are residue from `D115579176 ("[velox] perf(nimble): Reduce index
projector slice overhead")`, which hit a flat map in-map bug, drafted a writer
fix, dropped it as out of scope, and left the plumbing behind.

Removing it is not just tidying. The helper is a plausible-looking answer to
"which streams belong to this flat map value", and it is the wrong one: its
walk is a strict superset of `visitValueStreamLeaves()`, the traversal the
readers actually use to decide whether a key has data in a stripe. It includes
a Row's nulls descriptor -- which `visitValueStreamLeaves()` deliberately
excludes, per its own comment, "Row's own nulls stream may be omitted by the
writer, so it is not a reliable anchor" -- and descends into array elements
where the reader stops at lengths.

Anything that reasons about stream omission from this set would count bytes the
reader never inspects. That is a live hazard: the next change in this area is
likely to reach for it by name.

Safe by construction: all four live inside the anonymous namespace spanning
`Writer.cpp:270-1774`, so they have internal linkage and cannot be named from
another translation unit. `WriterStreamContext`, which owns the member, matches
in exactly one file repo-wide. None was ever declared in a header.

Differential Revision: D118067831


