### PR TITLE
fix: Mismatched iterator types in `std::copy` calls

### DIFF
--- a/velox/dwio/nimble/velox/FieldReader.cpp
+++ b/velox/dwio/nimble/velox/FieldReader.cpp
@@ -1053,7 +1053,8 @@ class LegacyStringFieldReader final : public FieldReader {
     size_t currentOffset = 0;
     if (!hasNulls) {
       for (uint32_t i = 0; i < rowCount; ++i) {
-        std::copy(buffer_[i].data(), buffer_[i].end(), dataPtr + currentOffset);
+        std::copy(
+            buffer_[i].begin(), buffer_[i].end(), dataPtr + currentOffset);
         valuesPtr[i] =
             velox::StringView(dataPtr + currentOffset, buffer_[i].length());
         currentOffset += buffer_[i].length();
@@ -1062,7 +1063,7 @@ class LegacyStringFieldReader final : public FieldReader {
       for (uint32_t i = 0; i < rowCount; ++i) {
         if (!vector->isNullAt(i)) {
           std::copy(
-              buffer_[i].data(), buffer_[i].end(), dataPtr + currentOffset);
+              buffer_[i].begin(), buffer_[i].end(), dataPtr + currentOffset);
           valuesPtr[i] =
               velox::StringView(dataPtr + currentOffset, buffer_[i].length());
           currentOffset += buffer_[i].length();


### PR DESCRIPTION
Summary:
## Context

fbcode is migrating from libstdc++ to libc++ for better performance, access to newer C++ features, and stronger safety guarantees. Some code that compiled under libstdc++ relies on non-standard extensions, implicit conversions, or header inclusion side effects that libc++ does not provide.

## Problem

`StringFieldReader::next` mixes `std::string_view::data()` (a `const char*`) with `std::string_view::end()` (a `const_iterator`) in the same `std::copy` call. Under libstdc++ both spell `const char*`, so template argument deduction succeeds. libc++ uses a bounded iterator wrapper, so `end()` is `std::__wrap_iter<const char*>` and deduction of `_InputIterator` conflicts:

```
velox/dwio/nimble/velox/FieldReader.cpp:827:9: error: no matching function for call to 'copy'
  827 |         std::copy(buffer_[i].data(), buffer_[i].end(), dataPtr + currentOffset);
third-party/tp2/llvm-fb/21/llvm-project/libcxx/include/__algorithm/copy.h:246:1: note: candidate template ignored: deduced conflicting types for parameter '_InputIterator' ('const_pointer' (aka 'const char *') vs. 'const_iterator' (aka '__wrap_iter<const char *>'))
```

## Fix

Use `begin()` instead of `data()` so both arguments are `const_iterator`. The copied range is unchanged.

Reviewed By: yuxuanchen1997

Differential Revision: D118291361


