### PR TITLE
feat(nimble): Add Nimble file detection utility (#18855)

### DIFF
--- a/velox/dwio/nimble/tablet/Postscript.cpp
+++ b/velox/dwio/nimble/tablet/Postscript.cpp
@@ -17,10 +17,17 @@
 
 #include <cstring>
 
+#include "velox/common/file/File.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
 
 namespace facebook::nimble {
+namespace {
+
+constexpr size_t kMajorVersionOffset{kPostscriptSize - 3 * sizeof(uint16_t)};
+constexpr size_t kMagicNumberOffset{kPostscriptSize - sizeof(uint16_t)};
+
+} // namespace
 
 Postscript::Postscript(
     uint32_t footerSize,
@@ -62,6 +69,37 @@ Postscript Postscript::parse(std::string_view data) {
   ps.checksumType_ = *reinterpret_cast<const ChecksumType*>(pos + 5);
   ps.checksum_ = *reinterpret_cast<const uint64_t*>(pos + 6);
   return ps;
+}
+
+bool isNimbleFile(const velox::ReadFile& file) {
+  const uint64_t fileSize = file.size();
+  if (fileSize < kPostscriptSize) {
+    return false;
+  }
+
+  const auto postscript =
+      file.pread(fileSize - kPostscriptSize, kPostscriptSize);
+  if (postscript.size() != kPostscriptSize) {
+    return false;
+  }
+
+  uint32_t footerSize;
+  std::memcpy(&footerSize, postscript.data(), sizeof(footerSize));
+
+  uint16_t majorVersion;
+  std::memcpy(
+      &majorVersion,
+      postscript.data() + kMajorVersionOffset,
+      sizeof(majorVersion));
+
+  uint16_t magicNumber;
+  std::memcpy(
+      &magicNumber,
+      postscript.data() + kMagicNumberOffset,
+      sizeof(magicNumber));
+
+  return magicNumber == kMagicNumber && majorVersion <= kVersionMajor &&
+      footerSize <= fileSize - kPostscriptSize;
 }
 
 std::string Postscript::serialize() const {

--- a/velox/dwio/nimble/tablet/Postscript.h
+++ b/velox/dwio/nimble/tablet/Postscript.h
@@ -20,6 +20,10 @@
 
 #include "velox/dwio/nimble/common/Types.h"
 
+namespace facebook::velox {
+class ReadFile;
+}
+
 namespace facebook::nimble {
 
 /// Postscript information (last 20 bytes of a Nimble file).
@@ -77,5 +81,12 @@ class Postscript {
   uint32_t majorVersion_{0};
   uint32_t minorVersion_{0};
 };
+
+/// Returns whether the file has a valid Nimble postscript.
+///
+/// Checks the file size, magic number, supported major version, and footer
+/// bounds. Does not parse the footer or verify the checksum. File read errors
+/// are propagated to the caller.
+bool isNimbleFile(const velox::ReadFile& file);
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/tablet/tests/PostscriptTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/PostscriptTest.cpp
@@ -18,9 +18,12 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/file/File.h"
+#include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
+#include "velox/dwio/nimble/tablet/TabletWriter.h"
 
 using namespace facebook::nimble;
 
@@ -116,4 +119,22 @@ TEST(PostscriptTest, parseBadMagic) {
   auto buf = ps.serialize();
   buf[Postscript::kSize - 1] = 'X';
   NIMBLE_ASSERT_THROW(Postscript::parse(buf), "Magic number mismatch");
+}
+
+TEST(PostscriptTest, identifiesNimbleFile) {
+  facebook::velox::memory::MemoryManager memoryManager;
+  auto pool = memoryManager.addLeafPool("PostscriptTest");
+
+  std::string data;
+  facebook::velox::InMemoryWriteFile writeFile{&data};
+  auto writer = TabletWriter::create(&writeFile, *pool, {});
+  writer->close();
+  writeFile.close();
+
+  facebook::velox::InMemoryReadFile file{std::string_view{data}};
+
+  EXPECT_TRUE(isNimbleFile(file));
+
+  data.back() = '\0';
+  EXPECT_FALSE(isNimbleFile(file));
 }


### PR DESCRIPTION
Summary:

Expose `isNimbleFile` for callers that need to recognize Nimble inputs without constructing a `TabletReader`. RocksDB integrations need content-based detection because files may all use the `.sst` extension regardless of whether their contents are block-based or Nimble. The probe reads the fixed postscript and validates its magic, supported major version, and footer bounds while propagating I/O failures.

Differential Revision: D118891022


