### PR TITLE
feat(hive): Add physicalFilePath to FileConnectorSplit (#18850)

### DIFF
--- a/velox/connectors/hive/FileConnectorSplit.h
+++ b/velox/connectors/hive/FileConnectorSplit.h
@@ -29,7 +29,14 @@ namespace facebook::velox::connector::hive {
 /// HiveIcebergSplit) extend this to add synthesized columns, serde parameters,
 /// and other format-specific fields.
 struct FileConnectorSplit : public ConnectorSplit {
+  /// Identity of the file this split covers. Use it to name the file; use
+  /// readPath() to open it.
   const std::string filePath;
+
+  /// Alternate location holding the same content as 'filePath', opened in its
+  /// place. Empty when there is none. The split builders set it.
+  std::string physicalFilePath;
+
   dwio::common::FileFormat fileFormat;
   const uint64_t start;
   const uint64_t length;
@@ -73,6 +80,11 @@ struct FileConnectorSplit : public ConnectorSplit {
 
   uint64_t size() const override {
     return length;
+  }
+
+  /// Location to open to read this split's bytes.
+  const std::string& readPath() const {
+    return physicalFilePath.empty() ? filePath : physicalFilePath;
   }
 
   std::string getFileName() const {

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -19,15 +19,20 @@
 namespace facebook::velox::connector::hive {
 
 std::string HiveConnectorSplit::toString() const {
+  const std::string physicalPath = physicalFilePath.empty()
+      ? ""
+      : fmt::format(" read from {}", physicalFilePath);
   if (tableBucketNumber.has_value()) {
     return fmt::format(
-        "Hive: {} {} - {} {}",
+        "Hive: {} {} - {} {}{}",
         filePath,
         start,
         length,
-        tableBucketNumber.value());
+        tableBucketNumber.value(),
+        physicalPath);
   }
-  return fmt::format("Hive: {} {} - {}", filePath, start, length);
+  return fmt::format(
+      "Hive: {} {} - {}{}", filePath, start, length, physicalPath);
 }
 
 folly::dynamic HiveConnectorSplit::serialize() const {
@@ -102,6 +107,9 @@ folly::dynamic HiveConnectorSplit::serialize() const {
   if (columnMappingMode.has_value()) {
     obj["columnMappingMode"] =
         dwio::common::ColumnMappingModeName::toName(*columnMappingMode);
+  }
+  if (!physicalFilePath.empty()) {
+    obj["physicalFilePath"] = physicalFilePath;
   }
 
   return obj;
@@ -195,7 +203,7 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
     columnMappingMode = *parsedColumnMappingMode;
   }
 
-  return std::make_shared<HiveConnectorSplit>(
+  auto split = std::make_shared<HiveConnectorSplit>(
       connectorId,
       filePath,
       fileFormat,
@@ -213,6 +221,10 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
       rowIdProperties,
       bucketConversion,
       columnMappingMode);
+  if (auto it = obj.find("physicalFilePath"); it != obj.items().end()) {
+    split->physicalFilePath = it->second.asString();
+  }
+  return split;
 }
 
 // static

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -210,6 +210,11 @@ class HiveConnectorSplitBuilder {
     return *this;
   }
 
+  HiveConnectorSplitBuilder& physicalFilePath(std::string path) {
+    physicalFilePath_ = std::move(path);
+    return *this;
+  }
+
   std::shared_ptr<connector::hive::HiveConnectorSplit> build() const {
     auto split = std::make_shared<connector::hive::HiveConnectorSplit>(
         connectorId_,
@@ -230,11 +235,13 @@ class HiveConnectorSplitBuilder {
         bucketConversion_,
         columnMappingMode_);
     split->batchSizeHint = batchSizeHint_;
+    split->physicalFilePath = physicalFilePath_;
     return split;
   }
 
  private:
   const std::string filePath_;
+  std::string physicalFilePath_;
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   uint64_t start_{0};
   uint64_t length_{std::numeric_limits<uint64_t>::max()};

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -104,7 +104,7 @@ HiveIcebergSplit::HiveIcebergSplit(
       identityPartitionKeys(identityPartitionKeys) {}
 
 std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
-  return std::make_shared<HiveIcebergSplit>(
+  auto split = std::make_shared<HiveIcebergSplit>(
       connectorId_,
       filePath_,
       fileFormat_,
@@ -121,5 +121,7 @@ std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
       dataSequenceNumber_,
       identityPartitionKeys_,
       columnMappingMode_);
+  split->physicalFilePath = physicalFilePath_;
+  return split;
 }
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -155,6 +155,11 @@ class IcebergSplitBuilder {
     return *this;
   }
 
+  IcebergSplitBuilder& physicalFilePath(std::string path) {
+    physicalFilePath_ = std::move(path);
+    return *this;
+  }
+
   IcebergSplitBuilder& columnMappingMode(dwio::common::ColumnMappingMode mode) {
     columnMappingMode_ = mode;
     return *this;
@@ -164,6 +169,7 @@ class IcebergSplitBuilder {
 
  private:
   const std::string filePath_;
+  std::string physicalFilePath_;
   std::string connectorId_;
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   uint64_t start_{0};

--- a/velox/connectors/hive/tests/FileConnectorSplitTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorSplitTest.cpp
@@ -74,6 +74,30 @@ TEST(FileConnectorSplitTest, getFileNameNoSlash) {
   EXPECT_EQ(split.getFileName(), "file.orc");
 }
 
+TEST(FileConnectorSplitTest, readPathDefaultsToFilePath) {
+  FileConnectorSplit split(
+      "connectorId",
+      "/path/to/file.parquet",
+      dwio::common::FileFormat::PARQUET);
+
+  EXPECT_TRUE(split.physicalFilePath.empty());
+  EXPECT_EQ(split.readPath(), "/path/to/file.parquet");
+}
+
+TEST(FileConnectorSplitTest, readPathUsesPhysicalFilePath) {
+  FileConnectorSplit split(
+      "connectorId",
+      "/path/to/file.parquet",
+      dwio::common::FileFormat::PARQUET);
+  split.physicalFilePath = "/replica/to/file.parquet";
+
+  EXPECT_EQ(split.readPath(), "/replica/to/file.parquet");
+
+  // Identity and everything derived from it stay on 'filePath'.
+  EXPECT_EQ(split.filePath, "/path/to/file.parquet");
+  EXPECT_EQ(split.getFileName(), "file.parquet");
+}
+
 TEST(FileConnectorSplitTest, fileProperties) {
   FileProperties props = {.fileSize = 1024, .modificationTime = 999};
   FileConnectorSplit split(

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -335,6 +335,15 @@ TEST_F(HiveConnectorSerDeTest, hiveConnectorSplit) {
   handles.push_back(makeColumnHandle("c0", INTEGER(), {}));
   split3.bucketConversion = {16, 2, std::move(handles)};
   testSerde(split3);
+
+  auto split4 = HiveConnectorSplit(connectorId, filePath, fileFormat);
+  split4.physicalFilePath = "/testSerde/replica/p";
+  testSerde(split4);
+  const auto clone4 =
+      ISerializable::deserialize<HiveConnectorSplit>(split4.serialize());
+  ASSERT_EQ(clone4->physicalFilePath, split4.physicalFilePath);
+  ASSERT_EQ(clone4->readPath(), split4.physicalFilePath);
+  ASSERT_EQ(clone4->filePath, filePath);
 }
 
 TEST_F(HiveConnectorSerDeTest, hiveConnectorSplitFileProperties) {


### PR DESCRIPTION
Summary:

A split's path does two jobs today. It names the file — delete-file matching, `$path`, row lineage, reporting — and it is also the location the reader opens. A reader that could fetch the same content from a cheaper location, such as a nearer replica, has no way to say so except by rewriting `filePath`, which silently changes the identity as well. Iceberg positional deletes make that concrete: the delete file records the canonical data-file path and is matched by exact string equality, so a rewritten `filePath` matches nothing and every delete is dropped without an error.

`FileConnectorSplit` gains a `physicalFilePath` and a `readPath()` accessor that returns it when non-empty and `filePath` otherwise. `filePath` keeps its current meaning and stays `const`. Nothing reads the new field yet, so a split behaves exactly as before unless a producer sets it.

The field is a `std::string` rather than an optional so that "no alternate location" has one representation instead of two; an engaged-but-empty optional would otherwise yield an empty read path. It is assignable after construction, matching `batchSizeHint`, because the location is chosen once the rest of the split is known. Both the Hive and Iceberg split builders take it, so raw assignment is the exception rather than the normal path.

`HiveConnectorSplit` carries it through `serialize()`, `create()` and `toString()`. The existing round-trip test compares `toString()`, so including it there is what keeps the field covered as the struct evolves. This does not make Iceberg splits round-trip: `HiveConnectorSplit::create` always returns a plain `HiveConnectorSplit`, so `deleteFiles`, `dataSequenceNumber` and `identityPartitionKeys` are already dropped today. That is pre-existing and deliberately left alone here.

Differential Revision: D118761869


