### PR TITLE
feat(dwrf): Support integer to varchar schema evolution

### DIFF
--- a/velox/dwio/common/TypeUtils.cpp
+++ b/velox/dwio/common/TypeUtils.cpp
@@ -117,11 +117,6 @@ std::unordered_set<uint32_t> makeCompatibilityMap() {
   return compat;
 }
 
-bool isCompatible(TypeKind from, TypeKind to) {
-  static auto compat = makeCompatibilityMap();
-  return from == to || compat.find(getKey(from, to)) != compat.end();
-}
-
 template <typename T, typename FKind, typename FShouldRead>
 void checkTypeCompatibility(
     const Type& from,
@@ -189,6 +184,11 @@ void checkTypeCompatibility(
         return selector.shouldReadNode(node.id());
       },
       exceptionMessageCreator);
+}
+
+bool isCompatible(TypeKind from, TypeKind to) {
+  static auto compat = makeCompatibilityMap();
+  return from == to || compat.find(getKey(from, to)) != compat.end();
 }
 
 } // namespace facebook::velox::dwio::common::typeutils

--- a/velox/dwio/common/TypeUtils.h
+++ b/velox/dwio/common/TypeUtils.h
@@ -39,4 +39,7 @@ void checkTypeCompatibility(
     const ColumnSelector& selector,
     const std::function<std::string()>& exceptionMessageCreator = nullptr);
 
+// Check type compatibility
+bool isCompatible(TypeKind from, TypeKind to);
+
 } // namespace facebook::velox::dwio::common::typeutils

--- a/velox/dwio/dwrf/reader/CMakeLists.txt
+++ b/velox/dwio/dwrf/reader/CMakeLists.txt
@@ -20,6 +20,7 @@ velox_add_library(
   DwrfReader.cpp
   FlatMapColumnReader.cpp
   ReaderBase.cpp
+  SelectiveByteRleColumnReader.cpp
   SelectiveDwrfReader.cpp
   SelectiveFlatMapColumnReader.cpp
   SelectiveIntegerDirectColumnReader.cpp

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -167,6 +167,35 @@ class DwrfParams : public dwio::common::FormatParams {
   FlatMapContext flatMapContext_;
 };
 
+template <typename T>
+VectorPtr convertIntegerToVarchar(
+    const VectorPtr& input,
+    memory::MemoryPool* pool) {
+  static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>);
+
+  const auto* values = input->as<SimpleVector<T>>();
+  auto strings = BaseVector::create<FlatVector<StringView>>(
+      VARCHAR(), input->size(), pool);
+
+  std::array<char, std::numeric_limits<T>::digits10 + 2> buffer;
+  for (vector_size_t i = 0; i < input->size(); ++i) {
+    if (input->isNullAt(i)) {
+      strings->setNull(i, true);
+      continue;
+    }
+
+    const auto [position, errorCode] = std::to_chars(
+        buffer.data(), buffer.data() + buffer.size(), values->valueAt(i));
+    VELOX_DCHECK_EQ(
+        errorCode,
+        std::errc(),
+        "Failed to convert value to varchar: {}.",
+        std::make_error_code(errorCode).message());
+    strings->set(i, StringView(buffer.data(), position - buffer.data()));
+  }
+  return strings;
+}
+
 inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
   switch (static_cast<int64_t>(kind)) {
     case proto::ColumnEncoding_Kind_DIRECT:

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -168,10 +168,8 @@ class DwrfParams : public dwio::common::FormatParams {
 };
 
 template <typename T>
-VectorPtr convertIntegerToVarchar(
-    const VectorPtr& input,
-    memory::MemoryPool* pool) {
-  static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>);
+VectorPtr convertToVarchar(const VectorPtr& input, memory::MemoryPool* pool) {
+  static_assert(std::is_integral_v<T>);
 
   const auto* values = input->as<SimpleVector<T>>();
   auto strings = BaseVector::create<FlatVector<StringView>>(
@@ -184,14 +182,18 @@ VectorPtr convertIntegerToVarchar(
       continue;
     }
 
-    const auto [position, errorCode] = std::to_chars(
-        buffer.data(), buffer.data() + buffer.size(), values->valueAt(i));
-    VELOX_DCHECK_EQ(
-        errorCode,
-        std::errc(),
-        "Failed to convert value to varchar: {}.",
-        std::make_error_code(errorCode).message());
-    strings->set(i, StringView(buffer.data(), position - buffer.data()));
+    if constexpr (std::is_same_v<T, bool>) {
+      strings->set(i, values->valueAt(i) ? "true" : "false");
+    } else {
+      const auto [position, errorCode] = std::to_chars(
+          buffer.data(), buffer.data() + buffer.size(), values->valueAt(i));
+      VELOX_DCHECK_EQ(
+          errorCode,
+          std::errc(),
+          "Failed to convert value to varchar: {}.",
+          std::make_error_code(errorCode).message());
+      strings->set(i, StringView(buffer.data(), position - buffer.data()));
+    }
   }
   return strings;
 }

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h"
+
+namespace facebook::velox::dwrf {
+
+SelectiveByteRleColumnReader::SelectiveByteRleColumnReader(
+    const TypePtr& requestedType,
+    std::shared_ptr<const dwio::common::TypeWithId> fileType,
+    DwrfParams& params,
+    common::ScanSpec& scanSpec,
+    bool isBool)
+    : dwio::common::SelectiveByteRleColumnReader(
+          requestedType,
+          std::move(fileType),
+          params,
+          scanSpec) {
+  const EncodingKey encodingKey{
+      fileType_->id(), params.flatMapContext().sequence};
+  auto& stripe = params.stripeStreams();
+  if (isBool) {
+    boolRle_ = createBooleanRleDecoder(
+        stripe.getStream(
+            StripeStreamsUtil::getStreamForKind(
+                stripe,
+                encodingKey,
+                proto::Stream_Kind_DATA,
+                proto::orc::Stream_Kind_DATA),
+            params.streamLabels().label(),
+            true),
+        encodingKey);
+  } else {
+    byteRle_ = createByteRleDecoder(
+        stripe.getStream(
+            StripeStreamsUtil::getStreamForKind(
+                stripe,
+                encodingKey,
+                proto::Stream_Kind_DATA,
+                proto::orc::Stream_Kind_DATA),
+            params.streamLabels().label(),
+            true),
+        encodingKey);
+  }
+}
+
+void SelectiveByteRleColumnReader::seekToRowGroup(int64_t index) {
+  dwio::common::SelectiveByteRleColumnReader::seekToRowGroup(index);
+  auto positionsProvider = formatData_->seekToRowGroup(index);
+  if (boolRle_) {
+    boolRle_->seekToRowGroup(positionsProvider);
+  } else {
+    byteRle_->seekToRowGroup(positionsProvider);
+  }
+
+  VELOX_CHECK(!positionsProvider.hasNext());
+}
+
+uint64_t SelectiveByteRleColumnReader::skip(uint64_t numValues) {
+  numValues = formatData_->skipNulls(numValues);
+  if (byteRle_) {
+    byteRle_->skip(numValues);
+  } else {
+    boolRle_->skip(numValues);
+  }
+  return numValues;
+}
+
+void SelectiveByteRleColumnReader::read(
+    int64_t offset,
+    const RowSet& rows,
+    const uint64_t* incomingNulls) {
+  readCommon<SelectiveByteRleColumnReader, true>(offset, rows, incomingNulls);
+  readOffset_ += rows.back() + 1;
+}
+
+void SelectiveByteRleColumnReader::getValues(
+    const RowSet& rows,
+    VectorPtr* result) {
+  if (requestedType_->kind() != TypeKind::VARCHAR) {
+    dwio::common::SelectiveByteRleColumnReader::getValues(rows, result);
+    return;
+  }
+
+  VectorPtr integers;
+  getFlatValues<int8_t, int8_t>(rows, &integers, TINYINT());
+  *result = convertIntegerToVarchar<int8_t>(integers, pool_);
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
@@ -95,9 +95,15 @@ void SelectiveByteRleColumnReader::getValues(
     return;
   }
 
-  VectorPtr integers;
-  getFlatValues<int8_t, int8_t>(rows, &integers, TINYINT());
-  *result = convertIntegerToVarchar<int8_t>(integers, pool_);
+  if (boolRle_) {
+    VectorPtr booleans;
+    getFlatValues<int8_t, bool>(rows, &booleans, BOOLEAN());
+    *result = convertToVarchar<bool>(booleans, pool_);
+  } else {
+    VectorPtr integers;
+    getFlatValues<int8_t, int8_t>(rows, &integers, TINYINT());
+    *result = convertToVarchar<int8_t>(integers, pool_);
+  }
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveByteRleColumnReader.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+#include "velox/dwio/dwrf/reader/DwrfData.h"
 
 namespace facebook::velox::dwrf {
 
@@ -30,71 +32,20 @@ class SelectiveByteRleColumnReader
       std::shared_ptr<const dwio::common::TypeWithId> fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,
-      bool isBool)
-      : dwio::common::SelectiveByteRleColumnReader(
-            requestedType,
-            std::move(fileType),
-            params,
-            scanSpec) {
-    const EncodingKey encodingKey{
-        fileType_->id(), params.flatMapContext().sequence};
-    auto& stripe = params.stripeStreams();
-    if (isBool) {
-      boolRle_ = createBooleanRleDecoder(
-          stripe.getStream(
-              StripeStreamsUtil::getStreamForKind(
-                  stripe,
-                  encodingKey,
-                  proto::Stream_Kind_DATA,
-                  proto::orc::Stream_Kind_DATA),
-              params.streamLabels().label(),
-              true),
-          encodingKey);
-    } else {
-      byteRle_ = createByteRleDecoder(
-          stripe.getStream(
-              StripeStreamsUtil::getStreamForKind(
-                  stripe,
-                  encodingKey,
-                  proto::Stream_Kind_DATA,
-                  proto::orc::Stream_Kind_DATA),
-              params.streamLabels().label(),
-              true),
-          encodingKey);
-    }
-  }
+      bool isBool);
+
+  void getValues(const RowSet& rows, VectorPtr* result) override;
 
   bool hasBulkPath() const override {
     return false;
   }
 
-  void seekToRowGroup(int64_t index) override {
-    dwio::common::SelectiveByteRleColumnReader::seekToRowGroup(index);
-    auto positionsProvider = formatData_->seekToRowGroup(index);
-    if (boolRle_) {
-      boolRle_->seekToRowGroup(positionsProvider);
-    } else {
-      byteRle_->seekToRowGroup(positionsProvider);
-    }
+  void seekToRowGroup(int64_t index) override;
 
-    VELOX_CHECK(!positionsProvider.hasNext());
-  }
-
-  uint64_t skip(uint64_t numValues) override {
-    numValues = formatData_->skipNulls(numValues);
-    if (byteRle_) {
-      byteRle_->skip(numValues);
-    } else {
-      boolRle_->skip(numValues);
-    }
-    return numValues;
-  }
+  uint64_t skip(uint64_t numValues) override;
 
   void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
-      override {
-    readCommon<SelectiveByteRleColumnReader, true>(offset, rows, incomingNulls);
-    readOffset_ += rows.back() + 1;
-  }
+      override;
 
   template <typename ColumnVisitor>
   void readWithVisitor(const RowSet& rows, ColumnVisitor visitor);

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -33,16 +33,46 @@ namespace facebook::velox::dwrf {
 
 using namespace facebook::velox::dwio::common;
 
+void checkType(
+    const TypePtr& fileType,
+    const TypePtr& requestedType,
+    const std::function<bool(const TypePtr&)>& isCompatible) {
+  if (!isCompatible(requestedType)) {
+    VELOX_SCHEMA_MISMATCH_ERROR(
+        fmt::format(
+            "Schema mismatch, From Kind: {}, To Kind: {}",
+            TypeKindName::toName(fileType->kind()),
+            TypeKindName::toName(requestedType->kind())));
+  }
+}
+
+bool isIntegerCompatible(
+    TypeKind fileType,
+    const TypePtr& requestedType,
+    const bool projectOnly) {
+  if (requestedType->isVarchar()) {
+    // Integer values are converted to VARCHAR in getValues(). Filters and
+    // value hooks run before this conversion and operate on integer values.
+    VELOX_USER_CHECK(
+        projectOnly,
+        "INTEGER to VARCHAR schema evolution only supports projection");
+    return true;
+  }
+
+  return !requestedType->isDecimal() &&
+      dwio::common::typeutils::isCompatible(fileType, requestedType->kind());
+}
+
 std::unique_ptr<SelectiveColumnReader> buildIntegerReader(
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
-    uint32_t numBytes,
     common::ScanSpec& scanSpec) {
   const EncodingKey encodingKey{
       fileType->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
 
+  const auto numBytes = sizeOfIntKind(fileType->type()->kind());
   if (StripeStreamsUtil::isColumnEncodingKindDictionary(stripe, encodingKey)) {
     return std::make_unique<SelectiveIntegerDictionaryColumnReader>(
         requestedType, fileType, params, scanSpec, numBytes);
@@ -66,33 +96,50 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     DwrfParams& params,
     common::ScanSpec& scanSpec,
     bool isRoot) {
+  const auto fileTypeKind = fileType->type()->kind();
   VELOX_CHECK(
-      !isRoot || fileType->type()->kind() == TypeKind::ROW,
+      !isRoot || fileTypeKind == TypeKind::ROW,
       "The root object can only be a row.");
 
-  dwio::common::typeutils::checkTypeCompatibility(
-      *fileType->type(), *requestedType);
   EncodingKey ek{fileType->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  switch (fileType->type()->kind()) {
-    case TypeKind::INTEGER:
-      return buildIntegerReader(
-          requestedType, fileType, params, INT_BYTE_SIZE, scanSpec);
+  const bool projectOnly = !scanSpec.filter() && !scanSpec.valueHook();
+  switch (fileTypeKind) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+      checkType(fileType->type(), requestedType, [=](const TypePtr& type) {
+        return isIntegerCompatible(fileTypeKind, requestedType, projectOnly);
+      });
+      return std::make_unique<SelectiveByteRleColumnReader>(
+          requestedType,
+          fileType,
+          params,
+          scanSpec,
+          fileType->type()->isBoolean());
     case TypeKind::BIGINT:
       if (fileType->type()->isDecimal()) {
+        checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+          return type->isShortDecimal();
+        });
         return std::make_unique<SelectiveDecimalColumnReader<int64_t>>(
             requestedType, fileType, params, scanSpec);
-      } else {
-        return buildIntegerReader(
-            requestedType, fileType, params, LONG_BYTE_SIZE, scanSpec);
       }
     case TypeKind::SMALLINT:
-      return buildIntegerReader(
-          requestedType, fileType, params, SHORT_BYTE_SIZE, scanSpec);
+    case TypeKind::INTEGER:
+      checkType(fileType->type(), requestedType, [=](const TypePtr& type) {
+        return isIntegerCompatible(fileTypeKind, requestedType, projectOnly);
+      });
+      return buildIntegerReader(requestedType, fileType, params, scanSpec);
     case TypeKind::ARRAY:
+      checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+        return type->isArray();
+      });
       return std::make_unique<SelectiveListColumnReader>(
           columnReaderOptions, requestedType, fileType, params, scanSpec);
     case TypeKind::MAP:
+      checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+        return type->isMap();
+      });
       if (stripe.format() == DwrfFormat::kDwrf &&
           stripe.getEncoding(ek).kind() ==
               proto::ColumnEncoding_Kind_MAP_FLAT) {
@@ -106,7 +153,10 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
       return std::make_unique<SelectiveMapColumnReader>(
           columnReaderOptions, requestedType, fileType, params, scanSpec);
     case TypeKind::REAL:
-      if (requestedType->kind() == TypeKind::REAL) {
+      checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+        return type->isReal() || type->isDouble();
+      });
+      if (requestedType->isReal()) {
         return std::make_unique<
             SelectiveFloatingPointColumnReader<float, float>>(
             requestedType, fileType, params, scanSpec);
@@ -116,10 +166,16 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
             requestedType, fileType, params, scanSpec);
       }
     case TypeKind::DOUBLE:
+      checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+        return type->isDouble();
+      });
       return std::make_unique<
           SelectiveFloatingPointColumnReader<double, double>>(
           requestedType, fileType, params, scanSpec);
     case TypeKind::ROW:
+      checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+        return type->isRow();
+      });
       return std::make_unique<SelectiveStructColumnReader>(
           columnReaderOptions,
           requestedType,
@@ -127,14 +183,11 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
           params,
           scanSpec,
           isRoot);
-    case TypeKind::BOOLEAN:
-      return std::make_unique<SelectiveByteRleColumnReader>(
-          requestedType, fileType, params, scanSpec, true);
-    case TypeKind::TINYINT:
-      return std::make_unique<SelectiveByteRleColumnReader>(
-          requestedType, fileType, params, scanSpec, false);
     case TypeKind::VARBINARY:
-    case TypeKind::VARCHAR:
+    case TypeKind::VARCHAR: {
+      checkType(fileType->type(), requestedType, [&](const TypePtr& type) {
+        return type->kind() == fileTypeKind;
+      });
       if (StripeStreamsUtil::isColumnEncodingKindDictionary(stripe, ek)) {
         return std::make_unique<SelectiveStringDictionaryColumnReader>(
             fileType, params, scanSpec);
@@ -144,11 +197,18 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
       } else {
         DWIO_RAISE("buildReader string unknown encoding");
       }
+    }
     case TypeKind::TIMESTAMP:
+      checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+        return type->isTimestamp();
+      });
       return std::make_unique<SelectiveTimestampColumnReader>(
           fileType, params, scanSpec);
     case TypeKind::HUGEINT:
       if (fileType->type()->isDecimal()) {
+        checkType(fileType->type(), requestedType, [](const TypePtr& type) {
+          return type->isLongDecimal();
+        });
         return std::make_unique<SelectiveDecimalColumnReader<int128_t>>(
             requestedType, fileType, params, scanSpec);
       }

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -46,21 +46,14 @@ void checkType(
   }
 }
 
-bool isIntegerCompatible(
-    TypeKind fileType,
-    const TypePtr& requestedType,
-    const bool projectOnly) {
+bool isIntegerCompatible(TypeKind fileType, const TypePtr& requestedType) {
   if (requestedType->isShortDecimal()) {
     // DWRF can store short decimals as BIGINT without decimal scale streams.
     // The integer reader materializes these values using the requested type.
     return fileType == TypeKind::BIGINT;
   }
   if (requestedType->isVarchar()) {
-    // Integer values are converted to VARCHAR in getValues(). Filters and
-    // value hooks run before this conversion and operate on integer values.
-    VELOX_USER_CHECK(
-        projectOnly,
-        "INTEGER to VARCHAR schema evolution only supports projection");
+    // Integer values are converted to VARCHAR in getValues().
     return true;
   }
 
@@ -107,12 +100,11 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
 
   EncodingKey ek{fileType->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  const bool projectOnly = !scanSpec.filter() && !scanSpec.valueHook();
   switch (fileTypeKind) {
     case TypeKind::BOOLEAN:
     case TypeKind::TINYINT:
       checkType(fileType->type(), requestedType, [=](const TypePtr& type) {
-        return isIntegerCompatible(fileTypeKind, requestedType, projectOnly);
+        return isIntegerCompatible(fileTypeKind, requestedType);
       });
       return std::make_unique<SelectiveByteRleColumnReader>(
           requestedType,
@@ -131,7 +123,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     case TypeKind::SMALLINT:
     case TypeKind::INTEGER:
       checkType(fileType->type(), requestedType, [=](const TypePtr& type) {
-        return isIntegerCompatible(fileTypeKind, requestedType, projectOnly);
+        return isIntegerCompatible(fileTypeKind, requestedType);
       });
       return buildIntegerReader(requestedType, fileType, params, scanSpec);
     case TypeKind::ARRAY:

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -50,6 +50,11 @@ bool isIntegerCompatible(
     TypeKind fileType,
     const TypePtr& requestedType,
     const bool projectOnly) {
+  if (requestedType->isShortDecimal()) {
+    // DWRF can store short decimals as BIGINT without decimal scale streams.
+    // The integer reader materializes these values using the requested type.
+    return fileType == TypeKind::BIGINT;
+  }
   if (requestedType->isVarchar()) {
     // Integer values are converted to VARCHAR in getValues(). Filters and
     // value hooks run before this conversion and operate on integer values.
@@ -59,8 +64,7 @@ bool isIntegerCompatible(
     return true;
   }
 
-  return !requestedType->isDecimal() &&
-      dwio::common::typeutils::isCompatible(fileType, requestedType->kind());
+  return dwio::common::typeutils::isCompatible(fileType, requestedType->kind());
 }
 
 std::unique_ptr<SelectiveColumnReader> buildIntegerReader(

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -64,6 +64,32 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
   scanState_.updateRawState();
 }
 
+void SelectiveIntegerDictionaryColumnReader::getValues(
+    const RowSet& rows,
+    VectorPtr* result) {
+  if (!requestedType_->isVarchar()) {
+    SelectiveIntegerColumnReader::getValues(rows, result);
+    return;
+  }
+
+  VectorPtr integers;
+  getIntValues(rows, fileType_->type(), &integers);
+  switch (fileType_->type()->kind()) {
+    case TypeKind::SMALLINT:
+      *result = convertIntegerToVarchar<int16_t>(integers, pool_);
+      return;
+    case TypeKind::INTEGER:
+      *result = convertIntegerToVarchar<int32_t>(integers, pool_);
+      return;
+    case TypeKind::BIGINT:
+      *result = convertIntegerToVarchar<int64_t>(integers, pool_);
+      return;
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected integer type: {}", fileType_->type()->toString());
+  }
+}
+
 uint64_t SelectiveIntegerDictionaryColumnReader::skip(uint64_t numValues) {
   numValues = SelectiveColumnReader::skip(numValues);
   dataReader_->skip(numValues);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -76,13 +76,13 @@ void SelectiveIntegerDictionaryColumnReader::getValues(
   getIntValues(rows, fileType_->type(), &integers);
   switch (fileType_->type()->kind()) {
     case TypeKind::SMALLINT:
-      *result = convertIntegerToVarchar<int16_t>(integers, pool_);
+      *result = convertToVarchar<int16_t>(integers, pool_);
       return;
     case TypeKind::INTEGER:
-      *result = convertIntegerToVarchar<int32_t>(integers, pool_);
+      *result = convertToVarchar<int32_t>(integers, pool_);
       return;
     case TypeKind::BIGINT:
-      *result = convertIntegerToVarchar<int64_t>(integers, pool_);
+      *result = convertToVarchar<int64_t>(integers, pool_);
       return;
     default:
       VELOX_UNREACHABLE(

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -47,6 +47,8 @@ class SelectiveIntegerDictionaryColumnReader
 
   uint64_t skip(uint64_t numValues) override;
 
+  void getValues(const RowSet& rows, VectorPtr* result) override;
+
   void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
       override;
 

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
@@ -18,6 +18,32 @@
 
 namespace facebook::velox::dwrf {
 
+void SelectiveIntegerDirectColumnReader::getValues(
+    const RowSet& rows,
+    VectorPtr* result) {
+  if (!requestedType_->isVarchar()) {
+    SelectiveIntegerColumnReader::getValues(rows, result);
+    return;
+  }
+
+  VectorPtr integers;
+  getIntValues(rows, fileType_->type(), &integers);
+  switch (fileType_->type()->kind()) {
+    case TypeKind::SMALLINT:
+      *result = convertIntegerToVarchar<int16_t>(integers, pool_);
+      return;
+    case TypeKind::INTEGER:
+      *result = convertIntegerToVarchar<int32_t>(integers, pool_);
+      return;
+    case TypeKind::BIGINT:
+      *result = convertIntegerToVarchar<int64_t>(integers, pool_);
+      return;
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected integer type: {}", fileType_->type()->toString());
+  }
+}
+
 uint64_t SelectiveIntegerDirectColumnReader::skip(uint64_t numValues) {
   numValues = SelectiveColumnReader::skip(numValues);
   intDecoder_->skip(numValues);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
@@ -30,13 +30,13 @@ void SelectiveIntegerDirectColumnReader::getValues(
   getIntValues(rows, fileType_->type(), &integers);
   switch (fileType_->type()->kind()) {
     case TypeKind::SMALLINT:
-      *result = convertIntegerToVarchar<int16_t>(integers, pool_);
+      *result = convertToVarchar<int16_t>(integers, pool_);
       return;
     case TypeKind::INTEGER:
-      *result = convertIntegerToVarchar<int32_t>(integers, pool_);
+      *result = convertToVarchar<int32_t>(integers, pool_);
       return;
     case TypeKind::BIGINT:
-      *result = convertIntegerToVarchar<int64_t>(integers, pool_);
+      *result = convertToVarchar<int64_t>(integers, pool_);
       return;
     default:
       VELOX_UNREACHABLE(

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -83,6 +83,8 @@ class SelectiveIntegerDirectColumnReader
     VELOX_CHECK(!positionsProvider.hasNext());
   }
 
+  void getValues(const RowSet& rows, VectorPtr* result) override;
+
   uint64_t skip(uint64_t numValues) override;
 
   void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -519,8 +519,8 @@ class SchemaMismatchTest : public TestWithParam<SchemaMismatchTestParam>,
     return parallelDecoding_;
   }
 
-  template <typename From, typename To>
-  void runTest(uint64_t size) {
+  template <typename From, typename To, typename AssertEqual>
+  void runTest(uint64_t size, const AssertEqual& assertEqual) {
     auto fileType = ROW({"c0"}, {CppToType<From>::create()});
     auto requestedType = ROW({"c0"}, {CppToType<To>::create()});
 
@@ -553,9 +553,16 @@ class SchemaMismatchTest : public TestWithParam<SchemaMismatchTestParam>,
       auto isNull = asIsField->isNullAt(i);
       EXPECT_EQ(isNull, mismatchField->isNullAt(i));
       if (!isNull) {
-        EXPECT_EQ(asIsField->valueAt(i), mismatchField->valueAt(i));
+        assertEqual(asIsField->valueAt(i), mismatchField->valueAt(i));
       }
     }
+  }
+
+  template <typename From, typename To>
+  void runTest(uint64_t size) {
+    runTest<From, To>(size, [](const auto& expected, const auto& actual) {
+      EXPECT_EQ(expected, actual);
+    });
   }
 
   // columnReader_ and selectiveColumnReader_ are mismatch ColumnReaders
@@ -5250,6 +5257,81 @@ TEST_P(SchemaMismatchTest, testFloat) {
           }));
 
   runTest<float, double>(size);
+}
+
+TEST_P(SchemaMismatchTest, testintegerToVarchar) {
+  // set format
+  streams_.setFormat(DwrfFormat::kOrc);
+  // set getEncoding
+  proto::orc::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::orc::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingOrcProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(_, proto::orc::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(_, proto::orc::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+
+  if (!useSelectiveReader()) {
+    const auto fileType = ROW({"c0"}, {BIGINT()});
+    const auto requestedType = ROW({"c0"}, {VARCHAR()});
+    VELOX_ASSERT_THROW(
+        buildReader(requestedType, fileType),
+        "Schema mismatch, From Kind: BIGINT, To Kind: VARCHAR");
+    return;
+  }
+
+  const std::vector<int64_t> values = {
+      std::numeric_limits<int64_t>::min(),
+      -1,
+      0,
+      1,
+      std::numeric_limits<int64_t>::max()};
+  std::array<char, 128> data;
+  data[0] = static_cast<char>(-values.size());
+  const auto encodedSize = writeVsLongs(data.data() + 1, values) + 1;
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(1, proto::orc::Stream_Kind_DATA, true))
+      .WillRepeatedly(Invoke([&](auto, auto, auto) {
+        return new SeekableArrayInputStream(data.data(), encodedSize);
+      }));
+
+  runTest<int64_t, StringView>(
+      values.size(), [](int64_t expected, StringView actual) {
+        EXPECT_EQ(std::to_string(expected), actual.str());
+      });
+}
+
+TEST_P(SchemaMismatchTest, testIntegerToVarcharWithFilter) {
+  if (!useSelectiveReader()) {
+    return;
+  }
+
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+  EXPECT_CALL(streams_, getStreamProxy(_, _, _))
+      .WillRepeatedly(Return(nullptr));
+
+  const auto requestedType = ROW({"c0"}, {VARCHAR()});
+  const std::vector<TypePtr> integerTypes = {
+      TINYINT(), SMALLINT(), INTEGER(), BIGINT()};
+  for (const auto& integerType : integerTypes) {
+    auto scanSpec = std::make_unique<common::ScanSpec>("root");
+    scanSpec->getOrCreateChild(common::Subfield("c0"))
+        ->setFilter(
+            std::make_unique<common::BytesValues>(
+                std::vector<std::string>{"1"}, false));
+    VELOX_ASSERT_THROW(
+        buildReader(
+            requestedType, ROW({"c0"}, {integerType}), {}, scanSpec.get()),
+        "to VARCHAR schema evolution only supports projection");
+  }
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -5083,6 +5083,11 @@ TEST_P(SchemaMismatchTest, testBoolean) {
   runTest<bool, int16_t>(size);
   runTest<bool, int32_t>(size);
   runTest<bool, int64_t>(size);
+  if (useSelectiveReader()) {
+    runTest<bool, StringView>(size, [](bool expected, StringView actual) {
+      EXPECT_EQ(expected ? "true" : "false", actual.str());
+    });
+  }
 }
 
 TEST_P(SchemaMismatchTest, testByte) {

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -5264,7 +5264,7 @@ TEST_P(SchemaMismatchTest, testFloat) {
   runTest<float, double>(size);
 }
 
-TEST_P(SchemaMismatchTest, testintegerToVarchar) {
+TEST_P(SchemaMismatchTest, testIntegerToVarchar) {
   // set format
   streams_.setFormat(DwrfFormat::kOrc);
   // set getEncoding
@@ -5309,34 +5309,20 @@ TEST_P(SchemaMismatchTest, testintegerToVarchar) {
       values.size(), [](int64_t expected, StringView actual) {
         EXPECT_EQ(std::to_string(expected), actual.str());
       });
-}
 
-TEST_P(SchemaMismatchTest, testIntegerToVarcharWithFilter) {
-  if (!useSelectiveReader()) {
-    return;
-  }
-
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams_, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-  EXPECT_CALL(streams_, getStreamProxy(_, _, _))
-      .WillRepeatedly(Return(nullptr));
-
+  // Filter on integer to varchar schema evolution is not supported.
+  auto scanSpec = std::make_unique<common::ScanSpec>("root");
+  scanSpec->getOrCreateChild(common::Subfield("c0"))
+      ->setFilter(
+          std::make_unique<common::BytesValues>(
+              std::vector<std::string>{"1"}, false));
+  const auto fileType = ROW({"c0"}, {BIGINT()});
   const auto requestedType = ROW({"c0"}, {VARCHAR()});
-  const std::vector<TypePtr> integerTypes = {
-      TINYINT(), SMALLINT(), INTEGER(), BIGINT()};
-  for (const auto& integerType : integerTypes) {
-    auto scanSpec = std::make_unique<common::ScanSpec>("root");
-    scanSpec->getOrCreateChild(common::Subfield("c0"))
-        ->setFilter(
-            std::make_unique<common::BytesValues>(
-                std::vector<std::string>{"1"}, false));
-    VELOX_ASSERT_THROW(
-        buildReader(
-            requestedType, ROW({"c0"}, {integerType}), {}, scanSpec.get()),
-        "to VARCHAR schema evolution only supports projection");
-  }
+  buildReader(requestedType, fileType, {}, scanSpec.get());
+  VectorPtr batch = newBatch(requestedType);
+  VELOX_ASSERT_THROW(
+      selectiveColumnReader_->next(values.size(), batch, nullptr),
+      "testInt64() is not supported");
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Context
Spark used orc-core supports integer to string schema evolution: https://github.com/apache/orc/blob/v2.2.1/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java#L1978-L1982

But velox does not support it yet, and cause gluten disabled related tests: https://github.com/apache/gluten/blob/2fe84a1a00842c519e1c3f12571114b10850c291/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala#L469-L470

## Change
Support reading integer columns as VARCHAR through the DWRF/ORC selective reader path.
- Moves type compatibility validation into `SelectiveDwrfReader::build()`
- Converts integers to string in related column readers's `getValues()`
- Add two unit tests