### PR TITLE
perf(nimble): Encode the largest streams first when encoding in parallel (#18825)

### DIFF
--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -4870,6 +4870,73 @@ TEST_F(WriterTest, runtimeStatsPublishesEveryCounter) {
   EXPECT_FALSE(writer.columnStats().empty());
 }
 
+TEST_F(WriterTest, parallelEncodeOutputIndependentOfEncodeOrder) {
+  // Parallel encoding dispatches streams in size-ordered batches, so the order
+  // in which streams are encoded differs from their schema order and changes
+  // with the concurrency setting. Encoded output is keyed by each stream's own
+  // descriptor offset rather than by encode order, so every one of these must
+  // produce a byte-identical file. This is the invariant that makes reordering
+  // safe; if it ever stops holding, the reorder silently changes file layout
+  // rather than failing.
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  constexpr velox::vector_size_t kRows = 256;
+  // Deliberately uneven per-column sizes, so size order differs from schema
+  // order and the batches group differently at each concurrency.
+  auto vector = vectorMaker.rowVector(
+      {"wide", "seq", "lowCard", "constant", "dbl", "nullable"},
+      {vectorMaker.flatVector<velox::StringView>(
+           kRows,
+           [](auto row) {
+             thread_local std::string value;
+             value.assign(200 + (row % 50), static_cast<char>('a' + row % 26));
+             return velox::StringView(value);
+           }),
+       vectorMaker.flatVector<int64_t>(
+           kRows, [](auto row) { return static_cast<int64_t>(row); }),
+       vectorMaker.flatVector<int32_t>(
+           kRows, [](auto row) { return static_cast<int32_t>(row % 5); }),
+       vectorMaker.flatVector<int64_t>(kRows, [](auto) { return int64_t{7}; }),
+       vectorMaker.flatVector<double>(
+           kRows, [](auto row) { return static_cast<double>(row) * 1.5; }),
+       vectorMaker.flatVector<int64_t>(
+           kRows,
+           [](auto row) { return static_cast<int64_t>(row % 13); },
+           [](auto row) { return row % 3 == 0; })});
+  const auto type = velox::asRowType(vector->type());
+
+  auto writeWith = [&](uint32_t parallelism) {
+    std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
+    nimble::WriterOptions options;
+    options.enableChunking = true;
+    options.minStreamChunkRawSize = 0;
+    options.flushPolicyFactory = []() {
+      return std::make_unique<nimble::LambdaFlushPolicy>(
+          /*flushLambda=*/[](auto&) { return false; },
+          /*chunkLambda=*/[](auto&) { return true; });
+    };
+    if (parallelism > 0) {
+      executor = std::make_shared<folly::CPUThreadPoolExecutor>(parallelism);
+      options.encodingExecutor = folly::getKeepAliveToken(*executor);
+      options.maxEncodeParallelism = parallelism;
+      options.minStreamsPerEncodingTask = 1;
+    }
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::Writer writer(
+        type, std::move(writeFile), *rootPool_, std::move(options));
+    for (int batch = 0; batch < 4; ++batch) {
+      writer.write(vector);
+    }
+    writer.close();
+    return file;
+  };
+
+  const auto serial = writeWith(/*parallelism=*/0);
+  ASSERT_FALSE(serial.empty());
+  EXPECT_EQ(writeWith(/*parallelism=*/2), serial);
+  EXPECT_EQ(writeWith(/*parallelism=*/8), serial);
+}
+
 TEST_F(WriterTest, cachedEncodingLayoutAcrossChunks) {
   // Isolation test: a single stripe holding multiple chunks, so a failure here
   // points at the chunk-boundary replay path specifically. The default

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <span>
 #include <string>
@@ -2665,6 +2666,42 @@ uint32_t Writer::encodingConcurrency(uint32_t streamCount) const {
   return std::min({streamCount, options.maxEncodeParallelism, maxByStreams});
 }
 
+namespace {
+
+// Encode tasks are dispatched in fixed-size batches that each wait on their
+// slowest member, so a batch mixing one large stream with small ones leaves
+// most of it idle. Grouping comparable sizes into the same batch keeps the
+// batch maximum close to its mean. Sizes are read before materialize(), so
+// this is the buffered size rather than the encoded one -- good enough to
+// rank by, and it costs no extra pass over the data.
+void sortByBufferedSizeDescending(
+    std::vector<uint32_t>& indices,
+    const std::vector<std::pair<uint32_t, std::unique_ptr<StreamData>>>&
+        streams) {
+  std::stable_sort(
+      indices.begin(), indices.end(), [&streams](uint32_t lhs, uint32_t rhs) {
+        return streams[lhs].second->memoryUsed() >
+            streams[rhs].second->memoryUsed();
+      });
+}
+
+} // namespace
+
+std::vector<uint32_t> Writer::encodeOrder(uint32_t streamCount) const {
+  std::vector<uint32_t> orderedIndices(streamCount);
+  std::iota(orderedIndices.begin(), orderedIndices.end(), 0u);
+  sortByBufferedSizeDescending(orderedIndices, context_->streams());
+  return orderedIndices;
+}
+
+std::vector<uint32_t> Writer::encodeOrder(
+    std::span<const uint32_t> streamIndices) const {
+  std::vector<uint32_t> orderedIndices{
+      streamIndices.begin(), streamIndices.end()};
+  sortByBufferedSizeDescending(orderedIndices, context_->streams());
+  return orderedIndices;
+}
+
 void Writer::ensureEncodingScratchBufferPools(uint32_t poolCount) {
   if (context_->options().maxCachedEncodingScratchBuffers == 0) {
     NIMBLE_CHECK(
@@ -2753,6 +2790,7 @@ void Writer::writeStreams() {
       NIMBLE_CHECK(
           encodingExecutor,
           "Encoding executor is required for parallel encoding.");
+      const auto orderedIndices = encodeOrder(streamCount);
       std::atomic_uint32_t nextStream{0};
       velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
       for (uint32_t taskId = 0; taskId < concurrency; ++taskId) {
@@ -2766,11 +2804,12 @@ void Writer::writeStreams() {
                   const_cast<uint32_t*>(&taskId));
               const auto startCpuNanos = velox::process::threadCpuNanos();
               while (true) {
-                const auto streamIndex =
+                const auto fetchIndex =
                     nextStream.fetch_add(1, std::memory_order_relaxed);
-                if (streamIndex >= streamCount) {
+                if (fetchIndex >= streamCount) {
                   break;
                 }
+                const auto streamIndex = orderedIndices[fetchIndex];
                 auto& [nodeId, streamData] = streams[streamIndex];
                 uint64_t streamSize{0};
                 processStream(
@@ -2992,6 +3031,7 @@ bool Writer::writeChunks(
       NIMBLE_CHECK(
           encodingExecutor,
           "Encoding executor is required for parallel encoding.");
+      const auto orderedIndices = encodeOrder(streamIndices);
       std::atomic_uint32_t nextStream{0};
       velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
       for (uint32_t taskId = 0; taskId < concurrency; ++taskId) {
@@ -3009,7 +3049,7 @@ bool Writer::writeChunks(
             if (inputIndex >= streamCount) {
               break;
             }
-            const auto streamIndex = streamIndices[inputIndex];
+            const auto streamIndex = orderedIndices[inputIndex];
             auto& [nodeId, streamData] = streams[streamIndex];
             const auto offset = streamData->descriptor().offset();
             uint64_t streamSize{0};

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -327,6 +327,13 @@ class Writer : public velox::dwio::common::Writer {
   // task because EncodingBufferPool is not thread-safe.
   std::unique_ptr<EncodingBufferPool> makeEncodingBufferPool() const;
   uint32_t encodingConcurrency(uint32_t streamCount) const;
+
+  // Orders stream indices largest-first, so that parallel encode batches group
+  // comparably sized streams together. The streamCount overload orders the
+  // identity range [0, streamCount) without materializing it first.
+  std::vector<uint32_t> encodeOrder(uint32_t streamCount) const;
+  std::vector<uint32_t> encodeOrder(
+      std::span<const uint32_t> streamIndices) const;
   void ensureEncodingScratchBufferPools(uint32_t poolCount);
   void ensureEncodingBufferPools(uint32_t poolCount);
   velox::BufferPool* encodingScratchBufferPool(uint32_t index = 0);


### PR DESCRIPTION
Summary:

**Problem**

Parallel encoding dispatches streams to an `ExecutorBarrier` in fixed-size
batches of `concurrency`, and each batch waits on its slowest member before the
next one starts. Streams are dispatched in schema order, so a batch that mixes
one large stream with small ones leaves most of its slots idle waiting on the
large one. Effective parallelism came out at 2.02-2.05 against a configured
concurrency well above that.

**Fix**

Sort the stream indices by buffered size, largest first, before dispatching.
Grouping comparable sizes into the same batch keeps the batch maximum close to
its mean. Sizes are read before `materialize()`, so this is the buffered size
rather than the encoded one, which is good enough to rank by and costs no extra
pass over the data.

Encoded output is keyed by each stream's own descriptor offset, not by encode
order, so reordering cannot change file layout. `parallelEncodeOutputIndependentOfEncodeOrder`
pins that invariant at parallelism 0, 2 and 8; if it ever stops holding, the
reorder would silently change layout rather than fail.

Reviewed By: xiaoxmeng

Differential Revision: D117972929


