### PR TITLE
feat(exchange): Add file durable exchange backend (#18871)

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -34,6 +34,9 @@ velox_add_library(
   ExchangeQueue.cpp
   ExchangeSink.cpp
   ExchangeSource.cpp
+  FileExchangeFormat.cpp
+  FileExchangeSink.cpp
+  FileExchangeSource.cpp
   MaterializedOutputBuffer.cpp
   MaterializedOutputBufferManager.cpp
   MaterializedPartitionedOutput.cpp
@@ -141,6 +144,9 @@ velox_add_library(
   ExchangeSink.h
   ExchangeSource.h
   Expand.h
+  FileExchangeFormat.h
+  FileExchangeSink.h
+  FileExchangeSource.h
   FilterProject.h
   GroupId.h
   GroupingSet.h

--- a/velox/exec/FileExchangeFormat.cpp
+++ b/velox/exec/FileExchangeFormat.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/FileExchangeFormat.h"
+
+#include <limits>
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec::file_exchange {
+namespace {
+
+constexpr std::string_view kExchangeOutputFilePrefix{"file-exchange:"};
+
+} // namespace
+
+std::string ExchangeOutputFile::serialize() const {
+  VELOX_CHECK(!path.empty(), "Exchange output file path cannot be empty");
+  VELOX_CHECK_LE(size, std::numeric_limits<int64_t>::max());
+  return std::string{kExchangeOutputFilePrefix} +
+      folly::toJson(
+             folly::dynamic::object("path", path)(
+                 "size", static_cast<int64_t>(size))(
+                 "checksum", static_cast<int64_t>(checksum)));
+}
+
+bool ExchangeOutputFile::serialized(std::string_view value) {
+  return value.starts_with(kExchangeOutputFilePrefix);
+}
+
+ExchangeOutputFile ExchangeOutputFile::deserialize(std::string_view value) {
+  VELOX_CHECK(serialized(value), "Invalid exchange output file: {}", value);
+
+  folly::dynamic metadata;
+  try {
+    metadata = folly::parseJson(
+        std::string{value.substr(kExchangeOutputFilePrefix.size())});
+  } catch (const std::exception& error) {
+    VELOX_FAIL("Invalid exchange output file: {}: {}", value, error.what());
+  }
+
+  VELOX_CHECK(
+      metadata.isObject() && metadata.count("path") == 1 &&
+          metadata.count("size") == 1 && metadata.count("checksum") == 1,
+      "Incomplete exchange output file: {}",
+      value);
+  VELOX_CHECK(
+      metadata["path"].isString() && !metadata["path"].asString().empty() &&
+          metadata["size"].isInt() && metadata["size"].asInt() >= 0 &&
+          metadata["checksum"].isInt() && metadata["checksum"].asInt() >= 0 &&
+          metadata["checksum"].asInt() <= std::numeric_limits<uint32_t>::max(),
+      "Invalid exchange output file metadata: {}",
+      value);
+
+  return {
+      .path = metadata["path"].asString(),
+      .size = static_cast<uint64_t>(metadata["size"].asInt()),
+      .checksum = static_cast<uint32_t>(metadata["checksum"].asInt()),
+  };
+}
+
+} // namespace facebook::velox::exec::file_exchange

--- a/velox/exec/FileExchangeFormat.h
+++ b/velox/exec/FileExchangeFormat.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <folly/lang/Bits.h>
+
+namespace facebook::velox::exec::file_exchange {
+
+/// Identifies one committed partition file in backend-private exchange
+/// metadata.
+struct ExchangeOutputFile {
+  std::string path;
+  uint64_t size;
+  uint32_t checksum;
+
+  std::string serialize() const;
+
+  static bool serialized(std::string_view value);
+
+  static ExchangeOutputFile deserialize(std::string_view value);
+};
+
+// Each page is a big-endian payload size followed by that many payload bytes.
+using PageSize = uint64_t;
+
+inline PageSize encodePageSize(uint64_t size) {
+  return folly::Endian::big(size);
+}
+
+inline uint64_t decodePageSize(PageSize size) {
+  return folly::Endian::big(size);
+}
+
+} // namespace facebook::velox::exec::file_exchange

--- a/velox/exec/FileExchangeSink.cpp
+++ b/velox/exec/FileExchangeSink.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/FileExchangeSink.h"
+
+#include <folly/dynamic.h>
+#include <folly/hash/Checksum.h>
+#include <folly/json.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/exec/FileExchangeFormat.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+std::string partitionPath(
+    const std::string& rootDir,
+    const std::string& exchangeId,
+    int32_t partition) {
+  return fmt::format("{}/{}/partition_{}", rootDir, exchangeId, partition);
+}
+
+} // namespace
+
+void FileExchangeSink::PartitionWriter::append(
+    const void* data,
+    size_t numBytes) {
+  VELOX_CHECK_NOT_NULL(file);
+  file->append(std::string_view{reinterpret_cast<const char*>(data), numBytes});
+  size += numBytes;
+  checksum =
+      folly::crc32c(reinterpret_cast<const uint8_t*>(data), numBytes, checksum);
+}
+
+FileExchangeSink::FileExchangeSink(
+    std::string rootDir,
+    std::string exchangeId,
+    std::string taskId,
+    int32_t numPartitions)
+    : rootDir_(std::move(rootDir)),
+      exchangeId_(std::move(exchangeId)),
+      taskId_(std::move(taskId)),
+      numPartitions_(numPartitions),
+      fileSystem_(filesystems::getFileSystem(rootDir_, nullptr)),
+      writers_(numPartitions) {
+  for (int32_t partition = 0; partition < numPartitions_; ++partition) {
+    fileSystem_->mkdir(partitionDir(partition));
+  }
+}
+
+std::string FileExchangeSink::partitionDir(int32_t partition) const {
+  return partitionPath(rootDir_, exchangeId_, partition);
+}
+
+std::string FileExchangeSink::partitionFile(int32_t partition) const {
+  return fmt::format("{}/{}.bin", partitionDir(partition), taskId_);
+}
+
+FileExchangeSink::PartitionWriter& FileExchangeSink::partitionWriter(
+    int32_t partition) {
+  auto& partitionWriter = writers_[partition];
+  if (partitionWriter.file == nullptr) {
+    const auto filePath = partitionFile(partition);
+    partitionWriter.file = fileSystem_->openFileForWrite(filePath);
+  }
+  return partitionWriter;
+}
+
+std::optional<file_exchange::ExchangeOutputFile> FileExchangeSink::closeWriter(
+    int32_t partition) {
+  auto& partitionWriter = writers_[partition];
+  if (partitionWriter.file == nullptr) {
+    return std::nullopt;
+  }
+  partitionWriter.file->close();
+  VELOX_CHECK_EQ(partitionWriter.file->size(), partitionWriter.size);
+  return file_exchange::ExchangeOutputFile{
+      .path = partitionFile(partition),
+      .size = partitionWriter.size,
+      .checksum = partitionWriter.checksum,
+  };
+}
+
+void FileExchangeSink::append(int32_t partition, std::string_view page) {
+  append(partition, folly::IOBuf::copyBuffer(page.data(), page.size()));
+}
+
+void FileExchangeSink::append(
+    int32_t partition,
+    std::unique_ptr<folly::IOBuf> page) {
+  VELOX_CHECK_GE(partition, 0);
+  VELOX_CHECK_LT(partition, numPartitions_);
+  VELOX_CHECK_NOT_NULL(page);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  VELOX_CHECK(!closed_);
+  auto& partitionWriter = this->partitionWriter(partition);
+  const auto pageSize = page->computeChainDataLength();
+  const auto encodedPageSize = file_exchange::encodePageSize(pageSize);
+  partitionWriter.append(&encodedPageSize, sizeof(file_exchange::PageSize));
+  for (const auto& range : *page) {
+    partitionWriter.append(range.data(), range.size());
+  }
+  totalBytesWritten_ += pageSize;
+  ++totalPages_;
+}
+
+CommittedExchangeOutput FileExchangeSink::finish() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  VELOX_CHECK(!closed_, "File exchange sink is already closed");
+
+  CommittedExchangeOutput output;
+  for (int32_t partition = 0; partition < numPartitions_; ++partition) {
+    if (auto outputFile = closeWriter(partition)) {
+      output.locations[partition] = outputFile->serialize();
+    }
+  }
+  closed_ = true;
+  return output;
+}
+
+void FileExchangeSink::abort() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (closed_) {
+    return;
+  }
+  for (int32_t partition = 0; partition < numPartitions_; ++partition) {
+    closeWriter(partition);
+  }
+  closed_ = true;
+}
+
+folly::F14FastMap<std::string, int64_t> FileExchangeSink::stats() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return {
+      {"totalBytesWritten", totalBytesWritten_},
+      {"totalPages", totalPages_},
+  };
+}
+
+std::shared_ptr<ExchangeSink> FileExchangeSink::create(
+    const std::string& config,
+    const std::string& taskId,
+    memory::MemoryPool* /*pool*/) {
+  auto parsed = folly::parseJson(config);
+  return std::make_shared<FileExchangeSink>(
+      parsed["rootDir"].asString(),
+      parsed["exchangeId"].asString(),
+      taskId,
+      parsed["numPartitions"].asInt());
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/FileExchangeSink.h
+++ b/velox/exec/FileExchangeSink.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/ExchangeSink.h"
+#include "velox/exec/FileExchangeFormat.h"
+
+namespace facebook::velox::exec {
+
+/// Writes one task attempt's partitioned output to durable files.
+class FileExchangeSink final : public ExchangeSink {
+ public:
+  /// Creates a sink from serialized transport options.
+  static std::shared_ptr<ExchangeSink> create(
+      const std::string& config,
+      const std::string& taskId,
+      memory::MemoryPool* pool);
+
+  /// Creates paged output files lazily for non-empty destination partitions.
+  FileExchangeSink(
+      std::string rootDir,
+      std::string exchangeId,
+      std::string taskId,
+      int32_t numPartitions);
+
+  /// Appends one length-delimited serialized page to a partition file.
+  void append(int32_t partition, std::string_view page) override;
+
+  /// Appends one length-delimited serialized page without coalescing its
+  /// IOBuf chain.
+  void append(int32_t partition, std::unique_ptr<folly::IOBuf> page) override;
+
+  /// Closes all partition files and returns non-empty committed locations.
+  CommittedExchangeOutput finish() override;
+
+  /// Closes all open partition files without committing output.
+  void abort() override;
+
+  /// Returns payload bytes and page count written by this sink.
+  folly::F14FastMap<std::string, int64_t> stats() const override;
+
+ private:
+  struct PartitionWriter {
+    // Writes bytes while maintaining the committed size and checksum.
+    void append(const void* data, size_t numBytes);
+
+    std::unique_ptr<WriteFile> file;
+    uint64_t size{0};
+    uint32_t checksum{~0U};
+  };
+
+  // Returns the directory containing one partition's task files.
+  std::string partitionDir(int32_t partition) const;
+
+  // Returns the single paged file written for one partition.
+  std::string partitionFile(int32_t partition) const;
+
+  // Returns the partition writer state, opening its file lazily.
+  PartitionWriter& partitionWriter(int32_t partition);
+
+  // Closes one partition writer and returns its output file, if non-empty.
+  std::optional<file_exchange::ExchangeOutputFile> closeWriter(
+      int32_t partition);
+
+  // Root directory for all file exchange data.
+  const std::string rootDir_;
+  // Identifier shared by all tasks writing one exchange.
+  const std::string exchangeId_;
+  // Identifier of the task attempt owned by this sink.
+  const std::string taskId_;
+  // Fixed number of destination partitions.
+  const int32_t numPartitions_;
+  // Filesystem selected from the root directory URI.
+  const std::shared_ptr<filesystems::FileSystem> fileSystem_;
+
+  // Serializes writer lifecycle and append calls.
+  mutable std::mutex mutex_;
+  // Lazily opened output and integrity state for each partition.
+  std::vector<PartitionWriter> writers_;
+  // Total payload bytes, excluding page-size headers.
+  int64_t totalBytesWritten_{0};
+  // Total number of pages written.
+  int64_t totalPages_{0};
+  // True after finish or abort closes this sink.
+  bool closed_{false};
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/FileExchangeSource.cpp
+++ b/velox/exec/FileExchangeSource.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/FileExchangeSource.h"
+
+#include <mutex>
+
+#include <folly/hash/Checksum.h>
+#include <folly/io/IOBuf.h>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/future/VeloxPromise.h"
+#include "velox/exec/FileExchangeFormat.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+namespace facebook::velox::exec {
+
+FileExchangeSource::FileExchangeSource(
+    const std::string& taskId,
+    int32_t destination,
+    std::shared_ptr<ExchangeQueue> queue,
+    memory::MemoryPool* pool)
+    : ExchangeSource(taskId, destination, queue, pool) {
+  auto outputFile = file_exchange::ExchangeOutputFile::deserialize(taskId);
+  filePath_ = std::move(outputFile.path);
+  expectedFileSize_ = outputFile.size;
+  expectedChecksum_ = outputFile.checksum;
+}
+
+bool FileExchangeSource::shouldRequestLocked() {
+  if (atEnd_ || closed_) {
+    return false;
+  }
+  return !requestPending_.exchange(true);
+}
+
+void FileExchangeSource::openFile() {
+  if (file_ != nullptr) {
+    return;
+  }
+  fileSystem_ = filesystems::getFileSystem(filePath_, nullptr);
+  file_ = fileSystem_->openFileForRead(filePath_);
+  const auto fileSize = file_->size();
+  VELOX_CHECK_EQ(
+      fileSize,
+      expectedFileSize_,
+      "File exchange size mismatch for {}",
+      filePath_);
+}
+
+std::unique_ptr<SerializedPageBase> FileExchangeSource::readPage() {
+  if (fileBytesRead_ == expectedFileSize_) {
+    return nullptr;
+  }
+  VELOX_CHECK_GE(
+      expectedFileSize_ - fileBytesRead_,
+      sizeof(file_exchange::PageSize),
+      "Incomplete page-size header in file: {}",
+      filePath_);
+
+  file_exchange::PageSize encodedPageSize;
+  const auto encodedPageSizeData = file_->pread(
+      fileBytesRead_, sizeof(file_exchange::PageSize), &encodedPageSize);
+  VELOX_CHECK_EQ(
+      encodedPageSizeData.size(),
+      sizeof(file_exchange::PageSize),
+      "Incomplete page-size header in file: {}",
+      filePath_);
+  fileChecksum_ = folly::crc32c(
+      reinterpret_cast<const uint8_t*>(&encodedPageSize),
+      sizeof(file_exchange::PageSize),
+      fileChecksum_);
+  fileBytesRead_ += sizeof(file_exchange::PageSize);
+
+  const auto pageSize = file_exchange::decodePageSize(encodedPageSize);
+  VELOX_CHECK_LE(
+      pageSize,
+      expectedFileSize_ - fileBytesRead_,
+      "Incomplete page payload in file: {}",
+      filePath_);
+  auto buffer = folly::IOBuf::create(pageSize);
+  const auto pageData =
+      file_->pread(fileBytesRead_, pageSize, buffer->writableData());
+  VELOX_CHECK_EQ(
+      pageData.size(),
+      pageSize,
+      "Incomplete page payload in file: {}",
+      filePath_);
+  fileChecksum_ =
+      folly::crc32c(buffer->writableData(), pageSize, fileChecksum_);
+  fileBytesRead_ += pageSize;
+  buffer->append(pageSize);
+  return std::make_unique<PrestoSerializedPage>(std::move(buffer));
+}
+
+void FileExchangeSource::verifyChecksum() const {
+  VELOX_CHECK_EQ(
+      fileChecksum_,
+      expectedChecksum_,
+      "File exchange checksum mismatch for {}",
+      filePath_);
+}
+
+void FileExchangeSource::enqueuePage(std::unique_ptr<SerializedPageBase> page) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> lock(queue_->mutex());
+    queue_->enqueueLocked(std::move(page), promises);
+  }
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+}
+
+void FileExchangeSource::enqueueEnd() {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> lock(queue_->mutex());
+    if (endEnqueued_) {
+      return;
+    }
+    verifyChecksum();
+    endEnqueued_ = true;
+    atEnd_ = true;
+    queue_->enqueueLocked(nullptr, promises);
+  }
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+}
+
+folly::SemiFuture<ExchangeSource::Response> FileExchangeSource::request(
+    uint32_t maxBytes,
+    std::chrono::microseconds /*maxWait*/) {
+  if (closed_) {
+    requestPending_ = false;
+    return folly::makeSemiFuture(
+        Response{.bytes = 0, .atEnd = false, .remainingBytes = {}});
+  }
+
+  openFile();
+  int64_t bytes{0};
+  bool atEnd{false};
+  while (bytes == 0 || bytes < maxBytes) {
+    auto page = readPage();
+    if (page == nullptr) {
+      enqueueEnd();
+      atEnd = true;
+      break;
+    }
+    bytes += page->size();
+    enqueuePage(std::move(page));
+  }
+  requestPending_ = false;
+  return folly::makeSemiFuture(
+      Response{.bytes = bytes, .atEnd = atEnd, .remainingBytes = {}});
+}
+
+void FileExchangeSource::close() {
+  closed_ = true;
+}
+
+// --- Factory ---
+
+std::shared_ptr<ExchangeSource> FileExchangeSourceFactory::operator()(
+    const std::string& taskId,
+    int32_t destination,
+    std::shared_ptr<ExchangeQueue> queue,
+    memory::MemoryPool* pool) {
+  if (file_exchange::ExchangeOutputFile::serialized(taskId)) {
+    return std::make_shared<FileExchangeSource>(
+        taskId, destination, std::move(queue), pool);
+  }
+  return nullptr;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/FileExchangeSource.h
+++ b/velox/exec/FileExchangeSource.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/dynamic.h>
+#include <atomic>
+#include <string>
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/ExchangeSource.h"
+#include "velox/exec/FileExchangeFormat.h"
+
+namespace facebook::velox::exec {
+
+/// ExchangeSource that reads from file-based exchange storage.
+///
+/// Used by the existing Velox Exchange operator to read durable exchange
+/// data in fault-tolerant mode. The serialized location identifies one
+/// successful task attempt's paged partition file.
+class FileExchangeSource : public ExchangeSource {
+ public:
+  /// Creates a source for one task/partition paged file.
+  FileExchangeSource(
+      const std::string& taskId,
+      int32_t destination,
+      std::shared_ptr<ExchangeQueue> queue,
+      memory::MemoryPool* pool);
+
+  /// Claims the next request while the source remains open.
+  bool shouldRequestLocked() override;
+
+  /// Reads and enqueues pages up to the requested byte budget.
+  folly::SemiFuture<Response> request(
+      uint32_t maxBytes,
+      std::chrono::microseconds maxWait) override;
+
+  void pause() override {}
+
+  /// Prevents new requests from starting.
+  void close() override;
+
+  folly::SemiFuture<Response> requestDataSizes(
+      std::chrono::microseconds maxWait) override {
+    return request(0, maxWait);
+  }
+
+  folly::F14FastMap<std::string, RuntimeMetric> metrics() const override {
+    return {};
+  }
+
+  bool supportsMetrics() const override {
+    return true;
+  }
+
+  folly::dynamic toJson() override {
+    return folly::dynamic::object("filePath", filePath_);
+  }
+
+ private:
+  // Opens the paged input file on first request.
+  void openFile();
+
+  // Reads the next page, or returns null at end of file.
+  std::unique_ptr<SerializedPageBase> readPage();
+
+  // Enqueues a page and wakes waiting consumers.
+  void enqueuePage(std::unique_ptr<SerializedPageBase> page);
+
+  // Verifies the complete file before publishing successful end of stream.
+  void enqueueEnd();
+
+  // Verifies the completed file against its committed checksum.
+  void verifyChecksum() const;
+
+  // Exact path of the task/partition paged file.
+  std::string filePath_;
+  // Committed physical file size in bytes.
+  uint64_t expectedFileSize_{0};
+  // Committed CRC32C of all physical file bytes.
+  uint32_t expectedChecksum_{0};
+  // Number of physical file bytes consumed so far.
+  uint64_t fileBytesRead_{0};
+  // Incremental CRC32C of physical file bytes consumed so far.
+  uint32_t fileChecksum_{~0U};
+  // Filesystem that owns the input file implementation.
+  std::shared_ptr<filesystems::FileSystem> fileSystem_;
+  // Lazily opened input file retained until this source is destroyed.
+  std::unique_ptr<ReadFile> file_;
+  // True after close prevents further reads.
+  std::atomic_bool closed_{false};
+  // True after the terminal queue marker has been emitted. Guarded by the
+  // exchange queue mutex together with ExchangeSource::atEnd_.
+  bool endEnqueued_{false};
+};
+
+/// Factory that creates FileExchangeSource instances for serialized file
+/// exchange locations.
+class FileExchangeSourceFactory {
+ public:
+  std::shared_ptr<ExchangeSource> operator()(
+      const std::string& taskId,
+      int32_t destination,
+      std::shared_ptr<ExchangeQueue> queue,
+      memory::MemoryPool* pool);
+
+  /// Returns a factory function for registration with
+  /// velox::exec::ExchangeSource::registerFactory().
+  static ExchangeSource::Factory toFactory() {
+    return [](const std::string& taskId,
+              int32_t destination,
+              std::shared_ptr<ExchangeQueue> queue,
+              memory::MemoryPool* pool) -> std::shared_ptr<ExchangeSource> {
+      FileExchangeSourceFactory f;
+      return f(taskId, destination, std::move(queue), pool);
+    };
+  }
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -152,6 +152,7 @@ set(
   FilterProjectTest.cpp
   AsyncConnectorTest.cpp
   VectorWindowPartitionTest.cpp
+  FileExchangeTest.cpp
 )
 
 set(

--- a/velox/exec/tests/FileExchangeTest.cpp
+++ b/velox/exec/tests/FileExchangeTest.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filesystem>
+#include <fstream>
+#include <limits>
+
+#include <fmt/format.h>
+#include <folly/hash/Checksum.h>
+#include <folly/testing/TestUtil.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/file/tests/FaultyFileSystem.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/exec/FileExchangeFormat.h"
+#include "velox/exec/FileExchangeSink.h"
+#include "velox/exec/FileExchangeSource.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+class FileExchangeTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+    filesystems::registerLocalFileSystem();
+    tests::utils::registerFaultyFileSystem();
+  }
+
+  void SetUp() override {
+    temporaryDirectory_ =
+        std::make_unique<folly::test::TemporaryDirectory>("file_exchange_test");
+    rootDirectory_ = temporaryDirectory_->path().string();
+    pool_ = memory::memoryManager()->addRootPool("file_exchange_test");
+  }
+
+  static std::string pageData(const SerializedPageBase& page) {
+    auto data = page.getIOBuf();
+    data->coalesce();
+    return std::string(
+        reinterpret_cast<const char*>(data->data()), data->length());
+  }
+
+  static std::string fileContents(
+      std::initializer_list<std::string_view> pages) {
+    std::string contents;
+    for (const auto page : pages) {
+      const auto encodedPageSize = file_exchange::encodePageSize(page.size());
+      contents.append(
+          reinterpret_cast<const char*>(&encodedPageSize),
+          sizeof(file_exchange::PageSize));
+      contents.append(page);
+    }
+    return contents;
+  }
+
+  static uint32_t checksum(std::string_view contents) {
+    return folly::crc32c(
+        reinterpret_cast<const uint8_t*>(contents.data()), contents.size());
+  }
+
+  static std::string fileLocation(
+      std::string_view path,
+      std::string_view contents) {
+    const file_exchange::ExchangeOutputFile outputFile{
+        .path = std::string{path},
+        .size = contents.size(),
+        .checksum = checksum(contents),
+    };
+    return outputFile.serialize();
+  }
+
+  std::unique_ptr<folly::test::TemporaryDirectory> temporaryDirectory_;
+  std::string rootDirectory_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(FileExchangeTest, multiplePagesShareOnePartitionFile) {
+  FileExchangeSink sink(rootDirectory_, "exchange", "task", 1);
+  sink.append(0, "first page");
+  sink.append(0, "second page");
+  const auto output = sink.finish();
+
+  const auto expectedPath =
+      fmt::format("{}/exchange/partition_0/task.bin", rootDirectory_);
+  const auto expectedContents = fileContents({"first page", "second page"});
+  const auto outputFile =
+      file_exchange::ExchangeOutputFile::deserialize(output.locations.at(0));
+  EXPECT_EQ(outputFile.path, expectedPath);
+  EXPECT_EQ(outputFile.size, expectedContents.size());
+  EXPECT_EQ(outputFile.checksum, checksum(expectedContents));
+  ASSERT_TRUE(std::filesystem::exists(expectedPath));
+
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    queue->addSourceLocked();
+  }
+  queue->noMoreSources();
+
+  FileExchangeSource source(output.locations.at(0), 0, queue, pool_.get());
+  const auto response =
+      source.request(std::numeric_limits<uint32_t>::max(), {}).get();
+  EXPECT_TRUE(response.atEnd);
+
+  bool atEnd = false;
+  ContinueFuture future;
+  auto stalePromise = ContinuePromise::makeEmpty();
+  std::vector<std::unique_ptr<SerializedPageBase>> pages;
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    pages = queue->dequeueLocked(
+        0,
+        std::numeric_limits<uint32_t>::max(),
+        &atEnd,
+        &future,
+        &stalePromise);
+  }
+
+  ASSERT_TRUE(atEnd);
+  ASSERT_EQ(pages.size(), 2);
+  EXPECT_EQ(pageData(*pages[0]), "first page");
+  EXPECT_EQ(pageData(*pages[1]), "second page");
+}
+
+TEST_F(FileExchangeTest, exchangeOutputFileRoundTrip) {
+  const file_exchange::ExchangeOutputFile expected{
+      .path = R"(test://root/path?size=inside&note="quoted")",
+      .size = 123,
+      .checksum = 456,
+  };
+
+  const auto serializedOutput = expected.serialize();
+  EXPECT_NE(serializedOutput.find(R"("checksum":456)"), std::string::npos);
+  EXPECT_EQ(serializedOutput.find(R"("crc32c")"), std::string::npos);
+  EXPECT_TRUE(file_exchange::ExchangeOutputFile::serialized(serializedOutput));
+  EXPECT_FALSE(file_exchange::ExchangeOutputFile::serialized("file://path"));
+  const auto actual =
+      file_exchange::ExchangeOutputFile::deserialize(serializedOutput);
+  EXPECT_EQ(actual.path, expected.path);
+  EXPECT_EQ(actual.size, expected.size);
+  EXPECT_EQ(actual.checksum, expected.checksum);
+}
+
+TEST_F(FileExchangeTest, pageSizeRoundTrip) {
+  for (const uint64_t size : std::initializer_list<uint64_t>{
+           0,
+           1,
+           1'024,
+           std::numeric_limits<uint64_t>::max(),
+       }) {
+    EXPECT_EQ(
+        file_exchange::decodePageSize(file_exchange::encodePageSize(size)),
+        size);
+  }
+}
+
+TEST_F(FileExchangeTest, usesRegisteredFileSystemForStoragePath) {
+  const auto rootDirectory = fmt::format("faulty:{}", rootDirectory_);
+  FileExchangeSink sink(rootDirectory, "exchange", "task", 1);
+  sink.append(0, "page");
+  const auto output = sink.finish();
+
+  EXPECT_EQ(
+      file_exchange::ExchangeOutputFile::deserialize(output.locations.at(0))
+          .path,
+      fmt::format("faulty:{}/exchange/partition_0/task.bin", rootDirectory_));
+  EXPECT_TRUE(
+      std::filesystem::exists(
+          fmt::format("{}/exchange/partition_0/task.bin", rootDirectory_)));
+
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    queue->addSourceLocked();
+  }
+  queue->noMoreSources();
+
+  FileExchangeSource source(output.locations.at(0), 0, queue, pool_.get());
+  const auto response =
+      source.request(std::numeric_limits<uint32_t>::max(), {}).get();
+  EXPECT_TRUE(response.atEnd);
+
+  bool atEnd = false;
+  ContinueFuture future;
+  auto stalePromise = ContinuePromise::makeEmpty();
+  std::vector<std::unique_ptr<SerializedPageBase>> pages;
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    pages = queue->dequeueLocked(
+        0,
+        std::numeric_limits<uint32_t>::max(),
+        &atEnd,
+        &future,
+        &stalePromise);
+  }
+  ASSERT_TRUE(atEnd);
+  ASSERT_EQ(pages.size(), 1);
+  EXPECT_EQ(pageData(*pages[0]), "page");
+}
+
+TEST_F(FileExchangeTest, chainedPageIsOnePage) {
+  FileExchangeSink sink(rootDirectory_, "exchange", "task", 1);
+  auto page = folly::IOBuf::copyBuffer("first ", 6);
+  page->appendToChain(folly::IOBuf::copyBuffer("second", 6));
+  sink.append(0, std::move(page));
+  const auto output = sink.finish();
+
+  const auto stats = sink.stats();
+  EXPECT_EQ(stats.at("totalBytesWritten"), 12);
+  EXPECT_EQ(stats.at("totalPages"), 1);
+
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    queue->addSourceLocked();
+  }
+  queue->noMoreSources();
+
+  FileExchangeSource source(output.locations.at(0), 0, queue, pool_.get());
+  const auto response =
+      source.request(std::numeric_limits<uint32_t>::max(), {}).get();
+  EXPECT_TRUE(response.atEnd);
+
+  bool atEnd = false;
+  ContinueFuture future;
+  auto stalePromise = ContinuePromise::makeEmpty();
+  std::vector<std::unique_ptr<SerializedPageBase>> pages;
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    pages = queue->dequeueLocked(
+        0,
+        std::numeric_limits<uint32_t>::max(),
+        &atEnd,
+        &future,
+        &stalePromise);
+  }
+
+  ASSERT_TRUE(atEnd);
+  ASSERT_EQ(pages.size(), 1);
+  EXPECT_EQ(pageData(*pages[0]), "first second");
+}
+
+TEST_F(FileExchangeTest, closePreventsReads) {
+  FileExchangeSink sink(rootDirectory_, "exchange", "task", 1);
+  sink.append(0, "page");
+  const auto output = sink.finish();
+
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  FileExchangeSource source(output.locations.at(0), 0, queue, pool_.get());
+
+  source.close();
+
+  const auto response =
+      source.request(std::numeric_limits<uint32_t>::max(), {}).get();
+  EXPECT_EQ(response.bytes, 0);
+  EXPECT_FALSE(response.atEnd);
+}
+
+TEST_F(FileExchangeTest, emptyPartitionsHaveNoCommittedLocation) {
+  FileExchangeSink sink(rootDirectory_, "exchange", "task", 2);
+  sink.append(1, "page");
+  const auto output = sink.finish();
+
+  EXPECT_EQ(output.locations.size(), 1);
+  EXPECT_EQ(output.locations.count(0), 0);
+  EXPECT_EQ(output.locations.count(1), 1);
+}
+
+TEST_F(FileExchangeTest, missingFileIsRejected) {
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  const file_exchange::ExchangeOutputFile outputFile{
+      .path = fmt::format("{}/missing.bin", rootDirectory_),
+      .size = 0,
+      .checksum = 0,
+  };
+  FileExchangeSource source(outputFile.serialize(), 0, queue, pool_.get());
+
+  EXPECT_THROW(
+      source.request(std::numeric_limits<uint32_t>::max(), {}),
+      VeloxRuntimeError);
+}
+
+TEST_F(FileExchangeTest, corruptedFileIsRejected) {
+  FileExchangeSink sink(rootDirectory_, "exchange", "task", 1);
+  sink.append(0, "page");
+  const auto output = sink.finish();
+
+  const auto filePath =
+      fmt::format("{}/exchange/partition_0/task.bin", rootDirectory_);
+  std::fstream file(filePath, std::ios::in | std::ios::out | std::ios::binary);
+  file.seekp(sizeof(file_exchange::PageSize));
+  file.put('P');
+  file.close();
+
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    queue->addSourceLocked();
+  }
+  queue->noMoreSources();
+
+  FileExchangeSource source(output.locations.at(0), 0, queue, pool_.get());
+  EXPECT_THROW(
+      source.request(std::numeric_limits<uint32_t>::max(), {}),
+      VeloxRuntimeError);
+}
+
+TEST_F(FileExchangeTest, incorrectFileSizeIsRejected) {
+  FileExchangeSink sink(rootDirectory_, "exchange", "task", 1);
+  sink.append(0, "page");
+  sink.finish();
+
+  const auto filePath =
+      fmt::format("{}/exchange/partition_0/task.bin", rootDirectory_);
+  const auto contents = fileContents({"page"});
+  const file_exchange::ExchangeOutputFile outputFile{
+      .path = filePath,
+      .size = contents.size() + 1,
+      .checksum = checksum(contents),
+  };
+  const auto location = outputFile.serialize();
+
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    queue->addSourceLocked();
+  }
+  queue->noMoreSources();
+
+  FileExchangeSource source(location, 0, queue, pool_.get());
+  EXPECT_THROW(
+      source.request(std::numeric_limits<uint32_t>::max(), {}),
+      VeloxRuntimeError);
+}
+
+TEST_F(FileExchangeTest, truncatedPageIsRejected) {
+  const auto filePath = fmt::format("{}/truncated.bin", rootDirectory_);
+  std::ofstream file(filePath, std::ios::binary);
+  const auto encodedPageSize = file_exchange::encodePageSize(10);
+  file.write(
+      reinterpret_cast<const char*>(&encodedPageSize),
+      sizeof(file_exchange::PageSize));
+  file.write("short", 5);
+  file.close();
+
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+  {
+    std::lock_guard<std::mutex> lock(queue->mutex());
+    queue->addSourceLocked();
+  }
+  queue->noMoreSources();
+
+  FileExchangeSource source(
+      fileLocation(filePath, fileContents({"short"})), 0, queue, pool_.get());
+  EXPECT_THROW(
+      source.request(std::numeric_limits<uint32_t>::max(), {}),
+      VeloxRuntimeError);
+}
+
+} // namespace
+} // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:

Add the reusable Velox file implementation of durable exchange. `FileExchangeSink` writes one task-attempt file per non-empty destination partition, preserving page boundaries over serialized IOBuf chains, and `FileExchangeSource` reads those committed locations through the standard exchange-source interface.

Keep integrity backend-private to the file implementation. The sink computes the physical file size and CRC32C over page-size headers plus payload bytes. The source validates the advertised size before reading and validates the streamed CRC32C before publishing end-of-source. This does not change generic durable-exchange or Cosco interfaces.


### Execution layout

Write side — one sink per producer task attempt, one file per non-empty destination partition:

```
+-------------------+       +----------------------+       +--------------------------+
| Producer task 0   | ----> | FileExchangeSink 0   | ----> | partition_0/task0.bin    |
| task attempt 0    |       |                      |       | [size][page][size][page] |
+-------------------+       | PartitionWriter[0]   |       +--------------------------+
                            | PartitionWriter[1]   | ----> | partition_1/task0.bin    |
                            +----------------------+       | [size][page][size][page] |
                                                           +--------------------------+

+-------------------+       +----------------------+       +--------------------------+
| Producer task 1   | ----> | FileExchangeSink 1   | ----> | partition_0/task1.bin    |
| task attempt 0    |       |                      |       +--------------------------+
+-------------------+       | PartitionWriter[0]   | ----> | partition_1/task1.bin    |
                            | PartitionWriter[1]   |       +--------------------------+
                            +----------------------+
```

Every `PartitionWriter::append()` writes the page-size header followed by the complete serialized page and incrementally updates both the physical byte count and CRC32C over those exact bytes. At `finish()`, each non-empty file becomes one opaque committed location:

```
+---------------------------------------------------------------+
| ExchangeOutputFile                                            |
| path:     partition_0/task0.bin                                |
| size:     complete physical file size                          |
| checksum: CRC32C of every page-size header and page payload    |
+---------------------------------------------------------------+
```

Empty partitions produce neither a file nor a location.

Read side — exactly one `FileExchangeSource` per committed file:

```
+--------------------------+      +----------------------+
| partition_0/task0.bin    | ---> | FileExchangeSource 0 | --\
| {size, checksum}         |      +----------------------+   \
+--------------------------+                                  \
                                                               +----------------------+     +-------------------+
+--------------------------+      +----------------------+     | Shared ExchangeQueue | --> | Exchange operator |
| partition_0/task1.bin    | ---> | FileExchangeSource 1 | --->| for consumer         |     +-------------------+
| {size, checksum}         |      +----------------------+     | partition 0          |
+--------------------------+                                  /
                                                             /
+--------------------------+      +----------------------+   /
| partition_0/task2.bin    | ---> | FileExchangeSource 2 | --/
| {size, checksum}         |      +----------------------+
+--------------------------+
```

Each source opens and sequentially reads only its own file. It validates the committed size when opening, updates CRC32C as it reads complete pages, and calls `verifyChecksum()` before publishing successful EOF. A `request(maxBytes)` may enqueue multiple complete pages but never splits a page. Files from all successful producer tasks therefore fan into the consumer partition's shared exchange queue.

------------- Change Log (Delete before merge) ---------------

2026-08-26 10:06 PDT: Folded in the filesystem-abstraction refactor. Sink and source storage operations now use Velox `FileSystem`, enabling registered URI schemes such as internal `ws://`; added registered-filesystem regression coverage.

2026-08-26 11:10 PDT: Replaced the hand-built nested URI and query-parameter encoding with backend-private `file_exchange::ExchangeOutputFile` JSON serialization. The object carries `path`, `size`, and generic `checksum` metadata; the checksum algorithm remains CRC32C, and Axel continues to receive only an opaque string.

2026-08-26 12:04 PDT: Simplified source cancellation ownership. `close()` now only publishes cancellation; file resources remain alive until source destruction, removing the read/close mutex. Successful EOF verifies the completed checksum before publishing the terminal marker, while cancellation reports no successful end.

2026-08-26 13:43 PDT: Removed the debug-only `TestValue` cancellation hook and replaced its timing-dependent test with deterministic close-before-request coverage that runs in optimized builds.

2026-08-26 14:00 PDT: Removed the unused per-task `.done` marker file. Successful `finish()` and its returned checksummed output locations are the sole commit signal.

2026-08-26 14:09 PDT: Consolidated sink finalization into `closeWriter(partition)`, which returns an optional `ExchangeOutputFile`. `finish()` consumes present descriptors in one pass; `abort()` ignores them.

2026-08-26 14:37 PDT: Moved physical append, byte accounting, and incremental checksum maintenance into `PartitionWriter::append()` and clarified local writer naming.

2026-08-26 14:50 PDT: Renamed the backend-local namespace from `fileexchange` to idiomatic `file_exchange`.

2026-08-26 15:05 PDT: Renamed the lazy writer accessor from `writer(partition)` to `partitionWriter(partition)` for consistency with the `PartitionWriter` type and local naming.

2026-08-26 16:19 PDT: Simplified source cancellation to a request-level guard. A request rejected after `close()` returns immediately; a request already accepted completes its byte budget or EOF without repeated cancellation checks.

2026-08-26 16:33 PDT: Kept the accepted-request path linear: `request()` now opens the file before its page loop, `readPage()` only reads, and the response uses the locally observed EOF result instead of locking the exchange queue to reread `atEnd_`.

2026-08-26 17:18 PDT: Moved the duplicate `endEnqueued_` guard ahead of checksum verification. The guard remains under the exchange-queue mutex; repeated terminal publication now returns before any validation or queue work.

Reviewed By: xiaoxmeng

Differential Revision: D102471442


