### PR TITLE
refactor(nimble): Generalize dictionary index dispatch

### DIFF
--- a/velox/dwio/nimble/encodings/NullableEncoding.h
+++ b/velox/dwio/nimble/encodings/NullableEncoding.h
@@ -385,7 +385,11 @@ void NullableEncoding<T>::readIndicesWithVisitor(
   NIMBLE_CHECK(
       !V::kHasHook, "readIndicesWithVisitor does not support value hooks");
   materializeNullsForVisitor(visitor, params);
-  callReadIndicesWithVisitor(*nonNullValues_, visitor, params);
+  if (nonNullValues_->dataType() == TypeTraits<T>::dataType) {
+    callReadIndicesWithVisitor<T>(*nonNullValues_, visitor, params);
+  } else {
+    callReadIndicesWithVisitor<physicalType>(*nonNullValues_, visitor, params);
+  }
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/velox/dwio/nimble/encodings/common/EncodingUtils.h
@@ -255,37 +255,41 @@ struct DefaultEncodingTrait {
 
 /// Dispatches readIndicesWithVisitor to the correct encoding type.
 /// Supports DictionaryEncoding, NullableEncoding, and MainlyConstantEncoding
-/// wrapping DictionaryEncoding. Currently only supports string
-/// (std::string_view) dictionary encodings. Non-legacy encodings only.
-template <typename V>
+/// wrapping DictionaryEncoding. Non-legacy encodings only.
+template <typename T, typename V>
 void callReadIndicesWithVisitor(
     Encoding& encoding,
     V& visitor,
     ReadWithVisitorParams& params) {
+  NIMBLE_CHECK_EQ(
+      encoding.dataType(),
+      TypeTraits<T>::dataType,
+      "Unexpected encoding data type: {}",
+      encoding.dataType());
   switch (encoding.encodingType()) {
     case EncodingType::Dictionary: {
-      static_cast<DictionaryEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<DictionaryEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::Nullable: {
-      static_cast<NullableEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<NullableEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::MainlyConstant: {
-      static_cast<MainlyConstantEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<MainlyConstantEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::RLE: {
-      static_cast<RLEEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<RLEEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     case EncodingType::Constant: {
-      static_cast<ConstantEncoding<std::string_view>&>(encoding)
-          .readIndicesWithVisitor(visitor, params);
+      static_cast<ConstantEncoding<T>&>(encoding).readIndicesWithVisitor(
+          visitor, params);
       return;
     }
     default:

--- a/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -3198,7 +3198,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, readIndicesWithVisitorInteger) {
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-    encoding->readIndicesWithVisitor(visitor, params);
+    callReadIndicesWithVisitor<T>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), kRows);
     const auto* indices = reader->rawIndices();
@@ -3298,7 +3298,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, fuzzReadIndicesWithVisitorInteger) {
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
 
-    encoding->readIndicesWithVisitor(visitor, params);
+    callReadIndicesWithVisitor<T>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), numRows);
     const auto* indices = reader->rawIndices();
@@ -3420,7 +3420,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, readIndicesWithVisitorNullable) {
       visitor(filter, reader, rows, extractValues);
   auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-  callReadIndicesWithVisitor(*encoding, visitor, params);
+  callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
   ASSERT_EQ(reader->numValues(), kRows);
   const auto* indices = reader->rawIndices();
@@ -3547,7 +3547,7 @@ TEST_P(
       visitor(filter, reader, rows, extractValues);
   auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-  callReadIndicesWithVisitor(*encoding, visitor, params);
+  callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
   ASSERT_EQ(reader->numValues(), kRows);
   const auto* indices = reader->rawIndices();
@@ -3688,7 +3688,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, fuzzReadIndicesWithVisitorNullable) {
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
 
-    callReadIndicesWithVisitor(*encoding, visitor, params);
+    callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), numRows);
     const auto* indices = reader->rawIndices();
@@ -3995,7 +3995,7 @@ TEST_P(
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-    callReadIndicesWithVisitor(*encoding, visitor, params);
+    callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), numRows);
     const auto* indices = reader->rawIndices();
@@ -4065,7 +4065,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, numValuesAfterMainlyConstantReadIndices) {
   auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
   ASSERT_EQ(reader->numValues(), 0);
-  callReadIndicesWithVisitor(*encoding, visitor, params);
+  callReadIndicesWithVisitor<std::string_view>(*encoding, visitor, params);
 
   // numValues must equal kRows (all rows), not just numNonCommon
   // (what the inner Dict encoding's bulkScan wrote via addNumValues).

--- a/velox/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/velox/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -331,7 +331,7 @@ class ChunkedDecoder {
   // reading stopped early at a chunk boundary (the callback returned false);
   // in that case it advances the reader's readOffset_ to the boundary so the
   // flat encoding fallback resumes the decode there.
-  template <typename DictionaryVisitor>
+  template <typename T, typename DictionaryVisitor>
   bool readDictionaryIndices(
       DictionaryVisitor& visitor,
       const ChunkBoundaryCallback& onChunkBoundary) {
@@ -385,7 +385,7 @@ class ChunkedDecoder {
           return nulls->template asMutable<uint64_t>();
         };
       }
-      return readDictionaryIndicesImpl<true>(
+      return readDictionaryIndicesImpl<T, true>(
           visitor, nulls->template as<uint64_t>(), onChunkBoundary, params);
     } else {
       const auto numRows = visitor.numRows();
@@ -404,7 +404,7 @@ class ChunkedDecoder {
             .nullsInReadRange()
             ->template asMutable<uint64_t>();
       };
-      return readDictionaryIndicesImpl<false>(
+      return readDictionaryIndicesImpl<T, false>(
           visitor, /*nulls=*/nullptr, onChunkBoundary, params);
     }
   }
@@ -420,7 +420,7 @@ class ChunkedDecoder {
   // readWithVisitorImpl, this handles chunk transitions explicitly at the
   // top of the loop (for both kHasNulls and !kHasNulls paths) instead of
   // relying on testNulls which counts non-nulls across chunk boundaries.
-  template <bool kHasNulls, typename V>
+  template <typename T, bool kHasNulls, typename V>
   bool readDictionaryIndicesImpl(
       V& visitor,
       const uint64_t* nulls,
@@ -521,7 +521,7 @@ class ChunkedDecoder {
       if (visitor.rowIndex() < endRowIndex) {
         visitor.setRows(velox::RowSet(visitor.rows(), endRowIndex));
         if (numNonNulls > 0) {
-          callReadIndicesWithVisitor(*encoding_, visitor, params);
+          callReadIndicesWithVisitor<T>(*encoding_, visitor, params);
         } else if (!visitor.allowNulls()) {
           visitor.setRowIndex(endRowIndex);
         } else {

--- a/velox/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/velox/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -490,8 +490,8 @@ bool StringColumnReader::readWithDictionary(
     // readDictionaryIndices returns false when the onChunkBoundary callback
     // returns false (new chunk is not dict-compatible), meaning the
     // dictionary path must be abandoned for the remaining rows.
-    abandonDictionary =
-        !decoder_.readDictionaryIndices(dictVisitor, onChunkBoundary);
+    abandonDictionary = !decoder_.readDictionaryIndices<std::string_view>(
+        dictVisitor, onChunkBoundary);
 
     // Offset the final chunk's indices into the merged alphabet.
     updateDictionaryIndices(alphabetOffset, valueOffset);


### PR DESCRIPTION
Summary:
`callReadIndicesWithVisitor` cast every encoding to `DictionaryEncoding<std::string_view>`, so the bulk dictionary-index read path was reachable only from string columns. The alphabet's value type is now an explicit template parameter, threaded through `ChunkedDecoder::readDictionaryIndices`. It cannot be deduced from the visitor: the visitor reads dictionary indices, so its `DataType` is the index type rather than the value type.

No behavior change. The only production caller is `StringColumnReader`, which passes `std::string_view` and gets the same dispatch as before. This unblocks a dictionary-index read path for integer columns, which does not exist yet.

Reviewed By: xiaoxmeng, HuamengJiang

Differential Revision: D117393220


