### PR TITLE
fix(exec): Preserve RowContainer flags in serialized rows

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -193,7 +193,7 @@ RowContainer::RowContainer(
   // Make offset at least sizeof pointer so that there is space for a
   // free list next pointer below the bit at 'freeFlagOffset_'.
   offset = std::max<int32_t>(offset, sizeof(void*));
-  const int32_t firstAggregateOffset = offset;
+  flagsByteOffset_ = offset;
   if (!accumulators.empty()) {
     // This moves flagOffset to the start of the next byte.
     // This is to guarantee the null and initialized bits for an aggregate
@@ -217,17 +217,17 @@ RowContainer::RowContainer(
     isVariableWidth |= !type->isFixedWidth();
   }
   if (hasProbedFlag) {
-    probedFlagOffset_ = flagOffset + firstAggregateOffset * 8;
+    probedFlagOffset_ = flagOffset + flagsByteOffset_ * 8;
     ++flagOffset;
   }
   // Free flag.
-  freeFlagOffset_ = flagOffset + firstAggregateOffset * 8;
+  freeFlagOffset_ = flagOffset + flagsByteOffset_ * 8;
   ++flagOffset;
   // Add 1 to the last null offset to get the number of bits.
   flagBytes_ = bits::nbytes(flagOffset);
   // Fixup 'nullOffsets_' to be the bit number from the start of the row.
   for (int32_t i = 0; i < nullOffsets_.size(); ++i) {
-    nullOffsets_[i] += firstAggregateOffset * 8;
+    nullOffsets_[i] += flagsByteOffset_ * 8;
   }
   offset += flagBytes_;
   for (const auto& accumulator : accumulators) {
@@ -319,7 +319,7 @@ char* RowContainer::initializeRow(char* row, bool reuse) {
   if (!nullOffsets_.empty()) {
     // Sets all null and initialized bits to 0 (for each accumulator,
     // initialized bit follows the null bit).
-    ::memset(row + nullByte(nullOffsets_[0]), 0x0, flagBytes_);
+    ::memset(row + flagsByteOffset_, 0x0, flagBytes_);
   }
   if (rowSizeOffset_) {
     variableRowSize(row) = 0;
@@ -735,7 +735,7 @@ void RowContainer::extractSerializedRows(
     size_t offset = 0;
 
     // Copy nulls and other flags.
-    ::memcpy(rawBuffer + offset, row + nullByte(nullOffsets_[0]), flagBytes_);
+    ::memcpy(rawBuffer + offset, row + flagsByteOffset_, flagBytes_);
     offset += flagBytes_;
 
     // Copy values.
@@ -767,7 +767,7 @@ void RowContainer::storeSerializedRow(
   const auto serialized = vector.valueAt(index);
   size_t offset = 0;
 
-  ::memcpy(row + nullByte(nullOffsets_[0]), serialized.data(), flagBytes_);
+  ::memcpy(row + flagsByteOffset_, serialized.data(), flagBytes_);
   offset += flagBytes_;
 
   RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -735,7 +735,7 @@ void RowContainer::extractSerializedRows(
     size_t offset = 0;
 
     // Copy nulls and other flags.
-    ::memcpy(rawBuffer + offset, row + rowColumns_[0].nullByte(), flagBytes_);
+    ::memcpy(rawBuffer + offset, row + nullByte(nullOffsets_[0]), flagBytes_);
     offset += flagBytes_;
 
     // Copy values.
@@ -767,7 +767,7 @@ void RowContainer::storeSerializedRow(
   const auto serialized = vector.valueAt(index);
   size_t offset = 0;
 
-  ::memcpy(row + rowColumns_[0].nullByte(), serialized.data(), flagBytes_);
+  ::memcpy(row + nullByte(nullOffsets_[0]), serialized.data(), flagBytes_);
   offset += flagBytes_;
 
   RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1606,6 +1606,8 @@ class RowContainer {
 
   // Bit position of free bit.
   int32_t freeFlagOffset_ = 0;
+  // Byte offset of the flags (null, probed, free).
+  int32_t flagsByteOffset_ = 0;
   int32_t rowSizeOffset_ = 0;
 
   int32_t fixedRowSize_;

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -2081,6 +2081,58 @@ TEST_F(RowContainerTest, partialWriteComplexTypedRow) {
   rowContainer->eraseRows(folly::Range<char**>(&row, 1));
 }
 
+TEST_F(RowContainerTest, extractSerializedRowWithNonNullableKeys) {
+  RowContainer rowContainer(
+      {BIGINT()},
+      false, // nullableKeys
+      std::vector<Accumulator>{},
+      {BIGINT()}, // dependentTypes
+      false, // hasNext
+      true, // isJoinBuild
+      true, // hasProbedFlag
+      false, // hasCountFlag
+      false, // hasNormalizedKey
+      false, // useListRowIndex
+      pool());
+
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({123}),
+      makeNullableFlatVector<int64_t>({std::nullopt}),
+  });
+  DecodedVector decodedKey(*input->childAt(0));
+  DecodedVector decodedDependent(*input->childAt(1));
+
+  auto* row = rowContainer.newRow();
+  rowContainer.store(decodedKey, 0, row, 0);
+  rowContainer.store(decodedDependent, 0, row, 1);
+  rowContainer.setProbedFlag(&row, 1);
+
+  auto serialized =
+      BaseVector::create<FlatVector<StringView>>(VARBINARY(), 1, pool());
+  rowContainer.extractSerializedRows(folly::Range<char**>(&row, 1), serialized);
+
+  rowContainer.clear();
+  row = rowContainer.newRow();
+  rowContainer.storeSerializedRow(*serialized, 0, row);
+
+  auto key = BaseVector::create<FlatVector<int64_t>>(BIGINT(), 1, pool());
+  rowContainer.extractColumn(&row, 1, 0, key);
+  EXPECT_EQ(key->valueAt(0), 123);
+
+  auto dependent = BaseVector::create<FlatVector<int64_t>>(BIGINT(), 1, pool());
+  rowContainer.extractColumn(&row, 1, 1, dependent);
+  EXPECT_TRUE(dependent->isNullAt(0));
+
+  auto probed = BaseVector::create<FlatVector<bool>>(BOOLEAN(), 1, pool());
+  rowContainer.extractProbedFlags(
+      &row,
+      1,
+      false, // setNullForNullKeysRow
+      false, // setNullForNonProbedRow
+      probed);
+  EXPECT_TRUE(probed->valueAt(0));
+}
+
 TEST_F(RowContainerTest, extractSerializedRow) {
   VectorFuzzer fuzzer(
       {


### PR DESCRIPTION
Fix `RowContainer` serialized-row round trips when keys are non-nullable.

`extractSerializedRows` and `storeSerializedRow` used the first column's `RowColumn::nullByte()` as the start of the row flags. For non-nullable keys, this does not point to the physical flags area, which is located after the key storage.

As a result, serialized rows could:

- Restore a nullable dependent from NULL as non-NULL with a default value.
- Lose a set probed flag.

Use `nullByte(nullOffsets_[0])`, which is adjusted to the row-relative physical flags offset during layout construction. This preserves the existing serialized format.