### PR TITLE
feat(nimble): Add integer dictionary-aware filtering gate (#18892)

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -33,6 +33,7 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kNimbleFooterSpeculativeIoSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kNimbleStringDecoderZeroCopySession);
     VELOX_HIVE_CONFIG_REGISTER(kNimblePreserveDictionaryEncodingSession);
+    VELOX_HIVE_CONFIG_REGISTER(kNimbleIntegerDictionaryAwareFilteringSession);
     VELOX_HIVE_CONFIG_REGISTER(kNimbleLazyColumnIoSession);
     VELOX_HIVE_CONFIG_REGISTER(kFileColumnNamesReadAsLowerCaseSession);
     VELOX_HIVE_CONFIG_REGISTER(kIgnoreMissingFilesSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -122,6 +122,16 @@ class FileConfig {
       "allocated, never which bytes are read.")
 
   VELOX_HIVE_CONFIG_LEGACY(
+      kNimbleIntegerDictionaryAwareFilteringSession,
+      kNimbleIntegerDictionaryAwareFiltering,
+      nimbleIntegerDictionaryAwareFiltering,
+      "nimble_integer_dictionary_aware_filtering",
+      "nimble.integer-dictionary-aware-filtering",
+      bool,
+      false,
+      "Enable dictionary-aware filtering for Nimble integer columns. Requires "
+      "nimble_string_decoder_zero_copy.")
+  VELOX_HIVE_CONFIG_LEGACY(
       kNimbleLazyColumnIoSession,
       kNimbleLazyColumnIo,
       nimbleLazyColumnIo,

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -232,6 +232,8 @@ void configureRowReaderOptions(
         fileConfig->nimbleStringDecoderZeroCopy(sessionProperties));
     rowReaderOptions.setNimblePreserveDictionaryEncoding(
         fileConfig->nimblePreserveDictionaryEncoding(sessionProperties));
+    rowReaderOptions.setNimbleIntegerDictionaryAwareFiltering(
+        fileConfig->nimbleIntegerDictionaryAwareFiltering(sessionProperties));
   }
 }
 

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -55,6 +55,8 @@ TEST(FileConfigTest, defaultConfig) {
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 8UL << 20);
   EXPECT_FALSE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_FALSE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
+  EXPECT_FALSE(
+      config.nimbleIntegerDictionaryAwareFiltering(emptySession.get()));
   EXPECT_FALSE(config.nimbleLazyColumnIo(emptySession.get()));
   EXPECT_FALSE(config.directBufferedInputSharedAllocation(emptySession.get()));
 }
@@ -79,6 +81,7 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
       {FileConfig::kNimbleStringDecoderZeroCopy, "true"},
       {FileConfig::kNimblePreserveDictionaryEncoding, "true"},
+      {FileConfig::kNimbleIntegerDictionaryAwareFiltering, "true"},
       {FileConfig::kNimbleLazyColumnIo, "true"},
       {FileConfig::kDirectBufferedInputSharedAllocation, "true"},
   };
@@ -106,6 +109,7 @@ TEST(FileConfigTest, overrideConfig) {
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 4UL << 20);
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
+  EXPECT_TRUE(config.nimbleIntegerDictionaryAwareFiltering(emptySession.get()));
   EXPECT_TRUE(config.nimbleLazyColumnIo(emptySession.get()));
   // The catalog key is the only way this gate can be enabled in production: the
   // session key contains a dot, so the Presto CLI cannot parse it, and there is
@@ -149,6 +153,7 @@ TEST(FileConfigTest, overrideSession) {
        std::to_string(2UL << 20)},
       {FileConfig::kNimbleStringDecoderZeroCopySession, "true"},
       {FileConfig::kNimblePreserveDictionaryEncodingSession, "true"},
+      {FileConfig::kNimbleIntegerDictionaryAwareFilteringSession, "true"},
       {FileConfig::kNimbleLazyColumnIoSession, "true"},
       {FileConfig::kDirectBufferedInputSharedAllocationSession, "true"},
   };
@@ -171,8 +176,33 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_EQ(config.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(session.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(session.get()));
+  EXPECT_TRUE(config.nimbleIntegerDictionaryAwareFiltering(session.get()));
   EXPECT_TRUE(config.nimbleLazyColumnIo(session.get()));
   EXPECT_TRUE(config.directBufferedInputSharedAllocation(session.get()));
+}
+
+TEST(
+    FileConfigTest,
+    nimbleIntegerDictionaryAwareFilteringSessionOverridesCatalog) {
+  const auto verifyOverride = [](bool catalogValue, bool sessionValue) {
+    FileConfig config(
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>{
+                {FileConfig::kNimbleIntegerDictionaryAwareFiltering,
+                 catalogValue ? "true" : "false"}}),
+        "hive.");
+    const auto session = std::make_unique<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>{
+            {FileConfig::kNimbleIntegerDictionaryAwareFilteringSession,
+             sessionValue ? "true" : "false"}});
+
+    EXPECT_EQ(
+        config.nimbleIntegerDictionaryAwareFiltering(session.get()),
+        sessionValue);
+  };
+
+  verifyOverride(/*catalogValue=*/true, /*sessionValue=*/false);
+  verifyOverride(/*catalogValue=*/false, /*sessionValue=*/true);
 }
 
 TEST(FileConfigTest, nullConfig) {

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -371,17 +371,19 @@ TEST_F(FileConnectorUtilTest, configureRowReaderOptions) {
   EXPECT_EQ(rowReaderOptions.length(), std::numeric_limits<uint64_t>::max());
 }
 
-TEST_F(FileConnectorUtilTest, configureRowReaderOptionsNimbleDictVectorFlags) {
+TEST_F(FileConnectorUtilTest, configureRowReaderOptionsNimbleFlags) {
   auto fileConfig = makeFileConfig();
   auto split = makeSplit(dwio::common::FileFormat::NIMBLE);
   auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
   auto rowType = ROW({"c0"}, {BIGINT()});
 
-  // Both session flags enabled => both RowReaderOptions flags true.
+  // Session flags enabled => RowReaderOptions flags true.
   {
     auto holder = makeConnectorQueryCtx(
         {{hive::FileConfig::kNimbleStringDecoderZeroCopySession, "true"},
-         {hive::FileConfig::kNimblePreserveDictionaryEncodingSession, "true"}});
+         {hive::FileConfig::kNimblePreserveDictionaryEncodingSession, "true"},
+         {hive::FileConfig::kNimbleIntegerDictionaryAwareFilteringSession,
+          "true"}});
     dwio::common::RowReaderOptions rowReaderOptions;
     hive::configureRowReaderOptions(
         /*tableParameters=*/{},
@@ -396,9 +398,10 @@ TEST_F(FileConnectorUtilTest, configureRowReaderOptionsNimbleDictVectorFlags) {
 
     EXPECT_TRUE(rowReaderOptions.stringDecoderZeroCopy());
     EXPECT_TRUE(rowReaderOptions.nimblePreserveDictionaryEncoding());
+    EXPECT_TRUE(rowReaderOptions.nimbleIntegerDictionaryAwareFiltering());
   }
 
-  // Keys absent => both flags fall back to their default (false).
+  // Keys absent => flags fall back to their default (false).
   {
     auto holder = makeConnectorQueryCtx();
     dwio::common::RowReaderOptions rowReaderOptions;
@@ -415,6 +418,7 @@ TEST_F(FileConnectorUtilTest, configureRowReaderOptionsNimbleDictVectorFlags) {
 
     EXPECT_FALSE(rowReaderOptions.stringDecoderZeroCopy());
     EXPECT_FALSE(rowReaderOptions.nimblePreserveDictionaryEncoding());
+    EXPECT_FALSE(rowReaderOptions.nimbleIntegerDictionaryAwareFiltering());
   }
 }
 

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -587,6 +587,14 @@ class RowReaderOptions {
     nimblePreserveDictionaryEncoding_ = value;
   }
 
+  bool nimbleIntegerDictionaryAwareFiltering() const {
+    return nimbleIntegerDictionaryAwareFiltering_;
+  }
+
+  void setNimbleIntegerDictionaryAwareFiltering(bool value) {
+    nimbleIntegerDictionaryAwareFiltering_ = value;
+  }
+
   bool lazyColumnIo() const {
     return lazyColumnIo_;
   }
@@ -685,6 +693,8 @@ class RowReaderOptions {
   // Controls whether dictionary-encoded Nimble string columns return
   // DictionaryVector instead of FlatVector.
   bool nimblePreserveDictionaryEncoding_{false};
+  // Enables dictionary-aware filtering for Nimble integer columns.
+  bool nimbleIntegerDictionaryAwareFiltering_{false};
   // Defers I/O for projected columns without pushdown or remaining filters.
   bool lazyColumnIo_{false};
   folly::F14FastSet<std::string> remainingFilterColumns_;


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexternal/presto-facebook/pull/3672

Add the default-off `nimble_integer_dictionary_aware_filtering` Hive session property and `nimble.integer-dictionary-aware-filtering` catalog property. Plumb the value into `RowReaderOptions` without changing reader behavior; a follow-up diff consumes the option.

Reviewed By: xiaoxmeng

Differential Revision: D117393223


