### PR TITLE
feat(nimble): Skip constant in-map streams on the chunked write path

### DIFF
--- a/velox/dwio/nimble/velox/SchemaReader.h
+++ b/velox/dwio/nimble/velox/SchemaReader.h
@@ -317,8 +317,27 @@ std::ostream& operator<<(
 /// as a hotspot in the Deserializer's per-batch flatmap in-map detection
 /// over hundreds of keys. Concrete-typed callables remove that dispatch
 /// without forcing every caller to materialize an intermediate offset list.
-template <typename Visitor>
-bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
+namespace detail {
+
+// Normalizes the child accessors of the two schema representations: Type
+// exposes children as shared pointers, TypeBuilder as references. Lets
+// visitValueStreamLeaves run unchanged over both, so the writer decides
+// whether a value stream is observable using the exact walk the reader will
+// perform.
+template <typename T>
+const T& derefChild(const T& child) {
+  return child;
+}
+
+template <typename T>
+const T& derefChild(const std::shared_ptr<T>& child) {
+  return *child;
+}
+
+} // namespace detail
+
+template <typename TypeT, typename Visitor>
+bool visitValueStreamLeaves(const TypeT& type, Visitor& visit) {
   switch (type.kind()) {
     case Kind::Scalar:
       return visit(type.asScalar().scalarDescriptor().offset());
@@ -340,7 +359,7 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
       // the writer, so it is not a reliable anchor; children are. The
       // visitor's return value short-circuits the walk on the first hit.
       for (size_t i = 0; i < row.childrenCount(); ++i) {
-        if (visitValueStreamLeaves(*row.childAt(i), visit)) {
+        if (visitValueStreamLeaves(detail::derefChild(row.childAt(i)), visit)) {
           return true;
         }
       }
@@ -355,7 +374,8 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
       // FlatMap children are independent keys; each may or may not carry
       // data in the current stripe, so all must be visited.
       for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-        if (visitValueStreamLeaves(*flatMap.childAt(i), visit)) {
+        if (visitValueStreamLeaves(
+                detail::derefChild(flatMap.childAt(i)), visit)) {
           return true;
         }
       }
@@ -366,8 +386,8 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
   }
 }
 
-template <typename Visitor>
-bool visitValueStreamLeaves(const Type& type, Visitor&& visit) {
+template <typename TypeT, typename Visitor>
+bool visitValueStreamLeaves(const TypeT& type, Visitor&& visit) {
   auto&& visitRef = std::forward<Visitor>(visit);
   return visitValueStreamLeaves(type, visitRef);
 }

--- a/velox/dwio/nimble/velox/StreamData.h
+++ b/velox/dwio/nimble/velox/StreamData.h
@@ -511,4 +511,12 @@ inline bool isConstantBoolStream(std::string_view data) {
   return ::memchr(data.data(), 1, data.size()) == nullptr;
 }
 
+/// Returns true if the boolean stream data is non-empty and every byte is
+/// true. Distinguished from isConstantBoolStream because an omitted all-true
+/// in-map stream and an omitted all-false one mean opposite things to the
+/// reader, so the two constants cannot share a code path.
+inline bool isAllTrueBoolStream(std::string_view data) {
+  return !data.empty() && ::memchr(data.data(), 0, data.size()) == nullptr;
+}
+
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
@@ -4129,7 +4129,7 @@ TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStream) {
   }
 }
 
-TEST_P(BatchReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
+TEST_P(BatchReaderTest, flatMapAllTrueInMapWithAllNullValues) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -4140,10 +4140,227 @@ TEST_P(BatchReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
   auto vector = vectorMaker.rowVector(
       {"flat_map"}, {vectorMaker.mapVector({0, 1, 2, 3}, keys, values)});
 
+  // Both chunking modes: the constant in-map skip lives in the non-chunked
+  // writer path today, and the chunked path is where it lands if that
+  // optimization is extended, so the invariant is pinned for both.
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    auto writerOptions = createFlatMapWriterOptions();
+    writerOptions.enableChunking = enableChunking;
+    writerOptions.flatMapColumns["flat_map"];
+    nimble::Writer writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(vector);
+    writer.close();
+
+    {
+      velox::InMemoryReadFile readFile(file);
+      auto selector =
+          std::make_shared<velox::dwio::common::ColumnSelector>(type);
+      nimble::BatchReader reader(
+          &readFile, *leafPool_, std::move(selector), createReadParams());
+      const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+      ASSERT_EQ(flatMap.childrenCount(), 1);
+      // Every value is null, so no value stream reaches disk. That leaves the
+      // in-map stream as the only record that the key is present at all, so
+      // the constant in-map skip must not drop it -- otherwise the key is
+      // byte-indistinguishable from one absent from the stripe.
+      EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                      .count(flatMap.inMapDescriptorAt(0).offset()));
+    }
+
+    {
+      velox::InMemoryReadFile readFile(file);
+      auto selector =
+          std::make_shared<velox::dwio::common::ColumnSelector>(type);
+      nimble::BatchReader reader(
+          &readFile, *leafPool_, std::move(selector), createReadParams());
+      velox::VectorPtr output;
+      uint64_t rowCount = 4;
+      ASSERT_TRUE(reader.next(rowCount, output));
+      ASSERT_EQ(output->size(), 4);
+      for (auto i = 0; i < 4; ++i) {
+        EXPECT_TRUE(vectorEquals(vector, output, i)) << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// Two stripes: the key is in every row of the first (all-true in-map, dropped
+// because the value stream proves presence) and in only one row of the second
+// (mixed in-map, which must reach disk). The all-true mark lives on the schema
+// descriptor, which outlives a stripe, so it has to be reassigned per stripe
+// rather than only set. Left stale, the sweep would drop the second stripe's
+// real in-map stream and the absent key would read back as present.
+TEST_P(BatchReaderTest, flatMapAllTrueInMapThenMixedAcrossStripes) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 10}}, {{1, 11}}})}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 12}}, {}})}),
+  };
+
+  auto writerOptions = createFlatMapWriterOptions();
+  writerOptions.flatMapColumns["flat_map"];
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_, vectors, std::move(writerOptions), /*flushAfterWrite=*/true);
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+namespace {
+
+// Writer options that emit one chunk per write call, so multi-batch tests
+// exercise real chunk boundaries instead of deferring everything to the final
+// chunk at stripe close.
+nimble::WriterOptions chunkPerWriteOptions(
+    nimble::WriterOptions options,
+    bool enableChunking) {
+  options.enableChunking = enableChunking;
+  options.minStreamChunkRawSize = 0;
+  options.flatMapColumns["flat_map"];
+  options.flushPolicyFactory = []() {
+    return std::make_unique<nimble::LambdaFlushPolicy>(
+        /*flushLambda=*/[](auto&) { return false; },
+        /*chunkLambda=*/[](auto&) { return true; });
+  };
+  return options;
+}
+
+} // namespace
+
+// A key whose values are null in an early batch and non-null in a later one
+// must survive the chunk boundary between them. The writer defers a chunk
+// while the stream is still empty of payload, and a deferred attempt consumes
+// nothing -- it stays "first chunk" and its rows fold into the next emitted
+// chunk. Were they dropped instead, the value stream would be short and every
+// later row would decode shifted.
+TEST_P(BatchReaderTest, flatMapNullValuesThenNonNullAcrossChunks) {
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector(
+              {0, 1},
+              vectorMaker.flatVector<int32_t>({1, 1}),
+              vectorMaker.flatVectorNullable<int64_t>(
+                  {std::nullopt, std::nullopt}))}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector(
+              {0, 1},
+              vectorMaker.flatVector<int32_t>({1, 1}),
+              vectorMaker.flatVectorNullable<int64_t>({10, 20}))}),
+  };
+
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    auto file = nimble::test::createNimbleFile(
+        *rootPool_,
+        vectors,
+        chunkPerWriteOptions(createFlatMapWriterOptions(), enableChunking),
+        /*flushAfterWrite=*/false);
+    velox::InMemoryReadFile readFile(file);
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+    velox::VectorPtr result;
+    for (const auto& expected : vectors) {
+      ASSERT_TRUE(reader.next(expected->size(), result));
+      ASSERT_EQ(expected->size(), result->size());
+      for (auto i = 0; i < expected->size(); ++i) {
+        EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+            << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// All values null for the key across several chunks, so no value stream is
+// written at all. The in-map stream is then the key's only record and must
+// survive, the same invariant as the single-batch case but with the stream
+// spanning chunk boundaries.
+TEST_P(BatchReaderTest, flatMapAllNullValuesAcrossChunks) {
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto allNullBatch = [&]() {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector(
+            {0, 1},
+            vectorMaker.flatVector<int32_t>({1, 1}),
+            vectorMaker.flatVectorNullable<int64_t>(
+                {std::nullopt, std::nullopt}))});
+  };
+  std::vector<velox::VectorPtr> vectors{
+      allNullBatch(), allNullBatch(), allNullBatch()};
+
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    auto file = nimble::test::createNimbleFile(
+        *rootPool_,
+        vectors,
+        chunkPerWriteOptions(createFlatMapWriterOptions(), enableChunking),
+        /*flushAfterWrite=*/false);
+    velox::InMemoryReadFile readFile(file);
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+    velox::VectorPtr result;
+    for (const auto& expected : vectors) {
+      ASSERT_TRUE(reader.next(expected->size(), result));
+      ASSERT_EQ(expected->size(), result->size());
+      for (auto i = 0; i < expected->size(); ++i) {
+        EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+            << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// Same invariant as flatMapAllTrueInMapWithAllNullValues, with string values.
+// Covers NullableContentStringStreamData, whose data() is only valid once
+// materialized. Deciding at stripe close, from what each stream actually
+// encoded, is what keeps this path off that trap.
+TEST_P(BatchReaderTest, flatMapAllTrueInMapWithAllNullStringValues) {
+  auto type = velox::ROW(
+      {{"flat_map", velox::MAP(velox::INTEGER(), velox::VARCHAR())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto keys = vectorMaker.flatVector<int32_t>({1, 1, 1, 1});
+  auto values = vectorMaker.flatVectorNullable<velox::StringView>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto vector = vectorMaker.rowVector(
+      {"flat_map"}, {vectorMaker.mapVector({0, 1, 2, 3}, keys, values)});
+
   std::string file;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
   auto writerOptions = createFlatMapWriterOptions();
-  writerOptions.enableChunking = true;
   writerOptions.flatMapColumns["flat_map"];
   nimble::Writer writer(
       type, std::move(writeFile), *rootPool_, std::move(writerOptions));

--- a/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
@@ -4245,7 +4245,166 @@ nimble::WriterOptions chunkPerWriteOptions(
   return options;
 }
 
+// Writer options that chunk every write call and enable chunking, for tests
+// that need the chunked write path specifically rather than the fixture's
+// parameterization.
+nimble::WriterOptions chunkedFlatMapOptions(nimble::WriterOptions options) {
+  return chunkPerWriteOptions(std::move(options), /*enableChunking=*/true);
+}
+
 } // namespace
+
+// Chunked writes suppress constant in-map streams too. The decision is read
+// back from each stream's own encoding at stripe close, so a stream split
+// across several chunks is dropped only when every chunk encodes a Constant
+// true -- there is no per-chunk in-map state to accumulate.
+TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStreamChunked) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto batch = [&](int64_t base) {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector<int32_t, int64_t>(
+            {{{1, base}}, {{1, base + 1}}})});
+  };
+  std::vector<velox::VectorPtr> vectors{batch(10), batch(20), batch(30)};
+
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_,
+      vectors,
+      chunkedFlatMapOptions(createFlatMapWriterOptions()),
+      /*flushAfterWrite=*/false);
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector =
+        std::make_shared<velox::dwio::common::ColumnSelector>(velox::ROW(
+            {{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}}));
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    const auto offsets = existingStreamOffsets(*leafPool_, &readFile, 0);
+    const auto inMapOffset = flatMap.inMapDescriptorAt(0).offset();
+    if (skipConstantFlatMapInMapStreams()) {
+      EXPECT_FALSE(offsets.count(inMapOffset))
+          << "all-true in-map stream should be dropped on the chunked path";
+    } else {
+      EXPECT_TRUE(offsets.count(inMapOffset));
+    }
+  }
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+// The all-null invariant holds on the chunked path: with no value stream to
+// prove the key was present, the all-true in-map stream is the only record of
+// it and must survive even though it is constant.
+TEST_P(BatchReaderTest, flatMapAllNullValuesKeepsInMapChunked) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto allNullBatch = [&]() {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector(
+            {0, 1},
+            vectorMaker.flatVector<int32_t>({1, 1}),
+            vectorMaker.flatVectorNullable<int64_t>(
+                {std::nullopt, std::nullopt}))});
+  };
+  std::vector<velox::VectorPtr> vectors{
+      allNullBatch(), allNullBatch(), allNullBatch()};
+
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_,
+      vectors,
+      chunkedFlatMapOptions(createFlatMapWriterOptions()),
+      /*flushAfterWrite=*/false);
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector =
+        std::make_shared<velox::dwio::common::ColumnSelector>(velox::ROW(
+            {{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}}));
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                    .count(flatMap.inMapDescriptorAt(0).offset()))
+        << "in-map stream is the key's only record and must be kept";
+  }
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+// A key present in some rows and absent in others produces a mixed in-map
+// stream, which is not Constant and so is never dropped -- including when the
+// all-true chunks come first and the mixed one only later.
+TEST_P(BatchReaderTest, flatMapMixedInMapAcrossChunksKeepsStream) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 10}}, {{1, 11}}})}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 12}}, {}})}),
+  };
+
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_,
+      vectors,
+      chunkedFlatMapOptions(createFlatMapWriterOptions()),
+      /*flushAfterWrite=*/false);
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector =
+        std::make_shared<velox::dwio::common::ColumnSelector>(velox::ROW(
+            {{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}}));
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                    .count(flatMap.inMapDescriptorAt(0).offset()))
+        << "a mixed in-map stream must reach disk";
+  }
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
 
 // A key whose values are null in an early batch and non-null in a later one
 // must survive the chunk boundary between them. The writer defers a chunk

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -36,10 +36,12 @@
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
+#include "velox/dwio/nimble/common/ChunkHeader.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/index/ClusterIndexConfig.h"
 #include "velox/dwio/nimble/index/ClusterIndexFactory.h"
@@ -57,6 +59,7 @@
 #include "velox/dwio/nimble/velox/MetadataGenerated.h"
 #include "velox/dwio/nimble/velox/RawSizeUtils.h"
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
+#include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SchemaTypes.h"
 
@@ -2762,6 +2765,140 @@ void Writer::encodeStream(
   streamData.reset();
 }
 
+namespace {
+
+// Visits every flat map in the schema tree.
+template <typename Visitor>
+void visitFlatMaps(const TypeBuilder& type, const Visitor& visit) {
+  if (type.kind() == Kind::FlatMap) {
+    const auto& flatMap = type.asFlatMap();
+    visit(flatMap);
+    for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+      visitFlatMaps(flatMap.childAt(i), visit);
+    }
+    return;
+  }
+  switch (type.kind()) {
+    case Kind::Row: {
+      const auto& row = type.asRow();
+      for (size_t i = 0; i < row.childrenCount(); ++i) {
+        visitFlatMaps(row.childAt(i), visit);
+      }
+      return;
+    }
+    case Kind::Array:
+      visitFlatMaps(type.asArray().elements(), visit);
+      return;
+    case Kind::ArrayWithOffsets:
+      visitFlatMaps(type.asArrayWithOffsets().elements(), visit);
+      return;
+    case Kind::Map:
+      visitFlatMaps(type.asMap().keys(), visit);
+      visitFlatMaps(type.asMap().values(), visit);
+      return;
+    case Kind::SlidingWindowMap:
+      visitFlatMaps(type.asSlidingWindowMap().keys(), visit);
+      visitFlatMaps(type.asSlidingWindowMap().values(), visit);
+      return;
+    case Kind::Scalar:
+    case Kind::TimestampMicroNano:
+      // Leaf kinds: no children to descend into.
+      return;
+    case Kind::FlatMap:
+      break;
+  }
+  // FlatMap returns above; every other kind returns from its case. Listing all
+  // kinds instead of a default keeps -Wswitch-enum quiet, which OSS builds
+  // with -Werror.
+  NIMBLE_UNREACHABLE("Unexpected type kind {}", type.kind());
+}
+
+// Whether every chunk of an already-encoded in-map stream is a Constant
+// encoding of true, i.e. the key was carried by every row of the stripe.
+//
+// Reads only the chunk and encoding prefixes; it never decodes or
+// decompresses. Anything it cannot prove -- no chunks, an unexpected chunk
+// shape, a compressed payload, a non-Constant encoding -- answers false and
+// the stream stays on disk. The asymmetry is deliberate: Constant means every
+// value is identical by the encoding's own contract, so a true answer cannot
+// be wrong, while a false answer costs only the space saving.
+bool isAllTrueEncodedStream(const Stream& stream) {
+  if (stream.chunks.empty()) {
+    return false;
+  }
+  for (const auto& chunk : stream.chunks) {
+    // ChunkedStreamWriter emits exactly {header, payload}.
+    if (chunk.content.size() != 2 ||
+        chunk.content[0].size() != kChunkHeaderSize) {
+      return false;
+    }
+    const char* headerPos = chunk.content[0].data();
+    if (readChunkHeader(headerPos).compressionType !=
+        CompressionType::Uncompressed) {
+      return false;
+    }
+    const auto payload = chunk.content[1];
+    if (payload.size() <= EncodingPrefix::kRowCountOffset ||
+        EncodingPrefix::encodingType(payload) != EncodingType::Constant ||
+        EncodingPrefix::dataType(payload) != DataType::Bool) {
+      return false;
+    }
+    // A ConstantEncoding<bool> payload is the prefix followed by its single
+    // value byte and nothing else, so the value is the last byte. Reading it
+    // that way avoids having to know whether the row count was serialized
+    // fixed-width or as a varint, which the prefix does not record.
+    if (payload.back() == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+void Writer::suppressRedundantInMapStreams() {
+  if (!context_->options().skipConstantFlatMapInMapStreams) {
+    return;
+  }
+
+  // Chunked writes have never skipped constant in-map streams: the old marking
+  // ran only in processStream(), which the chunked path does not call. Reading
+  // the encoding instead would start suppressing here for free, so this holds
+  // that behaviour until it is enabled deliberately, with its own coverage.
+  if (context_->options().enableChunking) {
+    return;
+  }
+
+  const auto hasEncodedStream = [this](offset_size offset) {
+    return offset < encodedStreams_.size() &&
+        !encodedStreams_[offset].chunks.empty();
+  };
+
+  visitFlatMaps(
+      *context_->schemaBuilder().root(),
+      [&](const FlatMapTypeBuilder& flatMap) {
+        // The schema pairs each key's in-map descriptor with its value type by
+        // index, so no separate bookkeeping is needed to relate the two.
+        for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+          const auto& inMapDescriptor = flatMap.inMapDescriptorAt(i);
+          const auto inMapOffset = inMapDescriptor.offset();
+          // Scoped to flat map in-map descriptors by construction: this walk
+          // only ever reaches the streams reached via inMapDescriptorAt().
+          if (inMapOffset >= encodedStreams_.size() ||
+              !isAllTrueEncodedStream(encodedStreams_[inMapOffset])) {
+            continue;
+          }
+
+          // Drop the all-true in-map stream only while a value stream proves
+          // the key was present. Asked with the reader's own traversal, so the
+          // writer cannot count bytes the reader will not look at.
+          if (visitValueStreamLeaves(flatMap.childAt(i), hasEncodedStream)) {
+            encodedStreams_[inMapOffset].chunks.clear();
+          }
+        }
+      });
+}
+
 void Writer::processStream(
     StreamData& streamData,
     velox::BufferPool* encodingScratchBufferPool,
@@ -2769,7 +2906,7 @@ void Writer::processStream(
     uint64_t& streamSize,
     std::atomic_uint64_t& chunkSize) {
   const auto offset = streamData.descriptor().offset();
-  const auto* context = streamData.descriptor().context<WriterStreamContext>();
+  auto* context = streamData.descriptor().context<WriterStreamContext>();
   NIMBLE_CHECK(encodedStreams_[offset].chunks.empty());
   if ((context != nullptr) && context->isNullStream()) {
     // For null streams we promote the null values to be written as
@@ -2786,15 +2923,26 @@ void Writer::processStream(
   } else if (
       (context != nullptr) && context->isInMapStream() &&
       context_->options().skipConstantFlatMapInMapStreams) {
-    // When enabled, skip encoding in-map streams that are all-true (every row
-    // has the key) or all-false (no row has the key). The reader distinguishes
-    // these by checking value stream presence: all-true keys have value
-    // streams, all-false keys do not.
+    // When enabled, skip encoding in-map streams that are constant, since the
+    // reader recovers the in-map state from value stream presence.
+    //
+    // All-false is dropped here: the key really is absent from this stripe,
+    // which is exactly what the reader concludes from two missing streams.
+    //
+    // All-true cannot be decided yet. It is only safe to drop while some value
+    // stream survives to prove the key was present, and whether that happens
+    // is not known until every stream in the stripe has been encoded --
+    // streams are encoded concurrently here and must not inspect each other.
+    // So it is encoded now and reconsidered by
+    // suppressRedundantInMapStreams() at stripe close, which recognizes it
+    // from its own encoding and drops it if a value stream did reach disk.
     //
     // NOTE: readers that don't infer missing in-map streams require
     // skipConstantFlatMapInMapStreams to remain false.
     streamData.materialize();
-    if (!isConstantBoolStream(streamData.data())) {
+    const auto data = streamData.data();
+    const bool allTrue = isAllTrueBoolStream(data);
+    if (allTrue || !isConstantBoolStream(data)) {
       encodeStream(
           streamData,
           encodingScratchBufferPool,
@@ -3047,6 +3195,8 @@ bool Writer::writeStripe() {
   uint64_t stripeSize{0};
   {
     LoggingScope scope{*context_->logger()};
+
+    suppressRedundantInMapStreams();
 
     size_t nonEmptyCount{0};
     for (auto i = 0; i < encodedStreams_.size(); ++i) {

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -600,10 +600,6 @@ class WriterStreamContext : public StreamContext {
     isInMapStream_ = value;
   }
 
-  void setFlatMapValueStreamOffsets(std::vector<offset_size> offsets) {
-    flatMapValueStreamOffsets_ = std::move(offsets);
-  }
-
   // The layout to replay for this stream: overlaid from the EncodingLayoutTree
   // at setup, or captured from this stream's first encode when
   // encoding-selection caching is enabled. Empty until one of those populates
@@ -641,10 +637,6 @@ class WriterStreamContext : public StreamContext {
  private:
   bool isNullStream_{false};
   bool isInMapStream_{false};
-  // Value stream descriptor offsets for this in-map stream's flat-map field.
-  // Empty for non in-map streams and flat-map values with no reader-visible
-  // value stream.
-  std::vector<offset_size> flatMapValueStreamOffsets_;
   std::optional<EncodingLayout> encoding_;
   std::optional<SharedDictionaryConfig> sharedDictionaryConfig_;
   mutable std::unique_ptr<SharedDictionaryWriter> sharedDictionaryWriter_;
@@ -1247,63 +1239,6 @@ void findNodeIds(
   }
 }
 
-void collectFlatMapValueStreamOffsets(
-    const TypeBuilder& type,
-    std::vector<offset_size>& offsets) {
-  switch (type.kind()) {
-    case Kind::Scalar:
-      offsets.push_back(type.asScalar().scalarDescriptor().offset());
-      return;
-    case Kind::TimestampMicroNano:
-      offsets.push_back(
-          type.asTimestampMicroNano().microsDescriptor().offset());
-      offsets.push_back(type.asTimestampMicroNano().nanosDescriptor().offset());
-      return;
-    case Kind::Array:
-      offsets.push_back(type.asArray().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asArray().elements(), offsets);
-      return;
-    case Kind::ArrayWithOffsets:
-      offsets.push_back(type.asArrayWithOffsets().offsetsDescriptor().offset());
-      offsets.push_back(type.asArrayWithOffsets().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asArrayWithOffsets().elements(), offsets);
-      return;
-    case Kind::Map:
-      offsets.push_back(type.asMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(type.asMap().values(), offsets);
-      return;
-    case Kind::SlidingWindowMap:
-      offsets.push_back(type.asSlidingWindowMap().offsetsDescriptor().offset());
-      offsets.push_back(type.asSlidingWindowMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().values(), offsets);
-      return;
-    case Kind::Row: {
-      const auto& row = type.asRow();
-      offsets.push_back(row.nullsDescriptor().offset());
-      for (size_t i = 0; i < row.childrenCount(); ++i) {
-        collectFlatMapValueStreamOffsets(row.childAt(i), offsets);
-      }
-      return;
-    }
-    case Kind::FlatMap: {
-      const auto& flatMap = type.asFlatMap();
-      offsets.push_back(flatMap.nullsDescriptor().offset());
-      for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-        offsets.push_back(flatMap.inMapDescriptorAt(i).offset());
-        collectFlatMapValueStreamOffsets(flatMap.childAt(i), offsets);
-      }
-      return;
-    }
-    default:
-      NIMBLE_UNREACHABLE("Unsupported type kind {}", type.kind());
-  }
-}
-
 FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodingsForFlatMap(
     const EncodingLayoutTree& encodingLayoutTree) {
   FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodings;
@@ -1737,9 +1672,6 @@ void configureAddedFlatMapField(
   auto& inMapContext = streamContext(
       flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1));
   inMapContext.setIsInMapStream(true);
-  std::vector<offset_size> valueStreamOffsets;
-  collectFlatMapValueStreamOffsets(fieldType, valueStreamOffsets);
-  inMapContext.setFlatMapValueStreamOffsets(std::move(valueStreamOffsets));
 
   auto* flatMapContext = flatmap.context<FlatmapEncodingLayoutContext>();
   if (flatMapContext == nullptr) {

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -2861,14 +2861,6 @@ void Writer::suppressRedundantInMapStreams() {
     return;
   }
 
-  // Chunked writes have never skipped constant in-map streams: the old marking
-  // ran only in processStream(), which the chunked path does not call. Reading
-  // the encoding instead would start suppressing here for free, so this holds
-  // that behaviour until it is enabled deliberately, with its own coverage.
-  if (context_->options().enableChunking) {
-    return;
-  }
-
   const auto hasEncodedStream = [this](offset_size offset) {
     return offset < encodedStreams_.size() &&
         !encodedStreams_[offset].chunks.empty();

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -237,6 +237,12 @@ class Writer : public velox::dwio::common::Writer {
       uint64_t& streamSize,
       std::atomic_uint64_t& chunkSize);
 
+  // Drops all-true flat map in-map streams whose key is still provable from a
+  // value stream. Runs once the stripe is fully encoded, where every stream's
+  // fate is known -- the concurrent encode cannot decide this, since a stream
+  // may not inspect its peers there.
+  void suppressRedundantInMapStreams();
+
   void processStream(
       StreamData& streamData,
       velox::BufferPool* encodingScratchBufferPool,


### PR DESCRIPTION
Summary:
`skipConstantFlatMapInMapStreams` has only ever applied to non-chunked writes.
Not by design -- the marking that drove it lived in `processStream()`, which
the chunked path never calls, so chunked files carried every all-true in-map
stream even with the option on.

The parent diff removed that marking and made the sweep read each stream's own
encoding instead, which works the same whether a stream was written in one
piece or many. All that is left here is deleting the early return that was
holding the previous behaviour, plus coverage.

Nothing else needed changing, and it is worth being explicit about why:

- The sweep already ran on both paths. It sits below the `enableChunking`
  branch in `writeStripe()`, so chunked stripes were reaching it and finding
  nothing marked.
- Omission granularity already matched. A stream is dropped by clearing its
  whole `chunks` vector, and the compaction loop then filters it before
  `writeStripe()`. There is no way to omit only some chunks of a stream.
- The readers already handle it. Both `FieldReader` and the selective
  `FlatMapColumnReader` decide per key, once per stripe: if the in-map stream
  is absent they consult value stream presence to tell "present in every row"
  from "absent this stripe". Neither branches on chunking, and neither has a
  per-chunk notion of in-map availability -- `streams().enqueue()` hands back
  the whole stream, wrapped in a single `ChunkedDecoder`. So a chunked file
  with a suppressed in-map stream takes the identical code path a non-chunked
  one already did.

The multi-chunk case needs no accumulation logic: the predicate requires every
chunk to encode a Constant true, so a stream that is all-true in one chunk and
mixed in another simply is not dropped.

Differential Revision: D118595038


