### PR TITLE
refactor(spark): Reorganize size registration and document ANSI compliance

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -307,14 +307,18 @@ Array Functions
         SELECT shuffle(array(0, 0, 0), 0); -- [0, 0, 0]
         SELECT shuffle(array(1, NULL, 1, NULL, 2), 0); -- [2, 1, NULL, NULL, 1]
 
-.. spark:function:: size(array(E), legacySizeOfNull) -> integer
+.. spark:function:: size(array(E), legacySizeOfNull) -> integer (ANSI compliant)
 
-    Returns the size of the array. Returns null for null input if `legacySizeOfNull`
-    is set to false. Otherwise, returns -1 for null input. ::
+    Returns the size of the array. Returns null for null input if ``legacySizeOfNull``
+    is false. Otherwise, returns -1 for null input. The ``legacySizeOfNull`` argument
+    reflects Spark's ``spark.sql.legacy.sizeOfNull`` configuration combined with ANSI
+    mode (``spark.sql.legacy.sizeOfNull`` AND NOT ``spark.sql.ansi.enabled``): it is
+    true only when Spark ANSI mode is disabled and ``spark.sql.legacy.sizeOfNull`` is
+    true, so under Spark ANSI mode null input always returns null. ::
 
         SELECT size(array(1, 2, 3), true); -- 3
-        SELECT size(NULL, true); -- -1
-        SELECT size(NULL, false); -- NULL
+        SELECT size(NULL, true); -- -1 (Spark ANSI mode disabled)
+        SELECT size(NULL, false); -- NULL (e.g. Spark ANSI mode enabled)
 
 .. spark:function:: slice(array(E), start, length) -> array(E)
 

--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -89,15 +89,19 @@ Map Functions
                             MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]),
                             (k, v1, v2) -> k || CAST(v1/v2 AS VARCHAR));
 
-.. spark:function:: size(map(K,V), legacySizeOfNull) -> integer
+.. spark:function:: size(map(K,V), legacySizeOfNull) -> integer (ANSI compliant)
     :noindex:
 
     Returns the size of the input map. Returns null for null input if ``legacySizeOfNull``
-    is set to false. Otherwise, returns -1 for null input. ::
+    is false. Otherwise, returns -1 for null input. The ``legacySizeOfNull`` argument
+    reflects Spark's ``spark.sql.legacy.sizeOfNull`` configuration combined with ANSI
+    mode (``spark.sql.legacy.sizeOfNull`` AND NOT ``spark.sql.ansi.enabled``): it is
+    true only when Spark ANSI mode is disabled and ``spark.sql.legacy.sizeOfNull`` is
+    true, so under Spark ANSI mode null input always returns null. ::
 
         SELECT size(map(array(1, 2), array(3, 4)), true); -- 2
-        SELECT size(NULL, true); -- -1
-        SELECT size(NULL, false); -- NULL
+        SELECT size(NULL, true); -- -1 (Spark ANSI mode disabled)
+        SELECT size(NULL, false); -- NULL (e.g. Spark ANSI mode enabled)
 
 .. spark:function:: transform_values(map(K,V1), func) -> map(K,V2)
 

--- a/velox/functions/sparksql/Size.cpp
+++ b/velox/functions/sparksql/Size.cpp
@@ -62,8 +62,8 @@ struct Size {
 } // namespace
 
 void registerSize(const std::string& prefix) {
-  registerFunction<Size, int32_t, Array<Any>, bool>({prefix});
-  registerFunction<Size, int32_t, Map<Any, Any>, bool>({prefix});
+  registerFunction<Size, int32_t, Array<Any>, bool>({prefix + "size"});
+  registerFunction<Size, int32_t, Map<Any, Any>, bool>({prefix + "size"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/Register.cpp
+++ b/velox/functions/sparksql/registration/Register.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/sparksql/registration/Register.h"
 #include "velox/expression/SimpleFunctionRegistry.h"
 #include "velox/expression/SpecialFormRegistry.h"
+#include "velox/functions/sparksql/Size.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -29,6 +30,7 @@ extern void registerMapFunctions(const std::string& prefix);
 extern void registerMathFunctions(const std::string& prefix);
 extern void registerMiscFunctions(const std::string& prefix);
 extern void registerRegexpFunctions(const std::string& prefix);
+extern void registerSize(const std::string& prefix);
 extern void registerSpecialFormGeneralFunctions(const std::string& prefix);
 extern void registerStringFunctions(const std::string& prefix);
 extern void registerUrlFunctions(const std::string& prefix);
@@ -44,6 +46,7 @@ void registerFunctions(const std::string& prefix) {
   registerMathFunctions(prefix);
   registerMiscFunctions(prefix);
   registerRegexpFunctions(prefix);
+  registerSize(prefix);
   registerSpecialFormGeneralFunctions(prefix);
   registerStringFunctions(prefix);
   registerUrlFunctions(prefix);

--- a/velox/functions/sparksql/registration/RegisterMap.cpp
+++ b/velox/functions/sparksql/registration/RegisterMap.cpp
@@ -16,7 +16,6 @@
 #include "velox/functions/lib/MapConcat.h"
 #include "velox/functions/lib/MapFromEntries.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
-#include "velox/functions/sparksql/Size.h"
 
 namespace facebook::velox::functions {
 extern void registerElementAtFunction(
@@ -47,7 +46,6 @@ void registerMapFunctions(const std::string& prefix) {
       udf_map_from_arrays, prefix + "map_from_arrays");
   // This is the semantics of spark.sql.ansi.enabled = false.
   registerElementAtFunction(prefix + "element_at", true);
-  registerSize(prefix + "size");
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Spark's `size` function accepts an explicit `legacySizeOfNull` argument in SQL. When it isn't provided, Spark resolves it at plan-construction time as:

```scala
getConf(SQLConf.LEGACY_SIZE_OF_NULL) && !getConf(ANSI_ENABLED)
```

(see [collectionOperations.scala#L121](https://github.com/apache/spark/blob/a4a991d21a9ee88b097069888f6a4cf84b06a142/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L121)).

As a result, the ANSI setting is already folded into the expression's `legacySizeOfNull` argument before it reaches Velox — Spark's `Size.eval` itself performs no ANSI check, and Gluten passes the resolved argument down. Velox therefore honors the argument as-is and needs no separate handling of the ANSI config.

This PR:
- Documents the `size` behavior under ANSI mode in `array.rst` and `map.rst`, marking the function `(ANSI compliant)` per the existing convention.
- Refactors the function registration by moving `registerSize` out of the map function registration into its own top-level registration, since `size` applies to arrays as well as maps.

No behavior change.
