### PR TITLE
feat(exec): Show what a table scan reads in plan text (#18842)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1292,6 +1292,26 @@ void TableScanNode::accept(
 
 void TableScanNode::addDetails(std::stringstream& stream) const {
   stream << tableHandle_->toString();
+
+  // Assignments are expected to name every output column, but some frontends
+  // build scans with no assignments at all.
+  if (assignments_.empty()) {
+    return;
+  }
+
+  bool first = true;
+  for (auto i = 0; i < outputType_->size(); ++i) {
+    if (outputType_->childAt(i)->isPrimitiveType()) {
+      continue;
+    }
+    const auto& outputName = outputType_->nameOf(i);
+    stream << (first ? ", assignments: [" : ", ");
+    first = false;
+    stream << outputName << " := " << assignments_.at(outputName)->toString();
+  }
+  if (!first) {
+    stream << "]";
+  }
 }
 
 void TableScanNode::addSummaryDetails(

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -182,7 +182,8 @@ std::string PlanNodeStats::toString(
   if (includeInputStats) {
     out << "Input: " << inputRows << " rows (" << succinctBytes(inputBytes)
         << ", " << inputVectors << " batches), ";
-    if ((rawInputRows > 0) && (rawInputRows != inputRows)) {
+    if (rawInputRows > 0 &&
+        (rawInputRows != inputRows || rawInputBytes != inputBytes)) {
       out << "Raw Input: " << rawInputRows << " rows ("
           << succinctBytes(rawInputBytes) << "), ";
     }

--- a/velox/exec/tests/PlanNodeStatsTest.cpp
+++ b/velox/exec/tests/PlanNodeStatsTest.cpp
@@ -31,4 +31,36 @@ TEST(PlanNodeStatsTest, exprStatsTotal) {
   EXPECT_EQ(total.expressionStats["foo"], stats.expressionStats["foo"]);
 }
 
+TEST(PlanNodeStatsTest, rawInput) {
+  // Everything the stats print beyond the input counts, which stay zero here.
+  const std::string kRest =
+      ", Output: 0 rows (0B, 0 batches), Cpu time: 0ns, Wall time: 0ns"
+      ", Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0"
+      ", CPU breakdown: B/I/O/F (0ns/0ns/0ns/0ns)";
+
+  PlanNodeStats stats;
+  stats.inputRows = 100;
+  stats.inputBytes = 1000;
+  stats.rawInputRows = 100;
+  stats.rawInputBytes = 50'000;
+
+  // Same rows, more bytes read than handed on.
+  ASSERT_EQ(
+      "Input: 100 rows (1000B, 0 batches), Raw Input: 100 rows (48.83KB)" +
+          kRest,
+      stats.toString(/*includeInputStats=*/true));
+
+  // Nothing to add when the raw input matches the input.
+  stats.rawInputBytes = stats.inputBytes;
+  ASSERT_EQ(
+      "Input: 100 rows (1000B, 0 batches)" + kRest,
+      stats.toString(/*includeInputStats=*/true));
+
+  // Rows dropped by a pushed-down filter.
+  stats.rawInputRows = 200;
+  ASSERT_EQ(
+      "Input: 100 rows (1000B, 0 batches), Raw Input: 200 rows (1000B)" + kRest,
+      stats.toString(/*includeInputStats=*/true));
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/core/FixedPointPlanNodes.h"
 #include "velox/exec/WindowFunction.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -789,6 +790,51 @@ TEST_F(PlanNodeToStringTest, tableScan) {
     ASSERT_EQ(
         "-- TableScan[0][table: hive_table, remaining filter: (not(like(ROW[\"comment\"],%special%request%)))] "
         "-> discount:DOUBLE, quantity:DOUBLE, shipdate:VARCHAR, comment:VARCHAR\n",
+        plan->toString(true, false));
+  }
+}
+
+TEST_F(PlanNodeToStringTest, tableScanAssignments) {
+  {
+    // A complex column shows the parts the scan asks for; a scalar column
+    // shows nothing.
+    RowTypePtr rowType{ROW({
+        {"m", MAP(VARCHAR(), BIGINT())},
+        {"n", BIGINT()},
+    })};
+
+    connector::ColumnHandleMap assignments;
+    assignments["m"] = test::HiveConnectorTestBase::makeColumnHandle(
+        "m", rowType->childAt(0), {"m[\"k\"]"});
+    assignments["n"] =
+        test::HiveConnectorTestBase::regularColumn("n", rowType->childAt(1));
+
+    auto plan = PlanBuilder(pool_.get())
+                    .tableScan(rowType, {}, "", nullptr, assignments)
+                    .planNode();
+
+    ASSERT_EQ(
+        "-- TableScan[0][table: hive_table, assignments: [m := HiveColumnHandle "
+        "[name: m, columnType: Regular, dataType: MAP<VARCHAR,BIGINT>, "
+        "requiredSubfields: [ m[\"k\"] ]]]] "
+        "-> m:MAP<VARCHAR,BIGINT>, n:BIGINT\n",
+        plan->toString(true, false));
+  }
+
+  {
+    // A scan of scalars alone adds nothing.
+    RowTypePtr rowType{ROW("n", BIGINT())};
+
+    connector::ColumnHandleMap assignments;
+    assignments["n"] =
+        test::HiveConnectorTestBase::regularColumn("n", rowType->childAt(0));
+
+    auto plan = PlanBuilder(pool_.get())
+                    .tableScan(rowType, {}, "", nullptr, assignments)
+                    .planNode();
+
+    ASSERT_EQ(
+        "-- TableScan[0][table: hive_table] -> n:BIGINT\n",
         plan->toString(true, false));
   }
 }


### PR DESCRIPTION
Summary:

A scan that reads a few subfields of a complex column printed the same as one reading the column whole, so plan text could not answer whether a column was pruned. The expressions above the scan do not answer it either: they say what the query needs, not what the scan asked its connector for. A scan of a pruned map now prints

    -- TableScan[0][table: hive_table, assignments: [m := HiveColumnHandle [name: m, columnType: Regular, dataType: MAP<VARCHAR,BIGINT>, requiredSubfields: [ m["k"] ]]]] -> m:MAP<VARCHAR,BIGINT>, n:BIGINT

Only complex columns are listed, since a scalar column has no parts to leave out, and a scan with no complex column prints nothing extra.

`PlanNodeStats` also hid the bytes a scan read whenever it produced as many rows as it read: `Raw Input` was printed only when the row counts differed, though `rawInputBytes` and `inputBytes` measure different things — bytes fetched from storage against bytes handed to the next operator. A scan with no filter reads the same rows it produces, so its IO never appeared. `Raw Input` is now printed when either the rows or the bytes differ.

Differential Revision: D118747030


