### PR TITLE
fix: Write only the selected rows in NULLIF

### DIFF
--- a/velox/expression/NullIfExpr.cpp
+++ b/velox/expression/NullIfExpr.cpp
@@ -79,6 +79,7 @@ void NullIfExpr::evalSpecialForm(
 
   // TODO: Spark uses kNullAsValue which produces different results for complex
   // types with nested nulls, e.g. NULLIF(ARRAY[1, NULL], ARRAY[1, NULL]).
+  bool anyEqual = false;
   rows.applyToSelected([&](auto row) {
     auto equal = compareA->equalValueAt(
         compareB.get(),
@@ -87,23 +88,20 @@ void NullIfExpr::evalSpecialForm(
         CompareFlags::NullHandlingMode::kNullAsIndeterminate);
     if (equal.has_value() && equal.value()) {
       nonNullRows->setValid(row, false);
+      anyEqual = true;
     }
   });
   nonNullRows->updateBounds();
 
-  if (nonNullRows->isSubset(rows) && rows.isSubset(*nonNullRows)) {
+  if (!anyEqual) {
     // No matches — return a as is.
     context.moveOrCopyResult(aResult, rows, result);
     return;
   }
 
-  if (!nonNullRows->hasSelections()) {
-    // All rows match — return constant null.
-    result = BaseVector::createNullConstant(type(), rows.end(), context.pool());
-    return;
-  }
-
-  // Some rows match — copy only non-null rows from a, set remaining to null.
+  // Copy the rows that do not match from a and null out the ones that do.
+  // Only 'rows' is written: under a conditional parent these are a subset of
+  // the batch, and the other rows keep whatever the parent put there.
   BaseVector::ensureWritable(rows, type(), context.pool(), result);
   result->copy(aResult.get(), *nonNullRows, /*toSourceRow=*/nullptr);
 

--- a/velox/expression/tests/NullIfExprTest.cpp
+++ b/velox/expression/tests/NullIfExprTest.cpp
@@ -78,6 +78,19 @@ class NullIfExprTest : public testing::Test, public VectorTestBase {
         aField, bField, makeRowVector({"a", "b"}, {a, b}), commonType);
   }
 
+  // Evaluates 'expr' over 'input'.
+  VectorPtr evaluate(
+      const core::TypedExprPtr& typedExpr,
+      const RowVectorPtr& input) {
+    ExprSet exprSet({typedExpr}, execCtx_.get());
+    EvalCtx context(execCtx_.get(), &exprSet, input.get());
+
+    std::vector<VectorPtr> result(1);
+    SelectivityVector rows(input->size());
+    exprSet.eval(rows, context, result);
+    return result[0];
+  }
+
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
@@ -254,6 +267,39 @@ TEST_F(NullIfExprTest, nonDeterministicWithCast) {
   EXPECT_THAT(
       uniqueNonNullValues<int16_t>(result),
       testing::UnorderedElementsAre(0, 1, 2, 4, 5));
+}
+
+// COALESCE evaluates its later arguments only on the rows the earlier ones
+// left null, so a nested NULLIF sees a subset of the batch. It must write only
+// those rows: the rows COALESCE already resolved keep their values.
+TEST_F(NullIfExprTest, nestedInCoalesce) {
+  auto empty =
+      std::make_shared<core::ConstantTypedExpr>(VARCHAR(), Variant(""));
+  auto field = [](const std::string& name) {
+    return std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), name);
+  };
+  auto coalesce = std::make_shared<core::CallTypedExpr>(
+      VARCHAR(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::NullIfTypedExpr>(field("a"), empty, VARCHAR()),
+          std::make_shared<core::NullIfTypedExpr>(field("b"), empty, VARCHAR()),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), Variant("zz"))},
+      "coalesce");
+
+  // Row 1 is the only row reaching the nested NULLIF, and it equals ''.
+  auto b = makeFlatVector<std::string>({"", "", ""});
+  auto input = makeRowVector(
+      {"a", "b"}, {makeFlatVector<std::string>({"keep", "", "keep2"}), b});
+  assertEqualVectors(
+      makeFlatVector<std::string>({"keep", "zz", "keep2"}),
+      evaluate(coalesce, input));
+
+  // The same, with that row before the batch's last row.
+  input = makeRowVector(
+      {"a", "b"}, {makeFlatVector<std::string>({"", "keep", "keep2"}), b});
+  assertEqualVectors(
+      makeFlatVector<std::string>({"zz", "keep", "keep2"}),
+      evaluate(coalesce, input));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
A conditional parent evaluates NULLIF on only the rows it has left to resolve. When every one of those rows compared equal, NULLIF replaced the whole result vector with a null constant sized to the last selected row, so rows the parent had already resolved lost their values:

    SELECT COALESCE(NULLIF(a, ''), NULLIF(b, ''), 'zz')
    FROM (VALUES ('keep', ''), ('', ''), ('keep2', '')) AS t(a, b)

returned NULL for the first row instead of 'keep'. When the selected rows ended before the batch did, the undersized vector failed downstream with "Index is too large" instead.

Removes that shortcut. The general path below it already produces the same values when every row matches — it copies no rows and nulls all of them — and it sizes the result to the batch and writes only the selected rows. Also replaces the pair of subset scans that detected the no-match case with a flag set while comparing.

Differential Revision: D119037107
