### PR TITLE
feat(hive): Open a split's bytes from readPath()

### DIFF
--- a/velox/connectors/hive/FileConnectorSplit.h
+++ b/velox/connectors/hive/FileConnectorSplit.h
@@ -29,7 +29,14 @@ namespace facebook::velox::connector::hive {
 /// HiveIcebergSplit) extend this to add synthesized columns, serde parameters,
 /// and other format-specific fields.
 struct FileConnectorSplit : public ConnectorSplit {
+  /// Identity of the file this split covers. Use it to name the file; use
+  /// readPath() to open it.
   const std::string filePath;
+
+  /// Alternate location holding the same content as 'filePath', opened in its
+  /// place. Empty when there is none. The split builders set it.
+  std::string physicalFilePath;
+
   dwio::common::FileFormat fileFormat;
   const uint64_t start;
   const uint64_t length;
@@ -73,6 +80,11 @@ struct FileConnectorSplit : public ConnectorSplit {
 
   uint64_t size() const override {
     return length;
+  }
+
+  /// Location to open to read this split's bytes.
+  const std::string& readPath() const {
+    return physicalFilePath.empty() ? filePath : physicalFilePath;
   }
 
   std::string getFileName() const {

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -263,7 +263,7 @@ std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   VELOX_CHECK_NULL(readerOpts.randomSkip());
 
   FileHandleKey fileHandleKey{
-      .filename = hiveSplit_->filePath,
+      .filename = hiveSplit_->readPath(),
       .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
 
   auto fileProperties = hiveSplit_->properties.value_or(FileProperties{});

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -223,7 +223,7 @@ void FileSplitReader::createReader(
 
   FileHandleCachedPtr fileHandleCachePtr;
   FileHandleKey fileHandleKey{
-      .filename = fileSplit_->filePath,
+      .filename = fileSplit_->readPath(),
       .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
 
   auto fileProperties = fileSplit_->properties.value_or(FileProperties{});

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -19,15 +19,20 @@
 namespace facebook::velox::connector::hive {
 
 std::string HiveConnectorSplit::toString() const {
+  const std::string physicalPath = physicalFilePath.empty()
+      ? ""
+      : fmt::format(" read from {}", physicalFilePath);
   if (tableBucketNumber.has_value()) {
     return fmt::format(
-        "Hive: {} {} - {} {}",
+        "Hive: {} {} - {} {}{}",
         filePath,
         start,
         length,
-        tableBucketNumber.value());
+        tableBucketNumber.value(),
+        physicalPath);
   }
-  return fmt::format("Hive: {} {} - {}", filePath, start, length);
+  return fmt::format(
+      "Hive: {} {} - {}{}", filePath, start, length, physicalPath);
 }
 
 folly::dynamic HiveConnectorSplit::serialize() const {
@@ -102,6 +107,9 @@ folly::dynamic HiveConnectorSplit::serialize() const {
   if (columnMappingMode.has_value()) {
     obj["columnMappingMode"] =
         dwio::common::ColumnMappingModeName::toName(*columnMappingMode);
+  }
+  if (!physicalFilePath.empty()) {
+    obj["physicalFilePath"] = physicalFilePath;
   }
 
   return obj;
@@ -195,7 +203,7 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
     columnMappingMode = *parsedColumnMappingMode;
   }
 
-  return std::make_shared<HiveConnectorSplit>(
+  auto split = std::make_shared<HiveConnectorSplit>(
       connectorId,
       filePath,
       fileFormat,
@@ -213,6 +221,10 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
       rowIdProperties,
       bucketConversion,
       columnMappingMode);
+  if (auto it = obj.find("physicalFilePath"); it != obj.items().end()) {
+    split->physicalFilePath = it->second.asString();
+  }
+  return split;
 }
 
 // static

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -210,6 +210,11 @@ class HiveConnectorSplitBuilder {
     return *this;
   }
 
+  HiveConnectorSplitBuilder& physicalFilePath(std::string path) {
+    physicalFilePath_ = std::move(path);
+    return *this;
+  }
+
   std::shared_ptr<connector::hive::HiveConnectorSplit> build() const {
     auto split = std::make_shared<connector::hive::HiveConnectorSplit>(
         connectorId_,
@@ -230,11 +235,13 @@ class HiveConnectorSplitBuilder {
         bucketConversion_,
         columnMappingMode_);
     split->batchSizeHint = batchSizeHint_;
+    split->physicalFilePath = physicalFilePath_;
     return split;
   }
 
  private:
   const std::string filePath_;
+  std::string physicalFilePath_;
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   uint64_t start_{0};
   uint64_t length_{std::numeric_limits<uint64_t>::max()};

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -104,7 +104,7 @@ HiveIcebergSplit::HiveIcebergSplit(
       identityPartitionKeys(identityPartitionKeys) {}
 
 std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
-  return std::make_shared<HiveIcebergSplit>(
+  auto split = std::make_shared<HiveIcebergSplit>(
       connectorId_,
       filePath_,
       fileFormat_,
@@ -121,5 +121,7 @@ std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
       dataSequenceNumber_,
       identityPartitionKeys_,
       columnMappingMode_);
+  split->physicalFilePath = physicalFilePath_;
+  return split;
 }
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -155,6 +155,11 @@ class IcebergSplitBuilder {
     return *this;
   }
 
+  IcebergSplitBuilder& physicalFilePath(std::string path) {
+    physicalFilePath_ = std::move(path);
+    return *this;
+  }
+
   IcebergSplitBuilder& columnMappingMode(dwio::common::ColumnMappingMode mode) {
     columnMappingMode_ = mode;
     return *this;
@@ -164,6 +169,7 @@ class IcebergSplitBuilder {
 
  private:
   const std::string filePath_;
+  std::string physicalFilePath_;
   std::string connectorId_;
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   uint64_t start_{0};

--- a/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
@@ -443,6 +443,41 @@ TEST_F(
       {2, 5, 7});
 }
 
+// Positional deletes match the data file by its recorded path, so redirecting
+// the read must not change which deletes apply. The replica holds different
+// values, so the returned rows show which file was opened.
+TEST_F(IcebergPositionalDeleteTest, readsPhysicalFileButDeletesKeyOffFilePath) {
+  auto dataFilePath = writeBigintDataFile({0, 1, 2, 3, 4});
+  auto replicaFilePath = writeBigintDataFile({5, 6, 7, 8, 9});
+
+  auto deleteFilePath = TempFilePath::create();
+  auto deleteFile =
+      makePositionalDeleteFile(dataFilePath->getPath(), {1, 3}, deleteFilePath);
+
+  // Real replicas are byte-identical; these two are not, so size the split to
+  // cover both.
+  auto split = IcebergSplitBuilder(dataFilePath->getPath())
+                   .connectorId(test::kIcebergConnectorId)
+                   .fileFormat(fileFormat_)
+                   .length(
+                       std::max(
+                           getFileSize(dataFilePath->getPath()),
+                           getFileSize(replicaFilePath->getPath())))
+                   .deleteFiles({deleteFile})
+                   .physicalFilePath(replicaFilePath->getPath())
+                   .build();
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector({makeFlatVector<int64_t>({5, 7, 9})});
+  exec::test::AssertQueryBuilder(plan).splits({split}).assertResults(
+      {expected});
+}
+
 TEST_F(IcebergPositionalDeleteTest, positionalDeletesMultipleSplits) {
   assertMultipleSplits(
       {1, 2, 3, 4},

--- a/velox/connectors/hive/tests/FileConnectorSplitTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorSplitTest.cpp
@@ -74,6 +74,30 @@ TEST(FileConnectorSplitTest, getFileNameNoSlash) {
   EXPECT_EQ(split.getFileName(), "file.orc");
 }
 
+TEST(FileConnectorSplitTest, readPathDefaultsToFilePath) {
+  FileConnectorSplit split(
+      "connectorId",
+      "/path/to/file.parquet",
+      dwio::common::FileFormat::PARQUET);
+
+  EXPECT_TRUE(split.physicalFilePath.empty());
+  EXPECT_EQ(split.readPath(), "/path/to/file.parquet");
+}
+
+TEST(FileConnectorSplitTest, readPathUsesPhysicalFilePath) {
+  FileConnectorSplit split(
+      "connectorId",
+      "/path/to/file.parquet",
+      dwio::common::FileFormat::PARQUET);
+  split.physicalFilePath = "/replica/to/file.parquet";
+
+  EXPECT_EQ(split.readPath(), "/replica/to/file.parquet");
+
+  // Identity and everything derived from it stay on 'filePath'.
+  EXPECT_EQ(split.filePath, "/path/to/file.parquet");
+  EXPECT_EQ(split.getFileName(), "file.parquet");
+}
+
 TEST(FileConnectorSplitTest, fileProperties) {
   FileProperties props = {.fileSize = 1024, .modificationTime = 999};
   FileConnectorSplit split(

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -335,6 +335,15 @@ TEST_F(HiveConnectorSerDeTest, hiveConnectorSplit) {
   handles.push_back(makeColumnHandle("c0", INTEGER(), {}));
   split3.bucketConversion = {16, 2, std::move(handles)};
   testSerde(split3);
+
+  auto split4 = HiveConnectorSplit(connectorId, filePath, fileFormat);
+  split4.physicalFilePath = "/testSerde/replica/p";
+  testSerde(split4);
+  const auto clone4 =
+      ISerializable::deserialize<HiveConnectorSplit>(split4.serialize());
+  ASSERT_EQ(clone4->physicalFilePath, split4.physicalFilePath);
+  ASSERT_EQ(clone4->readPath(), split4.physicalFilePath);
+  ASSERT_EQ(clone4->filePath, filePath);
 }
 
 TEST_F(HiveConnectorSerDeTest, hiveConnectorSplitFileProperties) {


### PR DESCRIPTION
Summary:
A split whose `physicalFilePath` is set now reads its bytes from that location instead of `filePath`. Producers that know of a cheaper copy of the same content — a nearer replica, for instance — can point the reader at it without disturbing anything that treats the path as the file's name. Nothing sets the field today, so this changes no behavior on its own.

The file-handle key is the only thing that moves to `readPath()`. Everything else keeps reading `filePath`, which is what makes Iceberg positional deletes keep working: the delete file records the canonical data-file path and is matched against the split by exact string equality, so the redirect has to stay invisible to it.

Differential Revision: D118761871


