### PR TITLE
refactor(nimble): Derive in-map stream identity from its value stream offsets (#18884)

### DIFF
--- a/velox/dwio/nimble/velox/SchemaReader.h
+++ b/velox/dwio/nimble/velox/SchemaReader.h
@@ -317,8 +317,27 @@ std::ostream& operator<<(
 /// as a hotspot in the Deserializer's per-batch flatmap in-map detection
 /// over hundreds of keys. Concrete-typed callables remove that dispatch
 /// without forcing every caller to materialize an intermediate offset list.
-template <typename Visitor>
-bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
+namespace detail {
+
+// Normalizes the child accessors of the two schema representations: Type
+// exposes children as shared pointers, TypeBuilder as references. Lets
+// visitValueStreamLeaves run unchanged over both, so the writer decides
+// whether a value stream is observable using the exact walk the reader will
+// perform.
+template <typename T>
+const T& derefChild(const T& child) {
+  return child;
+}
+
+template <typename T>
+const T& derefChild(const std::shared_ptr<T>& child) {
+  return *child;
+}
+
+} // namespace detail
+
+template <typename TypeT, typename Visitor>
+bool visitValueStreamLeaves(const TypeT& type, Visitor& visit) {
   switch (type.kind()) {
     case Kind::Scalar:
       return visit(type.asScalar().scalarDescriptor().offset());
@@ -340,7 +359,7 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
       // the writer, so it is not a reliable anchor; children are. The
       // visitor's return value short-circuits the walk on the first hit.
       for (size_t i = 0; i < row.childrenCount(); ++i) {
-        if (visitValueStreamLeaves(*row.childAt(i), visit)) {
+        if (visitValueStreamLeaves(detail::derefChild(row.childAt(i)), visit)) {
           return true;
         }
       }
@@ -355,7 +374,8 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
       // FlatMap children are independent keys; each may or may not carry
       // data in the current stripe, so all must be visited.
       for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-        if (visitValueStreamLeaves(*flatMap.childAt(i), visit)) {
+        if (visitValueStreamLeaves(
+                detail::derefChild(flatMap.childAt(i)), visit)) {
           return true;
         }
       }
@@ -366,8 +386,8 @@ bool visitValueStreamLeaves(const Type& type, Visitor& visit) {
   }
 }
 
-template <typename Visitor>
-bool visitValueStreamLeaves(const Type& type, Visitor&& visit) {
+template <typename TypeT, typename Visitor>
+bool visitValueStreamLeaves(const TypeT& type, Visitor&& visit) {
   auto&& visitRef = std::forward<Visitor>(visit);
   return visitValueStreamLeaves(type, visitRef);
 }

--- a/velox/dwio/nimble/velox/StreamData.h
+++ b/velox/dwio/nimble/velox/StreamData.h
@@ -511,4 +511,12 @@ inline bool isConstantBoolStream(std::string_view data) {
   return ::memchr(data.data(), 1, data.size()) == nullptr;
 }
 
+/// Returns true if the boolean stream data is non-empty and every byte is
+/// true. Distinguished from isConstantBoolStream because an omitted all-true
+/// in-map stream and an omitted all-false one mean opposite things to the
+/// reader, so the two constants cannot share a code path.
+inline bool isAllTrueBoolStream(std::string_view data) {
+  return !data.empty() && ::memchr(data.data(), 0, data.size()) == nullptr;
+}
+
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
+++ b/velox/dwio/nimble/velox/tests/BatchReaderTest.cpp
@@ -4129,7 +4129,7 @@ TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStream) {
   }
 }
 
-TEST_P(BatchReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
+TEST_P(BatchReaderTest, flatMapAllTrueInMapWithAllNullValues) {
   auto type =
       velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
@@ -4140,10 +4140,451 @@ TEST_P(BatchReaderTest, DISABLED_flatMapAllTrueInMapWithAllNullValues) {
   auto vector = vectorMaker.rowVector(
       {"flat_map"}, {vectorMaker.mapVector({0, 1, 2, 3}, keys, values)});
 
+  // Both chunking modes: the constant in-map skip lives in the non-chunked
+  // writer path today, and the chunked path is where it lands if that
+  // optimization is extended, so the invariant is pinned for both.
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    auto writerOptions = createFlatMapWriterOptions();
+    writerOptions.enableChunking = enableChunking;
+    writerOptions.flatMapColumns["flat_map"];
+    nimble::Writer writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(vector);
+    writer.close();
+
+    {
+      velox::InMemoryReadFile readFile(file);
+      auto selector =
+          std::make_shared<velox::dwio::common::ColumnSelector>(type);
+      nimble::BatchReader reader(
+          &readFile, *leafPool_, std::move(selector), createReadParams());
+      const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+      ASSERT_EQ(flatMap.childrenCount(), 1);
+      // Every value is null, so no value stream reaches disk. That leaves the
+      // in-map stream as the only record that the key is present at all, so
+      // the constant in-map skip must not drop it -- otherwise the key is
+      // byte-indistinguishable from one absent from the stripe.
+      EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                      .count(flatMap.inMapDescriptorAt(0).offset()));
+    }
+
+    {
+      velox::InMemoryReadFile readFile(file);
+      auto selector =
+          std::make_shared<velox::dwio::common::ColumnSelector>(type);
+      nimble::BatchReader reader(
+          &readFile, *leafPool_, std::move(selector), createReadParams());
+      velox::VectorPtr output;
+      uint64_t rowCount = 4;
+      ASSERT_TRUE(reader.next(rowCount, output));
+      ASSERT_EQ(output->size(), 4);
+      for (auto i = 0; i < 4; ++i) {
+        EXPECT_TRUE(vectorEquals(vector, output, i)) << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// Two stripes: the key is in every row of the first (all-true in-map, dropped
+// because the value stream proves presence) and in only one row of the second
+// (mixed in-map, which must reach disk). The all-true mark lives on the schema
+// descriptor, which outlives a stripe, so it has to be reassigned per stripe
+// rather than only set. Left stale, the sweep would drop the second stripe's
+// real in-map stream and the absent key would read back as present.
+TEST_P(BatchReaderTest, flatMapAllTrueInMapThenMixedAcrossStripes) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 10}}, {{1, 11}}})}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 12}}, {}})}),
+  };
+
+  auto writerOptions = createFlatMapWriterOptions();
+  writerOptions.flatMapColumns["flat_map"];
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_, vectors, std::move(writerOptions), /*flushAfterWrite=*/true);
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+namespace {
+
+// Writer options that emit one chunk per write call, so multi-batch tests
+// exercise real chunk boundaries instead of deferring everything to the final
+// chunk at stripe close.
+nimble::WriterOptions chunkPerWriteOptions(
+    nimble::WriterOptions options,
+    bool enableChunking) {
+  options.enableChunking = enableChunking;
+  options.minStreamChunkRawSize = 0;
+  options.flatMapColumns["flat_map"];
+  options.flushPolicyFactory = []() {
+    return std::make_unique<nimble::LambdaFlushPolicy>(
+        /*flushLambda=*/[](auto&) { return false; },
+        /*chunkLambda=*/[](auto&) { return true; });
+  };
+  return options;
+}
+
+// Writer options that chunk every write call and enable chunking, for tests
+// that need the chunked write path specifically rather than the fixture's
+// parameterization. Because minStreamChunkRawSize is 0, every mid-stripe pass
+// emits, so streams here end up split across several chunks.
+nimble::WriterOptions chunkedFlatMapOptions(nimble::WriterOptions options) {
+  return chunkPerWriteOptions(std::move(options), /*enableChunking=*/true);
+}
+
+// Chunking enabled with the default chunk sizing. A one-byte-per-row in-map
+// stream stays well under minStreamChunkRawSize, so it defers past every
+// mid-stripe pass and reaches disk as a single chunk -- the shape a real flat
+// map workload produces.
+nimble::WriterOptions chunkedSingleChunkFlatMapOptions(
+    nimble::WriterOptions options) {
+  options.enableChunking = true;
+  options.flatMapColumns["flat_map"];
+  return options;
+}
+
+} // namespace
+
+// Chunked writes suppress constant in-map streams too. The stream is cleared
+// before encoding, in the single-threaded prologue of the closing pass, so it
+// simply encodes to nothing.
+TEST_P(BatchReaderTest, flatMapSkipAllTrueInMapStreamChunked) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto batch = [&](int64_t base) {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector<int32_t, int64_t>(
+            {{{1, base}}, {{1, base + 1}}})});
+  };
+  std::vector<velox::VectorPtr> vectors{batch(10), batch(20), batch(30)};
+
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_,
+      vectors,
+      chunkedSingleChunkFlatMapOptions(createFlatMapWriterOptions()),
+      /*flushAfterWrite=*/false);
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector =
+        std::make_shared<velox::dwio::common::ColumnSelector>(velox::ROW(
+            {{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}}));
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    const auto offsets = existingStreamOffsets(*leafPool_, &readFile, 0);
+    const auto inMapOffset = flatMap.inMapDescriptorAt(0).offset();
+    if (skipConstantFlatMapInMapStreams()) {
+      EXPECT_FALSE(offsets.count(inMapOffset))
+          << "all-true in-map stream should be dropped on the chunked path";
+    } else {
+      EXPECT_TRUE(offsets.count(inMapOffset));
+    }
+  }
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+// An in-map stream already split across chunks mid-stripe opts out of the
+// optimization and reaches disk even when it is all-true. Clearing it would
+// discard only the rows still pending, leaving the chunks already encoded to
+// decode as a stream shorter than the stripe.
+//
+// This costs the space saving, never correctness, and real writes rarely get
+// here: an in-map stream is one byte per row, so it has to pass
+// minStreamChunkRawSize (512KiB, ~524k rows for a single key) while the flush
+// policy is also reporting memory pressure. The chunk-per-write options below
+// force it by setting minStreamChunkRawSize to 0.
+TEST_P(BatchReaderTest, flatMapMultiChunkInMapOptsOutOfSkip) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto batch = [&](int64_t base) {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector<int32_t, int64_t>(
+            {{{1, base}}, {{1, base + 1}}})});
+  };
+  std::vector<velox::VectorPtr> vectors{batch(10), batch(20), batch(30)};
+
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_,
+      vectors,
+      chunkedFlatMapOptions(createFlatMapWriterOptions()),
+      /*flushAfterWrite=*/false);
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector =
+        std::make_shared<velox::dwio::common::ColumnSelector>(velox::ROW(
+            {{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}}));
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                    .count(flatMap.inMapDescriptorAt(0).offset()))
+        << "a multi-chunk in-map stream must not be dropped";
+  }
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+// The all-null invariant holds on the chunked path: with no value stream to
+// prove the key was present, the all-true in-map stream is the only record of
+// it and must survive even though it is constant.
+TEST_P(BatchReaderTest, flatMapAllNullValuesKeepsInMapChunked) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto allNullBatch = [&]() {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector(
+            {0, 1},
+            vectorMaker.flatVector<int32_t>({1, 1}),
+            vectorMaker.flatVectorNullable<int64_t>(
+                {std::nullopt, std::nullopt}))});
+  };
+  std::vector<velox::VectorPtr> vectors{
+      allNullBatch(), allNullBatch(), allNullBatch()};
+
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_,
+      vectors,
+      chunkedFlatMapOptions(createFlatMapWriterOptions()),
+      /*flushAfterWrite=*/false);
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector =
+        std::make_shared<velox::dwio::common::ColumnSelector>(velox::ROW(
+            {{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}}));
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                    .count(flatMap.inMapDescriptorAt(0).offset()))
+        << "in-map stream is the key's only record and must be kept";
+  }
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+// A key present in some rows and absent in others produces a mixed in-map
+// stream, which is not Constant and so is never dropped -- including when the
+// all-true chunks come first and the mixed one only later.
+TEST_P(BatchReaderTest, flatMapMixedInMapAcrossChunksKeepsStream) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 10}}, {{1, 11}}})}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector<int32_t, int64_t>({{{1, 12}}, {}})}),
+  };
+
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_,
+      vectors,
+      chunkedFlatMapOptions(createFlatMapWriterOptions()),
+      /*flushAfterWrite=*/false);
+
+  {
+    velox::InMemoryReadFile readFile(file);
+    auto selector =
+        std::make_shared<velox::dwio::common::ColumnSelector>(velox::ROW(
+            {{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}}));
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, std::move(selector), createReadParams());
+    const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 1);
+    EXPECT_TRUE(existingStreamOffsets(*leafPool_, &readFile, 0)
+                    .count(flatMap.inMapDescriptorAt(0).offset()))
+        << "a mixed in-map stream must reach disk";
+  }
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::BatchReader reader(
+      &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+  velox::VectorPtr result;
+  for (const auto& expected : vectors) {
+    ASSERT_TRUE(reader.next(expected->size(), result));
+    ASSERT_EQ(expected->size(), result->size());
+    for (auto i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+          << "Mismatch at row " << i;
+    }
+  }
+}
+
+// A key whose values are null in an early batch and non-null in a later one
+// must survive the chunk boundary between them. The writer defers a chunk
+// while the stream is still empty of payload, and a deferred attempt consumes
+// nothing -- it stays "first chunk" and its rows fold into the next emitted
+// chunk. Were they dropped instead, the value stream would be short and every
+// later row would decode shifted.
+TEST_P(BatchReaderTest, flatMapNullValuesThenNonNullAcrossChunks) {
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  std::vector<velox::VectorPtr> vectors{
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector(
+              {0, 1},
+              vectorMaker.flatVector<int32_t>({1, 1}),
+              vectorMaker.flatVectorNullable<int64_t>(
+                  {std::nullopt, std::nullopt}))}),
+      vectorMaker.rowVector(
+          {"flat_map"},
+          {vectorMaker.mapVector(
+              {0, 1},
+              vectorMaker.flatVector<int32_t>({1, 1}),
+              vectorMaker.flatVectorNullable<int64_t>({10, 20}))}),
+  };
+
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    auto file = nimble::test::createNimbleFile(
+        *rootPool_,
+        vectors,
+        chunkPerWriteOptions(createFlatMapWriterOptions(), enableChunking),
+        /*flushAfterWrite=*/false);
+    velox::InMemoryReadFile readFile(file);
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+    velox::VectorPtr result;
+    for (const auto& expected : vectors) {
+      ASSERT_TRUE(reader.next(expected->size(), result));
+      ASSERT_EQ(expected->size(), result->size());
+      for (auto i = 0; i < expected->size(); ++i) {
+        EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+            << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// All values null for the key across several chunks, so no value stream is
+// written at all. The in-map stream is then the key's only record and must
+// survive, the same invariant as the single-batch case but with the stream
+// spanning chunk boundaries.
+TEST_P(BatchReaderTest, flatMapAllNullValuesAcrossChunks) {
+  auto type =
+      velox::ROW({{"flat_map", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto allNullBatch = [&]() {
+    return vectorMaker.rowVector(
+        {"flat_map"},
+        {vectorMaker.mapVector(
+            {0, 1},
+            vectorMaker.flatVector<int32_t>({1, 1}),
+            vectorMaker.flatVectorNullable<int64_t>(
+                {std::nullopt, std::nullopt}))});
+  };
+  std::vector<velox::VectorPtr> vectors{
+      allNullBatch(), allNullBatch(), allNullBatch()};
+
+  for (const bool enableChunking : {false, true}) {
+    SCOPED_TRACE(enableChunking ? "chunked" : "non-chunked");
+
+    auto file = nimble::test::createNimbleFile(
+        *rootPool_,
+        vectors,
+        chunkPerWriteOptions(createFlatMapWriterOptions(), enableChunking),
+        /*flushAfterWrite=*/false);
+    velox::InMemoryReadFile readFile(file);
+    nimble::BatchReader reader(
+        &readFile, *leafPool_, /*selector=*/nullptr, createReadParams());
+
+    velox::VectorPtr result;
+    for (const auto& expected : vectors) {
+      ASSERT_TRUE(reader.next(expected->size(), result));
+      ASSERT_EQ(expected->size(), result->size());
+      for (auto i = 0; i < expected->size(); ++i) {
+        EXPECT_TRUE(expected->equalValueAt(result.get(), i, i))
+            << "Mismatch at row " << i;
+      }
+    }
+  }
+}
+
+// Same invariant as flatMapAllTrueInMapWithAllNullValues, with string values.
+// Covers NullableContentStringStreamData, whose data() is only valid once
+// materialized. Deciding at stripe close, from what each stream actually
+// encoded, is what keeps this path off that trap.
+TEST_P(BatchReaderTest, flatMapAllTrueInMapWithAllNullStringValues) {
+  auto type = velox::ROW(
+      {{"flat_map", velox::MAP(velox::INTEGER(), velox::VARCHAR())}});
+
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto keys = vectorMaker.flatVector<int32_t>({1, 1, 1, 1});
+  auto values = vectorMaker.flatVectorNullable<velox::StringView>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto vector = vectorMaker.rowVector(
+      {"flat_map"}, {vectorMaker.mapVector({0, 1, 2, 3}, keys, values)});
+
   std::string file;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
   auto writerOptions = createFlatMapWriterOptions();
-  writerOptions.enableChunking = true;
   writerOptions.flatMapColumns["flat_map"];
   nimble::Writer writer(
       type, std::move(writeFile), *rootPool_, std::move(writerOptions));

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -600,10 +600,6 @@ class WriterStreamContext : public StreamContext {
     isInMapStream_ = value;
   }
 
-  void setFlatMapValueStreamOffsets(std::vector<offset_size> offsets) {
-    flatMapValueStreamOffsets_ = std::move(offsets);
-  }
-
   // The layout to replay for this stream: overlaid from the EncodingLayoutTree
   // at setup, or captured from this stream's first encode when
   // encoding-selection caching is enabled. Empty until one of those populates
@@ -641,10 +637,6 @@ class WriterStreamContext : public StreamContext {
  private:
   bool isNullStream_{false};
   bool isInMapStream_{false};
-  // Value stream descriptor offsets for this in-map stream's flat-map field.
-  // Empty for non in-map streams and flat-map values with no reader-visible
-  // value stream.
-  std::vector<offset_size> flatMapValueStreamOffsets_;
   std::optional<EncodingLayout> encoding_;
   std::optional<SharedDictionaryConfig> sharedDictionaryConfig_;
   mutable std::unique_ptr<SharedDictionaryWriter> sharedDictionaryWriter_;
@@ -1247,63 +1239,6 @@ void findNodeIds(
   }
 }
 
-void collectFlatMapValueStreamOffsets(
-    const TypeBuilder& type,
-    std::vector<offset_size>& offsets) {
-  switch (type.kind()) {
-    case Kind::Scalar:
-      offsets.push_back(type.asScalar().scalarDescriptor().offset());
-      return;
-    case Kind::TimestampMicroNano:
-      offsets.push_back(
-          type.asTimestampMicroNano().microsDescriptor().offset());
-      offsets.push_back(type.asTimestampMicroNano().nanosDescriptor().offset());
-      return;
-    case Kind::Array:
-      offsets.push_back(type.asArray().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asArray().elements(), offsets);
-      return;
-    case Kind::ArrayWithOffsets:
-      offsets.push_back(type.asArrayWithOffsets().offsetsDescriptor().offset());
-      offsets.push_back(type.asArrayWithOffsets().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asArrayWithOffsets().elements(), offsets);
-      return;
-    case Kind::Map:
-      offsets.push_back(type.asMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(type.asMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(type.asMap().values(), offsets);
-      return;
-    case Kind::SlidingWindowMap:
-      offsets.push_back(type.asSlidingWindowMap().offsetsDescriptor().offset());
-      offsets.push_back(type.asSlidingWindowMap().lengthsDescriptor().offset());
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().keys(), offsets);
-      collectFlatMapValueStreamOffsets(
-          type.asSlidingWindowMap().values(), offsets);
-      return;
-    case Kind::Row: {
-      const auto& row = type.asRow();
-      offsets.push_back(row.nullsDescriptor().offset());
-      for (size_t i = 0; i < row.childrenCount(); ++i) {
-        collectFlatMapValueStreamOffsets(row.childAt(i), offsets);
-      }
-      return;
-    }
-    case Kind::FlatMap: {
-      const auto& flatMap = type.asFlatMap();
-      offsets.push_back(flatMap.nullsDescriptor().offset());
-      for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-        offsets.push_back(flatMap.inMapDescriptorAt(i).offset());
-        collectFlatMapValueStreamOffsets(flatMap.childAt(i), offsets);
-      }
-      return;
-    }
-    default:
-      NIMBLE_UNREACHABLE("Unsupported type kind {}", type.kind());
-  }
-}
-
 FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodingsForFlatMap(
     const EncodingLayoutTree& encodingLayoutTree) {
   FlatmapEncodingLayoutContext::KeyEncodingMap keyEncodings;
@@ -1737,9 +1672,6 @@ void configureAddedFlatMapField(
   auto& inMapContext = streamContext(
       flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1));
   inMapContext.setIsInMapStream(true);
-  std::vector<offset_size> valueStreamOffsets;
-  collectFlatMapValueStreamOffsets(fieldType, valueStreamOffsets);
-  inMapContext.setFlatMapValueStreamOffsets(std::move(valueStreamOffsets));
 
   auto* flatMapContext = flatmap.context<FlatmapEncodingLayoutContext>();
   if (flatMapContext == nullptr) {

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -595,12 +595,19 @@ class WriterStreamContext : public StreamContext {
     isNullStream_ = value;
   }
 
+  // A stream is a flat map in-map stream exactly when it has value stream
+  // offsets recorded against it: setInMapValueStreamOffsets() is the only
+  // thing that populates them, and it is called for nothing else. Deriving it
+  // rather than carrying a parallel bool removes the obligation to keep the
+  // two in sync.
+  //
+  // The offsets are never empty for an in-map stream. Every arm of
+  // visitValueStreamLeaves() yields at least one descriptor -- scalars and
+  // containers visit their own, Row and FlatMap recurse under a
+  // NIMBLE_CHECK_GT(childrenCount, 0) -- so a key always has at least one
+  // value stream to record.
   bool isInMapStream() const {
-    return isInMapStream_;
-  }
-
-  void setIsInMapStream(bool value) {
-    isInMapStream_ = value;
+    return !flatMapValueStreamOffsets_.empty();
   }
 
   // Offsets of the value streams the reader consults to decide whether this
@@ -620,7 +627,11 @@ class WriterStreamContext : public StreamContext {
     return flatMapValueStreamOffsets_;
   }
 
-  void setFlatMapValueStreamOffsets(std::vector<offset_size> offsets) {
+  // Marks this stream as an in-map stream and records its value streams in one
+  // step: with isInMapStream() derived from these, a stream must never be
+  // observable as one without the other.
+  void setInMapValueStreamOffsets(std::vector<offset_size> offsets) {
+    NIMBLE_DCHECK(!offsets.empty(), "An in-map stream has value streams");
     flatMapValueStreamOffsets_ = std::move(offsets);
   }
 
@@ -660,7 +671,6 @@ class WriterStreamContext : public StreamContext {
 
  private:
   bool isNullStream_{false};
-  bool isInMapStream_{false};
   std::vector<offset_size> flatMapValueStreamOffsets_;
   std::optional<EncodingLayout> encoding_;
   std::optional<SharedDictionaryConfig> sharedDictionaryConfig_;
@@ -1696,14 +1706,13 @@ void configureAddedFlatMapField(
   auto& flatmapBuilder = flatmap.asFlatMap();
   auto& inMapContext = streamContext(
       flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1));
-  inMapContext.setIsInMapStream(true);
   std::vector<offset_size> valueStreamOffsets;
   visitValueStreamLeaves(fieldType, [&](offset_size offset) {
     valueStreamOffsets.push_back(offset);
     // Collect every leaf: the visitor's true short-circuits the walk.
     return false;
   });
-  inMapContext.setFlatMapValueStreamOffsets(std::move(valueStreamOffsets));
+  inMapContext.setInMapValueStreamOffsets(std::move(valueStreamOffsets));
 
   auto* flatMapContext = flatmap.context<FlatmapEncodingLayoutContext>();
   if (flatMapContext == nullptr) {

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -36,10 +36,12 @@
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
+#include "velox/dwio/nimble/common/ChunkHeader.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryCatalog.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/index/ClusterIndexConfig.h"
 #include "velox/dwio/nimble/index/ClusterIndexFactory.h"
@@ -57,6 +59,7 @@
 #include "velox/dwio/nimble/velox/MetadataGenerated.h"
 #include "velox/dwio/nimble/velox/RawSizeUtils.h"
 #include "velox/dwio/nimble/velox/SchemaBuilder.h"
+#include "velox/dwio/nimble/velox/SchemaReader.h"
 #include "velox/dwio/nimble/velox/SchemaSerialization.h"
 #include "velox/dwio/nimble/velox/SchemaTypes.h"
 
@@ -600,6 +603,27 @@ class WriterStreamContext : public StreamContext {
     isInMapStream_ = value;
   }
 
+  // Offsets of the value streams the reader consults to decide whether this
+  // in-map stream's key had data in a stripe. Empty for every other stream.
+  //
+  // Built with visitValueStreamLeaves(), the readers' own traversal, so the
+  // two cannot drift. That matters more than it looks: a walk that merely
+  // collects "every stream under this subtree" is a different question and
+  // answers it differently -- it would count a Row's nulls stream, and recurse
+  // past an Array's or Map's lengths, none of which the reader treats as
+  // evidence.
+  //
+  // Fixed once at schema configure time. The value subtree of a flat map key
+  // is static, because flat map keys are the only thing discovered
+  // dynamically and flat maps are never nested.
+  const std::vector<offset_size>& flatMapValueStreamOffsets() const {
+    return flatMapValueStreamOffsets_;
+  }
+
+  void setFlatMapValueStreamOffsets(std::vector<offset_size> offsets) {
+    flatMapValueStreamOffsets_ = std::move(offsets);
+  }
+
   // The layout to replay for this stream: overlaid from the EncodingLayoutTree
   // at setup, or captured from this stream's first encode when
   // encoding-selection caching is enabled. Empty until one of those populates
@@ -637,6 +661,7 @@ class WriterStreamContext : public StreamContext {
  private:
   bool isNullStream_{false};
   bool isInMapStream_{false};
+  std::vector<offset_size> flatMapValueStreamOffsets_;
   std::optional<EncodingLayout> encoding_;
   std::optional<SharedDictionaryConfig> sharedDictionaryConfig_;
   mutable std::unique_ptr<SharedDictionaryWriter> sharedDictionaryWriter_;
@@ -1672,6 +1697,13 @@ void configureAddedFlatMapField(
   auto& inMapContext = streamContext(
       flatmapBuilder.inMapDescriptorAt(flatmapBuilder.childrenCount() - 1));
   inMapContext.setIsInMapStream(true);
+  std::vector<offset_size> valueStreamOffsets;
+  visitValueStreamLeaves(fieldType, [&](offset_size offset) {
+    valueStreamOffsets.push_back(offset);
+    // Collect every leaf: the visitor's true short-circuits the walk.
+    return false;
+  });
+  inMapContext.setFlatMapValueStreamOffsets(std::move(valueStreamOffsets));
 
   auto* flatMapContext = flatmap.context<FlatmapEncodingLayoutContext>();
   if (flatMapContext == nullptr) {
@@ -2762,6 +2794,72 @@ void Writer::encodeStream(
   streamData.reset();
 }
 
+namespace {} // namespace
+
+std::vector<const StreamDescriptorBuilder*>
+Writer::collectAllTrueInMapStreams() {
+  std::vector<const StreamDescriptorBuilder*> candidates;
+  if (!context_->options().skipConstantFlatMapInMapStreams) {
+    return candidates;
+  }
+
+  // Runs before the encode loop because all-true is only knowable from the raw
+  // stream. Afterwards compact() has consumed it, and the encoded form only
+  // answers the question by decoding, which is what this avoids.
+  for (const auto& [_, stream] : context_->streams()) {
+    const auto& descriptor = stream->descriptor();
+    auto* streamContext = descriptor.context<WriterStreamContext>();
+    if (streamContext == nullptr || !streamContext->isInMapStream()) {
+      continue;
+    }
+    const auto offset = descriptor.offset();
+    // Only streams that are still whole. One already chunked mid-stripe has
+    // part of itself encoded, so the raw data left here is just the tail and
+    // says nothing about the stripe.
+    //
+    // Declining costs the space saving, never correctness, and it is hard to
+    // reach. An in-map stream is one byte per row, so it must pass
+    // minStreamChunkRawSize (512KiB, ~524k rows for this one key) AND do so
+    // while the flush policy reports memory pressure, since mid-stripe
+    // chunking only runs under shouldChunk(). A table wide enough to want flat
+    // maps fills a 256MB raw stripe long before one key's in-map reaches half
+    // a megabyte.
+    if (offset >= encodedStreams_.size() ||
+        !encodedStreams_[offset].chunks.empty()) {
+      continue;
+    }
+    // In-map streams are ContentStreamData<bool> (FieldWriter.cpp), so data()
+    // is a plain view: no materialization, and none of the string value
+    // streams are touched.
+    if (isAllTrueBoolStream(stream->data())) {
+      candidates.push_back(&descriptor);
+    }
+  }
+  return candidates;
+}
+
+void Writer::suppressAllTrueInMapStreams(
+    const std::vector<const StreamDescriptorBuilder*>& candidates) {
+  // After the encode loop a value stream reached disk exactly when it has
+  // chunks. Nothing needs to be read from the streams themselves, so this
+  // costs no materialization and inspects no encoded bytes.
+  const auto reachedDisk = [this](offset_size offset) {
+    return offset < encodedStreams_.size() &&
+        !encodedStreams_[offset].chunks.empty();
+  };
+
+  for (const auto* descriptor : candidates) {
+    // Drop the all-true in-map stream only while a value stream proves the key
+    // was present. The offsets were recorded with the reader's own traversal,
+    // so the writer cannot count bytes the reader will not look at.
+    const auto* streamContext = descriptor->context<WriterStreamContext>();
+    const auto& valueOffsets = streamContext->flatMapValueStreamOffsets();
+    if (std::any_of(valueOffsets.begin(), valueOffsets.end(), reachedDisk)) {
+      encodedStreams_[descriptor->offset()].chunks.clear();
+    }
+  }
+}
+
 void Writer::processStream(
     StreamData& streamData,
     velox::BufferPool* encodingScratchBufferPool,
@@ -2769,7 +2867,7 @@ void Writer::processStream(
     uint64_t& streamSize,
     std::atomic_uint64_t& chunkSize) {
   const auto offset = streamData.descriptor().offset();
-  const auto* context = streamData.descriptor().context<WriterStreamContext>();
+  auto* context = streamData.descriptor().context<WriterStreamContext>();
   NIMBLE_CHECK(encodedStreams_[offset].chunks.empty());
   if ((context != nullptr) && context->isNullStream()) {
     // For null streams we promote the null values to be written as
@@ -2786,15 +2884,23 @@ void Writer::processStream(
   } else if (
       (context != nullptr) && context->isInMapStream() &&
       context_->options().skipConstantFlatMapInMapStreams) {
-    // When enabled, skip encoding in-map streams that are all-true (every row
-    // has the key) or all-false (no row has the key). The reader distinguishes
-    // these by checking value stream presence: all-true keys have value
-    // streams, all-false keys do not.
+    // When enabled, skip encoding in-map streams that are constant, since the
+    // reader recovers the in-map state from value stream presence.
+    //
+    // All-false is dropped here: the key really is absent from this stripe,
+    // which is exactly what the reader concludes from two missing streams.
+    //
+    // All-true is still encoded here. collectAllTrueInMapStreams() has
+    // already noted it, and suppressAllTrueInMapStreams() drops the chunks
+    // after the stripe is encoded, once it is known whether a value stream
+    // survived to prove the key was present.
     //
     // NOTE: readers that don't infer missing in-map streams require
     // skipConstantFlatMapInMapStreams to remain false.
     streamData.materialize();
-    if (!isConstantBoolStream(streamData.data())) {
+    const auto data = streamData.data();
+    const bool allTrue = isAllTrueBoolStream(data);
+    if (allTrue || !isConstantBoolStream(data)) {
       encodeStream(
           streamData,
           encodingScratchBufferPool,
@@ -3033,6 +3139,12 @@ bool Writer::writeStripe() {
     return false;
   }
 
+  // Collected before the encode loop, applied after it: all-true is only
+  // visible in the raw stream, while "did a value stream reach disk" is only
+  // settled once encoding is done.
+  ensureWriteStreams();
+  const auto allTrueInMapStreams = collectAllTrueInMapStreams();
+
   if (context_->options().enableChunking) {
     // Chunk all streams.
     std::vector<uint32_t> streamIndices(context_->streams().size());
@@ -3047,6 +3159,8 @@ bool Writer::writeStripe() {
   uint64_t stripeSize{0};
   {
     LoggingScope scope{*context_->logger()};
+
+    suppressAllTrueInMapStreams(allTrueInMapStreams);
 
     size_t nonEmptyCount{0};
     for (auto i = 0; i < encodedStreams_.size(); ++i) {

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -237,6 +237,21 @@ class Writer : public velox::dwio::common::Writer {
       uint64_t& streamSize,
       std::atomic_uint64_t& chunkSize);
 
+  // Clears all-true flat map in-map streams whose key is still provable from a
+  // value stream, so they encode to nothing. Must run single-threaded in the
+  // encode prologue of the closing pass: it reads peer streams, which the
+  // concurrent encode is free to mutate, and by then no further rows can
+  // arrive so both "pending" and "already chunked" are stable.
+  // Descriptors of all-true, single-chunk flat map in-map streams, collected
+  // before the encode loop: all-true is only knowable from the raw stream,
+  // which compact() consumes during encoding.
+  std::vector<const StreamDescriptorBuilder*> collectAllTrueInMapStreams();
+
+  // Drops those whose key is still provable from a value stream. Runs after
+  // the encode loop, where "reached disk" is just chunk presence.
+  void suppressAllTrueInMapStreams(
+      const std::vector<const StreamDescriptorBuilder*>& candidates);
+
   void processStream(
       StreamData& streamData,
       velox::BufferPool* encodingScratchBufferPool,


### PR DESCRIPTION
Summary:

`WriterStreamContext` carried both `isInMapStream_` and
`flatMapValueStreamOffsets_`. They were always written together, in the one
place that configures a newly added flat map key, so the bool was a second
copy of a fact the offsets already told us.

`isInMapStream()` now derives it:

    bool isInMapStream() const {
      return !flatMapValueStreamOffsets_.empty();
    }

Callers are unchanged. Spelling `!offsets.empty()` at each call site would have
traded a name that says what it means for an invariant the reader has to know,
and `processStream()`'s guard is harder to read that way.

The two setters become one, `setInMapValueStreamOffsets()`. That is not just
tidiness: with identity derived from the offsets, a stream marked in-map but
without them would be a stream that is in-map by name and not by behaviour.
Setting both through a single call means that state is never observable, where
before there was a window between the two calls.

The derivation holds because the offsets are never empty for an in-map stream.
Every arm of `visitValueStreamLeaves()` yields at least one descriptor --
scalars and containers visit their own, `Row` and `FlatMap` recurse under a
`NIMBLE_CHECK_GT(childrenCount, 0)` -- so a key always has at least one value
stream to record. Worth being explicit that this holds by consequence of that
traversal rather than by construction, which is why the setter asserts it: if a
future type arm returned nothing, the failure would otherwise be silent, and it
would present as the in-map optimization quietly not applying rather than as
anything visibly wrong.

Reviewed By: xiaoxmeng

Differential Revision: D119072607
