### PR TITLE
fix(velox): Bucket on TIMESTAMP in TableEvolutionFuzzer by matching write precision (#18874)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -1285,8 +1285,10 @@ std::string TableEvolutionFuzzer::makeNewName() {
   return fmt::format("name_{}", ++sequenceNumber_);
 }
 
-TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth) {
-  // All types that can be written to file directly.
+TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth, bool allowTimestamp) {
+  // All types that can be written to file directly. TIMESTAMP has no widening
+  // target, so evolveType() and liftToType() leave it alone through their
+  // default arms; it is excluded from map keys by hasUnsupportedMapKey().
   static const std::vector<TypePtr> scalarTypes = {
       BOOLEAN(),
       TINYINT(),
@@ -1297,18 +1299,44 @@ TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth) {
       DOUBLE(),
       VARCHAR(),
       VARBINARY(),
+      TIMESTAMP(),
   };
-  return vectorFuzzer_.randType(scalarTypes, maxDepth);
+  // Same set without TIMESTAMP, for bucket columns. Bucketing a timestamp
+  // breaks the bucket-conversion invariant asserted in
+  // HiveSplitReader::bucketConversionRows(): a row read from the file for
+  // bucket B must hash to a partition congruent to B modulo the original
+  // bucket count. Whatever the writer hashed a timestamp to does not agree
+  // with what HivePartitionFunction computes at read time, so those rows land
+  // in the wrong bucket. Excluded at every nesting depth, not just the top
+  // level, because a bucket column may be a row/array/map.
+  static const std::vector<TypePtr> nonTimestampScalarTypes = {
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      VARBINARY(),
+  };
+  return vectorFuzzer_.randType(
+      allowTimestamp ? scalarTypes : nonTimestampScalarTypes, maxDepth);
 }
 
 RowTypePtr TableEvolutionFuzzer::makeInitialSchema(
+    const std::vector<column_index_t>& bucketColumnIndices,
     const std::vector<std::string>& additionalColumnNames,
     const std::vector<TypePtr>& additionalColumnTypes) {
+  const folly::F14FastSet<column_index_t> bucketColumns(
+      bucketColumnIndices.begin(), bucketColumnIndices.end());
   std::vector<std::string> names(config_.columnCount);
   std::vector<TypePtr> types(config_.columnCount);
   for (int i = 0; i < config_.columnCount; ++i) {
     names[i] = makeNewName();
-    types[i] = makeNewType(3);
+    // Bucket columns are never evolved (evolveRowType skips them), so keeping
+    // TIMESTAMP out here is enough to keep it out of bucketing entirely.
+    types[i] = makeNewType(3, /*allowTimestamp=*/bucketColumns.count(i) == 0);
   }
 
   // Add additional columns from generateRemainingFilters
@@ -1407,8 +1435,8 @@ std::vector<TableEvolutionFuzzer::Setup> TableEvolutionFuzzer::makeSetups(
   std::vector<Setup> setups(config_.evolutionCount);
   for (int i = 0; i < config_.evolutionCount; ++i) {
     if (i == 0) {
-      setups[i].schema =
-          makeInitialSchema(additionalColumnNames, additionalColumnTypes);
+      setups[i].schema = makeInitialSchema(
+          bucketColumnIndices, additionalColumnNames, additionalColumnTypes);
     } else {
       setups[i].schema = evolveRowType(
           *setups[i - 1].schema, bucketColumnIndices, columnNameMapping);

--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -160,6 +160,8 @@ VectorFuzzer::Options makeVectorFuzzerOptions(double nullRatio = 0) {
   options.allowSlice = false;
   options.nullRatio = nullRatio;
   options.containerHasNulls = nullRatio > 0;
+  options.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
   return options;
 }
 
@@ -1285,7 +1287,7 @@ std::string TableEvolutionFuzzer::makeNewName() {
   return fmt::format("name_{}", ++sequenceNumber_);
 }
 
-TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth, bool allowTimestamp) {
+TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth) {
   // All types that can be written to file directly. TIMESTAMP has no widening
   // target, so evolveType() and liftToType() leave it alone through their
   // default arms; it is excluded from map keys by hasUnsupportedMapKey().
@@ -1301,42 +1303,17 @@ TypePtr TableEvolutionFuzzer::makeNewType(int maxDepth, bool allowTimestamp) {
       VARBINARY(),
       TIMESTAMP(),
   };
-  // Same set without TIMESTAMP, for bucket columns. Bucketing a timestamp
-  // breaks the bucket-conversion invariant asserted in
-  // HiveSplitReader::bucketConversionRows(): a row read from the file for
-  // bucket B must hash to a partition congruent to B modulo the original
-  // bucket count. Whatever the writer hashed a timestamp to does not agree
-  // with what HivePartitionFunction computes at read time, so those rows land
-  // in the wrong bucket. Excluded at every nesting depth, not just the top
-  // level, because a bucket column may be a row/array/map.
-  static const std::vector<TypePtr> nonTimestampScalarTypes = {
-      BOOLEAN(),
-      TINYINT(),
-      SMALLINT(),
-      INTEGER(),
-      BIGINT(),
-      REAL(),
-      DOUBLE(),
-      VARCHAR(),
-      VARBINARY(),
-  };
-  return vectorFuzzer_.randType(
-      allowTimestamp ? scalarTypes : nonTimestampScalarTypes, maxDepth);
+  return vectorFuzzer_.randType(scalarTypes, maxDepth);
 }
 
 RowTypePtr TableEvolutionFuzzer::makeInitialSchema(
-    const std::vector<column_index_t>& bucketColumnIndices,
     const std::vector<std::string>& additionalColumnNames,
     const std::vector<TypePtr>& additionalColumnTypes) {
-  const folly::F14FastSet<column_index_t> bucketColumns(
-      bucketColumnIndices.begin(), bucketColumnIndices.end());
   std::vector<std::string> names(config_.columnCount);
   std::vector<TypePtr> types(config_.columnCount);
   for (int i = 0; i < config_.columnCount; ++i) {
     names[i] = makeNewName();
-    // Bucket columns are never evolved (evolveRowType skips them), so keeping
-    // TIMESTAMP out here is enough to keep it out of bucketing entirely.
-    types[i] = makeNewType(3, /*allowTimestamp=*/bucketColumns.count(i) == 0);
+    types[i] = makeNewType(3);
   }
 
   // Add additional columns from generateRemainingFilters
@@ -1435,8 +1412,8 @@ std::vector<TableEvolutionFuzzer::Setup> TableEvolutionFuzzer::makeSetups(
   std::vector<Setup> setups(config_.evolutionCount);
   for (int i = 0; i < config_.evolutionCount; ++i) {
     if (i == 0) {
-      setups[i].schema = makeInitialSchema(
-          bucketColumnIndices, additionalColumnNames, additionalColumnTypes);
+      setups[i].schema =
+          makeInitialSchema(additionalColumnNames, additionalColumnTypes);
     } else {
       setups[i].schema = evolveRowType(
           *setups[i - 1].schema, bucketColumnIndices, columnNameMapping);

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -173,9 +173,13 @@ class TableEvolutionFuzzer {
 
   std::string makeNewName();
 
-  TypePtr makeNewType(int maxDepth);
+  /// When 'allowTimestamp' is false, TIMESTAMP is left out of the generated
+  /// type, at any nesting depth. Used for bucket columns; see
+  /// makeInitialSchema().
+  TypePtr makeNewType(int maxDepth, bool allowTimestamp = true);
 
   RowTypePtr makeInitialSchema(
+      const std::vector<column_index_t>& bucketColumnIndices = {},
       const std::vector<std::string>& additionalColumnNames = {},
       const std::vector<TypePtr>& additionalColumnTypes = {});
 

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -173,13 +173,9 @@ class TableEvolutionFuzzer {
 
   std::string makeNewName();
 
-  /// When 'allowTimestamp' is false, TIMESTAMP is left out of the generated
-  /// type, at any nesting depth. Used for bucket columns; see
-  /// makeInitialSchema().
-  TypePtr makeNewType(int maxDepth, bool allowTimestamp = true);
+  TypePtr makeNewType(int maxDepth);
 
   RowTypePtr makeInitialSchema(
-      const std::vector<column_index_t>& bucketColumnIndices = {},
       const std::vector<std::string>& additionalColumnNames = {},
       const std::vector<TypePtr>& additionalColumnTypes = {});
 


### PR DESCRIPTION
Summary:

The parent kept TIMESTAMP out of bucket columns because a timestamp bucket
column tripped the bucket-conversion invariant in
`HiveSplitReader::bucketConversionRows()`. This removes that exclusion by
fixing the actual cause.

There is no type-level limitation here, and it is worth being precise about
why. The assertion is

    VELOX_CHECK_EQ((partitions_[i] - bucketToKeep) % partitionBucketCount, 0);

and it is pure arithmetic: `(h % (oldCount*k)) % oldCount == h % oldCount` holds
for any hash `h` and any type. Its one requirement is that the same row hashes
identically at write time and at read time. Nothing about that is specific to
timestamps.

What broke it is that the row did not survive the round trip. Dumping the
offending rows at the assertion showed every read-back timestamp landing on an
exact millisecond -- `1951-03-14T12:07:38.299000000`,
`2007-05-30T12:31:34.243000000`, `2021-05-13T02:10:47.618000000` -- while
`randTimestamp()` generates nanos as `rand<int64_t>(rng) % 1'000'000'000`, which
is arbitrary. The write path truncates sub-millisecond precision. So the writer
bucketed the full-precision value, the reader hashed the truncated one, and the
row landed outside its file's bucket.

The fix is to generate at the precision the format actually preserves, so the
bucket key round-trips. That restores the invariant and lets TIMESTAMP be a
bucket column like any other type, so `makeNewType()` goes back to a single type
pool and `makeInitialSchema()` loses the bucket-column plumbing the parent added.

Trade-off worth naming: this lowers generated timestamp precision for the whole
fuzzer, not just bucket columns -- the vector is fuzzed per schema, so the
setting is global. Sub-millisecond timestamps are no longer exercised anywhere
in this fuzzer. That is a real reduction, and the right long-term answer is for
the write path not to truncate; until then, generating values the format cannot
store only produces failures that say "the format truncated", which is not what
this fuzzer is for.

Reviewed By: xiaoxmeng

Differential Revision: D118995939


