### PR TITLE
fix(memory): Correct minFreeCapacity shrink config comments

### DIFF
--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -94,8 +94,9 @@ class ArbitrationParticipant
     /// Limits how much free capacity memory arbitration can shrink from a query
     /// memory pool, so that the pool keeps enough free capacity for its future
     /// allocations to reduce the chance of another arbitration. When both
-    /// settings are non-zero, a normal shrink of an active pool never reduces
-    /// free capacity below the smaller of:
+    /// 'minFreeCapacity' and 'minFreeCapacityRatio' are set to non-zero, a
+    /// normal shrink of an active pool never reduces free capacity below the
+    /// smaller of:
     /// - capacity * 'minFreeCapacityRatio'
     /// - 'minFreeCapacity'
     ///

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -93,8 +93,9 @@ class ArbitrationParticipant
 
     /// Limits how much free capacity memory arbitration can shrink from a query
     /// memory pool, so that the pool keeps enough free capacity for its future
-    /// allocations without triggering another arbitration round.
-    /// A shrink never reduces free capacity below the smaller of the following:
+    /// allocations to reduce the chance of another arbitration. When both
+    /// settings are non-zero, a normal shrink of an active pool never reduces
+    /// free capacity below the smaller of:
     /// - capacity * 'minFreeCapacityRatio'
     /// - 'minFreeCapacity'
     ///

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -91,20 +91,26 @@ class ArbitrationParticipant
     uint64_t fastExponentialGrowthCapacityLimit;
     double slowCapacityGrowRatio;
 
-    /// When shrinking a memory pool capacity, the shrink bytes will be adjusted
-    /// in a way such that AFTER shrink, the stricter (whichever is smaller) of
-    /// the following conditions is met, in order to better fit the query memory
-    /// pool's current memory usage:
-    /// - Free capacity is greater or equal to capacity *
-    /// 'minFreeCapacityRatio'
-    /// - Free capacity is greater or equal to 'minFreeCapacity'
+    /// Limits how much free capacity memory arbitration can shrink from a query
+    /// memory pool, so that the pool keeps enough free capacity for its future
+    /// allocations without triggering another arbitration round.
+    /// A shrink never reduces free capacity below the smaller of the following:
+    /// - capacity * 'minFreeCapacityRatio'
+    /// - 'minFreeCapacity'
     ///
-    /// NOTE: in the conditions when original requested shrink bytes ends up
-    /// with more free capacity than above 2 conditions, the adjusted shrink
-    /// bytes is not respected.
+    /// If the free capacity is already at or below this minimum, nothing is
+    /// shrunk. The pool may also give up less because its capacity is never
+    /// shrunk below 'minCapacity', so it keeps more free capacity than the
+    /// minimum.
     ///
-    /// NOTE: capacity shrink adjustment is enabled when both
-    /// 'minFreeCapacityRatio' and 'minFreeCapacity' are set.
+    /// For example, with capacity 1GB, 'minFreeCapacityRatio' 0.25 and
+    /// 'minFreeCapacity' 128MB, the minimum is the smaller of 1GB * 0.25 =
+    /// 256MB and 128MB, which is 128MB. So a pool with 400MB of free capacity
+    /// gives up at most 272MB through shrink.
+    ///
+    /// NOTE: this limit applies only when both 'minFreeCapacity' and
+    /// 'minFreeCapacityRatio' are set. It is bypassed when 'shrink' is called
+    /// with 'reclaimAll' set and for inactive pools.
     uint64_t minFreeCapacity;
     double minFreeCapacityRatio;
 

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -88,8 +88,9 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
     /// Limits how much free capacity memory arbitration can shrink from a query
     /// memory pool, so that the pool keeps enough free capacity for its future
-    /// allocations without triggering another arbitration round.
-    /// A shrink never reduces free capacity below the smaller of the following:
+    /// allocations to reduce the chance of another arbitration. When both
+    /// settings are non-zero, a normal shrink of an active pool never reduces
+    /// free capacity below the smaller of:
     /// - capacity * 'memoryPoolMinFreeCapacityPct'
     /// - 'memoryPoolMinFreeCapacity'
     ///

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -89,8 +89,9 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     /// Limits how much free capacity memory arbitration can shrink from a query
     /// memory pool, so that the pool keeps enough free capacity for its future
     /// allocations to reduce the chance of another arbitration. When both
-    /// settings are non-zero, a normal shrink of an active pool never reduces
-    /// free capacity below the smaller of:
+    /// 'memoryPoolMinFreeCapacity' and 'memoryPoolMinFreeCapacityPct' are set
+    /// to non-zero, a normal shrink of an active pool never reduces free
+    /// capacity below the smaller of:
     /// - capacity * 'memoryPoolMinFreeCapacityPct'
     /// - 'memoryPoolMinFreeCapacity'
     ///

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -86,20 +86,26 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static uint64_t maxMemoryArbitrationTimeNs(
         const std::unordered_map<std::string, std::string>& configs);
 
-    /// When shrinking capacity, the shrink bytes will be adjusted in a way such
-    /// that AFTER shrink, the stricter (whichever is smaller) of the following
-    /// conditions is met, in order to better fit the pool's current memory
-    /// usage:
-    /// - Free capacity is greater or equal to capacity *
-    /// 'memoryPoolMinFreeCapacityPct'
-    /// - Free capacity is greater or equal to 'memoryPoolMinFreeCapacity'
+    /// Limits how much free capacity memory arbitration can shrink from a query
+    /// memory pool, so that the pool keeps enough free capacity for its future
+    /// allocations without triggering another arbitration round.
+    /// A shrink never reduces free capacity below the smaller of the following:
+    /// - capacity * 'memoryPoolMinFreeCapacityPct'
+    /// - 'memoryPoolMinFreeCapacity'
     ///
-    /// NOTE: In the conditions when original requested shrink bytes ends up
-    /// with more free capacity than above 2 conditions, the adjusted shrink
-    /// bytes is not respected.
+    /// If the free capacity is already at or below this minimum, nothing is
+    /// shrunk. The pool may also give up less because its capacity is never
+    /// shrunk below 'memoryPoolReservedCapacity', so it keeps more free
+    /// capacity than the minimum.
     ///
-    /// NOTE: Capacity shrink adjustment is enabled when both
-    /// 'memoryPoolMinFreeCapacityPct' and 'memoryPoolMinFreeCapacity' are set.
+    /// For example, with capacity 1GB, 'memoryPoolMinFreeCapacityPct' 0.25 and
+    /// 'memoryPoolMinFreeCapacity' 128MB, the minimum is the smaller of 1GB *
+    /// 0.25 = 256MB and 128MB, which is 128MB. So a pool with 400MB of free
+    /// capacity gives up at most 272MB through shrink.
+    ///
+    /// NOTE: this limit applies only when both 'memoryPoolMinFreeCapacity'
+    /// and 'memoryPoolMinFreeCapacityPct' are set. It is bypassed when a pool
+    /// releases all its free capacity at once and for inactive pools.
     static constexpr std::string_view kMemoryPoolMinFreeCapacity{
         "memory-pool-min-free-capacity"};
     static constexpr std::string_view kDefaultMemoryPoolMinFreeCapacity{


### PR DESCRIPTION
The comments on 'minFreeCapacity' and 'minFreeCapacityRatio' in
ArbitrationParticipant.h, and the copy on the config keys in
SharedArbitrator.h, do not accurately describe the implementation:

- They describe the enforced bound as "the stricter (whichever is
  smaller)" of two conditions, which is a little confusing: both
  conditions are lower bounds on free capacity, where "stricter"
  suggests the larger of the two, while the code enforces the smaller
  one (std::min in maxShrinkCapacity()).
- They describe adjusting the requested shrink bytes, but `shrink()`
  takes no target size. It shrinks all reclaimable free capacity up to
  the limit, so there is no adjustment step and the NOTE about the
  adjusted bytes being "not respected" has no counterpart in the code.
- They omit the reclaimAll and inactive pool bypass cases.

The actual rule is that a normal shrink of an active pool never reduces
free capacity below the smaller of capacity * 'minFreeCapacityRatio'
and 'minFreeCapacity'. If the free capacity is already at or below that
minimum, nothing is shrunk. Rewrite both comments to state this rule
with a worked example.