### PR TITLE
fix(build): Stop installing googletest from Homebrew on macOS

### DIFF
--- a/scripts/docker/centos-multi.dockerfile
+++ b/scripts/docker/centos-multi.dockerfile
@@ -107,7 +107,7 @@ RUN /bin/bash -c 'source /setup-centos9.sh && \
       install_velox_deps_from_dnf && \
       dnf clean all'
 
-RUN ln -s $(which python3) /usr/bin/python
+RUN ln -sf $(which python3) /usr/bin/python
 
 COPY --from=base-build /deps /usr/local
 

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -43,7 +43,12 @@ export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 # gflags and glog are installed from source to ensure version compatibility.
 # Homebrew's glog 0.7.x has breaking API changes that are incompatible with folly.
-MACOS_VELOX_DEPS="bison double-conversion fast_float flex googletest icu4c libevent libsodium lz4 openssl simdjson snappy xz xxhash zstd"
+# googletest is left out because CMake always builds VELOX_GTEST_VERSION from
+# source. Homebrew's copy is never used, and its headers in
+# /opt/homebrew/include shadow the built-in gmock in targets that reach
+# /opt/homebrew/include before the bundled googlemock, mixing two googletest
+# versions in one translation unit.
+MACOS_VELOX_DEPS="bison double-conversion fast_float flex icu4c libevent libsodium lz4 openssl simdjson snappy xz xxhash zstd"
 MACOS_BUILD_DEPS="ninja cmake"
 
 SUDO="${SUDO:-""}"


### PR DESCRIPTION
CMake always builds googletest `VELOX_GTEST_VERSION` (1.13.0) from source:
`gtest.cmake` declares it with `FetchContent` and `OVERRIDE_FIND_PACKAGE`, and
nothing calls `find_package(GTest)`, so the Homebrew formula is never linked.

It is not inert, though. Homebrew installs its headers into
`/opt/homebrew/include`, which is on the include path of any target that
depends on a Homebrew-installed library. A target reaches that directory
before the bundled googlemock include directory unless it links `GTest::gmock`
ahead of everything else, so `<gmock/gmock.h>` resolves to Homebrew while
`<gtest/gtest.h>` resolves to the bundled copy. Compiling gmock headers from
one googletest release against gtest headers from another fails outright once
the two drift far enough apart.

Homebrew moved googletest from 1.17.0 to 1.18.0 on September 4, and the macOS
jobs have been red since. In Velox, `dwio/dwrf/test/TestColumnReader.cpp` now
sees the `Invoke()` deprecation that 1.13.0 does not have. In Axiom, which
sources this script, `gmock-actions.h` fails to compile at all:

```
/opt/homebrew/include/gmock/gmock-actions.h:1867:1: error: a type specifier is required for all declarations
 1867 | GTEST_INTERNAL_DEPRECATE_AND_INLINE("Avoid using DoAll() for single actions")
/opt/homebrew/include/gmock/gmock-matchers.h:4977:59: error: no template named 'StringType' in namespace 'testing::internal'
```

Dropping the formula leaves no gmock headers under `/opt/homebrew/include`, so
every target picks up the bundled copy that matches its gtest.

## Also in this pull request

`scripts/docker/centos-multi.dockerfile` runs `ln -s $(which python3)
/usr/bin/python`, which now fails with `File exists` because the
`quay.io/centos/centos:stream9` base image ships that symlink. The ci image has
not baked since the last green run on August 31, and the image build only runs
when a setup script, a dockerfile or `docker.yml` changes — so this pull
request is the one that surfaces it, and cannot show green checks without the
fix. `ln -sf` restores it. The fedora image has the same line and still builds,
since its base does not provide the symlink.
