### PR TITLE
feat(writer): Add nimble.feature.ordering.override SerDe key (#18849)

### DIFF
--- a/velox/dwio/nimble/velox/NimbleConfig.cpp
+++ b/velox/dwio/nimble/velox/NimbleConfig.cpp
@@ -389,6 +389,10 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     "nimble.encoding.enable_selection_cache",
     false);
 
+/* static */ Config::Entry<std::string> Config::FEATURE_ORDERING_OVERRIDE(
+    "feature.ordering.override",
+    "");
+
 // Defaults match the corresponding WriterOptions fields, so an absent key
 // leaves the writer exactly where it was. METADATA_COMPRESSION_THRESHOLD is the
 // exception: WriterOptions holds an optional and the writer substitutes its own

--- a/velox/dwio/nimble/velox/NimbleConfig.h
+++ b/velox/dwio/nimble/velox/NimbleConfig.h
@@ -181,6 +181,16 @@ class Config : public velox::config::ConfigBase {
   /// first encoding of each stream and replay it on subsequent chunks/stripes.
   static Entry<bool> ENABLE_ENCODING_SELECTION_CACHE;
 
+  /// Groups and orders FlatMap features on disk so features read together are
+  /// physically adjacent. Base64 of a compact-serialized
+  /// Apache::Hadoop::Hive::FeatureOrdering, whose column ids are top-level
+  /// ordinals in the write input schema.
+  ///
+  /// Overrides WriterOptions::featureReordering when set; leaves it alone when
+  /// unset, so a caller that resolved an order elsewhere keeps it.
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static Entry<std::string> FEATURE_ORDERING_OVERRIDE;
+
   /// Compresses stripe-group metadata only when it exceeds this many bytes.
   /// Unset leaves the writer's own threshold; UINT32_MAX disables metadata
   /// compression outright.


### PR DESCRIPTION
Summary:

Adding nimble feature ordering override key

| Key | Type | `WriterOptions` field | Default |
|---|---|---|---|
| `nimble.feature.ordering.override` | base64 `FeatureOrdering` | `featureReordering` | unset -> caller's value is left alone |

The value is base64 of a compact-serialized `Apache::Hadoop::Hive::FeatureOrdering`:
one entry per FlatMap column, each carrying that column's top-level ordinal in
the write input schema and its feature ids in layout order. `Writer` remaps the
ordinals when cluster index key columns are omitted from storage.

**`.override` is the operative part of the name.** When the key is set it
replaces whatever `WriterOptions::featureReordering` already held; when it is
unset it leaves that value alone rather than clearing it. That matters because a
caller can already resolve an order some other way.

The metastore struct is reused rather than a bespoke spelling so a feature order
has one representation across writers. `tools/fb/NimbleTransform.cpp` and
`tools/fb/DwrfTransform.cpp` already build the same struct from
`--serialized_feature_order`.

Reviewed By: HuamengJiang

Differential Revision: D118663098


