### PR TITLE
fix: Use `data()` instead of iterators where a raw pointer is required

### DIFF
--- a/velox/dwio/common/DataBufferHolder.cpp
+++ b/velox/dwio/common/DataBufferHolder.cpp
@@ -38,7 +38,7 @@ void DataBufferHolder::take(const std::vector<std::string_view>& buffers) {
   auto* data = buf.data();
   for (auto& buffer : buffers) {
     const auto size = buffer.size();
-    ::memcpy(data, buffer.cbegin(), size);
+    ::memcpy(data, buffer.data(), size);
     data += size;
   }
   // If possibly, write content of the data to output immediately. Otherwise,

--- a/velox/dwio/nimble/velox/FieldReader.cpp
+++ b/velox/dwio/nimble/velox/FieldReader.cpp
@@ -1053,7 +1053,8 @@ class LegacyStringFieldReader final : public FieldReader {
     size_t currentOffset = 0;
     if (!hasNulls) {
       for (uint32_t i = 0; i < rowCount; ++i) {
-        std::copy(buffer_[i].data(), buffer_[i].end(), dataPtr + currentOffset);
+        std::copy(
+            buffer_[i].begin(), buffer_[i].end(), dataPtr + currentOffset);
         valuesPtr[i] =
             velox::StringView(dataPtr + currentOffset, buffer_[i].length());
         currentOffset += buffer_[i].length();
@@ -1062,7 +1063,7 @@ class LegacyStringFieldReader final : public FieldReader {
       for (uint32_t i = 0; i < rowCount; ++i) {
         if (!vector->isNullAt(i)) {
           std::copy(
-              buffer_[i].data(), buffer_[i].end(), dataPtr + currentOffset);
+              buffer_[i].begin(), buffer_[i].end(), dataPtr + currentOffset);
           valuesPtr[i] =
               velox::StringView(dataPtr + currentOffset, buffer_[i].length());
           currentOffset += buffer_[i].length();


### PR DESCRIPTION
Summary:
## Context

fbcode is migrating from libstdc++ to libc++ for better performance, access to newer C++ features, and stronger safety guarantees. Some code that compiled under libstdc++ relies on non-standard extensions, implicit conversions, or header inclusion side effects that libc++ does not provide.

## Problem

Under libstdc++, `std::string_view::const_iterator` is a plain `const char*`, so passing `begin()`/`cbegin()` where a `const char*` or `const void*` is expected compiles. libc++ uses a bounded iterator wrapper (`std::__wrap_iter<const char*>`), which is a class type with no conversion to a pointer. Two sites break:

```
velox/serializers/PrestoVectorLexer.h:99:26: error: invalid operands to binary expression ('const char *const' and 'const_iterator' (aka '__wrap_iter<const char *>'))
   99 |     assert(committedPtr_ == source_.begin());

velox/dwio/common/DataBufferHolder.cpp:41:20: error: no viable conversion from 'const_iterator' (aka '__wrap_iter<const char *>') to 'const void *'
   41 |     ::memcpy(data, buffer.cbegin(), size);
```

## Fix

Use `std::string_view::data()`, which yields the `const char*` both sites actually want. In `PrestoVectorLexer` this also matches how `committedPtr_` is initialized (`committedPtr_{source.data()}`), so the assertion compares like with like.

Reviewed By: yuxuanchen1997

Differential Revision: D118291360


