### PR TITLE
refactor(nimble): Speed up block min-max statistics (#18876)

### DIFF
--- a/velox/dwio/nimble/docs/develop/encoding_cost_model.rst
+++ b/velox/dwio/nimble/docs/develop/encoding_cost_model.rst
@@ -128,9 +128,7 @@ statistics.minMaxBlocks()
 
 ← scans data\_ once
 
-// BlockStatsAccumulator: for each value,
-
-// track min/max, flush every 1024 rows
+// Find the exact min/max independently for each 1024-row block.
 
 // → vector < {count, min, max} >
 

--- a/velox/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <span>
@@ -46,6 +47,49 @@ void updateUniqueStats(uint32_t iters, const std::vector<T>& data) {
     const auto& uniqueCounts = statistics.uniqueCounts().value();
     folly::doNotOptimizeAway(uniqueCounts.size());
     folly::doNotOptimizeAway(uniqueCounts.at(data[data.size() / 2]));
+  }
+}
+
+template <typename T>
+void updateMinMaxBlockStats(
+    uint32_t iters,
+    const std::vector<T>& data,
+    uint16_t blockSize) {
+  while (iters-- > 0) {
+    const auto statistics = Statistics<T>::create(data);
+    const auto& blocks = statistics.minMaxBlocks(blockSize);
+    folly::doNotOptimizeAway(blocks.data());
+    folly::doNotOptimizeAway(blocks.size());
+  }
+}
+
+template <typename T>
+void updateMinMaxBlockStatsPerValue(
+    uint32_t iters,
+    const std::vector<T>& data,
+    uint16_t blockSize) {
+  using BlockStats = typename Statistics<T>::BlockStats;
+  while (iters-- > 0) {
+    std::vector<BlockStats> blocks;
+    blocks.reserve((data.size() - 1) / blockSize + 1);
+    uint64_t blockMin{std::numeric_limits<uint64_t>::max()};
+    uint64_t blockMax{0};
+    uint64_t blockCount{0};
+    for (const auto value : data) {
+      blockMin = std::min(blockMin, static_cast<uint64_t>(value));
+      blockMax = std::max(blockMax, static_cast<uint64_t>(value));
+      if (++blockCount == blockSize) {
+        blocks.push_back({blockCount, blockMin, blockMax});
+        blockMin = std::numeric_limits<uint64_t>::max();
+        blockMax = 0;
+        blockCount = 0;
+      }
+    }
+    if (blockCount != 0) {
+      blocks.push_back({blockCount, blockMin, blockMax});
+    }
+    folly::doNotOptimizeAway(blocks.data());
+    folly::doNotOptimizeAway(blocks.size());
   }
 }
 
@@ -101,6 +145,16 @@ BENCHMARK_RELATIVE(UniqueStats_Int64SparseRangeHash, iters) {
 
 BENCHMARK_RELATIVE(UniqueStats_Int64FullSpanHash, iters) {
   updateUniqueStats(iters, int64FullSpan);
+}
+
+BENCHMARK(MinMaxBlocks_PerValue_Uint64DenseRangeAtMax, iters) {
+  updateMinMaxBlockStatsPerValue(
+      iters, uint64DenseRangeAtMax, kBlockBitPackingBlockSize);
+}
+
+BENCHMARK_RELATIVE(MinMaxBlocks_BlockWise_Uint64DenseRangeAtMax, iters) {
+  updateMinMaxBlockStats(
+      iters, uint64DenseRangeAtMax, kBlockBitPackingBlockSize);
 }
 
 int main(int argc, char** argv) {

--- a/velox/dwio/nimble/encodings/selection/Statistics.cpp
+++ b/velox/dwio/nimble/encodings/selection/Statistics.cpp
@@ -240,11 +240,22 @@ void Statistics<T, InputType>::populateUniques() const {
 template <typename T, typename InputType>
 void Statistics<T, InputType>::populateMinMaxBlocks(uint16_t blockSize) const {
   static_assert(std::is_unsigned_v<T>);
-  BlockStatsAccumulator acc(blockSize);
-  for (const auto& v : data_) {
-    acc.add(static_cast<uint64_t>(static_cast<T>(v)));
+  static_assert(std::is_same_v<T, InputType>);
+
+  std::vector<BlockStats> blocks;
+  if (data_.empty()) {
+    minMaxBlocks_ = std::move(blocks);
+    return;
   }
-  minMaxBlocks_ = acc.finish();
+
+  const size_t effectiveBlockSize = blockSize == 0 ? data_.size() : blockSize;
+  blocks.reserve((data_.size() - 1) / effectiveBlockSize + 1);
+  for (size_t offset = 0; offset < data_.size(); offset += effectiveBlockSize) {
+    const auto count = std::min(effectiveBlockSize, data_.size() - offset);
+    const auto minMax = findMinMax(data_.subspan(offset, count));
+    blocks.push_back({count, minMax.min, minMax.max});
+  }
+  minMaxBlocks_ = std::move(blocks);
 }
 
 template <typename T, typename InputType>

--- a/velox/dwio/nimble/encodings/selection/Statistics.h
+++ b/velox/dwio/nimble/encodings/selection/Statistics.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <limits>
 #include <optional>
 #include <span>
 #include <type_traits>
@@ -241,45 +240,6 @@ class Statistics {
  private:
   Statistics() = default;
   std::span<const InputType> data_;
-
-  class BlockStatsAccumulator {
-   public:
-    explicit BlockStatsAccumulator(uint16_t blockSize)
-        : blockSize_{blockSize} {}
-
-    void add(uint64_t val) {
-      if (val < blockMin_) {
-        blockMin_ = val;
-      }
-      if (val > blockMax_) {
-        blockMax_ = val;
-      }
-      if (++blockCount_ == blockSize_) {
-        flush();
-      }
-    }
-
-    std::vector<BlockStats> finish() {
-      flush();
-      return std::move(result_);
-    }
-
-   private:
-    void flush() {
-      if (blockCount_ > 0) {
-        result_.push_back({blockCount_, blockMin_, blockMax_});
-      }
-      blockCount_ = 0;
-      blockMin_ = std::numeric_limits<uint64_t>::max();
-      blockMax_ = 0;
-    }
-
-    const uint16_t blockSize_;
-    uint64_t blockCount_ = 0;
-    uint64_t blockMin_ = std::numeric_limits<uint64_t>::max();
-    uint64_t blockMax_ = 0;
-    std::vector<BlockStats> result_;
-  };
 
   void populateRepeats(bool collectRunValues = false) const;
   void populateUniques() const;

--- a/velox/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -1082,7 +1082,7 @@ TEST_F(EncodingSizeEstimationTest, blockBitPackingConstantData) {
 
 TEST_F(EncodingSizeEstimationTest, blockBitPackingPartialLastBlock) {
   // 1500 values: 1 full block (1024) + 1 partial block (476).
-  // Verifies BlockStatsAccumulator correctly flushes the remainder.
+  // Verifies block statistics include the trailing partial block.
   std::vector<uint32_t> data;
   data.reserve(1500);
   for (uint32_t i = 0; i < 1500; ++i) {

--- a/velox/dwio/nimble/encodings/tests/StatisticsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/StatisticsTest.cpp
@@ -86,6 +86,27 @@ TEST(StatisticsTest, runValues) {
   EXPECT_TRUE(nimble::Statistics<int32_t>::create(empty).runValues().empty());
 }
 
+TEST(StatisticsTest, minMaxBlocks) {
+  const std::vector<uint64_t> data = {9, 3, 7, 2, 10, 4, 5};
+  const auto statistics = nimble::Statistics<uint64_t>::create(data);
+  const auto& blocks = statistics.minMaxBlocks(/*blockSize=*/3);
+
+  ASSERT_EQ(blocks.size(), 3);
+  EXPECT_EQ(blocks[0].count, 3);
+  EXPECT_EQ(blocks[0].min, 3);
+  EXPECT_EQ(blocks[0].max, 9);
+  EXPECT_EQ(blocks[1].count, 3);
+  EXPECT_EQ(blocks[1].min, 2);
+  EXPECT_EQ(blocks[1].max, 10);
+  EXPECT_EQ(blocks[2].count, 1);
+  EXPECT_EQ(blocks[2].min, 5);
+  EXPECT_EQ(blocks[2].max, 5);
+
+  const std::vector<uint64_t> empty;
+  EXPECT_TRUE(
+      nimble::Statistics<uint64_t>::create(empty).minMaxBlocks().empty());
+}
+
 TYPED_TEST(StatisticsNumericTests, create) {
   using T = TypeParam;
   using ValueType = typename T::valueType;


### PR DESCRIPTION
Summary:

Compute exact block min/max statistics one block at a time. This removes the per-value block-boundary branch while preserving the statistics and encoding-selection result.

A same-binary benchmark over one million `uint64_t` values with 1,024-row blocks improves from 1.06ms to 176.78us per iteration. This is a 6.0x throughput increase and an 83.3% latency reduction.

| Metric | Parent median | Optimized median | Change |
| --- | ---: | ---: | ---: |
| Encoding CPU | ~77s | ~72s | ~-6.5% |
| Encoding wall | 26.14s | 25.63s | -2.0% |


System CPU varied substantially between runs, so process total CPU was not used to attribute the change. Strobelight shows the inclusive `Statistics::populateMinMaxBlocks` share falling from `2.66%` to `0.28%`, an 89% reduction. 
Parent profiles:

{F1995455935} 

- https://fburl.com/jyankuo2
- https://fburl.com/qt7yym0k
- https://fburl.com/il4gv5a1

Optimized profiles:
 {F1995456022} 

- https://fburl.com/k81aawso
- https://fburl.com/qxvei1vg
- https://fburl.com/scuba/strobelight_services/on_demand/op2ftoxs

Reviewed By: xiaoxmeng

Differential Revision: D118328969


