### PR TITLE
feat(torchwave): Read a .pt2's flat inputs so a 1k-row graph can be tested

### DIFF
--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -293,11 +293,30 @@ void deepFlattenIValue(
   }
 }
 
+void fillFrameFromUserInputs(
+    const nativert::Graph& graph,
+    nativert::ExecutionFrame& frame,
+    const std::vector<c10::IValue>& inputs);
+
 void fillFrameInputs(
     const nativert::Graph& graph,
     nativert::ExecutionFrame& frame,
     std::vector<c10::IValue> inputs) {
   const auto& userInputNames = graph.signature().userInputs();
+  // The two lists are not the same for every model. graph.userInputs() carries
+  // one entry per placeholder, including the ones the signature omits -- the
+  // ROO preproc has 315 of them, string constants the export kept -- and only
+  // that list aligns positionally with an already-flat external inputs file.
+  // Prefer it when the counts say it is the one the caller flattened against;
+  // keying off the signature there silently shifts every input past the first
+  // omitted leaf, which surfaces far away as an int reaching an op that wanted
+  // a tensor.
+  const auto& graphInputs = graph.userInputs();
+  if (graphInputs.size() != userInputNames.size() &&
+      inputs.size() == graphInputs.size()) {
+    fillFrameFromUserInputs(graph, frame, inputs);
+    return;
+  }
   // Flatten one level to handle Objects/Tuples wrapping the actual inputs.
   std::vector<c10::IValue> flat;
   for (auto& v : inputs) {
@@ -319,11 +338,25 @@ void fillFrameInputs(
     }
     flat = std::move(next);
   }
+  if (flat.size() != userInputNames.size()) {
+    LOG(WARNING) << "fillFrameInputs: " << flat.size() << " inputs for "
+                 << userInputNames.size()
+                 << " user inputs; the alignment below will be wrong";
+  }
+  // One leaf per name, whether or not the name has a value in the graph. A
+  // placeholder the export kept but nothing reads -- the ROO preproc has 315
+  // of them, string constants that carry no graph value -- still occupies a
+  // position in the flattened inputs. Skipping the name without consuming its
+  // leaf shifts every input after it, which surfaces far away as an int
+  // arriving where an op wanted a tensor.
   size_t flatIdx = 0;
   for (const auto& name : userInputNames) {
-    auto* value = graph.tryGetValue(name);
-    if (value && flatIdx < flat.size()) {
-      frame.setIValue(value->id(), std::move(flat[flatIdx++]));
+    if (flatIdx >= flat.size()) {
+      break;
+    }
+    auto item = std::move(flat[flatIdx++]);
+    if (auto* value = graph.tryGetValue(name)) {
+      frame.setIValue(value->id(), std::move(item));
     }
   }
 }
@@ -853,6 +886,19 @@ void ExecutorTestBase::fillWaveFrame(
     nativert::ExecutionFrame& frame,
     const std::vector<c10::IValue>& deviceInputs) {
   const auto& userInputNames = graph.signature().userInputs();
+  // graph.userInputs() carries one entry per placeholder, including the ones
+  // the signature omits -- the ROO preproc has 315 of them, string constants
+  // the export kept -- and only that list aligns positionally with an
+  // already-flat external inputs file. Keying off the signature there consumes
+  // no leaf for an omitted placeholder, so every input past the first one is
+  // read from the wrong index and surfaces far away as an int reaching an op
+  // that wanted a tensor.
+  const auto& graphInputs = graph.userInputs();
+  if (graphInputs.size() != userInputNames.size() &&
+      deviceInputs.size() == graphInputs.size()) {
+    fillFrameFromUserInputs(graph, frame, deviceInputs);
+    return;
+  }
   // Flatten to match user input count.
   std::vector<c10::IValue> flat;
   for (const auto& v : deviceInputs) {


### PR DESCRIPTION
Summary:
The executor_test entry point was unavailable to any graph too large to
export as a sigmoid archive. At 1k rows that export exceeds the 2 GB thrift
limit, and the torch.export .pt2 that is used instead could not supply the
graph's inputs: the base runTest flattens an archive's sample inputs with
flattenIValue, which does not align ROO's structured (KJT-bearing) inputs to
the graph's user-input placeholders, and the run dies with "paramTensor:
actual value %328 is not a tensor". runTest already picks up an external
<base>_inputs.pt when one is there; dump_flat_inputs could not write it for a
.pt2.

Three things were in the way, so all three are here:

- dump_flat_inputs resolved (sample_inputs, in_spec) only through the sigmoid
  EP or the model thrift, neither of which a torch.export .pt2 carries. The
  new path reads both records out of the zip. It does NOT go through
  torch.export.load: rebuilding the ExportedProgram deserializes the graph,
  and the ROO preproc has a string among its outputs, which the deserializer
  refuses. Nothing here needs the graph.
- The .pt2's example_inputs are pickled as TrainAccelInput, so the binary
  needs the module that defines it. The sigmoid archive stores plain tuples
  and never did.
- treespec_loads refuses a namedtuple with no serialized name, the way it
  already did for the ads preproc's FirInferenceInputType.

A correct inputs file is still not enough to run the graph. fillWaveFrame --
and fillFrameInputs, which has the same shape -- key off
graph.signature().userInputs(), which omits those 315 constant_input
placeholders, and advance the input index only for a name that has a value in
the graph. An already-flat file is aligned to graph.userInputs() instead, so
every input past the first omitted placeholder is read from the wrong index and
surfaces far away as an int reaching an op that wanted a tensor. Both now use
whichever list the supplied inputs match; for a graph where the two agree
nothing changes.

dump_flat_inputs checks the flattened leaves against the placeholder kinds and
names the first divergence. A count match is not sufficient -- the leaves are
positional, so one misplaced entry is invisible here and fatal at the op.

--sigmoid_results points the comparison at a reference other than the
archive's sibling _results.pt, which is what makes a GPU-derived golden from
--save_gpu_golden usable without disturbing the checked-in one.

Reviewed By: Yuhta

Differential Revision: D118061297


