### PR TITLE
feat: Fused batch_flip_and_truncate_sparse (#18861)

### DIFF
--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -361,9 +361,11 @@ void hashSubgraphNode(
       }
     }
   }
-  // SymIntList attributes are baked into the generated code and into the
-  // subgraph's shape expressions, so they are part of a node's identity (see
-  // intListAttributesMatch).
+  // SymIntList attributes are baked into the generated code as literals (see
+  // emitScalarListSetup) and into the subgraph's shape expressions, so they are
+  // part of a node's identity (see intListAttributesMatch): two otherwise
+  // identical ops differing in one must not share a deduplicated kernel. Scalar
+  // attributes go through the param area and need no hashing.
   for (const auto& attr : node->attributes()) {
     if (!std::holds_alternative<std::vector<int64_t>>(attr.value)) {
       continue;
@@ -1637,26 +1639,37 @@ void CompileCtx::fusedCode(NodeCP node, std::vector<ResultSpec>& resultSpecs) {
 
   for (const auto& input : node->inputs()) {
     auto* value = input.value;
-    if (memOutputs.count(value)) {
-      auto* producer = value->producer();
-      if (producer && !placed_.count(producer)) {
-        if (producer->target() == "prim.ListPack") {
-          placed_.insert(producer);
-          for (const auto& lpInput : producer->inputs()) {
-            auto* lpValue = lpInput.value;
-            auto* lpProducer = lpValue->producer();
-            if (lpProducer && !placed_.count(lpProducer)) {
-              std::vector<ResultSpec> lpSpecs;
-              ResultSpec rs;
-              rs.value = lpValue;
-              lpSpecs.push_back(rs);
-              fusedCode(lpProducer, lpSpecs);
-            }
-          }
-        } else {
-          auto prodSpecs = outputSpecs(producer);
-          fusedCode(producer, prodSpecs);
+    if (!value) {
+      continue;
+    }
+    auto* producer = value->producer();
+    // A tensor list read by this (non-elementwise) op is consumed from memory,
+    // so every element must be materialized to its own Value buffer -- never
+    // left in a register -- in all modes. Do this whether or not the list is a
+    // boundary memOutput: an internal ListPack fed by fused elementwise
+    // producers (e.g. values built by an add) is not a memOutput and would
+    // otherwise never be written. Element producers already placed (a boundary
+    // list from a prior op) are skipped by the placed_ guard.
+    if (producer && producer->target() == "prim.ListPack" &&
+        !placed_.count(producer)) {
+      placed_.insert(producer);
+      for (const auto& lpInput : producer->inputs()) {
+        auto* lpValue = lpInput.value;
+        auto* lpProducer = lpValue ? lpValue->producer() : nullptr;
+        if (lpProducer && !placed_.count(lpProducer)) {
+          std::vector<ResultSpec> lpSpecs;
+          ResultSpec rs;
+          rs.value = lpValue;
+          lpSpecs.push_back(rs);
+          fusedCode(lpProducer, lpSpecs);
         }
+      }
+      continue;
+    }
+    if (memOutputs.count(value)) {
+      if (producer && !placed_.count(producer)) {
+        auto prodSpecs = outputSpecs(producer);
+        fusedCode(producer, prodSpecs);
       }
     }
   }
@@ -2240,26 +2253,27 @@ void CompileCtx::emitBarrier() {
 bool CompileCtx::callNeedsBarrier(NodeCP node) {
   // A call reads its inputs from memory, so if a producer ran earlier in this
   // same kernel with no barrier since, that producer's writes from other blocks
-  // may not yet be visible. Barrier for any such unsynchronized intra-kernel
-  // producer, regardless of whether the input is flagged random access -- a
-  // sequential read of an in-flight tensor is just as unsafe. An input read
-  // through a view is the base's storage: a view of something this kernel fills
-  // still needs the barrier, a view of anything else does not, and the view
-  // node itself never writes and so never justifies one.
-  for (const auto& input : node->inputs()) {
-    auto* value = viewBase(input.value);
+  // may not yet be visible. randomAccess is not consulted -- an aligned read is
+  // still unsafe across blocks, and the preBarrierValues_ check below avoids
+  // emitting a redundant barrier when one already separates them.
+  // Resolves the ordering question for one operand. An input read through a
+  // view is the base's storage: a view of something this kernel fills still
+  // needs the barrier, a view of anything else does not, and the view node
+  // itself never writes and so never justifies one. An in-place writer is not
+  // the base's producer either -- the storage was created elsewhere, often in
+  // an earlier kernel -- so the producer test alone cannot see it; ask the
+  // users too, since a writer running unsynchronized in this kernel is the same
+  // hazard as a producer running in it.
+  auto needsBarrierFor = [&](ValueCP operand) {
+    auto* value = viewBase(operand);
     if (!value) {
-      continue;
+      return false;
     }
     auto* producer = value->producer();
     if (producer && generatingOp_->allNodes().count(producer) &&
         !preBarrierValues_.count(value)) {
       return true;
     }
-    // An in-place writer is not the value's producer -- the storage was created
-    // elsewhere, often in an earlier kernel -- so the producer test above
-    // cannot see it. Ask the users instead: a writer running unsynchronized in
-    // this kernel is the same hazard as a producer running in it.
     for (auto* user : value->users()) {
       if (user == node || !generatingOp_->allNodes().count(user)) {
         continue;
@@ -2283,6 +2297,61 @@ bool CompileCtx::callNeedsBarrier(NodeCP node) {
       if (!synchronized) {
         return true;
       }
+    }
+    return false;
+  };
+  // One whole operand. For a tensor list the list node itself is
+  // metadata-only, so the real producers are the element nodes.
+  auto operandNeedsBarrier = [&](ValueCP value) {
+    if (!value) {
+      return false;
+    }
+    if (value->type().kind() == nativert::Type::Kind::TensorList) {
+      for (auto* elem : value->getListElements()) {
+        if (elem && needsBarrierFor(elem)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return needsBarrierFor(value);
+  };
+
+  const auto& inputs = node->inputs();
+  auto* meta = nodeMeta(node);
+  // The loop below can only reach inputs that argumentMeta describes, and a
+  // node with no metadata has none, so any input past that point is never
+  // tested for the hazard. That silence is the dangerous part: the result is a
+  // missing barrier, and a missing barrier is a cross-block race that surfaces
+  // as wrong data far from here and long after. Test what the loop skips
+  // instead of assuming it is harmless.
+  const size_t described =
+      meta ? std::min(inputs.size(), meta->argumentMeta.size()) : 0;
+  for (size_t i = described; i < inputs.size(); ++i) {
+    TORCH_CHECK(
+        !operandNeedsBarrier(inputs[i].value),
+        "Input ",
+        i,
+        " of ",
+        node->target(),
+        " needs a barrier but is not described by argumentMeta, so the "
+        "barrier would be silently dropped: the node has ",
+        inputs.size(),
+        " inputs and ",
+        meta ? meta->argumentMeta.size() : 0,
+        " argumentMeta entries");
+  }
+  if (!meta) {
+    return false;
+  }
+  for (size_t i = 0; i < described; ++i) {
+    // Register inputs flow inline as fused values, not through memory, so they
+    // never need a barrier.
+    if (meta->argumentMeta[i].isRegister) {
+      continue;
+    }
+    if (operandNeedsBarrier(inputs[i].value)) {
+      return true;
     }
   }
   return false;

--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -1584,6 +1584,71 @@ CompositeKernel::CompositeKernel(
     }
   }
 
+  // Diagnostic: one single-case kernel per op, queued alongside the composite
+  // below so the two compile concurrently. Each is the composite's preamble
+  // with a switch holding only this op's case, so its register / shared /
+  // local-memory footprint is that op's alone. Nothing launches them for
+  // results; WaveGraph warms them up once at the end of graph construction and
+  // logs their occupancy next to the composite's.
+  if (WaveConfig::get().configPerOp && facebook::velox::wave::currentDevice()) {
+    std::stringstream includeHeader;
+    includeHeader << "#include \"velox/experimental/torchwave/Core.cuh\"\n";
+    for (const auto& inc : includes) {
+      includeHeader << "#include \"" << inc << "\"\n";
+    }
+    auto headerStr = includeHeader.str();
+
+    for (const auto& kop : kernelOpStorage_) {
+      auto opName = kernelName + "_op_" + std::to_string(kop->opCode());
+      auto opEntry = "torch::wave::" + opName;
+      auto opFile = "/tmp/" + opName + ".cu";
+
+      std::stringstream os;
+      os << headerStr << "\nnamespace torch::wave {\n\n";
+      if (!kop->helperCode().empty()) {
+        os << kop->helperCode();
+      }
+      os << "__global__ void " << opName << "(TorchWaveParams params) {\n"
+         << "  ENTRY;\n";
+      for (const auto& decl : kop->sharedDeclarations()) {
+        os << decl;
+      }
+      os << "  switch (blockInfo.op) {\n"
+         << "    case " << kop->opCode() << ": {\n"
+         << kop->code() << "      break;\n"
+         << "    }\n"
+         << "  }\n"
+         << "  LEAVE();\n"
+         << "}\n\n"
+         << "} // namespace torch::wave\n";
+      auto opText = os.str();
+      {
+        std::ofstream out(opFile);
+        out << opText;
+      }
+
+      PerOpKernel perOp;
+      perOp.opCode = kop->opCode();
+      perOp.entryPoint = opEntry;
+      // Deliberately not the KernelFsCache: these are throwaway diagnostics and
+      // must not compete with the composite for the on-disk cache.
+      perOp.kernel = facebook::velox::wave::CompiledKernel::getKernel(
+          opText,
+          [code = opText,
+           opEntry,
+           opFile]() -> facebook::velox::wave::KernelSpec {
+            facebook::velox::wave::KernelSpec spec;
+            spec.code = code;
+            spec.entryPoints = {opEntry};
+            spec.filePath = opFile;
+            spec.numHeaders = 0;
+            spec.headers = nullptr;
+            return spec;
+          });
+      perOpKernels_.push_back(std::move(perOp));
+    }
+  }
+
   // Only compile the kernel if a GPU is available. The one-time
   // NVRTC/system-header initialization (CompiledKernel::initialize()) is run
   // eagerly on the main thread by torch::wave::initialize() before any kernel
@@ -1626,6 +1691,31 @@ void CompositeKernel::warmup() {
   facebook::velox::wave::Stream stream;
   kernel_->launch(0, 1, 1, 0, &stream, args);
   stream.wait();
+}
+
+std::vector<std::pair<std::string, facebook::velox::wave::KernelInfo>>
+CompositeKernel::perOpKernelInfo() {
+  std::vector<std::pair<std::string, facebook::velox::wave::KernelInfo>> result;
+  result.reserve(perOpKernels_.size());
+  for (auto& perOp : perOpKernels_) {
+    if (!perOp.kernel) {
+      continue;
+    }
+    // The launch is the sync point with the queued compile, exactly as
+    // warmup() is for the composite. blockInfo.op is kDebugNoOp, which matches
+    // no case, so the body does nothing.
+    TorchWaveParams params{};
+    memset(&params, 0, sizeof(params));
+    params.info = nullptr;
+    params.debugInfo = nullptr;
+    params.inlineInfo[0].op = kDebugNoOp;
+    void* args[] = {&params};
+    facebook::velox::wave::Stream stream;
+    perOp.kernel->launch(0, 1, 1, 0, &stream, args);
+    stream.wait();
+    result.emplace_back(perOp.entryPoint, perOp.kernel->info(0));
+  }
+  return result;
 }
 
 facebook::velox::wave::KernelInfo CompositeKernel::kernelInfo() const {

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -226,16 +226,33 @@ class CompositeKernel {
 
   void warmup();
 
+  /// Waits for the per-op diagnostic kernels queued under
+  /// WaveConfig::configPerOp and returns each one's entry point and occupancy,
+  /// in the order the ops appear in this kernel. Empty when configPerOp is off
+  /// or no GPU is present.
+  std::vector<std::pair<std::string, facebook::velox::wave::KernelInfo>>
+  perOpKernelInfo();
+
   const std::vector<std::unique_ptr<KernelOperation>>& kernelOps() const {
     return kernelOpStorage_;
   }
 
  private:
+  // One single-op kernel built beside the composite when configPerOp is set.
+  // Diagnostic only: never launched for results, only warmed up so its
+  // occupancy can be read.
+  struct PerOpKernel {
+    int32_t opCode{0};
+    std::string entryPoint;
+    std::unique_ptr<facebook::velox::wave::CompiledKernel> kernel;
+  };
+
   std::unique_ptr<facebook::velox::wave::CompiledKernel> kernel_;
   std::string entryPoint_;
   std::string text_;
   std::vector<std::unique_ptr<ProjectOperation>> ops_;
   std::vector<std::unique_ptr<KernelOperation>> kernelOpStorage_;
+  std::vector<PerOpKernel> perOpKernels_;
 };
 
 /// Records the grid variant (single-block vs multi-block) chosen for a

--- a/velox/experimental/torchwave/KernelOperation.cpp
+++ b/velox/experimental/torchwave/KernelOperation.cpp
@@ -1120,7 +1120,14 @@ SizeExpr KernelOperation::makeDeepSizeExpr() {
       leafIds.push_back(value->id());
     }
   }
-  return SizeExpr{SizeShortcut::kMax, std::move(leafIds), {}};
+  // An op whose work spans a whole tensor list is sized by the total, not the
+  // largest member; kMax would size its grid off one list element and starve
+  // it of blocks. See Metadata::gridSizeSumsInputs.
+  const auto* meta = expr_ ? Registry::metadata(expr_->target()) : nullptr;
+  auto shortcut = (meta != nullptr && meta->gridSizeSumsInputs)
+      ? SizeShortcut::kSum
+      : SizeShortcut::kMax;
+  return SizeExpr{shortcut, std::move(leafIds), {}};
 }
 
 void mergeOutputDesc(OutputDesc& dst, OutputDesc&& src) {

--- a/velox/experimental/torchwave/Registry.cpp
+++ b/velox/experimental/torchwave/Registry.cpp
@@ -305,6 +305,11 @@ MetadataBuilder& MetadataBuilder::alwaysSingleBlock(bool val) {
   return *this;
 }
 
+MetadataBuilder& MetadataBuilder::gridSizeSumsInputs(bool val) {
+  md_.gridSizeSumsInputs = val;
+  return *this;
+}
+
 MetadataBuilder& MetadataBuilder::metadataGetter(bool val) {
   md_.isMetadataGetter = val;
   return *this;

--- a/velox/experimental/torchwave/Registry.h
+++ b/velox/experimental/torchwave/Registry.h
@@ -249,6 +249,13 @@ struct Metadata {
   /// regardless of input size.
   bool alwaysSingleBlock{false};
 
+  /// If true, the grid is sized by the sum of the op's input element counts
+  /// rather than the largest one. Set this when an op's work is the total over
+  /// a tensor list, not the largest member: sizing by the largest gives a grid
+  /// that ignores the list length, so the op runs far fewer blocks than it has
+  /// independent work.
+  bool gridSizeSumsInputs{false};
+
   /// If true, the op reads tensor metadata (shape, size) rather than
   /// computing on tensor data. When used as a size arg producer, it runs as
   /// a standalone rather than a fused op.
@@ -627,6 +634,7 @@ class MetadataBuilder {
   MetadataBuilder& multiBlockReturnBarrier(bool val = true);
   MetadataBuilder& scanOutputReturnBarrier(bool val = true);
   MetadataBuilder& alwaysSingleBlock(bool val = true);
+  MetadataBuilder& gridSizeSumsInputs(bool val = true);
   MetadataBuilder& metadataGetter(bool val = true);
   MetadataBuilder& makeMultiKernelVariant(
       std::function<nativert::Node*(NodeCP, WaveGraph*)> func);

--- a/velox/experimental/torchwave/WaveConfig.cpp
+++ b/velox/experimental/torchwave/WaveConfig.cpp
@@ -95,6 +95,7 @@ std::string WaveConfig::toString() const {
   addBool("runAhead", &WaveConfig::runAhead);
   addInt("maxDelayedFree", &WaveConfig::maxDelayedFree);
   addBool("duplicateMetadata", &WaveConfig::duplicateMetadata);
+  addBool("configPerOp", &WaveConfig::configPerOp);
   addBool("donateBuffers", &WaveConfig::donateBuffers);
   addInt("donationCarryBytes", &WaveConfig::donationCarryBytes);
   addBool("enableAllocGroup", &WaveConfig::enableAllocGroup);

--- a/velox/experimental/torchwave/WaveConfig.h
+++ b/velox/experimental/torchwave/WaveConfig.h
@@ -301,6 +301,15 @@ struct WaveConfig {
   // one block. The concat then becomes a kernel break that copies nothing.
   bool parallelConcatFill{false};
 
+  // If true, alongside each composite kernel also compile one single-op kernel
+  // per op it contains, named <composite>_op_<opCode>. Diagnostic only: the
+  // per-op kernels are never launched for results, they exist so the register /
+  // shared / local memory and occupancy numbers logged after graph construction
+  // are available at one-op resolution instead of only for the fused whole.
+  // Their compiles are queued with the composite's, so the extra cost is
+  // compile parallelism rather than serial latency. Off by default.
+  bool configPerOp{false};
+
   /// Returns the active config: the thread-local override set by
   /// waveConfigOverride() when non-null, otherwise the process-wide singleton.
   /// The singleton is not thread-safe; all of its mutations must happen before

--- a/velox/experimental/torchwave/WaveGraph.cpp
+++ b/velox/experimental/torchwave/WaveGraph.cpp
@@ -325,6 +325,12 @@ WaveGraph::WaveGraph(ModelContext* modelContext)
     ck->warmup();
     auto info = ck->kernelInfo();
     LOG(INFO) << "Kernel " << ck->entryPoint() << ": " << info.toString();
+    // With configPerOp, the same numbers for each op on its own. Waiting here
+    // rather than at construction keeps the per-op compiles overlapped with the
+    // composites'.
+    for (const auto& [entryPoint, opInfo] : ck->perOpKernelInfo()) {
+      LOG(INFO) << "Kernel " << entryPoint << ": " << opInfo.toString();
+    }
   }
 
   // Build standaloneIndices_ by walking all launches across all compiled nodes.

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -198,6 +198,14 @@ DEFINE_bool(
     false,
     "Rematerialize each multiply-used sym_size / sym_numel at its use sites before partitioning, so it stops being a top-level output of a ProjectNode");
 DEFINE_bool(
+    config_per_op,
+    false,
+    "Alongside each composite kernel, compile one single-op kernel per op it "
+    "contains (<composite>_op_<opCode>) and log its register / shared / local "
+    "memory and occupancy after graph construction. Diagnostic only: the "
+    "per-op kernels are never launched for results, they resolve the occupancy "
+    "numbers to a single op instead of the fused whole");
+DEFINE_bool(
     input_contiguous,
     false,
     "Assume all model inputs, weights, and constants are contiguous in the graph optimizer; executeWave verifies and errors out if any is not contiguous");
@@ -681,6 +689,7 @@ void ExecutorTestBase::SetUpTestSuite() {
   WaveConfig::get().runAhead = FLAGS_run_ahead;
   WaveConfig::get().maxDelayedFree = FLAGS_max_delayed_free;
   WaveConfig::get().duplicateMetadata = FLAGS_duplicate_metadata;
+  WaveConfig::get().configPerOp = FLAGS_config_per_op;
   WaveConfig::get().donateBuffers = FLAGS_donate_buffers;
   WaveConfig::get().donationCarryBytes = FLAGS_donation_carry_bytes;
   WaveConfig::get().inputContiguous = FLAGS_input_contiguous;


### PR DESCRIPTION
Summary:

Fuses `torch.ops.fb.batch_flip_and_truncate_sparse` on wave by splitting it, in `maybeReplace`, into `tw.flip_and_truncate_head` and `tw.flip_and_truncate_final` (device functions in `Flip.cuh`). The head processes one feature per block: it computes each row's post-truncation length, inclusive-scans those into new offsets and the original lengths into old offsets, and after an op barrier accumulates the per-feature output totals. The final partitions the concatenated output into fixed 8192-element tiles and grid-strides over them, binary-searching once per tile for the owning feature and row, then walking rows to the end of the tile. Fixed tiles keep every block's work equal even though rows span roughly 300 to 10000 elements after truncation. Each thread resolves the same per-row copy descriptor, which hoists the flip-mode branch out of the element loop and leaves coalesced writes and forward or reversed coalesced reads. It matches the eager kernel across the four flip modes (none, flip_before, flip_after, flip_before_and_after), per-feature `max_lengths`, `pad_value`, and `adaptive_max_len` with a per-row `adaptive_mask`. On the four flip instances of an internal preproc graph the final reaches 75-76% of an A100's nominal bandwidth, against 89% for a `cudaMemcpy` of the same size and 53-66% for the eager kernel's thread mapping.

The final stages its per-feature constants (the offset, value and output pointers, row count, cap and mode) in shared memory rather than holding them in registers across the row loop. That is worth an occupancy step: the register version needs 64 registers and fits 4 blocks per SM, the shared version needs 48 and fits 5, and on a bandwidth-bound copy the extra block is worth about 3%. Sizing that array needs the feature count as a compile-time constant, which is where `Metadata::templateParamFuncs` comes in: a list of functions run on the node at codegen time to append extra template arguments to the device function call, empty for every other op. `Metadata::gridSizeSumsInputs` is the second new hook. An op whose work spans a whole tensor list was sized by its largest member, so the head got `ceil(768 / blockSize)` blocks no matter how many features it had, and most features queued onto three blocks; the flag switches that op to the sum instead. Neither hook changes any op that does not set it.

Three wave-core fixes in `Compile.cpp` support this and correct general bugs. First, an elementwise producer of a `TensorList` element that a fused op reads is now materialized to that element's memory buffer in all modes, so a list built inside the op (for example values from an add) is written where the consumer reads it. Second, a fused op that reads such a list emits a barrier when a same-op element producer is not already behind one, independent of the input's `randomAccess` flag. Third, subgraph deduplication now hashes int-list (ScalarList) attributes, whose element values are baked into the generated code; without this two otherwise-identical ops that differ only in such an attribute (for example `adaptive_mask`) would share a wrong kernel.

Reviewed By: Yuhta

Differential Revision: D111315788


