### PR TITLE
fix(build): Drop LazyRE2 from parse_duration

### DIFF
--- a/velox/common/base/Macros.h
+++ b/velox/common/base/Macros.h
@@ -43,25 +43,6 @@
 #define VELOX_UNSUPPRESS_DEPRECATED_WARNING _Pragma("GCC diagnostic pop")
 #endif
 
-// Disable missing-field-initializers for Clang and GCC
-#ifdef __clang__
-#if defined(__has_warning) && \
-    __has_warning("-Wmissing-designated-field-initializers")
-#define VELOX_SUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING \
-  _Pragma("clang diagnostic push");                                  \
-  _Pragma(                                                           \
-      "clang diagnostic ignored \"-Wmissing-designated-field-initializers\"")
-#define VELOX_UNSUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING \
-  _Pragma("clang diagnostic pop");
-#else
-#define VELOX_SUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING
-#define VELOX_UNSUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING
-#endif
-#else
-#define VELOX_SUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING
-#define VELOX_UNSUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING
-#endif
-
 #define VELOX_CONCAT(x, y) x##y
 // Need this extra layer to expand __COUNTER__.
 #define VELOX_VARNAME_IMPL(x, y) VELOX_CONCAT(x, y)

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -2061,18 +2061,14 @@ struct ParseDurationFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<IntervalDayTime>& result,
       const arg_type<Varchar>& amountUnit) {
-    VELOX_SUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING
-    static const LazyRE2 kDurationRegex{
-        .pattern_ = R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$)",
-    };
-    VELOX_UNSUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING
+    static const RE2 kDurationRegex(R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$)");
     // TODO: Remove re2::StringPiece != std::string_view hacks.
     // It's needed because for some systems in CI,
     // re2 and abseil libraries are old.
     re2::StringPiece valueStr;
     re2::StringPiece unitStr;
     re2::StringPiece amountUnitStr{amountUnit.data(), amountUnit.size()};
-    if (!RE2::FullMatch(amountUnitStr, *kDurationRegex, &valueStr, &unitStr)) {
+    if (!RE2::FullMatch(amountUnitStr, kDurationRegex, &valueStr, &unitStr)) {
       VELOX_USER_FAIL(
           "Input duration is not a valid data duration string: {}",
           std::string_view(amountUnitStr.data(), amountUnitStr.size()));


### PR DESCRIPTION
Summary:
clang-tidy fails on any change that pulls in `DateTimeFunctions.h`:

    error: missing field 'options_' initializer [clang-diagnostic-missing-field-initializers]

See https://github.com/facebookincubator/velox/actions/runs/33714451712/job/100530928196.

`parse_duration` declares its regex as a `LazyRE2`. The initializer names only the `pattern_` field, and `LazyRE2` has four more.

Two things were meant to silence this, and neither does:

- `VELOX_SUPPRESS_MISSING_DESIGNATED_FIELD_INITIALIZERS_WARNING` expands to nothing below clang 19.
- `.clang-tidy` turns off `clang-diagnostic-missing-designated-field-initializers`, which is the clang 19 name for the warning.

CI pins clang-tidy 18.1.8. That version reports the older name, `clang-diagnostic-missing-field-initializers`, and `clang-diagnostic-*` leaves it on. `clang-diagnostic-*` was allowlisted in https://github.com/facebookincubator/velox/pull/18260, after the last change to this header. This is the first change to run the check over it. cc pedroerp, kKPulla

`LazyRE2` gives an object at namespace scope lazy, thread-safe construction. This one is a function-local static, and the language already guarantees both for those. A plain `static const RE2` does the same work with no aggregate to initialize. It was the only use of the macro in the repository, so the macro goes too.

Differential Revision: D118628694
