### PR TITLE
feat(hive): Fall back to filePath when a physical path fails to open

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -62,6 +62,12 @@ void registerVeloxMetrics() {
       99,
       100);
 
+  // Tracks splits whose 'physicalFilePath' failed to open, falling back to
+  // 'filePath'.
+  DEFINE_METRIC(
+      kMetricHiveSplitPhysicalPathFallbackCount,
+      facebook::velox::StatType::COUNT);
+
   DEFINE_METRIC(kMetricCacheShrinkCount, facebook::velox::StatType::COUNT);
 
   // Tracks cache shrink latency in range of [0, 100s] with 10 buckets and

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -26,6 +26,9 @@ void registerVeloxMetrics();
 constexpr std::string_view kMetricHiveFileHandleGenerateLatencyMs{
     "velox.hive_file_handle_generate_latency_ms"};
 
+constexpr std::string_view kMetricHiveSplitPhysicalPathFallbackCount{
+    "velox.hive_split_physical_path_fallback_count"};
+
 constexpr std::string_view kMetricCacheShrinkCount{"velox.cache_shrink_count"};
 
 constexpr std::string_view kMetricCacheShrinkTimeMs{"velox.cache_shrink_ms"};

--- a/velox/connectors/hive/FileConnectorSplit.h
+++ b/velox/connectors/hive/FileConnectorSplit.h
@@ -29,7 +29,14 @@ namespace facebook::velox::connector::hive {
 /// HiveIcebergSplit) extend this to add synthesized columns, serde parameters,
 /// and other format-specific fields.
 struct FileConnectorSplit : public ConnectorSplit {
+  /// Identity of the file this split covers. Use it to name the file; use
+  /// readPath() to open it.
   const std::string filePath;
+
+  /// Alternate location holding the same content as 'filePath', opened in its
+  /// place. Empty when there is none. The split builders set it.
+  std::string physicalFilePath;
+
   dwio::common::FileFormat fileFormat;
   const uint64_t start;
   const uint64_t length;
@@ -73,6 +80,11 @@ struct FileConnectorSplit : public ConnectorSplit {
 
   uint64_t size() const override {
     return length;
+  }
+
+  /// Location to open to read this split's bytes.
+  const std::string& readPath() const {
+    return physicalFilePath.empty() ? filePath : physicalFilePath;
   }
 
   std::string getFileName() const {

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -19,6 +19,8 @@
 #include <fmt/format.h>
 #include <unordered_map>
 
+#include "velox/common/base/Counters.h"
+#include "velox/common/base/StatsReporter.h"
 #include "velox/common/config/Config.h"
 #include "velox/connectors/hive/FileColumnHandle.h"
 #include "velox/connectors/hive/FileConfig.h"
@@ -270,7 +272,50 @@ bool testFilterOnConstantVector(
       testFilterTyped, constantVec->typeKind(), filter, constantVec);
 }
 
+FileHandleCachedPtr openAt(
+    const std::string& path,
+    FileHandleFactory& fileHandleFactory,
+    const FileProperties& properties,
+    const std::shared_ptr<filesystems::TokenProvider>& tokenProvider,
+    IoStats* ioStats) {
+  const FileHandleKey fileHandleKey{
+      .filename = path, .tokenProvider = tokenProvider};
+  auto handle = fileHandleFactory.generate(fileHandleKey, &properties, ioStats);
+  VELOX_CHECK_NOT_NULL(handle.get());
+  return handle;
+}
+
 } // namespace
+
+FileHandleCachedPtr openSplitFile(
+    const FileConnectorSplit& split,
+    FileHandleFactory& fileHandleFactory,
+    const FileProperties& properties,
+    const std::shared_ptr<filesystems::TokenProvider>& tokenProvider,
+    IoStats* ioStats) {
+  if (split.readPath() == split.filePath) {
+    return openAt(
+        split.filePath, fileHandleFactory, properties, tokenProvider, ioStats);
+  }
+
+  try {
+    return openAt(
+        split.readPath(),
+        fileHandleFactory,
+        properties,
+        tokenProvider,
+        ioStats);
+  } catch (const VeloxRuntimeError& e) {
+    LOG(WARNING) << fmt::format(
+        "Failed to open split at its physical path, falling back to '{}'. Physical path: '{}'. Error: {}",
+        split.filePath,
+        split.physicalFilePath,
+        e.what());
+    RECORD_METRIC_VALUE(kMetricHiveSplitPhysicalPathFallbackCount);
+    return openAt(
+        split.filePath, fileHandleFactory, properties, tokenProvider, ioStats);
+  }
+}
 
 bool testFilters(
     const common::ScanSpec* scanSpec,

--- a/velox/connectors/hive/FileConnectorUtil.h
+++ b/velox/connectors/hive/FileConnectorUtil.h
@@ -75,6 +75,15 @@ void configureRowReaderOptions(
     folly::Executor* ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions);
 
+/// Opens the split's bytes at readPath(), retrying on 'filePath' when the two
+/// differ and the first open fails.
+FileHandleCachedPtr openSplitFile(
+    const FileConnectorSplit& split,
+    FileHandleFactory& fileHandleFactory,
+    const FileProperties& properties,
+    const std::shared_ptr<filesystems::TokenProvider>& tokenProvider,
+    IoStats* ioStats);
+
 /// Tests whether a file should be read based on partition key values and
 /// column statistics. Returns true if the file passes all filters, false
 /// if it can be skipped.

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -263,7 +263,7 @@ std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   VELOX_CHECK_NULL(readerOpts.randomSkip());
 
   FileHandleKey fileHandleKey{
-      .filename = hiveSplit_->filePath,
+      .filename = hiveSplit_->readPath(),
       .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
 
   auto fileProperties = hiveSplit_->properties.value_or(FileProperties{});

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/Casts.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/FileConfig.h"
+#include "velox/connectors/hive/FileConnectorUtil.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
@@ -262,14 +263,13 @@ std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   readerOpts.setFileFormat(hiveSplit_->fileFormat);
   VELOX_CHECK_NULL(readerOpts.randomSkip());
 
-  FileHandleKey fileHandleKey{
-      .filename = hiveSplit_->readPath(),
-      .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
-
-  auto fileProperties = hiveSplit_->properties.value_or(FileProperties{});
-  auto fileHandleCachePtr = fileHandleFactory_->generate(
-      fileHandleKey, &fileProperties, ioStats_ ? ioStats_.get() : nullptr);
-  VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
+  const auto fileProperties = hiveSplit_->properties.value_or(FileProperties{});
+  auto fileHandleCachePtr = openSplitFile(
+      *hiveSplit_,
+      *fileHandleFactory_,
+      fileProperties,
+      connectorQueryCtx_->fsTokenProvider(),
+      ioStats_ ? ioStats_.get() : nullptr);
 
   auto baseFileInput = BufferedInputBuilder::getInstance()->create(
       *fileHandleCachePtr,

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -222,9 +222,6 @@ void FileSplitReader::createReader(
       baseReaderOpts_.fileFormat(), dwio::common::FileFormat::UNKNOWN);
 
   FileHandleCachedPtr fileHandleCachePtr;
-  FileHandleKey fileHandleKey{
-      .filename = fileSplit_->readPath(),
-      .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
 
   auto fileProperties = fileSplit_->properties.value_or(FileProperties{});
   fileProperties.fileReadOps = fileReadOps;
@@ -242,9 +239,12 @@ void FileSplitReader::createReader(
       fileHandleFactory_->maxSize() == 0 ? dataIoStats_.get() : nullptr;
 
   try {
-    fileHandleCachePtr = fileHandleFactory_->generate(
-        fileHandleKey, &fileProperties, ioStats_ ? ioStats_.get() : nullptr);
-    VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
+    fileHandleCachePtr = openSplitFile(
+        *fileSplit_,
+        *fileHandleFactory_,
+        fileProperties,
+        connectorQueryCtx_->fsTokenProvider(),
+        ioStats_ ? ioStats_.get() : nullptr);
   } catch (const VeloxRuntimeError& e) {
     if (e.errorCode() == error_code::kFileNotFound &&
         fileConfig_->ignoreMissingFiles(

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -223,7 +223,7 @@ void FileSplitReader::createReader(
 
   FileHandleCachedPtr fileHandleCachePtr;
   FileHandleKey fileHandleKey{
-      .filename = fileSplit_->filePath,
+      .filename = fileSplit_->readPath(),
       .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
 
   auto fileProperties = fileSplit_->properties.value_or(FileProperties{});

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -19,15 +19,20 @@
 namespace facebook::velox::connector::hive {
 
 std::string HiveConnectorSplit::toString() const {
+  const std::string physicalPath = physicalFilePath.empty()
+      ? ""
+      : fmt::format(" read from {}", physicalFilePath);
   if (tableBucketNumber.has_value()) {
     return fmt::format(
-        "Hive: {} {} - {} {}",
+        "Hive: {} {} - {} {}{}",
         filePath,
         start,
         length,
-        tableBucketNumber.value());
+        tableBucketNumber.value(),
+        physicalPath);
   }
-  return fmt::format("Hive: {} {} - {}", filePath, start, length);
+  return fmt::format(
+      "Hive: {} {} - {}{}", filePath, start, length, physicalPath);
 }
 
 folly::dynamic HiveConnectorSplit::serialize() const {
@@ -102,6 +107,9 @@ folly::dynamic HiveConnectorSplit::serialize() const {
   if (columnMappingMode.has_value()) {
     obj["columnMappingMode"] =
         dwio::common::ColumnMappingModeName::toName(*columnMappingMode);
+  }
+  if (!physicalFilePath.empty()) {
+    obj["physicalFilePath"] = physicalFilePath;
   }
 
   return obj;
@@ -195,7 +203,7 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
     columnMappingMode = *parsedColumnMappingMode;
   }
 
-  return std::make_shared<HiveConnectorSplit>(
+  auto split = std::make_shared<HiveConnectorSplit>(
       connectorId,
       filePath,
       fileFormat,
@@ -213,6 +221,10 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
       rowIdProperties,
       bucketConversion,
       columnMappingMode);
+  if (auto it = obj.find("physicalFilePath"); it != obj.items().end()) {
+    split->physicalFilePath = it->second.asString();
+  }
+  return split;
 }
 
 // static

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -210,6 +210,11 @@ class HiveConnectorSplitBuilder {
     return *this;
   }
 
+  HiveConnectorSplitBuilder& physicalFilePath(std::string path) {
+    physicalFilePath_ = std::move(path);
+    return *this;
+  }
+
   std::shared_ptr<connector::hive::HiveConnectorSplit> build() const {
     auto split = std::make_shared<connector::hive::HiveConnectorSplit>(
         connectorId_,
@@ -230,11 +235,13 @@ class HiveConnectorSplitBuilder {
         bucketConversion_,
         columnMappingMode_);
     split->batchSizeHint = batchSizeHint_;
+    split->physicalFilePath = physicalFilePath_;
     return split;
   }
 
  private:
   const std::string filePath_;
+  std::string physicalFilePath_;
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   uint64_t start_{0};
   uint64_t length_{std::numeric_limits<uint64_t>::max()};

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -104,7 +104,7 @@ HiveIcebergSplit::HiveIcebergSplit(
       identityPartitionKeys(identityPartitionKeys) {}
 
 std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
-  return std::make_shared<HiveIcebergSplit>(
+  auto split = std::make_shared<HiveIcebergSplit>(
       connectorId_,
       filePath_,
       fileFormat_,
@@ -121,5 +121,7 @@ std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
       dataSequenceNumber_,
       identityPartitionKeys_,
       columnMappingMode_);
+  split->physicalFilePath = physicalFilePath_;
+  return split;
 }
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -155,6 +155,11 @@ class IcebergSplitBuilder {
     return *this;
   }
 
+  IcebergSplitBuilder& physicalFilePath(std::string path) {
+    physicalFilePath_ = std::move(path);
+    return *this;
+  }
+
   IcebergSplitBuilder& columnMappingMode(dwio::common::ColumnMappingMode mode) {
     columnMappingMode_ = mode;
     return *this;
@@ -164,6 +169,7 @@ class IcebergSplitBuilder {
 
  private:
   const std::string filePath_;
+  std::string physicalFilePath_;
   std::string connectorId_;
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   uint64_t start_{0};

--- a/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
@@ -443,6 +443,41 @@ TEST_F(
       {2, 5, 7});
 }
 
+// Positional deletes match the data file by its recorded path, so redirecting
+// the read must not change which deletes apply. The replica holds different
+// values, so the returned rows show which file was opened.
+TEST_F(IcebergPositionalDeleteTest, readsPhysicalFileButDeletesKeyOffFilePath) {
+  auto dataFilePath = writeBigintDataFile({0, 1, 2, 3, 4});
+  auto replicaFilePath = writeBigintDataFile({5, 6, 7, 8, 9});
+
+  auto deleteFilePath = TempFilePath::create();
+  auto deleteFile =
+      makePositionalDeleteFile(dataFilePath->getPath(), {1, 3}, deleteFilePath);
+
+  // Real replicas are byte-identical; these two are not, so size the split to
+  // cover both.
+  auto split = IcebergSplitBuilder(dataFilePath->getPath())
+                   .connectorId(test::kIcebergConnectorId)
+                   .fileFormat(fileFormat_)
+                   .length(
+                       std::max(
+                           getFileSize(dataFilePath->getPath()),
+                           getFileSize(replicaFilePath->getPath())))
+                   .deleteFiles({deleteFile})
+                   .physicalFilePath(replicaFilePath->getPath())
+                   .build();
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector({makeFlatVector<int64_t>({5, 7, 9})});
+  exec::test::AssertQueryBuilder(plan).splits({split}).assertResults(
+      {expected});
+}
+
 TEST_F(IcebergPositionalDeleteTest, positionalDeletesMultipleSplits) {
   assertMultipleSplits(
       {1, 2, 3, 4},

--- a/velox/connectors/hive/tests/FileConnectorSplitTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorSplitTest.cpp
@@ -74,6 +74,30 @@ TEST(FileConnectorSplitTest, getFileNameNoSlash) {
   EXPECT_EQ(split.getFileName(), "file.orc");
 }
 
+TEST(FileConnectorSplitTest, readPathDefaultsToFilePath) {
+  FileConnectorSplit split(
+      "connectorId",
+      "/path/to/file.parquet",
+      dwio::common::FileFormat::PARQUET);
+
+  EXPECT_TRUE(split.physicalFilePath.empty());
+  EXPECT_EQ(split.readPath(), "/path/to/file.parquet");
+}
+
+TEST(FileConnectorSplitTest, readPathUsesPhysicalFilePath) {
+  FileConnectorSplit split(
+      "connectorId",
+      "/path/to/file.parquet",
+      dwio::common::FileFormat::PARQUET);
+  split.physicalFilePath = "/replica/to/file.parquet";
+
+  EXPECT_EQ(split.readPath(), "/replica/to/file.parquet");
+
+  // Identity and everything derived from it stay on 'filePath'.
+  EXPECT_EQ(split.filePath, "/path/to/file.parquet");
+  EXPECT_EQ(split.getFileName(), "file.parquet");
+}
+
 TEST(FileConnectorSplitTest, fileProperties) {
   FileProperties props = {.fileSize = 1024, .modificationTime = 999};
   FileConnectorSplit split(

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -787,4 +787,62 @@ TEST_F(FileConnectorUtilTest, testFiltersMissingColumn) {
           /*asLocalTime=*/false));
 }
 
+TEST_F(FileConnectorUtilTest, openSplitFileUsesPhysicalFilePath) {
+  filesystems::registerLocalFileSystem();
+  auto tempFile = exec::test::TempFilePath::create();
+  // TempFilePath creates the file; LocalWriteFile will not reopen it.
+  remove(tempFile->getPath().c_str());
+  {
+    LocalWriteFile writeFile(tempFile->getPath());
+    writeFile.append("foo");
+  }
+
+  FileHandleFactory factory(
+      std::make_unique<SimpleLRUCache<FileHandleKey, FileHandle>>(1'000),
+      std::make_unique<FileHandleGenerator>());
+  const FileProperties properties;
+
+  hive::FileConnectorSplit split(
+      "connectorId", "/does/not/exist", dwio::common::FileFormat::DWRF);
+  split.physicalFilePath = tempFile->getPath();
+
+  auto handle = hive::openSplitFile(
+      split,
+      factory,
+      properties,
+      /*tokenProvider=*/nullptr,
+      /*ioStats=*/nullptr);
+  ASSERT_NE(handle.get(), nullptr);
+  EXPECT_EQ(handle->file->size(), 3);
+}
+
+TEST_F(FileConnectorUtilTest, openSplitFileFallsBackToFilePath) {
+  filesystems::registerLocalFileSystem();
+  auto tempFile = exec::test::TempFilePath::create();
+  // TempFilePath creates the file; LocalWriteFile will not reopen it.
+  remove(tempFile->getPath().c_str());
+  {
+    LocalWriteFile writeFile(tempFile->getPath());
+    writeFile.append("foo");
+  }
+
+  FileHandleFactory factory(
+      std::make_unique<SimpleLRUCache<FileHandleKey, FileHandle>>(1'000),
+      std::make_unique<FileHandleGenerator>());
+  const FileProperties properties;
+
+  hive::FileConnectorSplit split(
+      "connectorId", tempFile->getPath(), dwio::common::FileFormat::DWRF);
+  split.physicalFilePath = tempFile->getPath() + ".does_not_exist";
+
+  auto handle = hive::openSplitFile(
+      split,
+      factory,
+      properties,
+      /*tokenProvider=*/nullptr,
+      /*ioStats=*/nullptr);
+  ASSERT_NE(handle.get(), nullptr);
+  EXPECT_EQ(handle->file->size(), 3);
+}
+
 } // namespace facebook::velox::connector

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -335,6 +335,15 @@ TEST_F(HiveConnectorSerDeTest, hiveConnectorSplit) {
   handles.push_back(makeColumnHandle("c0", INTEGER(), {}));
   split3.bucketConversion = {16, 2, std::move(handles)};
   testSerde(split3);
+
+  auto split4 = HiveConnectorSplit(connectorId, filePath, fileFormat);
+  split4.physicalFilePath = "/testSerde/replica/p";
+  testSerde(split4);
+  const auto clone4 =
+      ISerializable::deserialize<HiveConnectorSplit>(split4.serialize());
+  ASSERT_EQ(clone4->physicalFilePath, split4.physicalFilePath);
+  ASSERT_EQ(clone4->readPath(), split4.physicalFilePath);
+  ASSERT_EQ(clone4->filePath, filePath);
 }
 
 TEST_F(HiveConnectorSerDeTest, hiveConnectorSplitFileProperties) {

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
@@ -809,6 +810,11 @@ class CapturingFileSystem : public filesystems::FileSystem {
     return instance;
   }
 
+  static std::vector<std::string>& openedPaths() {
+    static std::vector<std::string> instance;
+    return instance;
+  }
+
   explicit CapturingFileSystem(std::shared_ptr<const config::ConfigBase> config)
       : FileSystem(std::move(config)) {}
 
@@ -827,6 +833,7 @@ class CapturingFileSystem : public filesystems::FileSystem {
       std::string_view path,
       const filesystems::FileOptions& options) override {
     capturedFileReadOps() = options.fileReadOps;
+    openedPaths().emplace_back(path);
     auto localPath = extractPath(path);
     return filesystems::getFileSystem(localPath, config_)
         ->openFileForRead(localPath, options);
@@ -864,10 +871,8 @@ class CapturingFileSystem : public filesystems::FileSystem {
   }
 };
 
-TEST_F(HiveConnectorTest, fileReadOpsTableIdentityPropagation) {
-  // Register the capturing filesystem once.
-  static bool registered = false;
-  if (!registered) {
+void registerCapturingFileSystemOnce() {
+  static const bool registered = [] {
     filesystems::registerFileSystem(
         [](std::string_view path) {
           return path.find(CapturingFileSystem::kScheme) == 0;
@@ -875,8 +880,46 @@ TEST_F(HiveConnectorTest, fileReadOpsTableIdentityPropagation) {
         [](std::shared_ptr<const config::ConfigBase> config, std::string_view) {
           return std::make_shared<CapturingFileSystem>(std::move(config));
         });
-    registered = true;
-  }
+    return true;
+  }();
+  (void)registered;
+}
+
+TEST_F(HiveConnectorTest, unreadablePhysicalFilePathFallsBackToFilePath) {
+  registerCapturingFileSystemOnce();
+
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto vector = makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vector);
+
+  const auto canonical = fmt::format("capture:{}", filePath->getPath());
+  const auto physical = canonical + ".does_not_exist";
+  CapturingFileSystem::openedPaths().clear();
+
+  auto split = HiveConnectorSplitBuilder(canonical)
+                   .connectorId(kHiveConnectorId)
+                   .fileFormat(dwio::common::FileFormat::DWRF)
+                   .physicalFilePath(physical)
+                   .build();
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(rowType)
+                  .assignments(allRegularColumns(rowType))
+                  .endTableScan()
+                  .planNode();
+
+  AssertQueryBuilder(plan).split(split).assertResults(vector);
+
+  // The rows alone would look the same if the physical path were never tried.
+  EXPECT_THAT(
+      CapturingFileSystem::openedPaths(),
+      testing::ElementsAre(physical, canonical));
+}
+
+TEST_F(HiveConnectorTest, fileReadOpsTableIdentityPropagation) {
+  registerCapturingFileSystemOnce();
 
   // Write test data to a local temp file.
   auto rowType = ROW({"c0"}, {BIGINT()});


### PR DESCRIPTION
Summary:
A split that names an alternate location for its bytes in `physicalFilePath` no longer fails the query when that location is unreadable. The content also exists at `filePath`, so the reader retries there, logs a warning naming both paths, and bumps `velox.hive_split_physical_path_fallback_count`. Reading the canonical copy gives up whatever the alternate location was meant to save, which is a better outcome than failing.

Both places that open a split's bytes — the table scan and the index lookup — go through one `openSplitFile` helper, so the two cannot drift apart. The retry only happens when `readPath()` and `filePath` actually differ, so a split without an alternate location behaves exactly as before, including the existing `ignoreMissingFiles` handling, which now applies to the outcome of the retry rather than the first attempt.

The counter records the fallback attempt rather than its outcome, so a location that has become unusable still shows up even when the canonical read fails too.

Differential Revision: D118761872
