### PR TITLE
Draft: stage adaptive UCX GPU exchange flow control

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -69,6 +69,14 @@ class Exchange : public SourceOperator {
 
   bool isFinished() override;
 
+  std::shared_ptr<InMemoryExchangeClient> releaseExchangeClient() {
+    return std::move(exchangeClient_);
+  }
+
+  void resetExchangeClient() {
+    exchangeClient_.reset();
+  }
+
  protected:
   virtual VectorSerde* getSerde();
 

--- a/velox/exec/InMemoryExchangeClient.h
+++ b/velox/exec/InMemoryExchangeClient.h
@@ -45,6 +45,7 @@ class InMemoryExchangeClient
       bool lazyFetching = false)
       : taskId_{std::move(taskId)},
         destination_(destination),
+        numberOfConsumers_(numberOfConsumers),
         maxQueuedBytes_{maxQueuedBytes},
         requestDataSizesMaxWaitSec_{requestDataSizesMaxWaitSec},
         pool_(pool),
@@ -127,6 +128,14 @@ class InMemoryExchangeClient
     return remoteTaskIds_;
   }
 
+  int getDestination() const {
+    return destination_;
+  }
+
+  uint32_t getNumberOfConsumers() const {
+    return numberOfConsumers_;
+  }
+
  private:
   struct RequestSpec {
     std::shared_ptr<ExchangeSource> source;
@@ -175,6 +184,7 @@ class InMemoryExchangeClient
   // Handy for ad-hoc logging.
   const std::string taskId_;
   const int destination_;
+  const int32_t numberOfConsumers_;
   const int64_t maxQueuedBytes_;
   const std::chrono::seconds requestDataSizesMaxWaitSec_;
 

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -20,6 +20,8 @@
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
+#include "velox/core/Expressions.h"
+
 #include <cudf/sorting.hpp>
 
 namespace facebook::velox::cudf_velox {
@@ -27,29 +29,41 @@ namespace facebook::velox::cudf_velox {
 CudfOrderBy::CudfOrderBy(
     int32_t operatorId,
     exec::DriverCtx* driverCtx,
-    const std::shared_ptr<const core::OrderByNode>& orderByNode)
+    const std::shared_ptr<const core::PlanNode>& planNode)
     : CudfOperatorBase(
           operatorId,
           driverCtx,
-          orderByNode->outputType(),
-          orderByNode->id(),
+          planNode->outputType(),
+          planNode->id(),
           "CudfOrderBy",
           nvtx3::rgb{64, 224, 208}, // Turquoise
           NvtxMethodFlag::kAll,
           std::nullopt,
-          orderByNode),
-      orderByNode_(orderByNode) {
-  sortKeys_.reserve(orderByNode->sortingKeys().size());
-  columnOrder_.reserve(orderByNode->sortingKeys().size());
-  nullOrder_.reserve(orderByNode->sortingKeys().size());
-  for (int i = 0; i < orderByNode->sortingKeys().size(); ++i) {
-    const auto channel =
-        exec::exprToChannel(orderByNode->sortingKeys()[i].get(), outputType_);
+          planNode) {
+  const auto orderByNode =
+      std::dynamic_pointer_cast<const core::OrderByNode>(planNode);
+  const auto mergeExchangeNode =
+      std::dynamic_pointer_cast<const core::MergeExchangeNode>(planNode);
+  VELOX_CHECK(
+      orderByNode || mergeExchangeNode,
+      "CudfOrderBy requires OrderByNode or MergeExchangeNode, got {}",
+      planNode->name());
+
+  const auto& sortingKeys = orderByNode ? orderByNode->sortingKeys()
+                                        : mergeExchangeNode->sortingKeys();
+  const auto& sortingOrders = orderByNode ? orderByNode->sortingOrders()
+                                          : mergeExchangeNode->sortingOrders();
+
+  sortKeys_.reserve(sortingKeys.size());
+  columnOrder_.reserve(sortingKeys.size());
+  nullOrder_.reserve(sortingKeys.size());
+  for (int i = 0; i < sortingKeys.size(); ++i) {
+    const auto channel = exec::exprToChannel(sortingKeys[i].get(), outputType_);
     VELOX_CHECK(
         channel != kConstantChannel,
         "OrderBy doesn't allow constant sorting keys");
     sortKeys_.push_back(channel);
-    auto const& sortingOrder = orderByNode->sortingOrders()[i];
+    auto const& sortingOrder = sortingOrders[i];
     columnOrder_.push_back(
         sortingOrder.isAscending() ? cudf::order::ASCENDING
                                    : cudf::order::DESCENDING);

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -31,7 +31,7 @@ class CudfOrderBy : public CudfOperatorBase {
   CudfOrderBy(
       int32_t operatorId,
       exec::DriverCtx* driverCtx,
-      const std::shared_ptr<const core::OrderByNode>& orderByNode);
+      const std::shared_ptr<const core::PlanNode>& planNode);
 
   bool needsInput() const override {
     return !finished_;
@@ -53,7 +53,6 @@ class CudfOrderBy : public CudfOperatorBase {
 
  private:
   CudfVectorPtr outputTable_;
-  std::shared_ptr<const core::OrderByNode> orderByNode_;
   std::vector<CudfVectorPtr> inputs_;
   std::vector<cudf::size_type> sortKeys_;
   std::vector<cudf::order> columnOrder_;

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -22,6 +22,8 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/prefetch.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/cuda_async_managed_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
@@ -32,14 +34,29 @@
 
 #include <common/base/Exceptions.h>
 
+#include <glog/logging.h>
+
 #include <cstdlib>
 #include <string_view>
 
 namespace facebook::velox::cudf_velox {
 
+namespace {
+
+std::optional<cudaMemPool_t> currentAsyncPoolHandle_;
+
+void trackCurrentAsyncPool(cudaMemPool_t poolHandle, bool trackAsCurrent) {
+  if (trackAsCurrent) {
+    currentAsyncPoolHandle_ = poolHandle;
+  }
+}
+
+} // namespace
+
 cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
     std::string_view mode,
-    int percent) {
+    int percent,
+    bool trackAsCurrent) {
   if (mode == "cuda") {
     return rmm::mr::cuda_memory_resource{};
   } else if (mode == "pool") {
@@ -47,7 +64,9 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
         rmm::mr::cuda_memory_resource{},
         rmm::percent_of_free_device_memory(percent));
   } else if (mode == "async") {
-    return rmm::mr::cuda_async_memory_resource{};
+    auto resource = rmm::mr::cuda_async_memory_resource{};
+    trackCurrentAsyncPool(resource.pool_handle(), trackAsCurrent);
+    return resource;
   } else if (mode == "arena") {
     return rmm::mr::arena_memory_resource(
         rmm::mr::cuda_memory_resource{},
@@ -59,7 +78,9 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
         rmm::mr::managed_memory_resource{},
         rmm::percent_of_free_device_memory(percent));
   } else if (mode == "managed_async") {
-    return rmm::mr::cuda_async_managed_memory_resource{};
+    auto resource = rmm::mr::cuda_async_managed_memory_resource{};
+    trackCurrentAsyncPool(resource.pool_handle(), trackAsCurrent);
+    return resource;
   } else if (mode == "prefetch_managed") {
     cudf::prefetch::enable();
     return rmm::mr::prefetch_resource_adaptor(
@@ -72,6 +93,8 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
             rmm::percent_of_free_device_memory(percent)));
   } else if (mode == "prefetch_managed_async") {
     cudf::prefetch::enable();
+    // The prefetch adaptor hides the underlying async pool handle, so callers
+    // fall back to raw cudaMemGetInfo for this mode.
     return rmm::mr::prefetch_resource_adaptor(
         rmm::mr::cuda_async_managed_memory_resource{});
   }
@@ -90,6 +113,50 @@ std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> output_mr_;
 
 rmm::device_async_resource_ref get_output_mr() {
   return output_mr_.value();
+}
+
+std::optional<CudfDeviceMemoryInfo> currentDeviceMemoryInfo() {
+  size_t freeBytes = 0;
+  size_t totalBytes = 0;
+  const auto memInfoStatus = cudaMemGetInfo(&freeBytes, &totalBytes);
+  if (memInfoStatus != cudaSuccess) {
+    VLOG(1) << "cudaMemGetInfo failed while reading cuDF memory info: "
+            << cudaGetErrorString(memInfoStatus);
+    return std::nullopt;
+  }
+
+  CudfDeviceMemoryInfo info{
+      .freeBytes = static_cast<uint64_t>(freeBytes),
+      .totalBytes = static_cast<uint64_t>(totalBytes)};
+  if (!currentAsyncPoolHandle_.has_value()) {
+    return info;
+  }
+
+  uint64_t reservedBytes = 0;
+  uint64_t usedBytes = 0;
+  const auto reservedStatus = cudaMemPoolGetAttribute(
+      *currentAsyncPoolHandle_,
+      cudaMemPoolAttrReservedMemCurrent,
+      &reservedBytes);
+  const auto usedStatus = cudaMemPoolGetAttribute(
+      *currentAsyncPoolHandle_, cudaMemPoolAttrUsedMemCurrent, &usedBytes);
+  if (reservedStatus != cudaSuccess || usedStatus != cudaSuccess) {
+    VLOG(1) << "cudaMemPoolGetAttribute failed while reading cuDF pool info: "
+            << "reservedStatus=" << cudaGetErrorString(reservedStatus)
+            << " usedStatus=" << cudaGetErrorString(usedStatus);
+    return info;
+  }
+
+  info.poolReservedBytes = reservedBytes;
+  info.poolUsedBytes = usedBytes;
+  info.poolReusableBytes =
+      reservedBytes > usedBytes ? reservedBytes - usedBytes : 0;
+  info.hasPoolStats = true;
+  return info;
+}
+
+void clearCurrentDeviceMemoryInfo() {
+  currentAsyncPoolHandle_.reset();
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -22,6 +22,7 @@
 
 #include <cuda/memory_resource>
 
+#include <cstdint>
 #include <optional>
 #include <string_view>
 
@@ -34,6 +35,19 @@ extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
 /// Returns the memory resource designated for output vector allocations.
 rmm::device_async_resource_ref get_output_mr();
 
+struct CudfDeviceMemoryInfo {
+  uint64_t freeBytes{0};
+  uint64_t totalBytes{0};
+  uint64_t poolReservedBytes{0};
+  uint64_t poolUsedBytes{0};
+  uint64_t poolReusableBytes{0};
+  bool hasPoolStats{false};
+};
+
+[[nodiscard]] std::optional<CudfDeviceMemoryInfo> currentDeviceMemoryInfo();
+
+void clearCurrentDeviceMemoryInfo();
+
 /**
  * @brief Creates a memory resource based on the given mode.
  *
@@ -42,7 +56,10 @@ rmm::device_async_resource_ref get_output_mr();
  * resource.
  */
 [[nodiscard]] cuda::mr::any_resource<cuda::mr::device_accessible>
-createMemoryResource(std::string_view mode, int percent);
+createMemoryResource(
+    std::string_view mode,
+    int percent,
+    bool trackAsCurrent = false);
 
 /**
  * @brief Returns the global CUDA stream pool used by cudf.

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -105,8 +105,8 @@ bool CompileState::compile(bool allowCpuFallback) {
                 adapter->properties(op, planNode, ctx);
           }
         }
-        if (isAnyOf<CudfOperator>(op)) {
-          // CudfOperator is always fully GPU compatible
+        if (isAnyOf<CudfOperator, CudfOperatorBase>(op)) {
+          // Cudf operators are always fully GPU compatible
           // (runs on GPU, accepts GPU input, produces GPU output).
           props.canRunOnGPU = true;
           props.acceptsGpuInput = true;
@@ -189,8 +189,9 @@ bool CompileState::compile(bool allowCpuFallback) {
         isPureCpuOperator = false;
       }
     } else {
-      // special case for CudfOperator
-      if (isAnyOf<CudfOperator>(oper)) {
+      // Special case for cuDF operators that were inserted by an earlier
+      // DriverAdapter pass.
+      if (isAnyOf<CudfOperator, CudfOperatorBase>(oper)) {
         isPureCpuOperator = false;
       } else {
         // CPU operator without adapter
@@ -311,7 +312,7 @@ void registerCudf() {
 
   const std::string mrMode = CudfConfig::getInstance().memoryResource;
   auto mr = cudf_velox::createMemoryResource(
-      mrMode, CudfConfig::getInstance().memoryPercent);
+      mrMode, CudfConfig::getInstance().memoryPercent, true);
   cudf::set_current_device_resource(mr);
   mr_ = std::move(mr);
 
@@ -345,6 +346,7 @@ void registerCudf() {
 void unregisterCudf() {
   output_mr_.reset();
   mr_.reset();
+  clearCurrentDeviceMemoryInfo();
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),

--- a/velox/experimental/ucx-exchange/CMakeLists.txt
+++ b/velox/experimental/ucx-exchange/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
   UcxExchangeServer.cpp
   UcxExchangeQueue.cpp
   UcxExchangeClient.cpp
+  UcxCudfDriverAdapter.cpp
   Communicator.cpp
   Acceptor.cpp
   EndpointRef.cpp

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -14,24 +14,175 @@
  * limitations under the License.
  */
 #include "velox/experimental/ucx-exchange/Communicator.h"
+#ifdef VELOX_ENABLE_CUDF
 #include <cuda_runtime.h>
+#endif
+#include <gflags/gflags.h>
+#include <sys/stat.h>
 #include <ucxx/api.h>
 #include <ucxx/utils/ucx.h>
+#include <unistd.h>
 #include <algorithm>
-#include <iostream>
+#include <array>
+#include <cerrno>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <thread>
 #include "velox/common/base/Exceptions.h"
-#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/ucx-exchange/CommElement.h"
 #include "velox/experimental/ucx-exchange/EndpointRef.h"
+#include "velox/experimental/ucx-exchange/UcxCpuRowAcceptor.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeModules.h"
+#include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
+#ifdef VELOX_ENABLE_CUDF
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeServer.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeSource.h"
+#endif
 
 #include <glog/logging.h>
 
-using namespace facebook::velox::cudf_velox;
+// gflag for whether the UCX exchange is active.
+DEFINE_bool(velox_ucx_exchange, true, "Enable UCX exchange");
+
+namespace {
+
+int readIntEnv(const char* name, int defaultValue, int minValue, int maxValue) {
+  const char* env = std::getenv(name);
+  if (env == nullptr || *env == '\0') {
+    return defaultValue;
+  }
+
+  errno = 0;
+  char* end = nullptr;
+  const long parsed = std::strtol(env, &end, 10);
+  if (end == env || *end != '\0' || errno != 0) {
+    LOG(WARNING) << "Ignoring invalid " << name << "=" << env;
+    return defaultValue;
+  }
+  return static_cast<int>(
+      std::clamp<long>(parsed, static_cast<long>(minValue), maxValue));
+}
+
+#ifndef VELOX_ENABLE_CUDF
+bool readBoolEnv(const char* name, bool defaultValue) {
+  const char* env = std::getenv(name);
+  if (env == nullptr || *env == '\0') {
+    return defaultValue;
+  }
+  if (env[0] == '0' && env[1] == '\0') {
+    return false;
+  }
+  if (env[0] == '1' && env[1] == '\0') {
+    return true;
+  }
+  LOG(WARNING) << "Ignoring invalid " << name << "=" << env
+               << "; expected 0 or 1";
+  return defaultValue;
+}
+
+bool readBoolEnv(
+    const char* primaryName,
+    const char* fallbackName,
+    bool defaultValue) {
+  if (const char* env = std::getenv(primaryName);
+      env != nullptr && *env != '\0') {
+    return readBoolEnv(primaryName, defaultValue);
+  }
+  return readBoolEnv(fallbackName, defaultValue);
+}
+#endif
+
+int maxWorkItemsPerDrain() {
+  static const int value =
+      readIntEnv(
+          "VELOX_UCX_MAX_WORK_ITEMS_PER_DRAIN", 256, 1, 1 << 20);
+  return value;
+}
+} // namespace
 
 namespace facebook::velox::ucx_exchange {
+
+namespace {
+// Config knobs used by both the cudf and CPU-row exchange paths. cudf builds
+// use CudfConfig so existing config.properties continue to control UCX
+// exchange. CPU-only builds do not compile CudfConfig, so keep env overrides
+// for low-level transport diagnostics there.
+struct UcxConfigView {
+#ifdef VELOX_ENABLE_CUDF
+  static int exchangeLogLevel() {
+    return cudf_velox::CudfConfig::getInstance().exchangeLogLevel;
+  }
+  static bool ucxxBlockingPolling() {
+    return cudf_velox::CudfConfig::getInstance().ucxxBlockingPolling;
+  }
+  static bool ucxxErrorHandling() {
+    return cudf_velox::CudfConfig::getInstance().ucxxErrorHandling;
+  }
+#else
+  static int exchangeLogLevel() {
+    return readIntEnv("VELOX_UCX_LOG_LEVEL", 0, 0, 10);
+  }
+  static bool ucxxBlockingPolling() {
+    return readBoolEnv("VELOX_UCX_BLOCKING_POLLING", false);
+  }
+  static bool ucxxErrorHandling() {
+    return readBoolEnv(
+        "VELOX_UCX_ERROR_HANDLING", "VELOX_UCX_CPU_ERROR_HANDLING", true);
+  }
+#endif
+};
+
+std::string readLocalHostIdentity() {
+  if (const char* env = std::getenv("VELOX_UCX_CPU_HOST_ID")) {
+    if (*env != '\0') {
+      return std::string{"env:"} + env;
+    }
+  }
+
+  std::ifstream bootId("/proc/sys/kernel/random/boot_id");
+  std::string value;
+  if (bootId >> value && !value.empty()) {
+    value = std::string{"boot:"} + value;
+  }
+
+  if (value.empty()) {
+    std::array<char, 256> hostname{};
+    if (::gethostname(hostname.data(), hostname.size() - 1) == 0 &&
+        hostname[0] != '\0') {
+      value = std::string{"host:"} + hostname.data();
+    }
+  }
+
+  struct stat ipcNs {};
+  struct stat pidNs {};
+  if (value.empty() || ::stat("/proc/self/ns/ipc", &ipcNs) != 0 ||
+      ::stat("/proc/self/ns/pid", &pidNs) != 0) {
+    return "";
+  }
+
+  std::ostringstream out;
+  out << value << "|ipc:" << ipcNs.st_dev << ":" << ipcNs.st_ino
+      << "|pid:" << pidNs.st_dev << ":" << pidNs.st_ino;
+  return out.str();
+}
+
+uint32_t getLocalHostIdHash() {
+  const auto identity = readLocalHostIdentity();
+  if (identity.empty()) {
+    return 0;
+  }
+  return fnv1a_32(identity);
+}
+
+bool isSameKnownHost(uint32_t localHostIdHash, uint32_t peerHostIdHash) {
+  return localHostIdHash != 0 && peerHostIdHash != 0 &&
+      localHostIdHash == peerHostIdHash;
+}
+} // namespace
 
 // static
 std::once_flag Communicator::onceFlag;
@@ -57,7 +208,9 @@ std::shared_ptr<Communicator> Communicator::initAndGet(
     std::uniform_int_distribution<uint64_t> dist;
     instancePtr_->workerId_ = dist(gen);
     LOG(INFO) << "Communicator workerId=" << instancePtr_->workerId_;
-    auto logLevel = CudfConfig::getInstance().exchangeLogLevel;
+    instancePtr_->hostIdHash_ = getLocalHostIdHash();
+    LOG(INFO) << "Communicator hostIdHash=" << instancePtr_->hostIdHash_;
+    auto logLevel = UcxConfigView::exchangeLogLevel();
     LOG(INFO) << "ucx-exchange VLOG level set to " << logLevel;
     if (logLevel > 0) {
       // Set VLOG level for all ucx-exchange source files.
@@ -97,55 +250,98 @@ Communicator::~Communicator() {
   // Note: worker_->flush() was removed - it only applies to RMA (Remote Memory
   // Access) operations like ucp_put/ucp_get, which this code doesn't use.
   // This code only uses tag send/recv and active messages.
-  worker_->progressWorkerEvent(100);
   worker_.reset();
   context_.reset();
   VLOG(3) << "Communicator destructed";
 }
 
 /// @brief Run doesn't return until stop() is called.
-/// All operations of the communicator will be carried out in the thread
-/// that calls run.
+/// The thread that calls run owns communicator state dispatch. UCX worker
+/// progress is owned by the dedicated progress thread started by run().
 void Communicator::run() {
-  VLOG(3) << "Using error handling mode: "
-          << CudfConfig::getInstance().ucxxErrorHandling << std::endl;
+  VLOG(3) << "Using error handling mode: " << UcxConfigView::ucxxErrorHandling()
+          << std::endl;
   VLOG(3) << "Using blocking progress mode: "
-          << CudfConfig::getInstance().ucxxBlockingPolling << std::endl;
+          << UcxConfigView::ucxxBlockingPolling() << std::endl;
 
   running_.store(true);
-  // Force CUDA context creation.
+#ifdef VELOX_ENABLE_CUDF
+  // Force CUDA context creation. CPU-only builds skip this entirely:
+  // there is no GPU to initialize.
   auto cudaStatus = cudaFree(0);
   VELOX_CHECK(
       cudaStatus == cudaSuccess,
       "Failed to initialize CUDA context: {}",
       cudaGetErrorString(cudaStatus));
+  int cudaDevice = 0;
+  cudaStatus = cudaGetDevice(&cudaDevice);
+  VELOX_CHECK(
+      cudaStatus == cudaSuccess,
+      "Failed to get CUDA device: {} ({})",
+      static_cast<int>(cudaStatus),
+      cudaGetErrorString(cudaStatus));
+#endif
 
   // create the UCXX context, worker, listener-context etc.
-  if (CudfConfig::getInstance().ucxxBlockingPolling) {
+  if (UcxConfigView::ucxxBlockingPolling()) {
     context_ = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
   } else {
-    context_ = ucxx::createContext({}, UCP_FEATURE_TAG | UCP_FEATURE_AM);
+    // Keep wakeup enabled so external signals can interrupt a blocking worker
+    // and so ucxx can wake the progress thread when needed.
+    context_ = ucxx::createContext(
+        {}, UCP_FEATURE_TAG | UCP_FEATURE_AM | UCP_FEATURE_WAKEUP);
   }
 
-  worker_ = context_->createWorker();
-
-  if (CudfConfig::getInstance().ucxxBlockingPolling) {
-    // Communicator is using blocking progress mode.
-    worker_->initBlockingProgressMode();
-  }
+  worker_ = context_->createWorker(false);
 
   listener_ = worker_->createListener(
       port_, Communicator::cStyleListenerCallback, this);
 
+#ifdef VELOX_ENABLE_CUDF
   // Setup the active message callback that handles the
-  // initial handshake and creates the senders.
+  // initial handshake and creates the senders for the cudf path.
+  // CPU-only builds skip this: Acceptor.cpp / UcxExchangeServer.cpp
+  // aren't compiled in.
   ucxx::AmReceiverCallbackInfo info(kAmCallbackOwner, kAmCallbackId);
   worker_->registerAmReceiverCallback(info, &Acceptor::cStyleAMCallback);
+#endif
+
+  // Parallel callback for the CPU-row exchange path. The CPU acceptor
+  // creates a UcxCpuRowExchangeServer in response to its own handshakes.
+  ucxx::AmReceiverCallbackInfo cpuInfo(kAmCallbackOwner, kAmCpuCallbackId);
+  worker_->registerAmReceiverCallback(
+      cpuInfo, &UcxCpuRowAcceptor::cStyleAMCallback);
+
+  // The thread that called run() owns CommElement::process() /
+  // state-machine dispatch. The UCXX progress thread owns worker progress and
+  // callback execution so callbacks have one producer thread.
+  const bool blockingMode = UcxConfigView::ucxxBlockingPolling();
+  LOG(INFO) << "Communicator starting one UCXX progress thread "
+            << "(maxWorkItemsPerDrain=" << maxWorkItemsPerDrain() << ")";
+#ifdef VELOX_ENABLE_CUDF
+  worker_->setProgressThreadStartCallback(
+      [](void* arg) {
+        const int device = *static_cast<int*>(arg);
+        auto cudaStatus = cudaSetDevice(device);
+        VELOX_CHECK(
+            cudaStatus == cudaSuccess,
+            "Failed to set CUDA device on UCXX progress thread: {} ({})",
+            static_cast<int>(cudaStatus),
+            cudaGetErrorString(cudaStatus));
+        cudaStatus = cudaFree(0);
+        VELOX_CHECK(
+            cudaStatus == cudaSuccess,
+            "Failed to initialize CUDA context on UCXX progress thread: {} ({})",
+            static_cast<int>(cudaStatus),
+            cudaGetErrorString(cudaStatus));
+      },
+      &cudaDevice);
+#endif
+  worker_->startProgressThread(!blockingMode, blockingMode ? 0 : 1);
 
   promise_.setValue();
 
   VLOG(3) << "Communicator running.";
-  const bool blockingMode = CudfConfig::getInstance().ucxxBlockingPolling;
   while (running_) {
     try {
       // Periodic heartbeat for diagnostic logging.
@@ -153,6 +349,7 @@ void Communicator::run() {
       if (now - lastHeartbeat_ >= std::chrono::seconds(5)) {
         std::lock_guard<std::mutex> lock(elemMutex_);
 
+#ifdef VELOX_ENABLE_CUDF
         // GPU memory usage via CUDA runtime.
         size_t gpuFree = 0, gpuTotal = 0;
         auto memStatus = cudaMemGetInfo(&gpuFree, &gpuTotal);
@@ -164,7 +361,9 @@ void Communicator::run() {
         size_t gpuFreeMB = gpuFree / (1024 * 1024);
         size_t gpuTotalMB = gpuTotal / (1024 * 1024);
 
-        // Count ExSrv vs ExSrc elements.
+        // Count ExSrv vs ExSrc elements (cudf path only; the CPU path
+        // uses different CommElement subclasses and we don't have a
+        // typed dynamic_cast hook here for them yet).
         int numServers = 0, numSources = 0;
         for (const auto& elem : elements_) {
           if (dynamic_cast<UcxExchangeServer*>(elem.get())) {
@@ -173,6 +372,7 @@ void Communicator::run() {
             ++numSources;
           }
         }
+#endif
 
         size_t numEndpoints;
         {
@@ -181,15 +381,21 @@ void Communicator::run() {
         }
         VLOG(2) << "[COMM-HEARTBEAT] workQueue=" << workQueue_.size()
                 << " elements=" << elements_.size()
+#ifdef VELOX_ENABLE_CUDF
                 << " (servers=" << numServers << " sources=" << numSources
                 << ")"
+#endif
                 << " endpoints=" << numEndpoints
                 << " deferredCleanup=" << deferredEndpointCleanup_.size()
                 << " deferredRequests=" << deferredRequests_.size()
-                << " workItemsProcessed=" << workItemsProcessed_
+                << " workItemsProcessed="
+                << workItemsProcessed_.exchange(0, std::memory_order_relaxed)
+#ifdef VELOX_ENABLE_CUDF
                 << " GPU=" << gpuUsedMB << "/" << gpuTotalMB << "MB"
-                << " (free=" << gpuFreeMB << "MB)";
-        workItemsProcessed_ = 0;
+                << " (free=" << gpuFreeMB << "MB)"
+#endif
+            ;
+        // workItemsProcessed_ was already reset by exchange() above.
         lastHeartbeat_ = now;
       }
 
@@ -206,56 +412,52 @@ void Communicator::run() {
         removeEndpointRef(ep);
       }
 
-      // Process the work queue. Make sure that communication is progressed
-      // after each call to a comms element, otherwise we will deadlock.
-      while (auto comms = workQueue_.pop()) {
-        comms->process();
-        ++workItemsProcessed_;
-        // Progress after each work item to allow UCXX to advance
-        // its internal state (complete sends/receives, fire callbacks).
-        // Use non-blocking progress here to avoid blocking between
-        // work items -- we want to drain the queue promptly.
-        worker_->progress();
-      }
+      // Drain primary-thread work. The UCXX progress thread is the only
+      // thread that progresses the worker.
+      drainWorkQueue();
 
       // Clean up deferred requests that UCX has fully processed.
       // These are cancelled requests whose GPU buffers needed to stay
       // alive until UCX finished any in-flight operations on them.
-      if (!deferredRequests_.empty()) {
-        deferredRequests_.erase(
-            std::remove_if(
-                deferredRequests_.begin(),
-                deferredRequests_.end(),
-                [](const auto& req) { return req->isCompleted(); }),
-            deferredRequests_.end());
+      // The communicator thread sweeps this list; UCX callbacks append to it
+      // via deferRequestCleanup(), under the mutex.
+      {
+        std::lock_guard<std::mutex> lock(deferredRequestsMutex_);
+        if (!deferredRequests_.empty()) {
+          deferredRequests_.erase(
+              std::remove_if(
+                  deferredRequests_.begin(),
+                  deferredRequests_.end(),
+                  [](const auto& req) { return req->isCompleted(); }),
+              deferredRequests_.end());
+        }
       }
-
-      // All queues are drained. Now wait for UCXX network events.
-      // In blocking mode, this will block until a UCXX event arrives
-      // or worker_->signal() is called (from addToWorkQueue,
-      // deferEndpointCleanup, or stop).
-      if (blockingMode) {
-        worker_->progressWorkerEvent(0);
-      } else {
-        worker_->progress();
-      }
+      std::this_thread::yield();
     } catch (ucxx::IOError& e) {
       LOG(ERROR) << "In Communicator main loop UCXX Exception: " << e.what();
       throw;
     }
   }
   VLOG(3) << "Communicator stopping.";
+
+  if (worker_) {
+    worker_->stopProgressThread();
+  }
 }
 
 /// @brief Stops the communicator, called from an outside thread.
 void Communicator::stop() {
   running_.store(false);
   signalWorker();
-  // Only log fields that are safe to read from an outside thread.
-  // endpoints_ is only accessed from the Communicator thread, so reading
-  // it here would be a data race.
+  size_t elementsSize;
+  {
+    std::lock_guard<std::mutex> lock(elemMutex_);
+    elementsSize = elements_.size();
+  }
+  // endpoints_ is only accessed from the Communicator thread, so reading it
+  // here would be a data race.
   VLOG(3) << "In Communicator::stop "
-          << " elements_.size(): " << elements_.size()
+          << " elements_.size(): " << elementsSize
           << " workQueue_.size(): " << workQueue_.size();
 }
 
@@ -269,7 +471,7 @@ void Communicator::registerCommElement(std::shared_ptr<CommElement> comms) {
 }
 
 void Communicator::signalWorker() {
-  if (worker_ && CudfConfig::getInstance().ucxxBlockingPolling) {
+  if (worker_ && UcxConfigView::ucxxBlockingPolling()) {
     worker_->signal();
   }
 }
@@ -294,28 +496,122 @@ void Communicator::unregister(std::shared_ptr<CommElement> comms) {
 std::shared_ptr<EndpointRef> Communicator::assocEndpointRef(
     std::shared_ptr<CommElement> comms,
     HostPort hostPort) {
-  std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
-  auto it = endpoints_.find(hostPort);
-  if (it != endpoints_.end()) {
-    std::shared_ptr<EndpointRef> ep = it->second;
-    ep->addCommElem(comms);
-    return ep;
-  }
-  // endpoint doesn't exist. Need to connect. Enable error handling.
-  auto ep = worker_->createEndpointFromHostname(
-      hostPort.hostname,
-      hostPort.port,
-      CudfConfig::getInstance().ucxxErrorHandling);
-  std::shared_ptr<EndpointRef> epRef = nullptr;
-  if (ep != nullptr) {
-    epRef = std::make_shared<EndpointRef>(ep);
-    epRef->addCommElem(comms);
-    if (CudfConfig::getInstance().ucxxErrorHandling) {
-      ep->setCloseCallback(EndpointRef::onClose, epRef);
+  {
+    std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
+    auto it = endpoints_.find(hostPort);
+    if (it != endpoints_.end()) {
+      std::shared_ptr<EndpointRef> ep = it->second;
+      ep->addCommElem(comms);
+      return ep;
     }
-    endpoints_.insert(std::pair{hostPort, epRef});
+  }
+
+  // Endpoint doesn't exist; connect and register it. With error handling
+  // enabled, UCXX reports connection failures through request callbacks
+  // instead of leaving exchange sources waiting indefinitely.
+  const bool errorHandling = UcxConfigView::ucxxErrorHandling();
+  std::shared_ptr<ucxx::Endpoint> ep;
+  try {
+    ep = worker_->createEndpointFromHostname(
+        hostPort.hostname, hostPort.port, errorHandling);
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Failed to create UCX endpoint to " << hostPort.hostname
+                 << ":" << hostPort.port << ": " << e.what();
+    return nullptr;
+  }
+  if (ep == nullptr) {
+    return nullptr;
+  }
+
+  auto epRef = std::make_shared<EndpointRef>(ep);
+  epRef->addCommElem(comms);
+
+  {
+    std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
+    auto [it, inserted] = endpoints_.insert(std::pair{hostPort, epRef});
+    if (!inserted) {
+      std::shared_ptr<EndpointRef> existing = it->second;
+      existing->addCommElem(comms);
+      return existing;
+    }
+  }
+  if (errorHandling) {
+    ep->setCloseCallback(EndpointRef::onClose, epRef);
   }
   return epRef;
+}
+
+bool Communicator::hasSameHostTransportIdentity(uint32_t peerHostIdHash) const {
+  return isSameKnownHost(hostIdHash_, peerHostIdHash);
+}
+
+std::shared_ptr<EndpointRef>
+Communicator::createSameHostEndpointRefFromWorkerAddress(
+    std::string_view workerAddress,
+    std::string peerIp,
+    uint32_t peerHostIdHash) {
+  if (workerAddress.empty()) {
+    return nullptr;
+  }
+
+  if (!hasSameHostTransportIdentity(peerHostIdHash)) {
+    VLOG(1) << "[CPU-UCX] not creating same-host worker-address endpoint "
+            << "peerIp=" << peerIp << " localHostIdHash=" << hostIdHash_
+            << " peerHostIdHash=" << peerHostIdHash;
+    return nullptr;
+  }
+
+  std::string key{workerAddress};
+  {
+    std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
+    auto it = workerAddressEndpoints_.find(key);
+    if (it != workerAddressEndpoints_.end()) {
+      return it->second;
+    }
+  }
+
+  // This is a separate worker-address data connection, not the listener
+  // bootstrap connection. UCX wireup carries this endpoint's err_mode to the
+  // peer; the remote internal endpoint is created with the same mode. Do not
+  // mix modes across the two sides of a single listener/conn_request pair.
+  constexpr bool kErrorHandling = false;
+  VLOG(1) << "[CPU-UCX] creating same-host worker-address endpoint peerIp="
+          << peerIp << " localHostIdHash=" << hostIdHash_
+          << " peerHostIdHash=" << peerHostIdHash
+          << " errorHandling=" << kErrorHandling;
+  std::shared_ptr<ucxx::Endpoint> ep;
+  try {
+    auto address = ucxx::createAddressFromString(key);
+    ep = worker_->createEndpointFromWorkerAddress(address, kErrorHandling);
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Failed to create UCX endpoint from worker address: "
+                 << e.what();
+    return nullptr;
+  }
+  if (ep == nullptr) {
+    return nullptr;
+  }
+
+  auto epRef = std::make_shared<EndpointRef>(ep, std::move(peerIp));
+
+  {
+    std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
+    auto [it, inserted] = workerAddressEndpoints_.emplace(key, epRef);
+    if (!inserted) {
+      return it->second;
+    }
+  }
+  return epRef;
+}
+
+std::string Communicator::getWorkerAddress() const {
+  VELOX_CHECK_NOT_NULL(worker_, "Communicator worker is not initialized");
+  std::shared_ptr<ucxx::Address> address;
+  const bool success = worker_->registerGenericPre(
+      [&]() { address = worker_->getAddress(); }, 3000000000);
+  VELOX_CHECK(success, "Timed out reading UCX worker address");
+  VELOX_CHECK_NOT_NULL(address, "Communicator worker address is null");
+  return address->getString();
 }
 
 void Communicator::removeEndpointRef(std::shared_ptr<EndpointRef> ep) {
@@ -324,10 +620,9 @@ void Communicator::removeEndpointRef(std::shared_ptr<EndpointRef> ep) {
           << Communicator::getInstance()->port_;
 
   // Close the endpoint if it's still alive.
-  // NOTE: This calls closeBlocking() which progresses the worker internally,
-  // which can fire listenerCallback() re-entrantly — hence the recursive mutex.
-  // This method must NOT be called from within a UCX callback.
-  // Use deferEndpointCleanup() from callbacks instead.
+  // With the UCXX progress thread running, closeBlocking() schedules close
+  // work on that thread and waits for completion. Do not call it from a UCX
+  // callback; callbacks defer cleanup to this communicator loop instead.
   if (ep->endpoint_ && ep->endpoint_->isAlive()) {
     VLOG(3) << "In Communicator::removeEndpointRef call closeBlocking";
     ep->endpoint_->closeBlocking();
@@ -353,12 +648,49 @@ void Communicator::deferEndpointCleanup(std::shared_ptr<EndpointRef> ep) {
 
 void Communicator::deferRequestCleanup(std::shared_ptr<ucxx::Request> request) {
   if (request) {
+    std::lock_guard<std::mutex> lock(deferredRequestsMutex_);
     deferredRequests_.push_back(std::move(request));
+  }
+}
+
+void Communicator::drainWorkQueue() {
+  // Primary-thread work dispatch. The UCXX progress thread does not run
+  // CommElement::process(). Keep the try-lock path because close() can
+  // still race from driver / endpoint-cleanup paths.
+  std::vector<std::shared_ptr<CommElement>> deferred;
+  bool anyProcessed = false;
+  int poppedItems = 0;
+  while (poppedItems < maxWorkItemsPerDrain()) {
+    auto comms = workQueue_.pop();
+    if (!comms) {
+      break;
+    }
+    ++poppedItems;
+
+    std::unique_lock<std::recursive_mutex> lock(
+        comms->processMutex_, std::try_to_lock);
+    if (!lock.owns_lock()) {
+      deferred.push_back(std::move(comms));
+      continue;
+    }
+    comms->process();
+    workItemsProcessed_.fetch_add(1, std::memory_order_relaxed);
+    anyProcessed = true;
+  }
+  for (auto& c : deferred) {
+    workQueue_.push(std::move(c));
+  }
+  // If the only thing we did this round was push deferred items back,
+  // yield rather than spin; the lock-holder's progress (or another
+  // thread's progress) needs CPU time to make forward motion.
+  if (!anyProcessed && !deferred.empty()) {
+    std::this_thread::yield();
   }
 }
 
 std::shared_ptr<EndpointRef> Communicator::findEndpointRefByHandle(
     ucp_ep_h handle) {
+  std::lock_guard<std::mutex> lock(acceptor_.mutex_);
   auto it = acceptor_.handleToEndpointRef_.find(handle);
   if (it != acceptor_.handleToEndpointRef_.end()) {
     return it->second;
@@ -403,15 +735,15 @@ void Communicator::listenerCallback(ucp_conn_request_h conn_request) {
   // endpoints, one per direction. For compatibility reasons, both incoming and
   // outgoing endpoints are represented using the EndpointRef.
   auto endpoint = listener_->createEndpointFromConnRequest(
-      conn_request, CudfConfig::getInstance().ucxxErrorHandling);
+      conn_request, UcxConfigView::ucxxErrorHandling());
   // Pass the peer's actual IP to EndpointRef for reliable intra-node detection.
   auto epRef = std::make_shared<EndpointRef>(endpoint, std::string(ip_str));
-  if (CudfConfig::getInstance().ucxxErrorHandling) {
+  if (UcxConfigView::ucxxErrorHandling()) {
     endpoint->setCloseCallback(EndpointRef::onClose, epRef);
   }
   // Add this endpoint reference to the list of endpoints.
   // NOTE: This runs inside a UCX listener callback (during worker progress),
-  // so we must not throw — throwing from a UCX callback is undefined behavior.
+  // so we must not throw. Throwing from a UCX callback is undefined behavior.
   unsigned long val = std::strtoul(port_str, nullptr, 10);
   if (val > static_cast<unsigned long>(std::numeric_limits<uint16_t>::max())) {
     LOG(ERROR) << "listenerCallback: port out of range for uint16_t: " << val;

--- a/velox/experimental/ucx-exchange/UcxCudfDriverAdapter.cpp
+++ b/velox/experimental/ucx-exchange/UcxCudfDriverAdapter.cpp
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/ucx-exchange/UcxCudfDriverAdapter.h"
+
+#include <glog/logging.h>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+
+#include "velox/core/ExchangeTransportType.h"
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/Exchange.h"
+#include "velox/exec/Merge.h"
+#include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/Task.h"
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfOrderBy.h"
+#include "velox/experimental/ucx-exchange/Communicator.h"
+#include "velox/experimental/ucx-exchange/UcxExchange.h"
+#include "velox/experimental/ucx-exchange/UcxExchangeClient.h"
+#include "velox/experimental/ucx-exchange/UcxPartitionedOutput.h"
+
+namespace facebook::velox::ucx_exchange {
+
+namespace {
+
+constexpr const char* kAdapterLabel = "CudfUcx";
+
+std::once_flag communicatorStartedFlag;
+
+struct TaskPipelineKey {
+  std::string taskId;
+  int pipelineId;
+
+  bool operator==(const TaskPipelineKey& other) const {
+    return taskId == other.taskId && pipelineId == other.pipelineId;
+  }
+};
+
+struct TaskPipelineKeyHash {
+  size_t operator()(const TaskPipelineKey& key) const {
+    return std::hash<std::string>{}(key.taskId) ^
+        (static_cast<size_t>(key.pipelineId) << 1);
+  }
+};
+
+std::mutex& exchangeClientMapMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+auto& exchangeClientMap() {
+  static std::unordered_map<
+      TaskPipelineKey,
+      std::weak_ptr<UcxExchangeClient>,
+      TaskPipelineKeyHash>
+      map;
+  return map;
+}
+
+std::atomic<bool> communicatorStarted{false};
+std::once_flag communicatorNotStartedLoggedFlag;
+
+bool canUseCudfUcxExchange() {
+  if (communicatorStarted.load()) {
+    return true;
+  }
+
+  std::call_once(communicatorNotStartedLoggedFlag, []() {
+    LOG(WARNING)
+        << "[CUDF-UCX] cudf.exchange is enabled, but the startup communicator "
+           "is not running; keeping standard exchange operators";
+  });
+  return false;
+}
+
+core::PlanNodePtr findPlanNode(
+    const exec::DriverFactory& factory,
+    const core::PlanNodeId& id) {
+  for (const auto& node : factory.planNodes) {
+    if (node->id() == id) {
+      return node;
+    }
+  }
+  if (factory.consumerNode && factory.consumerNode->id() == id) {
+    return factory.consumerNode;
+  }
+  return nullptr;
+}
+
+std::shared_ptr<UcxExchangeClient> getOrCreateExchangeClient(
+    exec::Exchange* exchangeOp,
+    const exec::Operator* op,
+    exec::DriverCtx* ctx) {
+  const TaskPipelineKey key{op->taskId(), ctx->pipelineId};
+  std::lock_guard<std::mutex> lock(exchangeClientMapMutex());
+  auto& clientMap = exchangeClientMap();
+  for (auto it = clientMap.begin(); it != clientMap.end();) {
+    if (it->second.expired()) {
+      it = clientMap.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  auto it = clientMap.find(key);
+  if (it != clientMap.end()) {
+    if (auto existing = it->second.lock()) {
+      exchangeOp->resetExchangeClient();
+      return existing;
+    }
+  }
+
+  auto veloxExchangeClient = exchangeOp->releaseExchangeClient();
+  VELOX_CHECK_NOT_NULL(
+      veloxExchangeClient, "Velox exchange client can't be null.");
+  auto client = std::make_shared<UcxExchangeClient>(
+      op->taskId(),
+      veloxExchangeClient->getDestination(),
+      veloxExchangeClient->getNumberOfConsumers(),
+      ctx->task->queryCtx()->queryConfig().maxOutputBufferSize());
+  clientMap[key] = client;
+  return client;
+}
+
+bool adaptDriver(const exec::DriverFactory& factory, exec::Driver& driver) {
+  const auto& config = cudf_velox::CudfConfig::getInstance();
+  if (!config.enabled || !config.exchange) {
+    return false;
+  }
+
+  auto* ctx = driver.driverCtx();
+  auto operators = driver.operators();
+
+  for (int32_t i = static_cast<int32_t>(operators.size()) - 1; i >= 0; --i) {
+    auto* op = operators[i];
+    if (!op || op->planNodeId().empty() || op->planNodeId() == "N/A") {
+      continue;
+    }
+
+    if (dynamic_cast<exec::PartitionedOutput*>(op) != nullptr) {
+      auto planNode = findPlanNode(factory, op->planNodeId());
+      auto partitionedOutputNode =
+          std::dynamic_pointer_cast<const core::PartitionedOutputNode>(
+              planNode);
+      if (!partitionedOutputNode ||
+          ctx->task->queryCtx()->outputTransportType(op->planNodeId()) !=
+              core::ExchangeTransportType::kUcx) {
+        continue;
+      }
+
+      if (!canUseCudfUcxExchange()) {
+        continue;
+      }
+      std::vector<std::unique_ptr<exec::Operator>> replacement;
+      replacement.push_back(std::make_unique<UcxPartitionedOutput>(
+          op->operatorId(), ctx, partitionedOutputNode, /*eagerFlush=*/false));
+      [[maybe_unused]] auto replaced =
+          factory.replaceOperators(driver, i, i + 1, std::move(replacement));
+      VLOG(1) << "[CUDF-UCX] replacing PartitionedOutput at index " << i
+              << " (planNodeId=" << op->planNodeId() << ")";
+      continue;
+    }
+
+    if (dynamic_cast<exec::MergeExchange*>(op) != nullptr) {
+      auto planNode = findPlanNode(factory, op->planNodeId());
+      auto mergeExchangeNode =
+          std::dynamic_pointer_cast<const core::MergeExchangeNode>(planNode);
+      if (!mergeExchangeNode ||
+          ctx->task->queryCtx()->inputTransportType(op->planNodeId()) !=
+              core::ExchangeTransportType::kUcx) {
+        continue;
+      }
+
+      if (!canUseCudfUcxExchange()) {
+        continue;
+      }
+      std::vector<std::unique_ptr<exec::Operator>> replacement;
+      replacement.push_back(
+          std::make_unique<UcxExchange>(
+              op->operatorId(), ctx, mergeExchangeNode, nullptr));
+      replacement.push_back(
+          std::make_unique<cudf_velox::CudfOrderBy>(
+              op->operatorId(), ctx, mergeExchangeNode));
+      [[maybe_unused]] auto replaced =
+          factory.replaceOperators(driver, i, i + 1, std::move(replacement));
+      VLOG(1) << "[CUDF-UCX] replacing MergeExchange at index " << i
+              << " (planNodeId=" << op->planNodeId() << ")";
+      continue;
+    }
+
+    if (dynamic_cast<exec::Exchange*>(op) != nullptr) {
+      auto* exchangeOp = dynamic_cast<exec::Exchange*>(op);
+      auto planNode = findPlanNode(factory, op->planNodeId());
+      auto exchangeNode =
+          std::dynamic_pointer_cast<const core::ExchangeNode>(planNode);
+      if (!exchangeNode ||
+          ctx->task->queryCtx()->inputTransportType(op->planNodeId()) !=
+              core::ExchangeTransportType::kUcx) {
+        continue;
+      }
+
+      if (!canUseCudfUcxExchange()) {
+        continue;
+      }
+      std::vector<std::unique_ptr<exec::Operator>> replacement;
+      replacement.push_back(std::make_unique<UcxExchange>(
+              op->operatorId(),
+              ctx,
+              exchangeNode,
+              getOrCreateExchangeClient(exchangeOp, op, ctx)));
+      [[maybe_unused]] auto replaced =
+          factory.replaceOperators(driver, i, i + 1, std::move(replacement));
+      VLOG(1) << "[CUDF-UCX] replacing Exchange at index " << i
+              << " (planNodeId=" << op->planNodeId() << ")";
+      continue;
+    }
+  }
+
+  // Return false intentionally: the cuDF adapter must still run after this
+  // pass to replace compute operators around the UCX exchange boundary.
+  return false;
+}
+
+std::atomic<bool> registered{false};
+
+} // namespace
+
+bool startCudfUcxExchange() {
+  const auto& config = cudf_velox::CudfConfig::getInstance();
+  if (!config.enabled || !config.exchange) {
+    return false;
+  }
+
+  if (config.exchangeServerPort <= 0 || config.exchangeServerPort > 65535) {
+    LOG(ERROR) << "[CUDF-UCX] Invalid cudf.exchange.server.port="
+               << config.exchangeServerPort
+               << "; keeping standard exchange operators";
+    return false;
+  }
+
+  std::call_once(communicatorStartedFlag, [&config]() {
+    const auto port = static_cast<uint16_t>(config.exchangeServerPort);
+    LOG(INFO) << "[CUDF-UCX] Starting Communicator on port "
+              << config.exchangeServerPort;
+    auto communicator = Communicator::initAndGet(port, "");
+    if (!communicator) {
+      LOG(ERROR) << "[CUDF-UCX] Communicator::initAndGet failed";
+      return;
+    }
+    std::thread([communicator = std::move(communicator)]() {
+      communicator->run();
+    }).detach();
+    communicatorStarted.store(true);
+  });
+
+  return communicatorStarted.load();
+}
+
+bool cudfUcxExchangeStarted() {
+  return communicatorStarted.load();
+}
+
+void registerCudfUcxDriverAdapter() {
+  bool expected = false;
+  if (!registered.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  exec::DriverAdapter adapter{
+      std::string(kAdapterLabel),
+      /*inspect=*/{},
+      &adaptDriver};
+  exec::DriverFactory::registerAdapter(std::move(adapter));
+  LOG(INFO) << "[CUDF-UCX] DriverAdapter registered";
+}
+
+__attribute__((constructor)) static void cudfUcxAutoRegister() {
+  registerCudfUcxDriverAdapter();
+}
+
+} // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxCudfDriverAdapter.h
+++ b/velox/experimental/ucx-exchange/UcxCudfDriverAdapter.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::velox::ucx_exchange {
+
+/// Starts the cuDF UCX exchange communicator from the already-initialized
+/// CudfConfig. Returns false when cudf.exchange is disabled or the communicator
+/// cannot be started.
+bool startCudfUcxExchange();
+
+/// Returns true after startCudfUcxExchange() has successfully started the
+/// communicator.
+bool cudfUcxExchangeStarted();
+
+/// Registers the cuDF UCX DriverAdapter with exec::DriverFactory. Idempotent.
+void registerCudfUcxDriverAdapter();
+
+} // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxExchange.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchange.cpp
@@ -44,7 +44,6 @@ UcxExchange::UcxExchange(
           fmt::format("[{}]", planNode->id())),
       preferredOutputBatchBytes_{
           driverCtx->queryConfig().preferredOutputBatchBytes()},
-      closeExchangeClientOnClose_{ucxExchangeClient == nullptr},
       processSplits_{driverCtx->driverId == 0},
       pipelineId_{driverCtx->pipelineId},
       driverId_{driverCtx->driverId} {
@@ -59,8 +58,8 @@ UcxExchange::UcxExchange(
     exchangeClient_ = std::make_shared<UcxExchangeClient>(
         task->taskId(),
         task->destination(),
-        1 // number of consumers, is always 1.
-    );
+        1, // number of consumers, is always 1.
+        driverCtx->queryConfig().maxOutputBufferSize());
   }
 }
 
@@ -182,11 +181,27 @@ RowVectorPtr UcxExchange::getOutputFromPackedTable() {
   PackedTableWithStream& data = *currentData_;
   auto numRows = data.packedTable->table.num_rows();
   auto gpuDataSize = data.gpuDataSize();
+  auto stream = data.stream;
+  cudf_velox::CudfVector::ReleaseCallback releaseCallback;
+  if (exchangeClient_->tracksInFlightReceiveBytes()) {
+    std::weak_ptr<UcxExchangeClient> exchangeClient{exchangeClient_};
+    releaseCallback = [exchangeClient, gpuDataSize, stream]() {
+      stream.synchronize();
+      if (auto client = exchangeClient.lock()) {
+        client->releaseInFlightReceiveBytes(gpuDataSize);
+      }
+    };
+  }
 
   // Use the stream that was allocated in UcxExchangeSource::onMetadata
   // and the packed_table constructor of CudfVector to avoid copying data.
   auto result = std::make_shared<cudf_velox::CudfVector>(
-      pool(), outputType_, numRows, std::move(data.packedTable), data.stream);
+      pool(),
+      outputType_,
+      numRows,
+      std::move(data.packedTable),
+      stream,
+      std::move(releaseCallback));
 
   recordInputStats(gpuDataSize, result);
   // free the memory owned by PackedTableWithStream and set it to nullptr;
@@ -218,9 +233,7 @@ void UcxExchange::close() {
   currentData_.reset();
   if (exchangeClient_) {
     recordExchangeClientStats();
-    if (closeExchangeClientOnClose_) {
-      exchangeClient_->close();
-    }
+    exchangeClient_->close();
   }
   exchangeClient_ = nullptr;
 }

--- a/velox/experimental/ucx-exchange/UcxExchangeClient.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeClient.cpp
@@ -103,11 +103,9 @@ UcxExchangeClient::next(int consumerId, bool* atEnd, ContinueFuture* future) {
       return data;
     }
 
-    // TODO: Review this primitive form of flow control.
-    // Maybe need to inspect the #bytes rather than the #tables?
     // Don't request more data when queue size exceeds the configured limit.
     // NOTE: This check is currently a no-op because the UCX exchange is
-    // push-based — there is no mechanism to "request" or "not request" more
+    // push-based: there is no mechanism to "request" or "not request" more
     // data. The server pushes unconditionally. Real backpressure is
     // implemented in UcxExchangeSource::process() (ReadyToReceive state).
     if (data != nullptr && queue_->size() > maxQueuedColumns_) {
@@ -138,13 +136,19 @@ UcxExchangeClient::next(int consumerId, bool* atEnd, ContinueFuture* future) {
       }
     }
 
-    // Collect sources that need resuming while holding the lock.
+    // Collect sources that need resuming while holding the lock. Sources sleep
+    // when the receive queue reaches its adaptive byte prefetch budget. Wake
+    // them once the table queue is below low-water and the byte budget has room
+    // for another receive.
     // We call resumeFromBackpressure() outside the lock to avoid a
     // lock-ordering hazard: it acquires WorkQueue::mutex_ via
     // addToWorkQueue(), and holding queue_->mutex_ here would impose
-    // queue_->mutex_ → WorkQueue::mutex_ ordering.
-    if (data != nullptr &&
-        queue_->size() <= UcxExchangeSource::kBackpressureLowWaterMark) {
+    // queue_->mutex_ -> WorkQueue::mutex_ ordering.
+    const bool queueBelowTableLowWater =
+        queue_->size() <= UcxExchangeSource::backpressureLowWaterMark();
+    const bool shouldResume =
+        queueBelowTableLowWater && queue_->receiveCanPrefetchLocked();
+    if (shouldResume) {
       sourcesToResume.assign(sources_.begin(), sources_.end());
     }
   }
@@ -157,6 +161,24 @@ UcxExchangeClient::next(int consumerId, bool* atEnd, ContinueFuture* future) {
     stalePromise.setValue();
   }
   return data;
+}
+
+void UcxExchangeClient::releaseInFlightReceiveBytes(uint64_t bytes) {
+  std::vector<std::shared_ptr<UcxExchangeSource>> sourcesToResume;
+  {
+    std::lock_guard<std::mutex> l(queue_->mutex());
+    queue_->releaseInFlightReceiveBytesLocked(bytes);
+    const bool queueCanPrefetch =
+        queue_->receiveCanPrefetchLocked() &&
+        queue_->size() <= UcxExchangeSource::backpressureLowWaterMark();
+    if (!closed_ && queueCanPrefetch) {
+      sourcesToResume.assign(sources_.begin(), sources_.end());
+    }
+  }
+
+  for (auto& source : sourcesToResume) {
+    source->resumeFromBackpressure();
+  }
 }
 
 UcxExchangeClient::~UcxExchangeClient() {

--- a/velox/experimental/ucx-exchange/UcxExchangeClient.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeClient.h
@@ -34,12 +34,15 @@ class UcxExchangeClient
       std::string taskId,
       int destination,
       int32_t numberOfConsumers,
+      uint64_t receiveHighWaterBytes = 0,
       int32_t requestDataSizesMaxWaitSec = 10)
       : taskId_{std::move(taskId)},
         destination_(destination),
         maxQueuedColumns_(kDefaultMaxQueuedColumns),
         kRequestDataSizesMaxWaitSec_(requestDataSizesMaxWaitSec),
-        queue_(std::make_shared<UcxExchangeQueue>(numberOfConsumers)) {
+        queue_(std::make_shared<UcxExchangeQueue>(
+            numberOfConsumers,
+            receiveHighWaterBytes)) {
     VELOX_CHECK_GE(
         destination, 0, "Exchange client destination must not be negative");
   }
@@ -74,6 +77,12 @@ class UcxExchangeClient
   ///
   PackedTableWithStreamPtr
   next(int consumerId, bool* atEnd, ContinueFuture* future);
+
+  void releaseInFlightReceiveBytes(uint64_t bytes);
+
+  bool tracksInFlightReceiveBytes() const {
+    return queue_->tracksInFlightReceiveBytes();
+  }
 
   std::string toString() const;
 

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.cpp
@@ -41,10 +41,6 @@ void UcxExchangeQueue::enqueueLocked(
     std::vector<ContinuePromise>& promises) {
   if (data == nullptr) {
     ++numCompleted_;
-    VLOG(2) << "[EX-QUEUE] source completed (null enqueued)"
-            << " numCompleted=" << numCompleted_
-            << " numSources=" << numSources_
-            << " noMoreSources=" << noMoreSources_;
     auto completedPromises = checkCompleteLocked();
     promises.reserve(promises.size() + completedPromises.size());
     for (auto& promise : completedPromises) {
@@ -55,29 +51,12 @@ void UcxExchangeQueue::enqueueLocked(
 
   auto dataSize = data->gpuDataSize();
   totalBytes_ += dataSize;
-  if (peakBytes_ < totalBytes_) {
-    peakBytes_ = totalBytes_;
-  }
 
   ++receivedTables_;
   receivedBytes_ += dataSize;
 
   queue_.push_back(std::move(data));
 
-  // High-water-mark alerts: log when queue size crosses thresholds.
-  auto newSize = static_cast<int64_t>(queue_.size());
-  if (newSize > peakSize_) {
-    if ((peakSize_ < 100 && newSize >= 100) ||
-        (peakSize_ < 1000 && newSize >= 1000) ||
-        (peakSize_ < 10000 && newSize >= 10000)) {
-      VLOG(1) << "[EX-QUEUE] high water mark: queueSize=" << newSize
-              << " peakBytes=" << peakBytes_
-              << " receivedTables=" << receivedTables_;
-    }
-    peakSize_ = newSize;
-  }
-
-  size_t wokenConsumers = 0;
   while (!promises_.empty()) {
     VELOX_CHECK_LE(promises_.size(), numberOfConsumers_);
     const int32_t unblockedConsumers = numberOfConsumers_ - promises_.size();
@@ -89,12 +68,63 @@ void UcxExchangeQueue::enqueueLocked(
     auto it = promises_.begin();
     promises.push_back(std::move(it->second));
     promises_.erase(it);
-    ++wokenConsumers;
   }
-  if (wokenConsumers > 0) {
-    VLOG(2) << "[EX-QUEUE] waking " << wokenConsumers << " consumers"
-            << " queueSize=" << queue_.size();
+}
+
+bool UcxExchangeQueue::tryReserveReceiveBytesLocked(uint64_t bytes) {
+  if (receiveHighWaterBytes_ > 0) {
+    maybeGrowReceivePrefetchLimitLocked();
+    const auto queuedBytes = queuedReceiveBytesLocked();
+    const auto receiveLimit = receivePrefetchByteLimitLocked();
+    if (queuedBytes > 0 &&
+        (bytes > receiveLimit || queuedBytes > receiveLimit - bytes)) {
+      return false;
+    }
   }
+
+  reservedBytes_ += bytes;
+  return true;
+}
+
+void UcxExchangeQueue::releaseReceiveBytesLocked(uint64_t bytes) {
+  if (reservedBytes_ < bytes) {
+    reservedBytes_ = 0;
+  } else {
+    reservedBytes_ -= bytes;
+  }
+  maybeGrowReceivePrefetchLimitLocked();
+}
+
+void UcxExchangeQueue::releaseInFlightReceiveBytesLocked(uint64_t bytes) {
+  if (inFlightBytes_ < bytes) {
+    inFlightBytes_ = 0;
+  } else {
+    inFlightBytes_ -= bytes;
+  }
+
+  maybeGrowReceivePrefetchLimitLocked();
+}
+
+bool UcxExchangeQueue::recordReceiveAllocationPressureLocked(
+    uint64_t attemptedBytes) {
+  if (receiveHighWaterBytes_ == 0) {
+    return false;
+  }
+
+  const auto retainedBytes = retainedReceiveBytesLocked();
+  if (retainedBytes == 0) {
+    return false;
+  }
+
+  const auto defaultLimit = defaultReceivePrefetchByteLimitLocked();
+  const auto pressureBytes = retainedBytes + attemptedBytes;
+  const auto reducedLimit = pressureBytes - pressureBytes / 8;
+  const auto minimumLimit =
+      std::max<uint64_t>(receiveHighWaterBytes_, attemptedBytes);
+  receivePrefetchByteLimit_ =
+      std::min<uint64_t>(defaultLimit, std::max(minimumLimit, reducedLimit));
+  receivePrefetchLimitActive_ = true;
+  return true;
 }
 
 void UcxExchangeQueue::addPromiseLocked(
@@ -133,11 +163,6 @@ PackedTableWithStreamPtr UcxExchangeQueue::dequeueLocked(
     if (atEnd_) {
       *atEnd = true;
     } else {
-      VLOG(2) << "[EX-QUEUE] consumer=" << consumerId
-              << " blocked (empty queue, waiting for data)"
-              << " numSources=" << numSources_
-              << " numCompleted=" << numCompleted_
-              << " waitingConsumers=" << (promises_.size() + 1);
       addPromiseLocked(consumerId, future, stalePromise);
     }
     return data;
@@ -145,7 +170,12 @@ PackedTableWithStreamPtr UcxExchangeQueue::dequeueLocked(
 
   data = std::move(queue_.front());
   queue_.pop_front();
-  totalBytes_ -= data->gpuDataSize();
+  const auto dataSize = static_cast<int64_t>(data->gpuDataSize());
+  VELOX_CHECK_GE(totalBytes_, dataSize);
+  totalBytes_ -= dataSize;
+  if (tracksInFlightReceiveBytes()) {
+    inFlightBytes_ += dataSize;
+  }
 
   return data;
 }
@@ -162,6 +192,8 @@ void UcxExchangeQueue::setError(std::string_view error) {
     // NOTE: clear the serialized page queue as we won't consume from an
     // errored queue.
     queue_.clear();
+    totalBytes_ = 0;
+    reservedBytes_ = 0;
     promises = clearAllPromisesLocked();
   }
   clearPromises(promises);

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.h
@@ -17,7 +17,9 @@
 
 #include <cudf/contiguous_split.hpp>
 #include <rmm/cuda_stream_view.hpp>
+#include <algorithm>
 #include <cinttypes>
+#include <limits>
 #include <memory>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/future/VeloxPromise.h"
@@ -47,8 +49,12 @@ using PackedTableWithStreamPtr = std::unique_ptr<PackedTableWithStream>;
 
 class UcxExchangeQueue {
  public:
-  explicit UcxExchangeQueue(int32_t numberOfConsumers)
-      : numberOfConsumers_{numberOfConsumers} {
+  explicit UcxExchangeQueue(
+      int32_t numberOfConsumers,
+      uint64_t receiveHighWaterBytes = 0)
+      : numberOfConsumers_{numberOfConsumers},
+        receiveHighWaterBytes_{receiveHighWaterBytes},
+        receiveLowWaterBytes_{(receiveHighWaterBytes * kContinuePct) / 100} {
     VELOX_CHECK_GE(numberOfConsumers, 1);
   }
 
@@ -105,15 +111,112 @@ class UcxExchangeQueue {
     return totalBytes_;
   }
 
-  /// Returns the maximum value of total bytes.
-  uint64_t peakBytes() const {
-    return peakBytes_;
+  uint64_t retainedReceiveBytesLocked() const {
+    return totalBytes_ + reservedBytes_ + inFlightBytes_;
   }
 
-  /// Returns total number of packed tables received from all sources.
-  uint64_t receivedTables() const {
-    return receivedTables_;
+  uint64_t queuedReceiveBytesLocked() const {
+    return totalBytes_ + reservedBytes_;
   }
+
+  uint64_t reservedReceiveBytesLocked() const {
+    return reservedBytes_;
+  }
+
+  uint64_t inFlightReceiveBytesLocked() const {
+    return inFlightBytes_;
+  }
+
+  uint64_t receiveHighWaterBytes() const {
+    return receiveHighWaterBytes_;
+  }
+
+  bool tracksInFlightReceiveBytes() const {
+    return receiveHighWaterBytes_ > 0;
+  }
+
+  uint64_t receiveLowWaterBytes() const {
+    return receiveLowWaterBytes_;
+  }
+
+  bool receiveBytesAtHighWaterLocked() const {
+    return receiveHighWaterBytes_ > 0 &&
+        queuedReceiveBytesLocked() >= receiveHighWaterBytes_;
+  }
+
+  bool receiveBytesBelowLowWaterLocked() const {
+    return receiveHighWaterBytes_ == 0 ||
+        queuedReceiveBytesLocked() <= receiveLowWaterBytes_;
+  }
+
+  uint64_t receivePipelineTableLimitLocked() const {
+    // Keep one large GPU payload available to each consumer without letting the
+    // receive queue grow with the number of sources.
+    return std::max<int64_t>(2, numberOfConsumers_);
+  }
+
+  uint64_t estimatedReceivePayloadBytesLocked() const {
+    const auto averageBytes = averageReceivedTablesBytes();
+    return std::max<uint64_t>(averageBytes, receiveHighWaterBytes_);
+  }
+
+  uint64_t receivePrefetchByteLimitLocked() const {
+    if (receiveHighWaterBytes_ == 0) {
+      return std::numeric_limits<uint64_t>::max();
+    }
+
+    const auto defaultLimit = defaultReceivePrefetchByteLimitLocked();
+    if (receivePrefetchByteLimit_ > 0) {
+      return std::min<uint64_t>(receivePrefetchByteLimit_, defaultLimit);
+    }
+
+    return defaultLimit;
+  }
+
+  uint64_t defaultReceivePrefetchByteLimitLocked() const {
+    VELOX_CHECK_GT(receiveHighWaterBytes_, 0);
+
+    const auto payloadBytes = estimatedReceivePayloadBytesLocked();
+    const auto tableLimit = receivePipelineTableLimitLocked();
+    const auto max = std::numeric_limits<uint64_t>::max();
+    if (payloadBytes > max - receiveHighWaterBytes_) {
+      return max;
+    }
+    const auto payloadWithSlack = payloadBytes + receiveHighWaterBytes_;
+    if (payloadWithSlack > max / tableLimit) {
+      return max;
+    }
+    return payloadWithSlack * tableLimit;
+  }
+
+  bool receiveBytesBelowPrefetchLimitLocked() const {
+    const auto limit = receivePrefetchByteLimitLocked();
+    if (limit == std::numeric_limits<uint64_t>::max()) {
+      return true;
+    }
+
+    // Admission must be based on bytes still owned by the receive queue. Bytes
+    // already handed to downstream operators are useful congestion signal, but
+    // using them as a hard gate can block metadata/EOS progress.
+    const auto queuedBytes = queuedReceiveBytesLocked();
+    if (queuedBytes == 0) {
+      return true;
+    }
+    const auto payloadBytes = estimatedReceivePayloadBytesLocked();
+    return queuedBytes <= limit && payloadBytes <= limit - queuedBytes;
+  }
+
+  bool receiveCanPrefetchLocked() const {
+    return receiveBytesBelowPrefetchLimitLocked();
+  }
+
+  bool tryReserveReceiveBytesLocked(uint64_t bytes);
+
+  void releaseReceiveBytesLocked(uint64_t bytes);
+
+  void releaseInFlightReceiveBytesLocked(uint64_t bytes);
+
+  bool recordReceiveAllocationPressureLocked(uint64_t attemptedBytes);
 
   /// Returns an average size of tables. Returns 0 if hasn't received
   /// any tables yet.
@@ -133,6 +236,8 @@ class UcxExchangeQueue {
  private:
   std::vector<ContinuePromise> closeLocked() {
     queue_.clear();
+    totalBytes_ = 0;
+    reservedBytes_ = 0;
     return clearAllPromisesLocked();
   }
 
@@ -176,6 +281,34 @@ class UcxExchangeQueue {
     }
   }
 
+  static constexpr uint32_t kContinuePct{70};
+
+  void maybeGrowReceivePrefetchLimitLocked() {
+    if (!receivePrefetchLimitActive_ || receiveHighWaterBytes_ == 0) {
+      return;
+    }
+
+    const auto defaultLimit = defaultReceivePrefetchByteLimitLocked();
+    if (receivePrefetchByteLimit_ >= defaultLimit) {
+      receivePrefetchByteLimit_ = 0;
+      receivePrefetchLimitActive_ = false;
+      return;
+    }
+
+    if (retainedReceiveBytesLocked() > receivePrefetchByteLimit_ / 2) {
+      return;
+    }
+
+    const auto increment = std::max<uint64_t>(
+        receiveHighWaterBytes_, estimatedReceivePayloadBytesLocked() / 2);
+    if (receivePrefetchByteLimit_ > defaultLimit - increment) {
+      receivePrefetchByteLimit_ = 0;
+      receivePrefetchLimitActive_ = false;
+    } else {
+      receivePrefetchByteLimit_ += increment;
+    }
+  }
+
   const int32_t numberOfConsumers_;
 
   int numCompleted_{0};
@@ -193,15 +326,20 @@ class UcxExchangeQueue {
   std::string error_;
   // Total size of packed tables in queue.
   int64_t totalBytes_{0};
+  // Bytes reserved for posted or pending UCX receives not yet enqueued.
+  int64_t reservedBytes_{0};
+  // Bytes dequeued by an Exchange operator but still retained by downstream
+  // CudfVectors that own the packed table.
+  int64_t inFlightBytes_{0};
+  const uint64_t receiveHighWaterBytes_{0};
+  const uint64_t receiveLowWaterBytes_{0};
+  bool receivePrefetchLimitActive_{false};
+  uint64_t receivePrefetchByteLimit_{0};
   // Number of packed tables received.
   int64_t receivedTables_{0};
   // Total size of packed tables received. Used to calculate an average
   // expected size.
   int64_t receivedBytes_{0};
-  // Maximum value of totalBytes_.
-  int64_t peakBytes_{0};
-  // Peak queue size (number of items). Used for high-water-mark alerts.
-  int64_t peakSize_{0};
 };
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include <thread>
-
 #include <cudf/contiguous_split.hpp>
 #include <folly/String.h>
 #include <folly/Uri.h>
+#include "velox/common/EnumDefine.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeSource.h"
+#include "velox/experimental/ucx-exchange/UcxQueues.h"
 
 using namespace facebook::velox::exec;
 namespace facebook::velox::ucx_exchange {
@@ -42,6 +42,8 @@ receiverStateNames() {
           {UcxExchangeSource::ReceiverState::ReadyToReceive, "ReadyToReceive"},
           {UcxExchangeSource::ReceiverState::WaitingForMetadata,
            "WaitingForMetadata"},
+          {UcxExchangeSource::ReceiverState::WaitingForReceiveCredit,
+           "WaitingForReceiveCredit"},
           {UcxExchangeSource::ReceiverState::WaitingForData, "WaitingForData"},
           {UcxExchangeSource::ReceiverState::WaitingForIntraNodeData,
            "WaitingForIntraNodeData"},
@@ -55,6 +57,14 @@ VELOX_DEFINE_EMBEDDED_ENUM_NAME(
     UcxExchangeSource,
     ReceiverState,
     receiverStateNames)
+
+int32_t UcxExchangeSource::backpressureHighWaterMark() {
+  return kDefaultBackpressureHighWaterMark;
+}
+
+int32_t UcxExchangeSource::backpressureLowWaterMark() {
+  return kDefaultBackpressureLowWaterMark;
+}
 
 void UcxExchangeSource::setState(ReceiverState newState) {
   auto oldState = state_.exchange(newState, std::memory_order_seq_cst);
@@ -106,6 +116,8 @@ std::shared_ptr<UcxExchangeSource> UcxExchangeSource::create(
 }
 
 void UcxExchangeSource::process() {
+  drainStateEvents();
+
   if (closed_) {
     // Driver thread called closed
     cleanUp();
@@ -147,14 +159,9 @@ void UcxExchangeSource::process() {
       // This creates natural backpressure: the server's tagSend for data
       // will block at rendezvous until we post a matching tagRecv. For
       // intra-node: the server's publish future won't resolve until we poll.
-      int32_t queueSize = queue_->size();
-      if (queueSize > kBackpressureHighWaterMark) {
-        if (!backpressureActive_.exchange(true, std::memory_order_acq_rel)) {
-          VLOG(1) << "[BACKPRESSURE] [ExSrc " << toString()
-                  << "] pausing, queueSize=" << queueSize
-                  << " > highWater=" << kBackpressureHighWaterMark;
-        }
-        // Go dormant — do NOT re-enqueue into work queue.
+      if (receiveQueueExceedsHighWater()) {
+        backpressureActive_.store(true, std::memory_order_release);
+        // Go dormant; do not re-enqueue into work queue.
         // UcxExchangeClient::next() will call resumeFromBackpressure().
         break;
       }
@@ -174,6 +181,11 @@ void UcxExchangeSource::process() {
     } break;
     case ReceiverState::WaitingForMetadata:
       // Waiting for metadata is handled by an upcall from UCXX. Nothing to do
+      break;
+    case ReceiverState::WaitingForReceiveCredit:
+      if (pendingDataReceive_) {
+        startDataReceive(std::move(pendingDataReceive_));
+      }
       break;
     case ReceiverState::WaitingForData:
       // Waiting for data is handled by an upcall from UCXX. Nothing to do.
@@ -245,7 +257,7 @@ void UcxExchangeSource::close() {
   // Guarantee the end marker is delivered before transitioning to Done.
   deliverEndMarker();
 
-  // Let the Communicator progress thread do the actual clean-up.
+  // Let the communicator thread do the actual clean-up.
   setState(ReceiverState::Done);
   communicator_->addToWorkQueue(getSelfPtr());
 }
@@ -253,9 +265,7 @@ void UcxExchangeSource::close() {
 void UcxExchangeSource::resumeFromBackpressure() {
   bool expected = true;
   if (backpressureActive_.compare_exchange_strong(
-          expected, false, std::memory_order_acq_rel)) {
-    VLOG(1) << "[BACKPRESSURE] [ExSrc " << toString()
-            << "] resumed by consumer, queueSize=" << queue_->size();
+      expected, false, std::memory_order_acq_rel)) {
     communicator_->addToWorkQueue(getSelfPtr());
   }
 }
@@ -307,11 +317,16 @@ std::shared_ptr<UcxExchangeSource> UcxExchangeSource::getSelfPtr() {
   return ptr;
 }
 
-void UcxExchangeSource::enqueue(PackedTableWithStreamPtr data) {
+void UcxExchangeSource::enqueue(
+    PackedTableWithStreamPtr data,
+    uint64_t reservedReceiveBytes) {
   std::vector<velox::ContinuePromise> queuePromises;
   {
     std::lock_guard<std::mutex> l(queue_->mutex());
 
+    if (reservedReceiveBytes > 0) {
+      queue_->releaseReceiveBytesLocked(reservedReceiveBytes);
+    }
     queue_->enqueueLocked(std::move(data), queuePromises);
   }
   // wake up consumers of the UcxExchangeQueue
@@ -374,7 +389,10 @@ void UcxExchangeSource::sendHandshake() {
       false,
       [weak](ucs_status_t status, std::shared_ptr<void> arg) {
         if (auto self = weak.lock()) {
-          self->onHandshake(status, arg);
+          self->enqueueStateEvent(
+              self, [raw = self.get(), status, arg = std::move(arg)]() mutable {
+                raw->onHandshake(status, std::move(arg));
+              });
         }
       },
       handshakeReq);
@@ -383,7 +401,7 @@ void UcxExchangeSource::sendHandshake() {
 void UcxExchangeSource::onHandshake(
     ucs_status_t status,
     std::shared_ptr<void> /*arg*/) {
-  // arg holds the HandshakeMsg that was sent — it is unused here because this
+  // arg holds the HandshakeMsg that was sent. It is unused here because this
   // is a send completion callback (the outgoing data has already been
   // transmitted). The parameter exists only because UCXX uses it as a lifetime
   // handle; letting it go out of scope releases the send buffer.
@@ -445,7 +463,10 @@ void UcxExchangeSource::getMetadata() {
       false,
       [weak](ucs_status_t status, std::shared_ptr<void> arg) {
         if (auto self = weak.lock()) {
-          self->onMetadata(status, arg);
+          self->enqueueStateEvent(
+              self, [raw = self.get(), status, arg = std::move(arg)]() mutable {
+                raw->onMetadata(status, std::move(arg));
+              });
         }
       },
       metadataReq);
@@ -492,6 +513,11 @@ void UcxExchangeSource::onMetadata(
     ptr->metadata =
         std::move(MetadataMsg::deserializeMetadataMsg(metadataMsg->data()));
 
+    VELOX_CHECK_GE(
+        ptr->metadata.dataSizeBytes,
+        0,
+        "UCX metadata data size is negative");
+
     VLOG(3) << toString()
             << " Datasize bytes == " << ptr->metadata.dataSizeBytes;
 
@@ -507,70 +533,152 @@ void UcxExchangeSource::onMetadata(
       return;
     }
 
-    // REMOTE EXCHANGE PATH: Allocate buffer and receive via UCXX
-    // Get a stream from the global stream pool
-    auto stream =
-        facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
-    // Store the stream in the DataAndMetadata struct so it can be used later
-    // in onData() when creating the PackedTableWithStream.
-    ptr->stream = stream;
-    try {
-      ptr->dataBuf = std::make_unique<rmm::device_buffer>(
-          ptr->metadata.dataSizeBytes,
-          stream,
-          cudf::get_current_device_resource_ref());
-    } catch (const rmm::bad_alloc& e) {
-      VLOG(0) << toString() << " *** RMM  failed to allocate: " << e.what();
-      queue_->setError("Failed to alloc GPU memory"); // Let the operator know
-                                                      // via the queue
-      deliverEndMarker();
-      setState(ReceiverState::Done);
-      communicator_->addToWorkQueue(getSelfPtr());
-      return;
-    }
-
-    // sync after allocating.
-    stream.synchronize();
-
-    VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
-            << " bytes of device memory";
-
-    // Initiate the transfer of the actual data from GPU-2-GPU
-    uint64_t dataTag = getDataTag(partitionKeyHash_, sequenceNumber_);
-    VLOG(3) << toString() << " waiting for data for chunk: " << sequenceNumber_
-            << " using tag: " << std::hex << dataTag << std::dec;
-
-    if (!setStateIf(
-            ReceiverState::WaitingForMetadata, ReceiverState::WaitingForData)) {
-      VLOG(1) << toString() << " onMetadata Invalid previous state ";
-      return;
-    }
-    // Use weak_ptr to prevent use-after-free if close() is called during
-    // callback
-    std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
-    if (request_) {
-      completedRequests_.push_back(std::move(request_));
-    }
-    request_ = endpointRef_->endpoint_->tagRecv(
-        ptr->dataBuf->data(),
-        ptr->metadata.dataSizeBytes,
-        ucxx::Tag{dataTag},
-        ucxx::TagMaskFull,
-        false,
-        [weak](ucs_status_t status, std::shared_ptr<void> arg) {
-          if (auto self = weak.lock()) {
-            self->onData(status, arg);
-          }
-        },
-        ptr // DataAndMetadata
-    );
+    startDataReceive(std::move(ptr));
   }
+}
+
+bool UcxExchangeSource::tryReserveReceiveBytes(
+    std::shared_ptr<DataAndMetadata> ptr) {
+  VELOX_CHECK_NOT_NULL(ptr);
+  {
+    std::lock_guard<std::mutex> l(queue_->mutex());
+    const auto dataSizeBytes =
+        static_cast<uint64_t>(ptr->metadata.dataSizeBytes);
+    if (queue_->tryReserveReceiveBytesLocked(dataSizeBytes)) {
+      ptr->receiveBytesReserved = true;
+      return true;
+    }
+
+    pendingDataReceive_ = ptr;
+    backpressureActive_.store(true, std::memory_order_release);
+  }
+
+  const auto state = getState();
+  if (state == ReceiverState::WaitingForMetadata) {
+    setStateIf(
+        ReceiverState::WaitingForMetadata,
+        ReceiverState::WaitingForReceiveCredit);
+  } else {
+    VELOX_CHECK(
+        state == ReceiverState::WaitingForReceiveCredit,
+        "Unexpected state {} while waiting for receive credit",
+        toName(state));
+  }
+  return false;
+}
+
+void UcxExchangeSource::releaseReceiveBytes(
+    std::shared_ptr<DataAndMetadata> ptr) {
+  if (!ptr || !ptr->receiveBytesReserved) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> l(queue_->mutex());
+  queue_->releaseReceiveBytesLocked(
+      static_cast<uint64_t>(ptr->metadata.dataSizeBytes));
+  ptr->receiveBytesReserved = false;
+}
+
+void UcxExchangeSource::startDataReceive(
+    std::shared_ptr<DataAndMetadata> ptr) {
+  VELOX_CHECK_NOT_NULL(ptr);
+  if (closed_.load(std::memory_order_acquire)) {
+    deliverEndMarker();
+    return;
+  }
+
+  const auto expectedState = getState();
+  VELOX_CHECK(
+      expectedState == ReceiverState::WaitingForMetadata ||
+          expectedState == ReceiverState::WaitingForReceiveCredit,
+      "Unexpected state {} before starting UCX data receive",
+      toName(expectedState));
+
+  if (!tryReserveReceiveBytes(ptr)) {
+    return;
+  }
+
+  // REMOTE EXCHANGE PATH: Allocate buffer and receive via UCXX.
+  auto stream =
+      facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
+  ptr->stream = stream;
+  try {
+    ptr->dataBuf = std::make_unique<rmm::device_buffer>(
+        ptr->metadata.dataSizeBytes,
+        stream,
+        cudf::get_current_device_resource_ref());
+  } catch (const rmm::bad_alloc& e) {
+    releaseReceiveBytes(ptr);
+    VLOG(0) << toString() << " *** RMM  failed to allocate: " << e.what();
+    bool retryLater = false;
+    {
+      std::lock_guard<std::mutex> l(queue_->mutex());
+      retryLater = queue_->recordReceiveAllocationPressureLocked(
+          static_cast<uint64_t>(ptr->metadata.dataSizeBytes));
+    }
+    if (retryLater) {
+      pendingDataReceive_ = std::move(ptr);
+      backpressureActive_.store(true, std::memory_order_release);
+      if (expectedState == ReceiverState::WaitingForMetadata) {
+        setStateIf(
+            ReceiverState::WaitingForMetadata,
+            ReceiverState::WaitingForReceiveCredit);
+      }
+      return;
+    }
+
+    queue_->setError("Failed to alloc GPU memory");
+    deliverEndMarker();
+    setState(ReceiverState::Done);
+    communicator_->addToWorkQueue(getSelfPtr());
+    return;
+  }
+
+  // UCX receives into this raw pointer on a UCX-owned CUDA stream. The
+  // allocation comes from an async RMM pool on `stream`, so make the allocation
+  // complete on the host before handing the pointer to UCX.
+  stream.synchronize();
+
+  VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
+          << " bytes of device memory";
+
+  uint64_t dataTag = getDataTag(partitionKeyHash_, sequenceNumber_);
+  VLOG(3) << toString() << " waiting for data for chunk: " << sequenceNumber_
+          << " using tag: " << std::hex << dataTag << std::dec;
+
+  if (!setStateIf(expectedState, ReceiverState::WaitingForData)) {
+    releaseReceiveBytes(ptr);
+    VLOG(1) << toString() << " startDataReceive invalid previous state "
+            << toName(getState());
+    return;
+  }
+
+  std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
+  if (request_) {
+    completedRequests_.push_back(std::move(request_));
+  }
+  request_ = endpointRef_->endpoint_->tagRecv(
+      ptr->dataBuf->data(),
+      ptr->metadata.dataSizeBytes,
+      ucxx::Tag{dataTag},
+      ucxx::TagMaskFull,
+      false,
+      [weak](ucs_status_t status, std::shared_ptr<void> arg) {
+        if (auto self = weak.lock()) {
+          self->enqueueStateEvent(
+              self, [raw = self.get(), status, arg = std::move(arg)]() mutable {
+                raw->onData(status, std::move(arg));
+              });
+        }
+      },
+      ptr);
 }
 
 void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
   // Check if close() was called - avoid processing if we're shutting down
   if (closed_.load(std::memory_order_acquire)) {
     VLOG(3) << toString() << " onData called after close, ignoring";
+    releaseReceiveBytes(std::static_pointer_cast<DataAndMetadata>(arg));
     deliverEndMarker();
     return;
   }
@@ -578,11 +686,14 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
   if (getState() != ReceiverState::WaitingForData) {
     VLOG(2) << toString() << " onData called in state " << toName(getState())
             << ", ignoring (possible UCXX replay)";
+    releaseReceiveBytes(std::static_pointer_cast<DataAndMetadata>(arg));
     return;
   }
   VLOG(3) << toString() << " + onData " << ucs_status_string(status);
 
   if (status != UCS_OK) {
+    auto ptr = std::static_pointer_cast<DataAndMetadata>(arg);
+    releaseReceiveBytes(ptr);
     std::string errorMsg = fmt::format(
         "Failed to receive data from host {}:{}, task {}: {}",
         host_,
@@ -601,6 +712,10 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
 
     std::shared_ptr<DataAndMetadata> ptr =
         std::static_pointer_cast<DataAndMetadata>(arg);
+    const uint64_t reservedReceiveBytes = ptr->receiveBytesReserved
+        ? static_cast<uint64_t>(ptr->metadata.dataSizeBytes)
+        : 0;
+    ptr->receiveBytesReserved = false;
 
     metrics_.numPackedColumns_.addValue(1);
     metrics_.totalBytes_.addValue(ptr->metadata.dataSizeBytes);
@@ -618,7 +733,7 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
     auto data = std::make_unique<PackedTableWithStream>(
         std::move(packedTable), ptr->stream);
 
-    enqueue(std::move(data));
+    enqueue(std::move(data), reservedReceiveBytes);
     setStateIf(ReceiverState::WaitingForData, ReceiverState::ReadyToReceive);
   }
   communicator_->addToWorkQueue(getSelfPtr());
@@ -645,7 +760,10 @@ void UcxExchangeSource::receiveHandshakeResponse() {
       false,
       [weak](ucs_status_t status, std::shared_ptr<void> arg) {
         if (auto self = weak.lock()) {
-          self->onHandshakeResponse(status, arg);
+          self->enqueueStateEvent(
+              self, [raw = self.get(), status, arg = std::move(arg)]() mutable {
+                raw->onHandshakeResponse(status, std::move(arg));
+              });
         }
       },
       responseBuffer);
@@ -815,6 +933,12 @@ bool UcxExchangeSource::setStateIf(
           << toString() << " seq=" << sequenceNumber_ << "] "
           << toName(expected) << " -> " << toName(desired);
   return true;
+}
+
+bool UcxExchangeSource::receiveQueueExceedsHighWater() {
+  std::lock_guard<std::mutex> l(queue_->mutex());
+  return !queue_->receiveBytesBelowPrefetchLimitLocked() ||
+      queue_->size() >= backpressureHighWaterMark();
 }
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -64,29 +64,173 @@ void UcxOutputQueueManager::updateOutputBuffers(
     std::string_view taskId,
     int numBuffers,
     bool noMoreBuffers) {
-  getQueue(taskId)->updateOutputBuffers(numBuffers, noMoreBuffers);
+  if (auto queue = getQueueIfActive(taskId)) {
+    queue->updateOutputBuffers(numBuffers, noMoreBuffers);
+  }
 }
 
 void UcxOutputQueueManager::enqueue(
     std::string_view taskId,
     int destination,
     std::unique_ptr<cudf::packed_columns> txData,
-    int numRows) {
-  getQueue(taskId)->enqueue(destination, std::move(txData), numRows);
+    int numRows,
+    int64_t transferReservationBytes) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    queue->enqueue(
+        destination, std::move(txData), numRows, transferReservationBytes);
+  }
 }
 
 bool UcxOutputQueueManager::checkBlocked(
     std::string_view taskId,
     ContinueFuture* future) {
-  return getQueue(taskId)->checkBlocked(future);
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->checkBlocked(future);
+  }
+  return false;
+}
+
+bool UcxOutputQueueManager::checkTransferCapacity(
+    std::string_view taskId,
+    int destination,
+    int64_t maxBytes,
+    ContinueFuture* future) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->checkTransferCapacity(destination, maxBytes, future);
+  }
+  return false;
+}
+
+bool UcxOutputQueueManager::reserveTransferBytes(
+    std::string_view taskId,
+    int destination,
+    int64_t bytes,
+    int64_t maxBytes,
+    ContinueFuture* future) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->reserveTransferBytes(destination, bytes, maxBytes, future);
+  }
+  return false;
+}
+
+bool UcxOutputQueueManager::reserveFullTransferBytes(
+    std::string_view taskId,
+    int destination,
+    int64_t bytes,
+    ContinueFuture* future) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->reserveFullTransferBytes(destination, bytes, future);
+  }
+  return false;
+}
+
+bool UcxOutputQueueManager::waitForFullTransferCapacity(
+    std::string_view taskId,
+    int64_t bytes,
+    ContinueFuture* future) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->waitForFullTransferCapacity(bytes, future);
+  }
+  return false;
+}
+
+void UcxOutputQueueManager::releaseTransferReservation(
+    std::string_view taskId,
+    int destination,
+    int64_t bytes) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->releaseTransferReservation(destination, bytes);
+  }
+}
+
+int64_t UcxOutputQueueManager::transferWindowBytes(
+    std::string_view taskId,
+    int destination,
+    int64_t baseBytes,
+    int64_t normalBytes,
+    int64_t maxBytes) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->transferWindowBytes(
+        destination, baseBytes, normalBytes, maxBytes);
+  }
+  return baseBytes;
+}
+
+void UcxOutputQueueManager::recordTransferCongestion(
+    std::string_view taskId,
+    int destination,
+    int64_t baseBytes) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->recordTransferCongestion(destination, baseBytes);
+  }
+}
+
+void UcxOutputQueueManager::recordTransferDemand(
+    std::string_view taskId,
+    int destination,
+    int64_t targetBytes,
+    int64_t baseBytes,
+    int64_t maxBytes) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->recordTransferDemand(destination, targetBytes, baseBytes, maxBytes);
+  }
+}
+
+void UcxOutputQueueManager::recordFullTransferCongestion(
+    std::string_view taskId) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->recordFullTransferCongestion();
+  }
+}
+
+UcxDestinationTransferStats UcxOutputQueueManager::transferStats(
+    std::string_view taskId,
+    int destination) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->transferStats(destination);
+  }
+  return {};
+}
+
+bool UcxOutputQueueManager::reserveOutputBytes(
+    std::string_view taskId,
+    int64_t bytes,
+    ContinueFuture* future) {
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->reserveOutputBytes(bytes, future);
+  }
+  return false;
+}
+
+void UcxOutputQueueManager::releaseOutputReservation(
+    std::string_view taskId,
+    int64_t bytes) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->releaseOutputReservation(bytes);
+  }
+}
+
+void UcxOutputQueueManager::releaseInFlightBytes(
+    std::string_view taskId,
+    int destination,
+    int64_t bytes,
+    int64_t numPackedCols) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->releaseInFlightBytes(destination, bytes, numPackedCols);
+  }
 }
 
 void UcxOutputQueueManager::noMoreData(std::string_view taskId) {
-  getQueue(taskId)->noMoreData();
+  if (auto queue = getQueueIfActive(taskId)) {
+    queue->noMoreData();
+  }
 }
 
 bool UcxOutputQueueManager::isFinished(std::string_view taskId) {
-  return getQueue(taskId)->isFinished();
+  if (auto queue = getQueueIfActive(taskId)) {
+    return queue->isFinished();
+  }
+  return true;
 }
 
 void UcxOutputQueueManager::deleteResults(
@@ -108,21 +252,16 @@ void UcxOutputQueueManager::getData(
     auto it = queues.find(taskIdStr);
     if (it == queues.end()) {
       // Check if the task was already removed. If so, don't re-create a
-      // placeholder — the task is dead and any server calling getData() is a
+      // placeholder - the task is dead and any server calling getData() is a
       // stale leftover. Re-creating would produce an undersized queue that
       // crashes when deleteResults() is called for other destinations.
       if (removedTasks_.withLock(
               [&](auto& removed) { return removed.count(taskIdStr) > 0; })) {
-        VLOG(2) << "[QUEUE-MGR] task=" << taskId << " dest=" << destination
-                << " getData ignored (task already removed)";
         taskRemoved = true;
         return;
       }
       // create the queue structures such that the notify callback can be
       // stored. It will be later initialized once the task is being created.
-      VLOG(2)
-          << "[QUEUE-MGR] task=" << taskId << " dest=" << destination
-          << " creating placeholder queue (server arrived before task init)";
       outputQueue = std::make_shared<UcxOutputQueue>(nullptr, destination, 0);
       queues[taskIdStr] = outputQueue;
     } else {
@@ -137,7 +276,7 @@ void UcxOutputQueueManager::getData(
   }
   // outside of lock. Queue must exist.
   // get the data or install the notify callback.
-  outputQueue->getData(destination, notify);
+  outputQueue->getData(destination, std::move(notify));
 }
 
 bool UcxOutputQueueManager::canUseIntraNode(std::string_view taskId) {
@@ -167,8 +306,6 @@ void UcxOutputQueueManager::removeTask(std::string_view taskId) {
             [&](auto& removed) { removed.insert(taskIdStr); });
         return taskQueue;
       });
-  VLOG(2) << "[QUEUE-MGR] removeTask=" << taskId
-          << " queueExists=" << (queue != nullptr);
   if (queue != nullptr) {
     queue->terminate();
   }
@@ -184,6 +321,22 @@ std::shared_ptr<UcxOutputQueue> UcxOutputQueueManager::getQueueIfExists(
     auto it = queues.find(taskIdStr);
     return it == queues.end() ? nullptr : it->second;
   });
+}
+
+std::shared_ptr<UcxOutputQueue> UcxOutputQueueManager::getQueueIfActive(
+    std::string_view taskId) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    return queue;
+  }
+  VELOX_CHECK(
+      isRemovedTask(taskId), "Output cudf queue for task not found: {}", taskId);
+  return nullptr;
+}
+
+bool UcxOutputQueueManager::isRemovedTask(std::string_view taskId) {
+  std::string taskIdStr{taskId};
+  return removedTasks_.withLock(
+      [&](auto& removed) { return removed.count(taskIdStr) > 0; });
 }
 
 std::shared_ptr<UcxOutputQueue> UcxOutputQueueManager::getQueue(

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
@@ -68,20 +68,105 @@ class UcxOutputQueueManager {
       std::string_view taskId,
       int destination,
       std::unique_ptr<cudf::packed_columns> txData,
-      int32_t numRows);
+      int32_t numRows,
+      int64_t transferReservationBytes = 0);
 
   /// @brief Checks if the queue for a task is over capacity.
-  /// Should be called after enqueueing all partitions for a batch.
+  /// Producers call this before accepting more input and after enqueueing a
+  /// batch.
   /// @param taskId The unique task Id.
   /// @param future Output parameter - populated with a future if blocked.
   /// @return True if blocked (queue over capacity), false otherwise.
   bool checkBlocked(std::string_view taskId, ContinueFuture* future);
 
+  /// @brief Checks active producer queued/in-flight transfer bytes.
+  bool checkTransferCapacity(
+      std::string_view taskId,
+      int destination,
+      int64_t maxBytes,
+      ContinueFuture* future);
+
+  /// @brief Reserves destination-local transfer capacity before GPU output
+  /// materialization.
+  bool reserveTransferBytes(
+      std::string_view taskId,
+      int destination,
+      int64_t bytes,
+      int64_t maxBytes,
+      ContinueFuture* future);
+
+  /// @brief Reserves full contiguous_split payload capacity before GPU output
+  /// materialization.
+  bool reserveFullTransferBytes(
+      std::string_view taskId,
+      int destination,
+      int64_t bytes,
+      ContinueFuture* future);
+
+  /// @brief Blocks until the learned full-transfer retained-byte window has
+  /// room. Does not reserve bytes.
+  bool waitForFullTransferCapacity(
+      std::string_view taskId,
+      int64_t bytes,
+      ContinueFuture* future);
+
+  /// @brief Releases destination-local transfer capacity.
+  void releaseTransferReservation(
+      std::string_view taskId,
+      int destination,
+      int64_t bytes);
+
+  /// @brief Returns the destination-local adaptive transfer admission window.
+  int64_t transferWindowBytes(
+      std::string_view taskId,
+      int destination,
+      int64_t baseBytes,
+      int64_t normalBytes,
+      int64_t maxBytes);
+
+  /// @brief Records allocation/admission congestion for a destination.
+  void recordTransferCongestion(
+      std::string_view taskId,
+      int destination,
+      int64_t baseBytes);
+
+  /// @brief Records larger payload demand for adaptive transfer probing.
+  void recordTransferDemand(
+      std::string_view taskId,
+      int destination,
+      int64_t targetBytes,
+      int64_t baseBytes,
+      int64_t maxBytes);
+
+  /// @brief Records full contiguous_split allocation/admission pressure.
+  void recordFullTransferCongestion(std::string_view taskId);
+
+  /// @brief Returns queued/in-flight pressure for a single destination.
+  UcxDestinationTransferStats transferStats(
+      std::string_view taskId,
+      int destination);
+
+  /// @brief Reserves bytes for producer-side GPU output materialization.
+  bool reserveOutputBytes(
+      std::string_view taskId,
+      int64_t bytes,
+      ContinueFuture* future);
+
+  /// @brief Releases bytes reserved for output materialization.
+  void releaseOutputReservation(std::string_view taskId, int64_t bytes);
+
+  /// @brief Releases bytes retained by an in-flight exchange transfer.
+  void releaseInFlightBytes(
+      std::string_view taskId,
+      int destination,
+      int64_t bytes,
+      int64_t numPackedCols);
+
   /// @brief Indicates that no more data will be coming for this task.
   void noMoreData(std::string_view taskId);
 
-  /// @returns true if noMoreData has been called and all the accumulated data
-  /// have been fetched and acknowledged.
+  /// @returns true if noMoreData has been called and all accumulated data has
+  /// been fetched.
   bool isFinished(std::string_view taskId);
 
   /// @brief
@@ -104,7 +189,7 @@ class UcxOutputQueueManager {
   /// Returns true if the given task can use intra-node transfer.
   /// Returns false if the task is not yet initialized (placeholder queue
   /// from early sink connections) or if the task uses broadcast mode
-  /// (broadcast shares packed_columns across destinations — the intra-node
+  /// (broadcast shares packed_columns across destinations - the intra-node
   /// source's destructive move would corrupt data for other servers).
   bool canUseIntraNode(std::string_view taskId);
 
@@ -120,6 +205,12 @@ class UcxOutputQueueManager {
   // Retrieves the queue for a task if it exists.
   // Returns NULL if task not found.
   std::shared_ptr<UcxOutputQueue> getQueueIfExists(std::string_view taskId);
+
+  // Retrieves the queue for a task if it exists. Returns NULL only when the
+  // task is known to have been removed; unknown task IDs still fail fast.
+  std::shared_ptr<UcxOutputQueue> getQueueIfActive(std::string_view taskId);
+
+  bool isRemovedTask(std::string_view taskId);
 
   // Throws an exception if queue doesn't exist.
   std::shared_ptr<UcxOutputQueue> getQueue(std::string_view taskId);

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -15,10 +15,13 @@
  */
 #include "velox/experimental/ucx-exchange/UcxPartitionedOutput.h"
 #include <fmt/format.h>
+#include <glog/logging.h>
 #include "velox/core/PlanNode.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
@@ -28,9 +31,52 @@
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/partitioning.hpp>
 
+#include <algorithm>
+#include <atomic>
+#include <limits>
+#include <new>
+#include <optional>
+#include <utility>
+#include <folly/ScopeGuard.h>
+
 using namespace facebook::velox::cudf_velox;
 using facebook::velox::exec::Task;
 namespace facebook::velox::ucx_exchange {
+
+namespace {
+uint64_t multiplySaturated(uint64_t value, uint64_t multiplier) {
+  if (value == 0) {
+    return 0;
+  }
+  if (multiplier > std::numeric_limits<uint64_t>::max() / value) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return value * multiplier;
+}
+
+uint64_t addSaturated(uint64_t left, uint64_t right) {
+  if (right > std::numeric_limits<uint64_t>::max() - left) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return left + right;
+}
+
+uint64_t divideCeil(uint64_t value, uint64_t divisor) {
+  VELOX_CHECK_GT(divisor, 0);
+  return value / divisor + (value % divisor == 0 ? 0 : 1);
+}
+
+constexpr uint64_t kTransferWindowMultiplier = 4;
+
+std::atomic<uint64_t>& inProcessGpuMaterializationReservationBytes() {
+  static std::atomic<uint64_t> bytes{0};
+  return bytes;
+}
+
+uint64_t effectiveFreeBytes(const CudfDeviceMemoryInfo& info) {
+  return addSaturated(info.freeBytes, info.poolReusableBytes);
+}
+} // namespace
 
 // Computes a mapping from names in n2 to names in n1
 // and returns that mapping in remap.
@@ -70,7 +116,11 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       numPartitions_(planNode->numPartitions()),
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
-      targetRowsPerChunk_(ctx->queryConfig().ucxPartitionedOutputBatchRows()) {
+      targetRowsPerChunk_(ctx->queryConfig().get<int64_t>(
+          core::QueryConfig::kUcxPartitionedOutputBatchRows,
+          CudfConfig::getInstance().partitionedOutputBatchRows)),
+      initialPayloadBytes_(
+          std::max<uint64_t>(ctx->queryConfig().maxOutputBufferSize(), 1)) {
   this->initPartitionKeys(planNode);
   auto sources = planNode->sources();
   std::vector<std::string> inNames, outNames;
@@ -97,34 +147,160 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
       !future_.valid() || future_.hasValue(),
       "addInput with outstanding future!");
 
+  const auto inputBytes = input->estimateFlatSize();
   // Record stats per-input (before buffering).
   {
     auto lockedStats = stats_.wlock();
-    lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
+    lockedStats->addOutputVector(inputBytes, input->size());
   }
 
   pendingRows_ += cudfVector->getTableView().num_rows();
+  pendingBytes_ += inputBytes;
   pendingInputs_.push_back(std::move(cudfVector));
 
-  if (targetRowsPerChunk_ <= 0 || pendingRows_ >= targetRowsPerChunk_) {
+  if (shouldFlushPending()) {
     flushPending();
   }
 }
 
+void UcxPartitionedOutput::recordAllocationPressure(uint64_t waitBytes) {
+  auto queueManager = sharedQueueManager();
+  queueManager->recordFullTransferCongestion(this->taskId());
+
+  const auto destinationBaseBytes = std::max<uint64_t>(
+      initialPayloadBytes_,
+      divideCeil(
+          std::max<uint64_t>(waitBytes, 1),
+          std::max<uint64_t>(static_cast<uint64_t>(numPartitions_), 1)));
+  const auto clampedBaseBytes = static_cast<int64_t>(std::min<uint64_t>(
+      destinationBaseBytes,
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
+  for (size_t partition = 0; partition < numPartitions_; ++partition) {
+    queueManager->recordTransferCongestion(
+        this->taskId(), partition, clampedBaseBytes);
+  }
+
+  const auto clampedWaitBytes = static_cast<int64_t>(std::min<uint64_t>(
+      std::max<uint64_t>(waitBytes, 1),
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
+  if (queueManager->waitForFullTransferCapacity(
+          this->taskId(), clampedWaitBytes, &future_) ||
+      queueManager->checkBlocked(this->taskId(), &future_)) {
+    blockingReason_ = exec::BlockingReason::kWaitForConsumer;
+    return;
+  }
+
+  blockingReason_ = exec::BlockingReason::kNotBlocked;
+}
+
+void UcxPartitionedOutput::partitionPendingInputBatch() {
+  VELOX_CHECK(pendingInputBatch_.has_value());
+
+  auto& input = pendingInputBatch_.value();
+  const auto estimatedBytes = std::max<int64_t>(input.estimatedBytes, 1);
+
+  uint64_t materializationReservationBytes = 0;
+  auto releaseMaterializationReservation = folly::makeGuard([&]() {
+    if (materializationReservationBytes == 0) {
+      return;
+    }
+    inProcessGpuMaterializationReservationBytes().fetch_sub(
+        materializationReservationBytes, std::memory_order_acq_rel);
+  });
+
+  const bool needsPartitionMaterialization =
+      numPartitions_ > 1 && usesHashPartitioning();
+  if (needsPartitionMaterialization) {
+    const auto estimatedMaterializationBytes =
+        static_cast<uint64_t>(estimatedBytes);
+    const auto producerHeadroomBytes = std::max<uint64_t>(
+        estimatedMaterializationBytes, initialPayloadBytes_);
+    if (const auto memoryInfo = currentDeviceMemoryInfo()) {
+      const auto freeBytes = effectiveFreeBytes(*memoryInfo);
+      const auto inProcessReserved =
+          inProcessGpuMaterializationReservationBytes().load(
+              std::memory_order_acquire);
+      const auto requiredBytes = addSaturated(
+          addSaturated(inProcessReserved, estimatedMaterializationBytes),
+          producerHeadroomBytes);
+      if (freeBytes <= requiredBytes) {
+        recordAllocationPressure(estimatedMaterializationBytes);
+        return;
+      }
+
+      inProcessGpuMaterializationReservationBytes().fetch_add(
+          estimatedMaterializationBytes, std::memory_order_acq_rel);
+      materializationReservationBytes = estimatedMaterializationBytes;
+    }
+  }
+
+  try {
+    auto queueManager = sharedQueueManager();
+    if (numPartitions_ > 1) {
+      if (usesHashPartitioning()) {
+        hashPartition(input.tableView, input.stream, estimatedBytes);
+      } else {
+        equalPartition(
+            input.tableView,
+            input.stream,
+            std::move(input.tableOwner),
+            std::move(input.vectorOwners),
+            estimatedBytes);
+      }
+
+      pendingInputBatch_.reset();
+      drainPendingPartitionedBatch();
+      return;
+    }
+
+    auto packedCols = cudf::pack(
+        input.tableView, input.stream, cudf::get_current_device_resource_ref());
+    input.stream.synchronize();
+    auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+        std::move(packedCols.metadata), std::move(packedCols.gpu_data));
+    queueManager->enqueue(
+        this->taskId(),
+        0,
+        std::move(packedColsPtr),
+        input.tableView.num_rows());
+
+    pendingInputBatch_.reset();
+    const auto blocked = queueManager->checkBlocked(this->taskId(), &future_);
+    blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer
+                              : exec::BlockingReason::kNotBlocked;
+  } catch (const std::bad_alloc&) {
+    recordAllocationPressure(static_cast<uint64_t>(estimatedBytes));
+  }
+}
+
 void UcxPartitionedOutput::flushPending() {
+  if (pendingPartitionedBatch_) {
+    drainPendingPartitionedBatch();
+    return;
+  }
+
+  if (pendingInputBatch_) {
+    partitionPendingInputBatch();
+    return;
+  }
+
   if (pendingInputs_.empty()) {
     return;
   }
+
+  const auto estimatedBytes = std::max<int64_t>(pendingBytes_, 1);
 
   try {
     cudf::table_view tableView;
     rmm::cuda_stream_view stream = pendingInputs_.back()->stream();
     // Keeps the merged table alive while tableView references it.
     std::unique_ptr<cudf::table> mergedTable;
+    std::vector<CudfVectorPtr> vectorOwners;
 
     if (pendingInputs_.size() == 1) {
       // Fast path: use the single input's view directly (no GPU alloc).
-      auto& cv = pendingInputs_[0];
+      vectorOwners = std::move(pendingInputs_);
+      auto& cv = vectorOwners[0];
       stream = cv->stream();
       tableView = remap_.empty()
           ? cv->getTableView()
@@ -156,46 +332,17 @@ void UcxPartitionedOutput::flushPending() {
       tableView = mergedTable->view();
     }
 
-    // Partition + enqueue (identical to previous addInput logic).
-    auto queueManager = sharedQueueManager();
-    if (numPartitions_ > 1) {
-      if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
-        hashPartition(tableView, stream);
-      } else {
-        equalPartition(tableView, stream);
-      }
-    } else {
-      auto packedCols = cudf::pack(
-          tableView, stream, cudf::get_current_device_resource_ref());
-      stream.synchronize();
-      auto packedColsPtr = std::make_unique<cudf::packed_columns>(
-          std::move(packedCols.metadata), std::move(packedCols.gpu_data));
-      queueManager->enqueue(
-          this->taskId(), 0, std::move(packedColsPtr), tableView.num_rows());
-    }
-
-    // Check backpressure after enqueue.
-    auto blocked = queueManager->checkBlocked(this->taskId(), &future_);
-    if (blocked) {
-      VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
-              << " is blocked, can no longer write to output!";
-    }
-    blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer
-                              : exec::BlockingReason::kNotBlocked;
-
-    pendingInputs_.clear();
+    pendingInputBatch_.emplace(PendingInputBatch{
+        std::move(mergedTable),
+        std::move(vectorOwners),
+        tableView,
+        estimatedBytes,
+        stream});
     pendingRows_ = 0;
-
-  } catch (const rmm::bad_alloc& e) {
-    VLOG(1)
-        << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
-        << " caught memory alloc error, removing all memory in output queues";
-    pendingInputs_.clear();
-    pendingRows_ = 0;
-    for (int i = 0; i < numPartitions_; i++) {
-      sharedQueueManager()->deleteResults(this->taskId(), i);
-    }
-    throw;
+    pendingBytes_ = 0;
+    partitionPendingInputBatch();
+  } catch (const std::bad_alloc&) {
+    recordAllocationPressure(static_cast<uint64_t>(estimatedBytes));
   }
 }
 
@@ -203,6 +350,13 @@ exec::BlockingReason UcxPartitionedOutput::isBlocked(ContinueFuture* future) {
   if (blockingReason_ != exec::BlockingReason::kNotBlocked) {
     *future = std::move(future_);
     blockingReason_ = exec::BlockingReason::kNotBlocked;
+    return exec::BlockingReason::kWaitForConsumer;
+  }
+  if (shouldDrainPending()) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+  if (!finished_ &&
+      sharedQueueManager()->checkBlocked(this->taskId(), future)) {
     return exec::BlockingReason::kWaitForConsumer;
   }
   return exec::BlockingReason::kNotBlocked;
@@ -213,8 +367,14 @@ RowVectorPtr UcxPartitionedOutput::getOutput() {
   if (finished_) {
     return nullptr;
   }
+  if (shouldDrainPending()) {
+    flushPending();
+    if (shouldDrainPending() ||
+        blockingReason_ != exec::BlockingReason::kNotBlocked) {
+      return nullptr;
+    }
+  }
   if (noMoreInput_) {
-    flushPending(); // drain any remaining buffered inputs
     sharedQueueManager()->noMoreData(this->taskId());
     finished_ = true;
   }
@@ -231,6 +391,20 @@ UcxPartitionedOutput::sharedQueueManager() {
   VELOX_CHECK_NOT_NULL(
       shared_queueManager, "OutputQueueManager was already destructed");
   return shared_queueManager;
+}
+
+bool UcxPartitionedOutput::shouldFlushPending() const {
+  return !pendingInputs_.empty() &&
+      (targetRowsPerChunk_ <= 0 || pendingRows_ >= targetRowsPerChunk_);
+}
+
+bool UcxPartitionedOutput::shouldDrainPending() const {
+  return pendingPartitionedBatch_.has_value() || pendingInputBatch_.has_value() ||
+      shouldFlushPending() || (noMoreInput_ && !pendingInputs_.empty());
+}
+
+bool UcxPartitionedOutput::usesHashPartitioning() const {
+  return !partitionKeyIndices_.empty() || isGatherPartition_;
 }
 
 void UcxPartitionedOutput::initPartitionKeys(
@@ -250,6 +424,9 @@ void UcxPartitionedOutput::initPartitionKeys(
   // indices because we're going to merge all the incoming streams together.
 
   // Get partition function specification string
+  isGatherPartition_ =
+      dynamic_cast<const core::GatherPartitionFunctionSpec*>(
+          &planNode->partitionFunctionSpec()) != nullptr;
   spec_ = planNode->partitionFunctionSpec().toString();
 
   // Only parse keys if it's a hash function
@@ -287,7 +464,8 @@ void UcxPartitionedOutput::initPartitionKeys(
 
 void UcxPartitionedOutput::hashPartition(
     cudf::table_view tableView,
-    rmm::cuda_stream_view stream) {
+    rmm::cuda_stream_view stream,
+    int64_t estimatedBytes) {
   VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
           << " Hashing and partitioning into " << numPartitions_ << " chunks";
 
@@ -308,60 +486,849 @@ void UcxPartitionedOutput::hashPartition(
   VELOX_CHECK_EQ(partitionOffsets.size(), numPartitions_ + 1);
   VELOX_CHECK_EQ(partitionOffsets[0], 0);
 
-  // Erase first element since it's always 0 and we don't need it.
-  partitionOffsets.erase(partitionOffsets.begin());
-  partitionOffsets.pop_back();
-
-  splitAndEnqueue(partitionedTable->view(), partitionOffsets, stream);
+  auto partitionedView = partitionedTable->view();
+  pendingPartitionedBatch_.emplace(PendingPartitionedBatch{
+      std::move(partitionedTable),
+      {},
+      partitionedView,
+      std::move(partitionOffsets),
+      estimatedBytes,
+      false,
+      stream,
+      0,
+      {},
+      {},
+      {},
+      0});
 }
 
 void UcxPartitionedOutput::equalPartition(
     cudf::table_view tableView,
-    rmm::cuda_stream_view stream) {
+    rmm::cuda_stream_view stream,
+    std::unique_ptr<cudf::table> tableOwner,
+    std::vector<CudfVectorPtr> vectorOwners,
+    int64_t estimatedBytes) {
   VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
           << " Splitting into " << numPartitions_ << " chunks";
   std::vector<cudf::size_type> offsets;
   cudf::size_type size = tableView.num_rows();
+  offsets.reserve(numPartitions_ + 1);
+  offsets.push_back(0);
   for (int i = 1; i < numPartitions_; ++i) {
     cudf::size_type idx = size * i / numPartitions_;
     offsets.push_back(idx);
   }
-  splitAndEnqueue(tableView, offsets, stream);
+  offsets.push_back(size);
+
+  pendingPartitionedBatch_.emplace(PendingPartitionedBatch{
+      std::move(tableOwner),
+      std::move(vectorOwners),
+      tableView,
+      std::move(offsets),
+      estimatedBytes,
+      false,
+      stream,
+      0,
+      {},
+      {},
+      {},
+      0});
 }
 
-void UcxPartitionedOutput::splitAndEnqueue(
-    cudf::table_view tableView,
-    std::vector<cudf::size_type> offsets,
-    rmm::cuda_stream_view stream) {
-  auto contiguousTables = cudf::contiguous_split(
-      tableView, offsets, stream, cudf::get_current_device_resource_ref());
+// Estimate payload bytes for a partition using the reservation estimate. The
+// contiguous fast path rechecks real packed sizes before enqueueing if this
+// estimate still does not fit.
+uint64_t UcxPartitionedOutput::estimatedPartitionBytes(
+    const PendingPartitionedBatch& batch,
+    cudf::size_type start,
+    cudf::size_type end) const {
+  const auto partitionRows = end - start;
+  const auto totalRows = batch.tableView.num_rows();
+  if (partitionRows <= 0 || totalRows <= 0 || batch.estimatedBytes <= 0) {
+    return 0;
+  }
 
-  // Synchronize the stream to ensure CUDA operations complete before enqueuing.
-  // UCXX/UCX is not stream-aware, so without syncing, data could be sent before
-  // the GPU kernels have finished writing to the buffers.
-  stream.synchronize();
+  const auto estimatedBytes =
+      static_cast<long double>(batch.estimatedBytes) *
+      static_cast<long double>(partitionRows) /
+      static_cast<long double>(totalRows);
+  if (estimatedBytes >=
+      static_cast<long double>(std::numeric_limits<uint64_t>::max())) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+
+  const auto wholeBytes = static_cast<uint64_t>(estimatedBytes);
+  return estimatedBytes > static_cast<long double>(wholeBytes)
+      ? wholeBytes + 1
+      : wholeBytes;
+}
+
+uint64_t UcxPartitionedOutput::exactPartitionBytes(
+    const PendingPartitionedBatch& batch,
+    cudf::size_type start,
+    cudf::size_type end) const {
+  if (start == end) {
+    return 0;
+  }
+
+  std::vector<cudf::size_type> offsets{start, end};
+  auto views = cudf::slice(batch.tableView, offsets);
+  VELOX_CHECK_EQ(views.size(), 1);
+  return cudf::packed_size(
+      views[0], batch.stream, cudf::get_current_device_resource_ref());
+}
+
+// Estimate a row chunk size that keeps each packed UCX payload under the given
+// byte target. The caller increases the target geometrically, so large
+// partitions do not become many tiny messages, while the first allocations stay
+// small enough to avoid an immediate memory spike.
+cudf::size_type UcxPartitionedOutput::rowsForPayloadTarget(
+    const PendingPartitionedBatch& batch,
+    cudf::size_type start,
+    cudf::size_type end,
+    uint64_t targetBytes) const {
+  const auto partitionRows = end - start;
+  if (partitionRows <= 0) {
+    return 0;
+  }
+
+  const auto totalRows = batch.tableView.num_rows();
+  if (totalRows <= 0 || batch.estimatedBytes <= 0 || targetBytes == 0) {
+    return partitionRows;
+  }
+
+  const auto partitionBytes = estimatedPartitionBytes(batch, start, end);
+  if (partitionBytes <= targetBytes) {
+    return partitionRows;
+  }
+
+  const auto rows = static_cast<cudf::size_type>(
+      static_cast<long double>(partitionRows) *
+      static_cast<long double>(targetBytes) /
+      static_cast<long double>(partitionBytes));
+  return std::max<cudf::size_type>(rows, 1);
+}
+
+bool UcxPartitionedOutput::shouldSplitPayload(
+    const PendingPartitionedBatch& batch,
+    cudf::size_type start,
+    cudf::size_type end) const {
+  return estimatedPartitionBytes(batch, start, end) >
+      maxTransferWindowBytes(batch);
+}
+
+uint64_t UcxPartitionedOutput::baseTransferWindowBytes(
+    const PendingPartitionedBatch& batch) const {
+  if (batch.estimatedBytes <= 0 || numPartitions_ == 0) {
+    return initialPayloadBytes_;
+  }
+
+  const auto averagePartitionBytes = divideCeil(
+      static_cast<uint64_t>(batch.estimatedBytes),
+      static_cast<uint64_t>(numPartitions_));
+  return std::max<uint64_t>(initialPayloadBytes_, averagePartitionBytes);
+}
+
+uint64_t UcxPartitionedOutput::maxTransferWindowBytes(
+    const PendingPartitionedBatch& batch) const {
+  return std::min<uint64_t>(
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+      multiplySaturated(
+          baseTransferWindowBytes(batch), kTransferWindowMultiplier));
+}
+
+uint64_t UcxPartitionedOutput::normalTransferWindowBytes(
+    const PendingPartitionedBatch& batch) const {
+  return std::min<uint64_t>(
+      maxTransferWindowBytes(batch),
+      multiplySaturated(baseTransferWindowBytes(batch), 2));
+}
+
+uint64_t UcxPartitionedOutput::transferWindowBytes(
+    const PendingPartitionedBatch& batch,
+    int destination,
+    const std::shared_ptr<UcxOutputQueueManager>& queueManager) const {
+  const auto baseWindow = baseTransferWindowBytes(batch);
+  const auto normalWindow = normalTransferWindowBytes(batch);
+  const auto maxWindow = maxTransferWindowBytes(batch);
+  if (maxWindow <= baseWindow) {
+    return baseWindow;
+  }
+
+  return static_cast<uint64_t>(queueManager->transferWindowBytes(
+      this->taskId(),
+      destination,
+      static_cast<int64_t>(baseWindow),
+      static_cast<int64_t>(normalWindow),
+      static_cast<int64_t>(maxWindow)));
+}
+
+void UcxPartitionedOutput::initializePartitionDrainState(
+    PendingPartitionedBatch& batch) const {
+  if (!batch.nextRows.empty()) {
+    return;
+  }
 
   VELOX_CHECK_EQ(
-      offsets.size() + 1, numPartitions_, "mismatch in numPartitions_");
-  auto queueManager = sharedQueueManager();
-  for (int i = 0; i < numPartitions_; ++i) {
-    auto const& partitionTable = contiguousTables[i];
-    if (partitionTable.table.num_rows() == 0) {
-      // Skip empty partitions.
+      batch.offsets.size(), numPartitions_ + 1, "mismatch in numPartitions_");
+
+  const auto transferWindow = batch.conservativeChunkSizing
+      ? initialPayloadBytes_
+      : normalTransferWindowBytes(batch);
+  batch.nextRows.resize(numPartitions_);
+  batch.nextPayloadBytes.resize(numPartitions_, 0);
+  batch.drainDeficits.resize(numPartitions_, 0);
+  batch.remainingPartitions = 0;
+  batch.nextPartition = 0;
+
+  for (size_t partition = 0; partition < numPartitions_; ++partition) {
+    const auto start = batch.offsets[partition];
+    const auto end = batch.offsets[partition + 1];
+    VELOX_CHECK_LE(start, end);
+
+    batch.nextRows[partition] = start;
+    if (start == end) {
       continue;
     }
 
-    auto packedColsPtr = std::make_unique<cudf::packed_columns>(
-        std::move(contiguousTables[i].data.metadata),
-        std::move(contiguousTables[i].data.gpu_data));
+    batch.nextPayloadBytes[partition] =
+        (batch.conservativeChunkSizing || shouldSplitPayload(batch, start, end))
+        ? initialPayloadBytes_
+        : transferWindow;
+    ++batch.remainingPartitions;
+  }
+}
 
-    // enqueue partition data on Ucx Output Buffer
+bool UcxPartitionedOutput::tryDrainWithContiguousSplit(
+    PendingPartitionedBatch& batch) {
+  if (!batch.nextRows.empty() || batch.tableView.num_rows() == 0) {
+    return false;
+  }
+  if (batch.conservativeChunkSizing) {
+    return false;
+  }
+
+  VELOX_CHECK_EQ(
+      batch.offsets.size(), numPartitions_ + 1, "mismatch in numPartitions_");
+
+  auto queueManager = sharedQueueManager();
+  auto recordContiguousSplitPressure = [&]() {
+    batch.conservativeChunkSizing = true;
+    queueManager->recordFullTransferCongestion(this->taskId());
+    for (size_t partition = 0; partition < numPartitions_; ++partition) {
+      if (batch.offsets[partition] < batch.offsets[partition + 1]) {
+        queueManager->recordTransferCongestion(
+            this->taskId(),
+            partition,
+            static_cast<int64_t>(baseTransferWindowBytes(batch)));
+      }
+    }
+  };
+  std::vector<bool> eligible(numPartitions_, false);
+  std::vector<uint64_t> transferReservations(numPartitions_, 0);
+  std::vector<uint64_t> transferWindows(numPartitions_, 0);
+  auto releaseReservations = folly::makeGuard([&]() {
+    for (size_t partition = 0; partition < transferReservations.size();
+         ++partition) {
+      if (transferReservations[partition] == 0) {
+        continue;
+      }
+      queueManager->releaseTransferReservation(
+          this->taskId(),
+          partition,
+          static_cast<int64_t>(transferReservations[partition]));
+      transferReservations[partition] = 0;
+    }
+  });
+  auto releaseReservation = [&](size_t partition) {
+    if (transferReservations[partition] == 0) {
+      return;
+    }
+    queueManager->releaseTransferReservation(
+        this->taskId(),
+        partition,
+        static_cast<int64_t>(transferReservations[partition]));
+    transferReservations[partition] = 0;
+  };
+  size_t eligiblePartitions = 0;
+
+  for (size_t partition = 0; partition < numPartitions_; ++partition) {
+    const auto start = batch.offsets[partition];
+    const auto end = batch.offsets[partition + 1];
+    VELOX_CHECK_LE(start, end);
+    if (start == end) {
+      continue;
+    }
+
+    auto transferWindow = transferWindowBytes(batch, partition, queueManager);
+    auto partitionBytes = estimatedPartitionBytes(batch, start, end);
+    if (partitionBytes > transferWindow) {
+      try {
+        partitionBytes = exactPartitionBytes(batch, start, end);
+      } catch (const std::bad_alloc&) {
+        recordContiguousSplitPressure();
+        return false;
+      }
+      if (partitionBytes > transferWindow) {
+        queueManager->recordTransferDemand(
+            this->taskId(),
+            partition,
+            static_cast<int64_t>(std::min<uint64_t>(
+                partitionBytes,
+                static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))),
+            static_cast<int64_t>(baseTransferWindowBytes(batch)),
+            static_cast<int64_t>(maxTransferWindowBytes(batch)));
+        transferWindow = transferWindowBytes(batch, partition, queueManager);
+        if (partitionBytes > transferWindow) {
+          continue;
+        }
+      }
+    }
+
+    const auto reservationBytes = std::max<uint64_t>(partitionBytes, 1);
+    if (queueManager->reserveTransferBytes(
+            this->taskId(),
+            partition,
+            static_cast<int64_t>(reservationBytes),
+            static_cast<int64_t>(transferWindow),
+            nullptr)) {
+      continue;
+    }
+
+    transferReservations[partition] = reservationBytes;
+    transferWindows[partition] = transferWindow;
+    eligible[partition] = true;
+    ++eligiblePartitions;
+  }
+
+  if (eligiblePartitions == 0) {
+    return false;
+  }
+
+  initializePartitionDrainState(batch);
+
+  bool madeProgress = false;
+  for (size_t runStart = 0; runStart < numPartitions_;) {
+    while (runStart < numPartitions_ && !eligible[runStart]) {
+      ++runStart;
+    }
+    if (runStart == numPartitions_) {
+      break;
+    }
+
+    auto runEnd = runStart;
+    while (runEnd + 1 < numPartitions_ && eligible[runEnd + 1]) {
+      ++runEnd;
+    }
+
+    const auto sliceStart = batch.offsets[runStart];
+    const auto sliceEnd = batch.offsets[runEnd + 1];
+    VELOX_CHECK_LT(sliceStart, sliceEnd);
+
+    std::vector<cudf::size_type> sliceOffsets{sliceStart, sliceEnd};
+    auto slices = cudf::slice(batch.tableView, sliceOffsets, batch.stream);
+    VELOX_CHECK_EQ(slices.size(), 1);
+
+    std::vector<cudf::size_type> splitOffsets;
+    splitOffsets.reserve(runEnd - runStart);
+    for (size_t partition = runStart + 1; partition <= runEnd; ++partition) {
+      splitOffsets.push_back(batch.offsets[partition] - sliceStart);
+    }
+
+    std::vector<cudf::packed_table> contiguousTables;
+    try {
+      contiguousTables = cudf::contiguous_split(
+          slices[0],
+          splitOffsets,
+          batch.stream,
+          cudf::get_current_device_resource_ref());
+    } catch (const std::bad_alloc&) {
+      recordContiguousSplitPressure();
+      return false;
+    }
+
+    // UCXX/UCX is not stream-aware, so the packed payloads must be complete
+    // before exposing their raw device pointers to the exchange server.
+    batch.stream.synchronize();
+
+    VELOX_CHECK_EQ(contiguousTables.size(), runEnd - runStart + 1);
+    for (size_t index = 0; index < contiguousTables.size(); ++index) {
+      const auto partition = runStart + index;
+      auto& partitionTable = contiguousTables[index];
+      if (partitionTable.table.num_rows() == 0) {
+        releaseReservation(partition);
+        continue;
+      }
+
+      auto transferWindow = transferWindows[partition];
+      const auto actualBytes = partitionTable.data.gpu_data->size();
+      if (actualBytes > transferWindow) {
+        queueManager->recordTransferDemand(
+            this->taskId(),
+            partition,
+            static_cast<int64_t>(std::min<uint64_t>(
+                actualBytes,
+                static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))),
+            static_cast<int64_t>(baseTransferWindowBytes(batch)),
+            static_cast<int64_t>(maxTransferWindowBytes(batch)));
+        transferWindow = transferWindowBytes(batch, partition, queueManager);
+        transferWindows[partition] = transferWindow;
+        if (actualBytes > transferWindow) {
+          batch.conservativeChunkSizing = true;
+          batch.nextPayloadBytes[partition] = initialPayloadBytes_;
+          batch.drainDeficits[partition] = 0;
+          queueManager->recordTransferCongestion(
+              this->taskId(),
+              partition,
+              static_cast<int64_t>(baseTransferWindowBytes(batch)));
+          releaseReservation(partition);
+          return false;
+        }
+      }
+
+      if (actualBytes > transferReservations[partition]) {
+        const auto reservationDelta =
+            actualBytes - transferReservations[partition];
+        if (queueManager->reserveTransferBytes(
+                this->taskId(),
+                partition,
+                static_cast<int64_t>(reservationDelta),
+                static_cast<int64_t>(transferWindow),
+                nullptr)) {
+          batch.conservativeChunkSizing = true;
+          batch.nextPayloadBytes[partition] = initialPayloadBytes_;
+          batch.drainDeficits[partition] = 0;
+          queueManager->recordTransferCongestion(
+              this->taskId(),
+              partition,
+              static_cast<int64_t>(baseTransferWindowBytes(batch)));
+          releaseReservation(partition);
+          return false;
+        }
+        transferReservations[partition] += reservationDelta;
+      }
+
+      const auto transferReservationBytes =
+          static_cast<int64_t>(transferReservations[partition]);
+
+      auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+          std::move(partitionTable.data.metadata),
+          std::move(partitionTable.data.gpu_data));
+
+      queueManager->enqueue(
+          this->taskId(),
+          partition,
+          std::move(packedColsPtr),
+          partitionTable.table.num_rows(),
+          transferReservationBytes);
+      transferReservations[partition] = 0;
+
+      madeProgress = true;
+      if (batch.nextRows[partition] < batch.offsets[partition + 1]) {
+        batch.nextRows[partition] = batch.offsets[partition + 1];
+        VELOX_CHECK_GT(batch.remainingPartitions, 0);
+        --batch.remainingPartitions;
+      }
+      batch.nextPayloadBytes[partition] = 0;
+      batch.drainDeficits[partition] = 0;
+    }
+
+    runStart = runEnd + 1;
+  }
+
+  if (!madeProgress) {
+    return false;
+  }
+
+  if (batch.remainingPartitions > 0) {
+    blockingReason_ = exec::BlockingReason::kNotBlocked;
+    return false;
+  }
+
+  pendingPartitionedBatch_.reset();
+  pendingRows_ = 0;
+  pendingBytes_ = 0;
+  blockingReason_ = exec::BlockingReason::kNotBlocked;
+  releaseReservations.dismiss();
+  return true;
+}
+
+bool UcxPartitionedOutput::tryDrainWithFullContiguousSplit(
+    PendingPartitionedBatch& batch) {
+  if (!batch.nextRows.empty() || batch.tableView.num_rows() == 0) {
+    return false;
+  }
+
+  VELOX_CHECK_EQ(
+      batch.offsets.size(), numPartitions_ + 1, "mismatch in numPartitions_");
+
+  auto queueManager = sharedQueueManager();
+  std::vector<uint64_t> transferReservations(numPartitions_, 0);
+  auto releaseReservations = folly::makeGuard([&]() {
+    for (size_t partition = 0; partition < transferReservations.size();
+         ++partition) {
+      if (transferReservations[partition] == 0) {
+        continue;
+      }
+      queueManager->releaseTransferReservation(
+          this->taskId(),
+          partition,
+          static_cast<int64_t>(transferReservations[partition]));
+      transferReservations[partition] = 0;
+    }
+  });
+
+  const auto maxReservation =
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  auto recordFullSplitPressure = [&]() {
+    batch.conservativeChunkSizing = true;
+    queueManager->recordFullTransferCongestion(this->taskId());
+    for (size_t partition = 0; partition < numPartitions_; ++partition) {
+      if (batch.offsets[partition] < batch.offsets[partition + 1]) {
+        queueManager->recordTransferCongestion(
+            this->taskId(),
+            partition,
+            static_cast<int64_t>(baseTransferWindowBytes(batch)));
+      }
+    }
+  };
+
+  // Build split offsets first, then check live device headroom before
+  // materializing the full fanout.
+  std::vector<cudf::size_type> splitOffsets;
+  splitOffsets.reserve(numPartitions_ > 0 ? numPartitions_ - 1 : 0);
+  for (size_t partition = 1; partition < numPartitions_; ++partition) {
+    splitOffsets.push_back(batch.offsets[partition]);
+  }
+
+  uint64_t deviceReservationBytes = 0;
+  auto releaseDeviceReservation = folly::makeGuard([&]() {
+    if (deviceReservationBytes == 0) {
+      return;
+    }
+    inProcessGpuMaterializationReservationBytes().fetch_sub(
+        deviceReservationBytes, std::memory_order_acq_rel);
+  });
+
+  const auto estimatedPayloadBytes = std::max<uint64_t>(
+      static_cast<uint64_t>(std::max<int64_t>(batch.estimatedBytes, 1)), 1);
+  // A full fanout is only safe when the device can hold the fanout and still
+  // leave room for another producer-side allocation of comparable scale. This
+  // keeps small/free queries on the fast path, but prevents exchange-retained
+  // payloads from being the first actor to discover the GPU allocation cliff.
+  const auto producerHeadroomBytes =
+      std::max<uint64_t>(estimatedPayloadBytes, baseTransferWindowBytes(batch));
+  if (const auto memoryInfo = currentDeviceMemoryInfo()) {
+    const auto freeBytes = effectiveFreeBytes(*memoryInfo);
+    const auto inProcessReserved =
+        inProcessGpuMaterializationReservationBytes().load(
+            std::memory_order_acquire);
+    const auto requiredBytes = addSaturated(
+        addSaturated(inProcessReserved, estimatedPayloadBytes),
+        producerHeadroomBytes);
+    if (freeBytes <= requiredBytes) {
+      recordFullSplitPressure();
+      return false;
+    }
+
+    inProcessGpuMaterializationReservationBytes().fetch_add(
+        estimatedPayloadBytes, std::memory_order_acq_rel);
+    deviceReservationBytes = estimatedPayloadBytes;
+  }
+
+  std::vector<cudf::packed_table> contiguousTables;
+  try {
+    contiguousTables = cudf::contiguous_split(
+        batch.tableView,
+        splitOffsets,
+        batch.stream,
+        cudf::get_current_device_resource_ref());
+  } catch (const std::bad_alloc&) {
+    recordFullSplitPressure();
+    return false;
+  }
+
+  // UCXX/UCX is not stream-aware, so the packed payloads must be complete
+  // before exposing their raw device pointers to the exchange server.
+  batch.stream.synchronize();
+
+  VELOX_CHECK_EQ(contiguousTables.size(), numPartitions_);
+  for (size_t partition = 0; partition < numPartitions_; ++partition) {
+    auto& partitionTable = contiguousTables[partition];
+    if (partitionTable.table.num_rows() == 0) {
+      continue;
+    }
+
+    auto actualReservationBytes = transferReservations[partition];
+    const auto actualBytes = partitionTable.data.gpu_data->size();
+    if (actualBytes > actualReservationBytes) {
+      auto reservationDelta = actualBytes - actualReservationBytes;
+      reservationDelta = std::min<uint64_t>(reservationDelta, maxReservation);
+      const auto blocked = queueManager->reserveFullTransferBytes(
+          this->taskId(),
+          partition,
+          static_cast<int64_t>(reservationDelta),
+          nullptr);
+      if (blocked) {
+        recordFullSplitPressure();
+        return false;
+      }
+      actualReservationBytes += reservationDelta;
+      transferReservations[partition] = actualReservationBytes;
+    }
+  }
+
+  for (size_t partition = 0; partition < numPartitions_; ++partition) {
+    auto& partitionTable = contiguousTables[partition];
+    if (partitionTable.table.num_rows() == 0) {
+      if (transferReservations[partition] > 0) {
+        queueManager->releaseTransferReservation(
+            this->taskId(),
+            partition,
+            static_cast<int64_t>(transferReservations[partition]));
+        transferReservations[partition] = 0;
+      }
+      continue;
+    }
+
+    const auto actualReservationBytes = transferReservations[partition];
+    auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+        std::move(partitionTable.data.metadata),
+        std::move(partitionTable.data.gpu_data));
+
     queueManager->enqueue(
         this->taskId(),
-        i,
+        partition,
         std::move(packedColsPtr),
-        partitionTable.table.num_rows());
+        partitionTable.table.num_rows(),
+        static_cast<int64_t>(actualReservationBytes));
+    transferReservations[partition] = 0;
   }
+
+  pendingPartitionedBatch_.reset();
+  pendingRows_ = 0;
+  pendingBytes_ = 0;
+  blockingReason_ = exec::BlockingReason::kNotBlocked;
+  releaseReservations.dismiss();
+  return true;
+}
+
+bool UcxPartitionedOutput::drainPendingPartitionedBatch() {
+  VELOX_CHECK(pendingPartitionedBatch_.has_value());
+
+  auto queueManager = sharedQueueManager();
+  auto& batch = pendingPartitionedBatch_.value();
+  if (tryDrainWithFullContiguousSplit(batch)) {
+    return true;
+  }
+  if (blockingReason_ != exec::BlockingReason::kNotBlocked) {
+    return false;
+  }
+  if (tryDrainWithContiguousSplit(batch)) {
+    return true;
+  }
+  initializePartitionDrainState(batch);
+
+  VELOX_CHECK_EQ(
+      batch.offsets.size(), numPartitions_ + 1, "mismatch in numPartitions_");
+
+  while (batch.remainingPartitions > 0) {
+    int waitPartition = -1;
+    bool madeProgress = false;
+
+    for (size_t visited = 0; visited < numPartitions_; ++visited) {
+      const auto partition = batch.nextPartition;
+      batch.nextPartition = (batch.nextPartition + 1) % numPartitions_;
+
+      if (batch.nextRows[partition] >= batch.offsets[partition + 1]) {
+        continue;
+      }
+
+      const auto transferWindow =
+          transferWindowBytes(batch, partition, queueManager);
+      batch.drainDeficits[partition] = std::min<uint64_t>(
+          transferWindow,
+          addSaturated(batch.drainDeficits[partition], transferWindow));
+      batch.nextPayloadBytes[partition] =
+          std::min<uint64_t>(batch.nextPayloadBytes[partition], transferWindow);
+
+      while (batch.nextRows[partition] < batch.offsets[partition + 1]) {
+        if (queueManager->checkTransferCapacity(
+                this->taskId(), partition, transferWindow, nullptr)) {
+          if (waitPartition < 0) {
+            waitPartition = partition;
+          }
+          break;
+        }
+
+        if (batch.drainDeficits[partition] <
+            batch.nextPayloadBytes[partition]) {
+          break;
+        }
+
+        madeProgress = true;
+        const auto start = batch.offsets[partition];
+        const auto end = batch.offsets[partition + 1];
+        VELOX_CHECK_LE(start, end);
+        VELOX_CHECK_LT(batch.nextRows[partition], end);
+
+        const auto chunkStart = batch.nextRows[partition];
+        const auto rowsPerChunk = rowsForPayloadTarget(
+            batch, chunkStart, end, batch.nextPayloadBytes[partition]);
+        VELOX_CHECK_GT(rowsPerChunk, 0);
+        auto chunkEnd =
+            std::min<cudf::size_type>(end, chunkStart + rowsPerChunk);
+        auto recordChunkAllocationPressure = [&](uint64_t waitBytes) {
+          queueManager->recordFullTransferCongestion(this->taskId());
+          queueManager->recordTransferCongestion(
+              this->taskId(),
+              partition,
+              static_cast<int64_t>(baseTransferWindowBytes(batch)));
+          batch.conservativeChunkSizing = true;
+          batch.nextPayloadBytes[partition] = initialPayloadBytes_;
+          batch.drainDeficits[partition] = 0;
+          if (queueManager->waitForFullTransferCapacity(
+                  this->taskId(),
+                  static_cast<int64_t>(
+                      std::min<uint64_t>(
+                          std::max<uint64_t>(waitBytes, 1),
+                          static_cast<uint64_t>(
+                              std::numeric_limits<int64_t>::max()))),
+                  &future_)) {
+            blockingReason_ = exec::BlockingReason::kWaitForConsumer;
+          }
+        };
+
+        uint64_t exactBytes = 0;
+        try {
+          exactBytes = exactPartitionBytes(batch, chunkStart, chunkEnd);
+          while (exactBytes > transferWindow && chunkEnd - chunkStart > 1) {
+            const auto currentRows = chunkEnd - chunkStart;
+            auto adjustedRows = static_cast<cudf::size_type>(
+                static_cast<long double>(currentRows) *
+                static_cast<long double>(transferWindow) /
+                static_cast<long double>(exactBytes));
+            adjustedRows = std::clamp<cudf::size_type>(
+                adjustedRows, 1, currentRows - 1);
+            chunkEnd = chunkStart + adjustedRows;
+            exactBytes = exactPartitionBytes(batch, chunkStart, chunkEnd);
+          }
+        } catch (const std::bad_alloc&) {
+          recordChunkAllocationPressure(batch.nextPayloadBytes[partition]);
+          return false;
+        }
+
+        auto transferReservationBytes = std::max<uint64_t>(exactBytes, 1);
+        auto reservationLimit =
+            std::max<uint64_t>(transferWindow, transferReservationBytes);
+        const auto maxReservation =
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+        transferReservationBytes =
+            std::min<uint64_t>(transferReservationBytes, maxReservation);
+        reservationLimit =
+            std::min<uint64_t>(reservationLimit, maxReservation);
+
+        if (queueManager->reserveTransferBytes(
+                this->taskId(),
+                partition,
+                static_cast<int64_t>(transferReservationBytes),
+                static_cast<int64_t>(reservationLimit),
+                &future_)) {
+          blockingReason_ = exec::BlockingReason::kWaitForConsumer;
+          return false;
+        }
+        auto releaseReservation = folly::makeGuard([&]() {
+          queueManager->releaseTransferReservation(
+              this->taskId(),
+              partition,
+              static_cast<int64_t>(transferReservationBytes));
+        });
+
+        std::vector<cudf::size_type> sliceOffsets{chunkStart, chunkEnd};
+        auto tableSlices = cudf::slice(batch.tableView, sliceOffsets);
+        VELOX_CHECK_EQ(tableSlices.size(), 1);
+
+        std::optional<cudf::packed_columns> packedCols;
+        try {
+          packedCols.emplace(cudf::pack(
+              tableSlices[0],
+              batch.stream,
+              cudf::get_current_device_resource_ref()));
+        } catch (const std::bad_alloc&) {
+          recordChunkAllocationPressure(transferReservationBytes);
+          return false;
+        }
+
+        // UCXX/UCX is not stream-aware, so the packed payload must be complete
+        // before exposing its raw device pointer to the exchange server.
+        batch.stream.synchronize();
+
+        auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+            std::move(packedCols->metadata), std::move(packedCols->gpu_data));
+        const auto packedBytes = packedColsPtr->gpu_data->size();
+        if (packedBytes > transferReservationBytes) {
+          const auto reservationDelta = packedBytes - transferReservationBytes;
+          const auto actualReservationLimit = std::min<uint64_t>(
+              std::max<uint64_t>(reservationLimit, packedBytes),
+              maxReservation);
+          if (queueManager->reserveTransferBytes(
+                  this->taskId(),
+                  partition,
+                  static_cast<int64_t>(reservationDelta),
+                  static_cast<int64_t>(actualReservationLimit),
+                  &future_)) {
+            blockingReason_ = exec::BlockingReason::kWaitForConsumer;
+            return false;
+          }
+          transferReservationBytes += reservationDelta;
+        }
+        queueManager->enqueue(
+            this->taskId(),
+            partition,
+            std::move(packedColsPtr),
+            chunkEnd - chunkStart,
+            static_cast<int64_t>(transferReservationBytes));
+        releaseReservation.dismiss();
+
+        if (packedBytes >= batch.drainDeficits[partition]) {
+          batch.drainDeficits[partition] = 0;
+        } else {
+          batch.drainDeficits[partition] -= packedBytes;
+        }
+
+        batch.nextRows[partition] = chunkEnd;
+        if (chunkEnd == end) {
+          --batch.remainingPartitions;
+          batch.nextPayloadBytes[partition] = 0;
+          batch.drainDeficits[partition] = 0;
+          break;
+        }
+
+        batch.nextPayloadBytes[partition] = std::min<uint64_t>(
+            transferWindow,
+            multiplySaturated(batch.nextPayloadBytes[partition], 2));
+      }
+    }
+
+    if (madeProgress) {
+      continue;
+    }
+
+    VELOX_CHECK_GE(waitPartition, 0);
+    const auto transferWindow =
+        transferWindowBytes(batch, waitPartition, queueManager);
+    if (queueManager->checkTransferCapacity(
+            this->taskId(), waitPartition, transferWindow, &future_)) {
+      blockingReason_ = exec::BlockingReason::kWaitForConsumer;
+      return false;
+    }
+  }
+
+  pendingPartitionedBatch_.reset();
+  pendingRows_ = 0;
+  pendingBytes_ = 0;
+  blockingReason_ = exec::BlockingReason::kNotBlocked;
+  return true;
 }
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
@@ -20,6 +20,12 @@
 #include "velox/experimental/cudf/vector/CudfVector.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <memory>
+#include <optional>
+
 namespace facebook::velox::ucx_exchange {
 
 /// This is the cudf equivalent of the PartitionedOutput operator for cudf.
@@ -30,8 +36,9 @@ class UcxPartitionedOutput : public exec::Operator,
                              public cudf_velox::NvtxHelper {
  public:
   // Default minimum rows to accumulate before flushing. Matches HTTP
-  // PartitionedOutput's ~10,000 row target. Overridable via
-  // QueryConfig::kUcxPartitionedOutputBatchRows.
+  // PartitionedOutput's ~10,000 row target. The cudf exchange system property
+  // provides the cluster default; QueryConfig::kUcxPartitionedOutputBatchRows
+  // can override it per query.
   static constexpr int64_t kDefaultTargetRowsPerChunk = 10'000;
 
   UcxPartitionedOutput(
@@ -47,14 +54,14 @@ class UcxPartitionedOutput : public exec::Operator,
   /// a non-blocked state, otherwise blocked.
   RowVectorPtr getOutput() override;
 
-  /// always true but the caller will check isBlocked before adding input, hence
-  /// the blocked state does not accumulate input.
+  /// The caller checks isBlocked before adding input, so this only needs to
+  /// report whether the operator can still accept rows once unblocked.
   bool needsInput() const override {
-    return true;
+    return !finished_ && !noMoreInput_ && !shouldDrainPending() &&
+        blockingReason_ == exec::BlockingReason::kNotBlocked;
   }
 
-  // the operator is blocked if the queues are full, we are ignoring this so
-  // always return kNotBlocked
+  // The operator is blocked when its output queue is over capacity.
   exec::BlockingReason isBlocked(ContinueFuture* future) override;
 
   // The operaor is finished when the queue manager say the queues have all been
@@ -65,6 +72,8 @@ class UcxPartitionedOutput : public exec::Operator,
   std::shared_ptr<facebook::velox::ucx_exchange::UcxOutputQueueManager>
   sharedQueueManager();
 
+  bool usesHashPartitioning() const;
+
   // Heuristic method to derive the partition keys from the PartitionNode
   // specification.
   void initPartitionKeys(
@@ -72,20 +81,88 @@ class UcxPartitionedOutput : public exec::Operator,
 
   // Partitions the cudf table view using the partition keys and a hash
   // function using the given stream.
-  void hashPartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
+  void hashPartition(
+      cudf::table_view tableView,
+      rmm::cuda_stream_view stream,
+      int64_t estimatedBytes);
 
   // Splits the cudf table view into equal sizes. This is used when
   // RoundRobin partitioning is requested but round robin on a
   // row-by-row basis is not meaningful for UCX exchange.
-  void equalPartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
-
-  // Splits the table along the given offsets and enqueues each offset
-  // to the corresponding partition, i.e. first split to the partition 0,
-  // second split to partition 1 etc.
-  void splitAndEnqueue(
+  void equalPartition(
       cudf::table_view tableView,
-      std::vector<cudf::size_type> offsets,
-      rmm::cuda_stream_view stream);
+      rmm::cuda_stream_view stream,
+      std::unique_ptr<cudf::table> tableOwner,
+      std::vector<cudf_velox::CudfVectorPtr> vectorOwners,
+      int64_t estimatedBytes);
+
+  struct PendingPartitionedBatch {
+    std::unique_ptr<cudf::table> tableOwner;
+    std::vector<cudf_velox::CudfVectorPtr> vectorOwners;
+    cudf::table_view tableView;
+    std::vector<cudf::size_type> offsets;
+    int64_t estimatedBytes{0};
+    bool conservativeChunkSizing{false};
+    rmm::cuda_stream_view stream;
+    size_t nextPartition{0};
+    std::vector<cudf::size_type> nextRows;
+    std::vector<uint64_t> nextPayloadBytes;
+    std::vector<uint64_t> drainDeficits;
+    size_t remainingPartitions{0};
+  };
+
+  struct PendingInputBatch {
+    std::unique_ptr<cudf::table> tableOwner;
+    std::vector<cudf_velox::CudfVectorPtr> vectorOwners;
+    cudf::table_view tableView;
+    int64_t estimatedBytes{0};
+    rmm::cuda_stream_view stream;
+  };
+
+  void partitionPendingInputBatch();
+
+  bool drainPendingPartitionedBatch();
+
+  bool tryDrainWithFullContiguousSplit(PendingPartitionedBatch& batch);
+
+  bool tryDrainWithContiguousSplit(PendingPartitionedBatch& batch);
+
+  void initializePartitionDrainState(PendingPartitionedBatch& batch) const;
+
+  uint64_t estimatedPartitionBytes(
+      const PendingPartitionedBatch& batch,
+      cudf::size_type start,
+      cudf::size_type end) const;
+
+  uint64_t exactPartitionBytes(
+      const PendingPartitionedBatch& batch,
+      cudf::size_type start,
+      cudf::size_type end) const;
+
+  cudf::size_type rowsForPayloadTarget(
+      const PendingPartitionedBatch& batch,
+      cudf::size_type start,
+      cudf::size_type end,
+      uint64_t targetBytes) const;
+
+  bool shouldSplitPayload(
+      const PendingPartitionedBatch& batch,
+      cudf::size_type start,
+      cudf::size_type end) const;
+
+  uint64_t baseTransferWindowBytes(const PendingPartitionedBatch& batch) const;
+
+  uint64_t normalTransferWindowBytes(
+      const PendingPartitionedBatch& batch) const;
+
+  uint64_t maxTransferWindowBytes(const PendingPartitionedBatch& batch) const;
+
+  uint64_t transferWindowBytes(
+      const PendingPartitionedBatch& batch,
+      int destination,
+      const std::shared_ptr<UcxOutputQueueManager>& queueManager) const;
+
+  void recordAllocationPressure(uint64_t waitBytes);
 
   const std::weak_ptr<UcxOutputQueueManager> queueManager_;
   std::vector<column_index_t> partitionKeyIndices_;
@@ -94,11 +171,12 @@ class UcxPartitionedOutput : public exec::Operator,
   const int pipelineId_;
   const int driverId_;
 
-  exec::BlockingReason blockingReason_;
+  exec::BlockingReason blockingReason_{exec::BlockingReason::kNotBlocked};
   ContinueFuture future_;
 
   bool finished_{false};
   std::string spec_;
+  bool isGatherPartition_{false};
 
   // Used for switching columns when column order differs between input and
   // output.
@@ -107,12 +185,30 @@ class UcxPartitionedOutput : public exec::Operator,
   /// Concatenates pending inputs and partitions/enqueues the merged result.
   void flushPending();
 
+  bool shouldFlushPending() const;
+
+  bool shouldDrainPending() const;
+
   /// Accumulated CudfVectors awaiting flush.
   std::vector<cudf_velox::CudfVectorPtr> pendingInputs_;
   /// Total rows across pendingInputs_.
   int64_t pendingRows_{0};
+  /// Estimated bytes across pendingInputs_.
+  int64_t pendingBytes_{0};
   /// Configured row threshold for flushing (from QueryConfig).
   const int64_t targetRowsPerChunk_;
+  /// Initial target GPU payload size for geometrically chunked UCX messages.
+  const uint64_t initialPayloadBytes_;
+
+  /// Partitioned table waiting to be packed and enqueued destination-by-
+  /// destination. This avoids materializing the full fanout before UCX output
+  /// backpressure can take effect.
+  std::optional<PendingPartitionedBatch> pendingPartitionedBatch_;
+
+  /// Cudf input that has been materialized enough to retry partitioning after
+  /// GPU allocation pressure without asking the upstream driver for the row
+  /// again.
+  std::optional<PendingInputBatch> pendingInputBatch_;
 };
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -15,9 +15,34 @@
  */
 #include "velox/experimental/ucx-exchange/UcxQueues.h"
 
-#include <atomic>
+#include <algorithm>
+#include <limits>
+#include <sstream>
+
+#include <glog/logging.h>
 
 namespace facebook::velox::ucx_exchange {
+
+namespace {
+int64_t addSaturated(int64_t left, int64_t right) {
+  VELOX_CHECK_GE(left, 0);
+  VELOX_CHECK_GE(right, 0);
+  if (right > std::numeric_limits<int64_t>::max() - left) {
+    return std::numeric_limits<int64_t>::max();
+  }
+  return left + right;
+}
+
+int64_t multiplySaturated(int64_t value, int64_t multiplier) {
+  VELOX_CHECK_GE(value, 0);
+  VELOX_CHECK_GE(multiplier, 0);
+  if (value != 0 &&
+      multiplier > std::numeric_limits<int64_t>::max() / value) {
+    return std::numeric_limits<int64_t>::max();
+  }
+  return value * multiplier;
+}
+} // namespace
 
 void UcxDestinationQueue::Stats::recordEnqueue(
     const cudf::packed_columns* data) {
@@ -40,6 +65,8 @@ void UcxDestinationQueue::Stats::recordDequeue(
 
     bytesSent += size;
     packedColumnsSent++;
+    bytesInFlight += size;
+    packedColumnsInFlight++;
   }
 }
 
@@ -129,6 +156,24 @@ UcxDestinationQueue::Stats UcxDestinationQueue::stats() const {
   return stats_;
 }
 
+int64_t UcxDestinationQueue::transferBytes() const {
+  return stats_.bytesQueued + stats_.bytesInFlight;
+}
+
+bool UcxDestinationQueue::waitingForData() const {
+  return notify_ != nullptr;
+}
+
+void UcxDestinationQueue::releaseInFlight(
+    int64_t bytes,
+    int64_t numPackedCols) {
+  stats_.bytesInFlight -= bytes;
+  stats_.packedColumnsInFlight -= numPackedCols;
+
+  VELOX_CHECK_GE(stats_.bytesInFlight, 0);
+  VELOX_CHECK_GE(stats_.packedColumnsInFlight, 0);
+}
+
 std::string UcxDestinationQueue::toString() {
   std::stringstream out;
   out << "[available: " << queue_.size() << ", "
@@ -152,9 +197,15 @@ UcxOutputQueue::UcxOutputQueue(
     // initialize called.
   // create a queue for each destination.
   queues_.reserve(numDestinations);
+  transferReservedBytes_.reserve(numDestinations);
+  transferPromises_.reserve(numDestinations);
+  transferWindowBytes_.reserve(numDestinations);
   for (int i = 0; i < numDestinations; ++i) {
     // create the destination queues inside the vector using emplace_back.
     queues_.emplace_back(std::make_unique<UcxDestinationQueue>());
+    transferReservedBytes_.push_back(0);
+    transferPromises_.emplace_back();
+    transferWindowBytes_.push_back(0);
   }
 }
 
@@ -181,6 +232,18 @@ bool UcxOutputQueue::initialize(
   for (int i = queues_.size(); i < numDestinations; ++i) {
     // create the destination queues inside the vector using emplace_back.
     queues_.emplace_back(std::make_unique<UcxDestinationQueue>());
+    transferReservedBytes_.push_back(0);
+    transferPromises_.emplace_back();
+    transferWindowBytes_.push_back(0);
+  }
+  while (transferReservedBytes_.size() < queues_.size()) {
+    transferReservedBytes_.push_back(0);
+  }
+  while (transferPromises_.size() < queues_.size()) {
+    transferPromises_.emplace_back();
+  }
+  while (transferWindowBytes_.size() < queues_.size()) {
+    transferWindowBytes_.push_back(0);
   }
   return true;
 }
@@ -203,11 +266,26 @@ void UcxOutputQueue::updateNumDrivers(uint32_t newNumDrivers) {
 void UcxOutputQueue::enqueue(
     int destination,
     std::unique_ptr<cudf::packed_columns> data,
-    int32_t numRows) {
+    int32_t numRows,
+    int64_t transferReservationBytes) {
   VELOX_CHECK_NOT_NULL(data);
   VELOX_CHECK_NOT_NULL(task_);
-  VELOX_CHECK(
-      task_->isRunning(), "Task is terminated, cannot add data to output.");
+  VELOX_CHECK_GE(transferReservationBytes, 0);
+  if (!task_->isRunning()) {
+    std::vector<ContinuePromise> transferPromises;
+    if (transferReservationBytes > 0) {
+      std::lock_guard<std::mutex> l(mutex_);
+      if (destination >= 0 &&
+          static_cast<size_t>(destination) < transferReservedBytes_.size()) {
+        releaseTransferReservationLocked(destination, transferReservationBytes);
+        collectTransferPromisesLocked(destination, transferPromises);
+      }
+    }
+    for (auto& promise : transferPromises) {
+      promise.setValue();
+    }
+    return;
+  }
   std::vector<UcxDataAvailable> dataAvailableCallbacks;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -216,6 +294,10 @@ void UcxOutputQueue::enqueue(
 
     bool success = false;
     if (kind_ == core::PartitionedOutputNode::Kind::kBroadcast) {
+      VELOX_CHECK_EQ(
+          transferReservationBytes,
+          0,
+          "Broadcast output does not use transfer reservations");
       VELOX_CHECK_EQ(destination, 0, "Broadcast uses destination 0");
       enqueueBroadcastOutputLocked(
           std::move(sharedData), dataAvailableCallbacks);
@@ -235,10 +317,23 @@ void UcxOutputQueue::enqueue(
       totalRowsSent_ += numRows;
       totalPackedColumnsSent_++;
       success = true;
+    } else if (kind_ == core::PartitionedOutputNode::Kind::kArbitrary) {
+      VELOX_CHECK_EQ(
+          transferReservationBytes,
+          0,
+          "Arbitrary output does not use transfer reservations");
+      VELOX_CHECK_EQ(destination, 0, "Arbitrary uses destination 0");
+      enqueueArbitraryOutputLocked(
+          std::move(sharedData), dataAvailableCallbacks);
+      updateStatsWithEnqueuedLocked(numBytes, numRows);
+      success = true;
     } else {
       VELOX_CHECK_LT(destination, queues_.size());
       success = enqueuePartitionedOutputLocked(
-          destination, std::move(sharedData), dataAvailableCallbacks);
+          destination,
+          std::move(sharedData),
+          dataAvailableCallbacks,
+          transferReservationBytes);
       if (success) {
         updateStatsWithEnqueuedLocked(numBytes, numRows);
       }
@@ -252,16 +347,367 @@ void UcxOutputQueue::enqueue(
 
 bool UcxOutputQueue::checkBlocked(ContinueFuture* future) {
   std::lock_guard<std::mutex> l(mutex_);
-  if (queuedBytes_ >= maxSize_ && future) {
-    VLOG(2) << "[BACKPRESSURE] task=" << (task_ ? task_->taskId() : "n/a")
-            << " BLOCKED queuedBytes=" << queuedBytes_
-            << " maxSize=" << maxSize_
-            << " waitingProducers=" << (promises_.size() + 1);
+  const auto producerBlockedBytes = producerBlockedBytesLocked();
+  if (producerBlockedBytes >= maxSize_ && future) {
     promises_.emplace_back("UcxOutputQueue::checkBlocked");
     *future = promises_.back().getSemiFuture();
     return true;
   }
   return false;
+}
+
+bool UcxOutputQueue::checkTransferCapacity(
+    int destination,
+    int64_t maxBytes,
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_GT(maxBytes, 0);
+
+  VELOX_CHECK_GE(destination, 0);
+  VELOX_CHECK_LT(destination, queues_.size());
+  auto* queue = queues_[destination].get();
+  if (queue == nullptr) {
+    return false;
+  }
+
+  const auto destinationStats = queue->stats();
+  const auto reservedBytes = transferReservedBytes_[destination];
+  if (queue->waitingForData() && destinationStats.bytesQueued == 0 &&
+      reservedBytes == 0) {
+    return false;
+  }
+
+  const auto transferBytes = queue->transferBytes() + reservedBytes;
+  if (transferBytes >= maxBytes) {
+    if (future) {
+      transferPromises_[destination].emplace_back(
+          "UcxOutputQueue::checkTransferCapacity");
+      *future = transferPromises_[destination].back().getSemiFuture();
+    }
+    return true;
+  }
+  return false;
+}
+
+bool UcxOutputQueue::reserveTransferBytes(
+    int destination,
+    int64_t bytes,
+    int64_t maxBytes,
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_GT(bytes, 0);
+  VELOX_CHECK_GT(maxBytes, 0);
+  VELOX_CHECK_GE(destination, 0);
+  VELOX_CHECK_LT(destination, queues_.size());
+  auto* queue = queues_[destination].get();
+  if (queue == nullptr) {
+    return false;
+  }
+
+  if (fullTransferCongested_) {
+    const auto retainedBytes = retainedBytesWithTransferReservationsLocked();
+    if (retainedBytes > 0) {
+      maybeGrowFullTransferRetainedLimitLocked(retainedBytes);
+      const auto retainedLimit = fullTransferRetainedLimitLocked();
+      if (retainedLimit > 0 &&
+          addSaturated(retainedBytes, bytes) > retainedLimit) {
+        if (future) {
+          promises_.emplace_back("UcxOutputQueue::reserveTransferBytes");
+          *future = promises_.back().getSemiFuture();
+        }
+        return true;
+      }
+    }
+  }
+
+  const auto destinationStats = queue->stats();
+  if (queue->waitingForData() && destinationStats.bytesQueued == 0 &&
+      transferReservedBytes_[destination] == 0) {
+    VELOX_CHECK_LE(
+        transferReservedBytes_[destination],
+        std::numeric_limits<int64_t>::max() - bytes);
+    transferReservedBytes_[destination] += bytes;
+    return false;
+  }
+
+  const auto transferBytes =
+      queue->transferBytes() + transferReservedBytes_[destination];
+  if (bytes > maxBytes || transferBytes > maxBytes - bytes) {
+    if (future) {
+      transferPromises_[destination].emplace_back(
+          "UcxOutputQueue::reserveTransferBytes");
+      *future = transferPromises_[destination].back().getSemiFuture();
+    }
+    return true;
+  }
+
+  VELOX_CHECK_LE(
+      transferReservedBytes_[destination],
+      std::numeric_limits<int64_t>::max() - bytes);
+  transferReservedBytes_[destination] += bytes;
+  return false;
+}
+
+bool UcxOutputQueue::waitForFullTransferCapacity(
+    int64_t bytes,
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_GT(bytes, 0);
+
+  if (!fullTransferCongested_) {
+    return false;
+  }
+
+  const auto retainedBytes = retainedBytesWithTransferReservationsLocked();
+  if (retainedBytes <= 0) {
+    // A full-transfer wait can only be satisfied by transfer bytes draining
+    // from this queue. If nothing is retained or reserved, no later queue event
+    // is guaranteed to wake a promise created here.
+    return false;
+  }
+  maybeGrowFullTransferRetainedLimitLocked(retainedBytes);
+  const auto retainedLimit = fullTransferRetainedLimitLocked();
+  if (retainedLimit > 0 &&
+      addSaturated(retainedBytes, bytes) > retainedLimit) {
+    if (future) {
+      promises_.emplace_back("UcxOutputQueue::waitForFullTransferCapacity");
+      *future = promises_.back().getSemiFuture();
+    }
+    return true;
+  }
+  return false;
+}
+
+bool UcxOutputQueue::reserveFullTransferBytes(
+    int destination,
+    int64_t bytes,
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_GT(bytes, 0);
+  VELOX_CHECK_GE(destination, 0);
+  VELOX_CHECK_LT(destination, queues_.size());
+  auto* queue = queues_[destination].get();
+  if (queue == nullptr) {
+    return false;
+  }
+
+  const auto retainedBytes = retainedBytesWithTransferReservationsLocked();
+  if (retainedBytes > 0) {
+    maybeGrowFullTransferRetainedLimitLocked(retainedBytes);
+
+    auto retainedLimit = fullTransferRetainedLimitLocked();
+    const auto requestedRetainedBytes = addSaturated(retainedBytes, bytes);
+    if (retainedLimit > 0 && requestedRetainedBytes > retainedLimit) {
+      if (!fullTransferCongested_) {
+        fullTransferRetainedLimit_ = requestedRetainedBytes;
+        retainedLimit = fullTransferRetainedLimitLocked();
+      }
+    }
+    if (retainedLimit > 0 && requestedRetainedBytes > retainedLimit) {
+      if (future) {
+        promises_.emplace_back("UcxOutputQueue::reserveFullTransferBytes");
+        *future = promises_.back().getSemiFuture();
+      }
+      return true;
+    }
+  }
+
+  if (maxSize_ > 0 && fullTransferCongested_) {
+    const auto activeDestinations = activeDestinationCountLocked();
+    const auto fairDestinationBudget = std::max<int64_t>(
+        1, fullTransferRetainedLimitLocked() / activeDestinations);
+    const auto destinationBytes = addSaturated(
+        queue->transferBytes(), transferReservedBytes_[destination]);
+    const auto minimumDestinationBudget =
+        addSaturated(transferReservedBytes_[destination], bytes);
+    const auto destinationBudget =
+        std::max(fairDestinationBudget, minimumDestinationBudget);
+    if (destinationBytes > 0 &&
+        (bytes > destinationBudget ||
+         destinationBytes > destinationBudget - bytes)) {
+      if (future) {
+        transferPromises_[destination].emplace_back(
+            "UcxOutputQueue::reserveFullTransferBytes");
+        *future = transferPromises_[destination].back().getSemiFuture();
+      }
+      return true;
+    }
+  }
+
+  VELOX_CHECK_LE(
+      transferReservedBytes_[destination],
+      std::numeric_limits<int64_t>::max() - bytes);
+  transferReservedBytes_[destination] += bytes;
+  return false;
+}
+
+void UcxOutputQueue::releaseTransferReservation(
+    int destination,
+    int64_t bytes) {
+  std::vector<ContinuePromise> transferPromises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    releaseTransferReservationLocked(destination, bytes);
+    collectTransferPromisesLocked(destination, transferPromises);
+  }
+  for (auto& promise : transferPromises) {
+    promise.setValue();
+  }
+}
+
+int64_t UcxOutputQueue::transferWindowBytes(
+    int destination,
+    int64_t baseBytes,
+    int64_t normalBytes,
+    int64_t maxBytes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  return transferWindowBytesLocked(
+      destination, baseBytes, normalBytes, maxBytes);
+}
+
+void UcxOutputQueue::recordTransferCongestion(
+    int destination,
+    int64_t baseBytes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (destination < 0 || destination >= transferWindowBytes_.size()) {
+    return;
+  }
+
+  auto& window = transferWindowBytes_[destination];
+  if (window <= 0) {
+    window = baseBytes;
+    return;
+  }
+  window = std::max<int64_t>(baseBytes, window / 2);
+}
+
+void UcxOutputQueue::recordTransferDemand(
+    int destination,
+    int64_t targetBytes,
+    int64_t baseBytes,
+    int64_t maxBytes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (destination < 0 || destination >= transferWindowBytes_.size()) {
+    return;
+  }
+
+  auto& window = transferWindowBytes_[destination];
+  if (window <= 0) {
+    window = baseBytes;
+  }
+
+  const auto requestedWindow =
+      std::clamp<int64_t>(targetBytes, baseBytes, maxBytes);
+  const auto growthWindow =
+      window > maxBytes - baseBytes ? maxBytes : window + baseBytes;
+  const auto nextProbeWindow =
+      std::min<int64_t>(maxBytes, std::max(growthWindow, requestedWindow));
+  window = std::max<int64_t>(window, nextProbeWindow);
+}
+
+void UcxOutputQueue::recordFullTransferCongestion() {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (maxSize_ == 0) {
+    return;
+  }
+  fullTransferCongested_ = true;
+
+  const auto defaultLimit = defaultFullTransferRetainedLimitLocked();
+  auto retainedBytes = retainedBytesWithTransferReservationsLocked();
+  if (retainedBytes <= 0) {
+    retainedBytes =
+        fullTransferRetainedLimit_ > 0 ? fullTransferRetainedLimit_
+                                       : defaultLimit;
+  }
+
+  // Back off slightly from the observed pressure point. This preserves most of
+  // the successfully discovered backlog budget, but avoids immediately probing
+  // the same allocation cliff again.
+  const auto reducedLimit = retainedBytes - (retainedBytes / 8);
+  const auto boundedMaxSize = static_cast<int64_t>(std::min<uint64_t>(
+      maxSize_, static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
+  const auto minimumLimit = std::max<int64_t>(1, boundedMaxSize);
+  fullTransferRetainedLimit_ = std::max<int64_t>(minimumLimit, reducedLimit);
+}
+
+UcxDestinationTransferStats UcxOutputQueue::transferStats(int destination) {
+  std::lock_guard<std::mutex> l(mutex_);
+  UcxDestinationTransferStats stats;
+  stats.retainedBytes = retainedBytesLocked();
+  stats.maxBytes = maxSize_;
+
+  VELOX_CHECK_GE(destination, 0);
+  VELOX_CHECK_LT(destination, queues_.size());
+  auto* queue = queues_[destination].get();
+  if (queue == nullptr) {
+    return stats;
+  }
+
+  const auto destinationStats = queue->stats();
+  stats.bytesQueued = destinationStats.bytesQueued;
+  stats.bytesInFlight = destinationStats.bytesInFlight;
+  stats.bytesReserved = transferReservedBytes_[destination];
+  stats.waitingForData = queue->waitingForData();
+  return stats;
+}
+
+bool UcxOutputQueue::reserveOutputBytes(int64_t bytes, ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_GT(bytes, 0);
+  const auto reservationBytes = static_cast<uint64_t>(bytes);
+  if (maxSize_ > 0) {
+    const auto retainedBytes = static_cast<uint64_t>(retainedBytesLocked());
+    if (retainedBytes > 0 &&
+        (reservationBytes > maxSize_ ||
+         retainedBytes > maxSize_ - reservationBytes)) {
+      VELOX_CHECK_NOT_NULL(future);
+      promises_.emplace_back("UcxOutputQueue::reserveOutputBytes");
+      *future = promises_.back().getSemiFuture();
+      return true;
+    }
+  }
+
+  reservedBytes_ += bytes;
+  return false;
+}
+
+void UcxOutputQueue::releaseOutputReservation(int64_t bytes) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (reservedBytes_ < bytes) {
+      reservedBytes_ = 0;
+    } else {
+      reservedBytes_ -= bytes;
+    }
+    maybeContinueProducersLocked(promises);
+  }
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+}
+
+void UcxOutputQueue::releaseInFlightBytes(
+    int destination,
+    int64_t bytes,
+    int64_t numPackedCols) {
+  std::vector<ContinuePromise> promises;
+  std::vector<ContinuePromise> transferPromises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (destination >= 0 && destination < queues_.size() &&
+        queues_[destination] != nullptr) {
+      queues_[destination]->releaseInFlight(bytes, numPackedCols);
+    }
+    updateStatsWithSendCompleteLocked(bytes, numPackedCols, promises);
+    collectTransferPromisesLocked(destination, transferPromises);
+  }
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+  for (auto& promise : transferPromises) {
+    promise.setValue();
+  }
 }
 
 void UcxOutputQueue::getData(int destination, UcxDataAvailableCallback notify) {
@@ -275,45 +721,61 @@ void UcxOutputQueue::getData(int destination, UcxDataAvailableCallback notify) {
     for (int i = queues_.size(); i <= destination; ++i) {
       // create the destination queues inside the vector using emplace_back.
       queues_.emplace_back(std::make_unique<UcxDestinationQueue>());
+      transferReservedBytes_.push_back(0);
+      transferPromises_.emplace_back();
+      transferWindowBytes_.push_back(0);
+      if (kind_ == core::PartitionedOutputNode::Kind::kArbitrary && atEnd_) {
+        queues_.back()->enqueueBack(nullptr);
+      }
     }
     auto* queue = queues_[destination].get();
     // queue can be nullptr here if the task has terminated and results
     // have been removed. In this case, no data is returned.
     if (queue) {
+      // For arbitrary mode, pull from the shared buffer if the destination
+      // queue is empty. This ensures demand-driven distribution.
+      if (kind_ == core::PartitionedOutputNode::Kind::kArbitrary &&
+          !arbitraryBuffer_.empty()) {
+        queue->enqueueBack(std::move(arbitraryBuffer_.front()));
+        arbitraryBuffer_.pop_front();
+      }
       // Capture weak_ptr instead of raw `this` to prevent use-after-free.
       // The callback fires outside the lock (from enqueue() or terminate()),
       // and concurrent removeTask() can destroy the UcxOutputQueue while
       // the callback is still executing.
       std::weak_ptr<UcxOutputQueue> weakSelf = shared_from_this();
-      data = queue->getData([notify, weakSelf](
+      data = queue->getData([destination, notify, weakSelf](
                                 std::shared_ptr<cudf::packed_columns> data,
                                 std::vector<int64_t> remainingBytes) {
-        std::vector<ContinuePromise> promises;
         int64_t bytes = data ? data->gpu_data->size() : -1L;
-        notify(std::move(data), std::move(remainingBytes));
         if (bytes >= 0L) {
           auto self = weakSelf.lock();
-          if (!self) {
-            // Queue was destroyed by removeTask(), safe to skip stats update.
-            return;
+          if (self) {
+            std::vector<ContinuePromise> promises;
+            {
+              std::lock_guard<std::mutex> l(self->mutex_);
+              self->updateStatsWithDequeuedLocked(bytes, 1L, promises);
+            }
+            for (auto& promise : promises) {
+              promise.setValue();
+            }
           }
-          std::lock_guard<std::mutex> l(self->mutex_);
-          self->updateStatsWithFreedLocked(bytes, 1L, promises);
         }
-        // outside of lock:
-        // wake up any producers that are waiting for queue to become less full.
-        for (auto& promise : promises) {
-          promise.setValue();
-        }
+        notify(std::move(data), std::move(remainingBytes));
       });
       if (data.data) {
         // This implies data.immediate and no notify upcall will be done.
-        // Need to update the stats here.
-        updateStatsWithFreedLocked(data.data->gpu_data->size(), 1L, promises);
+        // Need to update the stats here. The data is retained by the server
+        // until transfer completion.
+        updateStatsWithDequeuedLocked(
+            data.data->gpu_data->size(), 1L, promises);
       }
     } else {
       data = UcxDestinationQueue::Data{nullptr, {}, true};
     }
+  }
+  for (auto& promise : promises) {
+    promise.setValue();
   }
   // outside lock: If we have data, then return it immediately.
   if (data.immediate) {
@@ -322,10 +784,6 @@ void UcxOutputQueue::getData(int destination, UcxDataAvailableCallback notify) {
     VLOG(2) << "[QUEUE] task=" << (task_ ? task_->taskId() : "n/a")
             << " dest=" << destination
             << " server waiting for data (callback installed)";
-  }
-  // wake up any producers that are waiting for queue to become less full.
-  for (auto& promise : promises) {
-    promise.setValue();
   }
 }
 
@@ -341,6 +799,7 @@ void UcxOutputQueue::noMoreDrivers() {
 
 void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
   std::vector<UcxDataAvailable> finished;
+  std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
     if (oneDriverFinished) {
@@ -352,22 +811,32 @@ void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
         "Each driver should call noMoreData exactly once");
     atEnd_ = numFinished_ == numDrivers_;
     if (!atEnd_) {
-      return;
-    }
-    {
-      int64_t avgRows = totalPackedColumnsSent_ > 0
-          ? totalRowsSent_ / totalPackedColumnsSent_
-          : 0;
-      VLOG(1) << "[OUTPUT-STATS] task=" << (task_ ? task_->taskId() : "n/a")
-              << " totalRows=" << totalRowsSent_
-              << " chunks=" << totalPackedColumnsSent_
-              << " avgRowsPerChunk=" << avgRows
-              << " totalBytes=" << totalBytesSent_;
-    }
-    for (auto& queue : queues_) {
-      if (queue != nullptr) {
-        queue->enqueueBack(nullptr);
-        finished.push_back(queue->getAndClearNotify());
+      maybeContinueProducersLocked(promises);
+    } else {
+      // For arbitrary, drain remaining shared pool to destination queues
+      // round-robin before sending end markers.
+      if (kind_ == core::PartitionedOutputNode::Kind::kArbitrary) {
+        int32_t bufferId =
+            queues_.empty() ? 0 : nextArbitraryLoadIndex_ % queues_.size();
+        int32_t nullCount = 0;
+        while (!arbitraryBuffer_.empty() && !queues_.empty()) {
+          auto* queue = queues_[bufferId].get();
+          if (queue != nullptr) {
+            queue->enqueueBack(std::move(arbitraryBuffer_.front()));
+            arbitraryBuffer_.pop_front();
+            nullCount = 0;
+          } else if (++nullCount >= queues_.size()) {
+            arbitraryBuffer_.clear();
+            break;
+          }
+          bufferId = (bufferId + 1) % queues_.size();
+        }
+      }
+      for (auto& queue : queues_) {
+        if (queue != nullptr) {
+          queue->enqueueBack(nullptr);
+          finished.push_back(queue->getAndClearNotify());
+        }
       }
     }
   }
@@ -375,22 +844,114 @@ void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
   for (auto& notification : finished) {
     notification.notify();
   }
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
 }
 
 bool UcxOutputQueue::enqueuePartitionedOutputLocked(
     int destination,
     std::shared_ptr<cudf::packed_columns> data,
-    std::vector<UcxDataAvailable>& dataAvailableCbs) {
+    std::vector<UcxDataAvailable>& dataAvailableCbs,
+    int64_t transferReservationBytes) {
   VELOX_DCHECK(dataAvailableCbs.empty());
   VELOX_CHECK_LT(destination, queues_.size());
   bool success = false;
   auto* queue = queues_[destination].get();
+  releaseTransferReservationLocked(destination, transferReservationBytes);
   if (queue != nullptr) {
     queue->enqueueBack(std::move(data));
     dataAvailableCbs.emplace_back(queue->getAndClearNotify());
     success = true;
   }
   return success;
+}
+
+void UcxOutputQueue::releaseTransferReservationLocked(
+    int destination,
+    int64_t bytes) {
+  if (bytes <= 0) {
+    return;
+  }
+
+  VELOX_CHECK_GE(destination, 0);
+  VELOX_CHECK_LT(destination, transferReservedBytes_.size());
+  if (transferReservedBytes_[destination] < bytes) {
+    transferReservedBytes_[destination] = 0;
+  } else {
+    transferReservedBytes_[destination] -= bytes;
+  }
+}
+
+int64_t UcxOutputQueue::transferWindowBytesLocked(
+    int destination,
+    int64_t baseBytes,
+    int64_t normalBytes,
+    int64_t maxBytes) {
+  VELOX_CHECK_GT(baseBytes, 0);
+  VELOX_CHECK_GE(normalBytes, baseBytes);
+  VELOX_CHECK_GE(maxBytes, normalBytes);
+  VELOX_CHECK_GE(destination, 0);
+  VELOX_CHECK_LT(destination, queues_.size());
+
+  if (destination >= transferWindowBytes_.size()) {
+    transferWindowBytes_.resize(queues_.size(), 0);
+  }
+
+  auto* queue = queues_[destination].get();
+  if (queue == nullptr) {
+    return baseBytes;
+  }
+
+  auto& window = transferWindowBytes_[destination];
+  if (window <= 0) {
+    window = normalBytes;
+  }
+  window = std::clamp<int64_t>(window, baseBytes, maxBytes);
+
+  const auto destinationStats = queue->stats();
+  const auto transferBytes =
+      queue->transferBytes() + transferReservedBytes_[destination];
+  const auto retainedBytes =
+      static_cast<uint64_t>(std::max<int64_t>(retainedBytesLocked(), 0));
+  const bool retainedPressure =
+      maxSize_ > 0 && retainedBytes >= maxSize_ - (maxSize_ / 10);
+
+  if (retainedPressure) {
+    window = baseBytes;
+  } else if (
+      queue->waitingForData() && destinationStats.bytesQueued == 0 &&
+      transferBytes == 0) {
+    window = std::min<int64_t>(
+        maxBytes, std::max<int64_t>(normalBytes, window + baseBytes));
+  } else if (transferBytes < window / 2 && window < normalBytes) {
+    window = std::min<int64_t>(normalBytes, window + baseBytes);
+  }
+
+  return window;
+}
+
+void UcxOutputQueue::collectTransferPromisesLocked(
+    int destination,
+    std::vector<ContinuePromise>& promises) {
+  if (destination < 0 || destination >= transferPromises_.size()) {
+    return;
+  }
+
+  for (auto& promise : transferPromises_[destination]) {
+    promises.push_back(std::move(promise));
+  }
+  transferPromises_[destination].clear();
+}
+
+void UcxOutputQueue::collectAllTransferPromisesLocked(
+    std::vector<ContinuePromise>& promises) {
+  for (auto& destinationPromises : transferPromises_) {
+    for (auto& promise : destinationPromises) {
+      promises.push_back(std::move(promise));
+    }
+    destinationPromises.clear();
+  }
 }
 
 void UcxOutputQueue::enqueueBroadcastOutputLocked(
@@ -411,6 +972,41 @@ void UcxOutputQueue::enqueueBroadcastOutputLocked(
   }
 }
 
+void UcxOutputQueue::enqueueArbitraryOutputLocked(
+    std::shared_ptr<cudf::packed_columns> data,
+    std::vector<UcxDataAvailable>& dataAvailableCbs) {
+  VELOX_DCHECK(dataAvailableCbs.empty());
+
+  arbitraryBuffer_.push_back(std::move(data));
+
+  // Distribute from the shared pool to destinations with waiting consumers,
+  // probing round-robin so no single destination starves.
+  int32_t bufferId =
+      queues_.empty() ? 0 : nextArbitraryLoadIndex_ % queues_.size();
+  for (int32_t i = 0; i < queues_.size(); ++i) {
+    if (arbitraryBuffer_.empty()) {
+      break;
+    }
+    auto* queue = queues_[bufferId].get();
+    if (queue != nullptr) {
+      auto pending = queue->getAndClearNotify();
+      if (pending.callback) {
+        pending.data = std::move(arbitraryBuffer_.front());
+        arbitraryBuffer_.pop_front();
+        pending.remainingBytes.clear();
+        for (const auto& item : arbitraryBuffer_) {
+          if (item != nullptr) {
+            pending.remainingBytes.push_back(item->gpu_data->size());
+          }
+        }
+        dataAvailableCbs.push_back(std::move(pending));
+      }
+    }
+    bufferId = (bufferId + 1) % queues_.size();
+  }
+  nextArbitraryLoadIndex_ = bufferId;
+}
+
 bool UcxOutputQueue::isFinished() {
   std::lock_guard<std::mutex> l(mutex_);
   return isFinishedLocked();
@@ -419,6 +1015,8 @@ bool UcxOutputQueue::isFinished() {
 bool UcxOutputQueue::isFinishedLocked() {
   // For broadcast, we can only be finished after receiving the no more
   // (destination) buffers signal, matching OutputBuffer::isFinishedLocked().
+  // For arbitrary, the coordinator lazily manages consumers and may never send
+  // noMoreBufferIds, so we only check that all queues have been consumed.
   if (kind_ == core::PartitionedOutputNode::Kind::kBroadcast &&
       !noMoreQueues_) {
     return false;
@@ -441,28 +1039,35 @@ void UcxOutputQueue::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
     return;
   }
 
-  VELOX_CHECK_EQ(kind_, Kind::kBroadcast);
+  VELOX_CHECK(kind_ == Kind::kBroadcast || kind_ == Kind::kArbitrary);
   bool isFinished;
   {
     std::lock_guard<std::mutex> l(mutex_);
 
     if (numBuffers > queues_.size()) {
-      // Add new destination queues and backfill with broadcast data.
       int32_t numNewBuffers = numBuffers - queues_.size();
       queues_.reserve(numBuffers);
       for (int32_t i = 0; i < numNewBuffers; ++i) {
         auto buffer = std::make_unique<UcxDestinationQueue>();
-        for (const auto& data : dataToBroadcast_) {
-          buffer->enqueueBack(data);
-          // Account for backfilled data in queuedBytes_ so that dequeue
-          // decrements don't drive it negative.
-          queuedBytes_ += data->gpu_data->size();
-          queuedPackedColumns_++;
+        if (kind_ == Kind::kBroadcast) {
+          // Backfill new destinations with previously broadcast data.
+          for (const auto& data : dataToBroadcast_) {
+            buffer->enqueueBack(data);
+            // Account for backfilled data in queuedBytes_ so that dequeue
+            // decrements don't drive it negative.
+            queuedBytes_ += data->gpu_data->size();
+            queuedPackedColumns_++;
+          }
         }
+        // No backfill for arbitrary. New consumers only get future data, or an
+        // end marker if production already completed.
         if (atEnd_) {
           buffer->enqueueBack(nullptr);
         }
         queues_.emplace_back(std::move(buffer));
+        transferReservedBytes_.push_back(0);
+        transferPromises_.emplace_back();
+        transferWindowBytes_.push_back(0);
       }
     }
 
@@ -484,6 +1089,7 @@ void UcxOutputQueue::deleteResults(int destination) {
   bool isFinished;
   UcxDataAvailable dataAvailable;
   std::vector<ContinuePromise> promises;
+  std::vector<ContinuePromise> transferPromises;
   {
     std::lock_guard<std::mutex> l(mutex_);
     if (destination >= queues_.size()) {
@@ -506,12 +1112,22 @@ void UcxOutputQueue::deleteResults(int destination) {
     isFinished = isFinishedLocked();
     // update UcxOutputQueue stats
     updateStatsWithFreedLocked(bytes, packedCols, promises);
+    if (destination < transferReservedBytes_.size()) {
+      transferReservedBytes_[destination] = 0;
+    }
+    if (destination < transferWindowBytes_.size()) {
+      transferWindowBytes_[destination] = 0;
+    }
+    collectTransferPromisesLocked(destination, transferPromises);
   }
 
   // Outside of mutex.
   dataAvailable.notify();
   // wake up any producers that are waiting for queue to become less full.
   for (auto& promise : promises) {
+    promise.setValue();
+  }
+  for (auto& promise : transferPromises) {
     promise.setValue();
   }
 
@@ -523,12 +1139,14 @@ void UcxOutputQueue::deleteResults(int destination) {
 void UcxOutputQueue::terminate() {
   std::vector<UcxDataAvailable> pendingCallbacks;
   std::vector<ContinuePromise> promises;
+  std::vector<ContinuePromise> transferPromises;
   {
     std::lock_guard<std::mutex> l(mutex_);
     if (task_ && task_->isRunning()) {
       LOG(WARNING) << "UcxOutputQueue::terminate() called while task "
                    << task_->taskId() << " is still running";
     }
+    arbitraryBuffer_.clear();
     // Fire all pending getData callbacks with nullptr to signal end-of-stream.
     // This handles the case where a producer task fails or is cancelled before
     // noMoreData() is called, preventing consumers from being orphaned.
@@ -539,7 +1157,11 @@ void UcxOutputQueue::terminate() {
       }
     }
     // Release any outstanding producer-side promises (blocked on queue-full).
+    reservedBytes_ = 0;
+    std::fill(transferReservedBytes_.begin(), transferReservedBytes_.end(), 0);
+    std::fill(transferWindowBytes_.begin(), transferWindowBytes_.end(), 0);
     promises = std::move(promises_);
+    collectAllTransferPromisesLocked(transferPromises);
   }
 
   // Fire callbacks outside of mutex to avoid potential deadlocks.
@@ -548,6 +1170,9 @@ void UcxOutputQueue::terminate() {
   }
   // Unblock any blocked producers.
   for (auto& promise : promises) {
+    promise.setValue();
+  }
+  for (auto& promise : transferPromises) {
     promise.setValue();
   }
 }
@@ -563,8 +1188,8 @@ exec::OutputBuffer::Stats UcxOutputQueue::stats() {
       noMoreQueues_,
       atEnd_,
       isFinishedLocked(),
-      queuedBytes_,
-      queuedPackedColumns_,
+      retainedBytesLocked(),
+      retainedPackedColumnsLocked(),
       totalBytesSent_,
       totalRowsSent_,
       totalPackedColumnsSent_,
@@ -587,6 +1212,25 @@ void UcxOutputQueue::updateStatsWithEnqueuedLocked(
   totalPackedColumnsSent_++;
 }
 
+void UcxOutputQueue::updateStatsWithDequeuedLocked(
+    int64_t bytes,
+    int64_t numPackedCols,
+    std::vector<ContinuePromise>& promises) {
+  updateTotalQueuedBytesMsLocked();
+
+  queuedBytes_ -= bytes;
+  queuedPackedColumns_ -= numPackedCols;
+  inFlightBytes_ += bytes;
+  inFlightPackedColumns_ += numPackedCols;
+
+  VELOX_CHECK_GE(queuedBytes_, 0);
+  VELOX_CHECK_GE(queuedPackedColumns_, 0);
+  VELOX_CHECK_GE(inFlightBytes_, 0);
+  VELOX_CHECK_GE(inFlightPackedColumns_, 0);
+
+  maybeContinueProducersLocked(promises);
+}
+
 void UcxOutputQueue::updateStatsWithFreedLocked(
     int64_t bytes,
     int64_t numPackedCols,
@@ -601,13 +1245,20 @@ void UcxOutputQueue::updateStatsWithFreedLocked(
 
   // Check whether queue is below low-water mark and return outstanding
   // promises
-  if (queuedBytes_ <= continueSize_ && !promises_.empty()) {
-    VLOG(2) << "[BACKPRESSURE] task=" << (task_ ? task_->taskId() : "n/a")
-            << " UNBLOCKING " << promises_.size() << " producers"
-            << " queuedBytes=" << queuedBytes_
-            << " continueSize=" << continueSize_;
-    promises = std::move(promises_);
-  }
+  maybeContinueProducersLocked(promises);
+}
+
+void UcxOutputQueue::updateStatsWithSendCompleteLocked(
+    int64_t bytes,
+    int64_t numPackedCols,
+    std::vector<ContinuePromise>& promises) {
+  inFlightBytes_ -= bytes;
+  inFlightPackedColumns_ -= numPackedCols;
+
+  VELOX_CHECK_GE(inFlightBytes_, 0);
+  VELOX_CHECK_GE(inFlightPackedColumns_, 0);
+
+  maybeContinueProducersLocked(promises);
 }
 
 void UcxOutputQueue::updateTotalQueuedBytesMsLocked() {
@@ -626,6 +1277,106 @@ int64_t UcxOutputQueue::getAverageQueueTimeMsLocked() const {
   }
 
   return 0;
+}
+
+void UcxOutputQueue::maybeContinueProducersLocked(
+    std::vector<ContinuePromise>& promises) {
+  auto producerBlockedBytes = producerBlockedBytesLocked();
+  auto continueBytes = static_cast<int64_t>(continueSize_);
+  if (fullTransferCongested_ && fullTransferRetainedLimit_ > 0) {
+    const auto retainedBytes = retainedBytesWithTransferReservationsLocked();
+    maybeGrowFullTransferRetainedLimitLocked(retainedBytes);
+    producerBlockedBytes = retainedBytes;
+    continueBytes = fullTransferRetainedLimitLocked();
+  }
+  if (producerBlockedBytes > continueBytes || promises_.empty()) {
+    return;
+  }
+  const auto numProducersToUnblock =
+      producerBlockedBytes == 0 ? promises_.size() : 1;
+  for (size_t i = 0; i < numProducersToUnblock; ++i) {
+    promises.push_back(std::move(promises_[i]));
+  }
+  promises_.erase(promises_.begin(), promises_.begin() + numProducersToUnblock);
+}
+
+int64_t UcxOutputQueue::retainedBytesLocked() const {
+  return reservedBytes_ + queuedBytes_ + inFlightBytes_;
+}
+
+int64_t UcxOutputQueue::producerBlockedBytesLocked() const {
+  return reservedBytes_ + queuedBytes_;
+}
+
+int64_t UcxOutputQueue::retainedPackedColumnsLocked() const {
+  return queuedPackedColumns_ + inFlightPackedColumns_;
+}
+
+int64_t UcxOutputQueue::transferBytesLocked(int destination) const {
+  VELOX_CHECK_GE(destination, 0);
+  VELOX_CHECK_LT(destination, queues_.size());
+  auto* queue = queues_[destination].get();
+  return (queue == nullptr ? 0 : queue->transferBytes()) +
+      transferReservedBytes_[destination];
+}
+
+int64_t UcxOutputQueue::transferReservedBytesLocked() const {
+  int64_t total = 0;
+  for (const auto bytes : transferReservedBytes_) {
+    total = addSaturated(total, std::max<int64_t>(bytes, 0));
+  }
+  return total;
+}
+
+int64_t UcxOutputQueue::retainedBytesWithTransferReservationsLocked() const {
+  return addSaturated(retainedBytesLocked(), transferReservedBytesLocked());
+}
+
+int64_t UcxOutputQueue::activeDestinationCountLocked() const {
+  int64_t count = 0;
+  for (const auto& queue : queues_) {
+    if (queue != nullptr) {
+      ++count;
+    }
+  }
+  return std::max<int64_t>(count, 1);
+}
+
+int64_t UcxOutputQueue::defaultFullTransferRetainedLimitLocked() const {
+  if (maxSize_ == 0) {
+    return 0;
+  }
+  const auto boundedMaxSize = static_cast<int64_t>(std::min<uint64_t>(
+      maxSize_, static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
+  return multiplySaturated(
+      boundedMaxSize, activeDestinationCountLocked());
+}
+
+int64_t UcxOutputQueue::fullTransferRetainedLimitLocked() const {
+  const auto defaultLimit = defaultFullTransferRetainedLimitLocked();
+  if (defaultLimit == 0) {
+    return 0;
+  }
+  if (fullTransferRetainedLimit_ <= 0) {
+    return defaultLimit;
+  }
+  return std::max<int64_t>(1, fullTransferRetainedLimit_);
+}
+
+void UcxOutputQueue::maybeGrowFullTransferRetainedLimitLocked(
+    int64_t retainedBytes) {
+  if (maxSize_ == 0 || !fullTransferCongested_ ||
+      fullTransferRetainedLimit_ <= 0) {
+    return;
+  }
+
+  if (retainedBytes <= fullTransferRetainedLimit_ / 2) {
+    const auto boundedMaxSize = static_cast<int64_t>(std::min<uint64_t>(
+        maxSize_, static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
+    const auto increment = std::max<int64_t>(1, boundedMaxSize);
+    fullTransferRetainedLimit_ =
+        addSaturated(fullTransferRetainedLimit_, increment);
+  }
 }
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxQueues.h
+++ b/velox/experimental/ucx-exchange/UcxQueues.h
@@ -17,9 +17,12 @@
 
 #include <cudf/contiguous_split.hpp>
 #include <atomic>
+#include <cstddef>
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <string>
 #include <vector>
 #include "velox/core/PlanNode.h"
 #include "velox/exec/OutputBuffer.h" // for the Stats structure
@@ -37,6 +40,15 @@ using UcxDataAvailableCallback = std::function<void(
     std::shared_ptr<cudf::packed_columns> data,
     std::vector<int64_t> remainingBytes)>;
 
+struct UcxDestinationTransferStats {
+  int64_t bytesQueued{0};
+  int64_t bytesInFlight{0};
+  int64_t bytesReserved{0};
+  int64_t retainedBytes{0};
+  int64_t maxBytes{0};
+  bool waitingForData{false};
+};
+
 struct UcxDataAvailable {
   UcxDataAvailableCallback callback{nullptr};
   std::shared_ptr<cudf::packed_columns> data;
@@ -44,7 +56,7 @@ struct UcxDataAvailable {
 
   void notify() {
     if (callback) {
-      callback(std::move(data), remainingBytes);
+      callback(std::move(data), std::move(remainingBytes));
     }
   }
 };
@@ -65,6 +77,11 @@ class UcxDestinationQueue {
     // what has been queued
     int64_t bytesQueued{0};
     int64_t packedColumnsQueued{0};
+
+    // What has left this destination queue but is still retained by a server
+    // send or intra-node handoff.
+    int64_t bytesInFlight{0};
+    int64_t packedColumnsInFlight{0};
 
     // what has been dequeued
     int64_t bytesSent{0};
@@ -106,6 +123,16 @@ class UcxDestinationQueue {
 
   /// Returns the stats of this buffer.
   Stats stats() const;
+
+  /// Returns bytes queued or in-flight for this destination.
+  int64_t transferBytes() const;
+
+  /// Returns true when a server has asked for data and is waiting for the next
+  /// enqueue to satisfy that request.
+  bool waitingForData() const;
+
+  /// Marks bytes for this destination as no longer in-flight.
+  void releaseInFlight(int64_t bytes, int64_t numPackedCols);
 
   std::string toString();
 
@@ -182,13 +209,92 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   void enqueue(
       int destination,
       std::unique_ptr<cudf::packed_columns> data,
-      int32_t numRows);
+      int32_t numRows,
+      int64_t transferReservationBytes = 0);
 
   /// @brief Checks if the queue is over capacity and returns a future if so.
-  /// This should be called after enqueueing all partitions for a batch.
+  /// Producers call this before accepting more input and after enqueueing a
+  /// batch.
   /// @param future Output parameter - populated with a future if blocked.
   /// @return True if blocked (queue over capacity), false otherwise.
   bool checkBlocked(ContinueFuture* future);
+
+  /// @brief Checks if queued/in-flight transfer bytes exceed the active
+  /// producer's drain window. Unlike checkBlocked(), this intentionally ignores
+  /// producer-side reserved bytes so the active producer can pause while
+  /// holding a materialized partitioned table without deadlocking on its own
+  /// reservation.
+  bool checkTransferCapacity(
+      int destination,
+      int64_t maxBytes,
+      ContinueFuture* future);
+
+  /// @brief Reserves destination-local transfer capacity before the producer
+  /// allocates a GPU payload for that destination.
+  bool reserveTransferBytes(
+      int destination,
+      int64_t bytes,
+      int64_t maxBytes,
+      ContinueFuture* future);
+
+  /// @brief Reserves capacity for a full contiguous_split payload. This uses a
+  /// task-wide retained-byte budget plus a destination fairness budget, so
+  /// receivers can build backlog for throughput without allowing unbounded GPU
+  /// retention.
+  bool reserveFullTransferBytes(
+      int destination,
+      int64_t bytes,
+      ContinueFuture* future);
+
+  /// @brief Blocks until the learned full-transfer retained-byte window has
+  /// room. Does not reserve bytes.
+  bool waitForFullTransferCapacity(int64_t bytes, ContinueFuture* future);
+
+  /// @brief Releases destination-local transfer capacity.
+  void releaseTransferReservation(int destination, int64_t bytes);
+
+  /// Returns the destination-local byte admission window for the next GPU
+  /// payload. The queue owns this feedback state so parallel producers share
+  /// the same congestion signal for a destination.
+  int64_t transferWindowBytes(
+      int destination,
+      int64_t baseBytes,
+      int64_t normalBytes,
+      int64_t maxBytes);
+
+  /// Records a failed allocation/admission probe and reduces the destination
+  /// admission window.
+  void recordTransferCongestion(int destination, int64_t baseBytes);
+
+  /// Records a larger payload demand that did not fit the current window. This
+  /// is not congestion: it is a signal to probe the destination window upward.
+  void recordTransferDemand(
+      int destination,
+      int64_t targetBytes,
+      int64_t baseBytes,
+      int64_t maxBytes);
+
+  /// Records GPU allocation/admission pressure from the full contiguous_split
+  /// path and lowers the learned retained-byte high watermark.
+  void recordFullTransferCongestion();
+
+  /// Returns transfer pressure for one destination. The snapshot is used by
+  /// producers to tune their admission window without exposing the queue lock.
+  UcxDestinationTransferStats transferStats(int destination);
+
+  /// @brief Reserves producer-side bytes before GPU output materialization.
+  /// Returns true and populates 'future' if accepting this reservation would
+  /// exceed the retained-byte budget.
+  bool reserveOutputBytes(int64_t bytes, ContinueFuture* future);
+
+  /// @brief Releases a producer-side byte reservation.
+  void releaseOutputReservation(int64_t bytes);
+
+  /// @brief Releases bytes retained by an in-flight exchange transfer.
+  void releaseInFlightBytes(
+      int destination,
+      int64_t bytes,
+      int64_t numPackedCols);
 
   /// @brief Returns the data for the given destination through the callback
   /// function. If data is available, notify will be called immediately. If
@@ -236,7 +342,15 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   // Methods that update the statistics.
   void updateStatsWithEnqueuedLocked(int64_t bytes, int64_t rows);
 
-  // updates the counters and returns promises if the queuedBytes_ counter falls
+  // Moves queued bytes into the in-flight transfer accounting. The data has
+  // left a destination queue, but UCX or the intra-node transfer registry still
+  // owns a reference to the packed columns.
+  void updateStatsWithDequeuedLocked(
+      int64_t bytes,
+      int64_t numPackedCols,
+      std::vector<ContinuePromise>& promises);
+
+  // updates the counters and returns promises if retained output bytes fall
   // below the continueSize_ low water mark. These promises then need to be
   // realized outside the lock.
   void updateStatsWithFreedLocked(
@@ -244,9 +358,36 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
       int64_t numPackedCols,
       std::vector<ContinuePromise>& promises);
 
+  void updateStatsWithSendCompleteLocked(
+      int64_t bytes,
+      int64_t numPackedCols,
+      std::vector<ContinuePromise>& promises);
+
   void updateTotalQueuedBytesMsLocked();
 
   int64_t getAverageQueueTimeMsLocked() const;
+
+  void maybeContinueProducersLocked(std::vector<ContinuePromise>& promises);
+
+  int64_t retainedBytesLocked() const;
+
+  int64_t producerBlockedBytesLocked() const;
+
+  int64_t retainedPackedColumnsLocked() const;
+
+  int64_t transferBytesLocked(int destination) const;
+
+  int64_t transferReservedBytesLocked() const;
+
+  int64_t retainedBytesWithTransferReservationsLocked() const;
+
+  int64_t activeDestinationCountLocked() const;
+
+  int64_t defaultFullTransferRetainedLimitLocked() const;
+
+  int64_t fullTransferRetainedLimitLocked() const;
+
+  void maybeGrowFullTransferRetainedLimitLocked(int64_t retainedBytes);
 
   // internal function that is called when all drivers are done.
   void noMoreDrivers();
@@ -259,9 +400,28 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   bool enqueuePartitionedOutputLocked(
       int destination,
       std::shared_ptr<cudf::packed_columns> data,
-      std::vector<UcxDataAvailable>& dataAvailableCbs);
+      std::vector<UcxDataAvailable>& dataAvailableCbs,
+      int64_t transferReservationBytes);
+
+  void releaseTransferReservationLocked(int destination, int64_t bytes);
+
+  int64_t transferWindowBytesLocked(
+      int destination,
+      int64_t baseBytes,
+      int64_t normalBytes,
+      int64_t maxBytes);
+
+  void collectTransferPromisesLocked(
+      int destination,
+      std::vector<ContinuePromise>& promises);
+
+  void collectAllTransferPromisesLocked(std::vector<ContinuePromise>& promises);
 
   void enqueueBroadcastOutputLocked(
+      std::shared_ptr<cudf::packed_columns> data,
+      std::vector<UcxDataAvailable>& dataAvailableCbs);
+
+  void enqueueArbitraryOutputLocked(
       std::shared_ptr<cudf::packed_columns> data,
       std::vector<UcxDataAvailable>& dataAvailableCbs);
 
@@ -280,6 +440,13 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   // For broadcast: stores data for late-arriving destinations that need
   // backfill. Cleared once noMoreQueues_ is set.
   std::vector<std::shared_ptr<cudf::packed_columns>> dataToBroadcast_;
+
+  // For arbitrary: shared pool of data that any consumer can pull from.
+  std::deque<std::shared_ptr<cudf::packed_columns>> arbitraryBuffer_;
+
+  // For arbitrary: round-robin index for distributing data to waiting
+  // consumers.
+  int32_t nextArbitraryLoadIndex_{0};
 
   /// If 'queuedBytes_' > 'maxSize_', each producer is blocked after adding
   /// data.
@@ -311,9 +478,43 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   // promises when buffer reached capacity and blocked further enqueueing.
   std::vector<ContinuePromise> promises_;
 
-  // actual data in 'queues_'
+  // Promises for active producers waiting for queued/in-flight UCX transfer
+  // bytes to drop on a specific destination. Kept separate from promises_
+  // because producer-side reservations remain held while a partitioned batch is
+  // partially drained.
+  std::vector<std::vector<ContinuePromise>> transferPromises_;
+
+  // Bytes admitted for destination-local transfer but not yet enqueued. This
+  // prevents multiple producers from simultaneously allocating fast-path
+  // payloads against the same apparent destination capacity.
+  std::vector<int64_t> transferReservedBytes_;
+
+  // Destination-local adaptive payload windows. These are logical admission
+  // windows, not GPU-size constants: they grow when consumers are starved and
+  // decay when retained/queued/in-flight pressure appears.
+  std::vector<int64_t> transferWindowBytes_;
+
+  // Learned task-wide retained-byte high watermark for full contiguous_split
+  // payloads. Zero means use the initial window derived from the output buffer
+  // size and number of active destinations. Before the first allocation or
+  // admission pressure signal, the full split path may grow beyond this initial
+  // window to probe available hardware headroom. After pressure, this becomes a
+  // congestion window that gates later full-split reservations.
+  int64_t fullTransferRetainedLimit_{0};
+  bool fullTransferCongested_{false};
+
+  // Bytes reserved by producers before GPU materialization is visible in the
+  // destination queues.
+  int64_t reservedBytes_{0};
+
+  // Bytes retained by destination queues.
   int64_t queuedBytes_{0};
   int64_t queuedPackedColumns_{0};
+
+  // Bytes already dequeued by servers but still retained by UCX sends or the
+  // intra-node transfer registry.
+  int64_t inFlightBytes_{0};
+  int64_t inFlightPackedColumns_{0};
 
   // The total number of bytes/rows/packedColumns sent via this output queue.
   int64_t totalBytesSent_{0};
@@ -322,10 +523,10 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
 
   // Time since last change in queuedBytes_. Used to compute total time data
   // is queued. Ignored if queuedBytes_ is zero.
-  uint64_t queueStartMs_;
+  uint64_t queueStartMs_{0};
 
   // Total time data is queued as bytes * time.
-  double totalQueuedBytesMs_;
+  double totalQueuedBytesMs_{0};
 };
 
 } // namespace facebook::velox::ucx_exchange


### PR DESCRIPTION
This is a staging PR for cbd87aa83764adb186a14019525c98a01ec0b958 from kjmph/velox, cherry-picked onto current main with conflicts resolved.

We do not intend to use this commit as-is. The goal is to preserve the resolved state in a draft PR so the useful pieces can be inspected, picked apart, and/or reimplemented as separate focused commits.

Conflict-resolution notes:
- Adapted the old ExchangeClient metadata changes onto current InMemoryExchangeClient.
- Kept the current ExchangeClient compatibility alias instead of resurrecting the old class.
- Preserved current main's deletion of obsolete CPU-row UCX files.
- Added the UCX/cuDF driver adapter header and CMake source wiring needed by the picked implementation.

Validation:
- git diff --check upstream/main..HEAD