### PR TITLE
fix(nimble): Bound parallel decode across reader tree (#18828)

### DIFF
--- a/velox/dwio/nimble/serializer/Deserializer.cpp
+++ b/velox/dwio/nimble/serializer/Deserializer.cpp
@@ -237,6 +237,7 @@ FieldReaderParams Deserializer::createFieldReaderParams() const {
   params.decodeExecutor = options_.decodeExecutor;
   params.maxDecodeParallelism = options_.maxDecodeParallelism;
   params.minStreamsPerDecodeTask = options_.minStreamsPerDecodeTask;
+  params.decodePools = options_.decodePools;
   if (options_.outputType == nullptr) {
     return params;
   }

--- a/velox/dwio/nimble/serializer/Options.h
+++ b/velox/dwio/nimble/serializer/Options.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <vector>
 
 #include "folly/Executor.h"
 #include "folly/container/F14Map.h"
@@ -33,6 +34,10 @@
 
 #include <set>
 #include "velox/type/Type.h"
+
+namespace facebook::velox::memory {
+class MemoryPool;
+}
 
 namespace facebook::nimble {
 
@@ -300,16 +305,20 @@ struct DeserializerOptions {
   /// When nullptr (default), child reads are performed sequentially.
   folly::Executor* decodeExecutor{nullptr};
 
-  /// Maximum number of parallel coroutine tasks scheduled by each field
-  /// reader. Children are grouped into this many batches, each decoded
-  /// sequentially within a single coroutine task. This is a per-reader limit;
-  /// the executor bounds the number of tasks that run concurrently across the
-  /// reader tree. 0 disables parallel decoding.
+  /// Maximum planned decode parallelism across the field reader tree. Nested
+  /// scalar stream counts determine how many child-field tasks to create. 0
+  /// disables parallel decoding.
   uint32_t maxDecodeParallelism{0};
 
-  /// Minimum number of child streams per parallel decode task. Ensures each
-  /// coroutine task has enough work to amortize threading overhead.
+  /// Minimum number of nested scalar streams per planned decode task. Ensures
+  /// each coroutine task has enough work to amortize threading overhead.
   uint32_t minStreamsPerDecodeTask{1};
+
+  /// Optional leaf pools distributed round-robin among independently decoded
+  /// row children and FlatMap-as-struct values. When provided, the pool count
+  /// must match maxDecodeParallelism. The caller must keep the pools alive
+  /// while returned vectors exist.
+  std::vector<velox::memory::MemoryPool*> decodePools{};
 };
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -114,6 +114,7 @@ TEST(OptionsTest, deserializerOptionsDefaults) {
   EXPECT_FALSE(options.hasHeader);
   EXPECT_EQ(options.decodeExecutor, nullptr);
   EXPECT_EQ(options.maxDecodeParallelism, 0u);
+  EXPECT_TRUE(options.decodePools.empty());
 }
 
 TEST(OptionsTest, deserializerOptionsWithVersion) {

--- a/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
@@ -6362,7 +6362,7 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeRow) {
     uint32_t parallelDecodeCount = 0;
     std::vector<uint32_t> observedTaskCounts;
     SCOPED_TESTVALUE_SET(
-        "facebook::nimble::RowFieldReader::co_next",
+        "facebook::nimble::decodeChildRanges",
         std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
           ++parallelDecodeCount;
           observedTaskCounts.emplace_back(*taskCount);
@@ -6407,16 +6407,38 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeNestedRows) {
   const auto schema =
       SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
 
-  folly::CPUThreadPoolExecutor executor{2};
+  constexpr uint32_t kMaxDecodeParallelism{4};
+  folly::CPUThreadPoolExecutor executor{kMaxDecodeParallelism};
   auto options = deserializerOptions();
   options.decodeExecutor = &executor;
-  options.maxDecodeParallelism = 2;
+  options.maxDecodeParallelism = kMaxDecodeParallelism;
 
-  std::atomic_uint32_t parallelDecodeCount{0};
+  // Keep the decode pool count aligned with the parallel task budget.
+  std::vector<std::shared_ptr<velox::memory::MemoryPool>> decodePoolOwners;
+  decodePoolOwners.reserve(kMaxDecodeParallelism);
+  for (uint32_t i = 0; i < kMaxDecodeParallelism; ++i) {
+    decodePoolOwners.emplace_back(
+        rootPool_->addLeafChild(fmt::format("parallel_decode_{}", i)));
+    options.decodePools.emplace_back(decodePoolOwners.back().get());
+  }
+
+  std::vector<uint32_t> plannedTaskCounts;
   SCOPED_TESTVALUE_SET(
-      "facebook::nimble::RowFieldReader::co_next",
-      std::function<void(const uint32_t*)>(
-          [&](const uint32_t*) { ++parallelDecodeCount; }));
+      "facebook::nimble::DecodePlanBuilder::build",
+      std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
+        plannedTaskCounts.emplace_back(*taskCount);
+      }));
+
+  std::atomic_uint32_t numParallelRowDecodes{0};
+  std::atomic_bool unexpectedTaskCount{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::decodeChildRanges",
+      std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
+        ++numParallelRowDecodes;
+        if (*taskCount != 2) {
+          unexpectedTaskCount = true;
+        }
+      }));
 
   Deserializer deserializer{schema, pool_.get(), options};
   velox::VectorPtr output;
@@ -6426,7 +6448,12 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeNestedRows) {
   for (velox::vector_size_t row = 0; row < output->size(); ++row) {
     EXPECT_TRUE(output->equalValueAt(input.get(), row, row));
   }
-  EXPECT_EQ(parallelDecodeCount, 3);
+  const std::vector<uint32_t> expectedTaskCounts{2, 2, 2};
+  EXPECT_EQ(plannedTaskCounts, expectedTaskCounts);
+  EXPECT_EQ(numParallelRowDecodes, expectedTaskCounts.size());
+  EXPECT_FALSE(unexpectedTaskCount);
+  EXPECT_GT(decodePoolOwners[0]->stats().cumulativeBytes, 0);
+  EXPECT_GT(decodePoolOwners[1]->stats().cumulativeBytes, 0);
 }
 
 DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeNestedRowsInArrays) {
@@ -6457,10 +6484,13 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeNestedRowsInArrays) {
   options.maxDecodeParallelism = 2;
 
   std::atomic_uint32_t numParallelRowDecodes{0};
+  std::atomic_uint32_t rootTaskCount{0};
   SCOPED_TESTVALUE_SET(
-      "facebook::nimble::RowFieldReader::co_next",
-      std::function<void(const uint32_t*)>(
-          [&](const uint32_t*) { ++numParallelRowDecodes; }));
+      "facebook::nimble::decodeChildRanges",
+      std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
+        ++numParallelRowDecodes;
+        rootTaskCount = *taskCount;
+      }));
 
   Deserializer deserializer{schema, pool_.get(), options};
   velox::VectorPtr output;
@@ -6470,7 +6500,9 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeNestedRowsInArrays) {
   for (velox::vector_size_t row = 0; row < output->size(); ++row) {
     EXPECT_TRUE(output->equalValueAt(input.get(), row, row));
   }
-  EXPECT_EQ(numParallelRowDecodes, 3);
+  // The breadth-first plan assigns the tree's only extra task to the root.
+  EXPECT_EQ(numParallelRowDecodes, 1);
+  EXPECT_EQ(rootTaskCount, 2);
 }
 
 // Verifies that parallel decode is triggered for StructFlatMapFieldReader
@@ -6562,15 +6594,15 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeFlatMapAsStruct) {
   struct ParallelDecodeParam {
     uint32_t maxDecodeParallelism;
     uint32_t minStreamsPerDecodeTask;
-    // Expected task count for the StructFlatMapFieldReader (8 keys).
     uint32_t expectedFlatMapTaskCount;
     // Whether parallel decode is expected for the Row (2 children: id +
-    // features). Depends on whether 2 >= minStreamsPerDecodeTask * 2.
+    // features). The features child contributes all of its nested scalar
+    // streams.
     bool rowParallelExpected;
 
     std::string debugString() const {
       return fmt::format(
-          "maxParallel={}, minStreams={}, expectedFlatMapTasks={}, rowParallel={}",
+          "maxParallel={}, minStreams={}, flatMapTasks={}, rowParallel={}",
           maxDecodeParallelism,
           minStreamsPerDecodeTask,
           expectedFlatMapTaskCount,
@@ -6578,18 +6610,20 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeFlatMapAsStruct) {
     }
   };
 
-  // 8 flatmap keys -> 8 children in StructFlatMapFieldReader.
-  // Parallel decode requires numChildren >= minStreamsPerDecodeTask * 2.
+  // 8 flatmap keys -> 8 scalar streams in StructFlatMapFieldReader and in the
+  // parent Row's features child.
   const std::vector<ParallelDecodeParam> testCases = {
-      {2, 1, 2, true},
-      {4, 1, 4, true},
-      {4, 4, 2, false}, // Row: 2 < 4*2=8
+      {2, 1, 1, true},
+      {4, 1, 3, true},
+      {4, 4, 2, true},
       {100, 1, 8, true},
   };
 
   folly::CPUThreadPoolExecutor executor(4);
 
-  for (const auto& testCase : testCases) {
+  for (size_t testCaseIndex = 0; testCaseIndex < testCases.size();
+       ++testCaseIndex) {
+    const auto& testCase = testCases[testCaseIndex];
     SCOPED_TRACE(testCase.debugString());
 
     auto opts = deserializerOptions();
@@ -6598,20 +6632,33 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeFlatMapAsStruct) {
     opts.maxDecodeParallelism = testCase.maxDecodeParallelism;
     opts.minStreamsPerDecodeTask = testCase.minStreamsPerDecodeTask;
 
+    std::vector<std::shared_ptr<velox::memory::MemoryPool>> decodePoolOwners;
+    if (testCase.maxDecodeParallelism == 4 &&
+        testCase.minStreamsPerDecodeTask == 1) {
+      decodePoolOwners.reserve(testCase.maxDecodeParallelism);
+      for (uint32_t i = 0; i < testCase.maxDecodeParallelism; ++i) {
+        decodePoolOwners.emplace_back(rootPool_->addLeafChild(
+            fmt::format("parallel_flatmap_decode_{}_{}", testCaseIndex, i)));
+        opts.decodePools.emplace_back(decodePoolOwners.back().get());
+      }
+    }
+
     Deserializer deserializer{schema, pool_.get(), opts};
 
-    uint32_t rowParallelCount = 0;
-    uint32_t flatMapParallelCount = 0;
-    std::vector<uint32_t> flatMapTaskCounts;
+    std::atomic_uint32_t numParallelDecodes{0};
+    std::atomic_uint32_t numMatchingTaskCounts{0};
+    std::atomic_bool unexpectedTaskCount{false};
     SCOPED_TESTVALUE_SET(
-        "facebook::nimble::RowFieldReader::co_next",
-        std::function<void(const uint32_t*)>(
-            [&](const uint32_t*) { ++rowParallelCount; }));
-    SCOPED_TESTVALUE_SET(
-        "facebook::nimble::StructFlatMapFieldReader::co_next",
+        "facebook::nimble::decodeChildRanges",
         std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
-          ++flatMapParallelCount;
-          flatMapTaskCounts.emplace_back(*taskCount);
+          ++numParallelDecodes;
+          if (*taskCount == testCase.expectedFlatMapTaskCount) {
+            ++numMatchingTaskCounts;
+          }
+          if (*taskCount != 2 &&
+              *taskCount != testCase.expectedFlatMapTaskCount) {
+            unexpectedTaskCount = true;
+          }
         }));
 
     velox::VectorPtr output;
@@ -6640,10 +6687,22 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeFlatMapAsStruct) {
       }
     }
 
-    EXPECT_EQ(rowParallelCount, testCase.rowParallelExpected ? numBatches : 0);
-    EXPECT_EQ(flatMapParallelCount, numBatches);
-    for (const auto taskCount : flatMapTaskCounts) {
-      EXPECT_EQ(taskCount, testCase.expectedFlatMapTaskCount);
+    const uint32_t expectedParallelDecodesPerBatch =
+        (testCase.rowParallelExpected ? 1 : 0) +
+        (testCase.expectedFlatMapTaskCount > 1 ? 1 : 0);
+    EXPECT_EQ(numParallelDecodes, expectedParallelDecodesPerBatch * numBatches);
+    const uint32_t expectedMatchingTaskCountsPerBatch =
+        (testCase.rowParallelExpected && testCase.expectedFlatMapTaskCount == 2
+             ? 1
+             : 0) +
+        (testCase.expectedFlatMapTaskCount > 1 ? 1 : 0);
+    EXPECT_EQ(
+        numMatchingTaskCounts, expectedMatchingTaskCountsPerBatch * numBatches);
+    EXPECT_FALSE(unexpectedTaskCount);
+    if (!decodePoolOwners.empty()) {
+      // Pool 2 is assigned to the first FlatMap-as-struct value child after
+      // the root row's two children consume pools 0 and 1.
+      EXPECT_GT(decodePoolOwners[2]->stats().cumulativeBytes, 0);
     }
   }
 }
@@ -6743,11 +6802,15 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeSkippedFewKeys) {
 
   Deserializer deserializer{schema, pool_.get(), opts};
 
-  std::vector<uint32_t> flatMapTaskCounts;
+  std::atomic_uint32_t numParallelDecodes{0};
+  std::atomic_bool unexpectedTaskCount{false};
   SCOPED_TESTVALUE_SET(
-      "facebook::nimble::StructFlatMapFieldReader::co_next",
+      "facebook::nimble::decodeChildRanges",
       std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
-        flatMapTaskCounts.emplace_back(*taskCount);
+        ++numParallelDecodes;
+        if (*taskCount != 2) {
+          unexpectedTaskCount = true;
+        }
       }));
 
   velox::VectorPtr output;
@@ -6764,11 +6827,10 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeSkippedFewKeys) {
     }
   }
 
-  // Only 1 non-null key node -> taskCount should be 1 (single coroutine task,
-  // no parallelism benefit).
-  for (const auto taskCount : flatMapTaskCounts) {
-    EXPECT_EQ(taskCount, 1);
-  }
+  // Only the two-child root is parallel. The one-key FlatMap child stays
+  // serial and does not trigger the parallel decode hook.
+  EXPECT_EQ(numParallelDecodes, numBatches);
+  EXPECT_FALSE(unexpectedTaskCount);
 }
 
 // Verifies that parallel decode is NOT triggered when the executor is not set
@@ -6846,11 +6908,11 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeDisabled) {
 
     Deserializer deserializer{schema, pool_.get(), opts};
 
-    uint32_t rowParallelCount = 0;
+    uint32_t parallelDecodeCount = 0;
     SCOPED_TESTVALUE_SET(
-        "facebook::nimble::RowFieldReader::co_next",
+        "facebook::nimble::decodeChildRanges",
         std::function<void(const uint32_t*)>(
-            [&](const uint32_t*) { ++rowParallelCount; }));
+            [&](const uint32_t*) { ++parallelDecodeCount; }));
 
     velox::VectorPtr output;
     for (size_t i = 0; i < numBatches; ++i) {
@@ -6862,7 +6924,7 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeDisabled) {
       }
     }
 
-    EXPECT_EQ(rowParallelCount, 0)
+    EXPECT_EQ(parallelDecodeCount, 0)
         << "Parallel decode should NOT be triggered for: "
         << testCase.debugString();
   }
@@ -6983,16 +7045,11 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeDisabledFlatMap) {
 
     Deserializer deserializer{schema, pool_.get(), opts};
 
-    uint32_t rowParallelCount = 0;
-    uint32_t flatMapParallelCount = 0;
+    uint32_t parallelDecodeCount = 0;
     SCOPED_TESTVALUE_SET(
-        "facebook::nimble::RowFieldReader::co_next",
+        "facebook::nimble::decodeChildRanges",
         std::function<void(const uint32_t*)>(
-            [&](const uint32_t*) { ++rowParallelCount; }));
-    SCOPED_TESTVALUE_SET(
-        "facebook::nimble::StructFlatMapFieldReader::co_next",
-        std::function<void(const uint32_t*)>(
-            [&](const uint32_t*) { ++flatMapParallelCount; }));
+            [&](const uint32_t*) { ++parallelDecodeCount; }));
 
     velox::VectorPtr output;
     for (size_t i = 0; i < numBatches; ++i) {
@@ -7015,11 +7072,8 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeDisabledFlatMap) {
       }
     }
 
-    EXPECT_EQ(rowParallelCount, 0)
-        << "Row parallel decode should NOT be triggered for: "
-        << testCase.debugString();
-    EXPECT_EQ(flatMapParallelCount, 0)
-        << "FlatMap parallel decode should NOT be triggered for: "
+    EXPECT_EQ(parallelDecodeCount, 0)
+        << "Parallel decode should NOT be triggered for: "
         << testCase.debugString();
   }
 }

--- a/velox/dwio/nimble/velox/FieldReader.cpp
+++ b/velox/dwio/nimble/velox/FieldReader.cpp
@@ -16,6 +16,7 @@
 #include "velox/dwio/nimble/velox/FieldReader.h"
 
 #include <velox/type/StringView.h>
+#include <algorithm>
 #include <cstddef>
 
 #include "velox/dwio/nimble/common/Exceptions.h"
@@ -25,9 +26,9 @@
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/legacy/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/legacy/TrivialEncoding.h"
+#include "velox/dwio/nimble/serializer/Options.h"
 #include "velox/dwio/nimble/velox/SchemaReader.h"
 
-#include <folly/Conv.h>
 #include <folly/coro/Collect.h>
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/FlatMapHelper.h"
@@ -39,7 +40,229 @@ namespace facebook::nimble {
 
 namespace {
 
+// Holds the task allocation for one field reader.
+struct DecodeTaskPlan {
+  // Number of sibling decode tasks assigned to the reader.
+  uint32_t numTasks{1};
+};
+
+uint32_t numDecodeTasks(const DecodeTaskPlan* plan) {
+  return plan == nullptr ? 1 : plan->numTasks;
+}
+
+// Builds a fixed task budget across a field reader tree in breadth-first
+// order. A reader with N tasks adds N - 1 to the tree's maximum parallelism.
+class DecodePlanBuilder {
+ public:
+  // Creates a builder with a tree-wide parallelism cap and a target minimum
+  // scalar-stream count per task.
+  DecodePlanBuilder(
+      uint32_t maxDecodeParallelism,
+      uint32_t minStreamsPerDecodeTask)
+      : maxDecodeParallelism_{maxDecodeParallelism},
+        minStreamsPerDecodeTask_{std::max(1u, minStreamsPerDecodeTask)} {
+    NIMBLE_CHECK_GT(maxDecodeParallelism, 1);
+  }
+
+  // Registers a reader candidate using its directly partitionable children
+  // and their recursively counted scalar streams. Returns the task allocation
+  // finalized by build().
+  std::shared_ptr<const DecodeTaskPlan>
+  add(size_t level, uint32_t numChildReaders, uint32_t numScalarStreams) {
+    auto plan = std::make_shared<DecodeTaskPlan>();
+    if (numChildReaders <= 1) {
+      return plan;
+    }
+
+    const uint32_t maxTasksByStreams =
+        numScalarStreams / minStreamsPerDecodeTask_;
+    const uint32_t targetNumTasks = std::clamp(
+        std::min(maxDecodeParallelism_, maxTasksByStreams),
+        1u,
+        numChildReaders);
+    if (targetNumTasks > 1) {
+      candidates_.push_back({level, targetNumTasks, plan});
+    }
+    return plan;
+  }
+
+  // Allocates the shared task budget breadth-first and publishes each
+  // candidate's final task count.
+  void build() {
+    std::stable_sort(
+        candidates_.begin(),
+        candidates_.end(),
+        [](const Candidate& lhs, const Candidate& rhs) {
+          return lhs.level < rhs.level;
+        });
+
+    uint32_t remainingParallelism = maxDecodeParallelism_ - 1;
+    size_t levelBeginIndex{0};
+    while (levelBeginIndex < candidates_.size() && remainingParallelism > 0) {
+      size_t levelEndIndex{levelBeginIndex + 1};
+      while (levelEndIndex < candidates_.size() &&
+             candidates_[levelEndIndex].level ==
+                 candidates_[levelBeginIndex].level) {
+        ++levelEndIndex;
+      }
+
+      // Add one task to each eligible candidate per pass so readers at the
+      // same depth grow evenly. Stop when the budget is exhausted or every
+      // candidate at this level reaches its cap.
+      bool assignedTask = true;
+      while (assignedTask && remainingParallelism > 0) {
+        assignedTask = false;
+        for (size_t i = levelBeginIndex;
+             i < levelEndIndex && remainingParallelism > 0;
+             ++i) {
+          auto& candidate = candidates_[i];
+          if (candidate.plan->numTasks < candidate.targetNumTasks) {
+            ++candidate.plan->numTasks;
+            --remainingParallelism;
+            assignedTask = true;
+          }
+        }
+      }
+      levelBeginIndex = levelEndIndex;
+    }
+
+    for (const auto& candidate : candidates_) {
+      if (candidate.plan->numTasks > 1) {
+        velox::common::testutil::TestValue::adjust(
+            "facebook::nimble::DecodePlanBuilder::build",
+            &candidate.plan->numTasks);
+      }
+    }
+  }
+
+ private:
+  // Tracks a reader eligible for tasks from the shared parallelism budget.
+  struct Candidate {
+    // Prioritizes shallower readers during breadth-first allocation.
+    size_t level;
+    // Caps the useful task count before applying the shared budget.
+    uint32_t targetNumTasks;
+    // Publishes the assigned count to the corresponding reader factory.
+    std::shared_ptr<DecodeTaskPlan> plan;
+  };
+
+  const uint32_t maxDecodeParallelism_;
+  const uint32_t minStreamsPerDecodeTask_;
+  std::vector<Candidate> candidates_;
+};
+
 constexpr uint32_t kSkipBatchSize = 1024;
+
+struct DecodeTaskRange {
+  size_t begin;
+  size_t end;
+};
+
+// Counts scalar streams represented by a type. A timestamp contributes its
+// separate microsecond and nanosecond streams; every other scalar leaf
+// contributes one.
+uint32_t countScalarStreams(const velox::TypePtr& type) {
+  if (type->kind() == velox::TypeKind::TIMESTAMP) {
+    return 2;
+  }
+  if (type->size() == 0) {
+    return 1;
+  }
+
+  uint32_t numStreams{0};
+  for (uint32_t i = 0; i < type->size(); ++i) {
+    numStreams += countScalarStreams(type->childAt(i));
+  }
+  return numStreams;
+}
+
+std::shared_ptr<const DecodeTaskPlan> addDecodePlan(
+    DecodePlanBuilder* decodePlanBuilder,
+    size_t level,
+    const std::vector<std::unique_ptr<FieldReaderFactory>>& children) {
+  if (decodePlanBuilder == nullptr) {
+    return nullptr;
+  }
+
+  uint32_t numChildReaders{0};
+  uint32_t numScalarStreams{0};
+  for (const auto& child : children) {
+    if (child != nullptr) {
+      ++numChildReaders;
+      numScalarStreams += countScalarStreams(child->veloxType());
+    }
+  }
+  return decodePlanBuilder->add(level, numChildReaders, numScalarStreams);
+}
+
+// Creates a builder when the task budget enables parallel decode.
+std::unique_ptr<DecodePlanBuilder> createDecodePlanBuilder(
+    const FieldReaderParams& parameters) {
+  if (parameters.decodeExecutor == nullptr ||
+      parameters.maxDecodeParallelism <= 1) {
+    return nullptr;
+  }
+  return std::make_unique<DecodePlanBuilder>(
+      parameters.maxDecodeParallelism, parameters.minStreamsPerDecodeTask);
+}
+
+std::vector<DecodeTaskRange> partitionDecodeTasks(
+    size_t numChildren,
+    uint32_t numTasks) {
+  NIMBLE_CHECK_GT(numTasks, 0);
+  NIMBLE_CHECK_LE(numTasks, numChildren);
+
+  std::vector<DecodeTaskRange> ranges;
+  ranges.reserve(numTasks);
+
+  const size_t numChildrenPerTask = numChildren / numTasks;
+  const size_t numRemainingChildren = numChildren % numTasks;
+  size_t nextChild{0};
+  for (uint32_t taskIndex = 0; taskIndex < numTasks; ++taskIndex) {
+    const size_t childBegin = nextChild;
+    nextChild +=
+        numChildrenPerTask + (taskIndex < numRemainingChildren ? 1 : 0);
+    ranges.push_back({childBegin, nextChild});
+  }
+  return ranges;
+}
+
+using DecodeRangeFunction =
+    std::function<folly::coro::Task<void>(DecodeTaskRange)>;
+
+folly::coro::Task<void> decodeChildRanges(
+    folly::Executor* executor,
+    size_t numChildren,
+    uint32_t plannedNumTasks,
+    DecodeRangeFunction decodeRange) {
+  if (numChildren == 0) {
+    co_return;
+  }
+  uint32_t numTasks{
+      static_cast<uint32_t>(std::min<size_t>(numChildren, plannedNumTasks))};
+  if (numTasks <= 1) {
+    co_await decodeRange({0, numChildren});
+    co_return;
+  }
+
+  velox::common::testutil::TestValue::adjust(
+      "facebook::nimble::decodeChildRanges", &numTasks);
+
+  const auto ranges = partitionDecodeTasks(numChildren, numTasks);
+  auto decodeOnExecutor =
+      [executor,
+       &decodeRange](DecodeTaskRange range) -> folly::coro::Task<void> {
+    co_await folly::coro::co_withExecutor(executor, decodeRange(range));
+  };
+
+  std::vector<folly::coro::Task<void>> tasks;
+  tasks.reserve(numTasks);
+  for (uint32_t taskIndex = 0; taskIndex < numTasks; ++taskIndex) {
+    tasks.emplace_back(decodeOnExecutor(ranges[taskIndex]));
+  }
+
+  co_await folly::coro::collectAllRange(std::move(tasks));
+}
 
 uint32_t scatterCount(
     uint32_t count,
@@ -2445,16 +2668,16 @@ class RowFieldReader final : public FieldReader {
       co_return;
     }
 
-    // Decodes children in [startIdx, endIdx).
+    // Decodes the assigned child range.
     auto decodeRange = [this, &outputContext, &nonNullChildren](
-                           uint32_t startIdx,
-                           uint32_t endIdx) -> folly::coro::Task<void> {
+                           DecodeTaskRange range) -> folly::coro::Task<void> {
       velox::bits::Bitmap bitmap{
           outputContext.scatterNullBits, outputContext.rowCount};
       auto* bitmapPtr =
           outputContext.scatterNullBits != nullptr ? &bitmap : nullptr;
-      for (uint32_t idx = startIdx; idx < endIdx; ++idx) {
-        const auto i = nonNullChildren[idx];
+      for (size_t childOffset = range.begin; childOffset < range.end;
+           ++childOffset) {
+        const auto i = nonNullChildren[childOffset];
         co_await childrenReaders_[i]->co_next(
             outputContext.selectedNonNullCount,
             outputContext.vector->childAt(i),
@@ -2463,34 +2686,11 @@ class RowFieldReader final : public FieldReader {
       co_return;
     };
 
-    const auto numChildren = folly::to<uint32_t>(nonNullChildren.size());
-    const uint32_t taskCount = decodeTaskCount(numChildren);
-    if (taskCount <= 1) {
-      co_await decodeRange(0, numChildren);
-      co_return;
-    }
-
-    velox::common::testutil::TestValue::adjust(
-        "facebook::nimble::RowFieldReader::co_next",
-        const_cast<uint32_t*>(&taskCount));
-
-    const uint32_t childrenPerTask = numChildren / taskCount;
-    const uint32_t numRemainderChildren = numChildren % taskCount;
-
-    // First 'numRemainderChildren' tasks get one extra child each.
-    std::vector<folly::coro::TaskWithExecutor<void>> tasks;
-    tasks.reserve(taskCount);
-    uint32_t nextChildIdx = 0;
-    for (uint32_t task = 0; task < taskCount; ++task) {
-      const uint32_t endChildIdx = nextChildIdx + childrenPerTask +
-          (task < numRemainderChildren ? 1 : 0);
-      tasks.emplace_back(
-          folly::coro::co_withExecutor(
-              decodeExecutor_, decodeRange(nextChildIdx, endChildIdx)));
-      nextChildIdx = endChildIdx;
-    }
-
-    co_await folly::coro::collectAllRange(std::move(tasks));
+    co_await decodeChildRanges(
+        decodeExecutor_,
+        nonNullChildren.size(),
+        numDecodeTasks_,
+        std::move(decodeRange));
   }
 
   folly::coro::Task<void> co_skip(uint32_t count) final {
@@ -2614,11 +2814,11 @@ class RowFieldReaderFactory final : public FieldReaderFactory {
       const Type* type,
       std::vector<std::unique_ptr<FieldReaderFactory>> children,
       velox::memory::MemoryPool* pool,
-      const FieldReaderParams& params)
+      const FieldReaderParams& params,
+      std::shared_ptr<const DecodeTaskPlan> decodeTaskPlan)
       : FieldReaderFactory{std::move(veloxType), type, pool},
         decodeExecutor_{params.decodeExecutor},
-        maxDecodeParallelism_{params.maxDecodeParallelism},
-        minStreamsPerDecodeTask_{params.minStreamsPerDecodeTask},
+        decodeTaskPlan_{std::move(decodeTaskPlan)},
         children_{std::move(children)},
         boolBuffer_{pool_} {}
 
@@ -2637,7 +2837,9 @@ class RowFieldReaderFactory final : public FieldReaderFactory {
     }
 
     const FieldReader::Options options{
-        decodeExecutor_, maxDecodeParallelism_, minStreamsPerDecodeTask_};
+        .decodeExecutor = decodeExecutor_,
+        .numDecodeTasks = numDecodeTasks(decodeTaskPlan_.get()),
+    };
     if (!nulls) {
       return std::make_unique<RowFieldReader<false>>(
           veloxType_,
@@ -2659,8 +2861,7 @@ class RowFieldReaderFactory final : public FieldReaderFactory {
 
  private:
   folly::Executor* const decodeExecutor_;
-  const uint32_t maxDecodeParallelism_;
-  const uint32_t minStreamsPerDecodeTask_;
+  const std::shared_ptr<const DecodeTaskPlan> decodeTaskPlan_;
   std::vector<std::unique_ptr<FieldReaderFactory>> children_;
   Vector<bool> boolBuffer_;
 };
@@ -3075,12 +3276,12 @@ class StructFlatMapFieldReader : public FlatMapFieldReaderBase<T, hasNull> {
       co_return;
     }
 
-    // Decodes children in [startIdx, endIdx).
+    // Decodes the assigned child range.
     auto decodeRange = [this, rowCount, &outputContext, &nonNullChildren](
-                           uint32_t startIdx,
-                           uint32_t endIdx) -> folly::coro::Task<void> {
-      for (uint32_t idx = startIdx; idx < endIdx; ++idx) {
-        const auto i = nonNullChildren[idx];
+                           DecodeTaskRange range) -> folly::coro::Task<void> {
+      for (size_t childOffset = range.begin; childOffset < range.end;
+           ++childOffset) {
+        const auto i = nonNullChildren[childOffset];
         co_await this->keyNodes_[i]->co_readAsChild(
             outputContext.vector->childAt(i),
             rowCount,
@@ -3090,34 +3291,11 @@ class StructFlatMapFieldReader : public FlatMapFieldReaderBase<T, hasNull> {
       co_return;
     };
 
-    const auto numChildren = folly::to<uint32_t>(nonNullChildren.size());
-    const uint32_t taskCount = this->decodeTaskCount(numChildren);
-    if (taskCount <= 1) {
-      co_await decodeRange(0, numChildren);
-      co_return;
-    }
-
-    velox::common::testutil::TestValue::adjust(
-        "facebook::nimble::StructFlatMapFieldReader::co_next",
-        const_cast<uint32_t*>(&taskCount));
-
-    const uint32_t childrenPerTask = numChildren / taskCount;
-    const uint32_t numRemainderChildren = numChildren % taskCount;
-
-    // First 'numRemainderChildren' tasks get one extra child each.
-    std::vector<folly::coro::TaskWithExecutor<void>> tasks;
-    tasks.reserve(taskCount);
-    uint32_t nextChildIdx = 0;
-    for (uint32_t task = 0; task < taskCount; ++task) {
-      const uint32_t endChildIdx = nextChildIdx + childrenPerTask +
-          (task < numRemainderChildren ? 1 : 0);
-      tasks.emplace_back(
-          folly::coro::co_withExecutor(
-              this->decodeExecutor_, decodeRange(nextChildIdx, endChildIdx)));
-      nextChildIdx = endChildIdx;
-    }
-
-    co_await folly::coro::collectAllRange(std::move(tasks));
+    co_await decodeChildRanges(
+        this->decodeExecutor_,
+        nonNullChildren.size(),
+        this->numDecodeTasks_,
+        std::move(decodeRange));
   }
 
  private:
@@ -3153,7 +3331,8 @@ class StructFlatMapFieldReaderFactory final
       std::vector<std::unique_ptr<FieldReaderFactory>> valueReaders,
       const std::vector<size_t>& selectedChildren,
       velox::memory::MemoryPool* pool,
-      const FieldReaderParams& params)
+      const FieldReaderParams& params,
+      std::shared_ptr<const DecodeTaskPlan> decodeTaskPlan)
       : FlatMapFieldReaderFactoryBase<T>(
             std::move(veloxType),
             type,
@@ -3162,8 +3341,7 @@ class StructFlatMapFieldReaderFactory final
             selectedChildren,
             pool),
         decodeExecutor_{params.decodeExecutor},
-        maxDecodeParallelism_{params.maxDecodeParallelism},
-        minStreamsPerDecodeTask_{params.minStreamsPerDecodeTask},
+        decodeTaskPlan_{std::move(decodeTaskPlan)},
         mergedNulls_{this->pool_} {
     NIMBLE_CHECK(this->nimbleType_->isFlatMap(), "Type should be a flat map.");
   }
@@ -3172,15 +3350,16 @@ class StructFlatMapFieldReaderFactory final
       const folly::F14FastMap<offset_size, std::unique_ptr<Decoder>>& decoders)
       final {
     const FieldReader::Options options{
-        decodeExecutor_, maxDecodeParallelism_, minStreamsPerDecodeTask_};
+        .decodeExecutor = decodeExecutor_,
+        .numDecodeTasks = numDecodeTasks(decodeTaskPlan_.get()),
+    };
     return this->template createFlatMapReader<ReaderType, true>(
         decoders, mergedNulls_, options);
   }
 
  private:
   folly::Executor* const decodeExecutor_;
-  const uint32_t maxDecodeParallelism_;
-  const uint32_t minStreamsPerDecodeTask_;
+  const std::shared_ptr<const DecodeTaskPlan> decodeTaskPlan_;
   Vector<char> mergedNulls_;
 };
 
@@ -3611,7 +3790,8 @@ std::unique_ptr<FieldReaderFactory> createFlatMapReaderFactory(
     std::vector<std::unique_ptr<FieldReaderFactory>> valueReaders,
     const std::vector<size_t>& selectedChildren,
     bool flatMapAsStruct,
-    const FieldReaderParams& params) {
+    const FieldReaderParams& params,
+    std::shared_ptr<const DecodeTaskPlan> decodeTaskPlan) {
   switch (keyKind) {
 #define SCALAR_CASE(veloxKind, fieldType)                                  \
   case velox::TypeKind::veloxKind: {                                       \
@@ -3623,7 +3803,8 @@ std::unique_ptr<FieldReaderFactory> createFlatMapReaderFactory(
           std::move(valueReaders),                                         \
           selectedChildren,                                                \
           pool,                                                            \
-          params);                                                         \
+          params,                                                          \
+          std::move(decodeTaskPlan));                                      \
     } else {                                                               \
       return std::make_unique<MergedFlatMapFieldReaderFactory<fieldType>>( \
           std::move(veloxType),                                            \
@@ -3690,8 +3871,12 @@ velox::TypePtr inferType(
 
 // TODO: use field reader params or another flag to control creating legacy
 // string field reader.
+using GetDecodePool = std::function<velox::memory::MemoryPool*()>;
+
 std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
     const FieldReaderParams& parameters,
+    DecodePlanBuilder* decodePlanBuilder,
+    const GetDecodePool& getDecodePool,
     const std::shared_ptr<const Type>& nimbleType,
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& veloxType,
     std::vector<uint32_t>& offsets,
@@ -3795,6 +3980,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
         auto elements = isSelected(elementType->id())
             ? createFieldReaderFactory(
                   parameters,
+                  decodePlanBuilder,
+                  getDecodePool,
                   nimbleArray.elements(),
                   elementType,
                   offsets,
@@ -3817,6 +4004,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
         auto elements = isSelected(elementType->id())
             ? createFieldReaderFactory(
                   parameters,
+                  decodePlanBuilder,
+                  getDecodePool,
                   nimbleArrayWithOffsets.elements(),
                   elementType,
                   offsets,
@@ -3844,18 +4033,22 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
 
       for (auto i = 0; i < veloxType->size(); ++i) {
         auto& child = veloxType->childAt(i);
+        const bool selected = isSelected(child->id());
+        auto* childPool = selected ? getDecodePool() : pool;
         std::unique_ptr<FieldReaderFactory> factory;
-        if (isSelected(child->id())) {
+        if (selected) {
           if (i < nimbleRow.childrenCount()) {
             factory = createFieldReaderFactory(
                 parameters,
+                decodePlanBuilder,
+                getDecodePool,
                 nimbleRow.childAt(i),
                 child,
                 offsets,
                 isSelected,
                 level + 1,
                 &veloxRow.nameOf(i),
-                pool);
+                childPool);
           } else {
             factory = std::make_unique<NullFieldReaderFactory>(
                 inferType(
@@ -3863,7 +4056,7 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
                     veloxRow.nameOf(i),
                     veloxRow.childAt(i),
                     level + 1),
-                pool);
+                childPool);
           }
         }
         childTypes.emplace_back(factory ? factory->veloxType() : child->type());
@@ -3874,6 +4067,7 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
       // specified (eg. flat map read as struct). So create new ROW type based
       // on child types. Note this special logic is only for Row type based
       // on the constraint that flatmap can only be top level fields.
+      auto decodeTaskPlan = addDecodePlan(decodePlanBuilder, level, children);
       return std::make_unique<RowFieldReaderFactory>(
           velox::ROW(
               std::vector<std::string>(veloxRow.names()),
@@ -3881,7 +4075,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
           nimbleType.get(),
           std::move(children),
           pool,
-          parameters);
+          parameters,
+          std::move(decodeTaskPlan));
     }
     case velox::TypeKind::MAP: {
       NIMBLE_CHECK(
@@ -3900,6 +4095,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
         auto keys = isSelected(keyType->id())
             ? createFieldReaderFactory(
                   parameters,
+                  decodePlanBuilder,
+                  getDecodePool,
                   nimbleMap.keys(),
                   keyType,
                   offsets,
@@ -3912,6 +4109,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
         auto values = isSelected(valueType->id())
             ? createFieldReaderFactory(
                   parameters,
+                  decodePlanBuilder,
+                  getDecodePool,
                   nimbleMap.values(),
                   valueType,
                   offsets,
@@ -3934,6 +4133,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
         auto keys = isSelected(keyType->id())
             ? createFieldReaderFactory(
                   parameters,
+                  decodePlanBuilder,
+                  getDecodePool,
                   nimbleMap.keys(),
                   keyType,
                   offsets,
@@ -3946,6 +4147,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
         auto values = isSelected(valueType->id())
             ? createFieldReaderFactory(
                   parameters,
+                  decodePlanBuilder,
+                  getDecodePool,
                   nimbleMap.values(),
                   valueType,
                   offsets,
@@ -4082,15 +4285,18 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
         std::vector<std::unique_ptr<FieldReaderFactory>> valueReaders;
         valueReaders.reserve(selectedChildren.size());
         for (auto childIdx : selectedChildren) {
+          auto* valuePool = flatMapAsStruct ? getDecodePool() : pool;
           valueReaders.emplace_back(createFieldReaderFactory(
               parameters,
+              decodePlanBuilder,
+              getDecodePool,
               nimbleFlatMap.childAt(childIdx),
               valueType,
               offsets,
               isSelected,
               level + 1,
               nullptr,
-              pool));
+              valuePool));
         }
 
         const auto& keySelectionCallback = parameters.keySelectionCallback;
@@ -4100,6 +4306,9 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
                .selectedKeys = selectedChildren.size()});
         }
 
+        auto decodeTaskPlan = flatMapAsStruct
+            ? addDecodePlan(decodePlanBuilder, level, valueReaders)
+            : nullptr;
         return createFlatMapReaderFactory(
             pool,
             veloxType->childAt(0)->type()->kind(),
@@ -4109,7 +4318,8 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
             std::move(valueReaders),
             selectedChildren,
             flatMapAsStruct,
-            parameters);
+            parameters,
+            std::move(decodeTaskPlan));
       }
     }
     default:
@@ -4134,21 +4344,7 @@ FieldReader::FieldReader(
       type_{std::move(type)},
       decoder_{decoder},
       decodeExecutor_{options.decodeExecutor},
-      maxDecodeParallelism_{options.maxDecodeParallelism},
-      minStreamsPerDecodeTask_{options.minStreamsPerDecodeTask} {}
-
-uint32_t FieldReader::decodeTaskCount(uint32_t numChildren) const {
-  if (numChildren == 0) {
-    return 0;
-  }
-  if (decodeExecutor_ == nullptr) {
-    return 1;
-  }
-  const uint32_t maxByStreams =
-      numChildren / std::max(1u, minStreamsPerDecodeTask_);
-  return std::clamp(
-      std::min(maxDecodeParallelism_, maxByStreams), 1u, numChildren);
-}
+      numDecodeTasks_{options.numDecodeTasks} {}
 
 void FieldReader::ensureNullConstant(
     const std::shared_ptr<const velox::Type>& type,
@@ -4209,8 +4405,23 @@ std::unique_ptr<FieldReaderFactory> FieldReaderFactory::create(
     std::vector<uint32_t>& offsets,
     const std::function<bool(uint32_t)>& isSelected,
     velox::memory::MemoryPool* pool) {
-  return createFieldReaderFactory(
+  NIMBLE_CHECK(
+      parameters.decodePools.empty() ||
+          parameters.decodePools.size() == parameters.maxDecodeParallelism,
+      "Decode pool count must match maxDecodeParallelism when configured.");
+  auto decodePlanBuilder = createDecodePlanBuilder(parameters);
+  size_t decodePoolIndex{0};
+  const GetDecodePool getDecodePool = [&] {
+    if (parameters.decodePools.empty()) {
+      return pool;
+    }
+    return parameters
+        .decodePools[decodePoolIndex++ % parameters.decodePools.size()];
+  };
+  auto factory = createFieldReaderFactory(
       parameters,
+      decodePlanBuilder.get(),
+      getDecodePool,
       nimbleType,
       veloxType,
       offsets,
@@ -4218,6 +4429,10 @@ std::unique_ptr<FieldReaderFactory> FieldReaderFactory::create(
       /*level=*/0,
       /*name=*/nullptr,
       pool);
+  if (decodePlanBuilder != nullptr) {
+    decodePlanBuilder->build();
+  }
+  return factory;
 }
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/FieldReader.h
+++ b/velox/dwio/nimble/velox/FieldReader.h
@@ -60,24 +60,27 @@ struct FieldReaderParams {
   /// Executor for parallel decoding of child fields.
   folly::Executor* decodeExecutor{nullptr};
 
-  /// Maximum number of parallel coroutine tasks scheduled by each field
-  /// reader. Children are grouped into this many batches, each decoded
-  /// sequentially within a single coroutine task. This is a per-reader limit;
-  /// the executor bounds the number of tasks that run concurrently across the
-  /// reader tree. 0 disables parallel decoding.
+  /// Maximum planned decode parallelism across the field reader tree. Nested
+  /// scalar stream counts determine how many child-field tasks to create. 0
+  /// disables parallel decoding.
   uint32_t maxDecodeParallelism{0};
 
-  /// Minimum number of child streams per parallel decode task. Ensures each
-  /// coroutine task has enough work to amortize threading overhead.
+  /// Minimum number of nested scalar streams per planned decode task. Ensures
+  /// each coroutine task has enough work to amortize threading overhead.
   uint32_t minStreamsPerDecodeTask{1};
+
+  /// Optional leaf pools distributed round-robin among independently decoded
+  /// row children and FlatMap-as-struct values. When provided, the pool count
+  /// must match maxDecodeParallelism. The caller must keep the pools alive
+  /// while returned vectors exist.
+  std::vector<velox::memory::MemoryPool*> decodePools;
 };
 
 class FieldReader {
  public:
   struct Options {
     folly::Executor* decodeExecutor{nullptr};
-    uint32_t maxDecodeParallelism{0};
-    uint32_t minStreamsPerDecodeTask{1};
+    uint32_t numDecodeTasks{1};
   };
 
   FieldReader(
@@ -130,16 +133,11 @@ class FieldReader {
       uint32_t count,
       velox::VectorPtr& output) const;
 
-  // Returns the number of decode tasks. A single task keeps decoding on the
-  // current executor; multiple tasks enable parallel child decoding.
-  uint32_t decodeTaskCount(uint32_t numChildren) const;
-
   velox::memory::MemoryPool* const pool_;
   const velox::TypePtr type_;
   Decoder* const decoder_;
   folly::Executor* const decodeExecutor_;
-  const uint32_t maxDecodeParallelism_;
-  const uint32_t minStreamsPerDecodeTask_;
+  const uint32_t numDecodeTasks_;
 };
 
 class FieldReaderFactory {

--- a/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
@@ -16,6 +16,7 @@
 #include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <limits>
 #include <optional>
@@ -38,14 +39,17 @@
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/io/Options.h"
 #include "velox/common/memory/MallocAllocator.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/dwio/nimble/common/tests/TestUtils.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/serializer/Options.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "velox/dwio/nimble/velox/BatchReader.h"
@@ -1925,6 +1929,85 @@ TEST_P(BatchReaderTest, readComplexData) {
         }
       }
     }
+  }
+}
+
+DEBUG_ONLY_TEST_P(BatchReaderTest, parallelDecode) {
+  velox::common::testutil::TestValue::enable();
+
+  const auto nestedType = velox::ROW({
+      {"integer", velox::BIGINT()},
+      {"floatingPoint", velox::DOUBLE()},
+  });
+  const auto type = velox::ROW({
+      {"left", nestedType},
+      {"right", nestedType},
+  });
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = 50, .nullRatio = 0}, leafPool_.get());
+  const auto input = fuzzer.fuzzInputRow(type);
+  const auto file = nimble::test::createNimbleFile(*rootPool_, input);
+  const auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  constexpr uint32_t kMaxDecodeParallelism{4};
+  folly::CPUThreadPoolExecutor executor{kMaxDecodeParallelism};
+
+  // Keep the decode pool count aligned with the parallel task budget.
+  std::vector<std::shared_ptr<velox::memory::MemoryPool>> decodePoolOwners;
+  decodePoolOwners.reserve(kMaxDecodeParallelism);
+  nimble::BatchReadParams params;
+  params.decodeExecutor = &executor;
+  params.maxDecodeParallelism = kMaxDecodeParallelism;
+  params.minStreamsPerDecodeTask = 1;
+  for (uint32_t i = 0; i < kMaxDecodeParallelism; ++i) {
+    decodePoolOwners.emplace_back(
+        rootPool_->addLeafChild(fmt::format("parallel_decode_{}", i)));
+    params.decodePools.emplace_back(decodePoolOwners.back().get());
+  }
+
+  velox::VectorPtr result;
+  {
+    std::vector<uint32_t> plannedTaskCounts;
+    SCOPED_TESTVALUE_SET(
+        "facebook::nimble::DecodePlanBuilder::build",
+        std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
+          plannedTaskCounts.emplace_back(*taskCount);
+        }));
+    std::atomic_uint32_t numParallelRowDecodes{0};
+    std::atomic_bool unexpectedTaskCount{false};
+    SCOPED_TESTVALUE_SET(
+        "facebook::nimble::decodeChildRanges",
+        std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
+          if (*taskCount != 2) {
+            unexpectedTaskCount = true;
+          }
+          ++numParallelRowDecodes;
+        }));
+
+    auto reader = createBatchReader(readFile, *leafPool_, nullptr, params);
+    ASSERT_TRUE(reader->next(input->size(), result));
+    EXPECT_FALSE(reader->next(1, result));
+
+    const std::vector<uint32_t> expectedTaskCounts{2, 2, 2};
+    EXPECT_EQ(plannedTaskCounts, expectedTaskCounts);
+    EXPECT_EQ(numParallelRowDecodes, expectedTaskCounts.size());
+    EXPECT_FALSE(unexpectedTaskCount);
+  }
+
+  ASSERT_EQ(result->size(), input->size());
+  for (velox::vector_size_t row = 0; row < result->size(); ++row) {
+    EXPECT_TRUE(input->equalValueAt(result.get(), row, row));
+  }
+  EXPECT_GT(decodePoolOwners[0]->stats().cumulativeBytes, 0);
+  EXPECT_GT(decodePoolOwners[1]->stats().cumulativeBytes, 0);
+
+  auto skipReader = createBatchReader(readFile, *leafPool_, nullptr, params);
+  constexpr uint32_t kNumSkippedRows{17};
+  EXPECT_EQ(skipReader->skipRows(kNumSkippedRows), kNumSkippedRows);
+  ASSERT_TRUE(skipReader->next(input->size(), result));
+  ASSERT_EQ(result->size(), input->size() - kNumSkippedRows);
+  for (velox::vector_size_t row = 0; row < result->size(); ++row) {
+    EXPECT_TRUE(input->equalValueAt(result.get(), row + kNumSkippedRows, row));
   }
 }
 
@@ -4297,11 +4380,15 @@ TEST_P(BatchReaderTest, flatMapSkipAllFalseInMapStream) {
 
   // Read back as struct selecting all keys and verify null pattern.
   {
+    folly::CPUThreadPoolExecutor executor{4};
     velox::InMemoryReadFile readFile(file);
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
     nimble::BatchReadParams readParams = createReadParams();
     readParams.readFlatMapFieldAsStruct.insert("flat_map");
     readParams.flatMapFeatureSelector["flat_map"].features = {"1", "2", "3"};
+    readParams.decodeExecutor = &executor;
+    readParams.maxDecodeParallelism = 4;
+    readParams.minStreamsPerDecodeTask = 1;
     nimble::BatchReader reader(
         &readFile, *leafPool_, std::move(selector), readParams);
     velox::VectorPtr output;


### PR DESCRIPTION
Summary:

Replaces dynamic atomic permit acquisition with a one-time `DecodePlanBuilder`. Eligible row and struct-flat-map readers register during factory construction, then receive fixed task counts in breadth-first order. Each reader using N tasks consumes N - 1 units, keeping `1 + sum(tasks - 1) <= maxDecodeParallelism` across the tree while allowing sibling complex columns to use nested parallelism deterministically.

Clamps each static task assignment to the number of child streams present in the current stripe. This preserves valid struct-flat-map reads when selected schema keys have no decoder stream in a stripe.

Adds an independent Unicorn `--max_decode_parallelism` setting, capped by the executor thread count and defaulting to eight active tasks.

Adds optional caller-owned decode pools. The pool count matches `maxDecodeParallelism`, and selected row children plus FlatMap-as-struct values are assigned round-robin while the root row vector remains on the reader pool. The benchmark creates and retains these pools automatically and reports the actual pool count.

Reviewed By: zacw7

Differential Revision: D118263069


