### PR TITLE
fix(torchwave): Barrier before an elementwise op reads a leaf this kernel wrote (#18862)

### DIFF
--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -2250,55 +2250,59 @@ void CompileCtx::emitBarrier() {
   }
 }
 
+// Resolves the ordering question for one operand. An input read through a
+// view is the base's storage: a view of something this kernel fills still
+// needs the barrier, a view of anything else does not, and the view node
+// itself never writes and so never justifies one. An in-place writer is not
+// the base's producer either -- the storage was created elsewhere, often in
+// an earlier kernel -- so the producer test alone cannot see it; ask the
+// users too, since a writer running unsynchronized in this kernel is the same
+// hazard as a producer running in it.
+bool CompileCtx::valueNeedsBarrier(ValueCP operand, NodeCP consumer) {
+  auto* value = viewBase(operand);
+  if (!value) {
+    return false;
+  }
+  auto* producer = value->producer();
+  if (producer && generatingOp_->allNodes().count(producer) &&
+      !preBarrierValues_.count(value)) {
+    return true;
+  }
+  for (auto* user : value->users()) {
+    if (user == consumer || !generatingOp_->allNodes().count(user)) {
+      continue;
+    }
+    const auto* userMeta = nodeMeta(user);
+    if (!userMeta || !userMeta->mutatesArg.has_value()) {
+      continue;
+    }
+    auto ordinal = static_cast<size_t>(*userMeta->mutatesArg);
+    const auto& userInputs = user->inputs();
+    if (ordinal >= userInputs.size() || userInputs[ordinal].value != value) {
+      continue;
+    }
+    bool synchronized = true;
+    for (auto* output : user->outputs()) {
+      if (!preBarrierValues_.count(output)) {
+        synchronized = false;
+        break;
+      }
+    }
+    if (!synchronized) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool CompileCtx::callNeedsBarrier(NodeCP node) {
   // A call reads its inputs from memory, so if a producer ran earlier in this
   // same kernel with no barrier since, that producer's writes from other blocks
   // may not yet be visible. randomAccess is not consulted -- an aligned read is
   // still unsafe across blocks, and the preBarrierValues_ check below avoids
   // emitting a redundant barrier when one already separates them.
-  // Resolves the ordering question for one operand. An input read through a
-  // view is the base's storage: a view of something this kernel fills still
-  // needs the barrier, a view of anything else does not, and the view node
-  // itself never writes and so never justifies one. An in-place writer is not
-  // the base's producer either -- the storage was created elsewhere, often in
-  // an earlier kernel -- so the producer test alone cannot see it; ask the
-  // users too, since a writer running unsynchronized in this kernel is the same
-  // hazard as a producer running in it.
   auto needsBarrierFor = [&](ValueCP operand) {
-    auto* value = viewBase(operand);
-    if (!value) {
-      return false;
-    }
-    auto* producer = value->producer();
-    if (producer && generatingOp_->allNodes().count(producer) &&
-        !preBarrierValues_.count(value)) {
-      return true;
-    }
-    for (auto* user : value->users()) {
-      if (user == node || !generatingOp_->allNodes().count(user)) {
-        continue;
-      }
-      const auto* userMeta = nodeMeta(user);
-      if (!userMeta || !userMeta->mutatesArg.has_value()) {
-        continue;
-      }
-      auto ordinal = static_cast<size_t>(*userMeta->mutatesArg);
-      const auto& userInputs = user->inputs();
-      if (ordinal >= userInputs.size() || userInputs[ordinal].value != value) {
-        continue;
-      }
-      bool synchronized = true;
-      for (auto* output : user->outputs()) {
-        if (!preBarrierValues_.count(output)) {
-          synchronized = false;
-          break;
-        }
-      }
-      if (!synchronized) {
-        return true;
-      }
-    }
-    return false;
+    return valueNeedsBarrier(operand, node);
   };
   // One whole operand. For a tensor list the list node itself is
   // metadata-only, so the real producers are the element nodes.

--- a/velox/experimental/torchwave/Compile.h
+++ b/velox/experimental/torchwave/Compile.h
@@ -212,6 +212,12 @@ class CompileCtx {
   /// same kernel (generatingOp_) without an intervening barrier.
   bool callNeedsBarrier(NodeCP node);
 
+  /// Returns true if reading 'operand' from memory needs a barrier first:
+  /// something earlier in this same kernel writes the storage it names and no
+  /// barrier has separated the two. 'consumer' is the node about to read it,
+  /// which is not counted as a writer of its own input.
+  bool valueNeedsBarrier(ValueCP operand, NodeCP consumer);
+
   void addInclude(std::string_view header);
 
   std::string declareAttributes(

--- a/velox/experimental/torchwave/Elementwise.cpp
+++ b/velox/experimental/torchwave/Elementwise.cpp
@@ -247,6 +247,13 @@ void CompileCtx::generateElementwise(
     newExprs.push_back(std::move(ee));
   }
 
+  // The leaves as they stand before the result values are appended below.
+  // These, and only these, are the values the generated expressions read from
+  // memory; everything else in the tree is a register temp. The barrier check
+  // further down needs the distinction.
+  const std::unordered_set<ValueCP> memoryLeaves(
+      leafInputs.begin(), leafInputs.end());
+
   for (size_t s = 0; s < resultSpecs.size(); ++s) {
     auto& rs = resultSpecs[s];
     if (!rs.value) {
@@ -467,9 +474,8 @@ void CompileCtx::generateElementwise(
   code_ << "  }\n"
         << "  __syncthreads();\n";
 
-  // If any node in any elementwise subgraph has a randomAccess input
-  // produced in this kernel without a prior barrier, emit one after
-  // the size setup.
+  // If anything the subgraphs read was written earlier in this same kernel
+  // without a barrier since, emit one after the size setup.
   {
     bool needsBarrier = false;
     std::function<void(ValueCP)> checkTree = [&](ValueCP value) {
@@ -485,8 +491,27 @@ void CompileCtx::generateElementwise(
         checkTree(input.value);
       }
     };
+    // A leaf is a memory read like any call operand, and callNeedsBarrier
+    // cannot see it: every argument of an elementwise op is registered
+    // isRegister, which is true of a value fused inline into the expression
+    // and false of one that reached memory. Nothing else covers a consumer
+    // that reads, at index i, an element another block wrote -- which is what
+    // a leaf that is a transposed view of a value this kernel just filled is.
+    auto leavesNeedBarrier = [&](const Subgraph& sg) {
+      const std::unordered_set<ValueCP> sgInputSet(
+          sg.inputs.begin(), sg.inputs.end());
+      std::unordered_set<ValueCP> visited;
+      std::vector<ValueCP> leaves;
+      collectSubgraphInputs(sg.root, sgInputSet, visited, leaves);
+      for (auto* leaf : leaves) {
+        if (memoryLeaves.count(leaf) && valueNeedsBarrier(leaf, sg.root)) {
+          return true;
+        }
+      }
+      return false;
+    };
     for (const auto& sg : subgraphs) {
-      if (callNeedsBarrier(sg.root)) {
+      if (callNeedsBarrier(sg.root) || leavesNeedBarrier(sg)) {
         needsBarrier = true;
         break;
       }

--- a/velox/experimental/torchwave/ParallelExpr.cpp
+++ b/velox/experimental/torchwave/ParallelExpr.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -112,6 +113,56 @@ float selfCost(NodeCP /*expr*/) {
 struct LevelData {
   NodeSet exprs;
 };
+
+// A metadata getter (sym_size / sym_numel) whose only role is to be a top-level
+// graph output, over an operand something else also reads.
+//
+// Such a getter is in `top`, so makeLevelsInner counts a second reference to
+// its operand's producer, and makeCseBorder turns that into a border: the
+// producer moves to its own earlier layer and every other consumer of it
+// follows a layer later than it needed to. The getter's own work is one scalar
+// field read on the host; the whole cost is the layer split it forces.
+//
+// Users are counted through 'reachable', not through users(): torch.export
+// leaves dead `_operator.ge` / `_operator.le` shape guards behind once the
+// asserts are stripped -- 428 of them on the ROO graph -- and they appear in a
+// value's users() while contributing to no level. Counting them refuses every
+// candidate.
+bool isDeferredSizeOutput(
+    NodeCP node,
+    NodeCP outputNode,
+    const NodeSet& reachable) {
+  const Metadata* meta = Registry::metadata(node->target());
+  if (meta == nullptr || !meta->isMetadataGetter) {
+    return false;
+  }
+  if (node->outputs().size() != 1 || node->outputs()[0] == nullptr) {
+    return false;
+  }
+  // Consumed on the device as well as returned: it has to stay a real op or the
+  // consumer has nothing to read.
+  for (auto* user : node->outputs()[0]->users()) {
+    if (user != outputNode && reachable.count(user) > 0) {
+      return false;
+    }
+  }
+  if (node->inputs().empty() || node->inputs()[0].value == nullptr) {
+    return false;
+  }
+  ValueCP operand = node->inputs()[0].value;
+  if (operand->producer() == nullptr) {
+    return false;
+  }
+  // Sole user: removing the reference merges no layer, so there is nothing to
+  // win and no reason to grow a second mechanism.
+  int32_t others = 0;
+  for (auto* user : operand->users()) {
+    if (user != node && reachable.count(user) > 0) {
+      ++others;
+    }
+  }
+  return others > 0;
+}
 
 size_t levelOf(std::vector<LevelData>& levels, NodeCP expr) {
   for (size_t i = 0; i < levels.size(); ++i) {
@@ -2017,6 +2068,36 @@ ProjectNode* ParallelNodes::makeParallelNodes(const nativert::Graph& graph) {
   auto topExprs = args(root);
   NodeSet top(topExprs.begin(), topExprs.end());
 
+  // Returned metadata getters, excluded from the level walk so they stop
+  // creating a CSE border on their operand. Put back before the last layer is
+  // built (below) so they still run and still fill their output slot.
+  //
+  // The reachable set is built here rather than at function scope so a run with
+  // the flag off does not pay for a walk of the whole graph.
+  std::vector<NodeCP> deferredSizes;
+  if (WaveConfig::get().deferSizeOutputs) {
+    NodeSet reachable;
+    std::vector<NodeCP> stack(topExprs.begin(), topExprs.end());
+    while (!stack.empty()) {
+      NodeCP n = stack.back();
+      stack.pop_back();
+      if (!reachable.insert(n).second) {
+        continue;
+      }
+      for (auto* in : args(n)) {
+        stack.push_back(in);
+      }
+    }
+    for (auto* expr : top) {
+      if (isDeferredSizeOutput(expr, root, reachable)) {
+        deferredSizes.push_back(expr);
+      }
+    }
+    for (auto* expr : deferredSizes) {
+      top.erase(expr);
+    }
+  }
+
   std::vector<LevelData> levelData;
   std::unordered_map<NodeCP, int32_t> refCount;
   makeExprLevels(top, levelData, refCount);
@@ -2073,11 +2154,31 @@ ProjectNode* ParallelNodes::makeParallelNodes(const nativert::Graph& graph) {
     current = project;
   }
 
+  // The deferred getters rejoin here: topExprs still lists them, so they are
+  // already in the layer's node set; putting them back in 'top' is what makes
+  // collectReachable pull their operands in as layer inputs.
+  for (auto* expr : deferredSizes) {
+    top.insert(expr);
+  }
+
   auto* project = makeParallelProject(current, top, topExprs);
   if (project == nullptr) {
     TORCH_CHECK(false, "makeParallelProject returned null");
   }
   current = project;
+
+  if ((WaveConfig::get().trace & WaveConfig::kTiming) &&
+      WaveConfig::get().deferSizeOutputs) {
+    int32_t layers = 0;
+    for (auto* p = current; p != nullptr; p = p->input()) {
+      ++layers;
+    }
+    std::cout << fmt::format(
+        "partition: {} layers, last layer has {} exprs, {} size outputs deferred\n",
+        layers,
+        current->nodes().size(),
+        deferredSizes.size());
+  }
 
   // All layers are now built in execution order; annotate each with its
   // last-use / reusable-last-use values.

--- a/velox/experimental/torchwave/WaveConfig.cpp
+++ b/velox/experimental/torchwave/WaveConfig.cpp
@@ -96,6 +96,7 @@ std::string WaveConfig::toString() const {
   addInt("maxDelayedFree", &WaveConfig::maxDelayedFree);
   addBool("duplicateMetadata", &WaveConfig::duplicateMetadata);
   addBool("configPerOp", &WaveConfig::configPerOp);
+  addBool("deferSizeOutputs", &WaveConfig::deferSizeOutputs);
   addBool("donateBuffers", &WaveConfig::donateBuffers);
   addInt("donationCarryBytes", &WaveConfig::donationCarryBytes);
   addBool("enableAllocGroup", &WaveConfig::enableAllocGroup);

--- a/velox/experimental/torchwave/WaveConfig.h
+++ b/velox/experimental/torchwave/WaveConfig.h
@@ -149,7 +149,7 @@ struct WaveConfig {
 
   // If true, adjust per-op cost multipliers after each execution based on
   // actual thread block clock distribution.
-  bool autoAdjustCost{false};
+  bool autoAdjustCost{true};
 
   // If true, reuse a value's buffer in place when an op is its unique last use
   // (turning copying ops into in-place ops), and drop clones that no consumer
@@ -243,6 +243,30 @@ struct WaveConfig {
   // by default.
   bool duplicateMetadata{false};
 
+  // EXPERIMENT, off by default and not correct yet. If true, a metadata getter
+  // whose only reachable user is the output node stops being counted as a use
+  // of its operand when the partitioner builds its levels, so the operand does
+  // not become a CSE border on the getter's account. The getter is put back
+  // before the last layer is built, so it still runs and still occupies its
+  // output slot.
+  //
+  // What it is for: on the ROO preproc graph 255 of the 297 top-level exprs are
+  // returned sym_size getters, and 248 of them have an operand whose only other
+  // reachable user is one consumer. Each of those is a border that exists
+  // purely because the size is returned, and each pushes its operand's producer
+  // into an earlier layer. Removing them is what would give the last layer more
+  // to carve.
+  //
+  // Why it is not correct yet: dropping the reference takes those 248 operands
+  // to a single user, so their producers stop being borders and fuse into that
+  // consumer -- and 238 of the 255 are produced by aten.slice (a view) or
+  // aten.zeros, neither of which leaves a tensor in the frame once inlined. The
+  // getter would then read the size of something that does not exist. The
+  // shapes are all host-computable, so the fix is shape propagation rather than
+  // a frame read, but that is not written. Use this only to measure what the
+  // partitioning change is worth.
+  bool deferSizeOutputs{false};
+
   // If true, the graph optimizer assumes every producer-less value (model
   // input, weight, or constant) is contiguous, so downstream passes may treat
   // them as densely laid out. When on, executeWave verifies each such tensor is
@@ -323,7 +347,7 @@ struct WaveConfig {
   }
 
   /// Returns a compact, comma-separated list of the settings whose value
-  /// differs from its default (e.g. "trace=16, autoAdjustCost=true,
+  /// differs from its default (e.g. "trace=16, autoAdjustCost=false,
   /// freeIntermediates=true"), or "defaults" when every field is at its
   /// default. Used in the performance report so a run's active configuration is
   /// self-documenting.

--- a/velox/experimental/torchwave/tests/CompileTest.cpp
+++ b/velox/experimental/torchwave/tests/CompileTest.cpp
@@ -1004,6 +1004,50 @@ return(%r)
   EXPECT_GT(countSteps(*standaloneGraph), fusedSteps)
       << standalonePlan.describe();
 }
+
+// An operand that is a transposed view of a value the same kernel just wrote
+// is read, at index i, as an element some other block produced. Only a
+// grid-wide barrier orders that; the __syncthreads() between two fused
+// expressions covers one block. The operand is marked isRegister like every
+// elementwise argument, which is why the barrier test cannot go by that flag.
+TEST_F(CompileTest, barrierBeforeATransposedLeafOfThisKernel) {
+  auto f = [] { return makeTensorMeta(c10::ScalarType::Float, 2); };
+  std::unordered_map<std::string, torch::_export::TensorMeta> meta = {
+      {"a", f()}, {"b", f()}, {"c", f()}, {"s", f()}, {"ts", f()}, {"r", f()}};
+  const char* graphStr = R"(graph(%a, %b, %c):
+%s = torch.ops.aten.add.Tensor(self=%a, other=%b)
+%ts = torch.ops.aten.transpose.int(self=%s, dim0=0, dim1=1)
+%r = torch.ops.aten.mul.Tensor(self=%ts, other=%c)
+return(%r)
+)";
+
+  auto waveGraph = compileGraphString(graphStr, meta);
+  ASSERT_NE(waveGraph, nullptr);
+  auto plan = CompiledPlan::from(*waveGraph, CompiledPlan::Mode::kMultiKernel);
+  EXPECT_TRUE(plan.fuses({"aten.add.Tensor", "aten.mul.Tensor"}))
+      << plan.describe();
+  EXPECT_TRUE(plan.barrierBetween("aten.mul.Tensor", "aten.add.Tensor"))
+      << plan.describe();
+
+  // Contrast: consumed straight through, the intermediate stays in a register
+  // and there is nothing to order. Without this the test would still pass if
+  // every fused elementwise pair started carrying a barrier.
+  std::unordered_map<std::string, torch::_export::TensorMeta> directMeta = {
+      {"a", f()}, {"b", f()}, {"c", f()}, {"s", f()}, {"r", f()}};
+  const char* directStr = R"(graph(%a, %b, %c):
+%s = torch.ops.aten.add.Tensor(self=%a, other=%b)
+%r = torch.ops.aten.mul.Tensor(self=%s, other=%c)
+return(%r)
+)";
+
+  auto directGraph = compileGraphString(directStr, directMeta);
+  ASSERT_NE(directGraph, nullptr);
+  auto directPlan =
+      CompiledPlan::from(*directGraph, CompiledPlan::Mode::kMultiKernel);
+  EXPECT_FALSE(directPlan.barrierBetween("aten.mul.Tensor", "aten.add.Tensor"))
+      << directPlan.describe();
+}
+
 // True when the node producing %<name> reads the same value twice, i.e. its
 // two operands were merged. Asking the consumer rather than counting nodes is
 // what keeps the answer independent of whether the merged-away node is later

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -150,8 +150,8 @@ DEFINE_bool(
     "Launch kernel once per block for debugging, waiting after each launch");
 DEFINE_bool(
     auto_adjust_cost,
-    false,
-    "Adjust per-op cost multipliers after each execution based on actual thread block clocks");
+    true,
+    "Adjust per-op cost multipliers after each execution based on actual thread block clocks. Defaults to WaveConfig's own default, which this flag assigns unconditionally: a different default here would silently override the engine's");
 
 DEFINE_bool(
     enable_reuse,
@@ -217,6 +217,10 @@ DEFINE_bool(
     cse_views,
     false,
     "Before partitioning, merge view nodes that produce the same value from the same operands");
+DEFINE_bool(
+    defer_size_outputs,
+    false,
+    "EXPERIMENT, not correct yet. Stop counting a returned sym_size / sym_numel as a use of its operand when the partitioner builds its levels, so the operand does not become a CSE border on the getter's account. Measures what removing those borders is worth; the getter can end up reading a tensor that was fused away");
 DEFINE_bool(
     mk_select,
     false,
@@ -690,6 +694,7 @@ void ExecutorTestBase::SetUpTestSuite() {
   WaveConfig::get().maxDelayedFree = FLAGS_max_delayed_free;
   WaveConfig::get().duplicateMetadata = FLAGS_duplicate_metadata;
   WaveConfig::get().configPerOp = FLAGS_config_per_op;
+  WaveConfig::get().deferSizeOutputs = FLAGS_defer_size_outputs;
   WaveConfig::get().donateBuffers = FLAGS_donate_buffers;
   WaveConfig::get().donationCarryBytes = FLAGS_donation_carry_bytes;
   WaveConfig::get().inputContiguous = FLAGS_input_contiguous;


### PR DESCRIPTION
Summary:

Two independent changes, folded into one diff. The first is the barrier fix
this diff was opened for; the second is the sym_size border experiment that
was D118061301.

## Barrier before an elementwise op reads a leaf this kernel wrote

An elementwise op's operands are all marked `isRegister` by
`registerElementwise`, and `callNeedsBarrier` skips register operands on
the grounds that they flow inline rather than through memory. That holds
for a value fused into the expression tree; it does not hold for a leaf,
which is a load like any other. The test was that the two are the same
thing, and they are not, so no pure-elementwise op ever asked for a
barrier.

What that costs is visible whenever the leaf does not map index to index.
The ROO preproc graph fuses

    (%3274)  = where.self(...)
    (%11769) = transpose.int(%3274, dim0=0, dim1=1)
    (%11800) = mul(%11771, %11769)

into one kernel with nothing but `__syncthreads()` between the write and
the read. Through the transpose the element thread i of the `mul` wants
was written by a different block, so `%11800` came out part stale and
part uninitialized -- and only in the multi-block modes, which is what
made it look like a miscompile rather than a race.

The operand test `callNeedsBarrier` already had is now
`valueNeedsBarrier`, and `generateElementwise` runs it over each
subgraph's own memory leaves.

## Stop a returned sym_size bordering its operand (was D118061301)

A metadata getter (`sym_size` / `sym_numel`) whose only role is to be a graph
output still counts as a use of its operand when the partitioner builds its
levels. `makeLevelsInner` increments the operand's producer refCount, and
`makeCseBorder` turns anything above one into a border: the producer moves to
its own earlier layer and every other consumer of it follows a layer later than
it needed to. The getter's own work is one scalar field read on the host; the
whole cost is the layer split it forces.

`WaveConfig::deferSizeOutputs`, OFF BY DEFAULT, drops those getters from `top`
before `makeExprLevels` so they stop being a reference, and puts them back
before the last layer is built so they still run and still fill their output
slot.

The predicate counts users through the set reachable from the output node, not
through `users()`. torch.export leaves dead `_operator.ge` / `_operator.le`
shape guards behind once the asserts are stripped -- 428 of them on the ROO
preproc graph -- and they appear in a value's `users()` while contributing to no
level. Counting them refuses every candidate; with them filtered out, 255 of the
graph's 297 top-level exprs qualify and 248 of those have an operand whose only
other reachable user is a single consumer.

It is off by default because on that graph it is a net loss, and the measurement
is the point of the commit rather than the feature. See the test plan.

Reviewed By: Yuhta

Differential Revision: D118061298


