### PR TITLE
refactor(connectors): Add is<T>() and as<T>() downcasts (#18847)

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "folly/CancellationToken.h"
+#include "velox/common/Casts.h"
 #include "velox/common/EnumDeclare.h"
 #include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/PrefixSortConfig.h"
@@ -104,6 +105,26 @@ struct ConnectorSplit : public ISerializable {
         splitWeight,
         cacheable ? "true" : "false");
   }
+
+  /// Returns true if this split is of connector-specific type 'T'.
+  template <typename T>
+  bool is() const {
+    return as<T>() != nullptr;
+  }
+
+  /// Returns this split as connector-specific type 'T', or nullptr if it is
+  /// not of that type.
+  template <typename T>
+  const T* as() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+  /// Returns this split as connector-specific type 'T'. Throws if it is not
+  /// of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return checkedPointerCast<const T>(this);
+  }
 };
 
 class ColumnHandle : public ISerializable {
@@ -114,6 +135,26 @@ class ColumnHandle : public ISerializable {
 
   virtual std::string toString() const {
     return name();
+  }
+
+  /// Returns true if this handle is of connector-specific type 'T'.
+  template <typename T>
+  bool is() const {
+    return as<T>() != nullptr;
+  }
+
+  /// Returns this handle as connector-specific type 'T', or nullptr if it is
+  /// not of that type.
+  template <typename T>
+  const T* as() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+  /// Returns this handle as connector-specific type 'T'. Throws if it is not
+  /// of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return checkedPointerCast<const T>(this);
   }
 
   folly::dynamic serialize() const override;
@@ -163,6 +204,26 @@ class ConnectorTableHandle : public ISerializable {
     return name();
   }
 
+  /// Returns true if this handle is of connector-specific type 'T'.
+  template <typename T>
+  bool is() const {
+    return as<T>() != nullptr;
+  }
+
+  /// Returns this handle as connector-specific type 'T', or nullptr if it is
+  /// not of that type.
+  template <typename T>
+  const T* as() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+  /// Returns this handle as connector-specific type 'T'. Throws if it is not
+  /// of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return checkedPointerCast<const T>(this);
+  }
+
   virtual folly::dynamic serialize() const override;
 
  protected:
@@ -184,6 +245,26 @@ class ConnectorInsertTableHandle : public ISerializable {
   }
 
   virtual std::string toString() const = 0;
+
+  /// Returns true if this handle is of connector-specific type 'T'.
+  template <typename T>
+  bool is() const {
+    return as<T>() != nullptr;
+  }
+
+  /// Returns this handle as connector-specific type 'T', or nullptr if it is
+  /// not of that type.
+  template <typename T>
+  const T* as() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+  /// Returns this handle as connector-specific type 'T'. Throws if it is not
+  /// of that type.
+  template <typename T>
+  const T* asChecked() const {
+    return checkedPointerCast<const T>(this);
+  }
 
   folly::dynamic serialize() const override {
     VELOX_NYI();

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -196,8 +196,7 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
     return fieldIds;
   }
 
-  const auto* hiveTableHandle =
-      dynamic_cast<const HiveTableHandle*>(tableHandle_.get());
+  const auto* hiveTableHandle = tableHandle_->as<HiveTableHandle>();
   const auto* dataColumnFieldIds = hiveTableHandle != nullptr
       ? &hiveTableHandle->dataColumnFieldIds()
       : nullptr;
@@ -727,8 +726,7 @@ IcebergSplitReader::resolveEqualityColumns(
       "table data columns are not available in IcebergTableHandle.",
       deleteFile.filePath);
   std::unordered_map<int32_t, uint32_t> columnIndexByFieldId;
-  if (const auto* hiveTableHandle =
-          dynamic_cast<const HiveTableHandle*>(tableHandle_.get())) {
+  if (const auto* hiveTableHandle = tableHandle_->as<HiveTableHandle>()) {
     const auto& dataColumnFieldIds = hiveTableHandle->dataColumnFieldIds();
     columnIndexByFieldId.reserve(dataColumnFieldIds.size());
     for (uint32_t i = 0; i < dataColumnFieldIds.size(); ++i) {

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1292,6 +1292,26 @@ void TableScanNode::accept(
 
 void TableScanNode::addDetails(std::stringstream& stream) const {
   stream << tableHandle_->toString();
+
+  // Assignments are expected to name every output column, but some frontends
+  // build scans with no assignments at all.
+  if (assignments_.empty()) {
+    return;
+  }
+
+  bool first = true;
+  for (auto i = 0; i < outputType_->size(); ++i) {
+    if (outputType_->childAt(i)->isPrimitiveType()) {
+      continue;
+    }
+    const auto& outputName = outputType_->nameOf(i);
+    stream << (first ? ", assignments: [" : ", ");
+    first = false;
+    stream << outputName << " := " << assignments_.at(outputName)->toString();
+  }
+  if (!first) {
+    stream << "]";
+  }
 }
 
 void TableScanNode::addSummaryDetails(

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -182,7 +182,8 @@ std::string PlanNodeStats::toString(
   if (includeInputStats) {
     out << "Input: " << inputRows << " rows (" << succinctBytes(inputBytes)
         << ", " << inputVectors << " batches), ";
-    if ((rawInputRows > 0) && (rawInputRows != inputRows)) {
+    if (rawInputRows > 0 &&
+        (rawInputRows != inputRows || rawInputBytes != inputBytes)) {
       out << "Raw Input: " << rawInputRows << " rows ("
           << succinctBytes(rawInputBytes) << "), ";
     }

--- a/velox/exec/tests/PlanNodeStatsTest.cpp
+++ b/velox/exec/tests/PlanNodeStatsTest.cpp
@@ -31,4 +31,36 @@ TEST(PlanNodeStatsTest, exprStatsTotal) {
   EXPECT_EQ(total.expressionStats["foo"], stats.expressionStats["foo"]);
 }
 
+TEST(PlanNodeStatsTest, rawInput) {
+  // Everything the stats print beyond the input counts, which stay zero here.
+  const std::string kRest =
+      ", Output: 0 rows (0B, 0 batches), Cpu time: 0ns, Wall time: 0ns"
+      ", Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0"
+      ", CPU breakdown: B/I/O/F (0ns/0ns/0ns/0ns)";
+
+  PlanNodeStats stats;
+  stats.inputRows = 100;
+  stats.inputBytes = 1000;
+  stats.rawInputRows = 100;
+  stats.rawInputBytes = 50'000;
+
+  // Same rows, more bytes read than handed on.
+  ASSERT_EQ(
+      "Input: 100 rows (1000B, 0 batches), Raw Input: 100 rows (48.83KB)" +
+          kRest,
+      stats.toString(/*includeInputStats=*/true));
+
+  // Nothing to add when the raw input matches the input.
+  stats.rawInputBytes = stats.inputBytes;
+  ASSERT_EQ(
+      "Input: 100 rows (1000B, 0 batches)" + kRest,
+      stats.toString(/*includeInputStats=*/true));
+
+  // Rows dropped by a pushed-down filter.
+  stats.rawInputRows = 200;
+  ASSERT_EQ(
+      "Input: 100 rows (1000B, 0 batches), Raw Input: 200 rows (1000B)" + kRest,
+      stats.toString(/*includeInputStats=*/true));
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/core/FixedPointPlanNodes.h"
 #include "velox/exec/WindowFunction.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -789,6 +790,51 @@ TEST_F(PlanNodeToStringTest, tableScan) {
     ASSERT_EQ(
         "-- TableScan[0][table: hive_table, remaining filter: (not(like(ROW[\"comment\"],%special%request%)))] "
         "-> discount:DOUBLE, quantity:DOUBLE, shipdate:VARCHAR, comment:VARCHAR\n",
+        plan->toString(true, false));
+  }
+}
+
+TEST_F(PlanNodeToStringTest, tableScanAssignments) {
+  {
+    // A complex column shows the parts the scan asks for; a scalar column
+    // shows nothing.
+    RowTypePtr rowType{ROW({
+        {"m", MAP(VARCHAR(), BIGINT())},
+        {"n", BIGINT()},
+    })};
+
+    connector::ColumnHandleMap assignments;
+    assignments["m"] = test::HiveConnectorTestBase::makeColumnHandle(
+        "m", rowType->childAt(0), {"m[\"k\"]"});
+    assignments["n"] =
+        test::HiveConnectorTestBase::regularColumn("n", rowType->childAt(1));
+
+    auto plan = PlanBuilder(pool_.get())
+                    .tableScan(rowType, {}, "", nullptr, assignments)
+                    .planNode();
+
+    ASSERT_EQ(
+        "-- TableScan[0][table: hive_table, assignments: [m := HiveColumnHandle "
+        "[name: m, columnType: Regular, dataType: MAP<VARCHAR,BIGINT>, "
+        "requiredSubfields: [ m[\"k\"] ]]]] "
+        "-> m:MAP<VARCHAR,BIGINT>, n:BIGINT\n",
+        plan->toString(true, false));
+  }
+
+  {
+    // A scan of scalars alone adds nothing.
+    RowTypePtr rowType{ROW("n", BIGINT())};
+
+    connector::ColumnHandleMap assignments;
+    assignments["n"] =
+        test::HiveConnectorTestBase::regularColumn("n", rowType->childAt(0));
+
+    auto plan = PlanBuilder(pool_.get())
+                    .tableScan(rowType, {}, "", nullptr, assignments)
+                    .planNode();
+
+    ASSERT_EQ(
+        "-- TableScan[0][table: hive_table] -> n:BIGINT\n",
         plan->toString(true, false));
   }
 }


### PR DESCRIPTION
Summary:

Connector code downcasts a handle by naming the pointee:

    dynamic_cast<const HiveTableHandle*>(tableHandle_.get())

which now reads

    tableHandle_->as<HiveTableHandle>()

or

    tableHandle_->asChecked<HiveTableHandle>()

`core::PlanNode` has carried an `is<T>()`/`as<T>()` pair for a while. This adds the same pair to the connector handle and split interfaces, and adopts it in the Iceberg split reader. Most of the remaining call sites are in downstream connectors and are left for a separate sweep.

Reviewed By: amitkdutta

Differential Revision: D118800738


