### PR TITLE
test(velox): Cover TIMESTAMP in TableEvolutionFuzzer (#18873)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -1285,8 +1285,10 @@ std::string TableEvolutionFuzzer::makeNewName() {
   return fmt::format("name_{}", ++sequenceNumber_);
 }
 
-TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth) {
-  // All types that can be written to file directly.
+TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth, bool allowTimestamp) {
+  // All types that can be written to file directly. TIMESTAMP has no widening
+  // target, so evolveType() and liftToType() leave it alone through their
+  // default arms; it is excluded from map keys by hasUnsupportedMapKey().
   static const std::vector<TypePtr> scalarTypes = {
       BOOLEAN(),
       TINYINT(),
@@ -1297,18 +1299,44 @@ TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth) {
       DOUBLE(),
       VARCHAR(),
       VARBINARY(),
+      TIMESTAMP(),
   };
-  return vectorFuzzer_.randType(scalarTypes, maxDepth);
+  // Same set without TIMESTAMP, for bucket columns. Bucketing a timestamp
+  // breaks the bucket-conversion invariant asserted in
+  // HiveSplitReader::bucketConversionRows(): a row read from the file for
+  // bucket B must hash to a partition congruent to B modulo the original
+  // bucket count. Whatever the writer hashed a timestamp to does not agree
+  // with what HivePartitionFunction computes at read time, so those rows land
+  // in the wrong bucket. Excluded at every nesting depth, not just the top
+  // level, because a bucket column may be a row/array/map.
+  static const std::vector<TypePtr> nonTimestampScalarTypes = {
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      VARBINARY(),
+  };
+  return vectorFuzzer_.randType(
+      allowTimestamp ? scalarTypes : nonTimestampScalarTypes, maxDepth);
 }
 
 RowTypePtr TableEvolutionFuzzer::makeInitialSchema(
+    const std::vector<column_index_t>& bucketColumnIndices,
     const std::vector<std::string>& additionalColumnNames,
     const std::vector<TypePtr>& additionalColumnTypes) {
+  const folly::F14FastSet<column_index_t> bucketColumns(
+      bucketColumnIndices.begin(), bucketColumnIndices.end());
   std::vector<std::string> names(config_.columnCount);
   std::vector<TypePtr> types(config_.columnCount);
   for (int i = 0; i < config_.columnCount; ++i) {
     names[i] = makeNewName();
-    types[i] = makeNewType(3);
+    // Bucket columns are never evolved (evolveRowType skips them), so keeping
+    // TIMESTAMP out here is enough to keep it out of bucketing entirely.
+    types[i] = makeNewType(3, /*allowTimestamp=*/bucketColumns.count(i) == 0);
   }
 
   // Add additional columns from generateRemainingFilters
@@ -1407,8 +1435,8 @@ std::vector<TableEvolutionFuzzer::Setup> TableEvolutionFuzzer::makeSetups(
   std::vector<Setup> setups(config_.evolutionCount);
   for (int i = 0; i < config_.evolutionCount; ++i) {
     if (i == 0) {
-      setups[i].schema =
-          makeInitialSchema(additionalColumnNames, additionalColumnTypes);
+      setups[i].schema = makeInitialSchema(
+          bucketColumnIndices, additionalColumnNames, additionalColumnTypes);
     } else {
       setups[i].schema = evolveRowType(
           *setups[i - 1].schema, bucketColumnIndices, columnNameMapping);

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -173,9 +173,13 @@ class TableEvolutionFuzzer {
 
   std::string makeNewName();
 
-  TypePtr makeNewType(int maxDepth);
+  /// When 'allowTimestamp' is false, TIMESTAMP is left out of the generated
+  /// type, at any nesting depth. Used for bucket columns; see
+  /// makeInitialSchema().
+  TypePtr makeNewType(int maxDepth, bool allowTimestamp = true);
 
   RowTypePtr makeInitialSchema(
+      const std::vector<column_index_t>& bucketColumnIndices = {},
       const std::vector<std::string>& additionalColumnNames = {},
       const std::vector<TypePtr>& additionalColumnTypes = {});
 


### PR DESCRIPTION
Summary:

`TableEvolutionFuzzer::makeNewType()` drew from nine scalar types and left
`TIMESTAMP` out. The comment above the list says "All types that can be written
to file directly", which is no longer accurate -- the writers round-trip
TIMESTAMP fine, and `NimbleWriterFuzzer::supportedScalarTypes()` already fuzzes
it. Nothing recorded why it was missing, so this reads as an unexamined gap
rather than a decision.

Adding it needs nothing else for the evolution machinery. TIMESTAMP has no
widening target, so `evolveType()` returns it unchanged through its default arm
and `liftToType()` passes the vector through untouched via `default: return
input`. `hasUnsupportedMapKey()` already rejects TIMESTAMP map keys, matching
what `FlatMapColumnWriter` supports.

It does need one exclusion. A TIMESTAMP bucket column breaks the
bucket-conversion invariant asserted in
`HiveSplitReader::bucketConversionRows()`:

    VELOX_CHECK_EQ((partitions_[i] - bucketToKeep) % partitionBucketCount, 0);

A row read out of the file for bucket B must hash to a partition congruent to B
modulo the original bucket count. For a timestamp the partition
`HivePartitionFunction` computes at read time does not agree with what the row
was bucketed by at write time, so rows land outside their file's bucket and the
check fires. So `makeNewType()` takes an `allowTimestamp` flag and
`makeInitialSchema()` passes false for bucket columns -- at every nesting depth,
since a bucket column may be a row/array/map. Bucket columns are never evolved
(`evolveRowType()` skips them), so excluding them at schema creation keeps
TIMESTAMP out of bucketing entirely.

Whether that mismatch is a bug worth fixing or a genuinely unsupported
combination is the subject of the diff on top; this one only stops the gap in
value-type coverage from being blocked on it.

Reviewed By: prashantgolash

Differential Revision: D118900597


