### PR TITLE
fix(build): Remove deprecated gMock `Invoke` wrappers

### DIFF
--- a/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
@@ -341,12 +341,12 @@ class WriterEncodingIndexTest2 {
         columnWriter->write(batch, common::Ranges::of(0, 1000));
         for (auto n = 0; n < mocks.size(); ++n) {
           EXPECT_CALL(*mocks.at(n), addEntry(_))
-              .WillOnce(Invoke([&, k = n](const StatisticsBuilder& builder) {
+              .WillOnce([&, k = n](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
                 if (k == 0) {
                   validateStats(batch, *stats);
                 }
-              }));
+              });
           // RecordPosition is invoked on call to createIndexEntry
           EXPECT_CALL(*mocks.at(n), add(_, -1)).Times(recordPositionCount[n]);
         }
@@ -777,10 +777,10 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
           }
           columnWriter->write(batch, common::Ranges::of(0, 1000));
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
-              .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
+              .WillOnce([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
                 validateStats<Integer>(batch, *stats);
-              }));
+              });
           // PRESENT stream positions are always recorded as soon as we create
           // new entries.
           EXPECT_CALL(*mockIndexBuilderPtr, add(_, -1)).Times(4);
@@ -798,10 +798,10 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
-              .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
+              .WillOnce([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
                 validateStats<Integer>(batch, *stats);
-              }));
+              });
           // We can record all stream positions immediately now that we have
           // determined the encoding.
           EXPECT_CALL(*mockIndexBuilderPtr, add(_, -1)).Times(positionCount);
@@ -837,10 +837,10 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
-              .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
+              .WillOnce([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
                 validateStats<Integer>(batch, *stats);
-              }));
+              });
           // We can record all stream positions immediately now that we have
           // determined the encoding.
           EXPECT_CALL(*mockIndexBuilderPtr, add(_, -1)).Times(positionCount);
@@ -955,10 +955,10 @@ class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
       for (size_t i = 0; i != pageCount; ++i) {
         columnWriter->write(batch, common::Ranges::of(0, 1000));
         EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
-            .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
+            .WillOnce([&](const StatisticsBuilder& builder) {
               auto stats = builder.build();
               validateStats(batch, *stats);
-            }));
+            });
         // PRESENT stream positions are always recorded as soon as we create new
         // entries.
         EXPECT_CALL(*mockIndexBuilderPtr, add(_, -1)).Times(4);
@@ -1087,10 +1087,10 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
           }
           columnWriter->write(batch, common::Ranges::of(0, 1000));
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
-              .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
+              .WillOnce([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
                 validateStats(batch, *stats);
-              }));
+              });
           // PRESENT stream positions are always recorded as soon as we create
           // new entries.
           EXPECT_CALL(*mockIndexBuilderPtr, add(_, -1)).Times(4);
@@ -1108,10 +1108,10 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
-              .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
+              .WillOnce([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
                 validateStats(batch, *stats);
-              }));
+              });
           // We can record all stream positions immediately now that we have
           // determined the encoding.
           EXPECT_CALL(*mockIndexBuilderPtr, add(_, -1)).Times(positionCount);
@@ -1147,10 +1147,10 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
-              .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
+              .WillOnce([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
                 validateStats(batch, *stats);
-              }));
+              });
           // We can record all stream positions immediately now that we have
           // determined the encoding.
           EXPECT_CALL(*mockIndexBuilderPtr, add(_, -1)).Times(positionCount);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -961,9 +961,9 @@ TEST_P(TestColumnReader, testIntegerRLEv2) {
   EXPECT_CALL(
       streams_, getStreamOrcProxy(2, proto::orc::Stream_Kind_DATA, true))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(data.data(), count + 1);
-          }));
+          });
   // col_2's DATA stream
   EXPECT_CALL(
       streams_, getStreamOrcProxy(3, proto::orc::Stream_Kind_DATA, true))
@@ -5061,15 +5061,15 @@ TEST_P(SchemaMismatchTest, testBoolean) {
   auto nulls = folly::make_array<char>(0x7f, 0x55);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
+          });
   auto data = folly::make_array<char>(0x7f, 0xaa);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(data.data(), data.size());
-          }));
+          });
 
   auto size = 100;
   runTest<bool, int8_t>(size);
@@ -5093,9 +5093,9 @@ TEST_P(SchemaMismatchTest, testByte) {
   auto nulls = folly::make_array<char>(0x7f, 0x55);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
+          });
 
   constexpr auto round = 10;
   constexpr auto batch = 8;
@@ -5109,9 +5109,9 @@ TEST_P(SchemaMismatchTest, testByte) {
   }
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(data.data(), data.size());
-          }));
+          });
 
   auto size = 100;
   runTest<int8_t, int16_t>(size);
@@ -5134,18 +5134,18 @@ TEST_P(SchemaMismatchTest, testIntDirect) {
   auto nulls = folly::make_array<char>(0x7f, 0x55);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
+          });
 
   // increasing values
   std::array<char, 1024> data;
   writeRange(data.data(), 0, 256);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(data.data(), data.size());
-          }));
+          });
 
   auto size = 100;
   runTest<int16_t, int32_t>(size);
@@ -5175,9 +5175,9 @@ TEST_P(SchemaMismatchTest, testIntDict) {
   auto nulls = folly::make_array<char>(0x7f, 0x55);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
+          });
 
   std::array<char, 1024> data;
   std::vector<uint64_t> v;
@@ -5188,9 +5188,9 @@ TEST_P(SchemaMismatchTest, testIntDict) {
   auto count = writeVuLongs(data.data() + 1, v);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(data.data(), count + 1);
-          }));
+          });
 
   EXPECT_CALL(
       streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
@@ -5233,9 +5233,9 @@ TEST_P(SchemaMismatchTest, testFloat) {
   auto nulls = folly::make_array<char>(0x7f, 0x55);
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
+          });
   constexpr auto size = 100;
   std::array<float, size> data;
   for (auto i = 0; i < size; ++i) {
@@ -5243,11 +5243,11 @@ TEST_P(SchemaMismatchTest, testFloat) {
   }
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+          [&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(
                 reinterpret_cast<char*>(data.data()),
                 data.size() * sizeof(float));
-          }));
+          });
 
   runTest<float, double>(size);
 }


### PR DESCRIPTION
Summary: macOS builds with current GoogleTest fail under `-Werror` when DWRF tests use the deprecated `Invoke` action wrapper. Pass lambdas directly to gMock actions to preserve test behavior while using the supported API.

Differential Revision: D118750417


