### PR TITLE
feat(writer): Expose nimble writer options as SerDe keys

### DIFF
--- a/velox/dwio/nimble/velox/NimbleConfig.cpp
+++ b/velox/dwio/nimble/velox/NimbleConfig.cpp
@@ -388,4 +388,46 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
 /* static */ Config::Entry<bool> Config::ENABLE_ENCODING_SELECTION_CACHE(
     "nimble.encoding.enable_selection_cache",
     false);
+
+// Defaults match the corresponding WriterOptions fields, so an absent key
+// leaves the writer exactly where it was. METADATA_COMPRESSION_THRESHOLD is the
+// exception: WriterOptions holds an optional and the writer substitutes its own
+// threshold when unset, so the builder applies this only when the key is
+// present rather than defaulting it here.
+/* static */ Config::Entry<uint32_t> Config::METADATA_COMPRESSION_THRESHOLD(
+    "nimble.metadata.compression.threshold",
+    0);
+
+/* static */ Config::Entry<std::string> Config::STRIPE_GROUP_ENCODING_LAYOUT(
+    "nimble.stripe_group.encoding_layout",
+    "raw");
+
+/* static */ Config::Entry<double> Config::CHUNK_STATS_MIN_AVG_CHUNKS(
+    "nimble.chunk.stats.min_avg_chunks",
+    2);
+
+/* static */ Config::Entry<uint32_t> Config::MAX_ENCODE_PARALLELISM(
+    "nimble.encoding.max_parallelism",
+    0);
+
+/* static */ Config::Entry<uint32_t> Config::MIN_STREAMS_PER_ENCODING_TASK(
+    "nimble.encoding.min_streams_per_task",
+    1);
+
+/* static */ Config::Entry<uint32_t>
+    Config::MAX_CACHED_ENCODING_SCRATCH_BUFFERS(
+        "nimble.encoding.max_cached_scratch_buffers",
+        0);
+
+/* static */ Config::Entry<uint32_t> Config::MAX_CACHED_NESTED_ENCODING_BUFFERS(
+    "nimble.encoding.max_cached_nested_buffers",
+    0);
+
+/* static */ Config::Entry<bool> Config::FIXED_BIT_WIDTH_USE_EXACT_BITS(
+    "nimble.fixedbitwidth.use_exact_bits",
+    false);
+
+/* static */ Config::Entry<bool> Config::SKIP_CONSTANT_FLATMAP_IN_MAP_STREAMS(
+    "nimble.flatmap.skip_constant_in_map_streams",
+    false);
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/NimbleConfig.h
+++ b/velox/dwio/nimble/velox/NimbleConfig.h
@@ -181,6 +181,45 @@ class Config : public velox::config::ConfigBase {
   /// first encoding of each stream and replay it on subsequent chunks/stripes.
   static Entry<bool> ENABLE_ENCODING_SELECTION_CACHE;
 
+  /// Compresses stripe-group metadata only when it exceeds this many bytes.
+  /// Unset leaves the writer's own threshold; UINT32_MAX disables metadata
+  /// compression outright.
+  static Entry<uint32_t> METADATA_COMPRESSION_THRESHOLD;
+
+  /// Selects how per-stripe-group stream offsets/sizes are serialized:
+  /// "raw" (default, readable by all readers) or "stream_major".
+  /// EXPERIMENTAL: see WriterOptions::experimentalStripeGroupEncodingLayout.
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static Entry<std::string> STRIPE_GROUP_ENCODING_LAYOUT;
+
+  /// Minimum average chunks per stripe before chunk stats are written.
+  /// Only consulted when nimble.chunk.index.enabled is true.
+  static Entry<double> CHUNK_STATS_MIN_AVG_CHUNKS;
+
+  /// Caps concurrent stream-encoding tasks. 0 (default) encodes serially.
+  /// Requires an encoding executor to be installed on the writer.
+  static Entry<uint32_t> MAX_ENCODE_PARALLELISM;
+
+  /// Minimum streams batched into one parallel encoding task, so that small
+  /// streams do not each pay task-dispatch cost.
+  static Entry<uint32_t> MIN_STREAMS_PER_ENCODING_TASK;
+
+  /// Caps encoding scratch buffers retained between stripes. 0 (default)
+  /// retains none, trading allocation churn for peak memory.
+  static Entry<uint32_t> MAX_CACHED_ENCODING_SCRATCH_BUFFERS;
+
+  /// Caps retained nested-encoding buffers; see
+  /// MAX_CACHED_ENCODING_SCRATCH_BUFFERS.
+  static Entry<uint32_t> MAX_CACHED_NESTED_ENCODING_BUFFERS;
+
+  /// Sizes FixedBitWidth encodings to the exact bits the values need rather
+  /// than rounding up to a byte-aligned width.
+  static Entry<bool> FIXED_BIT_WIDTH_USE_EXACT_BITS;
+
+  /// Omits in-map streams for FlatMap features whose in-map flag is constant,
+  /// which is the common case for dense feature sets.
+  static Entry<bool> SKIP_CONSTANT_FLATMAP_IN_MAP_STREAMS;
+
   static constexpr const char* kNimbleWriteTargetRawStripeSize =
       "nimble_write_target_raw_stripe_size";
 


### PR DESCRIPTION
Summary:
Nine `NimbleWriterOptions` parameters had no Nimble SerDe key, so a table could
declare them and the writer stack could not deliver them however the config was
spelled. A caller that configures the writer through a Velox `tableWrite`
reaches it exclusively via `NimbleWriterOptionBuilder::withSerdeParams`, so a
parameter with no key is unreachable from a Hive table.

| Key | Type | `WriterOptions` field | Default |
|---|---|---|---|
| `nimble.metadata.compression.threshold` | uint32 | `metadataCompressionThreshold` | unset -> writer default (optional) |
| `nimble.stripe_group.encoding_layout` | string | `experimentalStripeGroupEncodingLayout` | `raw` |
| `nimble.chunk.index.min_avg_chunks` | double | `chunkStatsMinAvgChunks` | `2` |
| `nimble.encoding.max_parallelism` | uint32 | `maxEncodeParallelism` | `0` |
| `nimble.encoding.min_streams_per_task` | uint32 | `minStreamsPerEncodingTask` | `1` |
| `nimble.encoding.max_cached_scratch_buffers` | uint32 | `maxCachedEncodingScratchBuffers` | `0` |
| `nimble.encoding.max_cached_nested_buffers` | uint32 | `maxCachedNestedEncodingBuffers` | `0` |
| `nimble.fixedbitwidth.use_exact_bits` | bool | `fixedBitWidthUseExactBits` | `false` |
| `nimble.flatmap.skip_constant_in_map_streams` | bool | `skipConstantFlatMapInMapStreams` | `false` |

Every default is the corresponding `WriterOptions` field's own default, so an
absent key leaves the writer exactly where it was. `absentKeysKeepWriterDefaults`
pins that against a default-constructed `WriterOptions` rather than against
literals, so a future change to a writer default cannot silently diverge from
the config.

`nimble.metadata.compression.threshold` is the one key that is not a plain
scalar passthrough: it is applied only when the key is present, because
`WriterOptions` holds an optional here and the writer substitutes its own
threshold when unset. Defaulting it would pin whatever threshold the writer
currently happens to use.

Reviewed By: tanjialiang

Differential Revision: D118593412


