### PR TITLE
fix: Align Spark string cast trimming with Spark semantics

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -40,6 +40,17 @@ behavior for supported cast pairs regardless of the session ANSI setting.
 ``spark_legacy_cast`` applies non-ANSI Spark cast behavior regardless of the
 session ANSI setting.
 
+String boundary trimming
+------------------------
+
+Spark-compatible casts trim leading and trailing string bytes before parsing,
+but the exact trim set depends on the target type. Casts to integral types,
+BOOLEAN, DATE, TIMESTAMP, TIMESTAMP_NTZ, and TIME use Spark UTF8String-style
+trimming, which removes boundary bytes ``0x00`` through ``0x20`` and ``0x7F``.
+Casts to REAL, DOUBLE, and DECIMAL use Java ``String.trim``-style trimming,
+which removes boundary characters ``<= U+0020``. Unicode spaces such as
+``U+2000`` are not trimmed by either path.
+
 Cast from UNKNOWN Type
 ----------------------
 
@@ -101,6 +112,9 @@ Casting a string to an integral type is allowed if the string represents a numbe
 Casting from strings that represent floating-point numbers truncates the
 decimal part of the input value when ANSI mode is disabled; throws an
 error otherwise.
+
+Leading and trailing string bytes are trimmed using Spark UTF8String-style
+trimming before parsing.
 
 Casting from other invalid strings returns NULL when ANSI mode is disabled;
 throws an error otherwise.
@@ -196,6 +210,8 @@ target type produce ``Infinity`` rather than an error, matching Spark.
 
 Casting from invalid strings returns NULL when ANSI mode is disabled; throws an
 error otherwise.
+Leading and trailing string characters are trimmed using Java
+``String.trim``-style trimming before parsing.
 
 Valid examples
 
@@ -230,6 +246,8 @@ The strings `t, f, y, n, 1, 0, yes, no, true, false` and their upper case
 equivalents are allowed to be cast to boolean.
 Casting from invalid strings throws an error when ANSI mode is enabled,
 or returns NULL when ANSI mode is disabled.
+Leading and trailing string bytes are trimmed using Spark UTF8String-style
+trimming before parsing.
 
 Valid examples
 
@@ -350,7 +368,8 @@ For the last two patterns, the trailing ``*`` can represent none or any sequence
   * "1970-01-01 123"
   * "1970-01-01 (BC)"
 
-All leading and trailing UTF8 white-spaces will be trimmed before cast.
+Leading and trailing string bytes are trimmed using Spark UTF8String-style
+trimming before cast.
 
 When ANSI mode is enabled, casting from invalid input values throws an error.
 When ANSI mode is disabled, casting from invalid input values returns NULL.
@@ -414,7 +433,8 @@ Supported format is ``H:m[:s[.SSSSSS]]`` where:
   * ``s`` is an optional second (0-59); omitted seconds default to zero
   * ``SSSSSS`` is optional fractional seconds (0-999999, up to microseconds)
 
-All leading and trailing UTF8 white-spaces are trimmed before casting.
+Leading and trailing string bytes are trimmed using Spark UTF8String-style
+trimming before casting.
 Velox represents Spark ``TIME`` using ``TIME MICRO UTC``, whose values are
 stored as microseconds since midnight (0 to 86,399,999,999).
 
@@ -452,7 +472,8 @@ From varchar
 *(ANSI compliant)*
 
 Casting varchar to a decimal of given precision and scale is allowed.
-The behavior is similar with Presto except Spark allows leading and trailing white-spaces in input varchars.
+The behavior is similar with Presto except Spark allows leading and trailing
+characters trimmed by Java ``String.trim`` in input varchars.
 
 When ANSI mode is enabled, casting from an invalid input value or a value that
 overflows the target precision and scale throws an error. Otherwise, such casts
@@ -695,8 +716,9 @@ Casting from strings to timestamp uses Spark-compatible timestamp parsing.
 The parser accepts date-only values, both ``' '`` and ``'T'`` as date-time
 separators, fractional seconds, and leading or trailing spaces. Both ``' '``
 and ``'T'`` date-time separators must be followed immediately by a digit.
-Outer whitespace is trimmed before the parser runs, so a bare trailing
-separator such as ``"2015-03-18 "`` is handled as a date-only value.
+Leading and trailing string bytes are trimmed using Spark UTF8String-style
+trimming before the parser runs, so a bare trailing separator such as
+``"2015-03-18 "`` is handled as a date-only value.
 
 Casting from invalid strings returns NULL when ANSI mode is disabled and throws
 an error when ANSI mode is enabled.
@@ -778,7 +800,8 @@ Casting a string to timestamp_utc parses the input as a local timestamp,
 not subject to session timezone adjustment.
 Any timezone suffix in the string is accepted but ignored — only the
 parsed timestamp is stored.
-Leading and trailing whitespace is stripped before parsing.
+Leading and trailing string bytes are trimmed using Spark UTF8String-style
+trimming before parsing.
 
 Valid examples
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -233,7 +233,8 @@ void CastExpr::applyCastKernel(
       if constexpr (
           TypeTraits<ToKind>::isPrimitiveType &&
           TypeTraits<ToKind>::isFixedWidth) {
-        inputRowValue = hooks_->removeWhiteSpaces(inputRowValue);
+        inputRowValue =
+            hooks_->removeWhiteSpaces(inputRowValue, *result->type());
         if (inputRowValue.size() == 0) {
           setError("Empty string");
           return;
@@ -410,7 +411,7 @@ void CastExpr::applyVarcharToDecimalCastKernel(
   rows.applyToSelected([&](auto row) {
     T decimalValue;
     const auto status = DecimalUtil::castFromString<T>(
-        hooks_->removeWhiteSpaces(sourceVector->valueAt(row)),
+        hooks_->removeWhiteSpaces(sourceVector->valueAt(row), *toType),
         toPrecisionScale.first,
         toPrecisionScale.second,
         decimalValue);

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -514,7 +514,7 @@ VectorPtr CastExpr::castToTime(
       applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
         bool wrapException = true;
         const auto inputString =
-            hooks_->removeWhiteSpaces(inputVector->valueAt(row));
+            hooks_->removeWhiteSpaces(inputVector->valueAt(row), *toType);
         const auto result =
             hooks_->castStringToTime(inputString, timeZone, sessionStartTimeMs);
         setResultOrError(

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -30,6 +30,10 @@ namespace facebook::velox::tz {
 class TimeZone;
 }
 
+namespace facebook::velox {
+class Type;
+}
+
 namespace facebook::velox::exec {
 
 enum PolicyType {
@@ -110,8 +114,10 @@ class CastHooks {
   /// removeWhiteSpaces.
   virtual Expected<double> castStringToDouble(const StringView& data) const = 0;
 
-  /// Trims all leading and trailing UTF8 whitespaces.
-  virtual StringView removeWhiteSpaces(const StringView& view) const = 0;
+  /// Trims leading and trailing whitespaces for string casts to 'toType'.
+  virtual StringView removeWhiteSpaces(
+      const StringView& view,
+      const Type& toType) const = 0;
 
   /// Returns the options to cast from timestamp to string.
   virtual const TimestampToStringOptions& timestampToStringOptions() const = 0;

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -167,7 +167,9 @@ Expected<double> PrestoCastHooks::castStringToDouble(
   return doCastToFloatingPoint<double>(data);
 }
 
-StringView PrestoCastHooks::removeWhiteSpaces(const StringView& view) const {
+StringView PrestoCastHooks::removeWhiteSpaces(
+    const StringView& view,
+    const Type& /*toType*/) const {
   return view;
 }
 

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -58,7 +58,8 @@ class PrestoCastHooks : public CastHooks {
   Expected<double> castStringToDouble(const StringView& data) const override;
 
   // Returns the input as is.
-  StringView removeWhiteSpaces(const StringView& view) const override;
+  StringView removeWhiteSpaces(const StringView& view, const Type& toType)
+      const override;
 
   // Returns cast options following 'isLegacyCast' and session timezone.
   const TimestampToStringOptions& timestampToStringOptions() const override;

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/expression/StringWriter.h"
 #include "velox/external/md5/md5.h"
 #include "velox/functions/lib/Utf8Utils.h"
 #include "velox/functions/lib/string/StringCore.h"
@@ -529,21 +530,11 @@ trimAscii(TOutString& output, const TInString& input, TShouldTrim shouldTrim) {
   output.setNoCopy(StringView(start, curPos - start + 1));
 }
 
-template <
-    bool leftTrim,
-    bool rightTrim,
-    typename TOutString,
-    typename TInString>
+template <bool leftTrim, bool rightTrim, typename TInString>
 FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
-    TOutString& output,
+    exec::StringWriter& output,
     const TInString& input) {
-  auto emptyOutput = [&]() {
-    if constexpr (std::is_same_v<TOutString, StringView>) {
-      output = StringView("");
-    } else {
-      output.setEmpty();
-    }
-  };
+  auto emptyOutput = [&]() { output.setEmpty(); };
   if (input.empty()) {
     emptyOutput();
     return;
@@ -592,11 +583,7 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
   }
 
   auto view = StringView(stringStart, endIndex - startIndex + 1);
-  if constexpr (std::is_same_v<TOutString, StringView>) {
-    output = view;
-  } else {
-    output.setNoCopy(view);
-  }
+  output.setNoCopy(view);
 }
 
 template <bool ascii, typename TOutString, typename TInString>

--- a/velox/functions/sparksql/specialforms/CMakeLists.txt
+++ b/velox/functions/sparksql/specialforms/CMakeLists.txt
@@ -31,6 +31,7 @@ velox_add_library(
   MakeDecimal.h
   SparkCastExpr.h
   SparkCastHooks.h
+  SparkCastStringTrim.h
 )
 
 velox_link_libraries(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -20,9 +20,9 @@
 #include <exception>
 
 #include "velox/common/base/VeloxException.h"
-#include "velox/functions/lib/string/StringImpl.h"
 #include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/TimestampUtils.h"
+#include "velox/functions/sparksql/specialforms/SparkCastStringTrim.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -167,7 +167,7 @@ Expected<int32_t> SparkCastHooks::castStringToDate(
   //   "1970-01-01 123"
   //   "1970-01-01 (BC)"
   return util::fromDateString(
-      removeWhiteSpaces(dateString), util::ParseMode::kSparkCast);
+      removeWhiteSpaces(dateString, *DATE()), util::ParseMode::kSparkCast);
 }
 
 Expected<int64_t> SparkCastHooks::castStringToTime(
@@ -192,11 +192,10 @@ Expected<double> SparkCastHooks::castStringToDouble(
   return util::Converter<TypeKind::DOUBLE>::tryCast(data);
 }
 
-StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
-  StringView output;
-  stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(
-      output, view);
-  return output;
+StringView SparkCastHooks::removeWhiteSpaces(
+    const StringView& view,
+    const Type& toType) const {
+  return trimStringForCast(view, toType);
 }
 
 void SparkCastHooks::castDateTimestampToGMT(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -70,10 +70,9 @@ class SparkCastHooks : public exec::CastHooks {
   // strings with different letter cases to double.
   Expected<double> castStringToDouble(const StringView& data) const override;
 
-  /// When casting from string to integral, floating-point, decimal, date, and
-  /// timestamp types, Spark hook trims all leading and trailing UTF8
-  /// whitespaces before cast.
-  StringView removeWhiteSpaces(const StringView& view) const override;
+  /// Matches Spark string cast trim semantics for casts to 'toType'.
+  StringView removeWhiteSpaces(const StringView& view, const Type& toType)
+      const override;
 
   // Supports Spark boolean to timestamp cast.
   Expected<Timestamp> castBooleanToTimestamp(bool seconds) const override;

--- a/velox/functions/sparksql/specialforms/SparkCastStringTrim.h
+++ b/velox/functions/sparksql/specialforms/SparkCastStringTrim.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "velox/type/StringView.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace detail {
+
+// Spark UTF8String.trimAll trims boundary bytes 0x00..0x20 and 0x7F.
+inline bool isUtf8StringTrimAllByte(char value) {
+  const auto byte = static_cast<uint8_t>(value);
+  return byte <= 0x20 || byte == 0x7F;
+}
+
+// Java String.trim trims boundary characters <= U+0020.
+inline bool isJavaStringTrimByte(char value) {
+  return static_cast<uint8_t>(value) <= 0x20;
+}
+
+template <typename TShouldTrim>
+inline StringView trimBytes(const StringView& view, TShouldTrim shouldTrim) {
+  if (view.empty()) {
+    return StringView("");
+  }
+
+  const auto* data = view.data();
+  size_t start = 0;
+  size_t end = view.size();
+
+  while (start < end && shouldTrim(data[start])) {
+    ++start;
+  }
+
+  if (start >= end) {
+    return StringView("");
+  }
+
+  while (end > start && shouldTrim(data[end - 1])) {
+    --end;
+  }
+
+  return StringView(data + start, end - start);
+}
+
+inline StringView trimUtf8StringAll(const StringView& view) {
+  return trimBytes(view, isUtf8StringTrimAllByte);
+}
+
+inline StringView trimJavaString(const StringView& view) {
+  return trimBytes(view, isJavaStringTrimByte);
+}
+
+} // namespace detail
+
+// Keep these target-type-specific rules in sync with Spark. Spark currently
+// uses UTF8String-style trimming for most casts but Java String.trim for
+// floating point and decimal casts. See
+// https://issues.apache.org/jira/browse/SPARK-59182.
+inline StringView trimStringForCast(
+    const StringView& view,
+    const Type& toType) {
+  if (toType.isDecimal() || toType.kind() == TypeKind::REAL ||
+      toType.kind() == TypeKind::DOUBLE) {
+    return detail::trimJavaString(view);
+  }
+
+  return detail::trimUtf8StringAll(view);
+}
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -926,12 +926,28 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
         DATE());
     testCast<std::string, float>(
         "real", {"\n\f\r\t\n\u001F 123.0\u000B\u001C\u001D\u001E"}, {123.0});
+    testCast<std::string, float>(
+        "real",
+        {std::string(
+            "\0"
+            "123.0\0",
+            7)},
+        {123.0});
     testCast<std::string, double>(
         "double", {"\n\f\r\t\n\u001F 123.0\u000B\u001C\u001D\u001E"}, {123.0});
+    testCast<std::string, double>(
+        "double",
+        {std::string(
+            "\0"
+            "123.0\0",
+            7)},
+        {123.0});
     testCast<std::string, Timestamp>(
         "timestamp",
         {"\n\f\r\t\n\u001F 2000-01-01 12:21:56\u000B\u001C\u001D\u001E"},
         {Timestamp(946729316, 0)});
+    testCast<std::string, bool>(
+        "boolean", {std::string("\0true\x7F", 6)}, {true});
     testCast(
         makeFlatVector<StringView>(
             {" 9999999999.99",
@@ -948,6 +964,12 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
              -30000,
              -30000},
             DECIMAL(12, 2)));
+    testCast<std::string, int64_t>(
+        "decimal(12, 2)",
+        {std::string("\0-3E+2\0", 7)},
+        {-30000},
+        VARCHAR(),
+        DECIMAL(12, 2));
   }
 
   void testPrimitiveValidCornerCases() {
@@ -956,6 +978,12 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
       // Valid strings.
       testCast<std::string, int8_t>("tinyint", {"+1"}, {1});
       testCast<std::string, int8_t>("tinyint", {"-1"}, {-1});
+      testCast<std::string, int32_t>(
+          "integer",
+          {std::string("123\0", 4),
+           std::string("\0-456\0", 6),
+           std::string("789\x7F", 4)},
+          {123, -456, 789});
 
       testCast<double, int8_t>("tinyint", {127.1}, {127});
 
@@ -1761,6 +1789,37 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
   }
 
   template <typename T>
+  void testStringCastNoTrimInvalidAcrossModes(
+      const std::string& typeString,
+      const TypePtr& toType,
+      const std::vector<std::optional<std::string>>& values) {
+    setAnsiSupport(true);
+    for (const auto& value : values) {
+      SCOPED_TRACE(value.value_or("<null>"));
+      auto input = makeRowVector(
+          {makeNullableFlatVector<std::string>({value}, VARCHAR())});
+      VELOX_ASSERT_THROW(
+          evaluate(fmt::format("cast(c0 as {})", typeString), input),
+          "Cannot cast");
+    }
+
+    auto input = makeRowVector({makeNullableFlatVector(values, VARCHAR())});
+    auto expected = makeNullableFlatVector<T>(
+        std::vector<std::optional<T>>(values.size(), std::nullopt), toType);
+
+    setAnsiSupport(false);
+    assertEqualVectors(
+        expected, evaluate(fmt::format("cast(c0 as {})", typeString), input));
+
+    for (const auto ansiEnabled : {false, true}) {
+      setAnsiSupport(ansiEnabled);
+      assertEqualVectors(
+          expected,
+          evaluate(fmt::format("try_cast(c0 as {})", typeString), input));
+    }
+  }
+
+  template <typename T>
   void testDecimalToFloatCasts() {
     // short to short, scale up.
     auto shortFlat = makeNullableFlatVector<int64_t>(
@@ -1884,6 +1943,53 @@ TEST_F(SparkCastExprTest, legacyCastModeIgnoresSessionAnsiOn) {
   auto expected =
       makeNullableFlatVector<int32_t>({std::nullopt, 123}, INTEGER());
   assertEqualVectors(expected, result);
+}
+
+TEST_F(SparkCastExprTest, stringCastNoTrimInvalidAcrossModes) {
+  const auto enQuad = std::string("\xE2\x80\x80", 3);
+  const auto leadingEnQuad = [&](const std::string& value) {
+    return enQuad + value;
+  };
+  const auto trailingEnQuad = [&](const std::string& value) {
+    return value + enQuad;
+  };
+  const auto leadingDel = [](const std::string& value) {
+    return std::string("\x7F", 1) + value;
+  };
+  const auto trailingDel = [](const std::string& value) {
+    return value + std::string("\x7F", 1);
+  };
+
+  testStringCastNoTrimInvalidAcrossModes<int32_t>(
+      "integer", INTEGER(), {leadingEnQuad("123"), trailingEnQuad("123")});
+  testStringCastNoTrimInvalidAcrossModes<bool>(
+      "boolean", BOOLEAN(), {leadingEnQuad("true"), trailingEnQuad("true")});
+  testStringCastNoTrimInvalidAcrossModes<int32_t>(
+      "date", DATE(), {leadingEnQuad("2015-03-18")});
+  testStringCastNoTrimInvalidAcrossModes<Timestamp>(
+      "timestamp", TIMESTAMP(), {leadingEnQuad("2015-03-18 12:03:17")});
+
+  testStringCastNoTrimInvalidAcrossModes<float>(
+      "real",
+      REAL(),
+      {leadingDel("1.5"),
+       trailingDel("1.5"),
+       leadingEnQuad("1.5"),
+       trailingEnQuad("1.5")});
+  testStringCastNoTrimInvalidAcrossModes<double>(
+      "double",
+      DOUBLE(),
+      {leadingDel("1.5"),
+       trailingDel("1.5"),
+       leadingEnQuad("1.5"),
+       trailingEnQuad("1.5")});
+  testStringCastNoTrimInvalidAcrossModes<int64_t>(
+      "decimal(12, 2)",
+      DECIMAL(12, 2),
+      {leadingDel("1.23"),
+       trailingDel("1.23"),
+       leadingEnQuad("1.23"),
+       trailingEnQuad("1.23")});
 }
 
 // ============================================================================
@@ -2708,6 +2814,11 @@ TEST_F(SparkCastExprTestAnsiOff, primitiveInvalidCornerCase) {
         "bigint",
         {"abc", "+", "-", "  "},
         {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+    const auto enQuad = std::string("\xE2\x80\x80", 3);
+    testCast<std::string, int32_t>(
+        "integer",
+        {enQuad + "123", std::string("123") + enQuad},
+        {std::nullopt, std::nullopt});
 
     // Overflow cases.
     testCast<std::string, int8_t>(
@@ -3397,8 +3508,21 @@ TEST_F(SparkCastExprTestAnsiOff, varcharToDecimal) {
 
   // Interior whitespace stays invalid; leading/trailing cases are valid and
   // covered in testVarcharToDecimal().
+  const auto enQuad = std::string("\xE2\x80\x80", 3);
   testCast<std::string, int128_t>(
       "decimal(38, 0)", {"1. 23"}, {std::nullopt}, VARCHAR(), DECIMAL(38, 0));
+  testCast<std::string, int128_t>(
+      "decimal(38, 0)",
+      {std::string("1.23\x7F", 5)},
+      {std::nullopt},
+      VARCHAR(),
+      DECIMAL(38, 0));
+  testCast<std::string, int128_t>(
+      "decimal(38, 0)",
+      {enQuad + "1.23"},
+      {std::nullopt},
+      VARCHAR(),
+      DECIMAL(38, 0));
   testCast<std::string, int64_t>(
       "decimal(12, 2)", {"-3E+ 2"}, {std::nullopt}, VARCHAR(), DECIMAL(12, 2));
 
@@ -3613,6 +3737,18 @@ TEST_F(SparkCastExprTestAnsiOff, stringToRealDoubleInvalidReturnsNull) {
   // Invalid format strings return NULL in legacy (ANSI off) mode. Empty and
   // whitespace-only strings (trimmed to empty) return NULL as well.
   for (const auto& value : invalidStringToRealDoubleInputs()) {
+    SCOPED_TRACE(value);
+    testCast<std::string, float>("real", {value}, {std::nullopt});
+    testCast<std::string, double>("double", {value}, {std::nullopt});
+  }
+  {
+    const std::string value = std::string("1.5\x7F", 4);
+    SCOPED_TRACE(value);
+    testCast<std::string, float>("real", {value}, {std::nullopt});
+    testCast<std::string, double>("double", {value}, {std::nullopt});
+  }
+  {
+    const auto value = std::string("\xE2\x80\x80", 3) + "1.5";
     SCOPED_TRACE(value);
     testCast<std::string, float>("real", {value}, {std::nullopt});
     testCast<std::string, double>("double", {value}, {std::nullopt});

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -303,7 +303,7 @@ struct Converter<
             break;
           }
         }
-        if (!std::isdigit(v[index])) {
+        if (!std::isdigit(static_cast<unsigned char>(v[index]))) {
           return folly::makeUnexpected(
               Status::UserError("Encountered a non-digit character"));
         }
@@ -321,7 +321,7 @@ struct Converter<
             break;
           }
         }
-        if (!std::isdigit(v[index])) {
+        if (!std::isdigit(static_cast<unsigned char>(v[index]))) {
           return folly::makeUnexpected(
               Status::UserError("Encountered a non-digit character"));
         }
@@ -338,6 +338,9 @@ struct Converter<
   static Expected<T> tryCast(std::string_view v) {
     if constexpr (TPolicy::truncate) {
       return convertStringToInt(v);
+    } else if constexpr (std::is_same_v<TPolicy, SparkTryCastPolicy>) {
+      // Spark cast hooks have already applied Spark-compatible string trim.
+      return detail::callFollyTo<T>(v);
     } else {
       auto trimmed = trimWhiteSpace(v.data(), v.size());
       return detail::callFollyTo<T>(trimmed);
@@ -347,6 +350,9 @@ struct Converter<
   static Expected<T> tryCast(const StringView& v) {
     if constexpr (TPolicy::truncate) {
       return convertStringToInt(std::string_view(v));
+    } else if constexpr (std::is_same_v<TPolicy, SparkTryCastPolicy>) {
+      // Spark cast hooks have already applied Spark-compatible string trim.
+      return detail::callFollyTo<T>(std::string_view(v));
     } else {
       auto trimmed = trimWhiteSpace(v.data(), v.size());
       return detail::callFollyTo<T>(trimmed);
@@ -356,6 +362,9 @@ struct Converter<
   static Expected<T> tryCast(const std::string& v) {
     if constexpr (TPolicy::truncate) {
       return convertStringToInt(v);
+    } else if constexpr (std::is_same_v<TPolicy, SparkTryCastPolicy>) {
+      // Spark cast hooks have already applied Spark-compatible string trim.
+      return detail::callFollyTo<T>(v);
     } else {
       auto trimmed = trimWhiteSpace(v.data(), v.length());
       return detail::callFollyTo<T>(trimmed);

--- a/velox/type/DecimalUtil.cpp
+++ b/velox/type/DecimalUtil.cpp
@@ -156,7 +156,7 @@ struct DecimalComponents {
 std::string_view extractDigits(const char* s, size_t start, size_t size) {
   size_t pos = start;
   for (; pos < size; ++pos) {
-    if (!std::isdigit(s[pos])) {
+    if (!std::isdigit(static_cast<unsigned char>(s[pos]))) {
       break;
     }
   }
@@ -219,7 +219,7 @@ parseDecimalComponents(const char* s, size_t size, DecimalComponents& out) {
     // Make sure all chars after sign are digits, as folly::tryTo allows
     // leading and trailing whitespaces.
     for (auto i = static_cast<size_t>(withSign); i < size - pos; ++i) {
-      if (!std::isdigit(s[pos + i])) {
+      if (!std::isdigit(static_cast<unsigned char>(s[pos + i]))) {
         return Status::UserError(
             "Non-digit character is not allowed in the exponent part.");
       }


### PR DESCRIPTION
#### Background

This patch aligns Velox Spark string cast trimming with Spark semantics. Spark 
uses two different trimming paths depending on the cast target type:

1. UTF8String trim path

   Applies to string casts to BYTE, SHORT, INT, LONG, BOOLEAN, DATE, TIMESTAMP /
TIMESTAMP_NTZ.

   Spark routes these casts through `UTF8String.trimAll()` or helpers that use the same
predicate. In practice this trims leading and trailing bytes in `0x00..0x20` and `0x7F`.

2. Java String trim path

   Applies to string casts to FLOAT, DOUBLE, DECIMAL

   Spark routes these casts through Java/Scala string parsing or `Decimal.fromString`,
which use Java `String.trim()` semantics. This trims leading and trailing characters
`<= U+0020`, so `\u0000` is trimmed, but `\u007F` and Unicode spaces such as
`U+2000` are not.

The `stringImpl::trimUnicodeWhiteSpace` path does not match Spark cast semantics.
It does not trim `\u0000` or `0x7F`, and it may trim Unicode spaces that Spark cast does
not trim.

#### Changes

The patch updates Spark cast hooks to select the correct trimming behavior based on the
target type, while keeping Presto cast behavior unchanged.

It also removes the obsolete `StringView` output branch from `trimUnicodeWhiteSpace`,
since Spark cast no longer uses that path and the remaining caller uses function string writers.

Also filed [SPARK-59182](https://issues.apache.org/jira/browse/SPARK-59182) to discuss whether Spark should align the trimming behavior across
its two string cast paths.

