### PR TITLE
fix(nimble): Skip stripes that project no streams

### DIFF
--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -298,7 +298,7 @@ void NimbleIndexProjector::prepareStripes() {
   const auto needResumeKey = ctx_.options->needResumeKey;
   auto& rowsPerRequest = ctx_.rowsPerRequest;
   rowsPerRequest.assign(ctx_.numRequests, 0);
-  ctx_.hasStripeRanges.assign(ctx_.numRequests, false);
+  ctx_.hasProcessedStripeRange.assign(ctx_.numRequests, false);
   ctx_.resumeKeys.assign(ctx_.numRequests, std::nullopt);
   // Reserve against the number of stripes that carry ranges, not the min..max
   // span: the CSR is now indexed by position in resolvedStripes, so the span
@@ -327,24 +327,54 @@ void NimbleIndexProjector::prepareStripes() {
     const auto rangeOffset = ctx_.plan.stripeRanges.size();
     uint32_t numStripeRanges{0};
 
+    // Located on demand by the first range that can still take rows. A stripe
+    // whose requests have all hit maxRowsPerRequest retains nothing and is
+    // dropped below, so it never pays for the lookup: stripeIdentifier()
+    // loads stripe-group and chunk-stats metadata on a cache miss, and
+    // streamLocations() scans every projected stream. The old ordering got
+    // that skip for free by locating only after the numStripeRanges check.
+    std::optional<StripeStreams> streams;
+
     uint64_t stripeRows{0};
     for (const auto& range : spanRanges) {
+      const auto requestIndex = range.requestIndex;
+      // The request reached this stripe, whether or not the stripe hands it
+      // any data. Recording that keeps it out of the retry path in
+      // setResumeKeys(), which would otherwise return its own lower key and
+      // have it scan the same ground again.
+      ctx_.hasProcessedStripeRange[requestIndex] = true;
+
+      if (maxRowsPerRequest > 0 &&
+          rowsPerRequest[requestIndex] >= maxRowsPerRequest) {
+        continue;
+      }
+
+      if (!streams.has_value()) {
+        streams = locateStripeStreams(stripeIndex);
+      }
+      // A stripe can hold none of the projected streams -- a flat map with
+      // none of the requested keys, for instance. It has no bytes to read and
+      // no slice to emit, and both the read and pack paths reject a stripe
+      // with nothing in it, so it must stay out of the plan. Deciding that
+      // before charging rows below is the point: the caller receives none of
+      // these rows, so counting them against maxRowsPerRequest would starve
+      // later stripes that do carry data. Retaining no range here is what
+      // drops the stripe, through the numStripeRanges check below.
+      if (streams->numStreams == 0) {
+        continue;
+      }
+
       auto stripeRange = range;
-      const auto requestIndex = stripeRange.requestIndex;
       const auto numRows =
           static_cast<uint64_t>(stripeRange.rowRange.numRows());
       if (maxRowsPerRequest == 0) {
         rowsPerRequest[requestIndex] += numRows;
         stripeRows += numRows;
-        ctx_.hasStripeRanges[requestIndex] = true;
         ctx_.plan.stripeRanges.push_back(stripeRange);
         ++numStripeRanges;
         continue;
       }
 
-      if (rowsPerRequest[requestIndex] >= maxRowsPerRequest) {
-        continue;
-      }
       const auto remaining = maxRowsPerRequest - rowsPerRequest[requestIndex];
       const auto rowsToRead = std::min(numRows, remaining);
       rowsPerRequest[requestIndex] += rowsToRead;
@@ -367,7 +397,6 @@ void NimbleIndexProjector::prepareStripes() {
             stripeRange.rowRange.endRow,
             partialRead);
       }
-      ctx_.hasStripeRanges[requestIndex] = true;
       ctx_.plan.stripeRanges.push_back(stripeRange);
       ++numStripeRanges;
     }
@@ -376,8 +405,10 @@ void NimbleIndexProjector::prepareStripes() {
       continue;
     }
 
+    // A retained range means the lookup ran, so `streams` is engaged.
+    appendStripePlan(stripeIndex, rangeOffset, *streams);
     totalRows += stripeRows;
-    totalBytes += appendStripePlan(stripeIndex, rangeOffset);
+    totalBytes += streams->projectedBytes;
     if ((ctx_.options->maxRows > 0 && totalRows >= ctx_.options->maxRows) ||
         (ctx_.options->maxBytes > 0 && totalBytes >= ctx_.options->maxBytes)) {
       ctx_.plan.truncated = true;
@@ -385,6 +416,8 @@ void NimbleIndexProjector::prepareStripes() {
     }
   }
   ctx_.plan.stripeRangeOffsets.push_back(ctx_.plan.stripeRanges.size());
+  ctx_.plan.projectedStreams.resize(
+      ctx_.plan.stripeIndices.size() * projection_->streamOffsets.size());
 }
 
 void NimbleIndexProjector::initRequest(
@@ -419,7 +452,7 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.plan.stripeRangeOffsets.clear();
   ctx_.plan.stripeRanges.clear();
   ctx_.plan.truncated = false;
-  ctx_.hasStripeRanges.clear();
+  ctx_.hasProcessedStripeRange.clear();
   ctx_.resumeKeys.clear();
   ctx_.dataInputIndices.clear();
   ctx_.dataHandle.reset();
@@ -654,19 +687,11 @@ void NimbleIndexProjector::finalizeSliceOutputBuffer() {
   ctx_.sliceOutputChunks.reset();
 }
 
-uint64_t NimbleIndexProjector::appendStripePlan(
-    uint32_t stripeIndex,
-    size_t rangeOffset) {
+NimbleIndexProjector::StripeStreams NimbleIndexProjector::locateStripeStreams(
+    uint32_t stripeIndex) {
   auto& plan = ctx_.plan;
   const auto stripeOffset = plan.stripeIndices.size();
   const auto numProjectedStreams = projection_->streamOffsets.size();
-  plan.stripeIndices.push_back(stripeIndex);
-  plan.numRows.push_back(stripeRowCount(stripeIndex));
-  plan.requiresNullBarriers.push_back(false);
-  plan.numStreams.push_back(0);
-  plan.projectedBytes.push_back(0);
-  plan.stripeFileOffsets.push_back(tablet_->stripeOffset(stripeIndex));
-  plan.stripeRangeOffsets.push_back(rangeOffset);
   plan.projectedStreams.resize((stripeOffset + 1) * numProjectedStreams);
 
   const auto stripeId = tablet_->stripeIdentifier(stripeIndex);
@@ -675,21 +700,36 @@ uint64_t NimbleIndexProjector::appendStripePlan(
   tablet_->streamLocations(
       stripeId, projection_->streamOffsets, projectedStreams);
 
-  uint64_t projectedBytes{0};
+  StripeStreams streams;
   for (size_t i = 0; i < projectedStreams.size(); ++i) {
     const auto& stream = projectedStreams[i];
     if (stream.size == 0) {
       continue;
     }
-    ++plan.numStreams.back();
-    projectedBytes += stream.size;
+    ++streams.numStreams;
+    streams.projectedBytes += stream.size;
     if (projection_->rowOrFlatMapNullStreams[i]) {
       // A present Row/FlatMap null stream means the slice may carry nulls.
-      plan.requiresNullBarriers.back() = true;
+      streams.requiresNullBarrier = true;
     }
   }
-  plan.projectedBytes.back() = projectedBytes;
-  return projectedBytes;
+  return streams;
+}
+
+void NimbleIndexProjector::appendStripePlan(
+    uint32_t stripeIndex,
+    size_t rangeOffset,
+    const StripeStreams& streams) {
+  NIMBLE_CHECK_GT(
+      streams.numStreams, 0, "Planned stripe must project at least one stream");
+  auto& plan = ctx_.plan;
+  plan.stripeIndices.push_back(stripeIndex);
+  plan.numRows.push_back(stripeRowCount(stripeIndex));
+  plan.requiresNullBarriers.push_back(streams.requiresNullBarrier);
+  plan.numStreams.push_back(streams.numStreams);
+  plan.projectedBytes.push_back(streams.projectedBytes);
+  plan.stripeFileOffsets.push_back(tablet_->stripeOffset(stripeIndex));
+  plan.stripeRangeOffsets.push_back(rangeOffset);
 }
 
 std::span<const StripeGroup::StreamLocation>
@@ -1058,11 +1098,13 @@ void NimbleIndexProjector::setResumeKeys(Result& result) {
     }
   }
 
-  // For requests that were never started (no stripe ranges in any plan),
-  // set resume key to their original lower key so the caller can retry.
+  // For requests planning never reached before truncation, set the resume key
+  // to their original lower key so the caller can retry. A request whose only
+  // stripes projected no streams was reached and is complete, so it is not
+  // sent back here to re-scan ground that holds nothing for it.
   for (size_t i = 0; i < result.responses.size(); ++i) {
     auto& response = result.responses[i];
-    if (!ctx_.hasStripeRanges[i] && !response.resumeKey.has_value()) {
+    if (!ctx_.hasProcessedStripeRange[i] && !response.resumeKey.has_value()) {
       const auto& keyBounds = ctx_.request->keyBounds[i];
       NIMBLE_CHECK(
           keyBounds.lowerKey.has_value(),

--- a/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/velox/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -319,8 +319,27 @@ class NimbleIndexProjector {
   // Returns this stripe's request ranges from the flat ScanPlan storage.
   std::span<const StripeRange> plannedStripeRanges(size_t stripeOffset) const;
 
-  // Appends one stripe to the plan and returns its projected byte count.
-  uint64_t appendStripePlan(uint32_t stripeIndex, size_t rangeOffset);
+  // Projected stream totals for one stripe, computed by locateStripeStreams()
+  // before the stripe is known to be worth keeping.
+  struct StripeStreams {
+    uint32_t numStreams{0};
+    uint64_t projectedBytes{0};
+    bool requiresNullBarrier{false};
+  };
+
+  // Locates this stripe's projected streams, staging them at the tail of
+  // ScanPlan::projectedStreams. The stripe is not part of the plan until
+  // appendStripePlan() commits it; a stripe dropped in between leaves the
+  // staged slots to be overwritten by the next stripe, and prepareStripes()
+  // trims any left over.
+  StripeStreams locateStripeStreams(uint32_t stripeIndex);
+
+  // Appends one stripe to the plan using streams already staged for it by
+  // locateStripeStreams().
+  void appendStripePlan(
+      uint32_t stripeIndex,
+      size_t rangeOffset,
+      const StripeStreams& streams);
 
   // Computes the stripe-relative body range based on request row ranges and
   // Options::maxOverfetchRowsRatio.
@@ -467,9 +486,13 @@ class NimbleIndexProjector {
     StripeRanges stripeRanges;
     // Populated by prepareStripes().
     ScanPlan plan;
-    // Per-request flag: true if the request has ranges in any planned stripe.
-    // Set by prepareStripes(), used by setResumeKeys().
-    std::vector<bool> hasStripeRanges;
+    // Per-request flag: true once planning has processed a stripe range for
+    // the request. Deliberately not "contributed a range to the plan": it is
+    // also set when the stripe is dropped for projecting no streams, because
+    // what setResumeKeys() needs to know is whether the request was reached
+    // before global truncation, not whether it produced output. Set by
+    // prepareStripes(), used by setResumeKeys().
+    std::vector<bool> hasProcessedStripeRange;
     // Per-request resume keys set when a request reaches maxRowsPerRequest and
     // Options::needResumeKey is enabled.
     std::vector<std::optional<std::string>> resumeKeys;

--- a/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/velox/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -202,6 +202,45 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     TabletReaderCache::testingReset();
   }
 
+  // Rows per batch produced by singleFeatureBatch().
+  static constexpr vector_size_t kFeatureRowsPerBatch = 4;
+
+  static RowTypePtr singleFeatureRowType() {
+    return ROW({{"key", BIGINT()}, {"features", MAP(VARCHAR(), DOUBLE())}});
+  }
+
+  // Builds a batch whose flat map carries exactly one key, so writing several
+  // with different keys yields stripes that project nothing for a projection
+  // pinned to one of them.
+  RowVectorPtr singleFeatureBatch(int64_t keyBase, StringView featureKey) {
+    auto offsets = allocateOffsets(kFeatureRowsPerBatch, leafPool_.get());
+    auto sizes = allocateSizes(kFeatureRowsPerBatch, leafPool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    for (vector_size_t row = 0; row < kFeatureRowsPerBatch; ++row) {
+      rawOffsets[row] = row;
+      rawSizes[row] = 1;
+    }
+    auto features = std::make_shared<MapVector>(
+        leafPool_.get(),
+        MAP(VARCHAR(), DOUBLE()),
+        nullptr,
+        kFeatureRowsPerBatch,
+        offsets,
+        sizes,
+        vectorMaker_->flatVector<StringView>(
+            kFeatureRowsPerBatch, [&](auto /*row*/) { return featureKey; }),
+        vectorMaker_->flatVector<double>(kFeatureRowsPerBatch, [](auto row) {
+          return static_cast<double>(row);
+        }));
+    return vectorMaker_->rowVector(
+        {"key", "features"},
+        {vectorMaker_->flatVector<int64_t>(
+             kFeatureRowsPerBatch,
+             [keyBase](auto row) { return keyBase + row; }),
+         features});
+  }
+
   // Writes sorted data with an index on the key column.
   void writeData(
       const std::vector<RowVectorPtr>& batches,
@@ -678,6 +717,133 @@ TEST_P(NimbleIndexProjectorTest, resultSlicesAreManaged) {
         << "slice " << s << "/" << response.slices.size()
         << " has an unmanaged (wrapBuffer) IOBuf node";
   }
+}
+
+// A stripe holding none of the requested flat map keys projects no streams at
+// all. Such a stripe has nothing to read and nothing to pack, and both paths
+// reject an empty stripe, so planning one used to abort the whole scan.
+TEST_P(NimbleIndexProjectorTest, stripeProjectingNoStreams) {
+  auto rowType = singleFeatureRowType();
+
+  // stripeSize=1 cuts a stripe per batch. Alternating the feature key leaves
+  // stripes 1 and 3 projecting nothing: one in the middle of the plan and one
+  // at its end, which used to fail through different checks.
+  writeData(
+      {singleFeatureBatch(0, StringView("a")),
+       singleFeatureBatch(kFeatureRowsPerBatch, StringView("b")),
+       singleFeatureBatch(2 * kFeatureRowsPerBatch, StringView("a")),
+       singleFeatureBatch(3 * kFeatureRowsPerBatch, StringView("b"))},
+      {"key"},
+      {{"features", {}}},
+      /*stripeSize=*/1);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("features[\"a\"]");
+  auto projector = createProjector(subfields);
+
+  // Spans every stripe, so the ones without "a" are still planned.
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 4 * kFeatureRowsPerBatch);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+
+  auto result = projector->project(request, {});
+  ASSERT_EQ(result.responses.size(), 1);
+  // Only the two stripes carrying "a" contribute; the others hold no projected
+  // data, so they produce no slice.
+  ASSERT_EQ(result.responses[0].slices.size(), 2);
+  for (const auto& slice : result.responses[0].slices) {
+    EXPECT_EQ(readEmbeddedRowRange(slice), RowRange(0, kFeatureRowsPerBatch));
+  }
+  // Nothing truncated the scan, so there is nothing to resume from. The retry
+  // path this fix also guards needs global truncation to run at all, and is
+  // covered by emptyStripeCountsAsReachedUnderTruncation below.
+  EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+}
+
+// A request whose only stripe projects no streams was still reached, so global
+// truncation must not hand it back its own lower key: it has nothing left to
+// read, and retrying would re-scan the same empty ground forever. Reaching
+// that path needs needResumeKey and a truncated plan, plus a following stripe
+// that still carries ranges, so it takes two requests to set up.
+TEST_P(NimbleIndexProjectorTest, emptyStripeCountsAsReachedUnderTruncation) {
+  auto rowType = singleFeatureRowType();
+
+  // stripe 0 holds only "b"; stripes 1 and 2 hold "a".
+  writeData(
+      {singleFeatureBatch(0, StringView("b")),
+       singleFeatureBatch(kFeatureRowsPerBatch, StringView("a")),
+       singleFeatureBatch(2 * kFeatureRowsPerBatch, StringView("a"))},
+      {"key"},
+      {{"features", {}}},
+      /*stripeSize=*/1);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("features[\"a\"]");
+  auto projector = createProjector(subfields);
+
+  // Request 0 covers only the "b" stripe, so it is reached but gets no data.
+  // Request 1 covers both "a" stripes; the first of them trips maxRows, so the
+  // plan truncates with the second still unprocessed.
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {
+      makeRangeLookup(rowType, {"key"}, 0, kFeatureRowsPerBatch),
+      makeRangeLookup(
+          rowType, {"key"}, kFeatureRowsPerBatch, 3 * kFeatureRowsPerBatch)};
+
+  NimbleIndexProjector::Options options;
+  options.needResumeKey = true;
+  options.maxRows = kFeatureRowsPerBatch;
+
+  auto result = projector->project(request, options);
+  ASSERT_EQ(result.responses.size(), 2);
+
+  // Request 0: reached, nothing to read, and — the point of the test — not
+  // told to start over.
+  EXPECT_TRUE(result.responses[0].slices.empty());
+  EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+
+  // Request 1: genuinely cut short, so it does carry a resume key.
+  ASSERT_EQ(result.responses[1].slices.size(), 1);
+  EXPECT_TRUE(result.responses[1].resumeKey.has_value());
+}
+
+// A stripe that projects nothing must not spend the request's row budget. The
+// caller receives none of its rows, so charging them would prune later stripes
+// that do carry data, and hand back a resume key past rows never returned.
+TEST_P(NimbleIndexProjectorTest, emptyStripeDoesNotConsumeRowBudget) {
+  auto rowType = singleFeatureRowType();
+
+  // stripeSize=1 cuts a stripe per batch, so stripe 0 carries only "b" and
+  // stripe 1 only "a". A projection pinned to "a" gets nothing from stripe 0.
+  writeData(
+      {singleFeatureBatch(0, StringView("b")),
+       singleFeatureBatch(kFeatureRowsPerBatch, StringView("a"))},
+      {"key"},
+      {{"features", {}}},
+      /*stripeSize=*/1);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("features[\"a\"]");
+  auto projector = createProjector(subfields);
+
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 2 * kFeatureRowsPerBatch);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+
+  // Budget for exactly one stripe. Spending it on the stripe that projects
+  // nothing would leave the "a" stripe pruned and the response empty.
+  NimbleIndexProjector::Options options;
+  options.maxRowsPerRequest = kFeatureRowsPerBatch;
+  options.needResumeKey = true;
+
+  auto result = projector->project(request, options);
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
+  EXPECT_EQ(
+      readEmbeddedRowRange(result.responses[0].slices[0]),
+      RowRange(0, kFeatureRowsPerBatch));
+  // All matching data was returned, so there is nothing to resume from.
+  EXPECT_FALSE(result.responses[0].resumeKey.has_value());
 }
 
 TEST_P(NimbleIndexProjectorTest, emptyResult) {


### PR DESCRIPTION
Summary:
`NimbleIndexProjector` assumed every planned stripe contributes at least one
projected stream. A stripe holding none of them — a flat map with none of the
requested keys, for instance — enqueues no read regions, and read groups must
be non-empty, so the whole scan aborted:

- an empty group followed by another stripe failed `startGroup()` with
  "Previous group is empty"
- an empty group at the end of the plan failed `load()` with "Read group must
  contain a region"
- past those, `packFullStripe()` hit a null chain with nothing to pack

Such a stripe has no bytes to read and no slice to emit, so keep it out of the
plan rather than teaching all three paths to tolerate it.

Knowing that requires the stream count before the per-request accounting runs,
which `appendStripePlan()` could not supply: it located the streams and
committed the stripe in one step. Split it. `locateStripeStreams()` fills the
stripe's slots at the tail of `ScanPlan::projectedStreams` and returns their
totals; `appendStripePlan()` commits the stripe once it is known to be kept.
Locating still writes straight into the plan's flat storage, so there is one
`streamLocations()` call per stripe as before, and no copy. `prepareStripes()`
trims the slots staged for a stripe that was then dropped, and
`appendStripePlan()` asserts that a committed stripe projects at least one
stream, so the plan can never carry one there is nothing to read from.

Locating early would otherwise cost more than the old ordering did.
`appendStripePlan()` used to run only after the `numStripeRanges == 0` check,
so a stripe whose requests had all hit `maxRowsPerRequest` never touched the
tablet at all; hoisting the lookup would make every resolved stripe pay a
`stripeIdentifier()` (a stripe-group and chunk-stats metadata load on a cache
miss) plus a `streamLocations()` scan over every projected stream, to produce
nothing. So the lookup is lazy: the first range that can still take rows
triggers it, and the per-request cap check the loop already performs is what
withholds it. A stripe reached only by requests that are out of budget never
locates anything, and no separate pass over the ranges is needed to know that.

Ordering matters beyond the abort. The caller receives none of an empty
stripe's rows, so charging them against `maxRowsPerRequest` would starve later
stripes that do carry data. These limits bound what a `project()` call
returns, not what it scans, so rows that yield no slice must not be charged.
Skipping the accounting entirely is what avoids that, and it is the part a
plausible half-fix gets wrong. With no range retained, the stripe then falls
out through the existing `numStripeRanges == 0` check.

`hasStripeRanges` is renamed `hasProcessedStripeRange` and moves to the top of
that loop so it is still recorded for every request the stripe reaches, empty
or not. The old name read as "contributed a range to the plan", which is no
longer what it tracks: what `setResumeKeys()` needs is whether planning
reached the request before global truncation, not whether it produced output. Without it a request whose
ranges live only in empty stripes would look "never started" to
`setResumeKeys()`, get handed back its own lower key, and re-scan the same
ground forever — trading an abort for a retry loop. This is a no-op for every
other path: the one branch that skips the assignment today
(`rowsPerRequest >= maxRowsPerRequest`) implies the request already consumed
rows, so the flag was set on an earlier stripe.

This was unreachable in practice until now: the only projector caller was
DataFM, whose trait maps are present in every stripe. Wiring EBF into the
projector benchmark (D117765647) is what first hits it, on real data from
`ad_delivery.sequence_storage_bulk_load_aidn_v2_daily`.

Reviewed By: xiaoxmeng

Differential Revision: D117810561


