### PR TITLE
feat(nimble): Align ALP estimation and encoding

### DIFF
--- a/velox/dwio/nimble/encodings/ALPEncoding.h
+++ b/velox/dwio/nimble/encodings/ALPEncoding.h
@@ -244,57 +244,94 @@ class ALPEncoding final
       logicalValues[i] = detail::alp::toLogical<cppDataType>(values[i]);
     }
 
-    ScopedVector<uint64_t> encodedValues{rowCount, pool, options.bufferPool};
-    ScopedVector<uint32_t> exceptionPositions{
-        /*size=*/0, pool, options.bufferPool};
-    ScopedVector<physicalType> exceptionValues{
-        /*size=*/0, pool, options.bufferPool};
     const auto [exponent, factor] = findBestExponentFactorByCount(
         std::span<const cppDataType>{
             logicalValues.data(), logicalValues.size()});
 
+    return encodeWithExponentFactor(
+        selection,
+        values,
+        {logicalValues.data(), logicalValues.size()},
+        exponent,
+        factor,
+        buffer,
+        options);
+  }
+
+  static std::string_view encodeWithExponentFactor(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      std::span<const cppDataType> logicalValues,
+      uint8_t exponent,
+      uint8_t factor,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    if (values.empty()) {
+      NIMBLE_INCOMPATIBLE_ENCODING("ALP encoding cannot encode empty data.");
+    }
+    NIMBLE_CHECK_EQ(values.size(), logicalValues.size());
+    NIMBLE_CHECK_LE(exponent, kMaxExponent);
+    NIMBLE_CHECK_LE(factor, kMaxFactor);
+
+    const uint32_t rowCount = values.size();
+    auto* pool = &buffer.getMemoryPool();
+    ScopedVector<uint64_t> encodedValues{rowCount, pool, options.bufferPool};
+    ScopedVector<uint32_t> exceptionPositions{0, pool, options.bufferPool};
+    ScopedVector<physicalType> exceptionValues{0, pool, options.bufferPool};
     const double exponentMultiplier = kPow10Double[exponent];
     const double factorMultiplier = kPow10Double[factor];
     alignas(64) uint64_t zigZagLanes[kBatchSize];
     alignas(64) bool okLanes[kBatchSize];
 
-    uint32_t i = 0;
-    for (; i + kBatchSize <= rowCount; i += kBatchSize) {
+    uint32_t row = 0;
+    for (; row + kBatchSize <= rowCount; row += kBatchSize) {
       batchTransform(
-          logicalValues.data() + i,
-          values.data() + i,
+          logicalValues.data() + row,
+          values.data() + row,
           exponentMultiplier,
           factorMultiplier,
           zigZagLanes,
           okLanes);
-      for (std::size_t k = 0; k < kBatchSize; ++k) {
-        const uint32_t position = i + static_cast<uint32_t>(k);
-        if (!okLanes[k]) {
-          encodedValues[position] = 0;
+      for (std::size_t lane = 0; lane < kBatchSize; ++lane) {
+        const uint32_t position = row + static_cast<uint32_t>(lane);
+        if (!okLanes[lane]) {
           exceptionPositions.push_back(position);
           exceptionValues.push_back(values[position]);
           continue;
         }
-        encodedValues[position] = zigZagLanes[k];
+        encodedValues[position] = zigZagLanes[lane];
       }
     }
-    for (; i < rowCount; ++i) {
+    for (; row < rowCount; ++row) {
       uint64_t zigZag = 0;
       if (!scalarTransformOne(
-              logicalValues[i],
-              values[i],
+              logicalValues[row],
+              values[row],
               exponentMultiplier,
               factorMultiplier,
               zigZag)) {
-        encodedValues[i] = 0;
-        exceptionPositions.push_back(i);
-        exceptionValues.push_back(values[i]);
+        exceptionPositions.push_back(row);
+        exceptionValues.push_back(values[row]);
         continue;
       }
-      encodedValues[i] = zigZag;
+      encodedValues[row] = zigZag;
     }
 
     const uint32_t exceptionCount = exceptionPositions.size();
+    if (exceptionCount > 0) {
+      uint64_t placeholder = 0;
+      if (exceptionCount < rowCount) {
+        uint32_t firstRepresentable = 0;
+        while (firstRepresentable < exceptionCount &&
+               exceptionPositions[firstRepresentable] == firstRepresentable) {
+          ++firstRepresentable;
+        }
+        placeholder = encodedValues[firstRepresentable];
+      }
+      for (const auto position : exceptionPositions) {
+        encodedValues[position] = placeholder;
+      }
+    }
 
     ScopedEncodingBuffer scopedBuffer{
         &buffer.getMemoryPool(), options.encodingBufferPool};
@@ -460,14 +497,12 @@ class ALPEncoding final
 
     const uint64_t rowCount = values.size();
     const uint32_t sampleSize = estimateSampleSize(rowCount);
-
-    std::vector<physicalType> sampledValues;
-    sampledValues.reserve(sampleSize);
-    // Select evenly spaced input positions without accumulating rounding error.
-    for (uint32_t i = 0; i < sampleSize; ++i) {
-      const auto inputIndex = sampledValueIndex(i, rowCount, sampleSize);
-      sampledValues.push_back(values[inputIndex]);
+    if (sampleSize == rowCount) {
+      return estimateSizeFromSample(rowCount, values, options);
     }
+
+    std::vector<physicalType> sampledValues(sampleSize);
+    gatherSample<physicalType>(values, sampledValues);
 
     return estimateSizeFromSample(rowCount, sampledValues, options);
   }
@@ -492,43 +527,33 @@ class ALPEncoding final
       logicalValues.push_back(detail::alp::toLogical<cppDataType>(value));
     }
 
-    const auto [exponent, factor] = findBestExponentFactorByCount(
-        std::span<const cppDataType>{
-            logicalValues.data(), logicalValues.size()});
-
-    std::vector<uint64_t> encodedValues;
-    encodedValues.reserve(sampleSize);
+    const auto [exponent, factor] =
+        findBestExponentFactorByCount(logicalValues);
+    const auto winnerScore =
+        scoreCombination(logicalValues, exponent, factor, options);
     std::vector<uint32_t> exceptionPositions;
-    exceptionPositions.reserve(sampleSize);
+    exceptionPositions.reserve(winnerScore.exceptionCount);
     std::vector<physicalType> exceptionValues;
-    exceptionValues.reserve(sampleSize);
+    exceptionValues.reserve(winnerScore.exceptionCount);
     uint64_t sampleExceptionCount{0};
-    for (auto i = 0; i < sampleSize; ++i) {
+    for (uint32_t sampleIndex = 0; sampleIndex < sampleSize; ++sampleIndex) {
       if (!canRepresentExactly(
-              logicalValues[i],
-              sampledValues[static_cast<size_t>(i)],
+              logicalValues[sampleIndex],
+              sampledValues[sampleIndex],
               exponent,
               factor)) {
-        encodedValues.push_back(0);
         exceptionPositions.push_back(
-            sampledValueIndex(i, rowCount, sampleSize));
-        exceptionValues.push_back(sampledValues[static_cast<size_t>(i)]);
+            sampledValueIndex(sampleIndex, rowCount, sampleSize));
+        exceptionValues.push_back(sampledValues[sampleIndex]);
         ++sampleExceptionCount;
-        continue;
       }
-
-      const auto encoded =
-          encodeValue(static_cast<double>(logicalValues[i]), exponent, factor);
-      encodedValues.push_back(velox::ZigZag::encode(encoded));
     }
 
-    const auto encodedStats = Statistics<uint64_t>::create(
-        std::span<const uint64_t>{encodedValues.data(), encodedValues.size()});
     // Model the inexpensive scalar candidates without recursively estimating
     // complex nested encodings.
     const uint64_t nestedEncodedValuesSize = std::min(
         FixedBitWidthEncoding<uint64_t>::estimateSize(
-            rowCount, encodedStats, options),
+            rowCount, winnerScore.zigZagMin, winnerScore.zigZagMax, options),
         TrivialEncoding<uint64_t>::estimateSize(rowCount));
     const uint64_t exceptionCount =
         (sampleExceptionCount * rowCount + sampleSize - 1) / sampleSize;
@@ -567,15 +592,52 @@ class ALPEncoding final
     return std::min(static_cast<uint32_t>(rowCount), kSampleSize);
   }
 
-  /// Maps a dense sample ordinal to an evenly spaced input row.
   static uint64_t sampledValueIndex(
       uint32_t sampleIndex,
       uint64_t rowCount,
       uint32_t sampleSize) {
-    return sampleIndex * rowCount / sampleSize;
+    if (sampleSize == 0) {
+      return 0;
+    }
+    if (sampleSize == rowCount || sampleSize <= kSamplingChunks ||
+        sampleSize % kSamplingChunks != 0) {
+      return static_cast<uint64_t>(sampleIndex) * rowCount / sampleSize;
+    }
+    const uint32_t chunkSize = sampleSize / kSamplingChunks;
+    const uint32_t chunk = sampleIndex / chunkSize;
+    return std::min<uint64_t>(
+        static_cast<uint64_t>(chunk) * rowCount / kSamplingChunks +
+            sampleIndex % chunkSize,
+        rowCount - 1);
   }
 
  private:
+  template <typename SampleType>
+  static void gatherSample(
+      std::span<const SampleType> values,
+      std::span<SampleType> sample) {
+    const uint32_t sampleSize = sample.size();
+    if (sampleSize == values.size()) {
+      std::copy(values.begin(), values.end(), sample.begin());
+      return;
+    }
+    if (sampleSize <= kSamplingChunks || sampleSize % kSamplingChunks != 0) {
+      for (uint32_t sampleIndex = 0; sampleIndex < sampleSize; ++sampleIndex) {
+        sample[sampleIndex] =
+            values[sampledValueIndex(sampleIndex, values.size(), sampleSize)];
+      }
+      return;
+    }
+    const uint32_t chunkSize = sampleSize / kSamplingChunks;
+    for (uint32_t chunk = 0; chunk < kSamplingChunks; ++chunk) {
+      const uint32_t sampleIndex = chunk * chunkSize;
+      const auto inputIndex =
+          sampledValueIndex(sampleIndex, values.size(), sampleSize);
+      std::copy_n(
+          values.data() + inputIndex, chunkSize, sample.data() + sampleIndex);
+    }
+  }
+
   struct SlicedExceptionStreams {
     uint32_t count{0};
     std::string_view positions;
@@ -675,6 +737,9 @@ class ALPEncoding final
       1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
       1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22, 1e23};
 
+  static constexpr uint32_t kSampleSize{1024};
+  static constexpr uint32_t kSamplingChunks{32};
+
  private:
   // Largest exponent and factor values backed by kPow10Double.
   static constexpr int kMaxExponent{23};
@@ -685,8 +750,6 @@ class ALPEncoding final
   static constexpr double kInt64MaxExclusiveAsDouble{0x1p63};
   // ALP-specific control word following the standard Encoding prefix.
   static constexpr uint32_t kHeaderSize{3};
-  // Sample up to this many values to find the best (exponent, factor) pair.
-  static constexpr uint32_t kSampleSize{1024};
 
   static bool
   tryRoundToInt64(double scaled, double factorMultiplier, int64_t& result) {
@@ -842,7 +905,101 @@ class ALPEncoding final
     }
   }
 
+  struct CombinationScore {
+    uint64_t estimatedBytes;
+    uint32_t exceptionCount;
+    uint64_t zigZagMin;
+    uint64_t zigZagMax;
+  };
+
+  static constexpr uint64_t kUnusableScore =
+      std::numeric_limits<uint64_t>::max();
+
+  FOLLY_NOINLINE static CombinationScore scoreCombination(
+      std::span<const cppDataType> logicalValues,
+      int exponent,
+      int factor,
+      const Encoding::Options& options) {
+    NIMBLE_CHECK(
+        exponent >= 0 && exponent <= kMaxExponent,
+        "ALP exponent must be between 0 and {}.",
+        kMaxExponent);
+    NIMBLE_CHECK(
+        factor >= 0 && factor <= kMaxFactor,
+        "ALP factor must be between 0 and {}.",
+        kMaxFactor);
+
+    const auto sampleSize = logicalValues.size();
+    const auto physicals =
+        EncodingPhysicalType<cppDataType>::asEncodingPhysicalTypeSpan(
+            logicalValues);
+    uint64_t zigZagMin = std::numeric_limits<uint64_t>::max();
+    uint64_t zigZagMax = 0;
+    uint32_t exceptionCount = 0;
+    const double exponentMultiplier = kPow10Double[exponent];
+    const double factorMultiplier = kPow10Double[factor];
+    alignas(64) uint64_t zigZagLanes[kBatchSize];
+    alignas(64) bool okLanes[kBatchSize];
+
+    size_t row = 0;
+    for (; row + kBatchSize <= sampleSize; row += kBatchSize) {
+      batchTransform(
+          logicalValues.data() + row,
+          physicals.data() + row,
+          exponentMultiplier,
+          factorMultiplier,
+          zigZagLanes,
+          okLanes);
+      for (size_t lane = 0; lane < kBatchSize; ++lane) {
+        if (!okLanes[lane]) {
+          ++exceptionCount;
+          continue;
+        }
+        zigZagMin = std::min(zigZagMin, zigZagLanes[lane]);
+        zigZagMax = std::max(zigZagMax, zigZagLanes[lane]);
+      }
+    }
+    for (; row < sampleSize; ++row) {
+      uint64_t zigZag = 0;
+      if (!scalarTransformOne(
+              logicalValues[row],
+              physicals[row],
+              exponentMultiplier,
+              factorMultiplier,
+              zigZag)) {
+        ++exceptionCount;
+        continue;
+      }
+      zigZagMin = std::min(zigZagMin, zigZag);
+      zigZagMax = std::max(zigZagMax, zigZag);
+    }
+    if (exceptionCount == sampleSize) {
+      return {kUnusableScore, exceptionCount, 0, 0};
+    }
+    const auto integerBytes = std::min(
+        FixedBitWidthEncoding<uint64_t>::estimateSize(
+            sampleSize, zigZagMin, zigZagMax, options),
+        TrivialEncoding<uint64_t>::estimateSize(sampleSize));
+    return {
+        integerBytes +
+            static_cast<uint64_t>(exceptionCount) *
+                (sizeof(uint32_t) + sizeof(physicalType)),
+        exceptionCount,
+        zigZagMin,
+        zigZagMax};
+  }
+
  private:
+  static std::span<const cppDataType> selectionSample(
+      std::span<const cppDataType> values,
+      std::array<cppDataType, kSampleSize>& buffer) {
+    if (values.size() <= kSampleSize) {
+      return values;
+    }
+    gatherSample<cppDataType>(values, buffer);
+    return buffer;
+  }
+
   // Counts the values exactly representable under (exponent, factor), routing
   // through the vectorized transform with a scalar tail. Kept out of line
   // because the candidate grid calls it a few hundred times, so a single
@@ -887,12 +1044,13 @@ class ALPEncoding final
     return representableCount;
   }
 
+ public:
   // Selects the sampled (exponent, factor) pair that preserves the most values.
   static std::pair<uint8_t, uint8_t> findBestExponentFactorByCount(
       std::span<const cppDataType> values) {
-    const uint32_t sampleSize =
-        std::min(static_cast<uint32_t>(values.size()), kSampleSize);
-    const auto sample = values.subspan(0, sampleSize);
+    std::array<cppDataType, kSampleSize> sampleBuffer;
+    const auto sample = selectionSample(values, sampleBuffer);
+    const uint32_t sampleSize = sample.size();
     // Free: physicalType has the same width as cppDataType, and the cast is
     // exactly what toPhysical does per value.
     const physicalType* physicals =
@@ -934,6 +1092,7 @@ class ALPEncoding final
     return {bestExponent, bestFactor};
   }
 
+ private:
   // Converts a floating-point value to the integer stored by ALP.
   static int64_t encodeValue(double value, int exponent, int factor) {
     const double scaled = value * kPow10Double[exponent];

--- a/velox/dwio/nimble/encodings/benchmarks/ALPEncodingBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/ALPEncodingBenchmark.cpp
@@ -16,9 +16,11 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <random>
@@ -46,6 +48,22 @@ DEFINE_uint32(
     rows,
     65'536,
     "Values per dataset; use --bm_regex to select cases.");
+DEFINE_bool(
+    profile,
+    false,
+    "Report repeated Release timings and encoded sizes.");
+DEFINE_string(
+    profile_filter,
+    "",
+    "Only profile dataset names containing this text.");
+DEFINE_uint32(
+    profile_trials,
+    5,
+    "Number of timed trials per profile operation.");
+DEFINE_uint32(
+    profile_min_ms,
+    10,
+    "Minimum calibrated duration per profile trial.");
 
 namespace {
 
@@ -60,6 +78,46 @@ using facebook::nimble::benchmarks::nullFactory;
 namespace alp = facebook::nimble::detail::alp;
 
 constexpr uint64_t kSeed = 0x51ED0FF1CEULL;
+constexpr uint32_t kSamplingChunks = 32;
+
+template <typename Function>
+void profileOperation(
+    const std::string& name,
+    std::string_view operation,
+    Function&& function) {
+  const auto timeIterations = [&](uint64_t iterations) {
+    const auto start = std::chrono::steady_clock::now();
+    for (uint64_t iteration = 0; iteration < iterations; ++iteration) {
+      function();
+    }
+    return std::chrono::duration<double, std::nano>(
+               std::chrono::steady_clock::now() - start)
+        .count();
+  };
+
+  uint64_t iterations = 1;
+  while (timeIterations(iterations) < FLAGS_profile_min_ms * 1'000'000.0) {
+    CHECK_LE(iterations, std::numeric_limits<uint64_t>::max() / 2);
+    iterations *= 2;
+  }
+  std::vector<double> timings;
+  for (uint32_t trial = 0; trial < FLAGS_profile_trials; ++trial) {
+    timings.push_back(timeIterations(iterations) / iterations);
+  }
+  std::sort(timings.begin(), timings.end());
+  const auto middle = timings.size() / 2;
+  const double median = timings.size() % 2 == 0
+      ? (timings[middle - 1] + timings[middle]) / 2
+      : timings[middle];
+  fmt::print(
+      "PROFILE,{},{},{},{:.2f},{:.2f},{:.2f}\n",
+      name,
+      operation,
+      iterations,
+      median,
+      timings.front(),
+      timings.back());
+}
 
 template <typename FloatType, typename Generator>
 std::vector<FloatType> makeValues(Generator generator) {
@@ -106,6 +164,7 @@ class AlpBenchmarkFixture {
       uint8_t exponent)
       : values_{std::move(values)},
         physicals_(values_.size()),
+        sample_(Alp::estimateSampleSize(values_.size())),
         zigZag_(values_.size()),
         mask_(values_.size()),
         output_(values_.size()),
@@ -129,11 +188,13 @@ class AlpBenchmarkFixture {
     encoded_ = std::string{encode(buffer)};
     auto encoding =
         EncodingFactory{}.create(*benchmarkPool(), encoded_, nullFactory());
+    int selectedExponent = -1;
+    int selectedFactor = -1;
     if (encoding->encodingType() == EncodingType::ALP) {
       const char* position = encoded_.data() + encoding->dataOffset();
       const auto header = alp::readHeader(position);
-      CHECK_EQ(header.exponent, batchGrid.exponent);
-      CHECK_EQ(header.factor, batchGrid.factor);
+      selectedExponent = header.exponent;
+      selectedFactor = header.factor;
     }
 
     decode();
@@ -141,19 +202,30 @@ class AlpBenchmarkFixture {
       CHECK_EQ(alp::toPhysical<FloatType>(output_[row]), physicals_[row]);
     }
 
+    uint64_t encodedHash = 14695981039346656037ULL;
+    for (const unsigned char byte : encoded_) {
+      encodedHash = (encodedHash ^ byte) * 1099511628211ULL;
+    }
+    const auto estimatedBytes = Alp::estimateSize(physicals_);
+    CHECK(estimatedBytes.has_value());
     fmt::print(
         "{}: rows={} transform=({},0) exceptions={:.2f}% "
-        "grid=({},{}) encoding={} bytes={} encoded/raw={:.4f}\n",
+        "head-grid=({},{}) selected=({},{}) encoding={} bytes={} "
+        "estimated={} encoded/raw={:.4f} hash={:016x}\n",
         name,
         values_.size(),
         exponent_,
         100.0 * (values_.size() - scalarCount) / values_.size(),
         batchGrid.exponent,
         batchGrid.factor,
+        selectedExponent,
+        selectedFactor,
         facebook::nimble::toString(encoding->encodingType()),
         encoded_.size(),
+        *estimatedBytes,
         static_cast<double>(encoded_.size()) /
-            (values_.size() * sizeof(FloatType)));
+            (values_.size() * sizeof(FloatType)),
+        encodedHash);
   }
 
   template <bool useBatch>
@@ -183,6 +255,42 @@ class AlpBenchmarkFixture {
       }
     }
     return best;
+  }
+
+  template <bool chunked>
+  void gatherSample() {
+    const uint64_t rowCount = values_.size();
+    const uint32_t sampleSize = sample_.size();
+    if constexpr (chunked) {
+      if (sampleSize == rowCount) {
+        std::copy(physicals_.begin(), physicals_.end(), sample_.begin());
+        folly::doNotOptimizeAway(sample_.data());
+        return;
+      }
+      if (rowCount > kSamplingChunks && sampleSize > kSamplingChunks) {
+        const uint32_t chunkSize = sampleSize / kSamplingChunks;
+        uint32_t written = 0;
+        for (uint32_t chunk = 0; chunk < kSamplingChunks; ++chunk) {
+          const auto start = chunk * rowCount / kSamplingChunks;
+          std::copy_n(
+              physicals_.data() + start, chunkSize, sample_.data() + written);
+          written += chunkSize;
+        }
+        while (written < sampleSize) {
+          sample_[written++] = physicals_.back();
+        }
+        folly::doNotOptimizeAway(sample_.data());
+        return;
+      }
+    }
+    for (uint32_t index = 0; index < sampleSize; ++index) {
+      sample_[index] = physicals_[index * rowCount / sampleSize];
+    }
+    folly::doNotOptimizeAway(sample_.data());
+  }
+
+  void estimate() const {
+    folly::doNotOptimizeAway(Alp::estimateSize(physicals_));
   }
 
   std::string_view encode(Buffer& buffer) const {
@@ -255,6 +363,7 @@ class AlpBenchmarkFixture {
 
   std::vector<FloatType> values_;
   std::vector<PhysicalType> physicals_;
+  std::vector<PhysicalType> sample_;
   std::vector<uint64_t> zigZag_;
   std::vector<uint8_t> mask_;
   std::vector<FloatType> output_;
@@ -269,8 +378,39 @@ void registerDataset(
     uint8_t exponent) {
   const auto name = fmt::format(
       "{}_{}", std::is_same_v<FloatType, float> ? "Float" : "Double", dataset);
+  if (FLAGS_profile && name.find(FLAGS_profile_filter) == std::string::npos) {
+    return;
+  }
   auto fixture = std::make_shared<AlpBenchmarkFixture<FloatType>>(
       name, std::move(values), exponent);
+
+  if (FLAGS_profile) {
+    profileOperation(name, "TransformScalar", [&] {
+      folly::doNotOptimizeAway(fixture->template runTransform<false>());
+    });
+    profileOperation(name, "TransformBatch", [&] {
+      folly::doNotOptimizeAway(fixture->template runTransform<true>());
+    });
+    profileOperation(name, "GridScalar", [&] {
+      folly::doNotOptimizeAway(fixture->template runGrid<false>());
+    });
+    profileOperation(name, "GridBatch", [&] {
+      folly::doNotOptimizeAway(fixture->template runGrid<true>());
+    });
+    profileOperation(name, "SamplingLegacy", [&] {
+      fixture->template gatherSample<false>();
+    });
+    profileOperation(name, "SamplingChunked", [&] {
+      fixture->template gatherSample<true>();
+    });
+    profileOperation(name, "Estimate", [&] { fixture->estimate(); });
+    profileOperation(name, "Encode", [&] {
+      Buffer buffer{*benchmarkPool()};
+      folly::doNotOptimizeAway(fixture->encode(buffer));
+    });
+    profileOperation(name, "Decode", [&] { fixture->decode(); });
+    return;
+  }
 
   folly::addBenchmark(
       __FILE__, fmt::format("TransformScalar_{}", name), [fixture] {
@@ -297,6 +437,20 @@ void registerDataset(
   });
   folly::addBenchmark(__FILE__, fmt::format("Decode_{}", name), [fixture] {
     fixture->decode();
+    return 1;
+  });
+  folly::addBenchmark(
+      __FILE__, fmt::format("SamplingLegacy_{}", name), [fixture] {
+        fixture->template gatherSample<false>();
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("%SamplingChunked_{}", name), [fixture] {
+        fixture->template gatherSample<true>();
+        return 1;
+      });
+  folly::addBenchmark(__FILE__, fmt::format("Estimate_{}", name), [fixture] {
+    fixture->estimate();
     return 1;
   });
 }
@@ -361,6 +515,23 @@ void registerDatasets() {
         return static_cast<FloatType>(chaotic(random));
       }),
       2);
+
+  auto headBiased = makeValues<FloatType>([&](auto& random) {
+    return static_cast<FloatType>(cents(random)) / static_cast<FloatType>(100);
+  });
+  const auto headSize = std::min<size_t>(1024, headBiased.size() / 4);
+  std::fill_n(headBiased.begin(), headSize, FloatType{1});
+  registerDataset("HeadBiased", std::move(headBiased), 2);
+
+  uint32_t row = 0;
+  registerDataset(
+      "SparseExceptions",
+      makeValues<FloatType>([&](auto& random) {
+        return row++ % 50 == 0
+            ? std::numeric_limits<FloatType>::infinity()
+            : FloatType{1'000'000} + static_cast<FloatType>(cents(random) % 16);
+      }),
+      0);
 }
 
 } // namespace
@@ -368,13 +539,18 @@ void registerDatasets() {
 int main(int argc, char** argv) {
   const folly::Init init{&argc, &argv};
   CHECK_GT(FLAGS_rows, 0);
+  CHECK_GT(FLAGS_profile_trials, 0);
+  CHECK_GT(FLAGS_profile_min_ms, 0);
   facebook::velox::memory::MemoryManager::initialize({});
   fmt::print(
       "Transform/encode/decode times are per {} rows; grid times are per "
-      "{}-value sample. Relative rows compare batch with scalar.\n",
+      "{}-value prefix sample. Relative rows compare batch with scalar "
+      "or chunked with legacy sampling.\n",
       FLAGS_rows,
       ALPEncoding<double>::estimateSampleSize(FLAGS_rows));
   registerDatasets<double>();
   registerDatasets<float>();
-  folly::runBenchmarks();
+  if (!FLAGS_profile) {
+    folly::runBenchmarks();
+  }
 }

--- a/velox/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -344,6 +344,547 @@ void expectInterleavedMaterializeAndSkip(
   }
 }
 
+template <typename DataType>
+std::string_view encodeAtPair(
+    nimble::Buffer& buffer,
+    std::span<const DataType> values,
+    uint8_t exponent,
+    uint8_t factor,
+    const nimble::Encoding::Options& options) {
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  const auto physicals =
+      nimble::EncodingPhysicalType<DataType>::asEncodingPhysicalTypeSpan(
+          values);
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<DataType>>(
+          std::vector<std::pair<nimble::EncodingType, float>>{
+              {nimble::EncodingType::FixedBitWidth, 1.0},
+              {nimble::EncodingType::Trivial, 1.0}},
+          std::nullopt,
+          std::nullopt);
+  nimble::EncodingSelection<PhysicalType> selection{
+      {.encodingType = nimble::EncodingType::ALP},
+      nimble::Statistics<PhysicalType>::create(physicals),
+      std::move(policy)};
+  return nimble::ALPEncoding<DataType>::encodeWithExponentFactor(
+      selection, physicals, values, exponent, factor, buffer, options);
+}
+
+TYPED_TEST(ALPEncodingTest, scoreCombinationRejectsInvalidIndices) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const std::array<DataType, 1> values{DataType{1}};
+  const auto outOfBounds = static_cast<int>(Alp::kPow10Double.size());
+  for (size_t sampleSize : {0, 1}) {
+    const std::span<const DataType> sample{values.data(), sampleSize};
+    for (int invalidIndex :
+         {-1,
+          outOfBounds,
+          std::numeric_limits<int>::min(),
+          std::numeric_limits<int>::max()}) {
+      SCOPED_TRACE(
+          fmt::format(
+              "sampleSize={} invalidIndex={}", sampleSize, invalidIndex));
+      NIMBLE_ASSERT_THROW(
+          Alp::scoreCombination(sample, invalidIndex, 0, options),
+          "ALP exponent must be between 0 and 23.");
+      NIMBLE_ASSERT_THROW(
+          Alp::scoreCombination(sample, 0, invalidIndex, options),
+          "ALP factor must be between 0 and 23.");
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, scoreCombinationBytesMatchClosedForm) {
+  using DataType = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  using Alp = nimble::ALPEncoding<DataType>;
+  for (bool exactBits : {false, true}) {
+    const nimble::Encoding::Options options{
+        .useVarintRowCount = TypeParam::useVarint,
+        .fixedBitWidthUseExactBits = exactBits};
+    std::vector<DataType> values{
+        DataType{100.00}, DataType{100.01}, DataType{100.50}, DataType{102.00}};
+    for (bool withExceptions : {false, true}) {
+      if (withExceptions) {
+        values.insert(
+            values.begin(), std::numeric_limits<DataType>::infinity());
+        values.push_back(-DataType{0});
+        values.push_back(std::numeric_limits<DataType>::quiet_NaN());
+      }
+      const auto score = Alp::scoreCombination(values, 2, 0, options);
+      const uint32_t expectedExceptions = withExceptions ? 3 : 0;
+      EXPECT_EQ(score.exceptionCount, expectedExceptions);
+      EXPECT_EQ(score.zigZagMin, 20'000);
+      EXPECT_EQ(score.zigZagMax, 20'400);
+      const auto integerBytes = std::min(
+          nimble::FixedBitWidthEncoding<uint64_t>::estimateSize(
+              values.size(), 20'000, 20'400, options),
+          nimble::TrivialEncoding<uint64_t>::estimateSize(values.size()));
+      EXPECT_EQ(
+          score.estimatedBytes,
+          integerBytes +
+              expectedExceptions * (sizeof(uint32_t) + sizeof(PhysicalType)));
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, scoreCombinationUnusableWhenAllExceptions) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const std::array<DataType, 5> values{
+      DataType{0.5}, DataType{1.5}, DataType{2.5}, DataType{3.5}, -DataType{0}};
+  const auto score = Alp::scoreCombination(values, 0, 0, options);
+  EXPECT_EQ(score.exceptionCount, values.size());
+  EXPECT_EQ(score.estimatedBytes, Alp::kUnusableScore);
+  EXPECT_EQ(score.zigZagMin, 0);
+  EXPECT_EQ(score.zigZagMax, 0);
+}
+
+TYPED_TEST(ALPEncodingTest, scoreCombinationMatchesScalarAcrossGrid) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const std::vector<DataType> values{
+      DataType{0},
+      -DataType{0},
+      DataType{0.5},
+      DataType{-1.25},
+      DataType{100.01},
+      DataType{-1'000'000},
+      DataType{1'000'000},
+      std::numeric_limits<DataType>::infinity(),
+      -std::numeric_limits<DataType>::infinity(),
+      std::numeric_limits<DataType>::quiet_NaN(),
+      std::numeric_limits<DataType>::denorm_min(),
+      static_cast<DataType>(0x1p63),
+      static_cast<DataType>(-0x1p63)};
+  for (uint8_t exponent = 0; exponent < Alp::kPow10Double.size(); ++exponent) {
+    for (uint8_t factor = 0; factor <= exponent; ++factor) {
+      uint32_t exceptions = 0;
+      uint64_t minimum = std::numeric_limits<uint64_t>::max();
+      uint64_t maximum = 0;
+      for (const auto value : values) {
+        uint64_t zigZag = 0;
+        if (!Alp::scalarTransformOne(
+                value,
+                nimble::detail::alp::toPhysical<DataType>(value),
+                Alp::kPow10Double[exponent],
+                Alp::kPow10Double[factor],
+                zigZag)) {
+          ++exceptions;
+          continue;
+        }
+        minimum = std::min(minimum, zigZag);
+        maximum = std::max(maximum, zigZag);
+      }
+      const auto score =
+          Alp::scoreCombination(values, exponent, factor, options);
+      EXPECT_EQ(score.exceptionCount, exceptions);
+      EXPECT_EQ(score.zigZagMin, minimum);
+      EXPECT_EQ(score.zigZagMax, maximum);
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, scoreCombinationMatchesEstimator) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const std::array<DataType, 8> values{
+      DataType{100.00},
+      DataType{100.01},
+      DataType{100.50},
+      DataType{100.99},
+      DataType{101.00},
+      DataType{101.25},
+      DataType{101.50},
+      DataType{102.00}};
+  const auto physicals =
+      nimble::EncodingPhysicalType<DataType>::asEncodingPhysicalTypeSpan(
+          values);
+  const auto [exponent, factor] = Alp::findBestExponentFactorByCount(values);
+  for (bool exactBits : {false, true}) {
+    const nimble::Encoding::Options options{
+        .useVarintRowCount = TypeParam::useVarint,
+        .fixedBitWidthUseExactBits = exactBits};
+    const auto score = Alp::scoreCombination(values, exponent, factor, options);
+    ASSERT_EQ(score.exceptionCount, 0);
+    ASSERT_GT(score.zigZagMin, 0);
+    for (uint32_t rowCount : {8, 8192}) {
+      const auto integerBytes = std::min(
+          nimble::FixedBitWidthEncoding<uint64_t>::estimateSize(
+              rowCount, score.zigZagMin, score.zigZagMax, options),
+          nimble::TrivialEncoding<uint64_t>::estimateSize(rowCount));
+      const auto estimate =
+          Alp::estimateSizeFromSample(rowCount, physicals, options);
+      ASSERT_TRUE(estimate.has_value());
+      EXPECT_EQ(
+          *estimate,
+          nimble::EncodingPrefix::serializedSize(
+              rowCount, options.useVarintRowCount) +
+              3 + nimble::varint::varintSize(integerBytes) + integerBytes);
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, scoreCombinationUsesEntireSuppliedSample) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  std::vector<DataType> values(Alp::kSampleSize + 3, DataType{100});
+  values[Alp::kSampleSize] = DataType{99};
+  values[Alp::kSampleSize + 1] = DataType{102};
+  const auto physicals =
+      nimble::EncodingPhysicalType<DataType>::asEncodingPhysicalTypeSpan(
+          std::span<const DataType>{values});
+  for (bool exactBits : {false, true}) {
+    const nimble::Encoding::Options options{
+        .useVarintRowCount = TypeParam::useVarint,
+        .fixedBitWidthUseExactBits = exactBits};
+    const auto score = Alp::scoreCombination(values, 0, 0, options);
+    EXPECT_EQ(score.exceptionCount, 0);
+    EXPECT_EQ(score.zigZagMin, 198);
+    EXPECT_EQ(score.zigZagMax, 204);
+    const auto integerBytes = std::min(
+        nimble::FixedBitWidthEncoding<uint64_t>::estimateSize(
+            values.size(), 198, 204, options),
+        nimble::TrivialEncoding<uint64_t>::estimateSize(values.size()));
+    EXPECT_EQ(score.estimatedBytes, integerBytes);
+    const auto estimate =
+        Alp::estimateSizeFromSample(values.size(), physicals, options);
+    ASSERT_TRUE(estimate.has_value());
+    EXPECT_EQ(
+        *estimate,
+        nimble::EncodingPrefix::serializedSize(
+            values.size(), options.useVarintRowCount) +
+            3 + nimble::varint::varintSize(integerBytes) + integerBytes);
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, exceptionPlaceholdersPreserveIntegerRange) {
+  using DataType = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  using Alp = nimble::ALPEncoding<DataType>;
+  for (bool exactBits : {false, true}) {
+    const nimble::Encoding::Options options{
+        .useVarintRowCount = TypeParam::useVarint,
+        .fixedBitWidthUseExactBits = exactBits};
+    std::vector<DataType> values(2 * Alp::kBatchSize + 3, DataType{1'000'000});
+    values.front() = std::numeric_limits<DataType>::infinity();
+    values[1] = -DataType{0};
+    values[Alp::kBatchSize] = std::numeric_limits<DataType>::quiet_NaN();
+    values.back() = -std::numeric_limits<DataType>::infinity();
+    const auto serialized =
+        encodeAtPair<DataType>(*this->buffer_, values, 0, 0, options);
+    const char* position = serialized.data() +
+        nimble::EncodingPrefix::prefixSize(
+                               serialized, options.useVarintRowCount);
+    const auto header = nimble::detail::alp::readHeader(position);
+    EXPECT_EQ(header.exponent, 0);
+    EXPECT_EQ(header.factor, 0);
+    ASSERT_TRUE(header.hasExceptions);
+    EXPECT_EQ(nimble::varint::readVarint32(&position), 4);
+    const auto integerBytes = nimble::varint::readVarint32(&position);
+    auto integers = nimble::EncodingFactory{}.create(
+        *this->pool_,
+        {position, integerBytes},
+        [](uint32_t) -> void* { return nullptr; },
+        options);
+    std::vector<uint64_t> encodedValues(values.size());
+    integers->materialize(values.size(), encodedValues.data());
+    for (const auto encoded : encodedValues) {
+      EXPECT_EQ(encoded, 2'000'000);
+    }
+
+    auto encoding = nimble::EncodingFactory{}.create(
+        *this->pool_,
+        serialized,
+        [](uint32_t) -> void* { return nullptr; },
+        options);
+    std::vector<PhysicalType> decoded(values.size());
+    encoding->materialize(values.size(), decoded.data());
+    for (size_t row = 0; row < values.size(); ++row) {
+      EXPECT_EQ(
+          decoded[row], nimble::detail::alp::toPhysical<DataType>(values[row]));
+    }
+    const auto physicals =
+        nimble::EncodingPhysicalType<DataType>::asEncodingPhysicalTypeSpan(
+            std::span<const DataType>{values});
+    const auto estimate =
+        Alp::estimateSizeFromSample(values.size(), physicals, options);
+    ASSERT_TRUE(estimate.has_value());
+    const auto score = Alp::scoreCombination(values, 0, 0, options);
+    const auto estimatedIntegerBytes = std::min(
+        nimble::FixedBitWidthEncoding<uint64_t>::estimateSize(
+            values.size(), score.zigZagMin, score.zigZagMax, options),
+        nimble::TrivialEncoding<uint64_t>::estimateSize(values.size()));
+    const std::array<uint32_t, 4> exceptionPositions{
+        0, 1, Alp::kBatchSize, static_cast<uint32_t>(values.size() - 1)};
+    std::array<PhysicalType, 4> exceptionValues;
+    for (size_t exception = 0; exception < exceptionPositions.size();
+         ++exception) {
+      exceptionValues[exception] = physicals[exceptionPositions[exception]];
+    }
+    const auto positionStats =
+        nimble::Statistics<uint32_t>::create(exceptionPositions);
+    const auto valueStats =
+        nimble::Statistics<PhysicalType>::create(exceptionValues);
+    const auto positionBytes = std::min(
+        nimble::FixedBitWidthEncoding<uint32_t>::estimateSize(
+            4, positionStats, options),
+        nimble::TrivialEncoding<uint32_t>::estimateSize(4));
+    const auto valueBytes = std::min(
+        nimble::FixedBitWidthEncoding<PhysicalType>::estimateSize(
+            4, valueStats, options),
+        nimble::TrivialEncoding<PhysicalType>::estimateSize(4));
+    EXPECT_EQ(
+        *estimate,
+        nimble::EncodingPrefix::serializedSize(
+            values.size(), options.useVarintRowCount) +
+            3 + nimble::varint::varintSize(4) +
+            nimble::varint::varintSize(estimatedIntegerBytes) +
+            estimatedIntegerBytes + nimble::varint::varintSize(positionBytes) +
+            positionBytes + nimble::varint::varintSize(valueBytes) +
+            valueBytes);
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, allExceptionPlaceholdersAreZero) {
+  using DataType = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  std::vector<DataType> values(Alp::kBatchSize + 1, DataType{0.5});
+  const auto serialized =
+      encodeAtPair<DataType>(*this->buffer_, values, 0, 0, options);
+  const char* position = serialized.data() +
+      nimble::EncodingPrefix::prefixSize(serialized, options.useVarintRowCount);
+  ASSERT_TRUE(nimble::detail::alp::readHeader(position).hasExceptions);
+  EXPECT_EQ(nimble::varint::readVarint32(&position), values.size());
+  const auto integerBytes = nimble::varint::readVarint32(&position);
+  auto integers = nimble::EncodingFactory{}.create(
+      *this->pool_,
+      {position, integerBytes},
+      [](uint32_t) -> void* { return nullptr; },
+      options);
+  std::vector<uint64_t> encodedValues(values.size());
+  integers->materialize(values.size(), encodedValues.data());
+  for (const auto encoded : encodedValues) {
+    EXPECT_EQ(encoded, 0);
+  }
+  auto encoding = nimble::EncodingFactory{}.create(
+      *this->pool_,
+      serialized,
+      [](uint32_t) -> void* { return nullptr; },
+      options);
+  std::vector<PhysicalType> decoded(values.size());
+  encoding->materialize(values.size(), decoded.data());
+  for (size_t row = 0; row < values.size(); ++row) {
+    EXPECT_EQ(
+        decoded[row], nimble::detail::alp::toPhysical<DataType>(values[row]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, placeholderCanComeFromScalarTail) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  std::vector<DataType> values(
+      2 * Alp::kBatchSize + 1, std::numeric_limits<DataType>::infinity());
+  values.back() = DataType{-123};
+  const auto serialized =
+      encodeAtPair<DataType>(*this->buffer_, values, 0, 0, options);
+  const char* position = serialized.data() +
+      nimble::EncodingPrefix::prefixSize(serialized, options.useVarintRowCount);
+  ASSERT_TRUE(nimble::detail::alp::readHeader(position).hasExceptions);
+  EXPECT_EQ(nimble::varint::readVarint32(&position), values.size() - 1);
+  const auto integerBytes = nimble::varint::readVarint32(&position);
+  auto integers = nimble::EncodingFactory{}.create(
+      *this->pool_,
+      {position, integerBytes},
+      [](uint32_t) -> void* { return nullptr; },
+      options);
+  std::vector<uint64_t> encodedValues(values.size());
+  integers->materialize(values.size(), encodedValues.data());
+  for (const auto encoded : encodedValues) {
+    EXPECT_EQ(encoded, velox::ZigZag::encode(int64_t{-123}));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, chunkedStrideSamplingCoversInput) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const uint32_t chunkSize = Alp::kSampleSize / Alp::kSamplingChunks;
+  for (uint64_t rowCount : {1025, 10'003, 1'000'000}) {
+    const auto sampleSize = Alp::estimateSampleSize(rowCount);
+    ASSERT_EQ(sampleSize, Alp::kSampleSize);
+    uint64_t previous = 0;
+    for (uint32_t sampleIndex = 0; sampleIndex < sampleSize; ++sampleIndex) {
+      const auto index =
+          Alp::sampledValueIndex(sampleIndex, rowCount, sampleSize);
+      EXPECT_LT(index, rowCount);
+      if (sampleIndex > 0) {
+        EXPECT_GT(index, previous);
+      }
+      EXPECT_EQ(
+          index,
+          (sampleIndex / chunkSize) * rowCount / Alp::kSamplingChunks +
+              sampleIndex % chunkSize);
+      previous = index;
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, smallInputSamplingUsesEveryRow) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  EXPECT_EQ(Alp::sampledValueIndex(0, 0, 0), 0);
+  for (uint32_t rowCount = 1; rowCount <= Alp::kSampleSize; ++rowCount) {
+    const auto sampleSize = Alp::estimateSampleSize(rowCount);
+    ASSERT_EQ(sampleSize, rowCount);
+    for (uint32_t sampleIndex = 0; sampleIndex < sampleSize; ++sampleIndex) {
+      ASSERT_EQ(
+          Alp::sampledValueIndex(sampleIndex, rowCount, sampleSize),
+          sampleIndex)
+          << "rowCount=" << rowCount << " sampleIndex=" << sampleIndex;
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, smallSampleFallbackMatchesStridedMapping) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  for (uint32_t sampleSize = 1; sampleSize <= Alp::kSamplingChunks;
+       ++sampleSize) {
+    for (uint32_t sampleIndex = 0; sampleIndex < sampleSize; ++sampleIndex) {
+      EXPECT_EQ(
+          Alp::sampledValueIndex(sampleIndex, 10'003, sampleSize),
+          static_cast<uint64_t>(sampleIndex) * 10'003 / sampleSize);
+    }
+  }
+  for (uint32_t sampleSize : {33, 63, 65, 1023}) {
+    for (uint32_t sampleIndex = 0; sampleIndex < sampleSize; ++sampleIndex) {
+      EXPECT_EQ(
+          Alp::sampledValueIndex(sampleIndex, 10'003, sampleSize),
+          static_cast<uint64_t>(sampleIndex) * 10'003 / sampleSize);
+    }
+  }
+}
+
+TYPED_TEST(
+    ALPEncodingTest,
+    selectionSampleMatchesEstimateOnUnrepresentativeHead) {
+  using DataType = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  nimble::Vector<DataType> values{this->pool_.get(), 65'537};
+  values.fill(DataType{1.25});
+  std::fill_n(values.begin(), Alp::kSampleSize, DataType{1});
+  const std::span<const DataType> logicals{values.data(), values.size()};
+  const auto headPair =
+      Alp::findBestExponentFactorByCount(logicals.first(Alp::kSampleSize));
+  std::vector<DataType> sampled;
+  std::vector<PhysicalType> sampledPhysicals;
+  for (uint32_t sampleIndex = 0; sampleIndex < Alp::kSampleSize;
+       ++sampleIndex) {
+    const auto value = values[Alp::sampledValueIndex(
+        sampleIndex, values.size(), Alp::kSampleSize)];
+    sampled.push_back(value);
+    sampledPhysicals.push_back(
+        nimble::detail::alp::toPhysical<DataType>(value));
+  }
+  const auto samplePair = Alp::findBestExponentFactorByCount(sampled);
+  EXPECT_NE(headPair, samplePair);
+  EXPECT_EQ(Alp::findBestExponentFactorByCount(logicals), samplePair);
+  const auto serialized = encodeWithLayout<DataType>(
+      *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
+  const char* position = serialized.data() +
+      nimble::EncodingPrefix::prefixSize(serialized, options.useVarintRowCount);
+  const auto header = nimble::detail::alp::readHeader(position);
+  EXPECT_EQ(header.exponent, samplePair.first);
+  EXPECT_EQ(header.factor, samplePair.second);
+  const auto physicals =
+      nimble::EncodingPhysicalType<DataType>::asEncodingPhysicalTypeSpan(
+          logicals);
+  EXPECT_EQ(
+      Alp::estimateSize(physicals, options),
+      Alp::estimateSizeFromSample(values.size(), sampledPhysicals, options));
+}
+
+TYPED_TEST(ALPEncodingTest, partialChunksDoNotOmitSmallInputValues) {
+  using DataType = typename TypeParam::data_type;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  for (uint32_t rowCount : {34, 63, 65, 1023, 1024}) {
+    std::vector<DataType> values(rowCount, DataType{1});
+    values[rowCount / 2 - 1] = DataType{1.25};
+    const auto physicals =
+        nimble::EncodingPhysicalType<DataType>::asEncodingPhysicalTypeSpan(
+            std::span<const DataType>{values});
+    EXPECT_EQ(
+        Alp::estimateSize(physicals, options),
+        Alp::estimateSizeFromSample(rowCount, physicals, options))
+        << "rowCount=" << rowCount;
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, chunkedEstimateMatchesMappedExceptions) {
+  using DataType = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint,
+      .fixedBitWidthUseExactBits = true};
+  constexpr uint32_t kRowCount = 65'537;
+  const auto clean = nimble::detail::alp::toPhysical<DataType>(DataType{100});
+  const auto exception = nimble::detail::alp::toPhysical<DataType>(
+      std::numeric_limits<DataType>::infinity());
+  std::vector<PhysicalType> values(kRowCount, clean);
+  const uint32_t chunkSize = Alp::kSampleSize / Alp::kSamplingChunks;
+  std::vector<PhysicalType> sample;
+  for (uint32_t sampleIndex = 0; sampleIndex < Alp::kSampleSize;
+       ++sampleIndex) {
+    const uint32_t chunk = sampleIndex / chunkSize;
+    const auto index =
+        static_cast<uint64_t>(chunk) * kRowCount / Alp::kSamplingChunks +
+        sampleIndex % chunkSize;
+    if (sampleIndex % 7 == 0 || sampleIndex % chunkSize == chunkSize - 1) {
+      values[index] = exception;
+    }
+    sample.push_back(values[index]);
+  }
+  EXPECT_EQ(
+      Alp::estimateSize(values, options),
+      Alp::estimateSizeFromSample(kRowCount, sample, options));
+}
+
+TYPED_TEST(ALPEncodingTest, strideSamplerEstimateStableOnUniformInput) {
+  using DataType = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  using Alp = nimble::ALPEncoding<DataType>;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  for (uint32_t rowCount : {31, 63, 1023, 1025, 100'000}) {
+    const auto physical =
+        nimble::detail::alp::toPhysical<DataType>(DataType{1.25});
+    const std::vector<PhysicalType> values(rowCount, physical);
+    const std::vector<PhysicalType> sample(
+        Alp::estimateSampleSize(rowCount), physical);
+    const auto estimate = Alp::estimateSize(values, options);
+    ASSERT_TRUE(estimate.has_value());
+    EXPECT_EQ(estimate, Alp::estimateSizeFromSample(rowCount, sample, options));
+  }
+}
+
 // batchTransform (xsimd) must produce lane-by-lane byte-identical output to
 // the scalar path (scalarTransformOne). This is the correctness contract that
 // lets the encode loop and the selection grid route through the vectorized


### PR DESCRIPTION
This PR aligns ALP size estimation and encoding through shared chunked sampling and count-based exponent/factor selection. It reuses vectorized scoring to estimate the representable integer range and back-fills exception slots with a representable value, preventing artificial zeros from inflating frame-of-reference widths. Small inputs remain densely sampled, with additional regression coverage and benchmarks in the existing files. Recorded benchmarks show geometric-mean speedups of 1.17–1.18× for estimation and 1.09–1.11× for encoding.