### PR TITLE
fix(nimble): Harden FSST decoding bounds

### DIFF
--- a/velox/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/velox/dwio/nimble/encodings/FsstEncoding.cpp
@@ -16,6 +16,8 @@
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 
 #include <cmath>
+#include <cstring>
+#include <limits>
 #include <memory>
 #include <numeric>
 
@@ -144,31 +146,118 @@ FsstEncoding::Header FsstEncoding::parseHeader(
       offset, encoding.size(), "FSST header offset exceeds encoding bounds.");
 
   Header header{};
-  header.symbolTableSize = readFsstHeaderVarint(encoding, offset);
+  const auto symbolTableSize = readFsstHeaderVarint(encoding, offset);
   NIMBLE_CHECK_GT(
-      header.symbolTableSize, 0, "FSST symbol table size must be positive.");
+      symbolTableSize, 0, "FSST symbol table size must be positive.");
   NIMBLE_CHECK_LE(
-      header.symbolTableSize,
+      symbolTableSize,
       static_cast<uint32_t>(FSST_MAXHEADER),
       "FSST symbol table size exceeds FSST_MAXHEADER.");
   NIMBLE_CHECK_LE(
-      static_cast<size_t>(header.symbolTableSize),
+      static_cast<size_t>(symbolTableSize),
       encoding.size() - offset,
       "FSST symbol table exceeds encoding bounds.");
-  header.symbolTable = encoding.data() + offset;
-  offset += header.symbolTableSize;
+  header.symbolTable = encoding.substr(offset, symbolTableSize);
+  offset += symbolTableSize;
 
-  header.lengthsSize = readFsstHeaderVarint(encoding, offset);
+  const auto lengthsSize = readFsstHeaderVarint(encoding, offset);
   NIMBLE_CHECK_GT(
-      header.lengthsSize, 0, "FSST lengths encoding size must be positive.");
+      lengthsSize, 0, "FSST lengths encoding size must be positive.");
   NIMBLE_CHECK_LE(
-      static_cast<size_t>(header.lengthsSize),
+      static_cast<size_t>(lengthsSize),
       encoding.size() - offset,
       "FSST lengths encoding exceeds encoding bounds.");
-  header.lengths = encoding.data() + offset;
-  offset += header.lengthsSize;
-  header.blob = encoding.data() + offset;
+  header.lengths = encoding.substr(offset, lengthsSize);
+  offset += lengthsSize;
+  header.blob = encoding.substr(offset);
   return header;
+}
+
+std::string_view FsstEncoding::validateEncodedPrefix(
+    std::string_view encoding,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK_FILE_GE(
+      encoding.size(),
+      EncodingPrefix::kRowCountOffset,
+      "Truncated FSST encoding prefix.");
+  NIMBLE_CHECK_FILE_EQ(
+      EncodingPrefix::encodingType(encoding),
+      EncodingType::Fsst,
+      "Expected FSST encoding.");
+  NIMBLE_CHECK_FILE_EQ(
+      EncodingPrefix::dataType(encoding),
+      DataType::String,
+      "FSST encoding must contain string data.");
+
+  if (options.useVarintRowCount) {
+    size_t offset = EncodingPrefix::kRowCountOffset;
+    readFsstHeaderVarint(encoding, offset);
+  } else {
+    NIMBLE_CHECK_FILE_GE(
+        encoding.size(),
+        EncodingPrefix::kFixedPrefixSize,
+        "Truncated FSST encoding prefix.");
+  }
+  return encoding;
+}
+
+void FsstEncoding::validateSymbolTable(std::string_view symbolTable) {
+  constexpr size_t kSerializedHeaderSize = 17;
+  NIMBLE_CHECK_FILE_GE(
+      symbolTable.size(),
+      kSerializedHeaderSize,
+      "Truncated FSST symbol table.");
+
+  const auto zeroTerminated = static_cast<uint8_t>(symbolTable[8]);
+  NIMBLE_CHECK_FILE_LE(zeroTerminated, 1, "Invalid FSST zero-terminated flag.");
+
+  uint32_t symbolCount{0};
+  uint64_t serializedSize = kSerializedHeaderSize;
+  for (uint32_t symbolLength = 1; symbolLength <= 8; ++symbolLength) {
+    const auto count = static_cast<uint8_t>(symbolTable[9 + symbolLength - 1]);
+    symbolCount += count;
+    serializedSize += static_cast<uint64_t>(count) * symbolLength;
+  }
+
+  NIMBLE_CHECK_FILE_LE(
+      symbolCount, 255, "FSST symbol table contains too many symbols.");
+  if (zeroTerminated != 0) {
+    const auto oneByteSymbolCount = static_cast<uint8_t>(symbolTable[9]);
+    NIMBLE_CHECK_FILE_GT(
+        oneByteSymbolCount,
+        0,
+        "FSST zero-terminated table has no terminator symbol.");
+    --serializedSize;
+  }
+  NIMBLE_CHECK_FILE_EQ(
+      serializedSize,
+      symbolTable.size(),
+      "FSST symbol table histogram does not match its serialized size.");
+}
+
+size_t FsstEncoding::validateCompressedLengths(
+    std::span<const uint32_t> lengths,
+    std::string_view blob,
+    size_t blobOffset) {
+  NIMBLE_CHECK_FILE_LE(
+      blobOffset, blob.size(), "FSST blob position exceeds its bounds.");
+
+  size_t compressedBytes{0};
+  for (const auto compressedLength : lengths) {
+    const auto currentOffset = blobOffset + compressedBytes;
+    NIMBLE_CHECK_FILE_LE(
+        static_cast<size_t>(compressedLength),
+        blob.size() - currentOffset,
+        "FSST compressed length exceeds the remaining blob.");
+    if (compressedLength > 0) {
+      NIMBLE_CHECK_FILE_NE(
+          static_cast<uint8_t>(blob[currentOffset + compressedLength - 1]),
+          FSST_ESC,
+          "FSST compressed string ends with an incomplete escape code.");
+    }
+    compressedBytes += compressedLength;
+  }
+  return compressedBytes;
 }
 
 FsstEncoding::CompressedValues FsstEncoding::compressValues(
@@ -277,46 +366,48 @@ FsstEncoding::FsstEncoding(
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
-    : TypedEncoding<std::string_view, std::string_view>{pool, data, options},
+    : TypedEncoding<
+          std::string_view,
+          std::
+              string_view>{pool, validateEncodedPrefix(data, options), options},
       stringBufferFactory_{std::move(stringBufferFactory)},
       lengthBuffer_{&pool},
       decompressBuffer_{&pool} {
   const auto header = parseHeader(data, this->dataOffset());
+  validateSymbolTable(header.symbolTable);
   const auto bytesConsumed = nimble_fsst_import(
       &decoder_,
       const_cast<unsigned char*>(
-          reinterpret_cast<const unsigned char*>(header.symbolTable)));
+          reinterpret_cast<const unsigned char*>(header.symbolTable.data())));
   NIMBLE_CHECK_EQ(
-      static_cast<uint32_t>(bytesConsumed),
-      header.symbolTableSize,
+      static_cast<size_t>(bytesConsumed),
+      header.symbolTable.size(),
       "FSST symbol table import size mismatch.");
 
   lengths_ = EncodingFactory().create(
-      pool,
-      {header.lengths, header.lengthsSize},
-      stringBufferFactory_,
-      options);
+      pool, header.lengths, stringBufferFactory_, options);
+  NIMBLE_CHECK_FILE_EQ(
+      lengths_->dataType(),
+      DataType::Uint32,
+      "FSST lengths encoding must contain Uint32 values.");
+  NIMBLE_CHECK_FILE(
+      !lengths_->isNullable(), "FSST lengths encoding must not be nullable.");
+  NIMBLE_CHECK_FILE_EQ(
+      lengths_->rowCount(),
+      this->rowCount(),
+      "FSST lengths row count does not match the parent encoding.");
   blob_ = header.blob;
-  pos_ = blob_;
+  validateLengthsAndBlob();
 }
 
 std::string_view FsstEncoding::lengthsEncoding(
     std::string_view encoding,
     const Encoding::Options& options) {
-  NIMBLE_CHECK_GE(
-      encoding.size(),
-      EncodingPrefix::kRowCountOffset,
-      "FSST encoding too small.");
-  NIMBLE_CHECK_EQ(
-      static_cast<EncodingType>(encoding[EncodingPrefix::kEncodingTypeOffset]),
-      EncodingType::Fsst,
-      "Expected FSST encoding.");
-
+  validateEncodedPrefix(encoding, options);
   const auto prefixSize =
       EncodingPrefix::prefixSize(encoding, options.useVarintRowCount);
-  NIMBLE_CHECK_GE(encoding.size(), prefixSize, "FSST encoding too small.");
   const auto header = parseHeader(encoding, prefixSize);
-  return {header.lengths, header.lengthsSize};
+  return header.lengths;
 }
 
 void FsstEncoding::captureNestedEncoding(
@@ -331,7 +422,7 @@ void FsstEncoding::captureNestedEncoding(
 
 void FsstEncoding::reset() {
   row_ = 0;
-  pos_ = blob_;
+  blobOffset_ = 0;
   lengths_->reset();
   pageUsedBytes_ = 0;
   currentPageIndex_ = 0;
@@ -344,42 +435,94 @@ void FsstEncoding::reset() {
   }
 }
 
+void FsstEncoding::validateLengthsAndBlob() {
+  constexpr uint32_t kValidationBatchSize = 1024;
+  size_t validatedBlobBytes{0};
+  uint32_t validatedRows{0};
+  while (validatedRows < this->rowCount()) {
+    const auto batchSize =
+        std::min(kValidationBatchSize, this->rowCount() - validatedRows);
+    lengthBuffer_.resize(batchSize);
+    lengths_->materialize(batchSize, lengthBuffer_.data());
+    validatedBlobBytes += validateCompressedLengths(
+        {lengthBuffer_.data(), lengthBuffer_.size()},
+        blob_,
+        validatedBlobBytes);
+    validatedRows += batchSize;
+  }
+  NIMBLE_CHECK_FILE_EQ(
+      validatedBlobBytes,
+      blob_.size(),
+      "FSST compressed lengths do not match the blob size.");
+  lengths_->reset();
+  lengthBuffer_.resize(0);
+}
+
+void FsstEncoding::checkReadRange(uint32_t rowCount, const char* operation)
+    const {
+  NIMBLE_CHECK_LE(row_, this->rowCount(), "Invalid FSST encoding position.");
+  NIMBLE_CHECK(rowCount <= this->rowCount() - row_, operation);
+}
+
+void FsstEncoding::checkFinalBlobPosition() const {
+  if (row_ == this->rowCount()) {
+    NIMBLE_CHECK_FILE_EQ(
+        blobOffset_,
+        blob_.size(),
+        "FSST compressed lengths do not match the blob size.");
+  }
+}
+
 void FsstEncoding::skip(uint32_t rowCount) {
+  checkReadRange(rowCount, "Skipping past end of FSST encoding.");
   lengthBuffer_.resize(rowCount);
   lengths_->materialize(rowCount, lengthBuffer_.data());
+  const auto compressedBytes = validateCompressedLengths(
+      {lengthBuffer_.data(), lengthBuffer_.size()}, blob_, blobOffset_);
   row_ += rowCount;
-  pos_ +=
-      std::accumulate(lengthBuffer_.begin(), lengthBuffer_.end(), uint64_t{0});
+  blobOffset_ += compressedBytes;
+  checkFinalBlobPosition();
 }
 
 void FsstEncoding::materialize(uint32_t rowCount, void* buffer) {
+  checkReadRange(rowCount, "Reading past end of FSST encoding.");
   lengthBuffer_.resize(rowCount);
   lengths_->materialize(rowCount, lengthBuffer_.data());
+  validateCompressedLengths(
+      {lengthBuffer_.data(), lengthBuffer_.size()}, blob_, blobOffset_);
 
   auto* output = static_cast<std::string_view*>(buffer);
   for (uint32_t i = 0; i < rowCount; ++i) {
     const auto compressedLen = lengthBuffer_[i];
-    output[i] = decompressToStringBuffer(pos_, compressedLen);
-    pos_ += compressedLen;
+    output[i] =
+        decompressToStringBuffer(blob_.substr(blobOffset_, compressedLen));
+    blobOffset_ += compressedLen;
   }
   row_ += rowCount;
+  checkFinalBlobPosition();
 }
 
 std::string_view FsstEncoding::decompressToStringBuffer(
-    const char* compressedData,
-    uint32_t compressedLength) {
-  if (compressedLength == 0) {
+    std::string_view compressed) {
+  if (compressed.empty()) {
     return {};
   }
 
-  const size_t maxDecompressedSize =
-      static_cast<size_t>(compressedLength) * kMaxSymbolLength;
+  NIMBLE_CHECK_FILE_NE(
+      static_cast<uint8_t>(compressed.back()),
+      FSST_ESC,
+      "FSST compressed string ends with an incomplete escape code.");
+  NIMBLE_CHECK_FILE_LE(
+      compressed.size(),
+      std::numeric_limits<uint32_t>::max() / kMaxSymbolLength,
+      "FSST decompressed string exceeds the supported size.");
+  const size_t maxDecompressedSize = compressed.size() * kMaxSymbolLength;
   decompressBuffer_.resize(maxDecompressedSize);
 
   const auto decompressedSize = nimble_fsst_decompress(
       &decoder_,
-      compressedLength,
-      reinterpret_cast<const unsigned char*>(compressedData),
+      compressed.size(),
+      reinterpret_cast<const unsigned char*>(compressed.data()),
       maxDecompressedSize,
       reinterpret_cast<unsigned char*>(decompressBuffer_.data()));
 
@@ -387,6 +530,10 @@ std::string_view FsstEncoding::decompressToStringBuffer(
       decompressedSize,
       0,
       "FSST decompression failed for non-empty compressed string.");
+  NIMBLE_CHECK_FILE_LE(
+      decompressedSize,
+      maxDecompressedSize,
+      "FSST decompressed string exceeds its output buffer.");
 
   ensurePage(decompressedSize);
 
@@ -489,6 +636,7 @@ std::string_view FsstEncoding::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  validateEncodedPrefix(encoded, options);
   const auto sourceRowCount =
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
@@ -497,38 +645,71 @@ std::string_view FsstEncoding::slice(
 
   const auto header = parseHeader(
       encoded, EncodingPrefix::prefixSize(encoded, options.useVarintRowCount));
-  const std::string_view lengths{
-      header.lengths, static_cast<size_t>(header.lengthsSize)};
+  validateSymbolTable(header.symbolTable);
 
   const auto rowEnd = offset + length;
   Vector<uint32_t> materializedLengths{&buffer.getMemoryPool(), rowEnd};
-  EncodingFactory{}
-      .create(
-          buffer.getMemoryPool(),
-          lengths,
-          [](uint32_t /*totalLength*/) -> void* { return nullptr; },
-          options)
-      ->materialize(rowEnd, materializedLengths.data());
+  auto lengthsEncoding = EncodingFactory{}.create(
+      buffer.getMemoryPool(),
+      header.lengths,
+      [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+      options);
+  NIMBLE_CHECK_FILE_EQ(
+      lengthsEncoding->dataType(),
+      DataType::Uint32,
+      "FSST lengths encoding must contain Uint32 values.");
+  NIMBLE_CHECK_FILE(
+      !lengthsEncoding->isNullable(),
+      "FSST lengths encoding must not be nullable.");
+  NIMBLE_CHECK_FILE_EQ(
+      lengthsEncoding->rowCount(),
+      sourceRowCount,
+      "FSST lengths row count does not match the parent encoding.");
+  lengthsEncoding->materialize(rowEnd, materializedLengths.data());
 
   const auto blobOffset = std::accumulate(
       materializedLengths.begin(),
       materializedLengths.begin() + offset,
-      uint32_t{0});
+      size_t{0});
   const auto blobBytes = std::accumulate(
       materializedLengths.begin() + offset,
       materializedLengths.end(),
-      uint32_t{0});
+      size_t{0});
+  validateCompressedLengths(
+      {materializedLengths.data(), materializedLengths.size()}, header.blob, 0);
+  if (rowEnd == sourceRowCount) {
+    NIMBLE_CHECK_FILE_EQ(
+        blobOffset + blobBytes,
+        header.blob.size(),
+        "FSST compressed lengths do not match the blob size.");
+  }
 
   auto* pool = &buffer.getMemoryPool();
   ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   const auto slicedLengths = EncodingFactory::slice(
-      lengths, offset, length, scopedBuffer.get(), options);
+      header.lengths, offset, length, scopedBuffer.get(), options);
 
-  const uint32_t encodingSize =
+  NIMBLE_CHECK_FILE_LE(
+      slicedLengths.size(),
+      std::numeric_limits<uint32_t>::max(),
+      "Sliced FSST lengths encoding exceeds the supported size.");
+  const uint64_t fixedEncodingSize =
       EncodingPrefix::serializedSize(length, options.useVarintRowCount) +
-      varint::varintSize(header.symbolTableSize) + header.symbolTableSize +
-      varint::varintSize(slicedLengths.size()) + slicedLengths.size() +
-      blobBytes;
+      varint::varintSize(header.symbolTable.size()) +
+      header.symbolTable.size() + varint::varintSize(slicedLengths.size()) +
+      slicedLengths.size();
+  constexpr auto kMaxEncodingSize =
+      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max());
+  NIMBLE_CHECK_FILE_LE(
+      fixedEncodingSize,
+      kMaxEncodingSize,
+      "Sliced FSST encoding exceeds the supported size.");
+  NIMBLE_CHECK_FILE_LE(
+      blobBytes,
+      kMaxEncodingSize - fixedEncodingSize,
+      "Sliced FSST encoding exceeds the supported size.");
+  const auto encodingSize =
+      static_cast<uint32_t>(fixedEncodingSize + blobBytes);
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   EncodingPrefix::serialize(
@@ -537,11 +718,13 @@ std::string_view FsstEncoding::slice(
       length,
       options.useVarintRowCount,
       pos);
-  encoding::writeVarintString(
-      {header.symbolTable, static_cast<size_t>(header.symbolTableSize)}, pos);
+  encoding::writeVarintString(header.symbolTable, pos);
   encoding::writeVarintString(slicedLengths, pos);
-  encoding::writeBytes({header.blob + blobOffset, blobBytes}, pos);
-  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  encoding::writeBytes(header.blob.substr(blobOffset, blobBytes), pos);
+  NIMBLE_CHECK_EQ(
+      static_cast<uint64_t>(pos - reserved),
+      encodingSize,
+      "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/velox/dwio/nimble/encodings/FsstEncoding.h
+++ b/velox/dwio/nimble/encodings/FsstEncoding.h
@@ -149,20 +149,14 @@ class FsstEncoding final
   };
 
   struct Header {
-    // Serialized FSST symbol table byte length.
-    uint32_t symbolTableSize;
+    // Serialized FSST symbol table.
+    std::string_view symbolTable;
 
-    // Start of the serialized FSST symbol table.
-    const char* symbolTable;
+    // Nested encoding for per-row compressed string sizes.
+    std::string_view lengths;
 
-    // Nested encoding byte length for per-row compressed string sizes.
-    uint32_t lengthsSize;
-
-    // Start of the nested compressed-lengths encoding.
-    const char* lengths;
-
-    // Start of the concatenated FSST-compressed string data.
-    const char* blob;
+    // Concatenated FSST-compressed string data.
+    std::string_view blob;
   };
 
   struct CompressedValues {
@@ -185,6 +179,32 @@ class FsstEncoding final
 
   // Parses the serialized FSST header at offset within encoding.
   static Header parseHeader(std::string_view encoding, size_t offset);
+
+  // Validates the common prefix before the base Encoding constructor parses
+  // it using the unchecked EncodingPrefix helpers.
+  static std::string_view validateEncodedPrefix(
+      std::string_view encoding,
+      const Encoding::Options& options);
+
+  // Validates a serialized FSST symbol table before calling fsst_import(),
+  // whose upstream API does not accept an input-buffer length.
+  static void validateSymbolTable(std::string_view symbolTable);
+
+  // Validates compressed lengths against blob bounds and FSST escape framing.
+  // Returns the number of compressed bytes covered by lengths.
+  static size_t validateCompressedLengths(
+      std::span<const uint32_t> lengths,
+      std::string_view blob,
+      size_t blobOffset);
+
+  // Validates the complete nested lengths stream and compressed blob.
+  void validateLengthsAndBlob();
+
+  // Checks that a sequential read remains within the row range.
+  void checkReadRange(uint32_t rowCount, const char* operation) const;
+
+  // Verifies the blob cursor when all rows have been consumed.
+  void checkFinalBlobPosition() const;
 
   // Trains FSST and compresses each input string independently.
   static CompressedValues compressValues(
@@ -214,9 +234,7 @@ class FsstEncoding final
 
   // Decompresses a single compressed string and copies the result into the
   // string buffer page. Returns a stable string_view.
-  std::string_view decompressToStringBuffer(
-      const char* compressedData,
-      uint32_t compressedLength);
+  std::string_view decompressToStringBuffer(std::string_view compressed);
 
   void ensurePage(size_t requiredBytes);
 
@@ -228,9 +246,9 @@ class FsstEncoding final
   // Nested encoding for compressed string lengths.
   std::unique_ptr<Encoding> lengths_;
 
-  // Pointer into the compressed string blob.
-  const char* blob_;
-  const char* pos_;
+  // Compressed string blob and the current byte offset within it.
+  std::string_view blob_;
+  size_t blobOffset_{0};
 
   // Current row index.
   uint32_t row_{0};
@@ -253,6 +271,10 @@ class FsstEncoding final
 
 template <typename V>
 void FsstEncoding::readWithVisitor(V& visitor, ReadWithVisitorParams& params) {
+  if (visitor.numRows() == 0) {
+    return;
+  }
+
   // Pre-materialize all compressed lengths needed for this read.
   const auto endRow = visitor.rowAt(visitor.numRows() - 1);
   auto numSelected = endRow + 1 - params.numScanned;
@@ -260,25 +282,34 @@ void FsstEncoding::readWithVisitor(V& visitor, ReadWithVisitorParams& params) {
     numSelected -= velox::bits::countNulls(
         nulls->template as<uint64_t>(), params.numScanned, endRow + 1);
   }
+  NIMBLE_CHECK_GE(numSelected, 0, "Invalid FSST visitor row range.");
+  checkReadRange(
+      static_cast<uint32_t>(numSelected), "Reading past end of FSST encoding.");
   lengthBuffer_.resize(numSelected);
   lengths_->materialize(numSelected, lengthBuffer_.data());
   auto* lengths = lengthBuffer_.data();
+  validateCompressedLengths(
+      {lengthBuffer_.data(), lengthBuffer_.size()}, blob_, blobOffset_);
 
   detail::readWithVisitorSlow(
       visitor,
       params,
       [&](auto toSkip) {
+        const auto compressedBytes =
+            std::accumulate(lengths, lengths + toSkip, static_cast<size_t>(0));
         row_ += toSkip;
-        pos_ += std::accumulate(lengths, lengths + toSkip, 0ull);
+        blobOffset_ += compressedBytes;
         lengths += toSkip;
       },
       [&] {
         const auto compressedLen = *lengths++;
-        auto result = decompressToStringBuffer(pos_, compressedLen);
+        auto result =
+            decompressToStringBuffer(blob_.substr(blobOffset_, compressedLen));
         ++row_;
-        pos_ += compressedLen;
+        blobOffset_ += compressedLen;
         return result;
       });
+  checkFinalBlobPosition();
 }
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
@@ -27,16 +27,26 @@
 #include "velox/dwio/nimble/common/Varint.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/NullableEncoding.h"
+#include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
 namespace facebook::nimble::test {
 namespace {
 
 class FsstEncodingTest : public ::testing::Test {
  protected:
+  struct FsstSections {
+    std::string_view prefix;
+    std::string_view symbolTable;
+    std::string_view lengths;
+    std::string_view blob;
+  };
+
   static void SetUpTestCase() {
     if (!velox::memory::MemoryManager::testInstance()) {
       velox::memory::MemoryManager::initialize({});
@@ -95,6 +105,80 @@ class FsstEncodingTest : public ::testing::Test {
         values,
         buffer,
         {.fsstCompressionTargetRatio = std::numeric_limits<double>::max()});
+  }
+
+  FsstSections splitFsst(std::string_view encoded) {
+    const auto prefixSize = EncodingPrefix::prefixSize(encoded, false);
+    const char* cursor = encoded.data() + prefixSize;
+    const auto symbolTableSize = varint::readVarint32(&cursor);
+    const std::string_view symbolTable{cursor, symbolTableSize};
+    cursor += symbolTableSize;
+    const auto lengthsSize = varint::readVarint32(&cursor);
+    const std::string_view lengths{cursor, lengthsSize};
+    cursor += lengthsSize;
+    return {
+        .prefix = encoded.substr(0, prefixSize),
+        .symbolTable = symbolTable,
+        .lengths = lengths,
+        .blob = {cursor, static_cast<size_t>(encoded.end() - cursor)},
+    };
+  }
+
+  std::string rebuildFsst(
+      const FsstSections& sections,
+      std::string_view symbolTable,
+      std::string_view lengths,
+      std::string_view blob) {
+    std::string rebuilt{sections.prefix};
+    const auto appendSection = [&](std::string_view section) {
+      NIMBLE_CHECK_LE(section.size(), std::numeric_limits<uint32_t>::max());
+      char encodedSize[5];
+      char* cursor = encodedSize;
+      varint::writeVarint(static_cast<uint32_t>(section.size()), &cursor);
+      rebuilt.append(encodedSize, cursor);
+      rebuilt.append(section);
+    };
+    appendSection(symbolTable);
+    appendSection(lengths);
+    rebuilt.append(blob);
+    return rebuilt;
+  }
+
+  template <typename T>
+  std::string encodeTrivialChild(std::span<const T> values) {
+    Vector<T> input{pool_.get(), values.size()};
+    std::copy(values.begin(), values.end(), input.begin());
+    Buffer buffer{*pool_};
+    return std::string{Encoder<TrivialEncoding<T>>::encode(buffer, input)};
+  }
+
+  std::string encodeNullableLengths(std::span<const uint32_t> values) {
+    Vector<uint32_t> input{pool_.get(), values.size()};
+    std::copy(values.begin(), values.end(), input.begin());
+    Vector<bool> nonNulls{pool_.get(), values.size()};
+    std::fill(nonNulls.begin(), nonNulls.end(), true);
+    Buffer buffer{*pool_};
+    return std::string{Encoder<NullableEncoding<uint32_t>>::encodeNullable(
+        buffer, input, nonNulls)};
+  }
+
+  std::vector<uint32_t> decodeLengths(std::string_view encodedLengths) {
+    auto encoding = EncodingFactory().create(
+        *pool_, encodedLengths, [](uint32_t /*totalLength*/) -> void* {
+          return nullptr;
+        });
+    std::vector<uint32_t> lengths(encoding->rowCount());
+    encoding->materialize(lengths.size(), lengths.data());
+    return lengths;
+  }
+
+  void expectMalformedEncoding(
+      std::string_view malformed,
+      const char* expectedMessage) {
+    NIMBLE_ASSERT_THROW(
+        EncodingFactory().create(
+            *pool_, malformed, createStringBufferFactory()),
+        expectedMessage);
   }
 
   void roundTrip(
@@ -553,6 +637,185 @@ TEST_F(FsstEncodingTest, rejectsHeaderSizesOutsideEncoding) {
           {emptySectionHeader.data(),
            static_cast<size_t>(cursor - emptySectionHeader.data())}),
       "FSST lengths encoding size must be positive.");
+}
+
+TEST_F(FsstEncodingTest, rejectsMalformedSymbolTablesBeforeImport) {
+  const std::vector<std::string_view> values{
+      "common/fsst/symbol/value/0000",
+      "common/fsst/symbol/value/0001",
+      "common/fsst/symbol/value/0002",
+  };
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Fsst);
+  const auto sections = splitFsst(encoded);
+  ASSERT_GE(sections.symbolTable.size(), 17);
+
+  const auto truncated = rebuildFsst(
+      sections,
+      sections.symbolTable.substr(0, 16),
+      sections.lengths,
+      sections.blob);
+  expectMalformedEncoding(truncated, "Truncated FSST symbol table.");
+
+  auto invalidFlag = std::string{sections.symbolTable};
+  invalidFlag[8] = 2;
+  const auto invalidFlagEncoding =
+      rebuildFsst(sections, invalidFlag, sections.lengths, sections.blob);
+  expectMalformedEncoding(
+      invalidFlagEncoding, "Invalid FSST zero-terminated flag.");
+
+  auto missingTerminator = std::string{sections.symbolTable};
+  missingTerminator[8] = 1;
+  missingTerminator[9] = 0;
+  const auto missingTerminatorEncoding =
+      rebuildFsst(sections, missingTerminator, sections.lengths, sections.blob);
+  expectMalformedEncoding(
+      missingTerminatorEncoding,
+      "FSST zero-terminated table has no terminator symbol.");
+
+  auto excessiveHistogram = std::string{sections.symbolTable};
+  std::fill(
+      excessiveHistogram.begin() + 9,
+      excessiveHistogram.begin() + 17,
+      static_cast<char>(0xff));
+  const auto excessiveHistogramEncoding = rebuildFsst(
+      sections, excessiveHistogram, sections.lengths, sections.blob);
+  expectMalformedEncoding(
+      excessiveHistogramEncoding,
+      "FSST symbol table contains too many symbols.");
+
+  auto mismatchedHistogram = std::string{sections.symbolTable};
+  const auto oneByteSymbolCount = static_cast<uint8_t>(mismatchedHistogram[9]);
+  mismatchedHistogram[9] =
+      static_cast<char>(oneByteSymbolCount == 0 ? 1 : oneByteSymbolCount - 1);
+  const auto mismatchedHistogramEncoding = rebuildFsst(
+      sections, mismatchedHistogram, sections.lengths, sections.blob);
+  expectMalformedEncoding(
+      mismatchedHistogramEncoding,
+      "FSST symbol table histogram does not match its serialized size.");
+
+  auto unsupportedVersion = std::string{sections.symbolTable};
+  std::fill(
+      unsupportedVersion.begin(), unsupportedVersion.begin() + 8, char{0});
+  const auto unsupportedVersionEncoding = rebuildFsst(
+      sections, unsupportedVersion, sections.lengths, sections.blob);
+  expectMalformedEncoding(
+      unsupportedVersionEncoding, "FSST symbol table import size mismatch.");
+}
+
+TEST_F(FsstEncodingTest, rejectsInvalidLengthsEncodingContract) {
+  const std::vector<std::string_view> values{
+      "common/fsst/length/value/0000",
+      "common/fsst/length/value/0001",
+      "common/fsst/length/value/0002",
+  };
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Fsst);
+  const auto sections = splitFsst(encoded);
+  const auto lengths = decodeLengths(sections.lengths);
+  ASSERT_EQ(lengths.size(), values.size());
+
+  std::vector<uint64_t> uint64Lengths(lengths.begin(), lengths.end());
+  const auto wrongTypeLengths = encodeTrivialChild<uint64_t>(uint64Lengths);
+  const auto wrongTypeEncoding = rebuildFsst(
+      sections, sections.symbolTable, wrongTypeLengths, sections.blob);
+  expectMalformedEncoding(
+      wrongTypeEncoding, "FSST lengths encoding must contain Uint32 values.");
+
+  const auto shortLengths = encodeTrivialChild<uint32_t>(
+      std::span<const uint32_t>{lengths}.first(lengths.size() - 1));
+  const auto wrongRowCountEncoding =
+      rebuildFsst(sections, sections.symbolTable, shortLengths, sections.blob);
+  expectMalformedEncoding(
+      wrongRowCountEncoding,
+      "FSST lengths row count does not match the parent encoding.");
+
+  const auto nullableLengths = encodeNullableLengths(lengths);
+  const auto nullableEncoding = rebuildFsst(
+      sections, sections.symbolTable, nullableLengths, sections.blob);
+  expectMalformedEncoding(
+      nullableEncoding, "FSST lengths encoding must not be nullable.");
+}
+
+TEST_F(FsstEncodingTest, rejectsCompressedLengthsOutsideBlob) {
+  const std::vector<std::string_view> values{
+      "common/fsst/blob/value/0000",
+      "common/fsst/blob/value/0001",
+      "common/fsst/blob/value/0002",
+  };
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Fsst);
+  const auto sections = splitFsst(encoded);
+  auto lengths = decodeLengths(sections.lengths);
+  ASSERT_FALSE(lengths.empty());
+  ASSERT_GT(lengths.back(), 0);
+
+  ++lengths.back();
+  const auto oversizedLengths = encodeTrivialChild<uint32_t>(lengths);
+  const auto oversizedEncoding = rebuildFsst(
+      sections, sections.symbolTable, oversizedLengths, sections.blob);
+  expectMalformedEncoding(
+      oversizedEncoding, "FSST compressed length exceeds the remaining blob.");
+
+  std::string blobWithTrailingByte{sections.blob};
+  blobWithTrailingByte.push_back('\0');
+  const auto trailingBlobEncoding = rebuildFsst(
+      sections, sections.symbolTable, sections.lengths, blobWithTrailingByte);
+  expectMalformedEncoding(
+      trailingBlobEncoding,
+      "FSST compressed lengths do not match the blob size.");
+
+  std::string incompleteEscapeBlob{sections.blob};
+  size_t rowEnd = 0;
+  for (const auto compressedLength : decodeLengths(sections.lengths)) {
+    rowEnd += compressedLength;
+    if (compressedLength > 0) {
+      incompleteEscapeBlob[rowEnd - 1] = static_cast<char>(FSST_ESC);
+      break;
+    }
+  }
+  const auto incompleteEscapeEncoding = rebuildFsst(
+      sections, sections.symbolTable, sections.lengths, incompleteEscapeBlob);
+  expectMalformedEncoding(
+      incompleteEscapeEncoding,
+      "FSST compressed string ends with an incomplete escape code.");
+
+  Buffer sliceBuffer{*pool_};
+  NIMBLE_ASSERT_THROW(
+      FsstEncoding::slice(
+          oversizedEncoding,
+          /*offset=*/0,
+          /*length=*/values.size(),
+          sliceBuffer),
+      "FSST compressed length exceeds the remaining blob.");
+}
+
+TEST_F(FsstEncodingTest, rejectsSequentialReadsPastEnd) {
+  const std::vector<std::string_view> values{"alpha", "bravo", "charlie"};
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+
+  auto encoding = EncodingFactory().create(
+      *pool_, encoded, createStringBufferFactory(), Encoding::Options{});
+  std::vector<std::string_view> decoded(values.size() + 1);
+  NIMBLE_ASSERT_THROW(
+      encoding->materialize(decoded.size(), decoded.data()),
+      "Reading past end of FSST encoding.");
+
+  encoding->reset();
+  NIMBLE_ASSERT_THROW(
+      encoding->skip(values.size() + 1), "Skipping past end of FSST encoding.");
+
+  FsstEncoding visitorEncoding{*pool_, encoded, createStringBufferFactory()};
+  StringReadWithVisitor visitor{{static_cast<vector_size_t>(values.size())}};
+  ReadWithVisitorParams params;
+  params.numScanned = 0;
+  NIMBLE_ASSERT_THROW(
+      visitorEncoding.readWithVisitor(visitor, params),
+      "Reading past end of FSST encoding.");
 }
 
 TEST_F(FsstEncodingTest, invalidSliceRange) {


### PR DESCRIPTION
Validate serialized FSST symbol tables before passing them to the unbounded upstream import API, and verify the lengths, child type, nullability, row count, compressed blob bounds, escape framing, cursor ranges, and decompression sizes. This prevents malformed Nimble data from causing out-of-bounds reads or invalid cursor advancement during construction, materialization, skipping, visitor reads, and slicing. The existing wire format remains unchanged.