### PR TITLE
feat(torchwave): Split a starved step into balanced kernel launches (#18865)

### DIFF
--- a/velox/experimental/torchwave/AllocGroup.cpp
+++ b/velox/experimental/torchwave/AllocGroup.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/torchwave/AllocGroup.h"
 
 #include <fmt/core.h>
+#include <folly/CppAttributes.h>
 #include <algorithm>
 #include <iostream>
 #include <map>
@@ -329,25 +330,31 @@ void sizeExprValues(const SizeExpr& expr, std::vector<nativert::ValueId>& out) {
 // there yet, so its extent has to come from a size expression over values that
 // are: a reserve function is rejected rather than run early, since what it
 // reads is its own business and need not exist yet.
-bool operandMeasurableAt(
+// Why an operand's extent cannot be computed at 'point', or nullptr when it
+// can. The layout needs every operand measurable at one common point, so a
+// single operand answering non-null here refuses the whole concat -- and the
+// first three reasons hold at every point, not just this one.
+const char* FOLLY_NULLABLE operandUnmeasurableReason(
     const ConcatInputInfo& operand,
     const ProducedMap& produced,
     ExecPoint point) {
-  // A view is measurable even though it can never be carved: its extent is the
-  // host's to compute like any other operand's, and it is only its lack of
-  // storage of its own that keeps it out of the group's members. Refusing it
-  // here would instead sink the whole concat, since one view operand would make
-  // the layout look uncomputable at every point.
   if (operand.hasShapeOnDevice) {
-    return false;
+    return "extent settled on device";
   }
   if (operand.isSubgraphInput) {
     const auto it = produced.find(operand.valueId);
-    return it == produced.end() || !(point < it->second.at);
+    return (it == produced.end() || !(point < it->second.at))
+        ? nullptr
+        : "produced after this point";
   }
-  if (operand.reserveShape != nullptr || operand.hasReserveInChain ||
-      operand.sizeExpr.op == SizeShortcut::kNone) {
-    return false;
+  if (operand.reserveShape != nullptr) {
+    return "behind a reserveShape";
+  }
+  if (operand.hasReserveInChain) {
+    return "behind a reserveShape in its chain";
+  }
+  if (operand.sizeExpr.op == SizeShortcut::kNone) {
+    return "no size shortcut for its extent";
   }
   std::vector<nativert::ValueId> reads;
   sizeExprValues(operand.sizeExpr, reads);
@@ -360,11 +367,26 @@ bool operandMeasurableAt(
     // own reserve -- so the expression has to give the same answer both times.
     // A value written at more than one point can change in between, and the two
     // would disagree about where every operand after it starts.
-    if (point < it->second.at || it->second.numWrites != 1) {
-      return false;
+    if (point < it->second.at) {
+      return "its size expression reads a value produced later";
+    }
+    if (it->second.numWrites != 1) {
+      return "its size expression reads a value written more than once";
     }
   }
-  return true;
+  return nullptr;
+}
+
+// A view is measurable even though it can never be carved: its extent is the
+// host's to compute like any other operand's, and it is only its lack of
+// storage of its own that keeps it out of the group's members. Refusing it
+// here would instead sink the whole concat, since one view operand would make
+// the layout look uncomputable at every point.
+bool operandMeasurableAt(
+    const ConcatInputInfo& operand,
+    const ProducedMap& produced,
+    ExecPoint point) {
+  return operandUnmeasurableReason(operand, produced, point) == nullptr;
 }
 
 // The concat 'layout' describes, in the frame values of the invocation that
@@ -423,6 +445,20 @@ std::vector<AllocGroup> graphConcatGroups(
     }
   };
 
+  // The per-reason counters say how many concats were refused but not which,
+  // and a wide one left out is the difference between a parallel fill and a
+  // chain of __concatCopy walked by a single block. Name them.
+  auto refuse = [&](int32_t AllocGroupStats::* counter,
+                    const ConcatFootprint& concat,
+                    const char* reason) {
+    count(counter);
+    if (WaveConfig::get().trace & WaveConfig::kTiming) {
+      std::cout << "  concat %" << concat.resultId << " of "
+                << concat.operands.size() << " operands not placed: " << reason
+                << std::endl;
+    }
+  };
+
   for (const auto& node : nodes) {
     for (const auto& launch : node.launches) {
       const ExecPoint concatPoint{node.node, launch.step};
@@ -436,7 +472,10 @@ std::vector<AllocGroup> graphConcatGroups(
         const auto resultIt = produced.find(concat.resultId);
         if (resultIt == produced.end() || resultIt->second.numWrites != 1 ||
             claimed.count(concat.resultId) != 0) {
-          count(&AllocGroupStats::numConcatUnplaceableOperand);
+          refuse(
+              &AllocGroupStats::numConcatUnplaceableOperand,
+              concat,
+              "the result is not this launch's to place");
           continue;
         }
 
@@ -447,7 +486,10 @@ std::vector<AllocGroup> graphConcatGroups(
           }
         }
         if (onDevice) {
-          count(&AllocGroupStats::numConcatOnDevice);
+          refuse(
+              &AllocGroupStats::numConcatOnDevice,
+              concat,
+              "an operand's extent is settled on device");
           continue;
         }
 
@@ -474,7 +516,30 @@ std::vector<AllocGroup> graphConcatGroups(
           }
         }
         if (at.first < 0) {
-          count(&AllocGroupStats::numConcatUnplaceableOperand);
+          std::string why = "no execution point measures every operand";
+          if (WaveConfig::get().trace & WaveConfig::kTiming) {
+            // Which operands are in the way, tallied at the concat's own point
+            // -- the latest one the layout may use, so anything unmeasurable
+            // here is unmeasurable everywhere.
+            std::map<std::string, std::vector<nativert::ValueId>> blockers;
+            for (const auto& operand : concat.operands) {
+              if (const auto* reason = operandUnmeasurableReason(
+                      operand, produced, concatPoint)) {
+                blockers[reason].push_back(operand.valueId);
+              }
+            }
+            for (const auto& [reason, ids] : blockers) {
+              why += fmt::format(" [{} x {}:", ids.size(), reason);
+              for (size_t i = 0; i < ids.size() && i < 6; ++i) {
+                why += fmt::format(" %{}", ids[i]);
+              }
+              why += "]";
+            }
+          }
+          refuse(
+              &AllocGroupStats::numConcatUnplaceableOperand,
+              concat,
+              why.c_str());
           continue;
         }
 
@@ -509,11 +574,24 @@ std::vector<AllocGroup> graphConcatGroups(
         // and one already materialized before 'at' is copied into it. What
         // still cannot take a view is an operand that is not a value of its
         // own to redirect.
+        // Why each operand the group could not carve was left out, so a wide
+        // concat that still copies says which rule cost it. Tallied only under
+        // the trace bit; the loop is per operand of every concat.
+        std::map<std::string, std::vector<nativert::ValueId>> uncarved;
+        const bool tallyUncarved =
+            (WaveConfig::get().trace & WaveConfig::kTiming) != 0;
+        auto leaveOut = [&](const char* reason, nativert::ValueId id) {
+          if (tallyUncarved) {
+            uncarved[reason].push_back(id);
+          }
+        };
         for (size_t i = 0; i < concat.operands.size(); ++i) {
           const auto& operand = concat.operands[i];
           // A view aliases somebody else's buffer, so there is no write of its
           // own to redirect into the region; it is copied in instead.
           if (operand.isView) {
+            leaveOut(
+                "a view, so no write of its own to redirect", operand.valueId);
             continue;
           }
           // Joining anywhere but the outermost axis makes the operand's region
@@ -522,22 +600,32 @@ std::vector<AllocGroup> graphConcatGroups(
           // their own and the concat copies it in.
           if (concat.dim != 0 && !operand.mayWriteStrided) {
             count(&AllocGroupStats::numConcatStridedBand);
+            leaveOut(
+                "a pitched band its producer cannot write", operand.valueId);
             continue;
           }
           // cat([x, y, x]): one buffer cannot be two regions of the result.
           if (occurrences[operand.valueId] != 1) {
+            leaveOut("joined at more than one position", operand.valueId);
             continue;
           }
           const auto it = produced.find(operand.valueId);
-          if (it == produced.end() || it->second.numWrites != 1) {
+          if (it == produced.end()) {
+            leaveOut("no kernel launch writes it", operand.valueId);
+            continue;
+          }
+          if (it->second.numWrites != 1) {
+            leaveOut("written at more than one point", operand.valueId);
             continue;
           }
           // A view cannot value-convert, so an operand the concat would promote
           // has to keep its own buffer and be copied in.
           if (it->second.dtype != concat.dtype) {
+            leaveOut("a dtype the concat would promote", operand.valueId);
             continue;
           }
           if (claimed.count(operand.valueId) != 0) {
+            leaveOut("already claimed by another group", operand.valueId);
             continue;
           }
           layout->memberOfOperand[i] =
@@ -545,6 +633,20 @@ std::vector<AllocGroup> graphConcatGroups(
           group.actualIds.push_back(operand.valueId);
           group.dtypes.push_back(concat.dtype);
           group.needsSync = group.needsSync || it->second.needsSync;
+        }
+        if (tallyUncarved && !uncarved.empty()) {
+          std::cout << "  concat %" << concat.resultId << " of "
+                    << concat.operands.size()
+                    << " operands: " << group.actualIds.size()
+                    << " carved, left out";
+          for (const auto& [reason, ids] : uncarved) {
+            std::cout << " [" << ids.size() << " x " << reason << ":";
+            for (size_t k = 0; k < ids.size() && k < 8; ++k) {
+              std::cout << " %" << ids[k];
+            }
+            std::cout << "]";
+          }
+          std::cout << std::endl;
         }
         // A group with nothing to carve is still worth forming: it owns the
         // result's backing store and lays every operand's region out on the

--- a/velox/experimental/torchwave/Builtins.cpp
+++ b/velox/experimental/torchwave/Builtins.cpp
@@ -729,10 +729,16 @@ bool viewHasDynamicShapeArgs(NodeCP node, const ValueTypes& /*types*/) {
 // Consulting the consumer's isStandalone cannot recurse back here: a getter
 // takes a tensor and yields a scalar, so a getter is never the user of a
 // getter.
-// Unused while the isStandaloneFunc call sites below are disabled.
-[[maybe_unused]] bool metadataGetterIsAlone(
-    NodeCP node,
-    const ValueTypes& types) {
+//
+// A getter left fused when it is alone costs a whole thread block that reads
+// one field and exits. That block is charged against the launch's slowest
+// block, so a handful of them drag a step's reported balance down and the
+// packer has nothing it can do about it -- there is no block count at which a
+// no-op op balances.
+bool metadataGetterIsAlone(NodeCP node, const ValueTypes& types) {
+  if (!WaveConfig::get().metadataGetterStandalone) {
+    return false;
+  }
   if (node->outputs().empty() || node->outputs()[0] == nullptr) {
     return false;
   }
@@ -1812,7 +1818,10 @@ void registerBuiltins() {
         .numArgs(1)
         .ignoreAttrs({"self", "non_blocking"})
         .argumentMeta({{}, {.isRegister = true}, {}})
-        .returnMeta({{.isRegister = true, .reserveShape = selfShape}})
+        .returnMeta(
+            {{.isRegister = true,
+              .reserveShape = selfShape,
+              .shapeFromInput = 0}})
         .normalize(resolveDtypeFromInputExact)
         .rankArgument(0)
         .outputConstraints(selfRankContiguous)
@@ -1860,7 +1869,10 @@ void registerBuiltins() {
         .hasDtypeTemplateParam()
         .ignoreAttrs({"self", "non_blocking"})
         .argumentMeta({{}, {.isRegister = true}})
-        .returnMeta({{.isRegister = false, .reserveShape = selfShape}})
+        .returnMeta(
+            {{.isRegister = false,
+              .reserveShape = selfShape,
+              .shapeFromInput = 0}})
         .normalize(resolveDtypeFromInputExact)
         .rankArgument(0)
         .outputConstraints(selfRankContiguous)
@@ -1965,7 +1977,8 @@ void registerBuiltins() {
                                const NodeMap& /*nodeMap*/)
                 -> std::vector<std::vector<Dim>> {
               return elementwiseInputShape(node, frame, map, 0);
-            }}})
+            },
+            .shapeFromInput = 0}})
       .normalize(resolveDtypeFromInputExact)
       .rankArgument(0)
       .hasDtypeTemplateParam()
@@ -1985,7 +1998,8 @@ void registerBuiltins() {
                                const NodeMap& /*nodeMap*/)
                 -> std::vector<std::vector<Dim>> {
               return elementwiseInputShape(node, frame, map, 0);
-            }}})
+            },
+            .shapeFromInput = 0}})
       .normalize(resolveDtypeFromInputExact)
       .rankArgument(0)
       .hasDtypeTemplateParam()
@@ -2086,7 +2100,7 @@ void registerBuiltins() {
       .returnMeta({{.isRegister = true}})
       .metadataGetter()
       .metadataOnly()
-      // TEMP-AB-DISABLED .isStandaloneFunc(metadataGetterIsAlone)
+      .isStandaloneFunc(metadataGetterIsAlone)
       .isScalarElementwise()
       .registerOp();
 
@@ -2099,7 +2113,7 @@ void registerBuiltins() {
       .returnMeta({{.isRegister = true}})
       .metadataGetter()
       .metadataOnly()
-      // TEMP-AB-DISABLED .isStandaloneFunc(metadataGetterIsAlone)
+      .isStandaloneFunc(metadataGetterIsAlone)
       .isScalarElementwise()
       .registerOp();
 
@@ -3837,7 +3851,8 @@ void registerBuiltins() {
                                const NodeMap& /*nodeMap*/)
                 -> std::vector<std::vector<Dim>> {
               return elementwiseInputShape(node, frame, map, 0);
-            }}})
+            },
+            .shapeFromInput = 0}})
       .normalize(resolveDtypeFromInput)
       .makeMultiKernelVariant(
           singlePass ? makeCumsumSinglePassVariant : makeCumsumVariant)
@@ -3925,7 +3940,10 @@ void registerBuiltins() {
       .sizeOrdinal({0})
       .argumentMeta(
           {{.isRegister = false}, {.isRegister = false}, {.linkOnly = true}})
-      .returnMeta({{.isRegister = false, .reserveShape = inputShape}})
+      .returnMeta(
+          {{.isRegister = false,
+            .reserveShape = inputShape,
+            .shapeFromInput = 0}})
       .inputFromPreviousKernel(2)
       .headerFile(kScanHeader)
       .deviceFunc("cumsum_final")
@@ -3963,7 +3981,10 @@ void registerBuiltins() {
       .sizeShortcut(SizeShortcut::kMax)
       .hasBarrier()
       .singleBlockIfFused()
-      .returnMeta({{.isRegister = false, .reserveShape = inputShapePlusOne}})
+      .returnMeta(
+          {{.isRegister = false,
+            .reserveShape = inputShapePlusOne,
+            .shapeFromInput = 0}})
       .normalize(resolveDtypeFromInput)
       .makeMultiKernelVariant(
           singlePass ? makeExclusiveSumSinglePassVariant
@@ -4054,7 +4075,10 @@ void registerBuiltins() {
       .sizeOrdinal({0})
       .argumentMeta(
           {{.isRegister = false}, {.isRegister = false}, {.linkOnly = true}})
-      .returnMeta({{.isRegister = false, .reserveShape = inputShapePlusOne}})
+      .returnMeta(
+          {{.isRegister = false,
+            .reserveShape = inputShapePlusOne,
+            .shapeFromInput = 0}})
       .inputFromPreviousKernel(2)
       .headerFile(kScanHeader)
       .deviceFunc("exclusive_sum_final")
@@ -4092,7 +4116,10 @@ void registerBuiltins() {
       .sizeShortcut(SizeShortcut::kMax)
       .hasBarrier()
       .singleBlockIfFused()
-      .returnMeta({{.isRegister = false, .reserveShape = inputShape}})
+      .returnMeta(
+          {{.isRegister = false,
+            .reserveShape = inputShape,
+            .shapeFromInput = 0}})
       .normalize(resolveDtypeFromInputExact)
       .headerFile(kScanHeader)
       .deviceFunc("lengths_to_offsets")
@@ -4162,7 +4189,9 @@ void registerBuiltins() {
       .sizeShortcut(SizeShortcut::kMax)
       .hasBarrier()
       .returnMeta(
-          {{.isRegister = false, .reserveShape = inputShape},
+          {{.isRegister = false,
+            .reserveShape = inputShape,
+            .shapeFromInput = 0},
            {.isRegister = false, .reserveShape = numBlocksShape}})
       .normalize(resolveDtypeFromInput)
       .headerFile(kScanHeader)
@@ -4196,7 +4225,9 @@ void registerBuiltins() {
       .sizeShortcut(SizeShortcut::kMax)
       .hasBarrier()
       .returnMeta(
-          {{.isRegister = false, .reserveShape = inputShapePlusOne},
+          {{.isRegister = false,
+            .reserveShape = inputShapePlusOne,
+            .shapeFromInput = 0},
            {.isRegister = false, .reserveShape = numBlocksShape}})
       .normalize(resolveDtypeFromInput)
       .headerFile(kScanHeader)
@@ -4231,6 +4262,7 @@ void registerBuiltins() {
       .returnMeta(
           {{.isRegister = false,
             .reserveShape = inputShape,
+            .shapeFromInput = 0,
             .shapeSetOnDevice = true},
            {.isRegister = false, .reserveShape = numBlocksShape}})
       .headerFile(kScanHeader)
@@ -4270,7 +4302,9 @@ void registerBuiltins() {
       .sizeShortcut(SizeShortcut::kMax)
       .hasBarrier()
       .returnMeta(
-          {{.isRegister = false, .reserveShape = inputShape},
+          {{.isRegister = false,
+            .reserveShape = inputShape,
+            .shapeFromInput = 0},
            {.isRegister = false, .reserveShape = lookbackStateShape}})
       .normalize(resolveDtypeFromInput)
       .headerFile(kScanHeader)
@@ -4316,7 +4350,9 @@ void registerBuiltins() {
       .sizeShortcut(SizeShortcut::kMax)
       .hasBarrier()
       .returnMeta(
-          {{.isRegister = false, .reserveShape = inputShapePlusOne},
+          {{.isRegister = false,
+            .reserveShape = inputShapePlusOne,
+            .shapeFromInput = 0},
            {.isRegister = false, .reserveShape = lookbackStateShape}})
       .normalize(resolveDtypeFromInput)
       .headerFile(kScanHeader)
@@ -4366,6 +4402,7 @@ void registerBuiltins() {
       .returnMeta(
           {{.isRegister = false,
             .reserveShape = inputShape,
+            .shapeFromInput = 0,
             .shapeSetOnDevice = true},
            {.isRegister = false, .reserveShape = lookbackStateShape}})
       .headerFile(kScanHeader)
@@ -4620,7 +4657,9 @@ void registerBuiltins() {
       .sizeOrdinal({0})
       .hasBarrier()
       .returnMeta(
-          {{.isRegister = false, .reserveShape = inputShape},
+          {{.isRegister = false,
+            .reserveShape = inputShape,
+            .shapeFromInput = 0},
            {.neededOnHost = true}})
       .headerFile(kScanHeader)
       .deviceFunc("repeat_interleave_head")
@@ -5985,7 +6024,8 @@ void registerBuiltins() {
                                const NodeMap& /*nodeMap*/)
                 -> std::vector<std::vector<Dim>> {
               return elementwiseInputShape(node, frame, map, 0);
-            }}})
+            },
+            .shapeFromInput = 0}})
       .normalize(resolveDtypeFromInputExact)
       .rankArgument(0)
       .hasDtypeTemplateParam()

--- a/velox/experimental/torchwave/Cat.cpp
+++ b/velox/experimental/torchwave/Cat.cpp
@@ -198,10 +198,17 @@ bool hasShapeOnDeviceInChain(
 }
 
 // Returns true if any node in the producer chain of 'node' (stopping at
-// subgraphInputs) sizes a return with a reserve function. See
-// ConcatInputInfo::hasReserveInChain. The walk stops at subgraph inputs on
-// purpose: an earlier kernel's output is in the frame by the time the group is
-// carved, however its shape was arrived at.
+// subgraphInputs) sizes a return with a reserve function whose answer cannot be
+// known before it runs. See ConcatInputInfo::hasReserveInChain. The walk stops
+// at subgraph inputs on purpose: an earlier kernel's output is in the frame by
+// the time the group is carved, however its shape was arrived at.
+//
+// A reserve that returns the shape of one of its inputs (ArgumentMeta::
+// shapeFromInput -- ones_like and the rest of the *_like factories, _to_copy,
+// cumsum) is not such a reserve: its answer is that input's extent, which the
+// recursion below reaches on its own. Treating it as opaque used to refuse the
+// whole concat, since one operand unmeasurable at every point leaves no point
+// where all of them are.
 bool hasReserveShapeInChain(
     NodeCP node,
     const std::unordered_set<ValueCP>& subgraphInputs,
@@ -212,7 +219,7 @@ bool hasReserveShapeInChain(
   auto* meta = Registry::metadata(node->target());
   if (meta) {
     for (const auto& rm : meta->returnMeta) {
-      if (rm.reserveShape != nullptr) {
+      if (rm.reserveShape != nullptr && rm.shapeFromInput < 0) {
         return true;
       }
     }
@@ -683,8 +690,16 @@ void insertConcatOperandCopies(
           {{"self", const_cast<nativert::Value*>(operand)}});
       graph->insertBefore(clone, mutableListPack);
       auto* copied = waveGraph.newTensorValue(clone, "cat_copy", resultDtype);
+      // newTensorValue records the dtype but no shape, and a value of unknown
+      // rank makes concatIsStandalone give up on the whole cat -- it needs
+      // every element to have the same known rank. A clone has its source's
+      // rank and, being a fresh dense buffer, is contiguous.
+      auto& constraint = types.constraints.at(copied->id());
+      constraint.rank = types.rank(operand);
+      constraint.contiguity = Contiguity::kContiguous;
       input.value = copied;
       copied->addUser(mutableListPack);
+      waveGraph.markConcatFillClone(copied);
     }
     const_cast<nativert::Value*>(operand)->eraseUser(mutableListPack);
   }

--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -945,6 +945,29 @@ static bool setsSizeOnDevice(NodeCP producer) {
   return false;
 }
 
+// True when the node's extent is only known once its reserve function has run,
+// so nothing upstream of that can compute it. A reserve that just returns an
+// input's shape (ArgumentMeta::shapeFromInput) does not count -- that extent is
+// the input's, and whoever needs it can read the input instead.
+static bool sizeNeedsReserve(NodeCP producer) {
+  const auto* meta = nodeMeta(producer);
+  // An elementwise output has the extent of its inputs whatever its reserve
+  // does with it, so there is never anything to wait for. Same exclusion
+  // setsSizeOnDevice makes, and for the same reason.
+  if (!meta || meta->elementwise) {
+    return false;
+  }
+  // More than one output means the op is half of a split (a head feeding a
+  // final), whose two parts are placed as a pair. Ending the kernel between
+  // them is not this pass's to do -- inputFromPreviousKernel already arranges
+  // where they break -- and doing it anyway produces wrong values.
+  if (meta->returnMeta.size() != 1) {
+    return false;
+  }
+  const auto& ret = meta->returnMeta.front();
+  return ret.reserveShape != nullptr && ret.shapeFromInput < 0;
+}
+
 // True when a node other than 'reader' overwrites 'value' in place (it is that
 // node's mutatesArg "self"). Such a write is invisible to a producer walk: the
 // writer's own output is a different value, so 'value' still names whoever
@@ -1181,7 +1204,7 @@ Context CompileCtx::placeKernels(NodeCP node, Context /*context*/) {
       const bool parallelFill = concatFillsInParallel(node, types_);
       for (const auto& listInput : producer->inputs()) {
         if (hostShapes) {
-          breakDeviceSizedProducers(listInput.value);
+          breakUnmeasurableProducers(listInput.value);
         }
         if (parallelFill) {
           breakConcatOperandIntoOwnKernel(listInput.value, node->outputs()[0]);
@@ -1308,19 +1331,26 @@ void CompileCtx::pushdownFused(NodeCP node) {
   placed_.insert(node);
 }
 
-void CompileCtx::breakDeviceSizedProducers(ValueCP value) {
+void CompileCtx::breakUnmeasurableProducers(ValueCP value) {
   auto* producer = value->producer();
   if (!producer || placed_.count(producer) ||
       (inputs_ && inputs_->count(producer))) {
     return;
   }
-  // Post-order: the innermost device-sized op ends its kernel first, so the ops
-  // above it read a host tensor that already carries the real extent and can
-  // stay fused with the concat.
+  // Post-order: the innermost one ends its kernel first, so the ops above it
+  // read a host tensor that already carries the real extent and can stay fused
+  // with the concat.
   for (const auto& input : producer->inputs()) {
-    breakDeviceSizedProducers(input.value);
+    breakUnmeasurableProducers(input.value);
   }
-  if (setsSizeOnDevice(producer)) {
+  // Two ways an operand's extent can be out of reach when the concat lays its
+  // result out: the device settles it, or only the producer's own reserve
+  // knows it. Either way the concat cannot place a single operand until this
+  // one is measurable, because the layout needs every extent at one point --
+  // so the producer ends its kernel here and the value is materialized in an
+  // earlier step, where it becomes an ordinary frame tensor the host can
+  // measure and the concat can hand a view of its band.
+  if (setsSizeOnDevice(producer) || sizeNeedsReserve(producer)) {
     breakProducerIntoOwnKernel(producer);
   }
 }

--- a/velox/experimental/torchwave/Compile.h
+++ b/velox/experimental/torchwave/Compile.h
@@ -302,10 +302,14 @@ class CompileCtx {
   void pushdownFused(NodeCP node);
 
   /// Ends the kernel of every op in 'value's producer chain whose output extent
-  /// is computed on device, so the extent is read back to the host before the
-  /// consuming launch sizes its outputs. Used for a rank > 1 cat / stack, which
-  /// must know every operand's shape on the host to lay the result out.
-  void breakDeviceSizedProducers(ValueCP value);
+  /// the host cannot work out ahead of the launch -- settled on device, or
+  /// known only to the producer's own reserve function -- so the value is
+  /// materialized in an earlier step and its extent is an ordinary frame
+  /// tensor's by the time the consuming launch sizes its outputs. Used for a
+  /// cat / stack that must lay its result out on the host: it needs every
+  /// operand's extent at one point, so one unmeasurable operand would refuse
+  /// the whole concat.
+  void breakUnmeasurableProducers(ValueCP value);
 
   /// Places 'producer' and its own inputs, then emits 'producer' as its own
   /// kernel launch so a consumer reads its output as a materialized border

--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -26,6 +26,7 @@
 #include <ATen/ATen.h>
 #include <c10/core/CachingDeviceAllocator.h>
 #include <c10/util/StringUtil.h>
+#include <fmt/format.h>
 #include <folly/ScopeGuard.h>
 #include <folly/chrono/Hardware.h>
 #include <gflags/gflags.h>
@@ -33,6 +34,7 @@
 #include <atomic>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <type_traits>
 #include <unordered_set>
@@ -491,34 +493,204 @@ int32_t dynamicSharedBytes(const std::vector<LaunchData>& launches) {
 // launch of more blocks than fit fails outright. A caller that only wants an
 // upper bound can pass dynSharedPerBlock == 0, which skips that reduction and
 // so can only over-estimate.
-int32_t targetBlockCount(
+GridDevice currentGridDevice(
     int32_t maxBlocksPerSM,
-    int32_t dynSharedPerBlock,
-    int32_t staticSharedPerBlock) {
+    int32_t staticSharedPerBlock,
+    std::function<int32_t(int32_t)> occupancyFor = nullptr) {
   auto* device = facebook::velox::wave::currentDevice();
   int32_t numSMs = WaveConfig::get().numSms;
   if (numSMs == 0) {
     numSMs = device ? device->numSM : kDefaultNumSMs;
   }
-  int32_t blocksPerSM =
-      maxBlocksPerSM > 0 ? maxBlocksPerSM : kDefaultBlocksPerSM;
-  if (dynSharedPerBlock > 0) {
-    const int32_t sharedPerSM =
-        device ? device->sharedMemPerSM : kDefaultSharedMemPerSM;
-    blocksPerSM = std::max(
-        1,
-        std::min(
-            blocksPerSM,
-            sharedPerSM / (dynSharedPerBlock + staticSharedPerBlock)));
-  }
-  return numSMs * blocksPerSM;
+  return {
+      .numSMs = numSMs,
+      .maxBlocksPerSM =
+          maxBlocksPerSM > 0 ? maxBlocksPerSM : kDefaultBlocksPerSM,
+      .sharedPerSM = device ? device->sharedMemPerSM : kDefaultSharedMemPerSM,
+      .staticSharedPerBlock = staticSharedPerBlock,
+      .occupancyFor = std::move(occupancyFor)};
 }
+
+// Asks the driver for the kernel's occupancy, memoized per dynamic shared size.
+// The packer calls it once per op while grouping, and a step's ops fall into a
+// handful of distinct shared-memory sizes, so the driver is asked a handful of
+// times rather than once per op.
+std::function<int32_t(int32_t)> occupancyQuery(const CompositeKernel* kernel) {
+  if (kernel == nullptr) {
+    return nullptr;
+  }
+  const int32_t blockSize = WaveConfig::get().blockSize;
+  auto cache = std::make_shared<folly::F14FastMap<int32_t, int32_t>>();
+  return [kernel, blockSize, cache](int32_t dynamicShared) -> int32_t {
+    auto it = cache->find(dynamicShared);
+    if (it != cache->end()) {
+      return it->second;
+    }
+    const int32_t blocks = kernel->occupancy(blockSize, dynamicShared);
+    cache->emplace(dynamicShared, blocks);
+    return blocks;
+  };
+}
+
+int32_t targetBlockCount(
+    int32_t maxBlocksPerSM,
+    int32_t dynSharedPerBlock,
+    int32_t staticSharedPerBlock) {
+  const auto device = currentGridDevice(maxBlocksPerSM, staticSharedPerBlock);
+  return device.numSMs * blocksPerSM(device, dynSharedPerBlock);
+}
+
+namespace {
+
+// Nanoseconds one thread-block clock tick is worth. The performance report
+// converts block clocks to microseconds with the same figure.
+constexpr double kNsPerBlockClock = 0.7;
+
+// The step's ops as the launch layout sees them: cost and block cap from the
+// pass above, occupancy and splittability from the op itself.
+std::vector<GridOp> describeGridOps(
+    const std::vector<LaunchData>& launches,
+    const StepVectors& sv) {
+  std::vector<GridOp> ops(launches.size());
+  for (size_t i = 0; i < launches.size(); ++i) {
+    auto* kernelOp = launches[i].launch->op;
+    ops.at(i).cost = sv.costs.at(i);
+    ops.at(i).maxBlocks = sv.maxBlocks.at(i);
+    ops.at(i).dynamicShared =
+        kernelOp ? static_cast<int32_t>(kernelOp->dynamicSharedBytes()) : 0;
+    ops.at(i).alwaysSingleBlock = kernelOp && kernelOp->alwaysSingleBlock();
+    ops.at(i).hasBarrier = kernelOp && !kernelOp->barrierCounters().empty();
+  }
+  return ops;
+}
+
+// WaveConfig::minBlockUs in the cost units the block quantum is expressed in,
+// from the clocks per unit cost this step's previous execution measured. 0
+// when nothing has been measured yet, which leaves the quantum at an even
+// division of the step over one wave.
+float minBlockCost(const StepVectors& sv) {
+  const float targetUs = WaveConfig::get().minBlockUs;
+  if (targetUs <= 0 || sv.clocksPerCost <= 0) {
+    return 0;
+  }
+  const double clocks = targetUs * 1000.0 / kNsPerBlockClock;
+  return static_cast<float>(clocks / sv.clocksPerCost);
+}
+
+// Splits the step into several launches when its single launch is skewed or
+// occupancy-starved enough to be worth the serialization.
+//
+// A step with barrier ops is not refused. opBarrier needs every block of ITS
+// op co-resident, which the packer already guarantees -- a barrier op is never
+// split across launches and no launch is wider than a wave -- and each segment
+// carries its own cooperative flag, exactly as the whole-step launch derives
+// one today. This is the case that matters on the real graph: the cg trim
+// below reduces a step with more ops than a wave has blocks to one block per
+// op, whatever the costs say, and then launches it non-cooperatively anyway.
+PartitionParams partitionParams(const StepVectors& sv) {
+  const auto& config = WaveConfig::get();
+  return PartitionParams{
+      .maxWaves = config.maxLaunchWaves,
+      .skewThreshold = config.launchSkewThreshold,
+      .minBlockCost = minBlockCost(sv),
+      .measuredUtil = sv.measuredUtil,
+      .measuredBlocks = sv.measuredBlocks};
+}
+
+std::optional<LaunchPlan> maybePartition(
+    const std::vector<GridOp>& ops,
+    const GridDevice& device,
+    const StepVectors& sv) {
+  const auto& config = WaveConfig::get();
+  if (config.debugSingleOps) {
+    return std::nullopt;
+  }
+  const auto params = partitionParams(sv);
+  // Sizing every step by quantum needs no skew gate: the question it answers is
+  // how many blocks the work is worth, which does not depend on the step being
+  // skewed. Presized, so a step that packs into one launch still gets the
+  // quantum's counts rather than falling back to the pro-rata ones.
+  if (config.quantumGrid) {
+    const auto want = sizeByQuantum(ops, device, params);
+    return partitionLaunches(ops, device, sv.gridStats, params, &want);
+  }
+  // A step that would launch cooperatively wider than the device holds
+  // co-resident has to be split whatever the skew gate says: the driver
+  // refuses such a launch outright, so leaving it whole is not a slower plan
+  // but a broken one. The one-block-per-op floor alone reaches this on a step
+  // with more ops than a wave has blocks -- the trim in makeGrid cannot go
+  // below one block per op -- which is how a 631-op step came to ask for 631
+  // blocks against a 540-block cooperative capacity.
+  const bool mustSplit =
+      exceedsCooperativeCapacity(ops, sv.numBlocksPerLaunch, device);
+  if (!config.partitionLaunches) {
+    return std::nullopt;
+  }
+  if (!mustSplit && !shouldPartition(sv.gridStats, params)) {
+    return std::nullopt;
+  }
+  return partitionLaunches(ops, device, sv.gridStats, params);
+}
+
+// Turns the laid-out grid into the BlockInfo array the kernel reads. An op
+// split across launches keeps one blockInOp series over the whole step, so a
+// block finds its slice the same way wherever it was launched from.
+void emitGrid(
+    const std::vector<LaunchData>& launches,
+    const LaunchPlan& plan,
+    StepVectors& sv) {
+  sv.blocks.resize(plan.blocks.size());
+  sv.launchIndices.resize(plan.blocks.size());
+  for (size_t b = 0; b < plan.blocks.size(); ++b) {
+    const auto& gridBlock = plan.blocks[b];
+    auto& info = sv.blocks[b];
+    info.op = launches[gridBlock.op].launch->op->opCode();
+    info.blockInOp = gridBlock.blockInOp;
+    info.numBlocksInOp = plan.blocksPerOp.at(gridBlock.op);
+    info.params = nullptr;
+    sv.launchIndices[b] = gridBlock.op;
+  }
+}
+
+// Prints one line per step under WaveConfig::kGrid: what the block allocator
+// was working with and how balanced the grid came out.
+void traceGrid(int32_t sequenceNumber, int32_t stepIdx, const StepVectors& sv) {
+  const auto& stats = sv.gridStats;
+  std::string text = fmt::format(
+      "  grid {}.{}: ops={} target={} blocks={} cost={:.4g} skew={:.2f} starved={} occ={}/{} poison={:.2f}",
+      sequenceNumber,
+      stepIdx,
+      stats.numOps,
+      stats.targetBlocks,
+      stats.totalBlocks,
+      stats.totalCost,
+      stats.skew,
+      stats.numStarved,
+      stats.occupancy,
+      stats.bestOccupancy,
+      stats.poison);
+  if (sv.segments.size() > 1) {
+    text += fmt::format(" launches={} [", sv.segments.size());
+    for (size_t i = 0; i < sv.segments.size(); ++i) {
+      text += fmt::format(
+          "{}{}b/{}KB",
+          i == 0 ? "" : " ",
+          sv.segments[i].numBlocks,
+          sv.segments[i].dynamicShared / 1024);
+    }
+    text += "]";
+  }
+  std::cout << text << std::endl;
+}
+
+} // namespace
 
 int32_t makeGrid(
     std::vector<LaunchData>& launches,
     StepVectors& sv,
     int32_t maxBlocksPerSM,
-    int32_t staticSharedPerBlock) {
+    int32_t staticSharedPerBlock,
+    const std::function<int32_t(int32_t)>& occupancyFor) {
   const int32_t blockSize = WaveConfig::get().blockSize;
 
   // Compute cost per launch: numElements * unitCost * costAdjustFactor.
@@ -559,8 +731,10 @@ int32_t makeGrid(
   }
 
   // Target blocks from device SM count and kernel occupancy.
-  int32_t maxBlocks = targetBlockCount(
-      maxBlocksPerSM, dynamicSharedBytes(launches), staticSharedPerBlock);
+  const auto budgetDevice =
+      currentGridDevice(maxBlocksPerSM, staticSharedPerBlock, occupancyFor);
+  int32_t maxBlocks = budgetDevice.numSMs *
+      blocksPerSM(budgetDevice, dynamicSharedBytes(launches));
   int32_t targetBlocks = maxBlocks;
 
   // Assign blocks pro rata by cost, at least 1 per launch, capped by
@@ -686,23 +860,32 @@ int32_t makeGrid(
     launches[i].expectedFraction = totalCost > 0 ? sv.costs[i] / totalCost : 0;
   }
 
-  // Fill blocks and launchIndices.
-  sv.blocks.resize(totalAssigned);
-  sv.launchIndices.resize(totalAssigned);
-  int32_t blockIdx = 0;
-  for (size_t i = 0; i < launches.size(); ++i) {
-    auto opCode = launches[i].launch->op->opCode();
-    auto nBlocks = sv.numBlocksPerLaunch[i];
-    for (int32_t b = 0; b < nBlocks; ++b) {
-      auto& info = sv.blocks[blockIdx];
-      info.op = opCode;
-      info.blockInOp = b;
-      info.numBlocksInOp = nBlocks;
-      info.params = nullptr;
-      sv.launchIndices.at(blockIdx) = static_cast<int32_t>(i);
-      ++blockIdx;
+  const auto device =
+      currentGridDevice(maxBlocksPerSM, staticSharedPerBlock, occupancyFor);
+  const auto gridOps = describeGridOps(launches, sv);
+  // Measured on the grid above, i.e. on the single launch the step would run
+  // as today. That is the opportunity the partitioning gate reads, so it must
+  // not describe the split the gate went on to make.
+  sv.gridStats = gridStats(gridOps, sv.numBlocksPerLaunch, device);
+
+  auto plan = maybePartition(gridOps, device, sv);
+  if (plan.has_value()) {
+    sv.numBlocksPerLaunch = plan->blocksPerOp;
+    // With no gate to feed, the reported grid should describe what ran rather
+    // than the pro-rata split that was discarded. util and starved are how the
+    // sizing is judged, so they have to be measured on it.
+    if (WaveConfig::get().quantumGrid) {
+      const auto segments = sv.gridStats.numSegments;
+      sv.gridStats = gridStats(gridOps, sv.numBlocksPerLaunch, device);
+      sv.gridStats.numSegments = segments;
     }
+  } else {
+    plan = singleLaunchPlan(
+        gridOps, sv.numBlocksPerLaunch, WaveConfig::get().orderBlocksByCost);
   }
+  emitGrid(launches, *plan, sv);
+  sv.segments = std::move(plan->segments);
+  sv.gridStats.numSegments = static_cast<int32_t>(sv.segments.size());
   return blockSize;
 }
 
@@ -1723,6 +1906,15 @@ facebook::velox::wave::KernelInfo CompositeKernel::kernelInfo() const {
     return kernel_->info(0);
   }
   return {};
+}
+
+int32_t CompositeKernel::occupancy(
+    int32_t numThreads,
+    int32_t dynamicSharedBytes) const {
+  if (!kernel_) {
+    return 0;
+  }
+  return kernel_->occupancy(0, numThreads, dynamicSharedBytes);
 }
 
 void CompositeKernel::launch(
@@ -2761,16 +2953,24 @@ void CompositeInvocation::layoutParamSlots(int32_t stepIdx, StepVectors& sv) {
   // (the per-launch cap, the round-down to whole blockSize chunks) and the
   // rebalancing pass conserves the total. So the sum cannot exceed
   // targetBlocks plus 1.5 per launch; take 2 per launch.
+  //
+  // Partitioning a step deliberately emits more than one wave -- that is the
+  // point of it -- so the reservation grows by the same cap the packer bounds
+  // itself with. Without the flag the figure is exactly what it always was.
   const auto numSlots = static_cast<int32_t>(sv.slotOffsets.size());
-  sv.blockCapacity =
-      2 * numSlots +
-      targetBlockCount(
-          kernel_->kernelInfo().maxOccupancy0,
-          // A bound, so skip the shared-memory reduction: it only ever lowers
-          // the count makeGrid will actually use, and a step's dynamic
-          // shared-memory need is not known until its launches are gathered.
-          /*dynSharedPerBlock=*/0,
-          /*staticSharedPerBlock=*/0);
+  const int32_t waves = WaveConfig::get().partitionLaunches
+      ? std::max(1, WaveConfig::get().maxLaunchWaves)
+      : 1;
+  sv.blockCapacity = 2 * numSlots +
+      waves *
+          targetBlockCount(
+              kernel_->kernelInfo().maxOccupancy0,
+              // A bound, so skip the shared-memory reduction: it only ever
+              // lowers the count makeGrid will actually use, and a step's
+              // dynamic shared-memory need is not known until its launches are
+              // gathered.
+              /*dynSharedPerBlock=*/0,
+              /*staticSharedPerBlock=*/0);
 }
 
 bool CompositeInvocation::chooseGridVariant(
@@ -4227,7 +4427,11 @@ void CompositeInvocation::execute(ExecutionState& state) {
       } else {
         const auto kernelInfo = kernel_->kernelInfo();
         blockSize = makeGrid(
-            sv.kernels, sv, kernelInfo.maxOccupancy0, kernelInfo.sharedMemory);
+            sv.kernels,
+            sv,
+            kernelInfo.maxOccupancy0,
+            kernelInfo.sharedMemory,
+            occupancyQuery(kernel_.get()));
         TORCH_CHECK(
             (blockSize & (blockSize - 1)) == 0,
             "Block size must be a power of two, got ",
@@ -4237,6 +4441,9 @@ void CompositeInvocation::execute(ExecutionState& state) {
       }
       if (doTiming) {
         sv.gridUs = elapsed(t0);
+      }
+      if (WaveConfig::get().trace & WaveConfig::kGrid) {
+        traceGrid(sequenceNumber_, stepIdx, sv);
       }
     }
 
@@ -4929,8 +5136,12 @@ void CompositeInvocation::executeAllocGroups(ExecutionState& state) {
       if (gridSizesMatch(sv.kernels, sv)) {
         blockSize = sv.cachedBlockSize;
       } else {
-        blockSize =
-            makeGrid(sv.kernels, sv, kernel_->kernelInfo().maxOccupancy0);
+        blockSize = makeGrid(
+            sv.kernels,
+            sv,
+            kernel_->kernelInfo().maxOccupancy0,
+            /*staticSharedPerBlock=*/0,
+            occupancyQuery(kernel_.get()));
         TORCH_CHECK(
             (blockSize & (blockSize - 1)) == 0,
             "Block size must be a power of two, got ",
@@ -4940,6 +5151,9 @@ void CompositeInvocation::executeAllocGroups(ExecutionState& state) {
       }
       if (doTiming) {
         sv.gridUs = elapsed(t0);
+      }
+      if (WaveConfig::get().trace & WaveConfig::kGrid) {
+        traceGrid(sequenceNumber_, stepIdx, sv);
       }
     }
 
@@ -5187,6 +5401,43 @@ void CompositeInvocation::launch(
   auto* pinnedBlocks =
       reinterpret_cast<BlockInfo*>(pinnedBase + sv.blockInfoOffset);
 
+  // Ordinarily one launch over every block of the step. A step the packer
+  // split runs its launches back to back on the same stream, each over its own
+  // slice of the block array and with only the shared memory its own ops need
+  // -- which is where the occupancy a split buys actually lands.
+  std::vector<LaunchSegment> wholeStep;
+  if (sv.segments.empty()) {
+    wholeStep.push_back(
+        {.firstBlock = 0,
+         .numBlocks = numBlocks,
+         .dynamicShared = dynShared,
+         .cooperative = cooperative});
+  }
+  const auto& segments = sv.segments.empty() ? wholeStep : sv.segments;
+  auto* deviceBlocks =
+      reinterpret_cast<BlockInfo*>(deviceBase + sv.blockInfoOffset);
+  auto launchSegment = [&](const LaunchSegment& segment) {
+    params.info = deviceBlocks + segment.firstBlock;
+    // ENTRY reads the block's DebugInfo at blockIdx.x of whatever base it is
+    // handed, so the base has to move with the segment; otherwise every launch
+    // would overwrite the first one's per-block timings.
+    params.debugInfo = deviceDebugBase != nullptr
+        ? deviceDebugBase + segment.firstBlock
+        : nullptr;
+    // A step that was not split keeps deciding this here, from the block
+    // counts as they stand at launch time rather than as makeGrid left them.
+    // The two agree, but this one cannot go stale behind a reused grid.
+    const bool launchCooperative =
+        segments.size() > 1 ? segment.cooperative : cooperative;
+    if (launchCooperative) {
+      kernel_->launchCooperative(
+          segment.numBlocks, blockSize, segment.dynamicShared, stream, args);
+    } else {
+      kernel_->launch(
+          segment.numBlocks, blockSize, segment.dynamicShared, stream, args);
+    }
+  };
+
   if (WaveConfig::get().debugSingleOps) {
     std::vector<int32_t> originalOps(numBlocks);
     for (int32_t b = 0; b < numBlocks; ++b) {
@@ -5197,99 +5448,119 @@ void CompositeInvocation::launch(
     stream->hostToDeviceAsync(deviceBase, pinnedBase, h2dBytes);
     stream->wait();
 
-    auto* deviceBlocks =
-        reinterpret_cast<BlockInfo*>(deviceBase + sv.blockInfoOffset);
+    // One op at a time, inside one launch at a time. maybePartition declines to
+    // partition under this flag, but a step whose grid was laid out by the
+    // normal pass keeps that pass's segments, and a step split because it
+    // exceeded the cooperative capacity must be walked segment by segment:
+    // launching its whole block array as one cooperative grid is wider than the
+    // device holds co-resident, and fails here alone.
+    for (const auto& segment : segments) {
+      // Per launch, not per step: an op with blocks in two launches has to run
+      // in both. Hoisting this out of the loop would silently drop its second
+      // half and leave the output partly written.
+      folly::F14FastSet<uintptr_t> launched;
+      const int32_t segFirst = segment.firstBlock;
+      const int32_t segEnd = segment.firstBlock + segment.numBlocks;
+      params.info = deviceBlocks + segFirst;
+      params.debugInfo =
+          deviceDebugBase != nullptr ? deviceDebugBase + segFirst : nullptr;
+      for (int32_t active = segFirst; active < segEnd; ++active) {
+        // launchIndices has one entry per block; at() so a short vector fails
+        // loudly instead of reading out of bounds.
+        auto launchIdx = sv.launchIndices.at(active);
+        // A barrier op needs cooperative grouping only when it spans more than
+        // one block (see 'cooperative' above): opBarrier waits for
+        // numBlocksInOp arrivals, which is immediate for a single-block op.
+        bool hasBarriers =
+            launchIdx < static_cast<int32_t>(sv.kernels.size()) &&
+            sv.kernels.at(launchIdx).launch &&
+            sv.kernels.at(launchIdx).launch->op &&
+            !sv.kernels.at(launchIdx).launch->op->barrierCounters().empty() &&
+            launchIdx < static_cast<int32_t>(sv.numBlocksPerLaunch.size()) &&
+            sv.numBlocksPerLaunch.at(launchIdx) > 1;
 
-    // Run blocks individually or grouped. Ops with barrierCounters need all
-    // blocks of the same project op launched together with cooperative launch.
-    folly::F14FastSet<uintptr_t> launched;
-    for (int32_t active = 0; active < numBlocks; ++active) {
-      // launchIndices has one entry per block; guard the access so a short
-      // vector fails loudly instead of reading out of bounds.
-      TORCH_CHECK(active < static_cast<int32_t>(sv.launchIndices.size()));
-      auto launchIdx = sv.launchIndices[active];
-      // A barrier op needs cooperative grouping only when it spans more than
-      // one block (see 'cooperative' above): opBarrier waits for numBlocksInOp
-      // arrivals, which is immediate for a single-block op.
-      bool hasBarriers = launchIdx < static_cast<int32_t>(sv.kernels.size()) &&
-          sv.kernels[launchIdx].launch && sv.kernels[launchIdx].launch->op &&
-          !sv.kernels[launchIdx].launch->op->barrierCounters().empty() &&
-          launchIdx < static_cast<int32_t>(sv.numBlocksPerLaunch.size()) &&
-          sv.numBlocksPerLaunch[launchIdx] > 1;
+        // Only a barrier op has to move as a unit. Everything else advances one
+        // block per launch, which is what makes a failure land on a block
+        // rather than on an op. A cg step still launches cooperatively -- the
+        // kernel was compiled that way -- it just runs with one live block.
+        bool groupAll = hasBarriers;
 
-      // Under a cooperative grid the whole step is compiled as one cooperative
-      // kernel whose cross-block barriers require every block of an op to be
-      // co-resident and launched cooperatively. Single-stepping a subset of an
-      // op's blocks, or launching that kernel via the regular (non-cooperative)
-      // path, faults with an illegal memory access. So when the step needs a
-      // cooperative launch, treat every op like a barrier op: activate all of
-      // its blocks and launch cooperatively, mirroring the non-debug path
-      // below.
-      bool groupAndCooperative = hasBarriers || cooperative;
+        // Quiet this launch's blocks; the rest are not in the grid.
+        setOpCodes(
+            deviceBlocks, segFirst, segment.numBlocks, kDebugNoOp, stream);
 
-      // Set all opcodes to kDebugNoOp on device.
-      setOpCodes(deviceBlocks, 0, numBlocks, kDebugNoOp, stream);
-
-      if (groupAndCooperative) {
-        auto* inv = sv.kernels.at(launchIdx).invocation;
-        if (!launched.insert(reinterpret_cast<intptr_t>(inv)).second) {
-          continue;
-        }
-        // Activate all blocks belonging to the same project op.
-        for (int32_t b = 0; b < numBlocks; ++b) {
-          auto bIdx = sv.launchIndices[b];
-          bool sameOp = bIdx < static_cast<int32_t>(sv.kernels.size()) &&
-              sv.kernels[bIdx].invocation == inv;
-          if (sameOp) {
-            setOpCodes(deviceBlocks, b, 1, originalOps[b], stream);
+        if (groupAll) {
+          auto* inv = sv.kernels.at(launchIdx).invocation;
+          if (!launched.insert(reinterpret_cast<intptr_t>(inv)).second) {
+            continue;
           }
+          // Activate the op's blocks inside this launch. A barrier op is never
+          // split across launches, so this reaches all of them.
+          for (int32_t b = segFirst; b < segEnd; ++b) {
+            auto bIdx = sv.launchIndices.at(b);
+            bool sameOp = bIdx < static_cast<int32_t>(sv.kernels.size()) &&
+                sv.kernels.at(bIdx).invocation == inv;
+            if (sameOp) {
+              setOpCodes(deviceBlocks, b, 1, originalOps[b], stream);
+            }
+          }
+        } else {
+          setOpCodes(deviceBlocks, active, 1, originalOps[active], stream);
         }
-      } else {
-        setOpCodes(deviceBlocks, active, 1, originalOps[active], stream);
-      }
 
-      // Reset barrier counters on device for the active op. Ops without
-      // barriers have an empty barrierCounters(), so this loop is a no-op for
-      // them even when it runs under a cooperative grid.
-      if (groupAndCooperative) {
-        for (size_t li = 0; li < sv.kernels.size(); ++li) {
-          if (sv.kernels[li].invocation == sv.kernels[launchIdx].invocation) {
-            auto* kernelOp = sv.kernels[li].launch->op;
-            for (auto offset : kernelOp->barrierCounters()) {
-              int32_t zero = 0;
-              auto* dest = deviceBase + sv.paramOffsets.at(li) + offset;
-              stream->hostToDeviceAsync(dest, &zero, sizeof(zero));
+        // Reset barrier counters on device for the active op. Ops without
+        // barriers have an empty barrierCounters(), so this loop is a no-op for
+        // them even when it runs under a cooperative grid.
+        if (groupAll) {
+          for (size_t li = 0; li < sv.kernels.size(); ++li) {
+            if (sv.kernels[li].invocation == sv.kernels[launchIdx].invocation) {
+              auto* kernelOp = sv.kernels[li].launch->op;
+              for (auto offset : kernelOp->barrierCounters()) {
+                int32_t zero = 0;
+                auto* dest = deviceBase + sv.paramOffsets.at(li) + offset;
+                stream->hostToDeviceAsync(dest, &zero, sizeof(zero));
+              }
             }
           }
         }
-      }
 
-      try {
-        if (groupAndCooperative) {
-          kernel_->launchCooperative(
-              numBlocks, blockSize, dynShared, stream, args);
-        } else {
-          kernel_->launch(numBlocks, blockSize, dynShared, stream, args);
+        try {
+          if (groupAll || segment.cooperative) {
+            kernel_->launchCooperative(
+                segment.numBlocks,
+                blockSize,
+                segment.dynamicShared,
+                stream,
+                args);
+          } else {
+            kernel_->launch(
+                segment.numBlocks,
+                blockSize,
+                segment.dynamicShared,
+                stream,
+                args);
+          }
+          stream->wait();
+        } catch (const std::exception& e) {
+          auto opCode = originalOps[active];
+          std::string opText;
+          std::string paramText;
+          if (launchIdx < static_cast<int32_t>(sv.kernels.size()) &&
+              sv.kernels.at(launchIdx).launch &&
+              sv.kernels.at(launchIdx).launch->op) {
+            auto* kernelOp = sv.kernels.at(launchIdx).launch->op;
+            opText = kernelOp->toString(sv.kernels.at(launchIdx).invocation);
+            auto* opParams = pinnedBase + sv.paramOffsets.at(launchIdx);
+            paramText = dumpOpParams(
+                *kernelOp, opParams, sv.kernels.at(launchIdx).invocation);
+          }
+          LOG(ERROR) << "debug_single_ops: block " << active << " opCode "
+                     << opCode << " blockInOp "
+                     << pinnedBlocks[active].blockInOp << " stepIdx " << stepIdx
+                     << " op: " << opText << "\nparams:\n"
+                     << paramText << "error: " << e.what();
+          throw;
         }
-        stream->wait();
-      } catch (const std::exception& e) {
-        auto opCode = originalOps[active];
-        std::string opText;
-        std::string paramText;
-        if (launchIdx < static_cast<int32_t>(sv.kernels.size()) &&
-            sv.kernels[launchIdx].launch && sv.kernels[launchIdx].launch->op) {
-          auto* kernelOp = sv.kernels[launchIdx].launch->op;
-          opText = kernelOp->toString(sv.kernels[launchIdx].invocation);
-          auto* opParams = pinnedBase + sv.paramOffsets.at(launchIdx);
-          paramText = dumpOpParams(
-              *kernelOp, opParams, sv.kernels[launchIdx].invocation);
-        }
-        LOG(ERROR) << "debug_single_ops: block " << active << " opCode "
-                   << opCode << " blockInOp " << pinnedBlocks[active].blockInOp
-                   << " stepIdx " << stepIdx << " op: " << opText
-                   << "\nparams:\n"
-                   << paramText << "error: " << e.what();
-        throw;
       }
     }
 
@@ -5312,10 +5583,8 @@ void CompositeInvocation::launch(
     }
   } else {
     stream->hostToDeviceAsync(deviceBase, pinnedBase, h2dBytes);
-    if (cooperative) {
-      kernel_->launchCooperative(numBlocks, blockSize, dynShared, stream, args);
-    } else {
-      kernel_->launch(numBlocks, blockSize, dynShared, stream, args);
+    for (const auto& segment : segments) {
+      launchSegment(segment);
     }
     if (returnBegin >= 0) {
       stream->deviceToHostAsync(

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -214,6 +214,13 @@ class CompositeKernel {
   /// default KernelInfo if no GPU is available.
   facebook::velox::wave::KernelInfo kernelInfo() const;
 
+  /// Blocks of this kernel that stay resident on one SM at 'dynamicSharedBytes'
+  /// of dynamic shared memory, as the driver computes it. 0 when there is no
+  /// compiled kernel to ask. Sizing a cooperative launch by anything else risks
+  /// a grid the driver will refuse, so the launch partitioner reads this rather
+  /// than dividing KernelInfo's zero-shared figure down.
+  int32_t occupancy(int32_t numThreads, int32_t dynamicSharedBytes) const;
+
   std::string toString(Listing mode = kExprs) const;
 
   const std::string& entryPoint() const {

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -25,6 +25,7 @@
 #include <folly/chrono/Hardware.h>
 #include <gflags/gflags.h>
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -1943,6 +1944,51 @@ void computeGpuTimeline(ExecutionState& state) {
 
 } // namespace
 
+namespace {
+
+// Records how many thread-block clocks one unit of the step's modelled cost
+// bought, so the next execution of the same step can express a minimum block
+// size in microseconds rather than in cost units. Total block time over total
+// modelled work: both scale with the step's size, so the ratio survives a
+// change of batch.
+void recordStepClockRate(ExecutionState& state, const LaunchDebugInfo& info) {
+  if (info.pinnedInfo == nullptr || info.numBlocks <= 0 ||
+      info.sequenceNumber < 0 ||
+      info.sequenceNumber >= static_cast<int32_t>(state.stepVectors.size())) {
+    return;
+  }
+  auto& steps = state.stepVectors.at(info.sequenceNumber);
+  if (info.stepIdx < 0 || info.stepIdx >= static_cast<int32_t>(steps.size())) {
+    return;
+  }
+  auto& sv = steps.at(info.stepIdx);
+  double totalCost = 0;
+  for (auto cost : sv.costs) {
+    totalCost += cost;
+  }
+  if (totalCost <= 0) {
+    return;
+  }
+  int64_t totalClocks = 0;
+  int64_t maxClocks = 0;
+  for (int32_t block = 0; block < info.numBlocks; ++block) {
+    const auto clocks = info.pinnedInfo[block].clocks;
+    totalClocks += clocks;
+    maxClocks = std::max(maxClocks, clocks);
+  }
+  if (totalClocks > 0) {
+    sv.clocksPerCost = static_cast<double>(totalClocks) / totalCost;
+  }
+  // Same figure the balance line prints: mean block clocks over the slowest.
+  if (maxClocks > 0) {
+    sv.measuredUtil = static_cast<double>(totalClocks) /
+        (static_cast<double>(maxClocks) * info.numBlocks);
+    sv.measuredBlocks = info.numBlocks;
+  }
+}
+
+} // namespace
+
 void WaveGraphExecutor::collectDebugInfo(ExecutionState& state) {
   auto& infos = state.launchDebugInfos;
   threadInfo.debugInfo.clear();
@@ -1991,6 +2037,7 @@ void WaveGraphExecutor::collectDebugInfo(ExecutionState& state) {
     } else {
       threadInfo.debugInfo.emplace_back();
     }
+    recordStepClockRate(state, info);
     LaunchMeta meta;
     meta.sequenceNumber = info.sequenceNumber;
     meta.stepIdx = info.stepIdx;
@@ -2029,6 +2076,8 @@ void WaveGraphExecutor::collectDebugInfo(ExecutionState& state) {
         meta.numFused = static_cast<int32_t>(sv.kernels.size());
         meta.numStandalone = static_cast<int32_t>(sv.standalones.size());
         meta.numShortcut = static_cast<int32_t>(sv.shortcutStandalones.size());
+        meta.gridStats = sv.gridStats;
+        meta.segments = sv.segments;
       }
     }
     threadInfo.launchMeta.push_back(std::move(meta));
@@ -2091,20 +2140,18 @@ void WaveGraphExecutor::adjustCosts(ExecutionState& state) {
     }
     const auto& debugBlocks = info.debugInfo[mi];
 
-    // Sum clocks per launch using block position, not opcode matching.
-    // Block 0..numBlocksPerLaunch[0]-1 belong to launch 0, etc.
+    // Sum clocks per launch through launchIndices rather than opcode matching.
+    // The blocks of one launch are not necessarily a contiguous run: the emit
+    // order follows projected latency, and a partitioned step splits an op
+    // across launches.
     std::vector<int64_t> launchClocks(sv.kernels.size(), 0);
-    int32_t blockStart = 0;
-    for (size_t li = 0; li < sv.kernels.size(); ++li) {
-      int32_t nBlocks =
-          li < sv.numBlocksPerLaunch.size() ? sv.numBlocksPerLaunch.at(li) : 0;
-      for (int32_t b = 0; b < nBlocks; ++b) {
-        auto idx = blockStart + b;
-        if (idx < static_cast<int32_t>(debugBlocks.size())) {
-          launchClocks[li] += debugBlocks[idx].clocks;
-        }
+    for (size_t b = 0; b < debugBlocks.size() && b < sv.launchIndices.size();
+         ++b) {
+      const auto launchIdx = sv.launchIndices[b];
+      if (launchIdx >= 0 &&
+          launchIdx < static_cast<int32_t>(launchClocks.size())) {
+        launchClocks[launchIdx] += debugBlocks[b].clocks;
       }
-      blockStart += nBlocks;
     }
 
     int64_t totalActualClocks = 0;
@@ -2425,6 +2472,70 @@ std::string WaveGraphExecutor::makePerfReport(
     ss << fmt::format(
         "  fused outputs built by a host-side view: {}\n", viewDescs);
   }
+  // How far each step's grid is from a balanced, fully occupied wave, and
+  // which of the two pathologies it suffers from. They need different fixes:
+  // starvation is ops stuck on one block once a step has as many ops as the
+  // wave has blocks, poisoning is one shared-memory-hungry op cutting the
+  // occupancy of a step whose work sits elsewhere.
+  {
+    const std::array<float, 4> kSkewBuckets{1.1f, 1.5f, 2.0f, 4.0f};
+    std::array<int32_t, 5> skewHistogram{};
+    int32_t measuredSteps = 0;
+    int32_t starvedSteps = 0;
+    int64_t starvedOps = 0;
+    int32_t poisonedSteps = 0;
+    int32_t splitSteps = 0;
+    float worstSkew = 0;
+    int32_t worstSeq = -1;
+    int32_t worstStep = -1;
+    for (const auto& m : info.launchMeta) {
+      const auto& stats = m.gridStats;
+      if (stats.numOps == 0) {
+        continue;
+      }
+      ++measuredSteps;
+      size_t bucket = 0;
+      while (bucket < kSkewBuckets.size() &&
+             stats.skew >= kSkewBuckets[bucket]) {
+        ++bucket;
+      }
+      ++skewHistogram[bucket];
+      if (stats.numStarved > 0) {
+        ++starvedSteps;
+        starvedOps += stats.numStarved;
+      }
+      if (stats.occupancy < stats.bestOccupancy) {
+        ++poisonedSteps;
+      }
+      if (stats.numSegments > 1) {
+        ++splitSteps;
+      }
+      if (stats.skew > worstSkew) {
+        worstSkew = stats.skew;
+        worstSeq = m.sequenceNumber;
+        worstStep = m.stepIdx;
+      }
+    }
+    if (measuredSteps > 0) {
+      ss << fmt::format(
+          "Grid balance: {} steps; skew <1.1 {}, <1.5 {}, <2 {}, <4 {}, >=4 {}; worst {:.1f} at node {} step {}\n",
+          measuredSteps,
+          skewHistogram[0],
+          skewHistogram[1],
+          skewHistogram[2],
+          skewHistogram[3],
+          skewHistogram[4],
+          worstSkew,
+          worstSeq,
+          worstStep);
+      ss << fmt::format(
+          "  block starvation: {} steps, {} ops left on one block that could use more; shared-memory poisoning: {} steps; split into several launches: {}\n",
+          starvedSteps,
+          starvedOps,
+          poisonedSteps,
+          splitSteps);
+    }
+  }
   ss << "WaveConfig: " << WaveConfig::get().toString() << "\n";
 
   // Per-node, per-step report.
@@ -2629,6 +2740,7 @@ std::string WaveGraphExecutor::makePerfReport(
       // Thread block balance for this step.
       if (idx < info.debugInfo.size() && !info.debugInfo[idx].empty()) {
         const auto& blocks = info.debugInfo[idx];
+        const auto numBlocks = static_cast<int32_t>(blocks.size());
         int64_t maxClocks = 0;
         int64_t totalClocks = 0;
         int64_t totalBarrier = 0;
@@ -2637,17 +2749,93 @@ std::string WaveGraphExecutor::makePerfReport(
           totalClocks += b.clocks;
           totalBarrier += b.barrierClocks;
         }
-        double util = maxClocks > 0 ? 100.0 * totalClocks /
-                (maxClocks * static_cast<int64_t>(blocks.size()))
-                                    : 0.0;
         double syncPct =
             totalClocks > 0 ? 100.0 * totalBarrier / totalClocks : 0.0;
-        ss << fmt::format(
-            "    balance: util={:.1f}% sync={:.1f}% maxClk={} blocks={}\n",
-            util,
-            syncPct,
-            maxClocks,
-            blocks.size());
+
+        // The launches of a split step run back to back on one stream, so the
+        // step's makespan is the sum of their maxima rather than the largest
+        // block anywhere in it, and a block is only idle relative to the
+        // launch it actually ran in. Scoring the whole step against one global
+        // max reads a short launch queued behind a long one as imbalance: on
+        // the ROO graph node 36 step 3 reported 70% while both of its launches
+        // were above 75%. Each launch owns a contiguous range of this block
+        // array, so score them one at a time and add the rectangles up.
+        struct Span {
+          int32_t first;
+          int32_t count;
+          int64_t max{0};
+          int64_t sum{0};
+        };
+        std::vector<Span> spans;
+        for (const auto& s : m.segments) {
+          if (s.firstBlock >= 0 && s.numBlocks > 0 &&
+              s.firstBlock + s.numBlocks <= numBlocks) {
+            spans.push_back({s.firstBlock, s.numBlocks});
+          }
+        }
+        // A step the packer left whole, or one whose segments do not describe
+        // this array, is one launch over all of it -- which makes the numbers
+        // below identical to scoring the step as a single rectangle.
+        int32_t covered = 0;
+        for (const auto& s : spans) {
+          covered += s.count;
+        }
+        if (spans.empty() || covered != numBlocks) {
+          spans.assign(1, Span{0, numBlocks});
+        }
+        int64_t makespan = 0;
+        int64_t rectangles = 0;
+        for (auto& s : spans) {
+          for (int32_t b = s.first; b < s.first + s.count; ++b) {
+            s.max = std::max(s.max, blocks[b].clocks);
+            s.sum += blocks[b].clocks;
+          }
+          makespan += s.max;
+          rectangles += s.max * s.count;
+        }
+        double util = rectangles > 0
+            ? 100.0 * static_cast<double>(totalClocks) /
+                static_cast<double>(rectangles)
+            : 0.0;
+
+        if (spans.size() == 1) {
+          ss << fmt::format(
+              "    balance: util={:.1f}% sync={:.1f}% maxClk={} blocks={}\n",
+              util,
+              syncPct,
+              maxClocks,
+              numBlocks);
+        } else {
+          ss << fmt::format(
+              "    balance: util={:.1f}% sync={:.1f}% makespan={} maxClk={} "
+              "blocks={} launches={}\n",
+              util,
+              syncPct,
+              makespan,
+              maxClocks,
+              numBlocks,
+              spans.size());
+          // targetBlocks is one wave at the occupancy the step launches with,
+          // so this says whether a launch is also several hardware waves --
+          // the same effect one level down, and invisible in the block count.
+          const int32_t wave = m.gridStats.targetBlocks;
+          for (size_t li = 0; li < spans.size(); ++li) {
+            const auto& s = spans[li];
+            ss << fmt::format(
+                "      launch {}: util={:.1f}% max={} blocks={} first={}",
+                li,
+                s.max > 0 ? 100.0 * static_cast<double>(s.sum) /
+                        static_cast<double>(s.max * s.count)
+                          : 0.0,
+                s.max,
+                s.count,
+                s.first);
+            if (wave > 0) {
+              ss << fmt::format(" waves={}", (s.count + wave - 1) / wave);
+            }
+            ss << "\n";
+          }
+        }
 
         // Per-op breakdown sorted by max clocks descending.
         struct OpStats {
@@ -2658,9 +2846,24 @@ std::string WaveGraphExecutor::makePerfReport(
           int64_t opBarrier{0};
           int64_t count{0};
           int64_t numElements{0};
+          /// Blocks this op contributed to each launch, parallel to 'spans'.
+          /// Which launch an op landed in is the thing that decides whether it
+          /// is holding one up: an op is only measured against the others it
+          /// actually ran beside.
+          std::vector<int32_t> perLaunch;
         };
+        // Block index -> launch, from the contiguous ranges above.
+        std::vector<int32_t> blockLaunch(numBlocks, 0);
+        for (size_t li = 0; li < spans.size(); ++li) {
+          for (int32_t b = spans[li].first;
+               b < spans[li].first + spans[li].count;
+               ++b) {
+            blockLaunch[b] = static_cast<int32_t>(li);
+          }
+        }
         std::map<int32_t, OpStats> opMap;
-        for (const auto& b : blocks) {
+        for (int32_t i = 0; i < numBlocks; ++i) {
+          const auto& b = blocks[i];
           auto& s = opMap[b.op];
           s.op = b.op;
           s.opMin = std::min(s.opMin, b.clocks);
@@ -2668,6 +2871,8 @@ std::string WaveGraphExecutor::makePerfReport(
           s.opSum += b.clocks;
           s.opBarrier += b.barrierClocks;
           s.count++;
+          s.perLaunch.resize(spans.size(), 0);
+          ++s.perLaunch[blockLaunch[i]];
           referencedOps.insert(b.op);
           opTotalClocks[b.op] += b.clocks;
         }
@@ -2703,7 +2908,7 @@ std::string WaveGraphExecutor::makePerfReport(
         for (auto& s : sortedOps) {
           auto opAvg = s.opSum / s.count;
           ss << fmt::format(
-              "      op {} ({} blocks, {}): clk max/avg/min={}/{}/{} barrier={}\n",
+              "      op {} ({} blocks, {}): clk max/avg/min={}/{}/{} barrier={}",
               s.op,
               s.count,
               fmtSize(s.numElements),
@@ -2711,6 +2916,15 @@ std::string WaveGraphExecutor::makePerfReport(
               opAvg,
               s.opMin,
               s.opBarrier);
+          if (spans.size() > 1) {
+            ss << " in";
+            for (size_t li = 0; li < s.perLaunch.size(); ++li) {
+              if (s.perLaunch[li] > 0) {
+                ss << fmt::format(" L{}={}", li, s.perLaunch[li]);
+              }
+            }
+          }
+          ss << "\n";
         }
       }
     }

--- a/velox/experimental/torchwave/Executor.h
+++ b/velox/experimental/torchwave/Executor.h
@@ -21,6 +21,7 @@
 #include <deque>
 #include "velox/experimental/torchwave/Compile.h"
 #include "velox/experimental/torchwave/CompiledOp.h"
+#include "velox/experimental/torchwave/LaunchPartition.h"
 #include "velox/experimental/torchwave/Registry.h"
 #include "velox/experimental/torchwave/Utils.h"
 #include "velox/experimental/wave/common/Buffer.h"
@@ -131,6 +132,15 @@ struct LaunchMeta {
   int32_t numFused{0};
   int32_t numStandalone{0};
   int32_t numShortcut{0};
+  // How balanced this step's grid came out, and how many launches it ran as.
+  GridStats gridStats;
+
+  /// The launches the step ran as, each owning a contiguous range of the block
+  /// array the DebugInfo of this step is indexed by. Empty for a step that was
+  /// not split. Kept so the balance report can score each launch on its own:
+  /// they run back to back, so a block in one was never able to run beside a
+  /// block in another.
+  std::vector<LaunchSegment> segments;
 };
 
 /// Per-thread debug info from the most recent wave execution. Populated by
@@ -278,6 +288,38 @@ struct StepVectors {
   /// Used by makeGrid (output).
   std::vector<BlockInfo> blocks;
   std::vector<int32_t> launchIndices;
+
+  /// The kernel launches 'blocks' is run as, in order. Always at least one
+  /// entry; more only when WaveConfig::partitionLaunches split the step. Each
+  /// launch takes its own slice of 'blocks' and its own dynamic shared memory,
+  /// which is where the occupancy a split buys actually lands.
+  std::vector<LaunchSegment> segments;
+
+  /// How balanced this step's grid came out, from the last makeGrid that ran
+  /// for it. Reported per step under WaveConfig::kGrid and summarized in the
+  /// performance report; also what the partitioning gate reads.
+  GridStats gridStats;
+
+  /// Thread-block clocks this step spent per unit of cost, measured on its
+  /// previous execution. Turns WaveConfig::minBlockUs into the cost units the
+  /// block quantum is expressed in. 0 until the first execution has been
+  /// measured, which falls the quantum back to an even division of the step.
+  double clocksPerCost{0};
+
+  /// How well the blocks of this step's previous execution filled the time its
+  /// slowest one took: mean block clocks over max, the same figure the per-step
+  /// balance line reports. 0 until measured.
+  ///
+  /// This is the only honest signal that a step needs MORE blocks. The
+  /// cost-model skew in gridStats cannot tell -- it is derived from the same
+  /// costs the sizing uses, so a step whose costs are wrong looks balanced to
+  /// it. A step already near 1.0 here has nothing to gain from a wider grid and
+  /// everything to lose, since the extra blocks arrive as serialized launches.
+  double measuredUtil{0};
+
+  /// Blocks the previous execution actually ran, so a step that measured well
+  /// can be held to what already worked.
+  int32_t measuredBlocks{0};
 
   /// Used by makeGrid (internal temporaries).
   std::vector<float> costs;
@@ -788,11 +830,17 @@ void runShortcutStandalones(
 /// 'maxBlocksPerSM' is the kernel's occupancy at zero dynamic shared memory and
 /// 'staticSharedPerBlock' its static shared memory; both are needed to bound a
 /// cooperative grid when an op in the step asks for dynamic shared memory.
+/// 'occupancyFor' answers the same question from the driver at a given dynamic
+/// shared memory, and supersedes the other two when given: a cooperative launch
+/// is packed to exactly that figure, so deriving it any other way risks a grid
+/// the driver refuses. See GridDevice::occupancyFor.
 int32_t makeGrid(
     std::vector<LaunchData>& launches,
     StepVectors& sv,
     int32_t maxBlocksPerSM = 0,
-    int32_t staticSharedPerBlock = 0);
+    int32_t staticSharedPerBlock = 0,
+    const std::function<int32_t(int32_t dynamicShared)>& occupancyFor =
+        nullptr);
 
 /// Looks up 'value' in 'map' and returns the corresponding tensor from 'frame'.
 at::Tensor paramTensor(

--- a/velox/experimental/torchwave/LaunchPartition.cpp
+++ b/velox/experimental/torchwave/LaunchPartition.cpp
@@ -1,0 +1,783 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/LaunchPartition.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <numeric>
+
+namespace torch::wave {
+
+int32_t blocksPerSM(const GridDevice& device, int32_t dynamicShared) {
+  int32_t perSM = std::max(1, device.maxBlocksPerSM);
+  if (dynamicShared > 0 && device.sharedPerSM > 0) {
+    const int32_t perBlock = dynamicShared + device.staticSharedPerBlock;
+    perSM = std::max(1, std::min(perSM, device.sharedPerSM / perBlock));
+  }
+  return perSM;
+}
+
+int32_t coopBlocksPerSM(
+    const GridDevice& device,
+    int32_t classOccupancy,
+    int32_t dynamicShared) {
+  if (!device.occupancyFor) {
+    return classOccupancy;
+  }
+  const int32_t fromDriver = device.occupancyFor(dynamicShared);
+  if (fromDriver <= 0) {
+    return classOccupancy;
+  }
+  // Only ever downwards, and only away from 'classOccupancy'. The occupancy
+  // classes, the block budget and the BlockInfo reservation are all derived
+  // from blocksPerSM; raising the figure here would let a launch outgrow a
+  // reservation sized from that one, and returning anything but
+  // 'classOccupancy' when there is no driver to ask would repartition a graph
+  // that has no GPU behind it.
+  return std::max(1, std::min(classOccupancy, fromDriver));
+}
+
+namespace {
+
+// Cost per block of op 'index', i.e. how long it is projected to keep the
+// blocks it was given busy. Balancing a launch means levelling this.
+float latencyOf(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    int32_t index) {
+  const int32_t blocks = blocksPerOp[index];
+  return blocks > 0 ? ops[index].cost / static_cast<float>(blocks) : 0.0f;
+}
+
+// Op indices in the order their blocks should be emitted. Blocks are
+// dispatched to SMs roughly in index order, so the ops projected to run
+// longest go first and the cheap ones backfill SMs as the long ones retire.
+std::vector<int32_t> latencyOrder(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp) {
+  std::vector<int32_t> order(ops.size());
+  std::iota(order.begin(), order.end(), 0);
+  std::stable_sort(order.begin(), order.end(), [&](int32_t lhs, int32_t rhs) {
+    return latencyOf(ops, blocksPerOp, lhs) > latencyOf(ops, blocksPerOp, rhs);
+  });
+  return order;
+}
+
+// Largest dynamic shared memory any op needs.
+int32_t maxDynamicShared(const std::vector<GridOp>& ops) {
+  int32_t bytes = 0;
+  for (const auto& op : ops) {
+    bytes = std::max(bytes, op.dynamicShared);
+  }
+  return bytes;
+}
+
+// The same over a subset, which is what a launch holding only those ops will
+// ask the driver for.
+int32_t maxDynamicShared(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& members) {
+  int32_t bytes = 0;
+  for (auto op : members) {
+    bytes = std::max(bytes, ops.at(op).dynamicShared);
+  }
+  return bytes;
+}
+
+// Whether a launch holding these ops has to be cooperative.
+bool needsCooperative(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    int32_t index) {
+  return ops[index].hasBarrier && blocksPerOp[index] > 1;
+}
+
+} // namespace
+
+bool exceedsCooperativeCapacity(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    const GridDevice& device) {
+  int32_t total = 0;
+  bool anyCooperative = false;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    const int32_t blocks = i < blocksPerOp.size() ? blocksPerOp[i] : 0;
+    total += std::max(0, blocks);
+    anyCooperative = anyCooperative ||
+        needsCooperative(ops, blocksPerOp, static_cast<int32_t>(i));
+  }
+  if (!anyCooperative) {
+    return false;
+  }
+  // Unsplit, the whole step goes out as one cooperative launch, so its total
+  // is what the device has to hold co-resident.
+  const int32_t capacity = std::max(1, device.numSMs) *
+      coopBlocksPerSM(device,
+                      blocksPerSM(device, maxDynamicShared(ops)),
+                      maxDynamicShared(ops));
+  return total > capacity;
+}
+
+GridStats gridStats(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    const GridDevice& device) {
+  GridStats stats;
+  stats.numOps = static_cast<int32_t>(ops.size());
+  const int32_t stepShared = maxDynamicShared(ops);
+  stats.occupancy = blocksPerSM(device, stepShared);
+  stats.bestOccupancy = stats.occupancy;
+  for (const auto& op : ops) {
+    stats.bestOccupancy =
+        std::max(stats.bestOccupancy, blocksPerSM(device, op.dynamicShared));
+  }
+  stats.targetBlocks = std::max(1, device.numSMs) * stats.occupancy;
+
+  float worstLatency = 0;
+  float poisonCost = 0;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    stats.totalCost += ops[i].cost;
+    const int32_t blocks = i < blocksPerOp.size() ? blocksPerOp[i] : 0;
+    stats.totalBlocks += blocks;
+    if (blocks > 0) {
+      worstLatency =
+          std::max(worstLatency, ops[i].cost / static_cast<float>(blocks));
+    }
+    if (blocks == 1 && ops[i].maxBlocks > 1) {
+      ++stats.numStarved;
+    }
+    if (stepShared > 0 && ops[i].dynamicShared == stepShared) {
+      poisonCost += ops[i].cost;
+    }
+  }
+  if (stats.totalCost > 0) {
+    stats.skew = worstLatency /
+        (stats.totalCost / static_cast<float>(stats.targetBlocks));
+    stats.poison = poisonCost / stats.totalCost;
+  }
+  return stats;
+}
+
+LaunchPlan singleLaunchPlan(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    bool orderByLatency) {
+  LaunchPlan plan;
+  plan.blocksPerOp = blocksPerOp;
+  plan.blocksPerOp.resize(ops.size(), 0);
+
+  int32_t total = 0;
+  for (auto blocks : plan.blocksPerOp) {
+    total += std::max(0, blocks);
+  }
+  plan.blocks.reserve(total);
+
+  if (orderByLatency) {
+    for (auto index : latencyOrder(ops, plan.blocksPerOp)) {
+      for (int32_t block = 0; block < plan.blocksPerOp[index]; ++block) {
+        plan.blocks.push_back({index, block});
+      }
+    }
+  } else {
+    for (size_t i = 0; i < ops.size(); ++i) {
+      for (int32_t block = 0; block < plan.blocksPerOp[i]; ++block) {
+        plan.blocks.push_back({static_cast<int32_t>(i), block});
+      }
+    }
+  }
+  bool cooperative = false;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    cooperative = cooperative ||
+        needsCooperative(ops, plan.blocksPerOp, static_cast<int32_t>(i));
+  }
+  plan.segments.push_back(
+      {.firstBlock = 0,
+       .numBlocks = static_cast<int32_t>(plan.blocks.size()),
+       .dynamicShared = maxDynamicShared(ops),
+       .cooperative = cooperative});
+  return plan;
+}
+
+namespace {
+
+// Share of the step's cost that may sit in the ops setting the step-wide max
+// dynamic shared memory before splitting them off stops being worth it. Above
+// this the expensive ops are the hungry ones, so the occupancy they force is
+// the occupancy the step needs anyway.
+constexpr float kPoisonFraction = 0.25f;
+
+// How full an emitted launch must be, as a fraction of its group's capacity.
+// Same-stream launches serialize, so a launch far short of a full wave leaves
+// most of the machine idle for its whole duration.
+constexpr float kMinLaunchFill = 0.8f;
+
+// A run of consecutive blocks of one op inside one launch. An op split across
+// two launches contributes one chunk to each.
+struct Chunk {
+  int32_t op{0};
+  int32_t firstBlockInOp{0};
+  int32_t count{0};
+};
+
+// Ops only share a launch when they need the same occupancy, since a launch's
+// shared memory is the max over what is in it. Ops needing a cooperative
+// launch are kept apart as well: that launch is capped at what fits
+// co-resident, so mixing splittable work into it would strand the rest.
+struct GroupKey {
+  bool cooperative{false};
+  int32_t occupancy{1};
+
+  bool operator<(const GroupKey& other) const {
+    if (cooperative != other.cooperative) {
+      return cooperative < other.cooperative;
+    }
+    return occupancy < other.occupancy;
+  }
+};
+
+// One occupancy class, packed.
+struct PackedGroup {
+  GroupKey key;
+  float cost{0};
+  std::vector<std::vector<Chunk>> launches;
+  /// Ops in this class, needed to re-derive the launch's shared memory when
+  /// topping a cooperative launch back up.
+  std::vector<int32_t> members;
+};
+
+// Most blocks a step may emit over all of its launches. Matches the multiple
+// of one wave StepVectors::blockCapacity reserves the block array for, so the
+// packer cannot outrun the reservation.
+int32_t blockBudget(const GridDevice& device, const PartitionParams& params) {
+  const int32_t oneWave =
+      std::max(1, device.numSMs) * std::max(1, device.maxBlocksPerSM);
+  return std::max(1, params.maxWaves) * oneWave;
+}
+
+// Scales 'want' down until it fits 'budget', keeping every op on at least one
+// block. Only the blocks above that floor are scaled, so the ops with the most
+// to give up give up the most.
+void shrinkToBudget(std::vector<int32_t>& want, int32_t budget) {
+  int64_t total = 0;
+  for (auto blocks : want) {
+    total += blocks;
+  }
+  if (total <= budget) {
+    return;
+  }
+  const auto floorTotal = static_cast<int64_t>(want.size());
+  if (budget <= floorTotal) {
+    std::fill(want.begin(), want.end(), 1);
+    return;
+  }
+  const double scale = static_cast<double>(budget - floorTotal) /
+      static_cast<double>(total - floorTotal);
+  total = 0;
+  for (auto& blocks : want) {
+    blocks = 1 + static_cast<int32_t>((blocks - 1) * scale);
+    total += blocks;
+  }
+  while (total > budget) {
+    auto* widest = &*std::max_element(want.begin(), want.end());
+    if (*widest <= 1) {
+      break;
+    }
+    --*widest;
+    --total;
+  }
+}
+
+// shrinkToBudget over the subset of 'want' named by 'members'.
+void shrinkMembersToBudget(
+    std::vector<int32_t>& want,
+    const std::vector<int32_t>& members,
+    int32_t budget) {
+  std::vector<int32_t> subset;
+  subset.reserve(members.size());
+  for (auto op : members) {
+    subset.push_back(want.at(op));
+  }
+  shrinkToBudget(subset, budget);
+  for (size_t i = 0; i < members.size(); ++i) {
+    want.at(members[i]) = subset.at(i);
+  }
+}
+
+// Waves to size one cooperative occupancy class to. Rounding down and then
+// shrinking to fit is what makes the waves full: a class wanting 1.2 waves
+// packs better as one wave of fatter blocks than as a full wave plus a tail
+// launch holding a fifth of the machine, since the work is the same either way
+// and the tail costs a whole extra serialization.
+int32_t cooperativeWaves(
+    const std::vector<int32_t>& want,
+    const std::vector<int32_t>& members,
+    int32_t capacity,
+    int32_t maxWaves) {
+  int64_t total = 0;
+  for (auto op : members) {
+    total += std::min(want.at(op), capacity);
+  }
+  return std::clamp(
+      static_cast<int32_t>(total / std::max(1, capacity)),
+      1,
+      std::max(1, maxWaves));
+}
+
+// Packs one cooperative occupancy class. A barrier op is never split --
+// opBarrier waits for every block of its op and only a single launch can hold
+// them co-resident -- but its block count is free, so once the class is at its
+// wave target an op that does not fit the current launch is trimmed into what
+// is left rather than opening another one.
+//
+// Trimming only ever removes blocks, so every launch stays within 'capacity'
+// whatever the wave estimate was. That is the invariant packGroup and
+// mergeThinTail could not offer between them: packGroup fills a launch to
+// exactly capacity and mergeThinTail then appends a tail to it, which on a
+// cooperative launch overruns the device's co-residency limit outright.
+std::vector<std::vector<Chunk>> packCooperative(
+    std::vector<int32_t>& want,
+    const std::vector<int32_t>& members,
+    int32_t capacity,
+    int32_t targetLaunches) {
+  std::vector<std::vector<Chunk>> launches(1);
+  int32_t remaining = capacity;
+  for (auto op : members) {
+    int32_t blocks = std::min(want.at(op), capacity);
+    if (blocks > remaining) {
+      // A launch with nothing left always yields: an op trimmed to no blocks
+      // would never run at all.
+      if (remaining <= 0 ||
+          static_cast<int32_t>(launches.size()) < targetLaunches) {
+        launches.emplace_back();
+        remaining = capacity;
+      } else {
+        blocks = remaining;
+      }
+    }
+    want.at(op) = blocks;
+    launches.back().push_back({.op = op, .firstBlockInOp = 0, .count = blocks});
+    remaining -= blocks;
+  }
+  if (launches.back().empty()) {
+    launches.pop_back();
+  }
+  return launches;
+}
+
+// LPT packing of one occupancy class: ops in descending cost, each opening a
+// new launch when the current one is full. A barrier op is shrunk to the
+// launch capacity rather than split, since opBarrier waits for all of its
+// blocks and only a single launch can hold them co-resident. Shrinking it
+// rewrites its entry in 'want', which is what the emitted blocks report as
+// numBlocksInOp -- an op told it has more blocks than were launched would skip
+// the slices of the ones that never ran.
+std::vector<std::vector<Chunk>> packGroup(
+    const std::vector<GridOp>& ops,
+    std::vector<int32_t>& want,
+    const std::vector<int32_t>& members,
+    int32_t capacity) {
+  std::vector<std::vector<Chunk>> launches(1);
+  int32_t remaining = capacity;
+  for (auto op : members) {
+    if (ops.at(op).hasBarrier) {
+      const int32_t blocks = std::min(want.at(op), capacity);
+      want.at(op) = blocks;
+      if (blocks > remaining && !launches.back().empty()) {
+        launches.emplace_back();
+        remaining = capacity;
+      }
+      launches.back().push_back(
+          {.op = op, .firstBlockInOp = 0, .count = blocks});
+      remaining -= blocks;
+      if (remaining <= 0) {
+        launches.emplace_back();
+        remaining = capacity;
+      }
+      continue;
+    }
+    int32_t placed = 0;
+    while (placed < want.at(op)) {
+      const int32_t take = std::min(want.at(op) - placed, remaining);
+      launches.back().push_back(
+          {.op = op, .firstBlockInOp = placed, .count = take});
+      placed += take;
+      remaining -= take;
+      if (remaining <= 0) {
+        launches.emplace_back();
+        remaining = capacity;
+      }
+    }
+  }
+  if (launches.back().empty()) {
+    launches.pop_back();
+  }
+  return launches;
+}
+
+int32_t blocksIn(const std::vector<Chunk>& launch) {
+  int32_t blocks = 0;
+  for (const auto& chunk : launch) {
+    blocks += chunk.count;
+  }
+  return blocks;
+}
+
+// Folds a launch that is far short of a full wave back into the one before it.
+// Splitting trades one skewed wave for several packed ones plus their tails,
+// which only pays while each is close to full; a thin tail costs a whole
+// serialized launch for a sliver of the machine.
+//
+// The merged launch can exceed 'capacity', which an ordinary launch may do --
+// the hardware runs the surplus in a second wave. Only a cooperative launch may
+// not, and those are packed by packCooperative, which leaves no thin tail to
+// fold.
+void mergeThinTail(
+    std::vector<std::vector<Chunk>>& launches,
+    int32_t capacity) {
+  const auto minBlocks =
+      static_cast<int32_t>(kMinLaunchFill * static_cast<float>(capacity));
+  while (launches.size() > 1 && blocksIn(launches.back()) < minBlocks) {
+    auto tail = std::move(launches.back());
+    launches.pop_back();
+    launches.back().insert(launches.back().end(), tail.begin(), tail.end());
+  }
+}
+
+// Fills what a cooperative launch leaves of its wave with splittable work from
+// the same occupancy class. A cooperative launch is capped at what fits
+// co-resident, so when the barrier ops do not reach that cap the rest of the
+// machine would otherwise idle through the launch while the class's non-barrier
+// work waits its turn in a launch of its own.
+//
+// Donating within one occupancy class is what makes this safe. A launch's
+// shared memory is the max over its ops, and every member of a class yields the
+// same blocksPerSM, so the donated blocks cannot lower the co-residency the
+// barrier ops were sized against. Blocks are taken off the end of the donor's
+// last launch, which is the one a thin tail would have landed in.
+void backfillCooperative(
+    std::vector<PackedGroup>& packed,
+    const std::vector<GridOp>& ops,
+    const GridDevice& device) {
+  const int32_t numSMs = std::max(1, device.numSMs);
+  for (auto& coop : packed) {
+    if (!coop.key.cooperative || coop.launches.size() != 1) {
+      continue;
+    }
+    // The same bound packCooperative filled to, for the same reason.
+    int32_t slack = std::max(
+                        1,
+                        numSMs *
+                            coopBlocksPerSM(
+                                device,
+                                coop.key.occupancy,
+                                maxDynamicShared(ops, coop.members))) -
+        blocksIn(coop.launches.front());
+    if (slack <= 0) {
+      continue;
+    }
+    for (auto& donor : packed) {
+      if (donor.key.cooperative || donor.key.occupancy != coop.key.occupancy) {
+        continue;
+      }
+      while (slack > 0 && !donor.launches.empty()) {
+        auto& last = donor.launches.back();
+        if (last.empty()) {
+          donor.launches.pop_back();
+          continue;
+        }
+        auto& chunk = last.back();
+        const int32_t take = std::min(slack, chunk.count);
+        coop.launches.front().push_back(
+            {.op = chunk.op,
+             .firstBlockInOp = chunk.firstBlockInOp + chunk.count - take,
+             .count = take});
+        chunk.count -= take;
+        slack -= take;
+        if (chunk.count == 0) {
+          last.pop_back();
+        }
+      }
+      break;
+    }
+  }
+}
+
+// Orders one launch's chunks by descending projected latency, for the same
+// reason latencyOrder does it across a whole step.
+void orderChunks(
+    std::vector<Chunk>& launch,
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& want) {
+  std::stable_sort(
+      launch.begin(), launch.end(), [&](const Chunk& lhs, const Chunk& rhs) {
+        return latencyOf(ops, want, lhs.op) > latencyOf(ops, want, rhs.op);
+      });
+}
+
+} // namespace
+
+std::vector<int32_t> sizeByQuantum(
+    const std::vector<GridOp>& ops,
+    const GridDevice& device,
+    const PartitionParams& params) {
+  std::vector<int32_t> want(ops.size(), 1);
+  if (ops.empty()) {
+    return want;
+  }
+  const int32_t oneWave =
+      std::max(1, device.numSMs) * std::max(1, device.maxBlocksPerSM);
+
+  float totalCost = 0;
+  for (const auto& op : ops) {
+    totalCost += std::max(0.0f, op.cost);
+  }
+  if (totalCost <= 0) {
+    return want;
+  }
+
+  // What one block is worth. The measured figure when there is one -- it is
+  // the only one that knows what the ops actually do -- and an even division
+  // of the step over a wave otherwise, which is where the pro-rata split
+  // starts from too.
+  float quantum = params.minBlockCost > 0
+      ? params.minBlockCost
+      : totalCost / static_cast<float>(oneWave);
+  if (quantum <= 0) {
+    return want;
+  }
+
+  auto sizeAt = [&](float q) {
+    int64_t total = 0;
+    for (size_t i = 0; i < ops.size(); ++i) {
+      const int32_t cap =
+          ops[i].alwaysSingleBlock ? 1 : std::max(1, ops[i].maxBlocks);
+      const auto scaled = static_cast<int32_t>(std::lround(ops[i].cost / q));
+      want[i] = std::clamp(scaled, 1, cap);
+      total += want[i];
+    }
+    return total;
+  };
+
+  int64_t total = sizeAt(quantum);
+
+  // Too much for the waves we may emit: lengthen the block until it fits,
+  // rather than trimming the tallest ops afterwards. Bisection because an op
+  // at its cap or on its floor does not shrink with the quantum, so the total
+  // is not proportional to it.
+  const int64_t budget = blockBudget(device, params);
+  if (total > budget) {
+    float lo = quantum;
+    float hi = quantum * 2;
+    for (int32_t i = 0; i < 40 && sizeAt(hi) > budget; ++i) {
+      lo = hi;
+      hi *= 2;
+    }
+    for (int32_t i = 0; i < 40; ++i) {
+      const float mid = (lo + hi) / 2;
+      if (mid <= lo || mid >= hi) {
+        break;
+      }
+      if (sizeAt(mid) > budget) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    total = sizeAt(hi);
+    if (total > budget) {
+      shrinkToBudget(want, static_cast<int32_t>(budget));
+      return want;
+    }
+  }
+
+  // A step whose blocks already finished together does not get widened. The
+  // quantum says how much work there is, not whether the machine has room to
+  // absorb it in parallel: expanding an already-full step turns one wave into
+  // several serialized launches running the same work. Only the measurement can
+  // distinguish the two cases -- the cost-model skew is derived from the same
+  // costs this sizing uses, so it calls a mis-costed step balanced.
+  if (params.measuredBlocks > 0 &&
+      params.measuredUtil >= params.keepWidthUtil &&
+      total > params.measuredBlocks) {
+    shrinkToBudget(want, params.measuredBlocks);
+    return want;
+  }
+
+  // Round up to a whole wave and hand the surplus to whoever has the most work
+  // left per block. Half a wave of idle SMs is free capacity, and the op that
+  // would use it is by definition the one holding the step up.
+  const int64_t waves = (total + oneWave - 1) / oneWave;
+  const int64_t targetTotal = std::min<int64_t>(waves * oneWave, budget);
+  for (int64_t spare = targetTotal - total; spare > 0; --spare) {
+    int32_t best = -1;
+    float bestLatency = 0;
+    for (size_t i = 0; i < ops.size(); ++i) {
+      const int32_t cap =
+          ops[i].alwaysSingleBlock ? 1 : std::max(1, ops[i].maxBlocks);
+      if (want.at(i) >= cap) {
+        continue;
+      }
+      const float latency = ops[i].cost / static_cast<float>(want.at(i));
+      if (latency > bestLatency) {
+        bestLatency = latency;
+        best = static_cast<int32_t>(i);
+      }
+    }
+    if (best < 0) {
+      break;
+    }
+    ++want.at(best);
+  }
+  return want;
+}
+
+bool shouldPartition(const GridStats& stats, const PartitionParams& params) {
+  if (stats.numOps < 2 || stats.totalCost <= 0) {
+    return false;
+  }
+  if (stats.skew >= params.skewThreshold) {
+    return true;
+  }
+  // No skew to fix, but a cheap op is still cutting everyone's occupancy.
+  return stats.occupancy < stats.bestOccupancy &&
+      stats.poison < kPoisonFraction;
+}
+
+std::optional<LaunchPlan> partitionLaunches(
+    const std::vector<GridOp>& ops,
+    const GridDevice& device,
+    const GridStats& stats,
+    const PartitionParams& params,
+    const std::vector<int32_t>* presized) {
+  if (ops.empty() || stats.targetBlocks <= 0 || stats.totalCost <= 0) {
+    return std::nullopt;
+  }
+
+  // Cost one block is worth. Under an even division of the step over one wave
+  // the assignment reproduces today's pro-rata split; a larger minBlockCost
+  // makes blocks fewer and longer, so a step is only split when the work
+  // genuinely does not fit in a wave of blocks that size.
+  std::vector<int32_t> want;
+  if (presized != nullptr) {
+    want = *presized;
+    want.resize(ops.size(), 1);
+  } else {
+    const float quantum = std::max(
+        params.minBlockCost,
+        stats.totalCost / static_cast<float>(stats.targetBlocks));
+    if (quantum <= 0) {
+      return std::nullopt;
+    }
+    want.assign(ops.size(), 1);
+    for (size_t i = 0; i < ops.size(); ++i) {
+      const auto scaled =
+          static_cast<int32_t>(std::lround(ops[i].cost / quantum));
+      want.at(i) = std::clamp(scaled, 1, std::max(1, ops[i].maxBlocks));
+    }
+    shrinkToBudget(want, blockBudget(device, params));
+  }
+
+  // A barrier op that came out on one block passes its barrier as soon as it
+  // runs, so it needs no cooperative launch and can ride along with everything
+  // else rather than costing a serialized launch of its own.
+  std::map<GroupKey, std::vector<int32_t>> groups;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    const GroupKey key{
+        .cooperative = needsCooperative(ops, want, static_cast<int32_t>(i)),
+        .occupancy = blocksPerSM(device, ops[i].dynamicShared)};
+    groups[key].push_back(static_cast<int32_t>(i));
+  }
+
+  std::vector<PackedGroup> packed;
+  for (auto& [key, members] : groups) {
+    std::stable_sort(
+        members.begin(), members.end(), [&](int32_t lhs, int32_t rhs) {
+          return ops[lhs].cost > ops[rhs].cost;
+        });
+    // A cooperative launch is packed to exactly its capacity, so that figure
+    // has to be one the driver will accept rather than an estimate of it. An
+    // ordinary launch may exceed its capacity -- the hardware runs the surplus
+    // in a later wave -- so it keeps the estimate and the occupancy classes
+    // stay as they were.
+    const int32_t capacity = std::max(
+        1,
+        std::max(1, device.numSMs) *
+            (key.cooperative
+                 ? coopBlocksPerSM(
+                       device, key.occupancy, maxDynamicShared(ops, members))
+                 : key.occupancy));
+    PackedGroup group;
+    group.key = key;
+    group.members = members;
+    if (key.cooperative) {
+      const int32_t waves =
+          cooperativeWaves(want, members, capacity, params.maxWaves);
+      shrinkMembersToBudget(want, members, waves * capacity);
+      group.launches = packCooperative(want, members, capacity, waves);
+    } else {
+      group.launches = packGroup(ops, want, members, capacity);
+      mergeThinTail(group.launches, capacity);
+    }
+    for (auto member : members) {
+      group.cost += ops[member].cost;
+    }
+    packed.push_back(std::move(group));
+  }
+  backfillCooperative(packed, ops, device);
+
+  size_t numLaunches = 0;
+  for (const auto& group : packed) {
+    for (const auto& launch : group.launches) {
+      numLaunches += launch.empty() ? 0 : 1;
+    }
+  }
+  if (numLaunches <= 1 && presized == nullptr) {
+    return std::nullopt;
+  }
+  std::stable_sort(
+      packed.begin(), packed.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.cost > rhs.cost;
+      });
+
+  LaunchPlan plan;
+  plan.blocksPerOp = want;
+  for (auto& group : packed) {
+    for (auto& launch : group.launches) {
+      orderChunks(launch, ops, want);
+      LaunchSegment segment;
+      segment.firstBlock = static_cast<int32_t>(plan.blocks.size());
+      for (const auto& chunk : launch) {
+        segment.dynamicShared =
+            std::max(segment.dynamicShared, ops[chunk.op].dynamicShared);
+        segment.cooperative =
+            segment.cooperative || needsCooperative(ops, want, chunk.op);
+        for (int32_t block = 0; block < chunk.count; ++block) {
+          plan.blocks.push_back({chunk.op, chunk.firstBlockInOp + block});
+        }
+      }
+      segment.numBlocks =
+          static_cast<int32_t>(plan.blocks.size()) - segment.firstBlock;
+      if (segment.numBlocks > 0) {
+        plan.segments.push_back(segment);
+      }
+    }
+  }
+  return plan;
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/LaunchPartition.h
+++ b/velox/experimental/torchwave/LaunchPartition.h
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace torch::wave {
+
+/// Occupancy and width of the device a step's grid is laid out for. Passed in
+/// rather than read from the driver so the layout can be exercised without a
+/// GPU.
+struct GridDevice {
+  /// Streaming multiprocessors the grid spreads over.
+  int32_t numSMs{1};
+
+  /// Blocks of this step's kernel that stay resident on one SM when no op in
+  /// it asks for dynamic shared memory.
+  int32_t maxBlocksPerSM{1};
+
+  /// Shared memory one SM has for all of its resident blocks.
+  int32_t sharedPerSM{0};
+
+  /// Static shared memory every block of this kernel takes, whatever op it
+  /// runs.
+  int32_t staticSharedPerBlock{0};
+
+  /// Blocks of this step's kernel that stay resident on one SM at the given
+  /// dynamic shared memory, as the DRIVER computes it. Read by coopBlocksPerSM,
+  /// which bounds a cooperative launch; blocksPerSM keeps the estimate below,
+  /// since changing that would move ops between occupancy classes and
+  /// repartition the graph.
+  ///
+  /// The division is only an approximation of what the driver does: the driver
+  /// also rounds each block's shared allocation up to the hardware granularity,
+  /// subtracts the shared memory reserved per block, and honours the L1/shared
+  /// carveout. Each of those can only lower the true figure, so the division
+  /// can come out a block per SM too high -- and a cooperative launch is packed
+  /// to exactly this number, so an over-estimate is not slack but a grid the
+  /// driver refuses outright.
+  ///
+  /// Left unset by tests, which have no kernel to ask and want the layout to be
+  /// reproducible without a GPU.
+  std::function<int32_t(int32_t dynamicShared)> occupancyFor;
+};
+
+/// What laying out a step's launches needs to know about one of its ops.
+/// Reduced from LaunchData and KernelOperation so the layout depends on
+/// neither.
+struct GridOp {
+  /// numElements * unitCost * costAdjustFactor: the op's share of the step's
+  /// work, in the units blocks are divided by.
+  float cost{0};
+
+  /// Most blocks this op may be given.
+  int32_t maxBlocks{1};
+
+  /// extern __shared__ bytes the op needs. Only the ops sharing a launch with
+  /// it pay for them.
+  int32_t dynamicShared{0};
+
+  /// Set when the op folds its cross-block barriers into __syncthreads and is
+  /// only correct as a single block.
+  bool alwaysSingleBlock{false};
+
+  /// Set when the op spin-waits until all of its blocks arrive (opBarrier), so
+  /// they must be co-resident in one launch and the op may not be split
+  /// across two.
+  bool hasBarrier{false};
+};
+
+/// One kernel launch of a step, over a contiguous range of the step's blocks.
+struct LaunchSegment {
+  /// Index into the step's block array where this launch starts.
+  int32_t firstBlock{0};
+
+  int32_t numBlocks{0};
+
+  /// Dynamic shared memory to launch with: the max over the ops in THIS
+  /// launch, not over the whole step. Launching the ops that need none apart
+  /// from the one that does is what keeps a single hungry op from cutting
+  /// everyone's occupancy.
+  int32_t dynamicShared{0};
+
+  /// Set when a barrier op in this launch spans more than one block. opBarrier
+  /// waits for all of them to arrive, which only a cooperative launch keeps
+  /// co-resident. A barrier op on a single block passes its barrier as soon as
+  /// it runs, so it needs nothing.
+  bool cooperative{false};
+};
+
+/// One thread block of the emitted grid.
+struct GridBlock {
+  /// Index into the step's ops.
+  int32_t op{0};
+
+  /// This block's position among that op's blocks, counted over the whole
+  /// step: an op split across two launches still numbers its blocks 0..n-1,
+  /// which is what lets it compute its slice the same way either way.
+  int32_t blockInOp{0};
+};
+
+/// How far a step's grid is from a balanced, fully occupied one. Computed for
+/// every step; reported under WaveConfig::kGrid and summarized in the
+/// performance report.
+struct GridStats {
+  int32_t numOps{0};
+
+  /// Blocks one wave holds at the occupancy the step actually launches with.
+  int32_t targetBlocks{0};
+
+  /// Blocks the step was given.
+  int32_t totalBlocks{0};
+
+  float totalCost{0};
+
+  /// The step's makespan over that of a perfectly balanced, fully occupied
+  /// one: max_i(cost_i / blocks_i) divided by totalCost / targetBlocks. 1
+  /// means there is nothing to win. With every op on one block it degenerates
+  /// to the cost spread of the step, which is what block starvation costs.
+  float skew{0};
+
+  /// Ops left on a single block although they could have used more. This is
+  /// what block starvation looks like: once numOps reaches targetBlocks the
+  /// pro-rata split has nothing left to give.
+  int32_t numStarved{0};
+
+  /// Blocks per SM the step launches with, i.e. after the step-wide max
+  /// dynamic shared memory has cut it.
+  int32_t occupancy{0};
+
+  /// Best blocks per SM any op of the step would reach launched on its own.
+  /// Above 'occupancy' means some op is taxing the others.
+  int32_t bestOccupancy{0};
+
+  /// Share of the step's cost belonging to the ops that ask for the most
+  /// dynamic shared memory. A small share with occupancy below bestOccupancy
+  /// is a cheap op holding the whole step down.
+  float poison{0};
+
+  /// Launches the step was split into. 1 unless the packer ran.
+  int32_t numSegments{1};
+};
+
+/// The blocks of one step, grouped into the launches that run them.
+struct LaunchPlan {
+  /// Blocks each op ends up with, parallel to the ops. The packer may differ
+  /// from what was passed in; a single launch never does.
+  std::vector<int32_t> blocksPerOp;
+
+  /// The grid, flattened over the segments in launch order.
+  std::vector<GridBlock> blocks;
+
+  /// Contiguous ranges of 'blocks', one kernel launch each.
+  std::vector<LaunchSegment> segments;
+};
+
+/// Knobs of the packer, from WaveConfig.
+struct PartitionParams {
+  /// Most launches one step may be split into, and so the multiple of one
+  /// wave the block array is reserved for.
+  int32_t maxWaves{3};
+
+  /// GridStats::skew at and above which a step is worth splitting.
+  float skewThreshold{1.3f};
+
+  /// Cost a block must be worth for the packer to open one, so a split does
+  /// not produce blocks too short to be worth scheduling. 0 falls back to an
+  /// even division of the step over one wave.
+  float minBlockCost{0};
+
+  /// Mean block clocks over the slowest, measured on the previous execution of
+  /// this step. 0 when nothing has been measured.
+  double measuredUtil{0};
+
+  /// Blocks that execution ran.
+  int32_t measuredBlocks{0};
+
+  /// Measured utilization at and above which a step is left at the width it
+  /// already had. Sizing by quantum asks how many blocks the work is worth, but
+  /// a step whose blocks already finish together has no idle capacity for more
+  /// blocks to fill: widening it only buys serialized launches and host time
+  /// spent filling BlockInfo. On the ROO graph, four steps already at 90-98%
+  /// were tripled to the wave budget for +1.2 ms and slightly WORSE
+  /// utilization.
+  float keepWidthUtil{0.85f};
+};
+
+/// Blocks of this kernel that fit on one SM alongside each other when each
+/// takes 'dynamicShared' bytes of dynamic shared memory.
+int32_t blocksPerSM(const GridDevice& device, int32_t dynamicShared);
+
+/// True when this step, left as a single launch, would go out as a cooperative
+/// grid wider than the device can hold co-resident -- which the driver refuses
+/// outright. Such a step must be split whatever its skew, since the alternative
+/// is not a slower plan but a failed launch.
+/// True when 'ops' laid out as one launch would need a cooperative grid wider
+/// than the device holds co-resident, so the step has to be split whatever the
+/// skew gate says. On the 1k ROO graph this fires on two steps, both of which
+/// otherwise fail the launch outright.
+bool exceedsCooperativeCapacity(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    const GridDevice& device);
+
+/// The same, but for a launch that has to be cooperative: the driver's own
+/// figure via GridDevice::occupancyFor when there is one, else the estimate.
+/// Never above blocksPerSM, since the occupancy classes and the BlockInfo
+/// reservation are both derived from that and a launch may not outgrow them.
+///
+/// Separate from blocksPerSM because only a cooperative launch is packed to
+/// exactly its capacity. An ordinary launch may exceed it -- the hardware runs
+/// the surplus in a later wave -- so it keeps the estimate, and using the
+/// driver's figure for it would repartition the graph for no gain.
+int32_t coopBlocksPerSM(
+    const GridDevice& device,
+    int32_t classOccupancy,
+    int32_t dynamicShared);
+
+/// Measures the balance of a grid that gives op i blocksPerOp[i] blocks.
+GridStats gridStats(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    const GridDevice& device);
+
+/// Lays the step out as the single launch it is today. With 'orderByLatency'
+/// the ops are emitted in descending cost per block instead of in index
+/// order, so the long poles start at t=0 and the cheap ops backfill SMs as
+/// those retire. Blocks are dispatched to SMs roughly in index order, which is
+/// what makes the order matter at all.
+LaunchPlan singleLaunchPlan(
+    const std::vector<GridOp>& ops,
+    const std::vector<int32_t>& blocksPerOp,
+    bool orderByLatency);
+
+/// Blocks per op sized against a common per-block work quantum, with the total
+/// rounded up to a whole number of waves.
+///
+/// The pro-rata split divides one wave's worth of blocks among the ops, so what
+/// an op gets depends on how many other ops the step has. This asks the other
+/// question: how many blocks of about 'params.minBlockCost' is each op's work
+/// worth? The answer is a property of the op alone, and the step emits as many
+/// waves as the sum needs -- up to params.maxWaves, after which it scales back.
+///
+/// Having sized them, the total is rounded UP to a whole wave and the surplus
+/// given to the ops with the most work per block, so the last wave is not left
+/// half empty. An op already at its maxBlocks, or marked alwaysSingleBlock,
+/// takes no part in that.
+///
+/// Ops whose maxBlocks is 1 -- a launch too small to divide -- still take a
+/// block each. That floor is why a step of many tiny ops can exceed a wave
+/// however it is sized; the difference is that it now costs an extra launch
+/// rather than the large ops' blocks.
+std::vector<int32_t> sizeByQuantum(
+    const std::vector<GridOp>& ops,
+    const GridDevice& device,
+    const PartitionParams& params);
+
+/// Whether 'stats' says the step has something to gain from being split:
+/// either it is badly skewed, or one op's shared memory is cutting the
+/// occupancy of ops that hold most of the work.
+bool shouldPartition(const GridStats& stats, const PartitionParams& params);
+
+/// Splits a step into balanced launches: ops are sized against a common block
+/// quantum, grouped by the occupancy their shared memory allows, and packed
+/// into full waves of that group's capacity. A barrier op is shrunk to fit a
+/// launch but never split across two; any other op may straddle, since its
+/// blocks only need blockInOp and numBlocksInOp to find their slice.
+///
+/// Returns nullopt when the step is no better off split -- one launch came
+/// out of the packing, or there is nothing to pack.
+/// 'presized' overrides the block counts the packer would compute for itself,
+/// for a caller that has sized the step by another rule -- sizeByQuantum. It
+/// also forces a plan out: with counts supplied, a packing that came out as a
+/// single launch is still the answer, not a reason to fall back to the
+/// pro-rata split.
+std::optional<LaunchPlan> partitionLaunches(
+    const std::vector<GridOp>& ops,
+    const GridDevice& device,
+    const GridStats& stats,
+    const PartitionParams& params,
+    const std::vector<int32_t>* presized = nullptr);
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/ParallelExpr.cpp
+++ b/velox/experimental/torchwave/ParallelExpr.cpp
@@ -1101,7 +1101,10 @@ bool tryElideMultiUserClone(
 // dropping one is always a win when it is safe. Safety is exactly
 // tryElideMultiUserClone's: no user writes it, it does not escape as a graph
 // output, and the source's storage is never mutated anywhere.
-int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types) {
+int64_t elideReadOnlyClones(
+    nativert::Graph& graph,
+    const ValueTypes& types,
+    const folly::F14FastSet<ValueCP>& keep) {
   std::unordered_set<ValueCP> mutatedBases;
   for (const auto& node : graph.nodes()) {
     for (auto* mutated : dataMutatedInputs(&node)) {
@@ -1122,6 +1125,9 @@ int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types) {
 
   int64_t elided = 0;
   for (NodeCP cloneNode : clones) {
+    if (keep.count(cloneNode->outputs()[0]) > 0) {
+      continue;
+    }
     if (tryElideMultiUserClone(cloneNode, graph, mutatedBases, types)) {
       ++elided;
     }
@@ -1136,6 +1142,12 @@ int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types) {
   std::map<std::pair<ValueCP, std::string>, ValueCP> firstCloneOf;
   for (NodeCP cloneNode : clones) {
     if (isDeadNode(cloneNode) || cloneNode->outputs()[0]->users().empty()) {
+      continue;
+    }
+    // Two fill clones of one source are NOT interchangeable: cat([x, y, x])
+    // needs one buffer per region, which is the whole reason they were made
+    // per occurrence.
+    if (keep.count(cloneNode->outputs()[0]) > 0) {
       continue;
     }
     ValueCP src = cloneNode->inputs()[0].value;

--- a/velox/experimental/torchwave/ParallelExpr.h
+++ b/velox/experimental/torchwave/ParallelExpr.h
@@ -33,7 +33,16 @@ namespace torch::wave {
 /// before partitioning: ParallelNodes::rewriteInPlace walks one ProjectNode
 /// layer at a time and cannot see a source whose clones land in different
 /// layers. Returns the number elided.
-int64_t elideReadOnlyClones(nativert::Graph& graph, const ValueTypes& types);
+/// Drops clones nobody writes, whose source is never mutated and which do not
+/// escape as graph outputs, then merges the identical ones that remain.
+/// 'keep' names clone outputs that must survive both halves: a wide cat's fill
+/// clones exist precisely so each operand has a buffer of its own for the
+/// allocation group to carve into the result, which is invisible here -- they
+/// read as pointless read-only copies.
+int64_t elideReadOnlyClones(
+    nativert::Graph& graph,
+    const ValueTypes& types,
+    const folly::F14FastSet<ValueCP>& keep = {});
 
 /// Merges nodes that compute the same value from the same operands, to a
 /// fixpoint: merging two nodes can make their consumers congruent in turn. Only

--- a/velox/experimental/torchwave/Registry.h
+++ b/velox/experimental/torchwave/Registry.h
@@ -131,6 +131,14 @@ struct ArgumentMeta {
   /// size to allocate based on inputs and execution state.
   OutputReserveFunc reserveShape{nullptr};
 
+  /// Ordinal of the input whose shape 'reserveShape' returns, or -1 when the
+  /// shape is the reserve's own business. An elementwise or *_like output has
+  /// the extent of an operand, so anything that only needs to know WHEN the
+  /// shape becomes computable -- rather than what it is -- can look at that
+  /// input instead of treating the reserve as opaque. Concat layout is the
+  /// caller: one operand it cannot place early refuses the whole concat.
+  int32_t shapeFromInput{-1};
+
   /// True if actual size is determined on device, e.g. stream compaction.
   bool shapeSetOnDevice{false};
 

--- a/velox/experimental/torchwave/WaveConfig.cpp
+++ b/velox/experimental/torchwave/WaveConfig.cpp
@@ -41,6 +41,11 @@ std::string WaveConfig::toString() const {
       parts.push_back(std::string(name) + "=" + std::to_string(this->*field));
     }
   };
+  auto addFloat = [&](const char* name, float WaveConfig::* field) {
+    if (this->*field != kDefaults.*field) {
+      parts.push_back(std::string(name) + "=" + std::to_string(this->*field));
+    }
+  };
   auto addOptBool = [&](const char* name,
                         std::optional<bool> WaveConfig::* field) {
     const std::optional<bool>& value = this->*field;
@@ -89,6 +94,7 @@ std::string WaveConfig::toString() const {
   addBool("cseCompute", &WaveConfig::cseCompute);
   addBool("cseViews", &WaveConfig::cseViews);
   addBool("decomposeLists", &WaveConfig::decomposeLists);
+  addBool("metadataGetterStandalone", &WaveConfig::metadataGetterStandalone);
   addBool("foldSharedChains", &WaveConfig::foldSharedChains);
   addBool("mkSelect", &WaveConfig::mkSelect);
   addBool("stepLastUse", &WaveConfig::stepLastUse);
@@ -103,7 +109,13 @@ std::string WaveConfig::toString() const {
   addInt("donationCarryBytes", &WaveConfig::donationCarryBytes);
   addBool("enableAllocGroup", &WaveConfig::enableAllocGroup);
   addBool("enableConcatAllocGroup", &WaveConfig::enableConcatAllocGroup);
+  addBool("enableLifetimeAllocGroup", &WaveConfig::enableLifetimeAllocGroup);
   addBool("parallelConcatFill", &WaveConfig::parallelConcatFill);
+  addBool("orderBlocksByCost", &WaveConfig::orderBlocksByCost);
+  addBool("partitionLaunches", &WaveConfig::partitionLaunches);
+  addInt("maxLaunchWaves", &WaveConfig::maxLaunchWaves);
+  addFloat("launchSkewThreshold", &WaveConfig::launchSkewThreshold);
+  addFloat("minBlockUs", &WaveConfig::minBlockUs);
   addBool("singlePassSelect", &WaveConfig::singlePassSelect);
   addBool("singlePass", &WaveConfig::singlePass);
 

--- a/velox/experimental/torchwave/WaveConfig.h
+++ b/velox/experimental/torchwave/WaveConfig.h
@@ -48,6 +48,7 @@ struct WaveConfig {
   static constexpr int32_t kTensors = 4;
   static constexpr int32_t kFrame = 8;
   static constexpr int32_t kTiming = 16;
+  static constexpr int32_t kGrid = 32;
 
   int32_t blockSize{256};
   bool allStandalone{false};
@@ -57,7 +58,7 @@ struct WaveConfig {
   int32_t numSms{0};
 
   /// Trace bit mask. kNodes prints node headers, kLaunches prints per-launch
-  /// details.
+  /// details, kGrid prints one block-balance line per step.
   int32_t trace{0};
 
   /// If set, forces the grid choice between single-block and multi-block
@@ -291,6 +292,15 @@ struct WaveConfig {
   // op supports it. On by default; the switch is for A/B against the list form.
   bool decomposeLists{true};
 
+  // If true, a metadata getter (aten.sym_size.int / aten.sym_numel.default)
+  // that is not a subexpression of a single fusable consumer runs as a
+  // host-side shortcut standalone instead of a fused kernel op. Fused, such a
+  // getter costs a whole thread block that reads one field and exits; that
+  // block is charged against its launch's slowest block, so a handful of them
+  // sink a step's balance and no block count can fix it -- there is no width at
+  // which a no-op op balances.
+  bool metadataGetterStandalone{true};
+
   // If true, a column folds its producer's gather into its own even when the
   // producer has several readers, provided every reader is a consumer that can
   // absorb a chain itself. The sole-reader rule two foldable consumers can
@@ -360,6 +370,55 @@ struct WaveConfig {
   // Their compiles are queued with the composite's, so the extra cost is
   // compile parallelism rather than serial latency. Off by default.
   bool configPerOp{false};
+  // If true, emit a step's blocks in descending projected latency instead of
+  // in op order, so the ops expected to run longest start at t=0 and the cheap
+  // ones backfill SMs as those retire. Blocks are dispatched to SMs roughly in
+  // index order, which is what makes the order matter; nothing about the work
+  // itself changes. Off by default.
+  bool orderBlocksByCost{false};
+
+  // If true, a step whose single launch is badly balanced -- or whose
+  // occupancy one shared-memory-hungry op has cut for everyone -- is split
+  // into several launches, each packed to about one wave of the occupancy its
+  // own ops allow. Same-stream launches serialize, so this trades one skewed
+  // wave for a few full ones; it only pays where the imbalance is real, which
+  // is what the gate below measures.
+  //
+  // On by default: a step with more launches than the grid has blocks cannot
+  // give its large ops more than a block or two, because every launch takes one
+  // first and the cooperative trim then shaves what is left off the tallest.
+  // Splitting is the only thing that gets those blocks back.
+  bool partitionLaunches{true};
+
+  // Most launches one step may be split into. Also the multiple of one wave
+  // the block array is reserved for, so raising it costs pinned and device
+  // memory on every step whether or not it splits.
+  int32_t maxLaunchWaves{3};
+
+  // GridStats::skew (the step's makespan over a perfectly balanced, fully
+  // occupied one) at and above which partitionLaunches splits a step.
+  float launchSkewThreshold{1.3f};
+
+  // Microseconds of GPU time a block should be worth before the packer opens
+  // one. Converted to cost units with the thread-block clocks the previous
+  // execution of the same step measured, so it adapts to what the ops actually
+  // do rather than to the static cost model. 0 divides the step evenly over
+  // one wave instead, which reproduces today's pro-rata split.
+  float minBlockUs{100.0f};
+
+  // If true, a step's blocks are sized against a per-block work quantum and
+  // the total rounded up to whole waves, instead of being handed out pro rata
+  // against a single wave's worth and then trimmed.
+  //
+  // The pro-rata split cannot survive a step with about as many ops as a wave
+  // has blocks: every op takes one block off the top whatever it costs, and
+  // the cooperative trim then takes what is left from the tallest. On the ROO
+  // graph one step spends 210 of 441 blocks on copies holding 0.1% of the work
+  // and leaves a 1.2M-element op on two. Sizing by quantum asks instead how
+  // many blocks of a given duration the work is worth, and emits that many --
+  // over several launches when it does not fit in one wave, which is what
+  // makes the answer independent of how many ops the step happens to have.
+  bool quantumGrid{false};
 
   /// Returns the active config: the thread-local override set by
   /// waveConfigOverride() when non-null, otherwise the process-wide singleton.

--- a/velox/experimental/torchwave/WaveGraph.cpp
+++ b/velox/experimental/torchwave/WaveGraph.cpp
@@ -243,7 +243,7 @@ WaveGraph::WaveGraph(ModelContext* modelContext)
   // survives fusion costs a copy and a barrier, so eliding is a win whenever
   // it is safe. Gated on enableReuse with the rest of the reuse work.
   if (WaveConfig::get().enableReuse && WaveConfig::get().elideClones) {
-    elideReadOnlyClones(*graph_, types_);
+    elideReadOnlyClones(*graph_, types_, concatFillClones_);
   }
 
   // Merge equal computations. After the rewrites above, which are what create
@@ -542,6 +542,12 @@ nativert::Value* WaveGraph::newListValue(
 
 bool WaveGraph::isCreatedValue(ValueCP value) const {
   return createdValueDtypes_.count(value->id()) > 0;
+}
+
+void WaveGraph::markConcatFillClone(ValueCP value) {
+  if (value != nullptr) {
+    concatFillClones_.insert(value);
+  }
 }
 
 void WaveGraph::declareMultiplyReferencedInput(const nativert::Value* value) {

--- a/velox/experimental/torchwave/WaveGraph.h
+++ b/velox/experimental/torchwave/WaveGraph.h
@@ -305,6 +305,20 @@ class WaveGraph {
   /// Returns true if 'value' was created by newTensorValue or newScalarValue.
   bool isCreatedValue(ValueCP value) const;
 
+  /// Records that 'value' is the output of a clone a wide cat inserted so the
+  /// operand has a buffer of its own to fill. Such a clone looks pointless in
+  /// isolation -- nobody writes it and its source is read-only -- and the
+  /// read-only clone elision would drop it, which is exactly what must not
+  /// happen: the concat's allocation group carves the clone into the region of
+  /// the result the operand occupies, so its producer writes the band directly
+  /// instead of the concat copying it in through a serial offset walk.
+  void markConcatFillClone(ValueCP value);
+
+  /// The clone outputs markConcatFillClone recorded.
+  const folly::F14FastSet<ValueCP>& concatFillClones() const {
+    return concatFillClones_;
+  }
+
   /// Creates a new Value with the same type and dtype as 'original', attached
   /// to an internal placeholder node. Registers it in idToValue_.
   nativert::Value* duplicateValue(ValueCP original);
@@ -467,6 +481,10 @@ class WaveGraph {
 
   // Pre-built map from Value::id() to Value* for fast lookups.
   IdToValueMap idToValue_;
+
+  // Clone outputs a wide cat inserted to fill its regions in parallel. See
+  // markConcatFillClone.
+  folly::F14FastSet<ValueCP> concatFillClones_;
 
   // Owns TensorMeta objects created by newTensorValue so pointers in
   // types_.types remain valid.

--- a/velox/experimental/torchwave/tests/ExecutorTest.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTest.cpp
@@ -1263,9 +1263,11 @@ TEST_F(ExecutorTest, catTest) {
   // operand's extent has to be known before the concat sizes anything. A
   // masked_select settles its extent on device, so it now ends its own kernel
   // first rather than fusing into the cat -- there is no serial fill to fall
-  // back on that could discover the extent as it goes. The multi-kernel grid
-  // already decomposed it, and its compaction step's extent is read back
-  // before the cat, so that one still fuses.
+  // back on that could discover the extent as it goes. Neither does the
+  // multi-kernel decomposition fuse: breakUnmeasurableProducers ends the kernel
+  // at a reserve-sized operand too, because the layout needs every extent at
+  // one point and only that op's own reserve knows this one. One kernel
+  // boundary is what placing the result costs.
   auto plans = compilePlans("data/cat_test.pt2");
   if (WaveConfig::get().singlePass) {
     // --tw_single_pass replaces both decompositions with one look-back op.
@@ -1277,7 +1279,7 @@ TEST_F(ExecutorTest, catTest) {
         {"aten.cat.default", "tw.masked_select_1pass"}));
   } else {
     EXPECT_FALSE(plans.cg.fuses({"aten.cat.default", "tw.masked_select_cg"}));
-    EXPECT_TRUE(plans.multiKernel.fuses(
+    EXPECT_FALSE(plans.multiKernel.fuses(
         {"aten.cat.default", "tw.masked_select_final"}));
   }
   EXPECT_FALSE(plans.singleBlock.fuses(
@@ -1382,25 +1384,23 @@ TEST_F(ExecutorTest, catAllocGroupTest) {
   config.enableConcatAllocGroup = true;
   runTest(pt2, results, "cg alloc groups, concat groups on");
 
-  // What the pass made of it. 'wide' places all four of its gathers and 'mixed'
-  // the two around the graph input it cannot place, so six operand allocations
-  // and six concat copies go away, and with the two results eight values stop
-  // being the lifetime grouping's to place.
+  // What the pass made of it. 'wide' places all four of its gathers, 'mixed'
+  // the two around the graph input it cannot place, and 'nd' its three, so nine
+  // operand allocations and nine concat copies go away; with the four results,
+  // thirteen values stop being the lifetime grouping's to place.
   auto stats = allocGroupStats(pt2);
-  EXPECT_EQ(stats.numConcatGroups, 2);
-  EXPECT_EQ(stats.numConcatMembers, 6);
-  EXPECT_EQ(stats.numInConcatGroup, stats.numConcatMembers + 2);
-  // 'pair' is below the threshold. 'nd' and 'scaled' have every operand
-  // computed by the concat's own kernel behind a reserveShape, so no earlier
-  // point knows their extents and the layout cannot be laid out ahead of them.
-  // 'scaled' is the case an operand's own descriptor does not show: the
-  // elementwise op between the gather and the concat gives the operand a size
-  // expression of its own, and only a walk up its producer chain finds the
-  // reserve behind it. Placed anyway, the regions are laid out from extents
-  // that are not there yet and overlap.
+  EXPECT_EQ(stats.numConcatGroups, 4);
+  EXPECT_EQ(stats.numConcatMembers, 4 + 2 + 3);
+  EXPECT_EQ(stats.numInConcatGroup, stats.numConcatMembers + 4);
+  // 'pair' is below the threshold. 'scaled' is placed but carves nothing: the
+  // elementwise op between each gather and the concat gives the operand a size
+  // expression of its own, so its extent is settled where the concat's own
+  // kernel computes it rather than at any earlier point, and there is no write
+  // left for the group to redirect. It still owns the result's buffer and lays
+  // the regions out, which is what the operands are filled through.
   EXPECT_EQ(stats.numConcatTooFew, 1);
-  EXPECT_EQ(stats.numConcatNoMembers, 0);
-  EXPECT_EQ(stats.numConcatUnplaceableOperand, 2);
+  EXPECT_EQ(stats.numConcatNoMembers, 1);
+  EXPECT_EQ(stats.numConcatUnplaceableOperand, 0);
 
   // Nothing is placed with the mode's concat half switched off, which is what
   // makes the arm above an A/B rather than two runs of the same thing.
@@ -1902,6 +1902,192 @@ TEST_F(ExecutorTest, dedupTest) {
 
 TEST_F(ExecutorTest, largeElementTest) {
   runTest("data/large_element_test.pt2", "data/large_element_test_results.pt");
+}
+
+// A step with far more ops than the wave has blocks, whose sizes span three
+// orders of magnitude and are settled on device. One thousand independent
+// repeat_interleave results -- 90% of them a few tens of thousands of elements,
+// a handful in the millions -- each scaled by an elementwise op, plus one
+// barrier op (a cooperative-grid cumsum) to make the step a cg grid.
+//
+// The barrier op is what turns the size spread into the pathology this is
+// about. A cg grid is trimmed back to one wave, and with more ops than the wave
+// has blocks the trim cannot get there: it strips the widest op a block at a
+// time until every op is on one, so the multi-million-element op ends up beside
+// the sixteen-thousand-element ones and the step's makespan becomes its alone.
+// (Without the barrier op the ordinary pro-rata split handles this graph fine
+// -- 1096 blocks over a 432-block wave, skew 1.0.) The size mix comes out of
+// the runtime counts tensor, so none of it is known when the grid is compiled.
+TEST_F(ExecutorTest, launchSkewTest) {
+  constexpr int32_t kNumOps = 1000;
+  // Elements in the tensor every op repeats, so an op's size is kSeedLen times
+  // its count.
+  constexpr int64_t kSeedLen = 32;
+
+  // Millions for a few, hundreds of thousands for a tenth, tens of thousands
+  // for the remaining 90%.
+  auto countFor = [](int32_t index) -> int64_t {
+    if (index < 3) {
+      return 62'500;
+    }
+    return index < 100 ? 1'875 : 500;
+  };
+
+  std::string graphStr = "graph(%seed, %counts):\n";
+  std::string returns;
+  std::unordered_map<std::string, torch::_export::TensorMeta> meta;
+  meta["seed"] = makeTensorMeta(c10::ScalarType::Float, 1);
+  meta["counts"] = makeTensorMeta(c10::ScalarType::Long, 1);
+  for (int32_t i = 0; i < kNumOps; ++i) {
+    graphStr += fmt::format(
+        "%c{0} = torch.ops.aten.select.int(self=%counts, dim=0, index={0})\n"
+        "%x{0} = torch.ops.aten.repeat_interleave.self_Tensor(self=%seed, repeats=%c{0})\n"
+        "%o{0} = torch.ops.aten.mul.Scalar(self=%x{0}, other=2.0)\n",
+        i);
+    meta[fmt::format("c{}", i)] = makeTensorMeta(c10::ScalarType::Long, 0);
+    meta[fmt::format("x{}", i)] = makeTensorMeta(c10::ScalarType::Float, 1);
+    meta[fmt::format("o{}", i)] = makeTensorMeta(c10::ScalarType::Float, 1);
+    returns += fmt::format("{}%o{}", i == 0 ? "" : ", ", i);
+  }
+  // One barrier op in the same step as the thousand scales: a cg cumsum over
+  // the smallest of them, so it contributes almost nothing to the step's work
+  // and only its barrier matters.
+  graphStr += fmt::format(
+      "%cs = torch.ops.aten.cumsum.default(self=%x{}, dim=0)\n", kNumOps - 1);
+  meta["cs"] = makeTensorMeta(c10::ScalarType::Float, 1);
+  returns += ", %cs";
+  graphStr += "return(" + returns + ")\n";
+
+  auto seed = at::arange(kSeedLen, at::kFloat);
+  std::vector<int64_t> countValues;
+  countValues.reserve(kNumOps);
+  for (int32_t i = 0; i < kNumOps; ++i) {
+    countValues.push_back(countFor(i));
+  }
+  auto counts = at::tensor(countValues, at::kLong);
+
+  // The op count and the size spread are the point of the test; if the graph
+  // ever stops producing them the assertions below would pass vacuously.
+  ASSERT_EQ(countFor(0) * kSeedLen, 2'000'000);
+  ASSERT_EQ(countFor(999) * kSeedLen, 16'000);
+
+  // launchMeta and the per-block clocks, and with them the grid measurement,
+  // are only collected under kTiming.
+  const int32_t savedTrace = WaveConfig::get().trace;
+  auto resetConfig = folly::makeGuard([savedTrace] {
+    WaveConfig::get().trace = savedTrace;
+    WaveConfig::get().partitionLaunches = false;
+    WaveConfig::get().isCg = std::nullopt;
+  });
+  WaveConfig::get().trace =
+      savedTrace | WaveConfig::kGrid | WaveConfig::kTiming;
+  WaveConfig::get().isCg = true;
+
+  // How evenly a step's blocks actually ran, from their own clocks: the work
+  // done over what the machine could have done in the longest block's time. 1
+  // is every block finishing together.
+  struct StepBalance {
+    LaunchMeta meta;
+    double util{0};
+    int64_t maxClocks{0};
+  };
+
+  // The step of the last run whose grid came out worst balanced, and how its
+  // blocks really ran.
+  auto worstStep = []() -> StepBalance {
+    const auto& info = waveThreadInfo();
+    StepBalance worst;
+    for (size_t i = 0; i < info.launchMeta.size(); ++i) {
+      const auto& step = info.launchMeta[i];
+      if (step.gridStats.numOps <= 1 ||
+          step.gridStats.skew <= worst.meta.gridStats.skew) {
+        continue;
+      }
+      worst = StepBalance{.meta = step};
+      if (i >= info.debugInfo.size() || info.debugInfo[i].empty()) {
+        continue;
+      }
+      int64_t total = 0;
+      for (const auto& block : info.debugInfo[i]) {
+        total += block.clocks;
+        worst.maxClocks = std::max(worst.maxClocks, block.clocks);
+      }
+      if (worst.maxClocks > 0) {
+        worst.util = static_cast<double>(total) /
+            (static_cast<double>(worst.maxClocks) *
+             static_cast<double>(info.debugInfo[i].size()));
+      }
+    }
+    return worst;
+  };
+
+  auto checkOutputs = [&](const std::vector<at::Tensor>& outputs,
+                          const char* label) {
+    ASSERT_EQ(outputs.size(), static_cast<size_t>(kNumOps) + 1) << label;
+    for (int32_t i = 0; i < kNumOps; ++i) {
+      auto reference =
+          at::repeat_interleave(seed, at::scalar_tensor(countFor(i), at::kLong))
+              .mul(2.0);
+      ASSERT_TRUE(tensorsMatch(outputs[i], reference))
+          << label << " output " << i << ": "
+          << firstDifference(outputs[i], reference);
+    }
+    // The barrier op. Its blocks have to stay co-resident in one cooperative
+    // launch however the step is split, and a scan is what notices when they
+    // do not.
+    auto scan = at::cumsum(
+        at::repeat_interleave(
+            seed, at::scalar_tensor(countFor(kNumOps - 1), at::kLong)),
+        0);
+    ASSERT_TRUE(tensorsMatch(outputs[kNumOps], scan))
+        << label << " cumsum: " << firstDifference(outputs[kNumOps], scan);
+  };
+
+  WaveConfig::get().partitionLaunches = false;
+  checkOutputs(
+      runWaveProgrammatic(
+          nativert::stringToGraph(graphStr), meta, {{seed, counts}}),
+      "one launch per step");
+  const auto unsplit = worstStep();
+
+  // The premise: more ops than the wave has blocks, so the cg trim leaves
+  // almost all of them on one block and the step runs many times longer than a
+  // balanced wave of the same work would.
+  EXPECT_GT(unsplit.meta.gridStats.numStarved, 0);
+  EXPECT_GT(unsplit.meta.gridStats.skew, 5.0f);
+  EXPECT_EQ(unsplit.meta.gridStats.numSegments, 1);
+
+  WaveConfig::get().partitionLaunches = true;
+  checkOutputs(
+      runWaveProgrammatic(
+          nativert::stringToGraph(graphStr), meta, {{seed, counts}}),
+      "partitioned");
+  const auto split = worstStep();
+
+  LOG(INFO) << fmt::format(
+      "launchSkew: node {} step {} ops={} target={} skew={:.1f} starved={}; "
+      "one launch: util={:.1f}% maxClk={} -> {} launches: util={:.1f}% maxClk={}",
+      unsplit.meta.sequenceNumber,
+      unsplit.meta.stepIdx,
+      unsplit.meta.gridStats.numOps,
+      unsplit.meta.gridStats.targetBlocks,
+      unsplit.meta.gridStats.skew,
+      unsplit.meta.gridStats.numStarved,
+      100.0 * unsplit.util,
+      unsplit.maxClocks,
+      split.meta.gridStats.numSegments,
+      100.0 * split.util,
+      split.maxClocks);
+
+  // Same step, now spread over several packed waves. An op straddling a launch
+  // boundary still computes its whole slice, which is what the matching outputs
+  // above establish.
+  EXPECT_EQ(split.meta.sequenceNumber, unsplit.meta.sequenceNumber);
+  EXPECT_EQ(split.meta.stepIdx, unsplit.meta.stepIdx);
+  EXPECT_GT(split.meta.gridStats.numSegments, 1);
+  // The point of the split: the longest block, which is the step's makespan,
+  // comes down because the op that owned it is no longer confined to one block.
+  EXPECT_LT(split.maxClocks, unsplit.maxClocks / 2);
 }
 
 TEST_F(ExecutorTest, referenceFrame) {

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -226,6 +226,10 @@ DEFINE_bool(
     true,
     "Before partitioning, split a list-producing op into one node per tensor so each column is costed and given blocks on its own, and fold chains of them where the op supports it");
 DEFINE_bool(
+    metadata_getter_standalone,
+    true,
+    "Run a lone aten.sym_size/sym_numel as a host-side shortcut standalone rather than a fused kernel op that spends a whole block reading one field");
+DEFINE_bool(
     fold_shared_chains,
     true,
     "Fold a chain producer into every consumer that can absorb one, instead of only into a sole reader. Removes the intermediate at the cost of running the producer's steps once per consumer");
@@ -249,6 +253,30 @@ DEFINE_bool(
     parallel_concat_fill,
     false,
     "Fill a cat/stack of more than two operands entirely in parallel: an operand that cannot write its own region of the result gets a clone of its own to fill it, so no operand is walked through a running offset inside the concat's kernel");
+DEFINE_bool(
+    order_blocks_by_cost,
+    false,
+    "Emit a step's blocks in descending projected latency instead of in op order, so the ops expected to run longest start first and the cheap ones backfill SMs as those retire");
+DEFINE_bool(
+    partition_launches,
+    true,
+    "Split a badly balanced or occupancy-starved step into several kernel launches, each packed to about one wave at the occupancy its own ops allow");
+DEFINE_int32(
+    max_launch_waves,
+    3,
+    "Most launches --partition_launches may split one step into, and the multiple of one wave the block array is reserved for");
+DEFINE_double(
+    launch_skew_threshold,
+    1.3,
+    "Step makespan over that of a perfectly balanced, fully occupied one, at and above which --partition_launches splits a step");
+DEFINE_double(
+    min_block_us,
+    100.0,
+    "GPU microseconds a block should be worth before --partition_launches opens one, converted to cost units with the thread-block clocks the step's previous execution measured");
+DEFINE_bool(
+    quantum_grid,
+    false,
+    "Size a step's blocks against a per-block work quantum and round the total up to whole waves, instead of handing out one wave's worth pro rata and trimming");
 DEFINE_bool(
     tw_single_pass,
     false,
@@ -709,6 +737,7 @@ void ExecutorTestBase::SetUpTestSuite() {
   WaveConfig::get().cseCompute = FLAGS_cse_compute;
   WaveConfig::get().cseViews = FLAGS_cse_views;
   WaveConfig::get().decomposeLists = FLAGS_decompose_lists;
+  WaveConfig::get().metadataGetterStandalone = FLAGS_metadata_getter_standalone;
   WaveConfig::get().foldSharedChains = FLAGS_fold_shared_chains;
   WaveConfig::get().mkSelect = FLAGS_mk_select;
   WaveConfig::get().enableAllocGroup = FLAGS_enable_alloc_group;
@@ -716,6 +745,13 @@ void ExecutorTestBase::SetUpTestSuite() {
   WaveConfig::get().enableLifetimeAllocGroup =
       FLAGS_enable_lifetime_alloc_group;
   WaveConfig::get().parallelConcatFill = FLAGS_parallel_concat_fill;
+  WaveConfig::get().orderBlocksByCost = FLAGS_order_blocks_by_cost;
+  WaveConfig::get().partitionLaunches = FLAGS_partition_launches;
+  WaveConfig::get().maxLaunchWaves = FLAGS_max_launch_waves;
+  WaveConfig::get().launchSkewThreshold =
+      static_cast<float>(FLAGS_launch_skew_threshold);
+  WaveConfig::get().minBlockUs = static_cast<float>(FLAGS_min_block_us);
+  WaveConfig::get().quantumGrid = FLAGS_quantum_grid;
   // Read by registerBuiltins(), which initialize() calls below.
   WaveConfig::get().singlePass = FLAGS_tw_single_pass;
   WaveConfig::get().singlePassSelect = FLAGS_tw_single_pass_select;

--- a/velox/experimental/torchwave/tests/LaunchPartitionTest.cpp
+++ b/velox/experimental/torchwave/tests/LaunchPartitionTest.cpp
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <numeric>
+
+#include "velox/experimental/torchwave/LaunchPartition.h"
+
+namespace torch::wave {
+namespace {
+
+using ::testing::ElementsAre;
+
+// A small machine, so a wave is 8 blocks and the arithmetic in the
+// expectations stays checkable by hand. 64 KB of shared memory per SM means an
+// op asking for 32 KB drops to 2 blocks per SM and one asking for 64 KB to 1.
+GridDevice smallDevice() {
+  return {
+      .numSMs = 4,
+      .maxBlocksPerSM = 2,
+      .sharedPerSM = 64 * 1024,
+      .staticSharedPerBlock = 0};
+}
+
+GridOp op(float cost, int32_t maxBlocks, int32_t dynamicShared = 0) {
+  return {
+      .cost = cost,
+      .maxBlocks = maxBlocks,
+      .dynamicShared = dynamicShared,
+      .alwaysSingleBlock = false,
+      .hasBarrier = false};
+}
+
+// Op index of every block, in emit order.
+std::vector<int32_t> blockOps(const LaunchPlan& plan) {
+  std::vector<int32_t> ops;
+  ops.reserve(plan.blocks.size());
+  for (const auto& block : plan.blocks) {
+    ops.push_back(block.op);
+  }
+  return ops;
+}
+
+// Blocks in each segment, in launch order.
+std::vector<int32_t> segmentSizes(const LaunchPlan& plan) {
+  std::vector<int32_t> sizes;
+  sizes.reserve(plan.segments.size());
+  for (const auto& segment : plan.segments) {
+    sizes.push_back(segment.numBlocks);
+  }
+  return sizes;
+}
+
+// Every op must see one contiguous 0..n-1 series of blockInOp values, and n
+// must be what its blocks report as numBlocksInOp -- a block computes its
+// slice from the pair, so a gap or a mismatch silently skips work. Straddling
+// a launch boundary must not disturb that.
+void expectCompleteBlockSeries(const LaunchPlan& plan) {
+  std::vector<std::vector<int32_t>> seen(plan.blocksPerOp.size());
+  for (const auto& block : plan.blocks) {
+    ASSERT_LT(block.op, static_cast<int32_t>(seen.size()));
+    seen[block.op].push_back(block.blockInOp);
+  }
+  for (size_t i = 0; i < seen.size(); ++i) {
+    std::sort(seen[i].begin(), seen[i].end());
+    std::vector<int32_t> expected(plan.blocksPerOp[i]);
+    std::iota(expected.begin(), expected.end(), 0);
+    EXPECT_EQ(seen[i], expected) << "op " << i;
+  }
+}
+
+// Segments must tile the block array exactly: the launch site hands each one a
+// pointer into the middle of it, so a gap or an overlap would run the wrong
+// blocks or none at all.
+void expectSegmentsTileBlocks(const LaunchPlan& plan) {
+  int32_t next = 0;
+  for (const auto& segment : plan.segments) {
+    EXPECT_EQ(segment.firstBlock, next);
+    EXPECT_GT(segment.numBlocks, 0);
+    next += segment.numBlocks;
+  }
+  EXPECT_EQ(next, static_cast<int32_t>(plan.blocks.size()));
+}
+
+// A cooperative launch runs only if every one of its blocks is co-resident, so
+// one carrying more than its occupancy allows does not run at all -- it fails
+// with "too many blocks in cooperative launch".
+void expectCooperativeSegmentsFitAWave(
+    const LaunchPlan& plan,
+    const GridDevice& device) {
+  for (size_t s = 0; s < plan.segments.size(); ++s) {
+    const auto& segment = plan.segments[s];
+    if (!segment.cooperative) {
+      continue;
+    }
+    EXPECT_LE(
+        segment.numBlocks,
+        device.numSMs * blocksPerSM(device, segment.dynamicShared))
+        << "segment " << s;
+  }
+}
+
+TEST(LaunchPartitionTest, sharedMemoryCutsBlocksPerSM) {
+  const auto device = smallDevice();
+  EXPECT_EQ(blocksPerSM(device, 0), 2);
+  EXPECT_EQ(blocksPerSM(device, 32 * 1024), 2);
+  EXPECT_EQ(blocksPerSM(device, 33 * 1024), 1);
+  // Never below one block: a block that does not fit still has to run.
+  EXPECT_EQ(blocksPerSM(device, 1024 * 1024), 1);
+}
+
+TEST(LaunchPartitionTest, skewIsTheMakespanOverABalancedWave) {
+  // Two ops of equal cost, each on half the wave: perfectly balanced.
+  const std::vector<GridOp> balanced = {op(100, 8), op(100, 8)};
+  EXPECT_NEAR(gridStats(balanced, {4, 4}, smallDevice()).skew, 1.0f, 0.01f);
+
+  // Same total work, but one op holds it all on one block. Its 200/1 against a
+  // balanced 200/8 is eight times the makespan.
+  const std::vector<GridOp> lopsided = {op(200, 8), op(0.0f, 8)};
+  EXPECT_NEAR(gridStats(lopsided, {1, 7}, smallDevice()).skew, 8.0f, 0.01f);
+}
+
+TEST(LaunchPartitionTest, countsOpsStuckOnOneBlock) {
+  // Only the op that could have used more blocks is starved; an
+  // alwaysSingleBlock op (maxBlocks 1) is on one block by construction.
+  const std::vector<GridOp> ops = {op(10, 4), op(10, 1), op(10, 4)};
+  const auto stats = gridStats(ops, {1, 1, 3}, smallDevice());
+  EXPECT_EQ(stats.numStarved, 1);
+}
+
+TEST(LaunchPartitionTest, reportsOccupancyLostToOneHungryOp) {
+  // The 48 KB op leaves room for one block per SM, so the whole step launches
+  // at 1 although the other two would run at 2. It holds a tenth of the cost.
+  const std::vector<GridOp> ops = {op(90, 8), op(90, 8), op(20, 8, 48 * 1024)};
+  const auto stats = gridStats(ops, {4, 3, 1}, smallDevice());
+  EXPECT_EQ(stats.occupancy, 1);
+  EXPECT_EQ(stats.bestOccupancy, 2);
+  EXPECT_EQ(stats.targetBlocks, 4);
+  EXPECT_NEAR(stats.poison, 0.1f, 0.01f);
+}
+
+TEST(LaunchPartitionTest, singleLaunchKeepsOpOrderByDefault) {
+  const std::vector<GridOp> ops = {op(1, 4), op(100, 4)};
+  const auto plan = singleLaunchPlan(ops, {2, 3}, /*orderByLatency=*/false);
+
+  EXPECT_THAT(blockOps(plan), ElementsAre(0, 0, 1, 1, 1));
+  EXPECT_THAT(segmentSizes(plan), ElementsAre(5));
+  expectCompleteBlockSeries(plan);
+  expectSegmentsTileBlocks(plan);
+}
+
+TEST(LaunchPartitionTest, singleLaunchPutsTheLongPolesFirst) {
+  // op 1 projects at 100/3 per block against op 0's 1/2, so its blocks go out
+  // first and op 0 backfills.
+  const std::vector<GridOp> ops = {op(1, 4), op(100, 4)};
+  const auto plan = singleLaunchPlan(ops, {2, 3}, /*orderByLatency=*/true);
+
+  EXPECT_THAT(blockOps(plan), ElementsAre(1, 1, 1, 0, 0));
+  EXPECT_THAT(segmentSizes(plan), ElementsAre(5));
+  expectCompleteBlockSeries(plan);
+}
+
+TEST(LaunchPartitionTest, gateIgnoresABalancedStep) {
+  const std::vector<GridOp> ops = {op(100, 8), op(100, 8)};
+  const auto stats = gridStats(ops, {4, 4}, smallDevice());
+
+  EXPECT_FALSE(shouldPartition(stats, PartitionParams{}));
+  EXPECT_FALSE(partitionLaunches(ops, smallDevice(), stats, PartitionParams{})
+                   .has_value());
+}
+
+TEST(LaunchPartitionTest, gateFiresOnLostOccupancyWithoutSkew) {
+  // Balanced, so nothing to rebalance, but the cheap 48 KB op is costing the
+  // other two half their occupancy. That alone is worth a split.
+  const std::vector<GridOp> ops = {op(100, 8), op(100, 8), op(1, 8, 48 * 1024)};
+  const auto stats = gridStats(ops, {2, 2, 1}, smallDevice());
+
+  EXPECT_EQ(stats.occupancy, 1);
+  EXPECT_EQ(stats.bestOccupancy, 2);
+  EXPECT_TRUE(shouldPartition(stats, PartitionParams{}));
+}
+
+TEST(LaunchPartitionTest, gateIgnoresOccupancyTheExpensiveOpsNeed) {
+  // Same lost occupancy, but now the hungry op holds most of the cost, so the
+  // occupancy it forces is the one the step needs anyway.
+  const std::vector<GridOp> ops = {op(10, 8), op(10, 8), op(200, 8, 48 * 1024)};
+  auto stats = gridStats(ops, {1, 1, 2}, smallDevice());
+  // Keep skew out of it; this test is about the poison term alone.
+  stats.skew = 1.0f;
+
+  EXPECT_LT(stats.occupancy, stats.bestOccupancy);
+  EXPECT_FALSE(shouldPartition(stats, PartitionParams{}));
+}
+
+TEST(LaunchPartitionTest, starvedStepBecomesSeveralFullWaves) {
+  // Sixteen ops too cheap to earn a block plus one that wants the whole wave:
+  // seventeen ops for eight blocks, which is the starvation case. Every op
+  // still gets its block, but they come out as three packed waves instead of
+  // one launch three waves deep.
+  std::vector<GridOp> ops = {op(1000, 8)};
+  for (int32_t i = 0; i < 16; ++i) {
+    ops.push_back(op(1, 1));
+  }
+  const std::vector<int32_t> blocks(ops.size(), 1);
+  const auto stats = gridStats(ops, blocks, smallDevice());
+  const auto plan =
+      partitionLaunches(ops, smallDevice(), stats, PartitionParams{});
+
+  ASSERT_TRUE(plan.has_value());
+  EXPECT_EQ(plan->blocksPerOp[0], 8);
+  EXPECT_THAT(segmentSizes(*plan), ElementsAre(8, 8, 8));
+  expectCompleteBlockSeries(*plan);
+  expectSegmentsTileBlocks(*plan);
+}
+
+TEST(LaunchPartitionTest, hungryOpGetsALaunchOfItsOwnAtItsOwnOccupancy) {
+  // The 48 KB op runs 1 block per SM, the others 2, so they cannot share a
+  // launch. The split is what lets the cheap ops keep the wave of 8 the hungry
+  // one would otherwise have cut to 4.
+  const std::vector<GridOp> ops = {
+      op(100, 8), op(100, 8), op(20, 4, 48 * 1024)};
+  const auto stats = gridStats(ops, {2, 1, 1}, smallDevice());
+  const auto plan =
+      partitionLaunches(ops, smallDevice(), stats, PartitionParams{});
+
+  ASSERT_TRUE(plan.has_value());
+  ASSERT_EQ(plan->segments.size(), 2);
+  // Most of the cost is in the shared-memory-free pair, so their launch goes
+  // first and asks for no shared memory at all.
+  EXPECT_EQ(plan->segments[0].dynamicShared, 0);
+  EXPECT_EQ(plan->segments[1].dynamicShared, 48 * 1024);
+  expectCompleteBlockSeries(*plan);
+  expectSegmentsTileBlocks(*plan);
+}
+
+// Segments an op's blocks appear in.
+std::vector<int32_t> segmentsWith(const LaunchPlan& plan, int32_t opIndex) {
+  std::vector<int32_t> found;
+  for (size_t s = 0; s < plan.segments.size(); ++s) {
+    const auto& segment = plan.segments[s];
+    for (int32_t b = 0; b < segment.numBlocks; ++b) {
+      if (plan.blocks[segment.firstBlock + b].op == opIndex) {
+        found.push_back(static_cast<int32_t>(s));
+        break;
+      }
+    }
+  }
+  return found;
+}
+
+// The wants a step of this shape produces never exceed one wave, so the
+// barrier and budget rules below cannot be reached through gridStats. Both
+// guard the packer's contract with its caller rather than a case makeGrid
+// produces today, so they are exercised against a wider target than this
+// device has -- which is what a real machine would hand them.
+GridStats statsWithTarget(
+    const std::vector<GridOp>& ops,
+    int32_t targetBlocks) {
+  const std::vector<int32_t> blocks(ops.size(), 1);
+  auto stats = gridStats(ops, blocks, smallDevice());
+  stats.targetBlocks = targetBlocks;
+  return stats;
+}
+
+TEST(LaunchPartitionTest, aBarrierOpIsShrunkToALaunchRatherThanSplit) {
+  // opBarrier waits for numBlocksInOp arrivals, so every block of the op has
+  // to be co-resident in one launch. Its group holds a wave of 8, so it is cut
+  // to 8 however much work it carries -- and blocksPerOp has to say 8 too, or
+  // the blocks that did launch would skip the slices of the ones that did not.
+  std::vector<GridOp> ops = {op(1000, 64), op(10, 8), op(10, 8)};
+  ops[0].hasBarrier = true;
+  const auto plan = partitionLaunches(
+      ops, smallDevice(), statsWithTarget(ops, 64), PartitionParams{});
+
+  ASSERT_TRUE(plan.has_value());
+  EXPECT_EQ(plan->blocksPerOp[0], 8);
+  EXPECT_THAT(segmentsWith(*plan, 0), ElementsAre(0));
+  // Only the launch holding the barrier op has to be cooperative; the ops with
+  // no barrier keep the ordinary launch, which has no co-residency limit.
+  ASSERT_EQ(plan->segments.size(), 2);
+  EXPECT_TRUE(plan->segments[0].cooperative);
+  EXPECT_FALSE(plan->segments[1].cooperative);
+  expectCompleteBlockSeries(*plan);
+  expectSegmentsTileBlocks(*plan);
+}
+
+TEST(LaunchPartitionTest, aSingleBlockBarrierOpNeedsNoCooperativeLaunch) {
+  // opBarrier waits for numBlocksInOp arrivals, which a lone block satisfies
+  // as soon as it runs. Demanding a cooperative launch for it would cap the
+  // grid at what fits co-resident for no reason.
+  std::vector<GridOp> ops = {op(100, 8), op(1, 1)};
+  ops[1].hasBarrier = true;
+
+  auto plan = singleLaunchPlan(ops, {4, 1}, /*orderByLatency=*/false);
+  ASSERT_EQ(plan.segments.size(), 1);
+  EXPECT_FALSE(plan.segments[0].cooperative);
+
+  plan = singleLaunchPlan(ops, {4, 2}, /*orderByLatency=*/false);
+  EXPECT_TRUE(plan.segments[0].cooperative);
+}
+
+TEST(LaunchPartitionTest, aBarrierFreeOpMayStraddleTwoLaunches) {
+  // Three ops of 3 blocks each into a wave of 8: the third does not fit whole.
+  // It has no barrier, so its blocks find their slice from blockInOp and
+  // numBlocksInOp wherever they were launched from, and the remainder simply
+  // runs in the next launch.
+  std::vector<GridOp> ops = {op(100, 8), op(100, 8), op(100, 8)};
+  for (int32_t i = 0; i < 12; ++i) {
+    ops.push_back(op(0.1f, 1));
+  }
+  const std::vector<int32_t> blocks(ops.size(), 1);
+  const auto stats = gridStats(ops, blocks, smallDevice());
+  const auto plan =
+      partitionLaunches(ops, smallDevice(), stats, PartitionParams{});
+
+  ASSERT_TRUE(plan.has_value());
+  EXPECT_EQ(plan->blocksPerOp[2], 3);
+  EXPECT_THAT(segmentsWith(*plan, 2), ElementsAre(0, 1));
+  expectCompleteBlockSeries(*plan);
+  expectSegmentsTileBlocks(*plan);
+}
+
+TEST(LaunchPartitionTest, aThinTailIsFoldedBackIntoThePreviousLaunch) {
+  // Nine ops, one block each, into a wave of eight. Serializing a whole launch
+  // for the ninth block would cost more than the imbalance it was split off to
+  // fix, so it rides along with the first launch and the step stays whole.
+  const std::vector<GridOp> ops(9, op(1, 1));
+  const std::vector<int32_t> blocks(ops.size(), 1);
+  const auto stats = gridStats(ops, blocks, smallDevice());
+
+  EXPECT_FALSE(partitionLaunches(ops, smallDevice(), stats, PartitionParams{})
+                   .has_value());
+}
+
+TEST(LaunchPartitionTest, barrierOpsAreSizedToWholeWaves) {
+  // Two barrier ops wanting five blocks each, into a wave of eight. Packed
+  // greedily they take a launch apiece and neither fills one, and folding the
+  // tail back would put ten blocks in a cooperative launch that holds eight.
+  // Their block counts are free, so the pair is scaled to four blocks each
+  // instead: the same work, one full wave, one launch.
+  std::vector<GridOp> ops = {op(600, 6), op(600, 6), op(200, 8), op(200, 8)};
+  ops[0].hasBarrier = true;
+  ops[1].hasBarrier = true;
+  const auto plan = partitionLaunches(
+      ops, smallDevice(), statsWithTarget(ops, 64), PartitionParams{});
+
+  ASSERT_TRUE(plan.has_value());
+  EXPECT_THAT(plan->blocksPerOp, ElementsAre(4, 4, 6, 6));
+  ASSERT_EQ(plan->segments.size(), 2);
+  EXPECT_TRUE(plan->segments[0].cooperative);
+  EXPECT_EQ(plan->segments[0].numBlocks, 8);
+  EXPECT_FALSE(plan->segments[1].cooperative);
+  expectCooperativeSegmentsFitAWave(*plan, smallDevice());
+  expectCompleteBlockSeries(*plan);
+  expectSegmentsTileBlocks(*plan);
+}
+
+TEST(LaunchPartitionTest, splittableWorkFillsWhatABarrierOpLeavesOfItsWave) {
+  // A barrier op that can only use three blocks leaves five of its wave empty,
+  // and a cooperative launch cannot be widened to use them. Ops of the same
+  // occupancy class can ride along in that space rather than wait for a launch
+  // of their own: the launch's shared memory is the max over its ops, and the
+  // class is exactly the set that yields one blocksPerSM, so the passengers
+  // cannot cost the barrier op the co-residency it was sized against.
+  std::vector<GridOp> ops = {op(600, 3), op(200, 8), op(200, 8)};
+  ops[0].hasBarrier = true;
+  const auto plan = partitionLaunches(
+      ops, smallDevice(), statsWithTarget(ops, 64), PartitionParams{});
+
+  ASSERT_TRUE(plan.has_value());
+  EXPECT_THAT(plan->blocksPerOp, ElementsAre(3, 8, 8));
+  EXPECT_THAT(segmentSizes(*plan), ElementsAre(8, 8, 3));
+  ASSERT_FALSE(plan->segments.empty());
+  EXPECT_TRUE(plan->segments[0].cooperative);
+  // The last op straddles the cooperative launch and one of its own.
+  EXPECT_THAT(segmentsWith(*plan, 2), ElementsAre(0, 2));
+  expectCooperativeSegmentsFitAWave(*plan, smallDevice());
+  expectCompleteBlockSeries(*plan);
+  expectSegmentsTileBlocks(*plan);
+}
+
+TEST(LaunchPartitionTest, blocksStayWithinTheReservedBudget) {
+  // Four ops that would each want sixteen blocks. maxWaves caps the step at
+  // two waves, which is exactly what the block array was reserved for.
+  const std::vector<GridOp> ops = {
+      op(1000, 64), op(1000, 64), op(1000, 64), op(1000, 64)};
+  const auto plan = partitionLaunches(
+      ops,
+      smallDevice(),
+      statsWithTarget(ops, 64),
+      PartitionParams{.maxWaves = 2});
+
+  ASSERT_TRUE(plan.has_value());
+  EXPECT_THAT(plan->blocksPerOp, ElementsAre(4, 4, 4, 4));
+  EXPECT_THAT(segmentSizes(*plan), ElementsAre(8, 8));
+  expectCompleteBlockSeries(*plan);
+  expectSegmentsTileBlocks(*plan);
+}
+
+TEST(LaunchPartitionTest, aLongerMinimumBlockKeepsTheStepInOneLaunch) {
+  // The same step that splits into four launches on an even division stays
+  // whole once a block is required to be worth 100 units of cost: four ops of
+  // 100 want one block each, which is half a wave.
+  const std::vector<GridOp> ops = {
+      op(100, 8), op(100, 8), op(100, 8), op(100, 8)};
+  const auto stats = gridStats(ops, {2, 2, 2, 2}, smallDevice());
+  const auto plan = partitionLaunches(
+      ops,
+      smallDevice(),
+      stats,
+      PartitionParams{.maxWaves = 4, .minBlockCost = 100.0f});
+
+  EXPECT_FALSE(plan.has_value());
+}
+
+} // namespace
+} // namespace torch::wave

--- a/velox/experimental/wave/common/Compile.cu
+++ b/velox/experimental/wave/common/Compile.cu
@@ -93,6 +93,11 @@ class CompiledModuleImpl : public CompiledModule {
 
   KernelInfo info(int32_t kernelIdx) override;
 
+  int32_t occupancy(
+      int32_t kernelIdx,
+      int32_t numThreads,
+      int32_t dynamicSharedBytes) override;
+
  private:
   // Opts the kernel in to more than the default 48KB of dynamic shared memory.
   // A launch asking for more than that fails without this.
@@ -597,6 +602,22 @@ KernelInfo CompiledModuleImpl::info(int32_t kernelIdx) {
   info.maxOccupancy32 = max;
   info.compileMs = compileMs_;
   return info;
+}
+
+int32_t CompiledModuleImpl::occupancy(
+    int32_t kernelIdx,
+    int32_t numThreads,
+    int32_t dynamicSharedBytes) {
+  // A launch asking for more than the default 48KB needs the opt-in before the
+  // driver will report an occupancy for it, and reports 0 otherwise.
+  allowLargeDynamicShared(kernelIdx, dynamicSharedBytes);
+  int32_t blocks = 0;
+  const auto result = cuOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks, kernels_[kernelIdx], numThreads, dynamicSharedBytes);
+  if (result != CUDA_SUCCESS) {
+    return 0;
+  }
+  return blocks;
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -338,6 +338,17 @@ struct CompiledModule {
 
   /// Returns resource utilization for 'kernelIdx'th entry point.
   virtual KernelInfo info(int32_t kernelIdx) = 0;
+
+  /// Blocks of 'kernelIdx' that stay resident on one SM at 'numThreads' threads
+  /// and 'dynamicSharedBytes' of dynamic shared memory, as the driver computes
+  /// it. KernelInfo samples the same thing at two fixed points; a caller sizing
+  /// a cooperative launch needs it at the shared memory that launch will
+  /// actually ask for, since the driver refuses a cooperative grid that cannot
+  /// be co-resident.
+  virtual int32_t occupancy(
+      int32_t kernelIdx,
+      int32_t numThreads,
+      int32_t dynamicSharedBytes) = 0;
 };
 
 using KernelGenFunc = std::function<KernelSpec()>;
@@ -381,6 +392,12 @@ class CompiledKernel {
       void** args) = 0;
 
   virtual KernelInfo info(int32_t kernelIdx) = 0;
+
+  /// See CompiledModule::occupancy.
+  virtual int32_t occupancy(
+      int32_t kernelIdx,
+      int32_t numThreads,
+      int32_t dynamicSharedBytes) = 0;
 };
 
 KernelInfo getRegisteredKernelInfo(const char* name);

--- a/velox/experimental/wave/common/KernelCache.cpp
+++ b/velox/experimental/wave/common/KernelCache.cpp
@@ -65,6 +65,14 @@ class FutureCompiledModule : public CompiledModule {
     return module_->info(kernelIdx);
   }
 
+  int32_t occupancy(
+      int32_t kernelIdx,
+      int32_t numThreads,
+      int32_t dynamicSharedBytes) override {
+    ensureReady();
+    return module_->occupancy(kernelIdx, numThreads, dynamicSharedBytes);
+  }
+
  private:
   void ensureReady() {
     std::lock_guard<std::mutex> l(mutex_);
@@ -110,6 +118,13 @@ class AsyncCompiledKernel : public CompiledKernel {
 
   KernelInfo info(int32_t kernelIdx) override {
     return (*ptr_)->info(kernelIdx);
+  }
+
+  int32_t occupancy(
+      int32_t kernelIdx,
+      int32_t numThreads,
+      int32_t dynamicSharedBytes) override {
+    return (*ptr_)->occupancy(kernelIdx, numThreads, dynamicSharedBytes);
   }
 
  private:


### PR DESCRIPTION
Summary:

Two commits that shape the same object -- the grid a step is laid out on and the
launches it runs as -- plus the occupancy work that made the second safe under
the single-ops debug pass.

== Balanced kernel launches ==

A step runs as one kernel launch capped at roughly one wave, so once it has as many ops as the wave has blocks, every op gets exactly one block and the step's makespan becomes the largest op's alone. On the ROO preproc graph node 30 step 0 has 272 ops against a 108-block wave, and one of them -- a 1.2M-element strided slice copy -- holds 87% of the work on that single block. Its 10.0M thread-block clocks against everything else's 1.4M leave the step 0.6% utilized and cost 8.0 ms. Sizing every op against a common per-block quantum and emitting the result as three packed launches takes the longest block to 0.60M clocks and the step to 1.4 ms, and the graph's kernel time from 23.1 ms to 17.1 ms.

`makeGrid` now hands its per-op costs and block caps to a launch layout that groups ops by the occupancy their shared memory allows, packs each group into wave-sized launches, and returns them as `StepVectors::segments`. The launch site loops over the segments, each with its own slice of the block array and its own shared memory. An op with no barrier may straddle two launches, since its blocks find their slice from `blockInOp` and `numBlocksInOp` wherever they run; an op with an `opBarrier` is shrunk to fit one launch rather than split, because that barrier waits for all of its blocks and only a cooperative launch keeps them co-resident. Every step also gets a `GridStats` measurement -- how far its grid is from a balanced, fully occupied wave, how many ops are stuck on one block, and how much occupancy one shared-memory-hungry op is costing the rest -- reported per step under the new `kGrid` trace bit and summarized in the performance report.

`partitionLaunches` is on by default; `--partition_launches=false` emits exactly the grid the graph does today. `--order_blocks_by_cost` is the cheaper half of the same idea, emitting a single launch's blocks in descending projected latency so the long poles start first; it is off by default, and measured no effect on ROO because the op it would have to help is the one pinned to a single block.

Two other passes change behaviour here, which is what moves the cat tests below. `breakDeviceSizedProducers` becomes `breakUnmeasurableProducers` and widens from `setsSizeOnDevice(producer)` to `setsSizeOnDevice(producer) || sizeNeedsReserve(producer)`: a concat lays its result out at one point and needs every operand's extent there, and an operand only its own reserve can measure is as far out of reach as one the device sizes. Both now end their kernel first. The cost is that a cat no longer fuses `tw.masked_select_final`, one more kernel boundary; the gain is that the concat can place its result at all, which takes `cat_alloc_group_test` from two placed concats to four and from two unplaceable operands to none.

Those are the assertions this diff updates in `ExecutorTest`. `catTest` drops the `multiKernel.fuses({cat, masked_select_final})` expectation for the reason above, and `catAllocGroupTest` moves to 4 groups, 9 members and 1 group that carves nothing -- `scaled`, whose operands are sized where the concat's own kernel computes them, so the group owns the result's buffer and lays the regions out but has no write to redirect. Both were correct-value failures: the numbers the graph produces never changed, only the plan the test asserts.

== Sizing a step's blocks by a per-block work quantum ==

The pro-rata split divides one wave's worth of blocks among a step's ops, so
what an op gets depends on how many other ops the step happens to have. A step
with about as many ops as a wave has blocks cannot give any of them more than
one: every op takes a block off the top whatever it costs, and the cooperative
trim then takes what is left from the tallest. On the ROO preproc graph one step
spends 210 of 441 blocks on copies holding 0.1% of the work and leaves a
1.2M-element op on two.

`sizeByQuantum` asks the other question -- how many blocks of a given duration
is this op's work worth -- which is a property of the op alone. The total is
rounded up to a whole wave and the surplus given to the ops with the most work
left per block; when the work exceeds `maxLaunchWaves` the quantum is bisected
LONGER rather than trimming the tallest ops, which is what avoids the trim.

Two things the sizing needs that were not previously recorded. `StepVectors`
now keeps `measuredUtil` -- mean block clocks over the slowest, the same figure
the per-step balance line reports -- and `measuredBlocks`, both from the
previous execution. A step whose blocks already finish together is left at the
width it had: the quantum says how much work there is, not whether the machine
has room to absorb it in parallel, and expanding an already-full step turns one
wave into several serialized launches running the same work. Only the
measurement can tell those apart. `GridStats::skew` cannot, because it is
derived from the same costs the sizing uses, so a mis-costed step looks
perfectly balanced to it -- which is exactly how the 1.2M-element op above
escaped the existing gate.

OFF BY DEFAULT, behind `WaveConfig::quantumGrid` / `--quantum_grid`, because it
is not a general win. Measured on the ROO graph at 256 rows, cg, three runs per
point, kernel time:

  - with the flip-and-truncate fusion ON, it pays: paired with
    `--auto_adjust_cost` it takes 32.5 ms to 24.8 ms. The two are superadditive
    (-9.3% and -7.7% alone, -30% together) because the feedback is what stops a
    frozen wrong cost from dominating a relative scheme.
  - with `--tw_fat=false`, it COSTS 7-9%, at every `--min_block_us` from 5 to
    100. It emits 34-60% more blocks (54k -> 72-86k) and none of them help:
    four steps already at 90-98% utilization were widened to the wave budget for
    +1.2 ms, and the extra blocks cost another +0.7 ms of interpretation filling
    BlockInfo.

So this is a fix for a grid pathology that turning the flip fusion off removes
more cheaply, and the two should not be combined. It is landed default-off with
the measurements above rather than left out, because the pathology is real where
it applies and the sizing is the only thing that addresses it directly.

Also note both halves need a previous execution to have been measured -- the
quantum from `clocksPerCost`, the gate from `measuredUtil` -- so neither does
anything for a single-shot workload.

== Cooperative capacity from the driver ==

A cooperative launch may be no wider than the device holds co-resident, and the
width was being checked against an estimate. `CompiledModule::occupancy` and
`CompiledKernel::occupancy` expose
`cuOccupancyMaxActiveBlocksPerMultiprocessor`, and `CompositeKernel::occupancy`
memoizes it per dynamic-shared size, so the packer asks the driver a handful of
times per step rather than once per op.

`coopBlocksPerSM` bounds a cooperative launch by that figure, and only ever
downwards: `min(classOccupancy, driver)`, falling back to `classOccupancy` when
there is no driver to ask. `blocksPerSM` deliberately keeps the estimate. The
occupancy classes, the block budget and the BlockInfo reservation all derive
from it, so raising it there lets a launch outgrow a reservation sized from the
same number, and it repartitions a graph with no GPU behind it.

`exceedsCooperativeCapacity` forces a split when a single-launch plan would
exceed that width, whatever the skew gate says: leaving the step whole is not a
slower plan but a broken one. The one-block-per-op floor reaches this on its
own, since the trim in `makeGrid` cannot go below one block per op.

`debugSingleOps` is what exposed it. That pass declines to partition, which
reads as "no segments", but a step whose grid the normal pass laid out keeps
that pass's `sv.segments`. It now walks them, launching each at its own
`firstBlock` / `numBlocks` / `dynamicShared` / `cooperative` the way
`launchSegment` does, and steps one op at a time within a launch -- a barrier op
whole, everything else one block at a time, which is what puts a failure on a
block rather than on an op.

The same widening reaches `fb.offsets_to_lengths.default` and
`fb.offsets_to_ranges.default`, and there it was breaking kernels it did not
need to. Both declare a `reserveShape` and neither declared `shapeFromInput`,
so `sizeNeedsReserve` read them as extents nothing upstream can compute and
ended their kernel -- which cost the concats they feed their fusion, and is what
`MetaExecutorTest.offsetsOpsTest` was asserting against. Both reserves read
input 0 and nothing else: one returns its shape, the other `{numel, 1, 2}` from
it. `shapeFromInput` asks WHEN the extent becomes computable, not what it is --
its only two readers, `sizeNeedsReserve` and `hasReserveShapeInChain`, use it
purely to exclude a reserve whose answer is reachable from an input -- so both
are `shapeFromInput = 0` and both stay fusable.

== SCORING A SPLIT STEP ==

Once a step can run as several launches, the balance figure it is judged by has
to know that. `util` was `totalClocks / (maxClocks * numBlocks)` -- one
rectangle, the slowest block anywhere in the step times every block in it. The
launches run back to back on one stream, so the step's makespan is the SUM of
their maxima, and a block is only idle relative to the launch it actually ran
in. Scoring the whole step against one global max reads a short launch queued
behind a long one as imbalance: one step here reported 70% utilisation while
BOTH of its launches were above 75%.

`LaunchMeta` now carries the step's `segments`, which are contiguous ranges of
the same block array the DebugInfo is indexed by, so the report scores each
launch on its own:

    util     = totalClocks / SUM over launches of (max_L * blocks_L)
    makespan = SUM over launches of max_L

A step that was not split collapses to exactly the old arithmetic and prints
exactly the old line, so no existing number moves. A split one gains a
per-launch breakdown, and each op line gains `in L0=n L1=m` -- how many of its
blocks landed in which launch, which is what says whether an op is holding one
up, since an op is only measured against the others it actually ran beside.
`waves` comes from `GridStats::targetBlocks`, already one wave at the occupancy
the step launched with, and says whether a launch is also several hardware
waves -- the same effect one level down, invisible in the block count.

== A GETTER IS NOT WORTH A BLOCK ==

`aten.sym_size.int` and `aten.sym_numel.default` fused into a kernel cost a
whole thread block that reads one field and exits. That block is charged
against its launch's slowest block, so a handful of them sink a step's balance
and no block count can fix it -- there is no width at which a no-op op
balances. `metadataGetterIsAlone` runs such a getter as a host-side shortcut
standalone instead, and stays fused when the getter is a subexpression of a
single fusable consumer, where the value is wanted on the device anyway.

The predicate already existed and was disabled at its two registration sites.
It is now on, behind `WaveConfig::metadataGetterStandalone` /
`--metadata_getter_standalone`. On the 1k ROO graph it takes about 232 blocks
per execution out of the grid -- node 36 step 0 goes from 800 blocks at 43.3%
utilisation to 540 at 65.6% -- and is worth 0.8% end to end.

Reviewed By: Yuhta

Differential Revision: D116667980


