### PR TITLE
feat(nimble): Add BitRangeSplit integer encoding (#18877)

### DIFF
--- a/velox/dwio/nimble/common/DataTypeDispatch.h
+++ b/velox/dwio/nimble/common/DataTypeDispatch.h
@@ -326,4 +326,96 @@ namespace facebook::nimble {
 #define NIMBLE_TRY_RETURN_BY_INTEGER_DATA_TYPE(dataType, Type, expression) \
   NIMBLE_RETURN_BY_INTEGER_DATA_TYPE_OR(dataType, Type, expression, return {})
 
+/// Dispatches unsigned integer types or evaluates the provided fallback.
+#define NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE_OR( \
+    dataType, Type, expression, ...)                    \
+  switch (dataType) {                                   \
+    case ::facebook::nimble::DataType::Uint8: {         \
+      using Type = uint8_t;                             \
+      return (expression);                              \
+    }                                                   \
+    case ::facebook::nimble::DataType::Uint16: {        \
+      using Type = uint16_t;                            \
+      return (expression);                              \
+    }                                                   \
+    case ::facebook::nimble::DataType::Uint32: {        \
+      using Type = uint32_t;                            \
+      return (expression);                              \
+    }                                                   \
+    case ::facebook::nimble::DataType::Uint64: {        \
+      using Type = uint64_t;                            \
+      return (expression);                              \
+    }                                                   \
+    case ::facebook::nimble::DataType::Undefined:       \
+    case ::facebook::nimble::DataType::Int8:            \
+    case ::facebook::nimble::DataType::Int16:           \
+    case ::facebook::nimble::DataType::Int32:           \
+    case ::facebook::nimble::DataType::Int64:           \
+    case ::facebook::nimble::DataType::Float:           \
+    case ::facebook::nimble::DataType::Double:          \
+    case ::facebook::nimble::DataType::Bool:            \
+    case ::facebook::nimble::DataType::String:          \
+    default: {                                          \
+      __VA_ARGS__;                                      \
+    }                                                   \
+  }
+
+/// Dispatches unsigned integer types and rejects unsupported data types.
+#define NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE( \
+    dataType, Type, expression)                      \
+  NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE_OR(    \
+      dataType,                                      \
+      Type,                                          \
+      expression,                                    \
+      NIMBLE_UNREACHABLE(                            \
+          "Unsupported unsigned integer data type {}.", dataType))
+
+/// Dispatches unsigned integer types and returns an empty result otherwise.
+#define NIMBLE_TRY_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE( \
+    dataType, Type, expression)                          \
+  NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE_OR(        \
+      dataType, Type, expression, return {})
+
+/// Dispatches wide integer types or evaluates the provided fallback.
+#define NIMBLE_RETURN_BY_WIDE_INTEGER_DATA_TYPE_OR( \
+    dataType, Type, expression, ...)                \
+  switch (dataType) {                               \
+    case ::facebook::nimble::DataType::Int32: {     \
+      using Type = int32_t;                         \
+      return (expression);                          \
+    }                                               \
+    case ::facebook::nimble::DataType::Uint32: {    \
+      using Type = uint32_t;                        \
+      return (expression);                          \
+    }                                               \
+    case ::facebook::nimble::DataType::Int64: {     \
+      using Type = int64_t;                         \
+      return (expression);                          \
+    }                                               \
+    case ::facebook::nimble::DataType::Uint64: {    \
+      using Type = uint64_t;                        \
+      return (expression);                          \
+    }                                               \
+    case ::facebook::nimble::DataType::Undefined:   \
+    case ::facebook::nimble::DataType::Int8:        \
+    case ::facebook::nimble::DataType::Uint8:       \
+    case ::facebook::nimble::DataType::Int16:       \
+    case ::facebook::nimble::DataType::Uint16:      \
+    case ::facebook::nimble::DataType::Float:       \
+    case ::facebook::nimble::DataType::Double:      \
+    case ::facebook::nimble::DataType::Bool:        \
+    case ::facebook::nimble::DataType::String:      \
+    default: {                                      \
+      __VA_ARGS__;                                  \
+    }                                               \
+  }
+
+/// Dispatches wide integer types and rejects unsupported data types.
+#define NIMBLE_RETURN_BY_WIDE_INTEGER_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_WIDE_INTEGER_DATA_TYPE_OR(                               \
+      dataType,                                                             \
+      Type,                                                                 \
+      expression,                                                           \
+      NIMBLE_UNREACHABLE("Unsupported wide integer data type {}.", dataType))
+
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/common/Types.cpp
+++ b/velox/dwio/nimble/common/Types.cpp
@@ -50,6 +50,7 @@ constexpr auto kEncodingTypes =
         {EncodingType::SharedDictionary, "SharedDictionary"},
         {EncodingType::Slice, "Slice"},
         {EncodingType::EliasFano, "EliasFano"},
+        {EncodingType::BitRangeSplit, "BitRangeSplit"},
     });
 
 constexpr auto kReadOnlyEncodingTypes = std::to_array<EncodingType>({

--- a/velox/dwio/nimble/common/Types.h
+++ b/velox/dwio/nimble/common/Types.h
@@ -172,6 +172,11 @@ enum class EncodingType {
   // EXPERIMENTAL: Not production-ready. Do not enable for production tables
   // without consulting the Nimble team (oncall: dwios).
   EliasFano = 24,
+  /// Splits 32- or 64-bit integers into configured, independently encoded
+  /// bit-range child streams inside one self-describing encoded chunk.
+  /// EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  /// without consulting the Nimble team (oncall: dwios).
+  BitRangeSplit = 25,
 };
 std::string toString(EncodingType encodingType);
 /// Returns the encoding type for 'name'. Throws if 'name' is unknown.

--- a/velox/dwio/nimble/common/tests/DataTypeDispatchTest.cpp
+++ b/velox/dwio/nimble/common/tests/DataTypeDispatchTest.cpp
@@ -87,6 +87,21 @@ std::string dispatchIntegerDataType(nimble::DataType dataType) {
   NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
 }
 
+std::string dispatchUnsignedIntegerDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE(
+      dataType, T, TypeName{}.operator()<T>());
+}
+
+std::string tryDispatchUnsignedIntegerDataType(nimble::DataType dataType) {
+  NIMBLE_TRY_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE(
+      dataType, T, TypeName{}.operator()<T>());
+}
+
+std::string dispatchWideIntegerDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_WIDE_INTEGER_DATA_TYPE(
+      dataType, T, TypeName{}.operator()<T>());
+}
+
 } // namespace
 
 TEST(DataTypeDispatchTest, dispatchesAllDataTypes) {
@@ -175,4 +190,38 @@ TEST(DataTypeDispatchTest, dispatchesIntegerDataTypes) {
   NIMBLE_ASSERT_THROW(
       dispatchIntegerDataType(nimble::DataType::Bool),
       "Unsupported integer data type");
+}
+
+TEST(DataTypeDispatchTest, dispatchesUnsignedIntegerDataTypes) {
+  EXPECT_EQ(dispatchUnsignedIntegerDataType(nimble::DataType::Uint8), "uint8");
+  EXPECT_EQ(
+      dispatchUnsignedIntegerDataType(nimble::DataType::Uint16), "uint16");
+  EXPECT_EQ(
+      dispatchUnsignedIntegerDataType(nimble::DataType::Uint32), "uint32");
+  EXPECT_EQ(
+      dispatchUnsignedIntegerDataType(nimble::DataType::Uint64), "uint64");
+
+  NIMBLE_ASSERT_THROW(
+      dispatchUnsignedIntegerDataType(nimble::DataType::Int32),
+      "Unsupported unsigned integer data type");
+}
+
+TEST(DataTypeDispatchTest, tryDispatchUnsignedIntegerDataTypes) {
+  EXPECT_EQ(
+      tryDispatchUnsignedIntegerDataType(nimble::DataType::Uint32), "uint32");
+  EXPECT_EQ(tryDispatchUnsignedIntegerDataType(nimble::DataType::Int32), "");
+}
+
+TEST(DataTypeDispatchTest, dispatchesWideIntegerDataTypes) {
+  EXPECT_EQ(dispatchWideIntegerDataType(nimble::DataType::Int32), "int32");
+  EXPECT_EQ(dispatchWideIntegerDataType(nimble::DataType::Uint32), "uint32");
+  EXPECT_EQ(dispatchWideIntegerDataType(nimble::DataType::Int64), "int64");
+  EXPECT_EQ(dispatchWideIntegerDataType(nimble::DataType::Uint64), "uint64");
+
+  NIMBLE_ASSERT_THROW(
+      dispatchWideIntegerDataType(nimble::DataType::Uint16),
+      "Unsupported wide integer data type");
+  NIMBLE_ASSERT_THROW(
+      dispatchWideIntegerDataType(nimble::DataType::Double),
+      "Unsupported wide integer data type");
 }

--- a/velox/dwio/nimble/common/tests/TypesTest.cpp
+++ b/velox/dwio/nimble/common/tests/TypesTest.cpp
@@ -52,6 +52,7 @@ TEST(TypesTest, encodingTypeStringConversion) {
       {EncodingType::Huffman, "Huffman"},
       {EncodingType::DeltaBlock, "DeltaBlock"},
       {EncodingType::EliasFano, "EliasFano"},
+      {EncodingType::BitRangeSplit, "BitRangeSplit"},
   };
   for (const auto& [type, name] : testCases) {
     SCOPED_TRACE(name);

--- a/velox/dwio/nimble/encodings/BitRangeSplitEncoding.h
+++ b/velox/dwio/nimble/encodings/BitRangeSplitEncoding.h
@@ -1,0 +1,695 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <limits>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <folly/Conv.h>
+
+#include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/DataTypeDispatch.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/EncodingSliceFactory.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingIdentifier.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
+
+namespace facebook::nimble {
+
+namespace detail {
+
+// Defines the serialized BitRangeSplit layout shared by decoders and tooling.
+class BitRangeSplitEncodingBase {
+ public:
+  // EncodingLayout config key for semicolon-separated inclusive ranges.
+  static constexpr std::string_view kRangesConfigKey = "bit-range-split.ranges";
+
+  // Number of bytes in a serialized section descriptor.
+  static constexpr size_t kSectionDescriptorBytes = 2 + sizeof(uint32_t);
+
+  // Describes one contiguous bit range and its nested encoded payload.
+  struct Section {
+    // First bit in the range, inclusive.
+    uint8_t bitStart{0};
+    // Last bit in the range, inclusive.
+    uint8_t bitEnd{0};
+    // Byte width of the unsigned integer type used by the child encoding.
+    uint8_t storageBytes{0};
+    // Start of the child payload, or null for a range parsed from config.
+    const char* data{nullptr};
+    // Child payload size, or zero for a range parsed from config.
+    uint32_t dataBytes{0};
+  };
+
+  // Describes all sections in one validated encoded chunk.
+  struct Header {
+    // Number of values encoded in every child stream.
+    uint32_t rowCount{0};
+    // Ordered, contiguous ranges covering the physical integer type.
+    std::vector<Section> sections{};
+  };
+
+  // Returns the narrowest integer storage width containing a bit range.
+  static constexpr uint8_t sectionStorageBytes(uint8_t bitWidth) {
+    if (bitWidth <= 8) {
+      return 1;
+    }
+    if (bitWidth <= 16) {
+      return 2;
+    }
+    if (bitWidth <= 32) {
+      return 4;
+    }
+    return 8;
+  }
+
+  // Returns the unsigned data type matching a section storage width.
+  static DataType sectionDataType(uint8_t storageBytes) {
+    switch (storageBytes) {
+      case 1:
+        return DataType::Uint8;
+      case 2:
+        return DataType::Uint16;
+      case 4:
+        return DataType::Uint32;
+      case 8:
+        return DataType::Uint64;
+      default:
+        NIMBLE_UNREACHABLE(
+            "Invalid BitRangeSplit section storage width: {}.",
+            static_cast<uint32_t>(storageBytes));
+    }
+  }
+
+  // Returns a mask restricted to the section's serialized bit range.
+  static constexpr uint64_t sectionMask(const Section& section) {
+    const auto width =
+        static_cast<uint8_t>(section.bitEnd - section.bitStart + 1);
+    return width == 64 ? std::numeric_limits<uint64_t>::max()
+                       : (uint64_t{1} << width) - 1;
+  }
+
+  // Returns whether an encoding participates in default child selection.
+  // Explicitly replayed layouts are not restricted by this preference.
+  static constexpr bool isValidSectionEncodingCandidate(
+      EncodingType encodingType) {
+    return encodingType != EncodingType::BitRangeSplit &&
+        encodingType != EncodingType::RLE &&
+        encodingType != EncodingType::MainlyConstant;
+  }
+
+  // Parses configured contiguous ranges or throws when they are invalid.
+  static std::vector<Section> parseSections(
+      std::string_view config,
+      uint8_t physicalBits);
+
+  // Serializes ranges for EncodingLayout replay.
+  static std::string serializeSections(std::span<const Section> sections);
+
+  // Parses and validates section metadata and payload boundaries.
+  static Header parseHeader(
+      std::string_view encoded,
+      const Encoding::Options& options);
+
+  // Visits each nested section and returns the validated outer header.
+  template <typename Visitor>
+  static Header visitSections(
+      std::string_view encoded,
+      const Encoding::Options& options,
+      Visitor&& visitor) {
+    auto header = parseHeader(encoded, options);
+    for (NestedEncodingIdentifier sectionIndex{0};
+         sectionIndex < header.sections.size();
+         ++sectionIndex) {
+      visitor(sectionIndex, header.sections[sectionIndex]);
+    }
+    return header;
+  }
+
+  // Captures child layouts and configuration required for replay.
+  template <typename Visitor>
+  static void captureLayout(
+      std::string_view encoded,
+      const Encoding::Options& options,
+      Visitor&& visitor,
+      EncodingLayout::Config& encodingConfig) {
+    const auto header =
+        visitSections(encoded, options, std::forward<Visitor>(visitor));
+    encodingConfig = EncodingLayout::Config{{{
+        std::string(kRangesConfigKey),
+        serializeSections(header.sections),
+    }}};
+  }
+};
+
+} // namespace detail
+
+/// Stores configured integer bit ranges as independently encoded child streams
+/// inside one self-describing encoding chunk.
+template <typename T>
+class BitRangeSplitEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+  static_assert(
+      isIntegralType<T>() && (sizeof(T) == 4 || sizeof(T) == 8),
+      "BitRangeSplit only supports 32- and 64-bit integers.");
+
+ public:
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  /// EncodingLayout config key for semicolon-separated inclusive ranges.
+  static constexpr std::string_view kRangesConfigKey =
+      detail::BitRangeSplitEncodingBase::kRangesConfigKey;
+
+  /// Constructs a decoder from a self-describing encoded chunk.
+  BitRangeSplitEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  /// Encodes values using ranges supplied by the per-stream encoding config.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Encodes rows [offset, offset + length) by slicing each child stream.
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+ private:
+  using Base = detail::BitRangeSplitEncodingBase;
+  using Section = Base::Section;
+  using Header = Base::Header;
+
+  // Encodes one range using the narrowest integer type that contains it.
+  template <typename SectionType>
+  static std::string_view encodeSection(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      const Section& section,
+      NestedEncodingIdentifier identifier,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
+  // Selects and encodes all range child streams.
+  static std::vector<std::string_view> encodeSections(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      std::span<const Section> sections,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
+  // Serializes the outer chunk around already encoded child streams.
+  static std::string_view serializeSections(
+      uint32_t rowCount,
+      std::span<const Section> sections,
+      std::span<const std::string_view> sectionData,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
+  // Materializes child streams and merges their disjoint ranges.
+  void readValues(uint32_t length, physicalType* output);
+
+  // Validated metadata and child-stream boundaries for this chunk.
+  Header header_{};
+  // Decoders ordered by the corresponding range in header_.sections.
+  std::vector<std::unique_ptr<Encoding>> nestedEncodings_{};
+  // Reused materialization storage sized for the widest child in a read.
+  Vector<uint8_t> scratch_;
+  // Next row consumed by the sequential interface.
+  uint32_t row_{0};
+};
+
+template <typename T>
+BitRangeSplitEncoding<T>::BitRangeSplitEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      header_{Base::parseHeader(data, options)},
+      scratch_{&pool} {
+  NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::BitRangeSplit);
+  NIMBLE_CHECK_EQ(header_.rowCount, this->rowCount_);
+  nestedEncodings_.reserve(header_.sections.size());
+  for (const auto& section : header_.sections) {
+    auto nested = EncodingFactory().create(
+        pool, {section.data, section.dataBytes}, stringBufferFactory, options);
+    NIMBLE_CHECK_EQ(nested->rowCount(), header_.rowCount);
+    NIMBLE_CHECK_EQ(
+        nested->dataType(), Base::sectionDataType(section.storageBytes));
+    nestedEncodings_.push_back(std::move(nested));
+  }
+}
+
+inline std::vector<detail::BitRangeSplitEncodingBase::Section>
+detail::BitRangeSplitEncodingBase::parseSections(
+    std::string_view config,
+    uint8_t physicalBits) {
+  NIMBLE_CHECK(!config.empty(), "BitRangeSplit ranges cannot be empty.");
+  NIMBLE_CHECK(
+      physicalBits == 32 || physicalBits == 64,
+      "BitRangeSplit requires a 32- or 64-bit physical type: {}.",
+      physicalBits);
+
+  std::vector<Section> sections;
+  sections.reserve(8);
+  uint16_t expectedStart{0};
+  size_t cursor{0};
+  while (cursor < config.size()) {
+    const auto dash = config.find('-', cursor);
+    NIMBLE_CHECK_NE(
+        dash,
+        std::string_view::npos,
+        "Invalid BitRangeSplit range config: '{}'.",
+        config);
+    const auto separator = config.find(';', dash + 1);
+    const auto startText = config.substr(cursor, dash - cursor);
+    const auto endText = config.substr(
+        dash + 1,
+        separator == std::string_view::npos ? config.size() - dash - 1
+                                            : separator - dash - 1);
+
+    uint32_t bitStart{0};
+    uint32_t bitEnd{0};
+    try {
+      bitStart = folly::to<uint32_t>(startText);
+      bitEnd = folly::to<uint32_t>(endText);
+    } catch (const std::exception&) {
+      NIMBLE_FAIL("Invalid BitRangeSplit range config: '{}'.", config);
+    }
+    NIMBLE_CHECK_EQ(
+        bitStart,
+        expectedStart,
+        "BitRangeSplit ranges are not contiguous: '{}'.",
+        config);
+    NIMBLE_CHECK_GE(
+        bitEnd, bitStart, "BitRangeSplit range is reversed: '{}'.", config);
+    NIMBLE_CHECK_LT(
+        bitEnd,
+        physicalBits,
+        "BitRangeSplit range exceeds the physical type: '{}'.",
+        config);
+
+    const auto width = static_cast<uint8_t>(bitEnd - bitStart + 1);
+    sections.push_back({
+        .bitStart = static_cast<uint8_t>(bitStart),
+        .bitEnd = static_cast<uint8_t>(bitEnd),
+        .storageBytes = sectionStorageBytes(width),
+    });
+    expectedStart = bitEnd + 1;
+    if (separator == std::string_view::npos) {
+      break;
+    }
+    cursor = separator + 1;
+    NIMBLE_CHECK_LT(
+        cursor,
+        config.size(),
+        "Invalid trailing separator in BitRangeSplit range config: '{}'.",
+        config);
+  }
+
+  NIMBLE_CHECK_EQ(
+      expectedStart,
+      physicalBits,
+      "BitRangeSplit ranges do not cover the physical type: '{}'.",
+      config);
+  return sections;
+}
+
+inline std::string detail::BitRangeSplitEncodingBase::serializeSections(
+    std::span<const Section> sections) {
+  std::string config;
+  for (size_t i{0}; i < sections.size(); ++i) {
+    if (i > 0) {
+      config.push_back(';');
+    }
+    config += std::to_string(sections[i].bitStart);
+    config.push_back('-');
+    config += std::to_string(sections[i].bitEnd);
+  }
+  return config;
+}
+
+inline detail::BitRangeSplitEncodingBase::Header
+detail::BitRangeSplitEncodingBase::parseHeader(
+    std::string_view encoded,
+    const Encoding::Options& options) {
+  const auto prefixSize =
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_FILE_GE(
+      encoded.size(), prefixSize + 1, "Truncated BitRangeSplit header.");
+  Header header{
+      .rowCount =
+          EncodingPrefix::readRowCount(encoded, options.useVarintRowCount),
+  };
+  NIMBLE_CHECK_FILE_GT(
+      header.rowCount, 0, "BitRangeSplit stream must contain rows.");
+
+  const auto dataType = EncodingPrefix::dataType(encoded);
+  const bool is32Bit =
+      dataType == DataType::Int32 || dataType == DataType::Uint32;
+  const bool is64Bit =
+      dataType == DataType::Int64 || dataType == DataType::Uint64;
+  NIMBLE_CHECK_FILE(
+      is32Bit || is64Bit,
+      "BitRangeSplit requires a 32- or 64-bit integer type: {}.",
+      dataType);
+  const uint8_t physicalBits = is32Bit ? 32 : 64;
+
+  const char* cursor = encoded.data() + prefixSize;
+  const char* const encodedEnd = encoded.end();
+  const auto numSections = encoding::read<uint8_t>(cursor);
+  NIMBLE_CHECK_FILE_GT(numSections, 0, "BitRangeSplit must contain sections.");
+  const auto descriptorBytes =
+      static_cast<size_t>(numSections) * kSectionDescriptorBytes;
+  NIMBLE_CHECK_FILE_GE(
+      static_cast<size_t>(encodedEnd - cursor),
+      descriptorBytes,
+      "Truncated BitRangeSplit section metadata.");
+
+  header.sections.reserve(numSections);
+  uint16_t expectedStart{0};
+  for (uint8_t sectionIndex{0}; sectionIndex < numSections; ++sectionIndex) {
+    const auto bitStart = encoding::read<uint8_t>(cursor);
+    const auto bitEnd = encoding::read<uint8_t>(cursor);
+    NIMBLE_CHECK_FILE_EQ(
+        bitStart, expectedStart, "BitRangeSplit ranges are not contiguous.");
+    NIMBLE_CHECK_FILE_GE(
+        bitEnd, bitStart, "Invalid BitRangeSplit range start.");
+    NIMBLE_CHECK_FILE_LT(
+        bitEnd, physicalBits, "Invalid BitRangeSplit range end.");
+    const auto rangeWidth = static_cast<uint8_t>(bitEnd - bitStart + 1);
+    header.sections.push_back({
+        .bitStart = bitStart,
+        .bitEnd = bitEnd,
+        .storageBytes = sectionStorageBytes(rangeWidth),
+        .dataBytes = encoding::readUint32(cursor),
+    });
+    expectedStart = bitEnd + 1;
+  }
+  NIMBLE_CHECK_FILE_EQ(
+      expectedStart,
+      physicalBits,
+      "BitRangeSplit ranges do not cover every physical bit.");
+
+  for (auto& section : header.sections) {
+    NIMBLE_CHECK_FILE_LE(
+        section.dataBytes,
+        static_cast<uint64_t>(encodedEnd - cursor),
+        "Truncated BitRangeSplit section payload.");
+    section.data = cursor;
+    cursor += section.dataBytes;
+  }
+  NIMBLE_CHECK_FILE_EQ(
+      cursor, encodedEnd, "Unexpected BitRangeSplit trailing bytes.");
+  return header;
+}
+
+template <typename T>
+void BitRangeSplitEncoding<T>::readValues(
+    uint32_t length,
+    physicalType* output) {
+  std::fill(output, output + length, physicalType{0});
+  const auto mergeSection = [&]<typename SectionType>(size_t sectionIndex) {
+    scratch_.resize(length * sizeof(SectionType));
+    auto* sectionValues = reinterpret_cast<SectionType*>(scratch_.data());
+    nestedEncodings_[sectionIndex]->materialize(length, sectionValues);
+    const auto& section = header_.sections[sectionIndex];
+    const auto mask = Base::sectionMask(section);
+    for (uint32_t row{0}; row < length; ++row) {
+      output[row] |= static_cast<physicalType>(
+          (static_cast<uint64_t>(sectionValues[row]) & mask)
+          << section.bitStart);
+    }
+  };
+  for (size_t sectionIndex{0}; sectionIndex < header_.sections.size();
+       ++sectionIndex) {
+    const auto storageBytes = header_.sections[sectionIndex].storageBytes;
+    [&] {
+      NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE(
+          Base::sectionDataType(storageBytes),
+          SectionType,
+          mergeSection.template operator()<SectionType>(sectionIndex));
+    }();
+  }
+}
+
+template <typename T>
+template <typename SectionType>
+std::string_view BitRangeSplitEncoding<T>::encodeSection(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    const Section& section,
+    NestedEncodingIdentifier identifier,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto rowCount = static_cast<uint32_t>(values.size());
+  const auto mask = Base::sectionMask(section);
+  ScopedVector<SectionType> sectionValues{
+      rowCount, &buffer.getMemoryPool(), options.bufferPool};
+  for (uint32_t row{0}; row < rowCount; ++row) {
+    const uint64_t rawValue = values[row];
+    sectionValues[row] =
+        static_cast<SectionType>((rawValue >> section.bitStart) & mask);
+  }
+  Encoding::Options sectionOptions = options;
+  sectionOptions.fixedBitWidthUseExactBits = true;
+  return selection.template encodeNested<SectionType>(
+      identifier,
+      std::span<const SectionType>(sectionValues.data(), sectionValues.size()),
+      buffer,
+      sectionOptions);
+}
+
+template <typename T>
+std::vector<std::string_view> BitRangeSplitEncoding<T>::encodeSections(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    std::span<const Section> sections,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  std::vector<std::string_view> sectionData;
+  sectionData.reserve(sections.size());
+  for (size_t sectionIndex{0}; sectionIndex < sections.size(); ++sectionIndex) {
+    const auto& section = sections[sectionIndex];
+    const auto encoded = [&]() -> std::string_view {
+      NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE(
+          Base::sectionDataType(section.storageBytes),
+          SectionType,
+          encodeSection<SectionType>(
+              selection,
+              values,
+              section,
+              static_cast<NestedEncodingIdentifier>(sectionIndex),
+              buffer,
+              options));
+    }();
+    NIMBLE_CHECK_LE(
+        encoded.size(),
+        std::numeric_limits<uint32_t>::max(),
+        "BitRangeSplit child encoding exceeds the maximum chunk size.");
+    sectionData.push_back(encoded);
+  }
+  return sectionData;
+}
+
+template <typename T>
+std::string_view BitRangeSplitEncoding<T>::serializeSections(
+    uint32_t rowCount,
+    std::span<const Section> sections,
+    std::span<const std::string_view> sectionData,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK_EQ(sections.size(), sectionData.size());
+  uint64_t totalPayloadSize{0};
+  for (const auto encoded : sectionData) {
+    totalPayloadSize += encoded.size();
+  }
+  const auto prefixSize =
+      Encoding::serializePrefixSize(rowCount, options.useVarintRowCount);
+  const auto metadataSize =
+      uint64_t{1} + sections.size() * Base::kSectionDescriptorBytes;
+  const auto encodingSize = prefixSize + metadataSize + totalPayloadSize;
+  NIMBLE_CHECK_LE(
+      encodingSize,
+      std::numeric_limits<uint32_t>::max(),
+      "BitRangeSplit encoding exceeds the maximum chunk size.");
+
+  char* const reserved = buffer.reserve(static_cast<uint32_t>(encodingSize));
+  char* cursor = reserved;
+  Encoding::serializePrefix(
+      EncodingType::BitRangeSplit,
+      TypeTraits<T>::dataType,
+      rowCount,
+      options.useVarintRowCount,
+      cursor);
+  encoding::write<uint8_t>(static_cast<uint8_t>(sections.size()), cursor);
+  for (size_t sectionIndex{0}; sectionIndex < sections.size(); ++sectionIndex) {
+    encoding::write<uint8_t>(sections[sectionIndex].bitStart, cursor);
+    encoding::write<uint8_t>(sections[sectionIndex].bitEnd, cursor);
+    encoding::writeUint32(
+        static_cast<uint32_t>(sectionData[sectionIndex].size()), cursor);
+  }
+  for (const auto encoded : sectionData) {
+    encoding::writeBytes(encoded, cursor);
+  }
+  NIMBLE_CHECK_EQ(
+      cursor - reserved, encodingSize, "BitRangeSplit encoding size mismatch.");
+  return {reserved, static_cast<size_t>(encodingSize)};
+}
+
+template <typename T>
+std::string_view BitRangeSplitEncoding<T>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK(
+      !values.empty(), "BitRangeSplit encoding cannot be used with 0 rows.");
+  const auto rangesConfig =
+      selection.getConfig(std::string(Base::kRangesConfigKey));
+  NIMBLE_CHECK(
+      rangesConfig.has_value(),
+      "BitRangeSplit requires the '{}' encoding config.",
+      Base::kRangesConfigKey);
+  const auto sections = Base::parseSections(
+      *rangesConfig, static_cast<uint8_t>(sizeof(physicalType) * 8));
+
+  ScopedEncodingBuffer scopedBuffer{
+      &buffer.getMemoryPool(), options.encodingBufferPool};
+  auto& sectionBuffer = scopedBuffer.get();
+  const auto sectionData =
+      encodeSections(selection, values, sections, sectionBuffer, options);
+  const auto rowCount = static_cast<uint32_t>(values.size());
+  return serializeSections(rowCount, sections, sectionData, buffer, options);
+}
+
+template <typename T>
+std::string_view BitRangeSplitEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto header = Base::parseHeader(encoded, options);
+  NIMBLE_CHECK_LE(offset, header.rowCount);
+  NIMBLE_CHECK_LE(length, header.rowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+  if (offset == 0 && length == header.rowCount) {
+    return buffer.writeString(encoded);
+  }
+
+  ScopedEncodingBuffer scopedBuffer{
+      &buffer.getMemoryPool(), options.encodingBufferPool};
+  auto& sectionBuffer = scopedBuffer.get();
+  std::vector<std::string_view> sectionData;
+  sectionData.reserve(header.sections.size());
+  for (const auto& section : header.sections) {
+    sectionData.push_back(
+        EncodingSliceFactory::slice(
+            {section.data, section.dataBytes},
+            offset,
+            length,
+            sectionBuffer,
+            options));
+  }
+  return serializeSections(
+      length, header.sections, sectionData, buffer, options);
+}
+
+template <typename T>
+void BitRangeSplitEncoding<T>::reset() {
+  for (auto& nested : nestedEncodings_) {
+    nested->reset();
+  }
+  row_ = 0;
+}
+
+template <typename T>
+void BitRangeSplitEncoding<T>::skip(uint32_t rowCount) {
+  NIMBLE_CHECK_LE(rowCount, this->rowCount_ - row_);
+  for (auto& nested : nestedEncodings_) {
+    nested->skip(rowCount);
+  }
+  row_ += rowCount;
+}
+
+template <typename T>
+void BitRangeSplitEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  NIMBLE_CHECK_LE(rowCount, this->rowCount_ - row_);
+  readValues(rowCount, static_cast<physicalType*>(buffer));
+  row_ += rowCount;
+}
+
+template <typename T>
+template <typename DecoderVisitor>
+void BitRangeSplitEncoding<T>::readWithVisitor(
+    DecoderVisitor& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&]() {
+        physicalType value{0};
+        materialize(1, &value);
+        return value;
+      });
+}
+
+template <typename T>
+std::string BitRangeSplitEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} sections={}",
+      std::string(offset, ' '),
+      Encoding::encodingType(),
+      Encoding::dataType(),
+      Encoding::rowCount(),
+      header_.sections.size());
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(
   views/DictionaryEncodingView.h
   views/ConstantEncodingView.h
   views/BlockBitPackingEncodingView.h
+  views/BitRangeSplitEncodingView.h
   views/ALPEncodingView.h
   selection/Statistics.h
   selection/NestedAlpSizeEstimation.h
@@ -108,6 +109,7 @@ add_library(
   DeltaBlockEncoding.h
   ConstantEncoding.h
   BlockBitPackingEncoding.h
+  BitRangeSplitEncoding.h
   ALPEncoding.h
 )
 

--- a/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/velox/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -23,6 +23,7 @@
 #include "velox/dwio/nimble/common/NimbleException.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
@@ -263,6 +264,23 @@ std::string_view sliceEliasFano(
       EliasFanoEncoding<T>::slice(encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceBitRangeSplit(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_WIDE_INTEGER_DATA_TYPE_OR(
+      dataType,
+      T,
+      BitRangeSplitEncoding<T>::slice(encoded, offset, length, buffer, options),
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "Cannot slice BitRangeSplit encoding for an incompatible data type "
+          "{}.",
+          dataType));
+}
+
 std::string_view slicePFOR(
     std::string_view encoded,
     DataType dataType,
@@ -374,6 +392,9 @@ std::string_view EncodingSliceFactory::slice(
           encoded, dataType, offset, length, buffer, options);
     case EncodingType::EliasFano:
       return sliceEliasFano(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::BitRangeSplit:
+      return sliceBitRangeSplit(
+          encoded, dataType, offset, length, buffer, options);
     case EncodingType::PFOR:
       return slicePFOR(encoded, dataType, offset, length, buffer, options);
     case EncodingType::SimdForBitpack:

--- a/velox/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
@@ -33,6 +33,7 @@
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
@@ -48,6 +49,7 @@
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
@@ -97,6 +99,42 @@ std::string encodeTrivialString(
   Buffer buffer{*benchmarkPool()};
   auto encoded = TrivialEncoding<std::string_view>::encode(
       selection, values, buffer, options);
+  return {encoded.data(), encoded.size()};
+}
+
+std::unique_ptr<EncodingSelectionPolicy<uint64_t>>
+makeBitRangeSplitSelectionPolicy() {
+  const auto childLayout = [] {
+    return EncodingLayout{
+        EncodingType::FixedBitWidth, {}, CompressionType::Uncompressed};
+  };
+  EncodingLayout layout{
+      EncodingType::BitRangeSplit,
+      EncodingLayout::Config{{
+          {std::string(BitRangeSplitEncoding<uint64_t>::kRangesConfigKey),
+           "0-15;16-58;59-63"},
+      }},
+      CompressionType::Uncompressed,
+      {childLayout(), childLayout(), childLayout()}};
+  return std::make_unique<ReplayedEncodingSelectionPolicy<uint64_t>>(
+      std::move(layout), std::nullopt, [](DataType dataType) {
+        return makeDefaultPolicy(dataType);
+      });
+}
+
+std::string_view encodeBitRangeSplit(
+    const Vector<uint64_t>& data,
+    Buffer& buffer) {
+  return EncodingFactory::encode<uint64_t>(
+      makeBitRangeSplitSelectionPolicy(),
+      physicalSpan(data),
+      buffer,
+      Encoding::Options{.fixedBitWidthUseExactBits = true});
+}
+
+std::string encodeBitRangeSplit(const Vector<uint64_t>& data) {
+  Buffer buffer{*benchmarkPool()};
+  const auto encoded = encodeBitRangeSplit(data, buffer);
   return {encoded.data(), encoded.size()};
 }
 
@@ -250,6 +288,20 @@ void readPositionsWithMaterialization(
       encoding.materialize(1, &value);
       folly::doNotOptimizeAway(value);
     }
+  }
+}
+
+template <typename T>
+void readRangesWithMaterialization(Encoding& encoding, uint32_t iters) {
+  auto output =
+      std::make_unique<typename TypeTraits<T>::physicalType[]>(kRangeSize);
+  while (iters--) {
+    encoding.reset();
+    for (uint32_t offset{0}; offset < kRows; offset += kRangeSize) {
+      encoding.materialize(
+          std::min<uint32_t>(kRangeSize, kRows - offset), output.get());
+    }
+    folly::doNotOptimizeAway(output[0]);
   }
 }
 
@@ -485,6 +537,15 @@ Vector<uint32_t> mainlyConstantData() {
   data.resize(kRows, 7);
   for (uint32_t i = 0; i < kRows; i += 17) {
     data[i] = i;
+  }
+  return data;
+}
+
+Vector<uint64_t> bitRangeSplitData() {
+  Vector<uint64_t> data{benchmarkPool().get()};
+  data.resize(kRows);
+  for (uint64_t row{0}; row < kRows; ++row) {
+    data[row] = row * 0x9e37'79b9'7f4a'7c15ULL;
   }
   return data;
 }
@@ -1122,6 +1183,46 @@ MATERIALIZE_BENCHMARK(
         EncodingType::SimdForBitpack,
         makeNarrow<uint8_t>(10, kRows)),
     randomPositions(kRows))
+VIEW_BENCHMARK(
+    View_BitRangeSplitUint64_Random130,
+    uint64_t,
+    encodeBitRangeSplit(bitRangeSplitData()),
+    randomPositions(kRows))
+BATCH_VIEW_BENCHMARK(
+    BatchView_BitRangeSplitUint64_Random130,
+    uint64_t,
+    encodeBitRangeSplit(bitRangeSplitData()),
+    randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_BitRangeSplitUint64_Range1024,
+    uint64_t,
+    encodeBitRangeSplit(bitRangeSplitData()))
+MATERIALIZE_BENCHMARK(
+    Materialize_BitRangeSplitUint64_Random130,
+    uint64_t,
+    encodeBitRangeSplit(bitRangeSplitData()),
+    randomPositions(kRows))
+BENCHMARK(Materialize_BitRangeSplitUint64_Range1024, iters) {
+  std::string encoded;
+  std::vector<facebook::velox::BufferPtr> stringBuffers;
+  std::unique_ptr<Encoding> encoding;
+  BENCHMARK_SUSPEND {
+    encoded = encodeBitRangeSplit(bitRangeSplitData());
+    encoding = createRegularEncoding(encoded, stringBuffers);
+  }
+  readRangesWithMaterialization<uint64_t>(*encoding, iters);
+}
+BENCHMARK(Encode_BitRangeSplitUint64_4096, iters) {
+  Vector<uint64_t> data{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    data = bitRangeSplitData();
+  }
+  while (iters--) {
+    Buffer buffer{*benchmarkPool()};
+    const auto encoded = encodeBitRangeSplit(data, buffer);
+    folly::doNotOptimizeAway(encoded);
+  }
+}
 VIEW_BENCHMARK(
     View_BlockBitPackingUint32_Random130,
     uint32_t,

--- a/velox/dwio/nimble/encodings/common/Encoding.h
+++ b/velox/dwio/nimble/encodings/common/Encoding.h
@@ -17,7 +17,6 @@
 
 #include "velox/buffer/BufferPool.h"
 #include "velox/common/base/BitUtil.h"
-#include "velox/common/base/SimdUtil.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/common/DecoderUtil.h"
@@ -31,6 +30,7 @@
 #include <memory>
 #include <string_view>
 #include <type_traits>
+#include <vector>
 
 /// The Encoding class defines an interface for interacting with encodings
 /// (aka vectors, aka arrays) of encoded data. The API is tailored for

--- a/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -19,6 +19,7 @@
 
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
@@ -181,6 +182,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::SimdForBitpack: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(SimdForBitpackEncoding, dataType);
+    }
+    case EncodingType::BitRangeSplit: {
+      RETURN_ENCODING_BY_WIDE_INTEGER_TYPE(BitRangeSplitEncoding, dataType);
     }
     case EncodingType::Huffman: {
       RETURN_ENCODING_BY_INTEGER_TYPE(HuffmanEncoding, dataType);
@@ -455,6 +459,16 @@ std::string_view EncodingFactory::encode(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "SimdForBitpack encoding only supports integral data types, got {}.",
+          TypeTraits<T>::dataType);
+    }
+    case EncodingType::BitRangeSplit: {
+      if constexpr (isIntegralType<T>() && (sizeof(T) == 4 || sizeof(T) == 8)) {
+        return BitRangeSplitEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "BitRangeSplit encoding only supports 32- and 64-bit integer data "
+          "types, got {}.",
           TypeTraits<T>::dataType);
     }
     case EncodingType::Huffman: {

--- a/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -20,6 +20,7 @@
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Varint.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -188,6 +189,7 @@ EncodingLayout EncodingLayoutCapture::capture(
         encoding::peek<uint8_t, CompressionType>(encoding.data() + prefixSize);
   }
 
+  EncodingLayout::Config encodingConfig;
   std::vector<std::optional<const EncodingLayout>> children;
   switch (encodingType) {
     case EncodingType::FixedBitWidth:
@@ -207,6 +209,19 @@ EncodingLayout EncodingLayoutCapture::capture(
       // stream, and the layout tree describes how data is encoded, not how a
       // slice was deferred. Reported as childless.
       break;
+    case EncodingType::BitRangeSplit: {
+      using Base = detail::BitRangeSplitEncodingBase;
+      Base::captureLayout(
+          encoding,
+          options,
+          [&](NestedEncodingIdentifier /* sectionIndex */,
+              const Base::Section& section) {
+            const char* position = section.data;
+            captureChild(children, position, section.dataBytes, options);
+          },
+          encodingConfig);
+      break;
+    }
     case EncodingType::ALP: {
       const char* pos = encoding.data() + prefixSize;
       const auto header = detail::alp::readHeader(pos);
@@ -402,8 +417,7 @@ EncodingLayout EncodingLayoutCapture::capture(
 
   return {
       encodingType,
-      /*encodingConfig=*/
-      {},
+      std::move(encodingConfig),
       compressionType,
       std::move(children)};
 }

--- a/velox/dwio/nimble/encodings/common/EncodingTypeDispatch.h
+++ b/velox/dwio/nimble/encodings/common/EncodingTypeDispatch.h
@@ -68,4 +68,15 @@ namespace facebook::nimble {
           "an incompatible data type {}.",                                     \
           toString(dataType)))
 
+/// Creates an encoding for a 32- or 64-bit integer data type.
+#define RETURN_ENCODING_BY_WIDE_INTEGER_TYPE(Encoding, dataType)               \
+  NIMBLE_RETURN_BY_WIDE_INTEGER_DATA_TYPE_OR(                                  \
+      dataType,                                                                \
+      T,                                                                       \
+      std::make_unique<Encoding<T>>(pool, data, stringBufferFactory, options), \
+      NIMBLE_INCOMPATIBLE_ENCODING(                                            \
+          #Encoding " only supports 32- and 64-bit integer data types, got "   \
+                    "{}.",                                                     \
+          dataType))
+
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/velox/dwio/nimble/encodings/common/EncodingUtils.h
@@ -19,6 +19,7 @@
 
 #include "velox/dwio/nimble/common/DataTypeDispatch.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaBlockEncoding.h"
@@ -194,6 +195,14 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       }
       NIMBLE_UNREACHABLE(
           "SimdForBitpack encoding only supports integral data types, got {}.",
+          encoding.dataType());
+    case EncodingType::BitRangeSplit:
+      if constexpr (isIntegralType<T>() && (sizeof(T) == 4 || sizeof(T) == 8)) {
+        return f(static_cast<BitRangeSplitEncoding<T>&>(encoding));
+      }
+      NIMBLE_UNREACHABLE(
+          "BitRangeSplit encoding only supports 32- and 64-bit integer data "
+          "types, got {}.",
           encoding.dataType());
     case EncodingType::Huffman:
       if constexpr (isIntegralType<T>()) {

--- a/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/dwio/nimble/common/Constants.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingType.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingIdentifier.h"
@@ -263,7 +264,11 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
         : candidateEncodingReadFactors_;
     nestedEncodingReadFactors.reserve(sourceEncodingReadFactors.size());
     for (const auto& entry : sourceEncodingReadFactors) {
-      if (entry.first != parentEncodingType) {
+      const bool isCandidate = parentEncodingType == EncodingType::BitRangeSplit
+          ? detail::BitRangeSplitEncodingBase::isValidSectionEncodingCandidate(
+                entry.first)
+          : entry.first != parentEncodingType;
+      if (isCandidate) {
         nestedEncodingReadFactors.emplace_back(entry);
       }
     }

--- a/velox/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -362,6 +362,39 @@ TEST(ManualEncodingSelectionPolicyFactoryTest, nestedReadFactorsInheritRoot) {
           {nimble::EncodingType::FixedBitWidth, 1.0}}));
 }
 
+TEST(
+    ManualEncodingSelectionPolicyFactoryTest,
+    bitRangeSplitExcludesSequentialChildEncodings) {
+  nimble::ManualEncodingSelectionPolicyFactory factory{
+      {
+          {nimble::EncodingType::Constant, 1.0},
+          {nimble::EncodingType::Trivial, 1.0},
+          {nimble::EncodingType::FixedBitWidth, 1.0},
+          {nimble::EncodingType::BlockBitPacking, 1.0},
+          {nimble::EncodingType::RLE, 1.0},
+          {nimble::EncodingType::MainlyConstant, 1.0},
+          {nimble::EncodingType::BitRangeSplit, 1.0},
+      },
+      /*compressionOptions=*/std::nullopt};
+
+  auto root = factory.createPolicy(nimble::DataType::Uint64);
+  auto childBase = root->create<uint32_t>(
+      nimble::EncodingType::BitRangeSplit, /*nestedEncodingIdentifier=*/0);
+  auto* child = dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint32_t>*>(
+      childBase.get());
+  ASSERT_NE(child, nullptr);
+  // Section point lookups exclude recursive and sequential child encodings
+  // from automatic selection, while retaining random-access encodings.
+  EXPECT_EQ(
+      child->candidateEncodingReadFactors(),
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::Constant, 1.0},
+          {nimble::EncodingType::Trivial, 1.0},
+          {nimble::EncodingType::FixedBitWidth, 1.0},
+          {nimble::EncodingType::BlockBitPacking, 1.0},
+      }));
+}
+
 TEST(ManualEncodingSelectionPolicyFactoryTest, nestedReadFactorsOverrideRoot) {
   nimble::ManualEncodingSelectionPolicyFactory factory{
       {{nimble::EncodingType::Trivial, 1.0}},

--- a/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingSliceTest.cpp
@@ -32,6 +32,7 @@
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/DeltaEncoding.h"
@@ -48,6 +49,8 @@
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/VarintEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
 using namespace facebook;
@@ -404,6 +407,120 @@ TEST_F(EncodingSliceTest, dictionaryRejectsZeroLengthRange) {
 
   NIMBLE_ASSERT_THROW(
       slice(encoded, /*offset=*/1, /*length=*/0), "Cannot slice zero rows.");
+}
+
+TEST_F(EncodingSliceTest, bitRangeSplitReplaysRanges) {
+  constexpr std::string_view kRangesConfig = "0-15;16-47;48-63";
+  const auto values = makeVector<uint64_t>({
+      0x299aff8ca62b0001,
+      0x299be75117820001,
+      0x0999c1e5b8460001,
+      0x299f100bfa830002,
+  });
+  const nimble::EncodingLayout layout{
+      nimble::EncodingType::BitRangeSplit,
+      nimble::EncodingLayout::Config{{
+          {std::string(
+               nimble::BitRangeSplitEncoding<uint64_t>::kRangesConfigKey),
+           std::string(kRangesConfig)},
+      }},
+      nimble::CompressionType::Uncompressed,
+      std::vector<std::optional<const nimble::EncodingLayout>>(3)};
+  const nimble::EncodingSelectionPolicyCreator policyCreator =
+      [](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return nimble::ManualEncodingSelectionPolicyFactory{}.createPolicy(
+        dataType);
+  };
+  const auto encoded = nimble::EncodingFactory::encode<uint64_t>(
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<uint64_t>>(
+          layout, std::nullopt, policyCreator),
+      values,
+      *buffer_,
+      {});
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/2);
+  auto encoding = createEncoding(sliced);
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::BitRangeSplit);
+  nimble::Vector<uint64_t> output{pool_.get(), 2};
+  encoding->materialize(/*rowCount=*/2, output.data());
+  EXPECT_EQ(
+      std::vector<uint64_t>(output.begin(), output.end()),
+      (std::vector<uint64_t>{values[1], values[2]}));
+
+  const auto captured = nimble::EncodingLayoutCapture::capture(sliced, {});
+  EXPECT_EQ(
+      captured.config().get(
+          std::string(
+              nimble::BitRangeSplitEncoding<uint64_t>::kRangesConfigKey)),
+      kRangesConfig);
+}
+
+TEST_F(
+    EncodingSliceTest,
+    bitRangeSplitSlicesAlignedBlockBitPackingChildrenNatively) {
+  constexpr std::string_view kRangesConfig = "0-15;16-47;48-63";
+  const auto values = makeVector<uint64_t>({
+      0x299aff8ca62b0001,
+      0x199be75117820002,
+      0x0999c1e5b8460003,
+      0x399f100bfa830004,
+      0x499c3851cd460005,
+      0x599d247e14c90006,
+  });
+  const auto blockBitPackingLayout = [] {
+    return nimble::EncodingLayout{
+        nimble::EncodingType::BlockBitPacking,
+        {},
+        nimble::CompressionType::Uncompressed,
+        {std::nullopt, std::nullopt, std::nullopt}};
+  };
+  const nimble::EncodingLayout layout{
+      nimble::EncodingType::BitRangeSplit,
+      nimble::EncodingLayout::Config{{
+          {std::string(
+               nimble::BitRangeSplitEncoding<uint64_t>::kRangesConfigKey),
+           std::string(kRangesConfig)},
+      }},
+      nimble::CompressionType::Uncompressed,
+      {
+          blockBitPackingLayout(),
+          blockBitPackingLayout(),
+          blockBitPackingLayout(),
+      }};
+  const nimble::EncodingSelectionPolicyCreator policyCreator =
+      [](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return nimble::ManualEncodingSelectionPolicyFactory{}.createPolicy(
+        dataType);
+  };
+  const nimble::Encoding::Options options{.blockBitPackingBlockSize = 2};
+  const auto encoded = nimble::EncodingFactory::encode<uint64_t>(
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<uint64_t>>(
+          layout, std::nullopt, policyCreator),
+      values,
+      *buffer_,
+      options);
+
+  const auto sliced = nimble::EncodingFactory::slice(
+      encoded, /*offset=*/2, /*length=*/2, *buffer_, options);
+  const auto captured = nimble::EncodingLayoutCapture::capture(sliced, options);
+  ASSERT_EQ(captured.childrenCount(), 3);
+  for (nimble::NestedEncodingIdentifier sectionIndex{0}; sectionIndex < 3;
+       ++sectionIndex) {
+    SCOPED_TRACE(testing::Message() << "sectionIndex=" << sectionIndex);
+    ASSERT_TRUE(captured.child(sectionIndex).has_value());
+    EXPECT_EQ(
+        captured.child(sectionIndex)->encodingType(),
+        nimble::EncodingType::BlockBitPacking);
+  }
+
+  auto encoding = createEncoding(sliced);
+  nimble::Vector<uint64_t> output{pool_.get(), 2};
+  encoding->materialize(/*rowCount=*/2, output.data());
+  EXPECT_EQ(
+      std::vector<uint64_t>(output.begin(), output.end()),
+      (std::vector<uint64_t>{values[2], values[3]}));
 }
 
 TYPED_TEST(EncodingSliceTypedTest, materializesRandomRanges) {

--- a/velox/dwio/nimble/encodings/tests/EncodingTypeDispatchTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingTypeDispatchTest.cpp
@@ -122,6 +122,15 @@ std::unique_ptr<ConstructedEncodingBase> makeEncodingByIntegerType(
   RETURN_ENCODING_BY_INTEGER_TYPE(ConstructedEncoding, dataType);
 }
 
+std::unique_ptr<ConstructedEncodingBase> makeEncodingByWideIntegerType(
+    nimble::DataType dataType) {
+  int pool{0};
+  std::string_view data;
+  int stringBufferFactory{0};
+  int options{0};
+  RETURN_ENCODING_BY_WIDE_INTEGER_TYPE(ConstructedEncoding, dataType);
+}
+
 } // namespace
 
 TEST(EncodingTypeDispatchTest, encodingConstructionMacrosDispatchDataTypes) {
@@ -148,6 +157,12 @@ TEST(
       "double");
   EXPECT_EQ(
       makeEncodingByIntegerType(nimble::DataType::Int16)->typeName(), "int16");
+  EXPECT_EQ(
+      makeEncodingByWideIntegerType(nimble::DataType::Int32)->typeName(),
+      "int32");
+  EXPECT_EQ(
+      makeEncodingByWideIntegerType(nimble::DataType::Uint64)->typeName(),
+      "uint64");
 
   NIMBLE_ASSERT_THROW(
       makeEncodingByVarintType(nimble::DataType::Int16),
@@ -161,4 +176,7 @@ TEST(
   NIMBLE_ASSERT_THROW(
       makeEncodingByIntegerType(nimble::DataType::Double),
       "Trying to deserialize an integer stream");
+  NIMBLE_ASSERT_THROW(
+      makeEncodingByWideIntegerType(nimble::DataType::Uint16),
+      "only supports 32- and 64-bit integer data types");
 }

--- a/velox/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
@@ -18,15 +18,20 @@
 
 #include <gtest/gtest.h>
 
+#include <tuple>
 #include <utility>
 #include <vector>
 
 #include "fmt/core.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/VarintEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 using namespace facebook;
 
@@ -48,6 +53,7 @@ TEST_F(EncodingViewTest, supportsEncodingViewMatchesViewableEncodingSet) {
       nimble::EncodingType::Huffman,
       nimble::EncodingType::PFOR,
       nimble::EncodingType::SimdForBitpack,
+      nimble::EncodingType::BitRangeSplit,
       nimble::EncodingType::BlockBitPacking};
   for (const auto encodingType : supportedEncodings) {
     SCOPED_TRACE(fmt::format("encodingType={}", encodingType));
@@ -83,6 +89,186 @@ TEST_F(EncodingViewTest, rejectsCompressedTrivialEncoding) {
   NIMBLE_ASSERT_THROW(
       nimble::createEncodingView(serialized, pool_.get(), options),
       "EncodingView does not support compressed Trivial streams");
+}
+
+TEST_F(EncodingViewTest, parsesArbitraryBitRangeSplitBoundaries) {
+  const auto sections =
+      nimble::detail::BitRangeSplitEncodingBase::parseSections(
+          "0-12;13-46;47-63", /*physicalBits=*/64);
+  std::vector<std::tuple<uint8_t, uint8_t, uint8_t>> actual;
+  actual.reserve(sections.size());
+  for (const auto& section : sections) {
+    actual.emplace_back(section.bitStart, section.bitEnd, section.storageBytes);
+  }
+  EXPECT_EQ(
+      actual,
+      (std::vector<std::tuple<uint8_t, uint8_t, uint8_t>>{
+          {0, 12, 2},
+          {13, 46, 8},
+          {47, 63, 4},
+      }));
+
+  NIMBLE_ASSERT_THROW(
+      nimble::detail::BitRangeSplitEncodingBase::parseSections(
+          "0-12;14-63", /*physicalBits=*/64),
+      "not contiguous");
+  NIMBLE_ASSERT_THROW(
+      nimble::detail::BitRangeSplitEncodingBase::parseSections(
+          "start-12;13-63", /*physicalBits=*/64),
+      "Invalid BitRangeSplit range config");
+}
+
+TEST_F(EncodingViewTest, readsConfigurableBitRangeSplitSections) {
+  const std::vector<uint64_t> values{
+      0x299aff8ca62b0001,
+      0x299be75117820001,
+      0x0999c1e5b8460001,
+      0x299f100bfa830002,
+  };
+  const nimble::EncodingSelectionPolicyCreator policyCreator =
+      [](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return nimble::ManualEncodingSelectionPolicyFactory{}.createPolicy(
+        dataType);
+  };
+  std::vector<std::pair<std::string, uint8_t>> rangeConfigs{
+      {"0-63", 1},
+      {"0-31;32-63", 2},
+      {"0-15;16-58;59-63", 3},
+      {"0-7;8-23;24-47;48-63", 4},
+  };
+  std::string singleBitRanges;
+  for (uint8_t bit{0}; bit < 64; ++bit) {
+    if (!singleBitRanges.empty()) {
+      singleBitRanges.push_back(';');
+    }
+    singleBitRanges += fmt::format("{}-{}", bit, bit);
+  }
+  rangeConfigs.emplace_back(std::move(singleBitRanges), 64);
+
+  for (const auto& [rangesConfig, numSections] : rangeConfigs) {
+    SCOPED_TRACE(fmt::format("sectionCount={}", numSections));
+    const nimble::EncodingLayout layout{
+        nimble::EncodingType::BitRangeSplit,
+        nimble::EncodingLayout::Config{{
+            {std::string(
+                 nimble::BitRangeSplitEncoding<uint64_t>::kRangesConfigKey),
+             rangesConfig},
+        }},
+        nimble::CompressionType::Uncompressed,
+        std::vector<std::optional<const nimble::EncodingLayout>>(numSections)};
+    const auto encoded = nimble::EncodingFactory::encode<uint64_t>(
+        std::make_unique<nimble::ReplayedEncodingSelectionPolicy<uint64_t>>(
+            layout, std::nullopt, policyCreator),
+        values,
+        *buffer_,
+        {});
+
+    auto decoded = nimble::EncodingFactory().create(
+        *pool_, encoded, nullptr, nimble::Encoding::Options{});
+    std::vector<uint64_t> materialized(values.size());
+    decoded->materialize(
+        static_cast<uint32_t>(values.size()), materialized.data());
+    EXPECT_EQ(materialized, values);
+
+    auto view = nimble::createEncodingView(encoded, pool_.get());
+    const std::vector<uint32_t> indices{3, 0, 2, 2};
+    std::vector<uint64_t> actual(indices.size());
+    view->readAt(indices, actual.data());
+    EXPECT_EQ(
+        actual,
+        (std::vector<uint64_t>{values[3], values[0], values[2], values[2]}));
+  }
+}
+
+TEST_F(EncodingViewTest, rejectsInvalidBitRangeSplitConfig) {
+  const std::vector<uint64_t> values{1, 2, 3, 4};
+  const nimble::EncodingSelectionPolicyCreator policyCreator =
+      [](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return nimble::ManualEncodingSelectionPolicyFactory{}.createPolicy(
+        dataType);
+  };
+  const auto encode = [&](nimble::EncodingLayout::Config config) {
+    const nimble::EncodingLayout layout{
+        nimble::EncodingType::BitRangeSplit,
+        std::move(config),
+        nimble::CompressionType::Uncompressed,
+        std::vector<std::optional<const nimble::EncodingLayout>>(2)};
+    return nimble::EncodingFactory::encode<uint64_t>(
+        std::make_unique<nimble::ReplayedEncodingSelectionPolicy<uint64_t>>(
+            layout, std::nullopt, policyCreator),
+        values,
+        *buffer_,
+        {});
+  };
+
+  NIMBLE_ASSERT_THROW(
+      encode({}), "requires the 'bit-range-split.ranges' encoding config");
+  NIMBLE_ASSERT_THROW(
+      encode(
+          nimble::EncodingLayout::Config{{
+              {std::string(
+                   nimble::BitRangeSplitEncoding<uint64_t>::kRangesConfigKey),
+               "0-15;17-63"},
+          }}),
+      "not contiguous");
+}
+
+TEST_F(EncodingViewTest, readsNestedBitRangeSplitSections) {
+  const std::vector<uint64_t> values{
+      0x299aff8ca62b0001,
+      0x299be75117820001,
+      0x0999c1e5b8460001,
+      0x299f100bfa830002,
+  };
+  constexpr std::string_view kRangesConfig = "0-15;16-58;59-63";
+  constexpr uint8_t kNumSections = 3;
+  const nimble::EncodingLayout layout{
+      nimble::EncodingType::BitRangeSplit,
+      nimble::EncodingLayout::Config{{
+          {std::string(
+               nimble::BitRangeSplitEncoding<uint64_t>::kRangesConfigKey),
+           std::string(kRangesConfig)},
+      }},
+      nimble::CompressionType::Uncompressed,
+      std::vector<std::optional<const nimble::EncodingLayout>>(kNumSections)};
+  const nimble::EncodingSelectionPolicyCreator policyCreator =
+      [](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return nimble::ManualEncodingSelectionPolicyFactory{}.createPolicy(
+        dataType);
+  };
+  const auto encoded = nimble::EncodingFactory::encode<uint64_t>(
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<uint64_t>>(
+          layout, std::nullopt, policyCreator),
+      values,
+      *buffer_,
+      {});
+
+  const auto captured = nimble::EncodingLayoutCapture::capture(encoded, {});
+  EXPECT_EQ(captured.encodingType(), nimble::EncodingType::BitRangeSplit);
+  EXPECT_EQ(captured.childrenCount(), kNumSections);
+  EXPECT_EQ(
+      captured.config().get(
+          std::string(
+              nimble::BitRangeSplitEncoding<uint64_t>::kRangesConfigKey)),
+      kRangesConfig);
+
+  auto decoded = nimble::EncodingFactory().create(
+      *pool_, encoded, nullptr, nimble::Encoding::Options{});
+  std::vector<uint64_t> materialized(values.size());
+  decoded->materialize(
+      static_cast<uint32_t>(values.size()), materialized.data());
+  EXPECT_EQ(materialized, values);
+
+  auto view = nimble::createEncodingView(encoded, pool_.get());
+  const std::vector<uint32_t> indices{3, 0, 2, 2};
+  std::vector<uint64_t> actual(indices.size());
+  view->readAt(indices, actual.data());
+  EXPECT_EQ(
+      actual,
+      (std::vector<uint64_t>{values[3], values[0], values[2], values[2]}));
 }
 
 TEST_F(EncodingViewTest, rejectsVarintEncoding) {

--- a/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -34,6 +34,7 @@
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingUtils.h"
@@ -231,6 +232,21 @@ EncodingLayout makeAlpEncodingLayout(EncodingType encodedValuesEncodingType) {
       {},
       CompressionType::Uncompressed,
       {encodedValuesLayout}};
+}
+
+EncodingLayout makeBitRangeSplitEncodingLayout() {
+  const auto sectionLayout = [] {
+    return EncodingLayout{
+        EncodingType::FixedBitWidth, {}, CompressionType::Uncompressed};
+  };
+  return EncodingLayout{
+      EncodingType::BitRangeSplit,
+      EncodingLayout::Config{{
+          {std::string(BitRangeSplitEncoding<int64_t>::kRangesConfigKey),
+           "0-15;16-58;59-63"},
+      }},
+      CompressionType::Uncompressed,
+      {sectionLayout(), sectionLayout(), sectionLayout()}};
 }
 
 WriterOptions makeSingleColumnWriterOptions(
@@ -1320,6 +1336,57 @@ TEST_P(ReadWithVisitorNonLegacyTest, columnReaderAlpFloatAndDouble) {
             toString(encodedValuesEncodingType)));
     testColumnReaderAlpFloatingPointRange<float>(encodedValuesEncodingType);
     testColumnReaderAlpFloatingPointRange<double>(encodedValuesEncodingType);
+  }
+}
+
+TEST_P(
+    ReadWithVisitorNonLegacyTest,
+    columnReaderBitRangeSplitBigintRangeFilter) {
+  constexpr vector_size_t kRows{512};
+  const auto valueAt = [](vector_size_t row) {
+    return static_cast<int64_t>(
+        (uint64_t{5} << 59) | ((uint64_t{1'760'000'000'000} + row) << 16) |
+        (static_cast<uint64_t>(row) % 4 + 1));
+  };
+  auto input = makeRowVector({makeFlatVector<int64_t>(kRows, valueAt)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(
+      input, makeSingleColumnWriterOptions(makeBitRangeSplitEncodingLayout()));
+
+  const auto captured = captureFirstColumnEncoding(*ctx);
+  ASSERT_TRUE(captured.has_value());
+  ASSERT_EQ(captured->encodingType(), EncodingType::BitRangeSplit);
+  ASSERT_EQ(captured->childrenCount(), 3);
+  for (NestedEncodingIdentifier sectionIndex{0}; sectionIndex < 3;
+       ++sectionIndex) {
+    SCOPED_TRACE(fmt::format("sectionIndex={}", sectionIndex));
+    ASSERT_TRUE(captured->child(sectionIndex).has_value());
+    EXPECT_EQ(
+        captured->child(sectionIndex)->encodingType(),
+        EncodingType::FixedBitWidth);
+  }
+
+  constexpr vector_size_t kFirstMatch{100};
+  constexpr vector_size_t kLastMatch{200};
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(
+          valueAt(kFirstMatch), valueAt(kLastMatch), false));
+
+  auto root =
+      buildReader(*ctx, rowType, *scanSpec, /*stringDecoderZeroCopy=*/true);
+  auto* child = readColumn(root.get(), kRows);
+  ASSERT_EQ(child->numValues(), kLastMatch - kFirstMatch + 1);
+
+  const auto outputRows = child->outputRows();
+  const auto values = getValues<int64_t>(child);
+  ASSERT_EQ(outputRows.size(), values.size());
+  for (vector_size_t index{0}; index < values.size(); ++index) {
+    SCOPED_TRACE(fmt::format("index={}", index));
+    const auto expectedRow = kFirstMatch + index;
+    EXPECT_EQ(outputRows[index], expectedRow);
+    EXPECT_EQ(values[index], valueAt(expectedRow));
   }
 }
 

--- a/velox/dwio/nimble/encodings/views/BitRangeSplitEncodingView.h
+++ b/velox/dwio/nimble/encodings/views/BitRangeSplitEncodingView.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "folly/ScopeGuard.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
+#include "velox/dwio/nimble/encodings/views/EncodingView.h"
+#include "velox/dwio/nimble/encodings/views/EncodingViewFactory.h"
+
+namespace facebook::nimble {
+
+/// Provides direct random access to a self-describing bit-range split stream.
+template <typename T>
+class BitRangeSplitEncodingView final : public TypedEncodingView<T> {
+ public:
+  using physicalType = typename TypedEncodingView<T>::physicalType;
+
+  /// Constructs a random-access view over a self-describing encoded chunk.
+  BitRangeSplitEncodingView(
+      std::string_view data,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options)
+      : TypedEncodingView<T>{data, pool, options},
+        header_{Base::parseHeader(data, options)} {
+    NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::BitRangeSplit);
+    NIMBLE_CHECK_EQ(header_.rowCount, this->rowCount_);
+    nestedViews_.reserve(header_.sections.size());
+    for (const auto& section : header_.sections) {
+      auto nested = createEncodingView(
+          {section.data, section.dataBytes}, this->pool_, options);
+      NIMBLE_CHECK_EQ(nested->rowCount(), header_.rowCount);
+      NIMBLE_CHECK_EQ(
+          nested->dataType(), Base::sectionDataType(section.storageBytes));
+      nestedViews_.push_back(std::move(nested));
+    }
+  }
+
+ private:
+  using Base = detail::BitRangeSplitEncodingBase;
+  using Section = Base::Section;
+
+  // Places one decoded child value into its range in the output value.
+  template <typename SectionType>
+  static physicalType mergeValue(
+      physicalType value,
+      SectionType sectionValue,
+      const Section& section) {
+    const auto shifted =
+        (static_cast<uint64_t>(sectionValue) & Base::sectionMask(section))
+        << section.bitStart;
+    return static_cast<physicalType>(static_cast<uint64_t>(value) | shifted);
+  }
+
+  // Reads and merges one child for a contiguous row range.
+  template <typename SectionType>
+  void mergeSection(
+      size_t sectionIndex,
+      uint32_t offset,
+      uint32_t length,
+      physicalType* output) const {
+    auto values = this->template getVectorBuffer<SectionType>();
+    SCOPE_EXIT {
+      this->releaseVectorBuffer(values);
+    };
+    values.resize(length);
+    nestedViews_[sectionIndex]->read(offset, length, values.data());
+    const auto& section = header_.sections[sectionIndex];
+    for (uint32_t row{0}; row < length; ++row) {
+      output[row] = mergeValue(output[row], values[row], section);
+    }
+  }
+
+  // Reads and merges one child for arbitrary row indices.
+  template <typename SectionType>
+  void mergeSectionAt(
+      size_t sectionIndex,
+      std::span<const uint32_t> indices,
+      physicalType* output) const {
+    auto values = this->template getVectorBuffer<SectionType>();
+    SCOPE_EXIT {
+      this->releaseVectorBuffer(values);
+    };
+    values.resize(indices.size());
+    nestedViews_[sectionIndex]->readAt(indices, values.data());
+    const auto& section = header_.sections[sectionIndex];
+    for (size_t indexOffset{0}; indexOffset < indices.size(); ++indexOffset) {
+      output[indexOffset] =
+          mergeValue(output[indexOffset], values[indexOffset], section);
+    }
+  }
+
+  // Dispatches each child using the integer type that contains its range.
+  template <typename Callback>
+  void forEachNestedSection(Callback&& callback) const {
+    for (size_t sectionIndex{0}; sectionIndex < header_.sections.size();
+         ++sectionIndex) {
+      [&] {
+        NIMBLE_RETURN_BY_UNSIGNED_INTEGER_DATA_TYPE(
+            Base::sectionDataType(header_.sections[sectionIndex].storageBytes),
+            SectionType,
+            callback.template operator()<SectionType>(sectionIndex));
+      }();
+    }
+  }
+
+  T readTypedAt(uint32_t index) const final {
+    NIMBLE_CHECK_LT(index, this->rowCount_);
+    physicalType value{0};
+    forEachNestedSection([&]<typename SectionType>(size_t sectionIndex) {
+      SectionType sectionValue{0};
+      nestedViews_[sectionIndex]->readAt(index, &sectionValue);
+      value = mergeValue(value, sectionValue, header_.sections[sectionIndex]);
+    });
+    return detail::castFromPhysicalType<T>(value);
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    std::fill(output, output + length, physicalType{0});
+    forEachNestedSection([&]<typename SectionType>(size_t sectionIndex) {
+      mergeSection<SectionType>(sectionIndex, offset, length, output);
+    });
+  }
+
+  void readPhysicalAt(std::span<const uint32_t> indices, physicalType* output)
+      const final {
+    std::fill(output, output + indices.size(), physicalType{0});
+    forEachNestedSection([&]<typename SectionType>(size_t sectionIndex) {
+      mergeSectionAt<SectionType>(sectionIndex, indices, output);
+    });
+  }
+
+  // Validated metadata and child-stream boundaries for this chunk.
+  Base::Header header_{};
+  // Random-access views ordered by the corresponding range in header_.sections.
+  std::vector<std::unique_ptr<EncodingView>> nestedViews_{};
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/views/EncodingViewFactory.cpp
+++ b/velox/dwio/nimble/encodings/views/EncodingViewFactory.cpp
@@ -19,6 +19,7 @@
 #include <array>
 
 #include "velox/dwio/nimble/encodings/views/ALPEncodingView.h"
+#include "velox/dwio/nimble/encodings/views/BitRangeSplitEncodingView.h"
 #include "velox/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h"
 #include "velox/dwio/nimble/encodings/views/ConstantEncodingView.h"
 #include "velox/dwio/nimble/encodings/views/DeltaBlockEncodingView.h"
@@ -130,6 +131,15 @@ std::unique_ptr<TypedEncodingView<T>> createTypedEncodingView(
       NIMBLE_INCOMPATIBLE_ENCODING(
           "SimdForBitpack encoding only supports integral data types, got {}.",
           TypeTraits<T>::dataType);
+    case EncodingType::BitRangeSplit:
+      if constexpr (isIntegralType<T>() && (sizeof(T) == 4 || sizeof(T) == 8)) {
+        return std::make_unique<BitRangeSplitEncodingView<T>>(
+            data, pool, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "BitRangeSplit encoding only supports 32- and 64-bit integer data "
+          "types, got {}.",
+          TypeTraits<T>::dataType);
     case EncodingType::BlockBitPacking:
       if constexpr (isNumericType<physicalType>()) {
         return std::make_unique<BlockBitPackingEncodingView<T>>(
@@ -182,6 +192,7 @@ bool supportsEncodingView(EncodingType encodingType) {
       EncodingType::Huffman,
       EncodingType::PFOR,
       EncodingType::SimdForBitpack,
+      EncodingType::BitRangeSplit,
       EncodingType::BlockBitPacking};
   return std::find(
              kViewableEncodings.begin(),

--- a/velox/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/velox/dwio/nimble/tools/EncodingUtilities.cpp
@@ -16,6 +16,7 @@
 #include "velox/dwio/nimble/tools/EncodingUtilities.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Varint.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/FsstEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingUtils.h"
@@ -70,6 +71,7 @@ void extractCompressionType(
     case EncodingType::Fsst:
     case EncodingType::PFOR:
     case EncodingType::SimdForBitpack:
+    case EncodingType::BitRangeSplit:
     // SubIntSplit integration is disabled; it carries no separate compression
     // byte, so treat it like the other encodings handled here.
     case EncodingType::SubIntSplit:
@@ -146,6 +148,25 @@ void traverseEncodings(
     // stream, so there is nothing to traverse into here.
     case EncodingType::Slice: {
       // don't have any nested encoding
+      break;
+    }
+    case EncodingType::BitRangeSplit: {
+      detail::BitRangeSplitEncodingBase::visitSections(
+          stream,
+          Encoding::Options{
+              .useVarintRowCount = useVarintRowCount,
+          },
+          [&](NestedEncodingIdentifier section,
+              const detail::BitRangeSplitEncodingBase::Section& metadata) {
+            traverseEncodings(
+                {metadata.data, metadata.dataBytes},
+                level + 1,
+                section,
+                "Bits" + std::to_string(metadata.bitStart) + "-" +
+                    std::to_string(metadata.bitEnd),
+                useVarintRowCount,
+                visitor);
+          });
       break;
     }
     case EncodingType::ALP: {

--- a/velox/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
+++ b/velox/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
@@ -23,8 +23,12 @@
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/Varint.h"
+#include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 #include "velox/dwio/nimble/tools/EncodingUtilities.h"
@@ -168,6 +172,34 @@ class EncodingUtilitiesTest : public ::testing::Test {
     encoding::writeBytes(offsets, pos);
     varint::writeVarint(kFirstBlockRows, &pos);
     return buf;
+  }
+
+  std::string buildBitRangeSplitUint32Stream(
+      const std::string& lowBits,
+      const std::string& highBits) {
+    constexpr uint32_t kRowCount{3};
+    const size_t totalSize =
+        EncodingPrefix::serializedSize(kRowCount, /*useVarint=*/false) +
+        1 /* numSections */ + 2 * (2 + sizeof(uint32_t)) + lowBits.size() +
+        highBits.size();
+    std::string buffer(totalSize, '\0');
+    char* position = buffer.data();
+    EncodingPrefix::serialize(
+        EncodingType::BitRangeSplit,
+        DataType::Uint32,
+        kRowCount,
+        /*useVarint=*/false,
+        position);
+    encoding::write<uint8_t>(2, position);
+    encoding::write<uint8_t>(0, position);
+    encoding::write<uint8_t>(15, position);
+    encoding::writeUint32(static_cast<uint32_t>(lowBits.size()), position);
+    encoding::write<uint8_t>(16, position);
+    encoding::write<uint8_t>(31, position);
+    encoding::writeUint32(static_cast<uint32_t>(highBits.size()), position);
+    encoding::writeBytes(lowBits, position);
+    encoding::writeBytes(highBits, position);
+    return buffer;
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -453,6 +485,136 @@ TEST_F(EncodingUtilitiesTest, traverseEncodingsBlockBitPackingChildren) {
   const std::vector<std::string> expected{
       "Baselines", "BitWidths", "DataOffsets"};
   EXPECT_EQ(nestedNames, expected);
+}
+
+TEST_F(EncodingUtilitiesTest, traverseEncodingsBitRangeSplitChildren) {
+  const auto lowBits = buildTrivialUint32Stream({1, 2, 3});
+  const auto highBits = buildTrivialUint32Stream({4, 5, 6});
+  const auto stream = buildBitRangeSplitUint32Stream(lowBits, highBits);
+
+  std::vector<std::string> nestedNames;
+  traverseEncodings(
+      stream,
+      [&](EncodingType /* encodingType */,
+          DataType /* dataType */,
+          uint32_t level,
+          uint32_t /* index */,
+          const std::string& nestedEncodingName,
+          const std::unordered_map<EncodingPropertyType, EncodingProperty>&
+          /* properties */) -> bool {
+        if (level > 0) {
+          nestedNames.push_back(nestedEncodingName);
+        }
+        return true;
+      });
+
+  const std::vector<std::string> expected{"Bits0-15", "Bits16-31"};
+  EXPECT_EQ(nestedNames, expected);
+}
+
+TEST_F(EncodingUtilitiesTest, bitRangeSplitIntegratesWithChildEncodings) {
+  constexpr std::string_view kRangesConfig = "0-7;8-23;24-39;40-63";
+  Vector<uint64_t> values{pool_.get()};
+  values.reserve(128);
+  for (uint64_t row{0}; row < 128; ++row) {
+    values.push_back(
+        uint64_t{7} | ((row * 17) << 8) | ((row * 3) << 24) |
+        ((row * 29) << 40));
+  }
+
+  const auto layout = [](EncodingType encodingType, uint8_t numChildren = 0) {
+    return EncodingLayout{
+        encodingType,
+        {},
+        CompressionType::Uncompressed,
+        std::vector<std::optional<const EncodingLayout>>(numChildren)};
+  };
+  const EncodingLayout encodingLayout{
+      EncodingType::BitRangeSplit,
+      EncodingLayout::Config{{
+          {std::string(BitRangeSplitEncoding<uint64_t>::kRangesConfigKey),
+           std::string(kRangesConfig)},
+      }},
+      CompressionType::Uncompressed,
+      {
+          layout(EncodingType::Constant),
+          layout(EncodingType::Trivial),
+          layout(EncodingType::FixedBitWidth),
+          layout(EncodingType::BlockBitPacking, 3),
+      }};
+  const EncodingSelectionPolicyCreator policyCreator =
+      [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+    return ManualEncodingSelectionPolicyFactory{}.createPolicy(dataType);
+  };
+  Buffer buffer{*pool_};
+  const auto encoded = EncodingFactory::encode<uint64_t>(
+      std::make_unique<ReplayedEncodingSelectionPolicy<uint64_t>>(
+          encodingLayout, std::nullopt, policyCreator),
+      values,
+      buffer,
+      Encoding::Options{.fixedBitWidthUseExactBits = true});
+
+  std::vector<std::pair<std::string, EncodingType>> visitedChildren;
+  const auto header = detail::BitRangeSplitEncodingBase::visitSections(
+      encoded,
+      {},
+      [&](NestedEncodingIdentifier sectionIndex,
+          const detail::BitRangeSplitEncodingBase::Section& section) {
+        visitedChildren.emplace_back(
+            "Bits" + std::to_string(section.bitStart) + "-" +
+                std::to_string(section.bitEnd),
+            EncodingPrefix::encodingType({section.data, section.dataBytes}));
+        EXPECT_EQ(sectionIndex, visitedChildren.size() - 1);
+      });
+  EXPECT_EQ(header.rowCount, values.size());
+  EXPECT_EQ(
+      visitedChildren,
+      (std::vector<std::pair<std::string, EncodingType>>{
+          {"Bits0-7", EncodingType::Constant},
+          {"Bits8-23", EncodingType::Trivial},
+          {"Bits24-39", EncodingType::FixedBitWidth},
+          {"Bits40-63", EncodingType::BlockBitPacking},
+      }));
+
+  const auto captured = EncodingLayoutCapture::capture(encoded, {});
+  ASSERT_EQ(captured.childrenCount(), visitedChildren.size());
+  EXPECT_EQ(
+      captured.config().get(
+          std::string(BitRangeSplitEncoding<uint64_t>::kRangesConfigKey)),
+      kRangesConfig);
+  for (NestedEncodingIdentifier sectionIndex{0};
+       sectionIndex < captured.childrenCount();
+       ++sectionIndex) {
+    SCOPED_TRACE(testing::Message() << "sectionIndex=" << sectionIndex);
+    ASSERT_TRUE(captured.child(sectionIndex).has_value());
+    EXPECT_EQ(
+        captured.child(sectionIndex)->encodingType(),
+        visitedChildren[sectionIndex].second);
+  }
+
+  std::vector<std::pair<std::string, EncodingType>> traversedChildren;
+  traverseEncodings(
+      encoded,
+      [&](EncodingType encodingType,
+          DataType /* dataType */,
+          uint32_t level,
+          uint32_t /* index */,
+          const std::string& nestedEncodingName,
+          const std::unordered_map<EncodingPropertyType, EncodingProperty>&
+          /* properties */) -> bool {
+        if (level == 1) {
+          traversedChildren.emplace_back(nestedEncodingName, encodingType);
+        }
+        return true;
+      });
+  EXPECT_EQ(traversedChildren, visitedChildren);
+
+  auto decoded = EncodingFactory{}.create(*pool_, encoded, nullptr);
+  Vector<uint64_t> output{pool_.get(), values.size()};
+  decoded->materialize(static_cast<uint32_t>(values.size()), output.data());
+  EXPECT_EQ(
+      std::vector<uint64_t>(output.begin(), output.end()),
+      std::vector<uint64_t>(values.begin(), values.end()));
 }
 
 TEST_F(EncodingUtilitiesTest, getEncodingLabelBlockBitPacking) {


### PR DESCRIPTION
Summary:

Adds `BitRangeSplitEncoding` for 32- and 64-bit integers. A self-describing chunk splits each value into configured contiguous bit ranges and stores every range as an independently selected nested encoding.

Accepts bit-range definitions from per-stream `EncodingLayout` configuration supplied through `WriterOptions.encodingLayoutTree`. Captured layouts retain the serialized ranges for replay, and native slicing preserves the structure by slicing each child stream directly. A shared format parser validates headers and exposes child streams to layout capture and encoding tools. The encoding view reconstructs point and batched reads directly from child views, and nested fixed-bit-width selection may retain exact bit widths.

The encoding remains experimental and opt-in.

Reviewed By: HuamengJiang

Differential Revision: D118982781


