### PR TITLE
feat(nimble): Add Elias-Fano integer encoding (#18875)

### DIFF
--- a/velox/dwio/nimble/common/Types.cpp
+++ b/velox/dwio/nimble/common/Types.cpp
@@ -49,6 +49,7 @@ constexpr auto kEncodingTypes =
         {EncodingType::DeltaBlock, "DeltaBlock"},
         {EncodingType::SharedDictionary, "SharedDictionary"},
         {EncodingType::Slice, "Slice"},
+        {EncodingType::EliasFano, "EliasFano"},
     });
 
 constexpr auto kReadOnlyEncodingTypes = std::to_array<EncodingType>({

--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -166,6 +166,12 @@ enum class EncodingType {
   // decode time. Produced only by EncodingSliceFactory, never by encoding
   // selection.
   Slice = 23,
+  // Stores non-decreasing integer streams using Elias-Fano coding. This is
+  // suited to sparse sorted identifiers and offsets that need compact storage,
+  // positional access, and lower-bound search.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
+  EliasFano = 24,
 };
 std::string toString(EncodingType encodingType);
 /// Returns the encoding type for 'name'. Throws if 'name' is unknown.

--- a/velox/dwio/nimble/common/tests/TypesTest.cpp
+++ b/velox/dwio/nimble/common/tests/TypesTest.cpp
@@ -51,6 +51,7 @@ TEST(TypesTest, encodingTypeStringConversion) {
       {EncodingType::Fsst, "Fsst"},
       {EncodingType::Huffman, "Huffman"},
       {EncodingType::DeltaBlock, "DeltaBlock"},
+      {EncodingType::EliasFano, "EliasFano"},
   };
   for (const auto& [type, name] : testCases) {
     SCOPED_TRACE(name);

--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
   selection/EncodingSelectionPolicy.cpp
   selection/Statistics.cpp
   views/DeltaBlockEncodingView.h
+  views/EliasFanoEncodingView.h
   views/EncodingViewFactory.cpp
   views/HuffmanEncodingView.h
   views/TrivialEncodingView.h
@@ -101,6 +102,7 @@ add_library(
   ForEncoding.h
   FixedBitWidthEncoding.h
   EncodingSliceFactory.h
+  EliasFanoEncoding.h
   DictionaryEncoding.h
   DeltaEncoding.h
   DeltaBlockEncoding.h

--- a/velox/dwio/nimble/encodings/EliasFanoEncoding.h
+++ b/velox/dwio/nimble/encodings/EliasFanoEncoding.h
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include <fmt/format.h>
+#include <folly/Range.h>
+#include <folly/compression/elias_fano/EliasFanoCoding.h>
+#include <folly/lang/Bits.h>
+
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
+
+namespace facebook::nimble {
+
+/// Encodes non-decreasing integers for compact positional and lower-bound
+/// access. This encoding is most useful for sparse sorted identifiers and
+/// offsets where random lookup matters as much as sequential decoding.
+template <typename T>
+class EliasFanoEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  /// Opens an Elias-Fano stream without copying its encoded payload.
+  EliasFanoEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  /// Rewinds sequential decoding to the start of the stream.
+  void reset() final;
+
+  /// Advances the sequential decoder by 'rowCount' rows.
+  void skip(uint32_t rowCount) final;
+
+  /// Materializes rows from the current sequential decoder position.
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  /// Materializes an absolute row range without changing sequential state.
+  /// This supports concurrent range reads through EncodingView.
+  void materializeAt(uint32_t offset, uint32_t rowCount, physicalType* output)
+      const;
+
+  /// Returns the value at an absolute row without changing sequential state.
+  /// This supports random index-key reconstruction and EncodingView reads.
+  physicalType valueAt(uint32_t row) const;
+
+  /// Returns the first row whose value is at least 'value'. This supports
+  /// value-to-row lookup in sorted index streams.
+  uint32_t lowerBound(physicalType value) const;
+
+  /// Decodes selected rows through the generic visitor interface.
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  /// Encodes a non-empty, non-decreasing integer span.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Encodes rows [offset, offset + length) as a standalone Elias-Fano stream.
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Estimates encoded bytes or returns nullopt for unsupported input.
+  static std::optional<uint64_t> estimateSize(
+      std::span<const physicalType> values);
+
+  /// Returns a human-readable description of the encoded layout.
+  std::string debugString(int offset) const final;
+
+ private:
+  static_assert(
+      std::is_integral_v<T> && !std::is_same_v<T, bool>,
+      "EliasFanoEncoding only supports non-bool integer types.");
+
+  using Encoder =
+      folly::compression::EliasFanoEncoder<uint64_t, uint64_t, 128, 256>;
+  using Reader = folly::compression::EliasFanoReader<Encoder>;
+
+  // Number of bytes between the common prefix and the Folly payload.
+  static constexpr uint8_t kHeaderSize{/*base=*/sizeof(uint64_t) +
+                                       /*lowerBits=*/sizeof(uint8_t) +
+                                       /*upperBytes=*/sizeof(uint32_t)};
+
+  // Makes Folly's word-at-a-time payload reads safe at the end of the stream.
+  static constexpr size_t kPayloadPaddingBytes{
+      folly::compression::kUpperTrailingBytes};
+
+  // Aligns Folly's uint64 pointer tables while encoding into the arena.
+  static constexpr size_t kPayloadAlignment{alignof(uint64_t)};
+
+  // Folly's encoder writes lower values with writeBits56().
+  static constexpr uint8_t kMaxLowerBits{56};
+
+  // Moves signed values into monotonically ordered unsigned space.
+  static constexpr uint64_t kSignMask{
+      uint64_t{1} << (sizeof(physicalType) * 8 - 1)};
+
+  // Signed logical types use an unsigned physical type of the same width, so
+  // toggling its sign bit maps two's-complement order to unsigned order.
+  static uint64_t toOrdered(physicalType value) {
+    if constexpr (std::is_signed_v<T>) {
+      using UnsignedPhysicalType = std::make_unsigned_t<physicalType>;
+      return static_cast<uint64_t>(static_cast<UnsignedPhysicalType>(value)) ^
+          kSignMask;
+    } else {
+      return static_cast<uint64_t>(value);
+    }
+  }
+
+  // Restores a physical value from its unsigned sortable representation.
+  static physicalType fromOrdered(uint64_t value) {
+    if constexpr (std::is_signed_v<T>) {
+      using UnsignedPhysicalType = std::make_unsigned_t<physicalType>;
+      return static_cast<physicalType>(
+          static_cast<UnsignedPhysicalType>(value ^ kSignMask));
+    } else {
+      return static_cast<physicalType>(value);
+    }
+  }
+
+  // Validates monotonicity and derives the Folly payload layout.
+  static std::optional<Encoder::Layout> layoutForValues(
+      std::span<const physicalType> values,
+      uint64_t& base);
+
+  // Returns the format-defined payload offset for the selected prefix size.
+  static constexpr size_t payloadOffset(uint32_t prefixSize) {
+    return (prefixSize + kHeaderSize + kPayloadAlignment - 1) &
+        ~(kPayloadAlignment - 1);
+  }
+
+  // Serializes values supplied relative to 'base' into a complete stream.
+  // Invokes 'relativeValueAt' exactly once per row in ascending row order.
+  template <typename RelativeValueAt>
+  static std::string_view encode(
+      uint32_t rowCount,
+      uint64_t base,
+      const Encoder::Layout& layout,
+      RelativeValueAt&& relativeValueAt,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
+  // Reads an absolute row with an independent, allocation-free cursor.
+  physicalType readValue(uint32_t row) const;
+
+  struct RandomReadCache {
+    uint64_t encodingId{0};
+    const uint8_t* upper{nullptr};
+    std::optional<Reader> reader;
+  };
+
+  // Returns this thread's reusable cursor for random reads on this encoding.
+  Reader& randomReader() const;
+
+  // Assigns a never-reused key so thread-local cursors survive address reuse.
+  static uint64_t nextEncodingId() {
+    static /* library-local */ std::atomic_uint64_t counter{1};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  // Reads and advances the stateful sequential cursor.
+  physicalType readNextValue();
+
+  // Creates the stateful cursor on its first sequential operation.
+  Reader& ensureReader();
+
+  // Absolute value represented by relative value zero in the payload.
+  uint64_t base_{0};
+
+  // Bit width of each lower-value component in the Folly layout.
+  uint8_t lowerBits_{0};
+
+  // Byte length of the unary-coded upper-value component.
+  uint32_t upperBytes_{0};
+
+  // Non-owning parsed view over the serialized Folly payload.
+  Encoder::CompressedList list_;
+
+  // Identifies this parsed stream in the per-thread random-read cache.
+  const uint64_t encodingId_{nextEncodingId()};
+
+  // Cursor created on demand for the stateful Encoding interface.
+  std::optional<Reader> reader_;
+
+  // Next logical row consumed by the stateful Encoding interface.
+  uint32_t row_{0};
+};
+
+template <typename T>
+EliasFanoEncoding<T>::EliasFanoEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /*stringBufferFactory*/,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options} {
+  NIMBLE_CHECK_FILE_GT(
+      this->rowCount(), 0, "EliasFano encoding requires at least one row.");
+  const auto dataOffset = this->dataOffset();
+  NIMBLE_CHECK_FILE_LE(dataOffset, data.size(), "Truncated EliasFano header.");
+  NIMBLE_CHECK_FILE_GE(
+      data.size() - dataOffset, kHeaderSize, "Truncated EliasFano header.");
+  const char* position = data.data() + dataOffset;
+  base_ = encoding::read<uint64_t>(position);
+  lowerBits_ = encoding::read<uint8_t>(position);
+  upperBytes_ = encoding::readUint32(position);
+  NIMBLE_CHECK_FILE_LE(
+      lowerBits_, kMaxLowerBits, "Invalid EliasFano lower bit count.");
+  NIMBLE_CHECK_FILE_GE(
+      static_cast<uint64_t>(upperBytes_) * 8,
+      this->rowCount(),
+      "Invalid EliasFano upper bit count.");
+
+  // Reconstructing the layout performs arithmetic only; it does not scan or
+  // decode values.
+  const auto layout = Encoder::Layout::fromInternalSizes(
+      lowerBits_, upperBytes_, this->rowCount());
+  const auto encodedPayloadOffset = payloadOffset(dataOffset);
+  NIMBLE_CHECK_FILE_LE(
+      encodedPayloadOffset, data.size(), "Invalid EliasFano payload size.");
+  position = data.data() + encodedPayloadOffset;
+  const auto remainingBytes = data.size() - encodedPayloadOffset;
+  NIMBLE_CHECK_FILE_GE(
+      remainingBytes, kPayloadPaddingBytes, "Invalid EliasFano payload size.");
+  NIMBLE_CHECK_FILE_LE(
+      layout.bytes(),
+      remainingBytes - kPayloadPaddingBytes,
+      "Invalid EliasFano payload size.");
+  folly::ByteRange range{
+      reinterpret_cast<const uint8_t*>(position), layout.bytes()};
+  // openList creates non-owning pointers into 'range' without allocation.
+  list_ = layout.openList(range);
+  uint64_t upperValueCount{0};
+  size_t upperByteOffset{0};
+  for (; upperByteOffset + sizeof(uint64_t) <= upperBytes_;
+       upperByteOffset += sizeof(uint64_t)) {
+    upperValueCount += std::popcount(
+        folly::loadUnaligned<uint64_t>(list_.upper + upperByteOffset));
+  }
+  if (upperByteOffset < upperBytes_) {
+    const auto remainingUpperBytes = upperBytes_ - upperByteOffset;
+    // The persisted trailing padding makes the final word readable.
+    const auto upperTail =
+        folly::loadUnaligned<uint64_t>(list_.upper + upperByteOffset) &
+        ((uint64_t{1} << (remainingUpperBytes * 8)) - 1);
+    upperValueCount += std::popcount(upperTail);
+  }
+  NIMBLE_CHECK_FILE_EQ(
+      upperValueCount, this->rowCount(), "Invalid EliasFano upper bits.");
+}
+
+template <typename T>
+void EliasFanoEncoding<T>::reset() {
+  if (reader_.has_value()) {
+    reader_->reset();
+  }
+  row_ = 0;
+}
+
+template <typename T>
+typename EliasFanoEncoding<T>::Reader& EliasFanoEncoding<T>::ensureReader() {
+  if (!reader_.has_value()) {
+    reader_.emplace(list_);
+  }
+  return *reader_;
+}
+
+template <typename T>
+typename EliasFanoEncoding<T>::Reader& EliasFanoEncoding<T>::randomReader()
+    const {
+  static thread_local RandomReadCache cache;
+  if (cache.encodingId != encodingId_ || cache.upper != list_.upper) {
+    cache.encodingId = encodingId_;
+    cache.upper = list_.upper;
+    cache.reader.emplace(list_);
+  }
+  return *cache.reader;
+}
+
+template <typename T>
+void EliasFanoEncoding<T>::skip(uint32_t rowCount) {
+  NIMBLE_CHECK_LE(row_, this->rowCount(), "Invalid encoding position.");
+  NIMBLE_CHECK_LE(
+      rowCount, this->rowCount() - row_, "Skipping past end of encoding.");
+  if (rowCount == 0) {
+    // Folly reports its initial before-first cursor as invalid for skip(0).
+    // The generic Encoding interface treats a zero-row advance as a no-op.
+    return;
+  }
+  const bool skipped = ensureReader().skip(rowCount);
+  NIMBLE_CHECK(skipped, "Unexpected end of EliasFano stream.");
+  row_ += rowCount;
+}
+
+template <typename T>
+typename EliasFanoEncoding<T>::physicalType EliasFanoEncoding<T>::readValue(
+    uint32_t row) const {
+  NIMBLE_CHECK_LT(row, this->rowCount(), "Reading past end of encoding.");
+  auto& reader = randomReader();
+  const bool found = reader.jump(row);
+  NIMBLE_CHECK(found, "Failed to seek EliasFano row.");
+  return fromOrdered(base_ + reader.value());
+}
+
+template <typename T>
+typename EliasFanoEncoding<T>::physicalType
+EliasFanoEncoding<T>::readNextValue() {
+  NIMBLE_CHECK_LT(row_, this->rowCount(), "Reading past end of encoding.");
+  auto& reader = ensureReader();
+  const bool advanced = reader.next();
+  NIMBLE_CHECK(advanced, "Unexpected end of EliasFano stream.");
+  ++row_;
+  return fromOrdered(base_ + reader.value());
+}
+
+template <typename T>
+typename EliasFanoEncoding<T>::physicalType EliasFanoEncoding<T>::valueAt(
+    uint32_t row) const {
+  return readValue(row);
+}
+
+template <typename T>
+uint32_t EliasFanoEncoding<T>::lowerBound(physicalType value) const {
+  const auto ordered = toOrdered(value);
+  if (ordered <= base_) {
+    return 0;
+  }
+  Reader reader{list_};
+  if (!reader.jumpTo(ordered - base_)) {
+    return this->rowCount();
+  }
+  return reader.position();
+}
+
+template <typename T>
+void EliasFanoEncoding<T>::materializeAt(
+    uint32_t offset,
+    uint32_t rowCount,
+    physicalType* output) const {
+  NIMBLE_CHECK_LE(offset, this->rowCount(), "Invalid encoding position.");
+  NIMBLE_CHECK_LE(
+      rowCount, this->rowCount() - offset, "Reading past end of encoding.");
+  if (rowCount == 0) {
+    // Zero-length reads are valid at any in-range offset.
+    return;
+  }
+
+  Reader reader{list_};
+  const bool found = reader.jump(offset);
+  NIMBLE_CHECK(found, "Failed to seek EliasFano row.");
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    output[i] = fromOrdered(base_ + reader.value());
+    if (i + 1 < rowCount) {
+      const bool advanced = reader.next();
+      NIMBLE_CHECK(advanced, "Unexpected end of EliasFano stream.");
+    }
+  }
+}
+
+template <typename T>
+void EliasFanoEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  NIMBLE_CHECK_LE(row_, this->rowCount(), "Invalid encoding position.");
+  NIMBLE_CHECK_LE(
+      rowCount, this->rowCount() - row_, "Reading past end of encoding.");
+  auto* output = static_cast<physicalType*>(buffer);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    output[i] = readNextValue();
+  }
+}
+
+template <typename T>
+template <typename DecoderVisitor>
+void EliasFanoEncoding<T>::readWithVisitor(
+    DecoderVisitor& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] { return readNextValue(); });
+}
+
+template <typename T>
+std::optional<typename EliasFanoEncoding<T>::Encoder::Layout> EliasFanoEncoding<
+    T>::layoutForValues(std::span<const physicalType> values, uint64_t& base) {
+  if (values.empty()) {
+    return std::nullopt;
+  }
+
+  base = toOrdered(values.front());
+  uint64_t previous = base;
+  for (size_t i = 1; i < values.size(); ++i) {
+    const auto current = toOrdered(values[i]);
+    if (current < previous) {
+      return std::nullopt;
+    }
+    previous = current;
+  }
+  return Encoder::Layout::fromUpperBoundAndSize(previous - base, values.size());
+}
+
+template <typename T>
+std::optional<uint64_t> EliasFanoEncoding<T>::estimateSize(
+    std::span<const physicalType> values) {
+  if (values.size() > std::numeric_limits<uint32_t>::max()) {
+    return std::nullopt;
+  }
+  uint64_t base;
+  const auto layout = layoutForValues(values, base);
+  if (!layout.has_value()) {
+    return std::nullopt;
+  }
+  const auto rowCount = static_cast<uint32_t>(values.size());
+  const auto maxPayloadOffset = std::max(
+      payloadOffset(EncodingPrefix::kFixedPrefixSize),
+      payloadOffset(
+          EncodingPrefix::serializedSize(rowCount, /*useVarint=*/true)));
+  return maxPayloadOffset + layout->bytes() + kPayloadPaddingBytes;
+}
+
+template <typename T>
+template <typename RelativeValueAt>
+std::string_view EliasFanoEncoding<T>::encode(
+    uint32_t rowCount,
+    uint64_t base,
+    const Encoder::Layout& layout,
+    RelativeValueAt&& relativeValueAt,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto payloadBytes = layout.bytes();
+  const auto prefixSize =
+      Encoding::serializePrefixSize(rowCount, options.useVarintRowCount);
+  const auto encodedPayloadOffset = payloadOffset(prefixSize);
+  const uint64_t encodingSize =
+      encodedPayloadOffset + payloadBytes + kPayloadPaddingBytes;
+  NIMBLE_CHECK_LE(
+      encodingSize,
+      std::numeric_limits<uint32_t>::max(),
+      "EliasFano encoding exceeds uint32 size.");
+
+  const auto allocationSize = encodingSize + kPayloadAlignment - 1;
+  void* reserved = buffer.reserve(allocationSize);
+  auto availableBytes = static_cast<size_t>(allocationSize);
+  NIMBLE_CHECK_NOT_NULL(
+      std::align(
+          kPayloadAlignment,
+          static_cast<size_t>(encodingSize),
+          reserved,
+          availableBytes));
+  auto* const encodedBegin = static_cast<char*>(reserved);
+  char* position = encodedBegin;
+  Encoding::serializePrefix(
+      EncodingType::EliasFano,
+      TypeTraits<T>::dataType,
+      rowCount,
+      options.useVarintRowCount,
+      position);
+  // The normalized base can require ten varint bytes for signed and unsigned
+  // 64-bit values. A fixed-width field is smaller in that case and keeps the
+  // payload offset constant.
+  encoding::write<uint64_t>(base, position);
+  encoding::write<uint8_t>(layout.numLowerBits, position);
+  encoding::writeUint32(static_cast<uint32_t>(layout.upper), position);
+  const auto payloadAlignmentPadding =
+      encodedPayloadOffset - static_cast<size_t>(position - encodedBegin);
+  std::memset(position, 0, payloadAlignmentPadding);
+  position += payloadAlignmentPadding;
+  NIMBLE_DCHECK_EQ(
+      reinterpret_cast<uintptr_t>(position) % kPayloadAlignment, 0);
+  folly::MutableByteRange payload{
+      reinterpret_cast<uint8_t*>(position), payloadBytes};
+  Encoder encoder{layout.openList(payload)};
+  for (uint32_t row{0}; row < rowCount; ++row) {
+    encoder.add(relativeValueAt(row));
+  }
+  encoder.finish();
+  position += payloadBytes;
+  std::memset(position, 0, kPayloadPaddingBytes);
+  position += kPayloadPaddingBytes;
+  NIMBLE_CHECK_EQ(
+      position - encodedBegin, encodingSize, "Encoding size mismatch.");
+  return {encodedBegin, static_cast<size_t>(encodingSize)};
+}
+
+template <typename T>
+std::string_view EliasFanoEncoding<T>::encode(
+    EncodingSelection<physicalType>& /*selection*/,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK_LE(
+      values.size(),
+      std::numeric_limits<uint32_t>::max(),
+      "EliasFano row count exceeds uint32.");
+  uint64_t base;
+  const auto layout = layoutForValues(values, base);
+  if (!layout.has_value()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "EliasFano requires non-empty non-decreasing values.");
+  }
+
+  return encode(
+      static_cast<uint32_t>(values.size()),
+      base,
+      *layout,
+      [&](uint32_t row) { return toOrdered(values[row]) - base; },
+      buffer,
+      options);
+}
+
+template <typename T>
+std::string_view EliasFanoEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  const EliasFanoEncoding<T> source{
+      buffer.getMemoryPool(), encoded, {}, options};
+  Reader reader{source.list_};
+  const bool foundFirst = reader.jump(offset);
+  NIMBLE_CHECK(foundFirst, "Failed to seek first EliasFano slice row.");
+  const auto firstRelative = reader.value();
+  const bool foundLast = reader.jump(offset + length - 1);
+  NIMBLE_CHECK(foundLast, "Failed to seek last EliasFano slice row.");
+  const auto lastRelative = reader.value();
+  const auto sliceBase = source.base_ + firstRelative;
+  const auto layout = Encoder::Layout::fromUpperBoundAndSize(
+      lastRelative - firstRelative, length);
+
+  const bool rewound = reader.jump(offset);
+  NIMBLE_CHECK(rewound, "Failed to rewind to first EliasFano slice row.");
+  // Encode directly from the compressed cursor. Generic slicing would first
+  // materialize the selected values into a temporary vector. Folly exposes
+  // scalar Reader::next() and Encoder::add() operations, and the new base and
+  // layout prevent copying the source payload as an encoded byte range.
+  return encode(
+      length,
+      sliceBase,
+      layout,
+      [&](uint32_t row) {
+        const auto relative = reader.value() - firstRelative;
+        if (row + 1 < length) {
+          const bool advanced = reader.next();
+          NIMBLE_CHECK(advanced, "Unexpected end of EliasFano stream.");
+        }
+        return relative;
+      },
+      buffer,
+      options);
+}
+
+template <typename T>
+std::string EliasFanoEncoding<T>::debugString(int offset) const {
+  return Encoding::debugString(offset) +
+      fmt::format(
+             "\n{}lowerBits={}, upperBytes={}",
+             std::string(offset, ' '),
+             lowerBits_,
+             upperBytes_);
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -26,6 +26,7 @@
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/ForEncoding.h"
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
@@ -249,6 +250,19 @@ std::string_view sliceBlockBitPacking(
           encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceEliasFano(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(
+      dataType,
+      T,
+      EliasFanoEncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
 std::string_view slicePFOR(
     std::string_view encoded,
     DataType dataType,
@@ -358,6 +372,8 @@ std::string_view EncodingSliceFactory::slice(
     case EncodingType::BlockBitPacking:
       return sliceBlockBitPacking(
           encoded, dataType, offset, length, buffer, options);
+    case EncodingType::EliasFano:
+      return sliceEliasFano(encoded, dataType, offset, length, buffer, options);
     case EncodingType::PFOR:
       return slicePFOR(encoded, dataType, offset, length, buffer, options);
     case EncodingType::SimdForBitpack:

--- a/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -24,6 +24,7 @@
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/EncodingSliceFactory.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/ForEncoding.h"
@@ -154,6 +155,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::DeltaBlock: {
       RETURN_ENCODING_BY_INTEGER_TYPE(DeltaBlockEncoding, dataType);
+    }
+    case EncodingType::EliasFano: {
+      RETURN_ENCODING_BY_INTEGER_TYPE(EliasFanoEncoding, dataType);
     }
     case EncodingType::ALP: {
       switch (dataType) {
@@ -408,6 +412,15 @@ std::string_view EncodingFactory::encode(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "DeltaBlock encoding only supports integral data types, got {}.",
+          TypeTraits<T>::dataType);
+    }
+    case EncodingType::EliasFano: {
+      if constexpr (isIntegralType<T>()) {
+        return EliasFanoEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "EliasFano encoding only supports integral data types, got {}.",
           TypeTraits<T>::dataType);
     }
     case EncodingType::ALP: {

--- a/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -195,6 +195,7 @@ EncodingLayout EncodingLayoutCapture::capture(
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::DeltaBlock:
+    case EncodingType::EliasFano:
     case EncodingType::SimdForBitpack:
     case EncodingType::SubIntSplit:
     case EncodingType::FrequencyPartition:

--- a/velox/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/velox/dwio/nimble/encodings/common/EncodingUtils.h
@@ -15,12 +15,16 @@
  */
 #pragma once
 
+#include <utility>
+
+#include "velox/dwio/nimble/common/DataTypeDispatch.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
@@ -65,6 +69,17 @@ inline int dataTypeSize(DataType type) {
     default:
       NIMBLE_UNSUPPORTED("{}", type);
   }
+}
+
+// Uses the stream's serialized type because it may differ in signedness from
+// the visitor type while sharing the same physical width.
+template <typename F>
+auto dispatchEliasFano(Encoding& encoding, F&& callback) {
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(
+      encoding.dataType(),
+      EncodingDataType,
+      std::forward<F>(callback)(
+          static_cast<EliasFanoEncoding<EncodingDataType>&>(encoding)));
 }
 
 template <typename F>
@@ -149,6 +164,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       }
       NIMBLE_UNREACHABLE(
           "DeltaBlock encoding only supports integral data types, got {}.",
+          encoding.dataType());
+    case EncodingType::EliasFano:
+      if constexpr (isIntegralType<T>()) {
+        return dispatchEliasFano(encoding, std::forward<F>(f));
+      }
+      NIMBLE_UNREACHABLE(
+          "EliasFano encoding only supports integral data types, got {}.",
           encoding.dataType());
     case EncodingType::ALP:
       if constexpr (isFloatingPointType<T>()) {

--- a/velox/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/velox/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/PFOREncoding.h"
@@ -292,6 +293,10 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::DeltaBlock: {
       RETURN_ENCODING_BY_INTEGRAL_TYPE(
           ::facebook::nimble::DeltaBlockEncoding, dataType);
+    }
+    case EncodingType::EliasFano: {
+      RETURN_ENCODING_BY_INTEGRAL_TYPE(
+          ::facebook::nimble::EliasFanoEncoding, dataType);
     }
     // SubIntSplit integration commented out (disabled):
     /*

--- a/velox/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/velox/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -17,6 +17,7 @@
 
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/PFOREncoding.h"
@@ -132,6 +133,15 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       } else {
         NIMBLE_UNREACHABLE(
             "DeltaBlock encoding only supports integral data types, got {}.",
+            encoding.dataType());
+      }
+    case EncodingType::EliasFano:
+      if constexpr (isIntegralType<T>()) {
+        return ::facebook::nimble::detail::dispatchEliasFano(
+            encoding, std::forward<F>(f));
+      } else {
+        NIMBLE_UNREACHABLE(
+            "EliasFano encoding only supports integral data types, got {}.",
             encoding.dataType());
       }
     case EncodingType::PFOR:

--- a/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -168,6 +168,7 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       EncodingType::SubIntSplit,
       EncodingType::BlockBitPacking,
       EncodingType::DeltaBlock,
+      EncodingType::EliasFano,
       EncodingType::Fsst,
       EncodingType::Huffman,
   };

--- a/velox/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/velox/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -25,6 +25,7 @@
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
@@ -179,6 +180,13 @@ struct EncodingSizeEstimation {
       case EncodingType::DeltaBlock: {
         if constexpr (isIntegralType<T>()) {
           return DeltaBlockEncoding<T>::estimateSize(values, options);
+        } else {
+          return std::nullopt;
+        }
+      }
+      case EncodingType::EliasFano: {
+        if constexpr (isIntegralType<T>()) {
+          return EliasFanoEncoding<T>::estimateSize(values);
         } else {
           return std::nullopt;
         }

--- a/velox/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -38,6 +38,8 @@ add_executable(
   ConstantEncodingTest.cpp
   DictionaryEncodingTest.cpp
   DictionaryEncodingViewTest.cpp
+  EliasFanoEncodingTest.cpp
+  EliasFanoEncodingViewTest.cpp
   EncodingLayoutTest.cpp
   EncodingSelectionTest.cpp
   EncodingSliceTest.cpp

--- a/velox/dwio/nimble/encodings/tests/EliasFanoEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EliasFanoEncodingTest.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
+
+#include <gtest/gtest.h>
+#include <limits>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/encodings/tests/TestUtils.h"
+
+using namespace facebook;
+
+class EliasFanoEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  nimble::Vector<T> toVector(const std::vector<T>& input) {
+    nimble::Vector<T> values{pool_.get()};
+    values.reserve(input.size());
+    for (const auto value : input) {
+      values.push_back(value);
+    }
+    return values;
+  }
+
+  template <typename T>
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const std::vector<T>& input) {
+    auto values = toVector(input);
+    return nimble::test::Encoder<nimble::EliasFanoEncoding<T>>::createEncoding(
+        *buffer_, values, nullptr);
+  }
+
+  template <typename T>
+  void roundTrip(const std::vector<T>& input) {
+    auto encoding = createEncoding(input);
+    std::vector<T> output(input.size());
+    encoding->materialize(static_cast<uint32_t>(input.size()), output.data());
+
+    EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::EliasFano);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), static_cast<uint32_t>(input.size()));
+    EXPECT_EQ(output, input);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+TEST_F(EliasFanoEncodingTest, roundTripUnsignedValues) {
+  roundTrip<uint32_t>({1, 2, 3, 7, 9, 12, 13, 15, 20, 100});
+  roundTrip<uint64_t>({0, 0, 0, 5, 5, 9, 1'000, 2'000, 2'000, 4'000});
+  roundTrip<uint16_t>({2, 4, 4, 4, 9, 12, 30});
+  roundTrip<uint8_t>({0, 1, 1, 2, 3, 8});
+}
+
+TEST_F(EliasFanoEncodingTest, roundTripSignedValues) {
+  roundTrip<int32_t>({-5, -3, -3, -1, 0, 2, 9, 10});
+  roundTrip<int64_t>({-100, -100, -7, -1, 0, 1, 1'000'000});
+  roundTrip<int16_t>({-10, -5, -5, 0, 2, 4});
+  roundTrip<int8_t>({-8, -2, -2, 0, 5, 9});
+}
+
+TEST_F(EliasFanoEncodingTest, roundTripSignedBoundaries) {
+  roundTrip<int8_t>({
+      std::numeric_limits<int8_t>::min(),
+      -1,
+      0,
+      std::numeric_limits<int8_t>::max(),
+  });
+  roundTrip<int16_t>({
+      std::numeric_limits<int16_t>::min(),
+      -1,
+      0,
+      std::numeric_limits<int16_t>::max(),
+  });
+  roundTrip<int32_t>({
+      std::numeric_limits<int32_t>::min(),
+      -1,
+      0,
+      std::numeric_limits<int32_t>::max(),
+  });
+  roundTrip<int64_t>({
+      std::numeric_limits<int64_t>::min(),
+      -1,
+      0,
+      std::numeric_limits<int64_t>::max(),
+  });
+}
+
+TEST_F(EliasFanoEncodingTest, roundTripSingleAndRepeatedValues) {
+  roundTrip<uint64_t>({std::numeric_limits<uint64_t>::max()});
+  roundTrip<int64_t>({-7, -7, -7, -7});
+}
+
+TEST_F(EliasFanoEncodingTest, resetSkipAndMaterialize) {
+  const std::vector<uint32_t> input{0, 1, 2, 10, 11, 12, 100, 101, 102};
+  auto encoding = createEncoding(input);
+
+  encoding->reset();
+  encoding->skip(0);
+  encoding->skip(4);
+  std::vector<uint32_t> output(3);
+  encoding->materialize(static_cast<uint32_t>(output.size()), output.data());
+  EXPECT_EQ(output, (std::vector<uint32_t>{11, 12, 100}));
+
+  encoding->reset();
+  output.resize(input.size());
+  encoding->materialize(static_cast<uint32_t>(output.size()), output.data());
+  EXPECT_EQ(output, input);
+}
+
+TEST_F(EliasFanoEncodingTest, supportsRandomAccessAndValueLowerBound) {
+  const std::vector<uint64_t> input{10, 20, 20, 40};
+  const auto encoding = createEncoding(input);
+  const auto* eliasFano =
+      dynamic_cast<const nimble::EliasFanoEncoding<uint64_t>*>(encoding.get());
+  ASSERT_NE(eliasFano, nullptr);
+
+  EXPECT_EQ(eliasFano->valueAt(0), 10);
+  EXPECT_EQ(eliasFano->valueAt(3), 40);
+  EXPECT_EQ(eliasFano->lowerBound(0), 0);
+  EXPECT_EQ(eliasFano->lowerBound(10), 0);
+  EXPECT_EQ(eliasFano->lowerBound(19), 1);
+  EXPECT_EQ(eliasFano->lowerBound(20), 1);
+  EXPECT_EQ(eliasFano->lowerBound(21), 3);
+  EXPECT_EQ(eliasFano->lowerBound(41), input.size());
+}
+
+TEST_F(EliasFanoEncodingTest, absoluteReadsPreserveSequentialPosition) {
+  const std::vector<uint64_t> input{10, 20, 20, 40, 80};
+  auto encoding = createEncoding(input);
+  auto* eliasFano =
+      dynamic_cast<nimble::EliasFanoEncoding<uint64_t>*>(encoding.get());
+  ASSERT_NE(eliasFano, nullptr);
+
+  std::vector<uint64_t> absoluteOutput(3);
+  eliasFano->materializeAt(
+      /*offset=*/1,
+      static_cast<uint32_t>(absoluteOutput.size()),
+      absoluteOutput.data());
+  EXPECT_EQ(absoluteOutput, (std::vector<uint64_t>{20, 20, 40}));
+
+  std::vector<uint64_t> sequentialOutput(2);
+  encoding->materialize(
+      static_cast<uint32_t>(sequentialOutput.size()), sequentialOutput.data());
+  EXPECT_EQ(sequentialOutput, (std::vector<uint64_t>{10, 20}));
+
+  eliasFano->materializeAt(
+      static_cast<uint32_t>(input.size()), /*rowCount=*/0, nullptr);
+  encoding->materialize(/*rowCount=*/0, nullptr);
+  NIMBLE_ASSERT_THROW(
+      eliasFano->materializeAt(
+          input.size(), /*rowCount=*/1, absoluteOutput.data()),
+      "Reading past end of encoding.");
+  NIMBLE_ASSERT_THROW(
+      eliasFano->valueAt(input.size()), "Reading past end of encoding.");
+}
+
+TEST_F(EliasFanoEncodingTest, slicesWithoutGenericMaterialization) {
+  const std::vector<int64_t> input{
+      std::numeric_limits<int64_t>::min(), -7, -7, 0, 4, 100, 1'000};
+  const auto values = toVector(input);
+  const auto encoded =
+      nimble::test::Encoder<nimble::EliasFanoEncoding<int64_t>>::encode(
+          *buffer_, values);
+
+  const std::vector<std::pair<uint32_t, uint32_t>> ranges{
+      {0, 1}, {1, 5}, {3, 1}, {6, 1}, {0, input.size()}};
+  for (const auto& [offset, length] : ranges) {
+    SCOPED_TRACE(
+        ::testing::Message() << "offset=" << offset << ", length=" << length);
+    nimble::Buffer sliceBuffer{*pool_};
+    const auto sliced = nimble::EliasFanoEncoding<int64_t>::slice(
+        encoded, offset, length, sliceBuffer);
+    auto encoding = nimble::EncodingFactory{}.create(
+        *pool_, sliced, /*stringBufferFactory=*/nullptr);
+    std::vector<int64_t> output(length);
+    encoding->materialize(length, output.data());
+
+    EXPECT_EQ(
+        output,
+        std::vector<int64_t>(
+            input.begin() + offset, input.begin() + offset + length));
+  }
+
+  nimble::Buffer sliceBuffer{*pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::EliasFanoEncoding<int64_t>::slice(
+          encoded, /*offset=*/0, /*length=*/0, sliceBuffer),
+      "Cannot slice zero rows.");
+}
+
+TEST_F(EliasFanoEncodingTest, factoryRoundTrip) {
+  const std::vector<uint64_t> input{10, 10, 12, 30, 1'000, 1'001};
+  auto values = toVector(input);
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint64_t>>(
+          std::vector<std::pair<nimble::EncodingType, float>>{
+              {nimble::EncodingType::EliasFano, 1.0}},
+          std::nullopt,
+          std::nullopt);
+  const auto encoded = nimble::EncodingFactory::encode<uint64_t>(
+      std::move(policy), values, *buffer_);
+  auto encoding = nimble::EncodingFactory{}.create(
+      *pool_, encoded, /*stringBufferFactory=*/nullptr);
+  std::vector<uint64_t> output(input.size());
+  encoding->materialize(static_cast<uint32_t>(input.size()), output.data());
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::EliasFano);
+  EXPECT_EQ(output, input);
+  EXPECT_NE(encoding->debugString(0).find("lowerBits="), std::string::npos);
+}
+
+TEST_F(EliasFanoEncodingTest, estimateRejectsEmptyAndUnsortedValues) {
+  EXPECT_EQ(
+      nimble::EliasFanoEncoding<uint64_t>::estimateSize({}), std::nullopt);
+
+  const std::vector<uint32_t> input{1, 5, 4, 8};
+  const auto values = toVector(input);
+  const auto physicalValues = std::span<const uint32_t>{
+      reinterpret_cast<const uint32_t*>(values.data()), values.size()};
+  EXPECT_EQ(
+      nimble::EliasFanoEncoding<uint32_t>::estimateSize(physicalValues),
+      std::nullopt);
+}
+
+TEST_F(EliasFanoEncodingTest, rejectsTruncatedHeader) {
+  const auto values = toVector<uint64_t>({1, 2, 3});
+  const auto encoded =
+      nimble::test::Encoder<nimble::EliasFanoEncoding<uint64_t>>::encode(
+          *buffer_, values);
+  std::string malformed{encoded};
+  constexpr size_t kTruncatedSize = nimble::EncodingPrefix::kFixedPrefixSize +
+      sizeof(uint64_t) + sizeof(uint8_t) + sizeof(uint32_t) - 1;
+  malformed.resize(kTruncatedSize);
+
+  NIMBLE_ASSERT_FILE_THROW(
+      nimble::EncodingFactory{}.create(
+          *pool_, malformed, /*stringBufferFactory=*/nullptr),
+      "Truncated EliasFano header.");
+}
+
+TEST_F(EliasFanoEncodingTest, rejectsInvalidLowerBitCount) {
+  const auto values = toVector<uint64_t>({1, 2, 3});
+  const auto encoded =
+      nimble::test::Encoder<nimble::EliasFanoEncoding<uint64_t>>::encode(
+          *buffer_, values);
+  std::string malformed{encoded};
+  constexpr size_t kLowerBitsOffset =
+      nimble::EncodingPrefix::kFixedPrefixSize + sizeof(uint64_t);
+  malformed[kLowerBitsOffset] = 57;
+
+  NIMBLE_ASSERT_FILE_THROW(
+      nimble::EncodingFactory{}.create(
+          *pool_, malformed, /*stringBufferFactory=*/nullptr),
+      "Invalid EliasFano lower bit count.");
+}
+
+TEST_F(EliasFanoEncodingTest, rejectsInsufficientUpperBits) {
+  const auto values = toVector<uint64_t>({1, 2, 3});
+  const auto encoded =
+      nimble::test::Encoder<nimble::EliasFanoEncoding<uint64_t>>::encode(
+          *buffer_, values);
+  std::string malformed{encoded};
+  char* upperBytes = malformed.data() +
+      nimble::EncodingPrefix::kFixedPrefixSize + sizeof(uint64_t) +
+      sizeof(uint8_t);
+  nimble::encoding::writeUint32(0, upperBytes);
+
+  NIMBLE_ASSERT_FILE_THROW(
+      nimble::EncodingFactory{}.create(
+          *pool_, malformed, /*stringBufferFactory=*/nullptr),
+      "Invalid EliasFano upper bit count.");
+}
+
+TEST_F(EliasFanoEncodingTest, rejectsMissingUpperBits) {
+  const auto values = toVector<uint64_t>({0, 0, 0});
+  const auto encoded =
+      nimble::test::Encoder<nimble::EliasFanoEncoding<uint64_t>>::encode(
+          *buffer_, values);
+  std::string malformed{encoded};
+  const auto upperByteOffset =
+      malformed.size() - folly::compression::kUpperTrailingBytes - 1;
+  malformed[upperByteOffset] = 0;
+
+  NIMBLE_ASSERT_FILE_THROW(
+      nimble::EncodingFactory{}.create(
+          *pool_, malformed, /*stringBufferFactory=*/nullptr),
+      "Invalid EliasFano upper bits.");
+}
+
+TEST_F(EliasFanoEncodingTest, alignsFollyPointerTables) {
+  std::vector<uint64_t> input(300);
+  for (size_t i{0}; i < input.size(); ++i) {
+    input[i] = i;
+  }
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(::testing::Message() << "useVarint=" << useVarint);
+    buffer_->reset();
+    buffer_->reserve(1);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    const auto encoded =
+        nimble::test::Encoder<nimble::EliasFanoEncoding<uint64_t>>::encode(
+            *buffer_,
+            toVector(input),
+            nimble::CompressionType::Uncompressed,
+            options);
+    const auto prefixSize = nimble::EncodingPrefix::serializedSize(
+        static_cast<uint32_t>(input.size()), useVarint);
+    const auto headerEndOffset =
+        prefixSize + sizeof(uint64_t) + sizeof(uint8_t) + sizeof(uint32_t);
+    const auto payloadOffset =
+        (headerEndOffset + alignof(uint64_t) - 1) & ~(alignof(uint64_t) - 1);
+
+    EXPECT_EQ(
+        reinterpret_cast<uintptr_t>(encoded.data()) % alignof(uint64_t), 0);
+    EXPECT_EQ(
+        reinterpret_cast<uintptr_t>(encoded.data() + payloadOffset) %
+            alignof(uint64_t),
+        0);
+    for (size_t offset{headerEndOffset}; offset < payloadOffset; ++offset) {
+      SCOPED_TRACE(::testing::Message() << "offset=" << offset);
+      EXPECT_EQ(encoded[offset], 0);
+    }
+  }
+}
+
+TEST_F(EliasFanoEncodingTest, encodeRejectsUnsortedValues) {
+  const std::vector<int32_t> input{-1, -2};
+  NIMBLE_ASSERT_THROW(
+      createEncoding(input),
+      "EliasFano requires non-empty non-decreasing values.");
+}
+
+TEST_F(EliasFanoEncodingTest, encodeRejectsEmptyValues) {
+  NIMBLE_ASSERT_THROW(
+      createEncoding(std::vector<uint64_t>{}),
+      "EliasFano requires non-empty non-decreasing values.");
+}

--- a/velox/dwio/nimble/encodings/tests/EliasFanoEncodingViewTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EliasFanoEncodingViewTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
+
+#include <cstdint>
+#include <limits>
+#include <random>
+
+#include <gtest/gtest.h>
+
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
+
+using namespace facebook;
+
+using EliasFanoEncodingViewTest = nimble::test::EncodingViewTest;
+
+TEST_F(EliasFanoEncodingViewTest, readsSignedAndUnsignedValues) {
+  expectReads<nimble::EliasFanoEncoding<int64_t>>(
+      makeVector<int64_t>({
+          std::numeric_limits<int64_t>::min(),
+          -1,
+          0,
+          0,
+          17,
+          std::numeric_limits<int64_t>::max(),
+      }),
+      {5, 0, 3, 1, 3, 4});
+  expectReads<nimble::EliasFanoEncoding<uint64_t>>(
+      makeVector<uint64_t>({0, 1, 1, 7, 1'000, 1'000, 1'000'000}),
+      {6, 0, 2, 3, 5, 1});
+}
+
+TEST_F(EliasFanoEncodingViewTest, supportsConcurrentReads) {
+  nimble::Vector<uint64_t> values{pool_.get()};
+  values.reserve(kConcurrentRows);
+  uint64_t value{1'000};
+  for (uint32_t row{0}; row < kConcurrentRows; ++row) {
+    value += row % 7;
+    values.push_back(value);
+  }
+
+  expectConcurrentReads<nimble::EliasFanoEncoding<uint64_t>>(
+      values, randomizedPositions(/*seed=*/43));
+}
+
+TEST_F(EliasFanoEncodingViewTest, randomizedReads) {
+  std::mt19937_64 random{44};
+  std::uniform_int_distribution<uint32_t> rowCountDistribution{1, 512};
+  std::uniform_int_distribution<uint64_t> deltaDistribution{0, 1'000};
+
+  for (uint32_t iteration{0}; iteration < 32; ++iteration) {
+    SCOPED_TRACE(::testing::Message() << "iteration=" << iteration);
+    const auto rowCount = rowCountDistribution(random);
+    nimble::Vector<uint64_t> values{pool_.get()};
+    values.reserve(rowCount);
+    uint64_t value{deltaDistribution(random)};
+    for (uint32_t row{0}; row < rowCount; ++row) {
+      value += deltaDistribution(random);
+      values.push_back(value);
+    }
+
+    std::uniform_int_distribution<uint32_t> positionDistribution{
+        0, rowCount - 1};
+    std::vector<uint32_t> positions;
+    positions.reserve(64);
+    for (uint32_t read{0}; read < 64; ++read) {
+      positions.push_back(positionDistribution(random));
+    }
+    expectReads<nimble::EliasFanoEncoding<uint64_t>>(values, positions);
+  }
+}

--- a/velox/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
@@ -44,6 +44,7 @@ TEST_F(EncodingViewTest, supportsEncodingViewMatchesViewableEncodingSet) {
       nimble::EncodingType::RLE,
       nimble::EncodingType::FOR,
       nimble::EncodingType::DeltaBlock,
+      nimble::EncodingType::EliasFano,
       nimble::EncodingType::Huffman,
       nimble::EncodingType::PFOR,
       nimble::EncodingType::SimdForBitpack,

--- a/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
@@ -151,6 +152,20 @@ TEST_F(SliceEncodingTest, wrapsFullRange) {
 
   const std::vector<int32_t> expected{10, 11, 12};
   EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, slicesEliasFano) {
+  const auto values = makeVector<uint32_t>({10, 11, 15, 15, 30, 100});
+  const auto encoded =
+      nimble::test::Encoder<nimble::EliasFanoEncoding<uint32_t>>::encode(
+          *buffer_, values);
+
+  auto encoding = createEncoding(slice(encoded, /*offset=*/1, /*length=*/4));
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::EliasFano);
+  EXPECT_EQ(encoding->rowCount(), 4);
+
+  const std::vector<uint32_t> expected{11, 15, 15, 30};
+  EXPECT_EQ(materialize<uint32_t>(*encoding, 4), expected);
 }
 
 TEST_F(SliceEncodingTest, wrapsRle) {

--- a/velox/dwio/nimble/encodings/tests/TestUtils.h
+++ b/velox/dwio/nimble/encodings/tests/TestUtils.h
@@ -24,6 +24,7 @@
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/ForEncoding.h"
 #include "velox/dwio/nimble/encodings/FrequencyPartitionEncoding.h"
@@ -76,6 +77,12 @@ template <typename T>
 struct EncodingTypeTraits<nimble::DeltaBlockEncoding<T>> {
   static constexpr inline nimble::EncodingType encodingType =
       nimble::EncodingType::DeltaBlock;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::EliasFanoEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::EliasFano;
 };
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/views/EliasFanoEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/EliasFanoEncodingView.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
+#include "velox/dwio/nimble/encodings/views/EncodingView.h"
+
+namespace facebook::nimble {
+
+/// Provides stateless random and contiguous access to Elias-Fano values.
+template <typename T>
+class EliasFanoEncodingView final : public TypedEncodingView<T> {
+ public:
+  using physicalType = typename TypedEncodingView<T>::physicalType;
+
+  /// Creates a view over an Elias-Fano encoded stream.
+  EliasFanoEncodingView(
+      std::string_view data,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options)
+      : TypedEncodingView<T>{data, pool, options},
+        encoding_{*pool, data, {}, options} {
+    NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::EliasFano);
+  }
+
+ private:
+  T readTypedAt(uint32_t index) const final {
+    return encoding_.valueAt(index);
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    encoding_.materializeAt(offset, length, output);
+  }
+
+  // Owns the parsed list. Random reads reuse a thread-local cursor, preserving
+  // safe concurrent and out-of-order access to a shared view.
+  EliasFanoEncoding<T> encoding_;
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/views/EncodingViewFactory.cpp
+++ b/velox/dwio/nimble/encodings/views/EncodingViewFactory.cpp
@@ -23,6 +23,7 @@
 #include "velox/dwio/nimble/encodings/views/ConstantEncodingView.h"
 #include "velox/dwio/nimble/encodings/views/DeltaBlockEncodingView.h"
 #include "velox/dwio/nimble/encodings/views/DictionaryEncodingView.h"
+#include "velox/dwio/nimble/encodings/views/EliasFanoEncodingView.h"
 #include "velox/dwio/nimble/encodings/views/FOREncodingView.h"
 #include "velox/dwio/nimble/encodings/views/FixedBitWidthEncodingView.h"
 #include "velox/dwio/nimble/encodings/views/HuffmanEncodingView.h"
@@ -98,6 +99,13 @@ std::unique_ptr<TypedEncodingView<T>> createTypedEncodingView(
       NIMBLE_INCOMPATIBLE_ENCODING(
           "DeltaBlock encoding only supports integral data types, got {}.",
           TypeTraits<T>::dataType);
+    case EncodingType::EliasFano:
+      if constexpr (isIntegralType<T>()) {
+        return std::make_unique<EliasFanoEncodingView<T>>(data, pool, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "EliasFano encoding only supports integral data types, got {}.",
+          TypeTraits<T>::dataType);
     case EncodingType::Huffman:
       if constexpr (
           isIntegralType<physicalType>() &&
@@ -170,6 +178,7 @@ bool supportsEncodingView(EncodingType encodingType) {
       EncodingType::RLE,
       EncodingType::FOR,
       EncodingType::DeltaBlock,
+      EncodingType::EliasFano,
       EncodingType::Huffman,
       EncodingType::PFOR,
       EncodingType::SimdForBitpack,

--- a/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/EncodingDispatchConsistencyTest.cpp
@@ -81,8 +81,8 @@ struct ColumnCase {
   // Whether every non-null value is the same. ConstantEncoding refuses
   // anything else, so this is what decides its expected outcome.
   bool isSingleValued{false};
-  // Whether the non-null values never decrease. DeltaBlockEncoding refuses
-  // anything else (NIMBLE_CHECK_GE, "requires non-decreasing values").
+  // Whether the non-null values never decrease. DeltaBlockEncoding and
+  // EliasFanoEncoding refuse anything else.
   bool isNonDecreasing{false};
 };
 
@@ -112,7 +112,9 @@ WriteOutcome expectedOutcome(
   if (encodingType == EncodingType::Constant && !columnCase.isSingleValued) {
     return WriteOutcome::kNotApplied;
   }
-  if (encodingType == EncodingType::DeltaBlock && !columnCase.isNonDecreasing) {
+  if ((encodingType == EncodingType::DeltaBlock ||
+       encodingType == EncodingType::EliasFano) &&
+      !columnCase.isNonDecreasing) {
     return WriteOutcome::kNotApplied;
   }
   // "Huffman encoding requires at least two symbols" -- a single-symbol

--- a/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
+++ b/velox/dwio/nimble/fuzzer/encoding_selection/NimbleWriterFuzzer.cpp
@@ -212,6 +212,7 @@ constexpr uint64_t kMinPairFiles = 10;
 bool hasDataPrecondition(EncodingType encodingType) {
   return encodingType == EncodingType::Constant ||
       encodingType == EncodingType::DeltaBlock ||
+      encodingType == EncodingType::EliasFano ||
       encodingType == EncodingType::Huffman;
 }
 
@@ -911,7 +912,8 @@ bool isTypeCompatible(EncodingType encodingType, DataType dataType) {
   if (encodingType == EncodingType::ALP) {
     return isFloatingPointDataType(dataType);
   }
-  if (encodingType == EncodingType::DeltaBlock) {
+  if (encodingType == EncodingType::DeltaBlock ||
+      encodingType == EncodingType::EliasFano) {
     return !isFloatingPointDataType(dataType);
   }
   // Varint's gate is isIntegralType<physicalType>() && sizeof(T) >= 4, so the
@@ -925,6 +927,7 @@ bool isTypeCompatible(EncodingType encodingType, DataType dataType) {
 
 bool isIntegralOnlyEncoding(EncodingType encodingType) {
   return encodingType == EncodingType::DeltaBlock ||
+      encodingType == EncodingType::EliasFano ||
       encodingType == EncodingType::PFOR ||
       encodingType == EncodingType::SimdForBitpack ||
       encodingType == EncodingType::Huffman;

--- a/velox/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/velox/dwio/nimble/tools/EncodingUtilities.cpp
@@ -62,6 +62,7 @@ void extractCompressionType(
     case EncodingType::Varint:
     case EncodingType::Delta:
     case EncodingType::DeltaBlock:
+    case EncodingType::EliasFano:
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
@@ -136,6 +137,7 @@ void traverseEncodings(
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::DeltaBlock:
+    case EncodingType::EliasFano:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as having no nested
     // encoding to traverse.

--- a/velox/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
@@ -353,6 +353,26 @@ TEST_P(ScalarColumnReaderTest, integerDeltaBlockWithFilter) {
   }
 }
 
+TEST_P(ScalarColumnReaderTest, integerEliasFanoWithFilter) {
+  const bool stringDecoderZeroCopy = GetParam();
+  auto input = makeRowVector({makeFlatVector<int64_t>(
+      513, [](auto row) { return int64_t{-300} + row / 3; })});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(-200, -100, false));
+
+  auto file = test::createNimbleFile(
+      *rootPool(),
+      input,
+      makeForcedEncodingWriterOptions(EncodingType::EliasFano));
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(*input, *readers.rowReader, 29, [](auto row) {
+    const auto value = int64_t{-300} + row / 3;
+    return value >= -200 && value <= -100;
+  });
+}
+
 TEST_P(ScalarColumnReaderTest, bigintWithNulls) {
   const bool stringDecoderZeroCopy = GetParam();
   auto input = makeRowVector({


### PR DESCRIPTION
Summary:

Adds `EliasFanoEncoding`, a leaf integer encoding for non-decreasing streams. The format stores an order-preserving base plus a self-contained Folly Elias-Fano payload. Readers support sequential decoding, lower-bound lookup, generic `EncodingView` random and range access, and native slices that encode directly from the source payload without a temporary materialized value buffer.

Wires the experimental encoding into factory dispatch, layout traversal, encoding utilities, and value-aware size selection.

Reviewed By: gggrace14

Differential Revision: D113142086


