### PR TITLE
fix(nimble): Synchronize encoding pool test callback

### DIFF
--- a/velox/dwio/nimble/velox/tests/WriterTest.cpp
+++ b/velox/dwio/nimble/velox/tests/WriterTest.cpp
@@ -18,8 +18,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <condition_variable>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <unordered_map>
@@ -780,10 +782,14 @@ DEBUG_ONLY_TEST_F(WriterTest, encodingPoolsPassedToEncodeOptions) {
     uint32_t pooledEncodingBufferCount{0};
     std::set<const void*> observedScratchPools;
     std::set<const void*> observedEncodingBufferPools;
+    // Parallel encoding can invoke the callback concurrently.
+    std::mutex statsMutex;
+    std::condition_variable poolsObserved;
     SCOPED_TESTVALUE_SET(
         "facebook::nimble::Writer::encode",
         std::function<void(nimble::Encoding::Options*)>(
             [&](nimble::Encoding::Options* encodingOptions) {
+              std::unique_lock lock{statsMutex};
               ++encodeCount;
               if (encodingOptions->bufferPool != nullptr) {
                 ++pooledScratchEncodeCount;
@@ -794,6 +800,16 @@ DEBUG_ONLY_TEST_F(WriterTest, encodingPoolsPassedToEncodeOptions) {
                 observedEncodingBufferPools.insert(
                     encodingOptions->encodingBufferPool);
               }
+              poolsObserved.notify_all();
+              // Make the pool-count check deterministic. Without this wait,
+              // one encoding task may consume every stream before the other
+              // task is scheduled, especially on a single CPU.
+              poolsObserved.wait(lock, [&] {
+                return observedScratchPools.size() >=
+                    testCase.expectedScratchPoolCount &&
+                    observedEncodingBufferPools.size() >=
+                    testCase.expectedEncodingPoolCount;
+              });
             }));
 
     std::shared_ptr<folly::CPUThreadPoolExecutor> executor;


### PR DESCRIPTION
>https://github.com/facebookincubator/velox/actions/runs/33963141457/job/101298433535?pr=18869
[  FAILED  ] WriterTest.encodingPoolsPassedToEncodeOptions

Fix a race in WriterTest.encodingPoolsPassedToEncodeOptions. Parallel encoding tasks can invoke the test callback concurrently, while the callback updates shared counters and sets without synchronization. Protect the captured test state with a mutex to prevent lost updates and unsafe concurrent std::set mutations, making the debug test deterministic.
