### PR TITLE
fix(nimble): Isolate vendored FSST C++ symbols

### DIFF
--- a/velox/external/fsst/CMakeLists.txt
+++ b/velox/external/fsst/CMakeLists.txt
@@ -31,6 +31,10 @@
 # sources into the single `velox` target, where those definitions would leak
 # into every other translation unit.
 #
+# The upstream sources also define C++ helpers with external linkage. Those
+# helpers live in the nimble_fsst_internal namespace to avoid colliding with
+# DuckDB's separately vendored copy of FSST in the same process.
+#
 # A plain static library would keep that isolation but leave a gap for installed
 # consumers: CMake does not merge static archives, so libfsst.a would stay
 # outside libvelox.a and go uninstalled, leaving fsst_* undefined downstream. An

--- a/velox/external/fsst/fsst_avx512.cpp
+++ b/velox/external/fsst/fsst_avx512.cpp
@@ -17,6 +17,8 @@
 // You can contact the authors via the FSST source repository : https://github.com/cwida/fsst
 #include "libfsst.hpp"
 
+namespace nimble_fsst_internal {
+
 #if defined(__x86_64__) || defined(_M_X64)
 #include <immintrin.h>
 
@@ -138,3 +140,5 @@ size_t fsst_compressAVX512(SymbolTable &symbolTable, u8* codeBase, u8* symbolBas
 #endif
    return processed;
 }
+
+} // namespace nimble_fsst_internal

--- a/velox/external/fsst/libfsst.cpp
+++ b/velox/external/fsst/libfsst.cpp
@@ -17,6 +17,8 @@
 // You can contact the authors via the FSST source repository : https://github.com/cwida/fsst
 #include "libfsst.hpp"
 
+namespace nimble_fsst_internal {
+
 Symbol concat(Symbol a, Symbol b) {
    Symbol s;
    u32 length = a.length()+b.length();
@@ -26,11 +28,13 @@ Symbol concat(Symbol a, Symbol b) {
    return s;
 }
 
+} // namespace nimble_fsst_internal
+
 namespace std {
 template <>
-class hash<QSymbol> {
+class hash<nimble_fsst_internal::QSymbol> {
    public:
-   size_t operator()(const QSymbol& q) const {
+   size_t operator()(const nimble_fsst_internal::QSymbol& q) const {
       uint64_t k = q.symbol.val.num;
       const uint64_t m = 0xc6a4a7935bd1e995;
       const int r = 47;
@@ -47,6 +51,8 @@ class hash<QSymbol> {
    }
 };
 }
+
+namespace nimble_fsst_internal {
 
 bool isEscapeCode(u16 pos) { return pos < FSST_CODE_BASE; }
 
@@ -639,3 +645,5 @@ extern "C" fsst_decoder_t fsst_decoder(fsst_encoder_t *encoder) {
    assert(cnt1 == cnt2); (void) cnt1; (void) cnt2; 
    return decoder;
 }
+
+} // namespace nimble_fsst_internal

--- a/velox/external/fsst/libfsst.hpp
+++ b/velox/external/fsst/libfsst.hpp
@@ -31,9 +31,11 @@
 #include <fcntl.h>
 #include <stddef.h>
 
-using namespace std;
-
 #include "fsst.h" // the official FSST API -- also usable by C mortals
+
+namespace nimble_fsst_internal {
+
+using namespace std;
 
 /* unsigned integers */
 typedef uint8_t u8;
@@ -448,3 +450,5 @@ fsst_compressAVX512(
 // C++ fsst-compress function with some more control of how the compression happens (algorithm flavor, simd unroll degree)
 size_t compressImpl(Encoder *encoder, size_t n, size_t lenIn[], u8 *strIn[], size_t size, u8 * output, size_t *lenOut, u8 *strOut[], bool noSuffixOpt, bool avoidBranch, int simd);
 size_t compressAuto(Encoder *encoder, size_t n, size_t lenIn[], u8 *strIn[], size_t size, u8 * output, size_t *lenOut, u8 *strOut[], int simd);
+
+} // namespace nimble_fsst_internal


### PR DESCRIPTION
This change moves Nimble’s vendored FSST C++ implementation into the nimble_fsst_internal namespace while keeping the existing nimble_fsst_* C API unchanged. This prevents duplicate symbol errors when Velox links both Nimble’s FSST and DuckDB’s separately vendored FSST implementation into the same binary.
