### PR TITLE
fix: Respect active rows in sorted aggregation input

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -360,7 +360,7 @@ void GroupingSet::addInputForActiveRows(
     if (!newGroups.empty()) {
       sortedAggregations_->initializeNewGroups(groups, newGroups);
     }
-    sortedAggregations_->addInput(groups, input);
+    sortedAggregations_->addInput(groups, input, activeRows_);
   }
 }
 

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -214,13 +214,16 @@ void SortedAggregations::initializeNewGroups(
   }
 }
 
-void SortedAggregations::addInput(char** groups, const RowVectorPtr& input) {
+void SortedAggregations::addInput(
+    char** groups,
+    const RowVectorPtr& input,
+    const SelectivityVector& rows) {
   for (auto i = 0; i < inputs_.size(); ++i) {
     decodedInputs_[i].decode(*input->childAt(inputs_[i]));
   }
 
-  // Add all the rows into the RowContainer.
-  for (auto row = 0; row < input->size(); ++row) {
+  // Add the selected rows into the RowContainer.
+  rows.applyToSelected([&](vector_size_t row) {
     char* newRow = inputData_->newRow();
 
     for (auto i = 0; i < inputs_.size(); ++i) {
@@ -228,7 +231,7 @@ void SortedAggregations::addInput(char** groups, const RowVectorPtr& input) {
     }
 
     addNewRow(groups[row], newRow);
-  }
+  });
 }
 
 void SortedAggregations::addNewRow(char* group, char* newRow) {

--- a/velox/exec/SortedAggregations.h
+++ b/velox/exec/SortedAggregations.h
@@ -69,7 +69,12 @@ class SortedAggregations {
       char** groups,
       folly::Range<const vector_size_t*> indices);
 
-  void addInput(char** groups, const RowVectorPtr& input);
+  /// 'rows' identifies the input rows to add. 'groups' has an entry only for
+  /// these rows; entries for other rows are not initialized.
+  void addInput(
+      char** groups,
+      const RowVectorPtr& input,
+      const SelectivityVector& rows);
 
   void addSingleGroupInput(char* group, const RowVectorPtr& input);
 

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -338,7 +338,7 @@ void StreamingAggregation::evaluateAggregates() {
   }
 
   if (sortedAggregations_) {
-    sortedAggregations_->addInput(inputGroups_.data(), input_);
+    sortedAggregations_->addInput(inputGroups_.data(), input_, inputRows_);
   }
 }
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2718,6 +2718,37 @@ TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
 
+// Sorted aggregation where the input batch is split at a pre-grouped key
+// boundary. The grouping set processes only the rows up to the boundary and
+// defers the rest, so 'groups' has entries for those rows only. The sorted
+// aggregation must not look at the rest.
+TEST_F(AggregationTest, sortedAggregationWithPreGroupedKeys) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2, 3, 3}),
+      makeFlatVector<int64_t>({10, 20, 10, 20, 10, 20}),
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6}),
+  });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .aggregation(
+                      {"c0", "c1"},
+                      /*preGroupedKeys=*/{"c0"},
+                      {"array_agg(c2 ORDER BY c2)"},
+                      /*masks=*/{},
+                      core::AggregationNode::Step::kSingle,
+                      /*ignoreNullKeys=*/false)
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2, 3, 3}),
+      makeFlatVector<int64_t>({10, 20, 10, 20, 10, 20}),
+      makeArrayVector<int64_t>({{1}, {2}, {3}, {4}, {5}, {6}}),
+  });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
 TEST_F(AggregationTest, adaptiveOutputBatchRows) {
   int32_t defaultOutputBatchRows = 10;
   vector_size_t size = defaultOutputBatchRows * 5;


### PR DESCRIPTION
Summary:
An aggregate over sorted input crashes when a grouping key is pre-grouped:

```
RowPointers::append                  SortedAggregations.cpp:31
SortedAggregations::addNewRow                            :237
SortedAggregations::addInput                             :230
HashAggregation::addInput
```

`SortedAggregations::addInput` walked every row of the input vector, but `groups` has an entry only for the rows the grouping set is currently processing. With a pre-grouped key, `GroupingSet::addInput` stops at the first change of that key and defers the remainder of the batch, and `prepareForGroupProbe` sizes `lookup.hits` to the rows it probed. Reading `groups[row]` beyond that point runs off the end of `hits` and dereferences whatever it finds.

`addInput` now takes the active rows, matching `DistinctAggregations::addInput`, and iterates only those. The selection passed is the unmasked one: `SortedAggregations` keeps an aggregate's mask as an input column and applies it in `extractSingleGroup`, so narrowing here would break `FILTER`.

`StreamingAggregation` assigns a group to every row, so passing its all-rows selection leaves that path unchanged.

Differential Revision: D119119119
