### PR TITLE
fix(datetime): Stop truncating intervals over 24 days

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -523,8 +523,7 @@ struct TimestampPlusInterval {
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalDayTime>& interval) {
-    result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+    result = addMillisToTimestampWithTimezone(*timestampWithTimezone, interval);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -710,8 +709,7 @@ struct IntervalPlusTimestamp {
       out_type<TimestampWithTimezone>& result,
       const arg_type<IntervalDayTime>& interval,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+    result = addMillisToTimestampWithTimezone(*timestampWithTimezone, interval);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -766,8 +764,8 @@ struct TimestampMinusInterval {
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalDayTime>& interval) {
-    result = addToTimestampWithTimezone(
-        *timestampWithTimezone, DateTimeUnit::kMillisecond, -interval);
+    result =
+        addMillisToTimestampWithTimezone(*timestampWithTimezone, -interval);
   }
 
   FOLLY_ALWAYS_INLINE void call(

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -90,68 +90,88 @@ FOLLY_ALWAYS_INLINE int64_t fromUnixtime(double unixtime, int16_t timeZoneId) {
 // apply operation, then convert back to UTC).
 FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
     const Timestamp& timestamp,
-    const DateTimeUnit unit,
-    const int32_t value,
+    DateTimeUnit unit,
+    int32_t value,
     const tz::TimeZone* timeZone) {
   if (timeZone == nullptr) {
     return addToTimestamp(timestamp, unit, value);
-  } else {
-    Timestamp zonedTimestamp = timestamp;
-    zonedTimestamp.toTimezone(*timeZone);
-    auto resultTimestamp = addToTimestamp(zonedTimestamp, unit, value);
-    resultTimestamp.toGMT(*timeZone);
-    return resultTimestamp;
   }
+
+  Timestamp zonedTimestamp = timestamp;
+  zonedTimestamp.toTimezone(*timeZone);
+  auto resultTimestamp = addToTimestamp(zonedTimestamp, unit, value);
+  resultTimestamp.toGMT(*timeZone);
+  return resultTimestamp;
 }
 
+/// Shifts the UTC instant by `millis`, keeping the time zone. A millisecond is
+/// a fixed duration, so this needs none of the local-time round trip that
+/// `addToTimestampWithTimezone` performs for calendar units, whose length
+/// varies across a daylight saving boundary. Takes int64 because a
+/// day-to-second interval does not fit in that function's int32.
+FOLLY_ALWAYS_INLINE int64_t addMillisToTimestampWithTimezone(
+    int64_t timestampWithTimezone,
+    int64_t millis) {
+  return pack(
+      unpackMillisUtc(timestampWithTimezone) + millis,
+      unpackZoneKeyId(timestampWithTimezone));
+}
+
+/// Adds `value` units to a packed TIMESTAMP WITH TIME ZONE, returning the
+/// result packed with the same time zone. Units below a day are fixed
+/// durations and shift the UTC instant, so the local wall clock can move an
+/// extra hour across a daylight saving boundary. A day and above are calendar
+/// units and are applied in local time, where their length varies.
+///
+/// `value` counts units. It is int32, so a caller holding a wider count must
+/// reject what does not fit; a day-to-second interval, whose millisecond count
+/// routinely exceeds int32, goes through `addMillisToTimestampWithTimezone`
+/// instead.
 FOLLY_ALWAYS_INLINE int64_t addToTimestampWithTimezone(
     int64_t timestampWithTimezone,
-    const DateTimeUnit unit,
-    const int32_t value) {
-  {
-    int64_t finalSysMs;
-    if (unit < DateTimeUnit::kDay) {
-      auto originalTimestamp = unpackTimestampUtc(timestampWithTimezone);
-      finalSysMs =
-          addToTimestamp(originalTimestamp, unit, (int32_t)value).toMillis();
-    } else {
-      // Use local time to handle crossing daylight savings time boundaries.
-      // E.g. the "day" when the clock moves back an hour is 25 hours long, and
-      // the day it moves forward is 23 hours long. Daylight savings time
-      // doesn't affect time units less than a day, and will produce incorrect
-      // results if we use local time.
-      const tz::TimeZone* timeZone =
-          tz::locateZone(unpackZoneKeyId(timestampWithTimezone));
-      auto originalTimestamp = Timestamp::fromMillis(
-          timeZone
-              ->to_local(
-                  std::chrono::milliseconds(
-                      unpackMillisUtc(timestampWithTimezone)))
-              .count());
-      auto updatedTimeStamp =
-          addToTimestamp(originalTimestamp, unit, (int32_t)value);
-      updatedTimeStamp = Timestamp(
-          timeZone
-              ->correct_nonexistent_time(
-                  std::chrono::seconds(updatedTimeStamp.getSeconds()))
-              .count(),
-          updatedTimeStamp.getNanos());
-      finalSysMs =
-          timeZone
-              ->to_sys(
-                  std::chrono::milliseconds(updatedTimeStamp.toMillis()),
-                  tz::TimeZone::TChoose::kEarliest)
-              .count();
-    }
-
-    return pack(finalSysMs, unpackZoneKeyId(timestampWithTimezone));
+    DateTimeUnit unit,
+    int32_t value) {
+  int64_t finalSysMs;
+  if (unit < DateTimeUnit::kDay) {
+    auto originalTimestamp = unpackTimestampUtc(timestampWithTimezone);
+    finalSysMs =
+        addToTimestamp(originalTimestamp, unit, (int32_t)value).toMillis();
+  } else {
+    // Use local time to handle crossing daylight savings time boundaries.
+    // E.g. the "day" when the clock moves back an hour is 25 hours long, and
+    // the day it moves forward is 23 hours long. Daylight savings time
+    // doesn't affect time units less than a day, and will produce incorrect
+    // results if we use local time.
+    const tz::TimeZone* timeZone =
+        tz::locateZone(unpackZoneKeyId(timestampWithTimezone));
+    auto originalTimestamp =
+        Timestamp::fromMillis(timeZone
+                                  ->to_local(
+                                      std::chrono::milliseconds(unpackMillisUtc(
+                                          timestampWithTimezone)))
+                                  .count());
+    auto updatedTimeStamp =
+        addToTimestamp(originalTimestamp, unit, (int32_t)value);
+    updatedTimeStamp = Timestamp(
+        timeZone
+            ->correct_nonexistent_time(
+                std::chrono::seconds(updatedTimeStamp.getSeconds()))
+            .count(),
+        updatedTimeStamp.getNanos());
+    finalSysMs = timeZone
+                     ->to_sys(
+                         std::chrono::milliseconds(updatedTimeStamp.toMillis()),
+                         tz::TimeZone::TChoose::kEarliest)
+                     .count();
   }
+
+  return pack(finalSysMs, unpackZoneKeyId(timestampWithTimezone));
 }
 
 FOLLY_ALWAYS_INLINE int64_t diffTimestampWithTimeZone(
-    const DateTimeUnit unit,
-    const int64_t fromTimestampWithTimeZone,
-    const int64_t toTimestampWithTimeZone) {
+    DateTimeUnit unit,
+    int64_t fromTimestampWithTimeZone,
+    int64_t toTimestampWithTimeZone) {
   auto fromTimeZoneId = unpackZoneKeyId(fromTimestampWithTimeZone);
   auto toTimeZoneId = unpackZoneKeyId(toTimestampWithTimeZone);
   VELOX_CHECK_EQ(
@@ -192,10 +212,7 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestampWithTimeZone(
 // diffDate is defined in velox/functions/lib/DateTimeUtil.h
 
 FOLLY_ALWAYS_INLINE
-int64_t diffTime(
-    const DateTimeUnit unit,
-    const int64_t fromTime,
-    const int64_t toTime) {
+int64_t diffTime(DateTimeUnit unit, int64_t fromTime, int64_t toTime) {
   // Validate time inputs are in valid range [0, 86400000)
   VELOX_USER_CHECK(
       fromTime >= 0 && fromTime < kMillisInDay,

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1132,6 +1132,44 @@ TEST_F(DateTimeFunctionsTest, timestampWithTimeZonePlusIntervalDayTime) {
       test("2024-11-03 01:30 America/Los_Angeles", 1 * kMillisInHour));
 }
 
+TEST_F(DateTimeFunctionsTest, timestampWithTimeZonePlusLargeIntervalDayTime) {
+  // An interval past int32 milliseconds, i.e. over ~24.8 days. Kept separate
+  // from the case above because date_add rejects such a value outright.
+  // c0 is the timestamp, c1 the interval.
+  const std::string ts = "cast(c0 as timestamp with time zone)";
+  const int64_t interval = 180 * kMillisInDay;
+
+  const auto eval = [&](const std::string& operation,
+                        const std::string& timestamp) {
+    return evaluateOnce<std::string>(
+               fmt::format("cast({} as varchar)", operation),
+               {VARCHAR(), INTERVAL_DAY_TIME()},
+               std::optional(timestamp),
+               std::optional(interval))
+        .value();
+  };
+
+  // Addition is commutative, so both operand orders must agree.
+  const auto plus = [&](const std::string& timestamp) {
+    const auto result = eval(fmt::format("plus({}, c1)", ts), timestamp);
+    EXPECT_EQ(result, eval(fmt::format("plus(c1, {})", ts), timestamp));
+    return result;
+  };
+
+  const std::string base = "2024-10-03 01:50 America/Los_Angeles";
+
+  EXPECT_EQ("2025-04-01 01:50:00.000 America/Los_Angeles", plus(base));
+  EXPECT_EQ(
+      "2024-04-06 01:50:00.000 America/Los_Angeles",
+      eval(fmt::format("minus({}, c1)", ts), base));
+
+  // A day-to-second interval is a fixed count of milliseconds, so crossing
+  // into daylight saving moves the wall clock forward an hour.
+  EXPECT_EQ(
+      "2025-05-30 02:50:00.000 America/Los_Angeles",
+      plus("2024-12-01 01:50 America/Los_Angeles"));
+}
+
 TEST_F(DateTimeFunctionsTest, minusTimestamp) {
   const auto minus = [&](std::optional<int64_t> t1, std::optional<int64_t> t2) {
     const auto timestamp1 = (t1.has_value()) ? Timestamp(t1.value(), 0)


### PR DESCRIPTION
Summary:
Adding or subtracting an `INTERVAL DAY TO SECOND` longer than about 24.8 days from a `TIMESTAMP WITH TIME ZONE` moved the timestamp the wrong way. For example:

    SELECT now() + INTERVAL '180' DAY

returned a timestamp roughly 19 days in the past rather than 180 days in the future. Plain `TIMESTAMP` was unaffected, and so was `date_add('day', 180, ts)`, so the failure only showed up when the timestamp carried a time zone and the interval was written as an interval.

An interval is a count of milliseconds, and 180 days is 15552000000 of them, which does not fit in the int32 that `addToTimestampWithTimezone` accepts. The plus and minus overloads now shift the UTC instant by an int64 instead. A millisecond is a fixed duration, so it needs none of the local-time handling that day and larger units require, which is also how Presto computes this.

Differential Revision: D118586539
