### PR TITLE
feat: Cache reusable unique-value statistics (#18878)

### DIFF
--- a/velox/dwio/nimble/encodings/MainlyConstantEncoding.cpp
+++ b/velox/dwio/nimble/encodings/MainlyConstantEncoding.cpp
@@ -52,17 +52,15 @@ std::string_view MainlyConstantEncoding<std::string_view>::encode(
   }
 
   const auto& uniqueCounts = selection.statistics().uniqueCounts().value();
-  const auto commonElement =
-      MainlyConstantEncodingBase<std::string_view>::mainlyConstantCommonValue(
-          uniqueCounts);
+  const auto commonElement = uniqueCounts.mostFrequent().value();
 
   const uint32_t entryCount = values.size();
 
   auto* pool = &buffer.getMemoryPool();
-  physicalType commonValue = commonElement->first;
+  physicalType commonValue = commonElement.first;
   auto childStreams =
       MainlyConstantEncodingBase<std::string_view>::prepareChildStreams(
-          pool, values, commonValue, commonElement->second);
+          pool, values, commonValue, commonElement.second);
 
   ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedIsCommon = selection.template encodeNested<bool>(

--- a/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/velox/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -109,21 +109,21 @@ class MainlyConstantEncodingBase
 
     // Find most common item count.
     const auto& uniqueCounts = statistics.uniqueCounts().value();
-    const auto maxUniqueCount = mainlyConstantCommonValue(uniqueCounts);
+    const auto maxUniqueCount = uniqueCounts.mostFrequent().value();
     // Deduce uncommon values count
-    const uint64_t uncommonCount = rowCount - maxUniqueCount->second;
+    const uint64_t uncommonCount = rowCount - maxUniqueCount.second;
     // Uncommon values (sparse bool) bitmap will have index per value,
     // stored bit packed.
     const uint64_t isCommonEncodingSize =
         SparseBoolEncoding::estimateSize(rowCount, uncommonCount, options);
 
     if constexpr (isStringType<physicalType>()) {
-      const uint64_t commonValueSize = maxUniqueCount->first.size();
+      const uint64_t commonValueSize = maxUniqueCount.first.size();
       uint64_t uncommonMinLength = 0;
       uint64_t uncommonMaxLength = 0;
       bool hasUncommonValue{false};
       for (const auto& uniqueCount : uniqueCounts) {
-        if (uniqueCount.first == maxUniqueCount->first) {
+        if (uniqueCount.first == maxUniqueCount.first) {
           continue;
         }
 
@@ -555,21 +555,6 @@ class MainlyConstantEncodingBase
   }
 
  protected:
-  template <typename UniqueCounts>
-  static auto mainlyConstantCommonValue(const UniqueCounts& uniqueCounts) {
-    // Select the highest-frequency value. Break count ties by the smaller value
-    // so absl::flat_hash_map iteration order cannot affect estimates or output.
-    return std::max_element(
-        uniqueCounts.cbegin(),
-        uniqueCounts.cend(),
-        [](const auto& left, const auto& right) {
-          if (left.second != right.second) {
-            return left.second < right.second;
-          }
-          return left.first > right.first;
-        });
-  }
-
   // Encode-time child streams: isCommon spans all input rows, while
   // otherValues contains only rows that differ from the common value.
   struct ChildStreams {
@@ -921,15 +906,14 @@ std::string_view MainlyConstantEncoding<T>::encode(
   }
 
   const auto& uniqueCounts = selection.statistics().uniqueCounts().value();
-  const auto commonElement =
-      MainlyConstantEncodingBase<T>::mainlyConstantCommonValue(uniqueCounts);
+  const auto commonElement = uniqueCounts.mostFrequent().value();
 
   const uint32_t entryCount = values.size();
 
   auto* pool = &buffer.getMemoryPool();
-  physicalType commonValue = commonElement->first;
+  physicalType commonValue = commonElement.first;
   auto childStreams = MainlyConstantEncodingBase<T>::prepareChildStreams(
-      pool, values, commonValue, commonElement->second);
+      pool, values, commonValue, commonElement.second);
 
   ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedIsCommon = selection.template encodeNested<bool>(

--- a/velox/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
@@ -17,7 +17,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <span>
+#include <utility>
 #include <vector>
 
 #include "folly/Benchmark.h"
@@ -93,6 +95,43 @@ void updateMinMaxBlockStatsPerValue(
   }
 }
 
+template <typename T>
+std::optional<std::pair<T, uint64_t>> scanMostFrequent(
+    const UniqueValueCounts<T>& uniqueCounts) {
+  if (uniqueCounts.size() == 0) {
+    return std::nullopt;
+  }
+  const auto it = std::max_element(
+      uniqueCounts.cbegin(),
+      uniqueCounts.cend(),
+      [](const auto& left, const auto& right) {
+        if (left.second != right.second) {
+          return left.second < right.second;
+        }
+        return left.first > right.first;
+      });
+  return std::make_pair(it->first, it->second);
+}
+
+template <typename T>
+void scanMostFrequent(uint32_t iters, const std::vector<T>& data) {
+  const auto statistics = Statistics<T>::create(data);
+  const auto& uniqueCounts = statistics.uniqueCounts().value();
+  while (iters-- > 0) {
+    folly::doNotOptimizeAway(scanMostFrequent(uniqueCounts));
+  }
+}
+
+template <typename T>
+void readCachedMostFrequent(uint32_t iters, const std::vector<T>& data) {
+  const auto statistics = Statistics<T>::create(data);
+  const auto& uniqueCounts = statistics.uniqueCounts().value();
+  folly::doNotOptimizeAway(uniqueCounts.mostFrequent());
+  while (iters-- > 0) {
+    folly::doNotOptimizeAway(uniqueCounts.mostFrequent());
+  }
+}
+
 void prepareData() {
   int64DenseRange.resize(kValueCount);
   int64SingleValue.resize(kValueCount);
@@ -155,6 +194,22 @@ BENCHMARK(MinMaxBlocks_PerValue_Uint64DenseRangeAtMax, iters) {
 BENCHMARK_RELATIVE(MinMaxBlocks_BlockWise_Uint64DenseRangeAtMax, iters) {
   updateMinMaxBlockStats(
       iters, uint64DenseRangeAtMax, kBlockBitPackingBlockSize);
+}
+
+BENCHMARK(MostFrequentScan_Int64DenseRange, iters) {
+  scanMostFrequent(iters, int64DenseRange);
+}
+
+BENCHMARK_RELATIVE(MostFrequentCached_Int64DenseRange, iters) {
+  readCachedMostFrequent(iters, int64DenseRange);
+}
+
+BENCHMARK(MostFrequentScan_Int64SingleValue, iters) {
+  scanMostFrequent(iters, int64SingleValue);
+}
+
+BENCHMARK_RELATIVE(MostFrequentCached_Int64SingleValue, iters) {
+  readCachedMostFrequent(iters, int64SingleValue);
 }
 
 int main(int argc, char** argv) {

--- a/velox/dwio/nimble/encodings/selection/Statistics.h
+++ b/velox/dwio/nimble/encodings/selection/Statistics.h
@@ -15,9 +15,12 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <limits>
 #include <optional>
 #include <span>
 #include <type_traits>
+#include <utility>
 #include <vector>
 #include "velox/dwio/nimble/common/Constants.h"
 #include "velox/dwio/nimble/common/Types.h"
@@ -88,13 +91,35 @@ class UniqueValueCounts {
     return uniqueCounts_.size();
   }
 
+  std::optional<std::pair<T, uint64_t>> mostFrequent() const noexcept {
+    if (uniqueCounts_.empty()) {
+      return std::nullopt;
+    }
+    if (!mostFrequent_.has_value()) {
+      const auto it = std::max_element(
+          uniqueCounts_.cbegin(),
+          uniqueCounts_.cend(),
+          [](const auto& left, const auto& right) {
+            if (left.second != right.second) {
+              return left.second < right.second;
+            }
+            return left.first > right.first;
+          });
+      mostFrequent_.emplace(it->first, it->second);
+    }
+    return mostFrequent_;
+  }
+
   uint64_t uniqueStringBytes() const noexcept {
     static_assert(nimble::isStringType<T>());
-    uint64_t totalBytes = 0;
-    for (const auto& unique : uniqueCounts_) {
-      totalBytes += unique.first.size();
+    if (!uniqueStringBytes_.has_value()) {
+      uint64_t totalBytes = 0;
+      for (const auto& unique : uniqueCounts_) {
+        totalBytes += unique.first.size();
+      }
+      uniqueStringBytes_ = totalBytes;
     }
-    return totalBytes;
+    return uniqueStringBytes_.value();
   }
 
   const_iterator begin() const noexcept {
@@ -117,6 +142,8 @@ class UniqueValueCounts {
 
  private:
   MapType uniqueCounts_;
+  mutable std::optional<std::pair<T, uint64_t>> mostFrequent_;
+  mutable std::optional<uint64_t> uniqueStringBytes_;
 };
 
 template <typename T, typename InputType = T>

--- a/velox/dwio/nimble/encodings/tests/StatisticsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/StatisticsTest.cpp
@@ -107,6 +107,23 @@ TEST(StatisticsTest, minMaxBlocks) {
       nimble::Statistics<uint64_t>::create(empty).minMaxBlocks().empty());
 }
 
+TEST(StatisticsTest, mostFrequent) {
+  const std::vector<int32_t> data = {3, 2, 3, 2, 4};
+  const auto statistics = nimble::Statistics<int32_t>::create(data);
+  const auto& uniqueCounts = statistics.uniqueCounts().value();
+
+  EXPECT_EQ(uniqueCounts.mostFrequent(), std::make_pair(2, uint64_t{2}));
+  EXPECT_EQ(uniqueCounts.mostFrequent(), std::make_pair(2, uint64_t{2}));
+
+  const std::vector<int32_t> empty;
+  EXPECT_EQ(
+      nimble::Statistics<int32_t>::create(empty)
+          .uniqueCounts()
+          .value()
+          .mostFrequent(),
+      std::nullopt);
+}
+
 TYPED_TEST(StatisticsNumericTests, create) {
   using T = TypeParam;
   using ValueType = typename T::valueType;


### PR DESCRIPTION
Summary:

Cache the deterministic most-frequent value/count and total unique string bytes in `UniqueValueCounts`. MainlyConstant cost-based size estimation and encoding reuse the same common-value result instead of scanning the unique-count map twice.

This optimization applies to cost-based selection. Replayed `EncodingLayoutTree` policies bypass size estimation, so the first full-file experiment with fixed per-trait overrides did not exercise a cache hit and is not evidence for this change.

Microbenchmark:
- 4,096 unique values: 12.57us scan -> 0.349ns cached lookup
- Single unique value: 1.09ns scan -> 0.346ns cached lookup

Strobelight validation:
- Inspected the raw `strobelight_services/on_demand` samples for all six full-file runs, including every run ID attached to each profile.
- The removed duplicate traversal appears as self samples in `MainlyConstantEncoding::encode`, primarily in `absl::raw_hash_set` iteration and `std::max_element`. Its aggregate sampled CPU share fell from 0.155% to 0.012%, a reduction of about 93%.
- The inclusive MainlyConstant stack share fell from 14.68% to 12.13%. The remaining cost is dominated by initial statistics construction and selection, including `Statistics::populateUniques`, hash-map insertion, `estimateSize`, and child-stream preparation. This change does not remove those costs.

Baseline profiles:
- https://fburl.com/kcjz1g9j
- https://fburl.com/scuba/strobelight_services/on_demand/hs4vnzp2
- https://fburl.com/tnafszmv

Cached profiles:
- https://fburl.com/hfp5zg9y
- https://fburl.com/4ak3hapx
- https://fburl.com/mkae8kmc

The function-level profiles confirm that the intended repeated traversal is removed. Full-file differences remain within run-to-run noise because the removed work represented only about 0.15% of sampled CPU; this draft does not claim a measurable end-to-end DataFM improvement.

Reviewed By: xiaoxmeng

Differential Revision: D118302768
