### PR TITLE
refactor: Share the Presto type display name (#18887)

### DIFF
--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -14,119 +14,15 @@
  * limitations under the License.
  */
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/prestosql/types/BigintEnumType.h"
-#include "velox/functions/prestosql/types/HyperLogLogType.h"
-#include "velox/functions/prestosql/types/IPPrefixType.h"
-#include "velox/functions/prestosql/types/KHyperLogLogType.h"
-#include "velox/functions/prestosql/types/P4HyperLogLogType.h"
-#include "velox/functions/prestosql/types/QDigestType.h"
-#include "velox/functions/prestosql/types/SetDigestType.h"
-#include "velox/functions/prestosql/types/TDigestType.h"
-#include "velox/functions/prestosql/types/VarcharEnumType.h"
+#include "velox/functions/prestosql/types/PrestoTypes.h"
 
 namespace facebook::velox::functions {
 namespace {
 
-// Converts a TypePtr to its string representation. Handles most types by
-// default, but provides special handling for types with mixed casing, custom
-// names, or complex formatting.
-std::string typeName(const TypePtr& type) {
-  // Handle decimal types with precision and scale
-  if (type->isDecimal()) {
-    auto precision = type->isShortDecimal() ? type->asShortDecimal().precision()
-                                            : type->asLongDecimal().precision();
-    auto scale = type->isShortDecimal() ? type->asShortDecimal().scale()
-                                        : type->asLongDecimal().scale();
-    return fmt::format("decimal({},{})", precision, scale);
-  }
-
-  // Handle complex types with recursive formatting
-  if (type->kind() == TypeKind::ARRAY) {
-    return fmt::format("array({})", typeName(type->childAt(0)));
-  }
-
-  if (type->kind() == TypeKind::MAP) {
-    return fmt::format(
-        "map({}, {})", typeName(type->childAt(0)), typeName(type->childAt(1)));
-  }
-
-  if (type->kind() == TypeKind::ROW) {
-    if (isIPPrefixType(type)) {
-      return "ipprefix";
-    }
-    const auto& rowType = type->asRow();
-    std::ostringstream out;
-    out << "row(";
-    for (auto i = 0; i < type->size(); ++i) {
-      if (i > 0) {
-        out << ", ";
-      }
-      if (!rowType.nameOf(i).empty()) {
-        out << "\"" << rowType.nameOf(i) << "\" ";
-      }
-      out << typeName(type->childAt(i));
-    }
-    out << ")";
-    return out.str();
-  }
-
-  // Handle enum types that have custom names
-  if (isBigintEnumType(*type)) {
-    return asBigintEnum(type)->enumName();
-  }
-  if (isVarcharEnumType(*type)) {
-    return asVarcharEnum(type)->enumName();
-  }
-
-  // Handle HyperLogLog types that use mixed case
-  if (isHyperLogLogType(type)) {
-    return "HyperLogLog";
-  }
-  if (isP4HyperLogLogType(type)) {
-    return "P4HyperLogLog";
-  }
-  if (isKHyperLogLogType(type)) {
-    return "KHyperLogLog";
-  }
-
-  // Handle SetDigest types
-  if (isSetDigestType(type)) {
-    return "SetDigest";
-  }
-
-  // Handle special digest types that need parameter formatting
-  if (*type == *TDIGEST(DOUBLE())) {
-    return "tdigest(double)";
-  }
-  if (*type == *QDIGEST(BIGINT())) {
-    return "qdigest(bigint)";
-  }
-  if (*type == *QDIGEST(REAL())) {
-    return "qdigest(real)";
-  }
-  if (*type == *QDIGEST(DOUBLE())) {
-    return "qdigest(double)";
-  }
-
-  if (type->kind() == TypeKind::UNKNOWN) {
-    return "unknown";
-  }
-
-  // Handle unsupported types
-  if (type->kind() == TypeKind::OPAQUE || type->kind() == TypeKind::FUNCTION ||
-      type->kind() == TypeKind::INVALID) {
-    VELOX_UNSUPPORTED("Unsupported type: {}", type->toString());
-  }
-
-  // Default: use type->name() and lowercase it
-  std::string name = type->name();
-  folly::toLowerAscii(name);
-  return name;
-}
-
 class TypeOfFunction : public exec::VectorFunction {
  public:
-  TypeOfFunction(const TypePtr& type) : typeName_{typeName(type)} {}
+  TypeOfFunction(const TypePtr& type)
+      : typeName_{PrestoTypes::displayName(*type)} {}
 
   void apply(
       const SelectivityVector& rows,

--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -59,6 +59,10 @@ inline bool isHyperLogLogType(const TypePtr& type) {
   return HyperLogLogType::get() == type;
 }
 
+inline bool isHyperLogLogType(const Type& type) {
+  return HyperLogLogType::get().get() == &type;
+}
+
 inline std::shared_ptr<const HyperLogLogType> HYPERLOGLOG() {
   return HyperLogLogType::get();
 }

--- a/velox/functions/prestosql/types/KHyperLogLogType.h
+++ b/velox/functions/prestosql/types/KHyperLogLogType.h
@@ -59,6 +59,10 @@ inline bool isKHyperLogLogType(const TypePtr& type) {
   return KHyperLogLogType::get() == type;
 }
 
+inline bool isKHyperLogLogType(const Type& type) {
+  return KHyperLogLogType::get().get() == &type;
+}
+
 inline std::shared_ptr<const KHyperLogLogType> KHYPERLOGLOG() {
   return KHyperLogLogType::get();
 }

--- a/velox/functions/prestosql/types/P4HyperLogLogType.h
+++ b/velox/functions/prestosql/types/P4HyperLogLogType.h
@@ -59,6 +59,10 @@ inline bool isP4HyperLogLogType(const TypePtr& type) {
   return P4HyperLogLogType::get() == type;
 }
 
+inline bool isP4HyperLogLogType(const Type& type) {
+  return P4HyperLogLogType::get().get() == &type;
+}
+
 inline std::shared_ptr<const P4HyperLogLogType> P4HYPERLOGLOG() {
   return P4HyperLogLogType::get();
 }

--- a/velox/functions/prestosql/types/PrestoTypes.cpp
+++ b/velox/functions/prestosql/types/PrestoTypes.cpp
@@ -17,10 +17,16 @@
 #include "velox/functions/prestosql/types/PrestoTypes.h"
 
 #include <fmt/format.h>
+#include <folly/String.h>
 #include <velox/common/base/Exceptions.h>
 #include <iomanip>
+
 #include <sstream>
 #include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
+#include "velox/functions/prestosql/types/P4HyperLogLogType.h"
+#include "velox/functions/prestosql/types/SetDigestType.h"
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/SimpleVector.h"
@@ -59,6 +65,102 @@ bool needsQuoting(const std::string& name) {
 }
 
 } // namespace
+
+std::string PrestoTypes::displayName(const Type& type) {
+  if (type.isDecimal()) {
+    const auto [precision, scale] = getDecimalPrecisionScale(type);
+    return fmt::format("decimal({},{})", precision, scale);
+  }
+
+  if (isPlainArray(type)) {
+    return fmt::format("array({})", displayName(*type.childAt(0)));
+  }
+
+  if (isPlainMap(type)) {
+    return fmt::format(
+        "map({}, {})",
+        displayName(*type.childAt(0)),
+        displayName(*type.childAt(1)));
+  }
+
+  if (isPlainRow(type)) {
+    const auto& rowType = type.asRow();
+    std::stringstream out;
+    out << "row(";
+    for (auto i = 0; i < rowType.size(); ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+      // Every field name a row has is quoted, whether or not it needs it.
+      if (!rowType.nameOf(i).empty()) {
+        out << '"' << rowType.nameOf(i) << "\" ";
+      }
+      out << displayName(*rowType.childAt(i));
+    }
+    out << ")";
+    return out.str();
+  }
+
+  if (isBigintEnumType(type)) {
+    return static_cast<const BigintEnumType&>(type).enumName();
+  }
+  if (isVarcharEnumType(type)) {
+    return static_cast<const VarcharEnumType&>(type).enumName();
+  }
+
+  // Types Presto spells in mixed case.
+  if (isHyperLogLogType(type)) {
+    return "HyperLogLog";
+  }
+  if (isP4HyperLogLogType(type)) {
+    return "P4HyperLogLog";
+  }
+  if (isKHyperLogLogType(type)) {
+    return "KHyperLogLog";
+  }
+  if (isSetDigestType(type)) {
+    return "SetDigest";
+  }
+
+  if (type.kind() == TypeKind::OPAQUE || type.kind() == TypeKind::FUNCTION ||
+      type.kind() == TypeKind::INVALID) {
+    VELOX_UNSUPPORTED("Unsupported type: {}", type.toString());
+  }
+
+  // A parameterized type appends its parameters, e.g. 'tdigest(double)'; the
+  // rest name themselves. A custom type, e.g. IPPREFIX, lands here rather than
+  // in the complex cases above, which admit only the plain types.
+  const auto& parameters = type.parameters();
+  std::string name{type.name()};
+  folly::toLowerAscii(name);
+  if (parameters.empty()) {
+    return name;
+  }
+
+  std::stringstream out;
+  out << name << "(";
+  for (auto i = 0; i < parameters.size(); ++i) {
+    if (i > 0) {
+      out << ",";
+    }
+    switch (parameters[i].kind) {
+      case TypeParameterKind::kType:
+        out << displayName(*parameters[i].type);
+        break;
+      case TypeParameterKind::kLongLiteral:
+        out << parameters[i].longLiteral.value();
+        break;
+      // An enum's parameters name its values; the enum itself is spelled by
+      // name above.
+      case TypeParameterKind::kLongEnumLiteral:
+      case TypeParameterKind::kVarcharEnumLiteral:
+        VELOX_UNSUPPORTED(
+            "Type parameter has no Presto name: {}", type.toString());
+    }
+  }
+  out << ")";
+  return out.str();
+}
 
 std::string PrestoTypes::toSql(const TypePtr& type) {
   if (isPlainArray(*type)) {

--- a/velox/functions/prestosql/types/PrestoTypes.h
+++ b/velox/functions/prestosql/types/PrestoTypes.h
@@ -34,7 +34,23 @@ namespace facebook::velox {
 class PrestoTypes {
  public:
   /// Returns the Presto SQL string representation of the given type.
+  ///
+  /// DEPRECATED: prefer 'displayName', which spells types the way Presto
+  /// itself does. This spells them in upper case and quotes a row's field
+  /// names only when they need it, matching no Presto output; it also names
+  /// HYPERLOGLOG where Presto writes HyperLogLog. A caller that only needs
+  /// SQL text Presto can parse gets that from 'displayName' too, as SQL type
+  /// names are case-insensitive.
   static std::string toSql(const TypePtr& type);
+
+  /// Returns the type as Presto displays it, the string 'typeof' and
+  /// information_schema.columns.data_type return: 'bigint', 'array(real)',
+  /// 'map(varchar, bigint)', 'row("x" bigint)', 'decimal(10,2)',
+  /// 'HyperLogLog'. Mirrors Presto's Type.getDisplayName(), whose spacing
+  /// differs between MAP and ROW, which separate with ', ', and the other
+  /// parameterized types, which separate with ','.
+  /// @throws for OPAQUE, FUNCTION and INVALID, which Presto cannot spell.
+  static std::string displayName(const Type& type);
 
   /// Formats a scalar value as a human-readable string using Presto type
   /// conventions. Handles Presto custom types (IPADDRESS, UUID,

--- a/velox/functions/prestosql/types/SetDigestType.h
+++ b/velox/functions/prestosql/types/SetDigestType.h
@@ -59,6 +59,10 @@ inline bool isSetDigestType(const TypePtr& type) {
   return SetDigestType::get() == type;
 }
 
+inline bool isSetDigestType(const Type& type) {
+  return SetDigestType::get().get() == &type;
+}
+
 inline std::shared_ptr<const SetDigestType> SETDIGEST() {
   return SetDigestType::get();
 }


### PR DESCRIPTION
Summary:

`typeof()` built its result with a private renderer in `TypeOf.cpp`, so nothing else could spell a type the way Presto does. Presto derives that text in one place, `Type.getDisplayName()`, and uses it for `typeof`, `information_schema.columns.data_type` and `SHOW CREATE TABLE` alike:

    typeof(CAST(NULL AS ARRAY(REAL)))  ->  array(real)

Moves that renderer to `PrestoTypes::displayName`, which `typeof()` now calls. The behavior is unchanged, including Presto's own inconsistencies — `map(varchar, bigint)` separates with a space while `decimal(10,2)` does not, and a row quotes every field name it has.

The move drops the hand-maintained cases the general rule already covers: `tdigest(double)` and the three `qdigest` spellings come from the type's name and parameters, `unknown` from its lower-cased name, and `ipprefix` from the custom-type path, since the complex-type branches now admit only plain arrays, maps and rows rather than anything of that kind. What remains listed are the four types Presto spells in mixed case, e.g. `HyperLogLog`.

`PrestoTypes::toSql` renders a type in upper case, quotes a row's field names only when they need it, and writes `HYPERLOGLOG`, so it matches no Presto output. It is marked deprecated in favour of `displayName`; its callers generate SQL for Presto to parse, which is case-insensitive, so they can move without a behavior change.

Reviewed By: amitkdutta

Differential Revision: D119093025


