### PR TITLE
feat(nimble): Cache grouped data reads (#18893)

### DIFF
--- a/velox/dwio/nimble/tablet/DataInput.cpp
+++ b/velox/dwio/nimble/tablet/DataInput.cpp
@@ -16,11 +16,15 @@
 #include "velox/dwio/nimble/tablet/DataInput.h"
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <numeric>
 
+#include <folly/executors/QueuedImmediateExecutor.h>
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CoalesceIo.h"
+#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
@@ -40,6 +44,15 @@ velox::ReadFile* checkedFile(velox::ReadFile* file) {
 uint64_t readAlignment(const velox::ReadFile& file) {
   uint64_t alignment{0};
   return file.directIo(/*alignment=*/alignment) ? alignment : 1;
+}
+
+DataInput::Region alignedRegion(DataInput::Region region, uint64_t alignment) {
+  NIMBLE_DCHECK_GT(alignment, 0);
+  NIMBLE_DCHECK(velox::bits::isPowerOfTwo(alignment));
+  const auto alignedOffset = region.offset & ~(alignment - 1);
+  const auto alignedEnd =
+      (region.offset + region.length + alignment - 1) & ~(alignment - 1);
+  return {alignedOffset, alignedEnd - alignedOffset};
 }
 
 } // namespace
@@ -73,6 +86,10 @@ DirectDataInput::DirectDataInput(velox::ReadFile* file, const Options& options)
   NIMBLE_CHECK_NOT_NULL(pool_);
   NIMBLE_CHECK_NOT_NULL(ioStats_);
   NIMBLE_CHECK_GT(alignment_, 0, "alignment must be positive");
+  NIMBLE_CHECK_LE(
+      alignment_,
+      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+      "alignment exceeds the memory allocator limit");
   NIMBLE_CHECK(
       velox::bits::isPowerOfTwo(alignment_), "alignment must be a power of 2");
 }
@@ -83,7 +100,7 @@ void DirectDataInput::reserve(uint32_t numRegions) {
   bufferRefs_.reserve(numRegions);
 }
 
-void DirectDataInput::startGroup() {
+void DirectDataInput::startGroup(std::optional<Region> /*groupRegion*/) {
   NIMBLE_CHECK_NE(state_, State::kLoaded);
   NIMBLE_CHECK(
       groupOffsets_.empty() ||
@@ -196,8 +213,14 @@ std::vector<DirectDataInput::IoGroup> DirectDataInput::computeIoGroups(
         const auto groupRegions = std::span<const EnqueuedRegion>(
             &sortedRegions[begin], static_cast<size_t>(end - begin));
         const auto [payloadSize, lastEnd] = computePayloadSize(groupRegions);
-        group.readOffset = alignDown(sortedRegions[begin].region.offset);
-        group.readSize = alignUp(lastEnd) - group.readOffset;
+        const auto readRegion = alignedRegion(
+            Region{
+                sortedRegions[begin].region.offset,
+                lastEnd - sortedRegions[begin].region.offset,
+            },
+            alignment_);
+        group.readOffset = readRegion.offset;
+        group.readSize = readRegion.length;
         group.payloadSize = payloadSize;
         group.regions = groupRegions;
         ioGroups.emplace_back(group);
@@ -352,6 +375,289 @@ void DirectDataInput::clear() {
   state_ = State::kInit;
   regions_.clear();
   groupOffsets_.clear();
+  bufferRefs_.clear();
+}
+
+// --- CachedDataInput ---
+
+CachedDataInput::CachedDataInput(velox::ReadFile* file, const Options& options)
+    : file_{checkedFile(file)},
+      pool_{options.pool},
+      cache_{options.cache},
+      fileId_{options.fileId},
+      ioStats_{options.ioStats},
+      alignment_{readAlignment(*file_)},
+      allocationAlignment_{std::max(
+          alignment_,
+          static_cast<uint64_t>(
+              velox::memory::MemoryAllocator::kMinAlignment))} {
+  NIMBLE_CHECK_NOT_NULL(pool_);
+  NIMBLE_CHECK_NOT_NULL(cache_);
+  NIMBLE_CHECK_NOT_NULL(ioStats_);
+  NIMBLE_CHECK_GT(alignment_, 0, "alignment must be positive");
+  NIMBLE_CHECK_LE(
+      alignment_,
+      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+      "alignment exceeds the memory allocator limit");
+  NIMBLE_CHECK(
+      velox::bits::isPowerOfTwo(alignment_), "alignment must be a power of 2");
+}
+
+void CachedDataInput::reserve(uint32_t numRegions) {
+  NIMBLE_CHECK(!loaded_, "Cannot reserve after load");
+  regions_.reserve(numRegions);
+  bufferRefs_.reserve(numRegions);
+}
+
+void CachedDataInput::startGroup(std::optional<Region> groupRegion) {
+  NIMBLE_CHECK(!loaded_, "Cannot start a group after load");
+  NIMBLE_CHECK(
+      groups_.empty() || groups_.back().enqueuedRegionOffset < regions_.size(),
+      "Previous group is empty");
+  NIMBLE_CHECK(groupRegion.has_value(), "Cached group region is required");
+  NIMBLE_CHECK_GT(
+      groupRegion->length, 0, "Cached group length must be positive");
+  NIMBLE_CHECK_LE(
+      groupRegion->length,
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max()),
+      "Cached group exceeds the maximum cache entry size");
+  if (!groups_.empty()) {
+    const auto& previous = groups_.back().groupRegion;
+    NIMBLE_CHECK_GE(
+        groupRegion->offset,
+        previous.offset + previous.length,
+        "Cached groups must be sorted and non-overlapping by file offset");
+  }
+  groups_.push_back(
+      Group{
+          .groupRegion = *groupRegion,
+          .enqueuedRegionOffset = static_cast<uint32_t>(regions_.size()),
+      });
+}
+
+uint32_t CachedDataInput::enqueue(Region region) {
+  NIMBLE_CHECK(!loaded_, "Cannot enqueue after load");
+  NIMBLE_CHECK(!groups_.empty(), "startGroup() must precede enqueue()");
+  NIMBLE_CHECK_GT(region.length, 0, "Read region length must be positive");
+  const auto& groupRegion = groups_.back().groupRegion;
+  NIMBLE_CHECK_GE(
+      region.offset,
+      groupRegion.offset,
+      "Read region begins before its cached group");
+  NIMBLE_CHECK_LE(
+      region.offset + region.length,
+      groupRegion.offset + groupRegion.length,
+      "Read region extends beyond its cached group");
+  const auto index = static_cast<uint32_t>(bufferRefs_.size());
+  bufferRefs_.emplace_back();
+  regions_.push_back(EnqueuedRegion{index, region});
+  return index;
+}
+
+uint64_t CachedDataInput::populateBufferRefs(
+    const Group& group,
+    uint32_t endRegion,
+    const char* buffer) {
+  std::vector<const EnqueuedRegion*> sortedRegions;
+  sortedRegions.reserve(endRegion - group.enqueuedRegionOffset);
+  for (uint32_t i = group.enqueuedRegionOffset; i < endRegion; ++i) {
+    sortedRegions.push_back(&regions_[i]);
+  }
+  std::sort(
+      sortedRegions.begin(),
+      sortedRegions.end(),
+      [](const EnqueuedRegion* lhs, const EnqueuedRegion* rhs) {
+        if (lhs->region.offset != rhs->region.offset) {
+          return lhs->region.offset < rhs->region.offset;
+        }
+        if (lhs->region.length != rhs->region.length) {
+          return lhs->region.length < rhs->region.length;
+        }
+        return lhs->enqueueIndex < rhs->enqueueIndex;
+      });
+
+  uint64_t payloadBytes{0};
+  uint64_t coveredEnd{group.groupRegion.offset};
+  const EnqueuedRegion* canonicalRegion{nullptr};
+  for (const auto* enqueued : sortedRegions) {
+    auto& ref = bufferRefs_[enqueued->enqueueIndex];
+    ref.data = buffer + enqueued->region.offset - group.groupRegion.offset;
+    ref.length = enqueued->region.length;
+    if (canonicalRegion != nullptr &&
+        canonicalRegion->region.offset == enqueued->region.offset &&
+        canonicalRegion->region.length == enqueued->region.length) {
+      ref.canonicalIndex = canonicalRegion->enqueueIndex;
+    } else {
+      canonicalRegion = enqueued;
+      ref.canonicalIndex = enqueued->enqueueIndex;
+    }
+
+    const auto regionEnd = enqueued->region.offset + enqueued->region.length;
+    if (regionEnd > coveredEnd) {
+      payloadBytes += regionEnd - std::max(coveredEnd, enqueued->region.offset);
+      coveredEnd = regionEnd;
+    }
+  }
+  return payloadBytes;
+}
+
+void CachedDataInput::loadCacheMissGroups(
+    std::span<const CacheMissGroup> cacheMissGroups,
+    uint64_t stagingBufferSize,
+    const std::vector<velox::cache::CachePin>& cachePins) {
+  char* stagingBuffer{nullptr};
+  Handle stagingHandle;
+  if (alignment_ > 1) {
+    stagingBuffer = static_cast<char*>(pool_->allocateAligned(
+        static_cast<int64_t>(stagingBufferSize),
+        static_cast<uint32_t>(allocationAlignment_)));
+    stagingHandle = Handle(
+        stagingBuffer,
+        [pool = pool_,
+         stagingBufferSize,
+         allocationAlignment = allocationAlignment_](void* buffer) {
+          pool->freeAligned(
+              buffer,
+              static_cast<int64_t>(stagingBufferSize),
+              static_cast<uint32_t>(allocationAlignment));
+        });
+  }
+
+  std::vector<Region> readRegions;
+  std::vector<folly::Range<char*>> readBuffers;
+  readRegions.reserve(cacheMissGroups.size());
+  readBuffers.reserve(cacheMissGroups.size());
+  uint64_t expectedReadBytes{0};
+  for (const auto& cacheMissGroup : cacheMissGroups) {
+    readRegions.push_back(cacheMissGroup.readRegion);
+    auto* entry = cachePins.at(cacheMissGroup.groupIndex).checkedEntry();
+    auto* destination = alignment_ == 1
+        ? entry->contiguousData()
+        : stagingBuffer + cacheMissGroup.stagingBufferOffset;
+    readBuffers.emplace_back(destination, cacheMissGroup.readRegion.length);
+    expectedReadBytes += cacheMissGroup.readRegion.length;
+  }
+
+  uint64_t storageReadUs{0};
+  uint64_t bytesRead{0};
+  {
+    velox::MicrosecondTimer timer(&storageReadUs);
+    bytesRead = file_->preadv(
+        folly::Range<const Region*>(readRegions.data(), readRegions.size()),
+        folly::Range<const folly::Range<char*>*>(
+            readBuffers.data(), readBuffers.size()));
+  }
+  NIMBLE_CHECK_EQ(bytesRead, expectedReadBytes, "preadv returned a short read");
+  ioStats_->queryThreadIoLatencyUs().increment(storageReadUs);
+  ioStats_->storageReadLatencyUs().increment(storageReadUs);
+  ioStats_->incTotalScanTimeNs(static_cast<int64_t>(storageReadUs) * 1'000);
+
+  for (const auto& cacheMissGroup : cacheMissGroups) {
+    auto* entry = cachePins.at(cacheMissGroup.groupIndex).checkedEntry();
+    const auto& group = groups_[cacheMissGroup.groupIndex];
+    if (alignment_ > 1) {
+      std::memcpy(
+          entry->contiguousData(),
+          stagingBuffer + cacheMissGroup.stagingBufferOffset +
+              group.groupRegion.offset - cacheMissGroup.readRegion.offset,
+          group.groupRegion.length);
+    }
+    ioStats_->read().increment(cacheMissGroup.readRegion.length);
+    ioStats_->incRawOverreadBytes(
+        static_cast<int64_t>(
+            cacheMissGroup.readRegion.length - cacheMissGroup.payloadBytes));
+    entry->setExclusiveToShared(/*ssdSavable=*/false);
+  }
+}
+
+DataInput::Handle CachedDataInput::load() {
+  NIMBLE_CHECK(!loaded_, "Data is already loaded");
+  NIMBLE_CHECK(!bufferRefs_.empty(), "No regions enqueued");
+  NIMBLE_CHECK(
+      groups_.back().enqueuedRegionOffset < regions_.size(),
+      "Read group must contain a region");
+  loaded_ = true;
+
+  // Releasing a pin removes an unfinished exclusive cache entry and wakes its
+  // waiters if any subsequent cache-fill work throws.
+  auto cachePins = std::make_shared<std::vector<velox::cache::CachePin>>();
+  cachePins->reserve(groups_.size());
+  std::vector<CacheMissGroup> cacheMissGroups;
+  cacheMissGroups.reserve(groups_.size());
+  uint64_t stagingBufferSize{0};
+  for (size_t groupIndex{0}; groupIndex < groups_.size(); ++groupIndex) {
+    const auto& group = groups_[groupIndex];
+    const auto endRegion = groupIndex + 1 < groups_.size()
+        ? groups_[groupIndex + 1].enqueuedRegionOffset
+        : static_cast<uint32_t>(regions_.size());
+
+    velox::cache::CachePin pin;
+    do {
+      folly::SemiFuture<bool> waitFuture{false};
+      pin = cache_->findOrCreate(
+          velox::cache::RawFileCacheKey{fileId_, group.groupRegion.offset},
+          group.groupRegion.length,
+          /*contiguous=*/true,
+          &waitFuture);
+      if (pin.empty()) {
+        NIMBLE_CHECK(waitFuture.valid(), "Cache wait future is invalid");
+        uint64_t waitUs{0};
+        {
+          velox::MicrosecondTimer timer(&waitUs);
+          std::move(waitFuture)
+              .via(&folly::QueuedImmediateExecutor::instance())
+              .wait();
+        }
+        ioStats_->queryThreadIoLatencyUs().increment(waitUs);
+        ioStats_->cacheWaitLatencyUs().increment(waitUs);
+        // The future only signals that the competing exclusive load finished;
+        // findOrCreate must run again to acquire a shared or exclusive pin.
+      }
+    } while (pin.empty());
+
+    auto* entry = pin.checkedEntry();
+    const bool firstUse = entry->getAndClearFirstUseFlag();
+    const bool loadedFromStorage = entry->isExclusive();
+    if (!loadedFromStorage && !firstUse) {
+      ioStats_->ramHit().increment(group.groupRegion.length);
+    }
+
+    const auto payloadBytes =
+        populateBufferRefs(group, endRegion, entry->contiguousData());
+    NIMBLE_CHECK_LE(payloadBytes, group.groupRegion.length);
+    ioStats_->incRawBytesRead(static_cast<int64_t>(payloadBytes));
+    if (loadedFromStorage) {
+      const auto readRegion = alignedRegion(group.groupRegion, alignment_);
+      cacheMissGroups.push_back(
+          CacheMissGroup{
+              .groupIndex = groupIndex,
+              .readRegion = readRegion,
+              .stagingBufferOffset = stagingBufferSize,
+              .payloadBytes = payloadBytes,
+          });
+      stagingBufferSize += readRegion.length;
+    }
+    cachePins->push_back(std::move(pin));
+  }
+
+  if (!cacheMissGroups.empty()) {
+    loadCacheMissGroups(cacheMissGroups, stagingBufferSize, *cachePins);
+  }
+
+  regions_.clear();
+  return std::static_pointer_cast<void>(cachePins);
+}
+
+const DataInput::BufferRef& CachedDataInput::bufferRef(uint32_t index) const {
+  NIMBLE_CHECK(loaded_, "Data has not been loaded");
+  NIMBLE_CHECK_LT(index, bufferRefs_.size());
+  return bufferRefs_[index];
+}
+
+void CachedDataInput::clear() {
+  loaded_ = false;
+  regions_.clear();
+  groups_.clear();
   bufferRefs_.clear();
 }
 

--- a/velox/dwio/nimble/tablet/DataInput.h
+++ b/velox/dwio/nimble/tablet/DataInput.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <span>
 #include <string_view>
 #include <vector>
@@ -27,6 +28,11 @@
 #include "velox/common/io/Options.h"
 #include "velox/common/memory/Memory.h"
 
+namespace facebook::velox::cache {
+class AsyncDataCache;
+class CachePin;
+} // namespace facebook::velox::cache
+
 namespace facebook::nimble {
 
 /// Base class for data I/O with an enqueue + batch load pattern.
@@ -36,15 +42,15 @@ namespace facebook::nimble {
 /// relative order is preserved (stripes are already in file order).
 /// After load(), bufferRef() provides zero-copy access to loaded data.
 ///
-/// Two planned implementations:
+/// Implementations:
 ///   - DirectDataInput: coalesced I/O, no caching
-///   - CachedDataInput: coalesced I/O + AsyncDataCache (future)
+///   - CachedDataInput: whole-group caching through AsyncDataCache
 class DataInput {
  public:
   using Region = velox::common::Region;
 
   /// Reference to a loaded buffer region. Points into a contiguous
-  /// aligned allocation.
+  /// allocation.
   struct BufferRef {
     const char* data{nullptr};
     uint64_t length{0};
@@ -66,9 +72,11 @@ class DataInput {
   /// Avoids reallocation during enqueue().
   virtual void reserve(uint32_t numRegions) = 0;
 
-  /// Start a new group (one per stripe). Reads within a group are
-  /// sorted by offset; across groups, relative order is preserved.
-  virtual void startGroup() = 0;
+  /// Starts a new group (one per stripe). Reads within a group are sorted by
+  /// offset; across groups, relative order is preserved. `groupRegion` is the
+  /// full physical region used by whole-group cache implementations. It is
+  /// required by CachedDataInput and ignored by DirectDataInput.
+  virtual void startGroup(std::optional<Region> groupRegion = std::nullopt) = 0;
 
   /// Enqueue a read in the current group. Returns an index for
   /// bufferRef() after load().
@@ -113,7 +121,7 @@ class DirectDataInput : public DataInput {
 
   void reserve(uint32_t numRegions) override;
 
-  void startGroup() override;
+  void startGroup(std::optional<Region> groupRegion = std::nullopt) override;
 
   uint32_t enqueue(Region region) override;
 
@@ -182,14 +190,6 @@ class DirectDataInput : public DataInput {
       char* buffer,
       uint64_t bufferSize);
 
-  uint64_t alignDown(uint64_t value) const {
-    return value & ~(alignment_ - 1);
-  }
-
-  uint64_t alignUp(uint64_t value) const {
-    return (value + alignment_ - 1) & ~(alignment_ - 1);
-  }
-
   // File to read from.
   velox::ReadFile* const file_;
   // Memory pool for allocating the read buffer.
@@ -216,6 +216,111 @@ class DirectDataInput : public DataInput {
   // Start index in regions_ for each group.
   std::vector<uint32_t> groupOffsets_;
   // Populated by load() with pointers into the aligned buffer.
+  std::vector<BufferRef> bufferRefs_;
+};
+
+/// Loads and caches one contiguous entry per group. Enqueued regions return
+/// zero-copy slices into their group's cached entry.
+///
+/// NOTE: CachedDataInput is not thread-safe. Each thread must use its own
+/// instance, while the underlying AsyncDataCache may be shared.
+class CachedDataInput final : public DataInput {
+ public:
+  /// Configures the cache, source-file identity, and memory accounting.
+  struct Options {
+    /// Pool used for direct-I/O staging buffers.
+    velox::memory::MemoryPool* pool{nullptr};
+    /// Shared cache receiving one entry for each loaded group.
+    velox::cache::AsyncDataCache* cache{nullptr};
+    /// Stable identity of the source file in the cache key space.
+    uint64_t fileId{0};
+    /// Statistics receiving storage-read and memory-hit counters.
+    std::shared_ptr<velox::io::IoStatistics> ioStats;
+  };
+
+  /// Constructs a grouped cache reader for `file`.
+  CachedDataInput(velox::ReadFile* file, const Options& options);
+
+  /// Reserves storage for the requested stream regions.
+  void reserve(uint32_t numRegions) override;
+
+  /// Starts a cache group. `groupRegion` must contain the complete physical
+  /// byte range to cache, including bytes not requested by enqueue().
+  void startGroup(std::optional<Region> groupRegion) override;
+
+  /// Adds a requested stream region to the current cache group.
+  uint32_t enqueue(Region region) override;
+
+  /// Loads all groups and returns ownership of their cache pins. BufferRef
+  /// pointers remain valid until the returned handle is released.
+  Handle load() override;
+
+  /// Returns the loaded bytes for a previously enqueued stream region.
+  const BufferRef& bufferRef(uint32_t index) const override;
+
+  /// Clears request state without releasing pins owned by a returned handle.
+  void clear() override;
+
+ private:
+  struct EnqueuedRegion {
+    // Position of this request in bufferRefs_.
+    uint32_t enqueueIndex{0};
+    // Logical file range requested by the caller.
+    Region region;
+  };
+
+  struct Group {
+    // Complete physical region stored in one cache entry.
+    Region groupRegion;
+    // First request for this group in regions_.
+    uint32_t enqueuedRegionOffset{0};
+  };
+
+  struct CacheMissGroup {
+    // Position shared by groups_ and the vector of cache pins.
+    size_t groupIndex{0};
+    // Physical range submitted to storage, including direct-I/O alignment.
+    Region readRegion;
+    // Offset of this read's destination in the aligned staging allocation.
+    uint64_t stagingBufferOffset{0};
+    // Distinct bytes requested from this group by the caller.
+    uint64_t payloadBytes{0};
+  };
+
+  // Returns the number of distinct requested bytes in the group.
+  uint64_t populateBufferRefs(
+      const Group& group,
+      uint32_t endRegion,
+      const char* buffer);
+
+  // Loads cache-miss groups in one positioned read batch.
+  void loadCacheMissGroups(
+      std::span<const CacheMissGroup> cacheMissGroups,
+      uint64_t stagingBufferSize,
+      const std::vector<velox::cache::CachePin>& cachePins);
+
+  // File to read from on a cache miss.
+  velox::ReadFile* const file_;
+  // Memory pool for allocating direct-I/O staging buffers.
+  velox::memory::MemoryPool* const pool_;
+  // Shared cache used for full-group entries.
+  velox::cache::AsyncDataCache* const cache_;
+  // Stable file identity used in cache keys.
+  const uint64_t fileId_;
+  // IO statistics for storage reads, cache hits, and logical bytes.
+  const std::shared_ptr<velox::io::IoStatistics> ioStats_;
+  // Required alignment for file offsets, read sizes, and destination buffers.
+  const uint64_t alignment_;
+  // Allocation alignment accepted by the memory pool.
+  const uint64_t allocationAlignment_;
+
+  // True between load() and clear().
+  bool loaded_{false};
+  // Requested stream regions in enqueue order.
+  std::vector<EnqueuedRegion> regions_;
+  // Cache groups in increasing physical file-offset order.
+  std::vector<Group> groups_;
+  // Loaded zero-copy slices corresponding to regions_.
   std::vector<BufferRef> bufferRefs_;
 };
 

--- a/velox/dwio/nimble/tablet/tests/DataInputTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/DataInputTest.cpp
@@ -22,6 +22,9 @@
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
 
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/SsdCache.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/IoUringReader.h"
 #include "velox/common/file/LocalFile.h"
@@ -116,6 +119,17 @@ class DataInputTest : public ::testing::Test {
 class DataInputParamTest : public DataInputTest,
                            public ::testing::WithParamInterface<OptionParams> {
 };
+
+struct CachedLocalReadMode {
+  const char* name;
+  bool bufferIo;
+  bool useIoUring;
+  uint64_t expectedReadBytes;
+};
+
+class CachedDataInputLocalFileTest
+    : public DataInputTest,
+      public ::testing::WithParamInterface<CachedLocalReadMode> {};
 
 TEST_P(DataInputParamTest, singleGroup) {
   // Use alignment-friendly size (multiple of 4096).
@@ -303,6 +317,281 @@ INSTANTIATE_TEST_SUITE_P(
     [](const auto& info) { return info.param.toString(); });
 
 // --- Non-parameterized tests ---
+
+TEST_F(DataInputTest, cachesWholeGroups) {
+  std::string data(4'096, '\0');
+  for (size_t i{0}; i < data.size(); ++i) {
+    data[i] = static_cast<char>(i % 251);
+  }
+  auto file = createFile(data);
+  auto cache = velox::cache::AsyncDataCache::create(
+      velox::memory::memoryManager()->allocator());
+  velox::StringIdLease fileId{
+      velox::fileIds(), "CachedDataInputTest.cachesWholeGroups"};
+
+  CachedDataInput::Options options{
+      .pool = pool_.get(),
+      .cache = cache.get(),
+      .fileId = fileId.id(),
+      .ioStats = ioStats_,
+  };
+  {
+    CachedDataInput input{file.get(), options};
+    for (int32_t cycle{0}; cycle < 2; ++cycle) {
+      SCOPED_TRACE(fmt::format("cycle={}", cycle));
+      input.reserve(4);
+      input.startGroup(DataInput::Region{100, 1'000});
+      const auto first = input.enqueue(DataInput::Region{180, 80});
+      const auto duplicate = input.enqueue(DataInput::Region{180, 80});
+      const auto second = input.enqueue(DataInput::Region{500, 50});
+      input.startGroup(DataInput::Region{2'000, 500});
+      const auto third = input.enqueue(DataInput::Region{2'100, 100});
+
+      auto handle = input.load();
+      EXPECT_EQ(refData(input.bufferRef(first)), data.substr(180, 80));
+      EXPECT_EQ(refData(input.bufferRef(duplicate)), data.substr(180, 80));
+      EXPECT_EQ(refData(input.bufferRef(second)), data.substr(500, 50));
+      EXPECT_EQ(refData(input.bufferRef(third)), data.substr(2'100, 100));
+      EXPECT_EQ(input.bufferRef(duplicate).canonicalIndex, first);
+      EXPECT_EQ(input.bufferRef(first).data, input.bufferRef(duplicate).data);
+
+      if (cycle == 0) {
+        EXPECT_EQ(ioStats_->read().count(), 2);
+        EXPECT_EQ(ioStats_->read().sum(), 1'500);
+        EXPECT_EQ(ioStats_->ramHit().count(), 0);
+        EXPECT_EQ(ioStats_->rawBytesRead(), 230);
+        EXPECT_EQ(ioStats_->rawOverreadBytes(), 1'270);
+      } else {
+        EXPECT_EQ(ioStats_->read().count(), 2);
+        EXPECT_EQ(ioStats_->read().sum(), 1'500);
+        EXPECT_EQ(ioStats_->ramHit().count(), 2);
+        EXPECT_EQ(ioStats_->ramHit().sum(), 1'500);
+        EXPECT_EQ(ioStats_->rawBytesRead(), 460);
+        EXPECT_EQ(ioStats_->rawOverreadBytes(), 1'270);
+      }
+
+      handle.reset();
+      input.clear();
+    }
+  }
+  cache->shutdown();
+}
+
+TEST_F(DataInputTest, loadHandlePinsCachedGroups) {
+  std::string data(4'096, '\0');
+  for (size_t i{0}; i < data.size(); ++i) {
+    data[i] = static_cast<char>(i % 251);
+  }
+  auto file = createFile(data);
+  auto cache = velox::cache::AsyncDataCache::create(
+      velox::memory::memoryManager()->allocator());
+  velox::StringIdLease fileId{
+      velox::fileIds(), "CachedDataInputTest.loadHandlePinsCachedGroups"};
+  CachedDataInput::Options options{
+      .pool = pool_.get(),
+      .cache = cache.get(),
+      .fileId = fileId.id(),
+      .ioStats = ioStats_,
+  };
+
+  DataInput::Handle handle;
+  const char* cachedData{nullptr};
+  {
+    CachedDataInput input{file.get(), options};
+    input.reserve(1);
+    input.startGroup(DataInput::Region{100, 1'000});
+    const auto stream = input.enqueue(DataInput::Region{180, 80});
+    handle = input.load();
+    cachedData = input.bufferRef(stream).data;
+    input.clear();
+  }
+
+  cache->clear();
+  auto cacheStats = cache->refreshStats();
+  EXPECT_EQ(cacheStats.numEntries, 1);
+  EXPECT_EQ(cacheStats.numShared, 1);
+  EXPECT_GT(cacheStats.sharedPinnedBytes, 0);
+  EXPECT_EQ(std::string_view(cachedData, 80), data.substr(180, 80));
+
+  handle.reset();
+  cache->clear();
+  cacheStats = cache->refreshStats();
+  EXPECT_EQ(cacheStats.numEntries, 0);
+  EXPECT_EQ(cacheStats.numShared, 0);
+  EXPECT_EQ(cacheStats.sharedPinnedBytes, 0);
+  cache->shutdown();
+}
+
+TEST_F(DataInputTest, cacheMissFailureReleasesEntries) {
+  std::string data(4'096, '\0');
+  for (size_t i{0}; i < data.size(); ++i) {
+    data[i] = static_cast<char>(i % 251);
+  }
+  auto cache = velox::cache::AsyncDataCache::create(
+      velox::memory::memoryManager()->allocator());
+  velox::StringIdLease fileId{
+      velox::fileIds(), "CachedDataInputTest.cacheMissFailureReleasesEntries"};
+  CachedDataInput::Options options{
+      .pool = pool_.get(),
+      .cache = cache.get(),
+      .fileId = fileId.id(),
+      .ioStats = ioStats_,
+  };
+
+  {
+    auto failingFile = std::make_unique<FailingPreadvInMemoryReadFile>(data);
+    CachedDataInput input{failingFile.get(), options};
+    input.reserve(1);
+    input.startGroup(DataInput::Region{100, 1'000});
+    input.enqueue(DataInput::Region{180, 80});
+    NIMBLE_ASSERT_THROW(input.load(), "Injected preadv failure");
+  }
+  auto cacheStats = cache->refreshStats();
+  EXPECT_EQ(cacheStats.numEntries, 0);
+  EXPECT_EQ(cacheStats.numExclusive, 0);
+
+  {
+    auto file = createFile(data);
+    CachedDataInput input{file.get(), options};
+    input.reserve(1);
+    input.startGroup(DataInput::Region{100, 1'000});
+    const auto stream = input.enqueue(DataInput::Region{180, 80});
+    auto handle = input.load();
+    EXPECT_EQ(refData(input.bufferRef(stream)), data.substr(180, 80));
+  }
+  cache->shutdown();
+}
+
+TEST_P(CachedDataInputLocalFileTest, cachesWholeGroups) {
+  const auto& readMode = GetParam();
+  if (readMode.useIoUring && !velox::IoUringReader::available()) {
+    GTEST_SKIP() << "io_uring is unavailable";
+  }
+
+  constexpr uint64_t kPageSize = velox::memory::AllocationTraits::kPageSize;
+  std::string data(8 * kPageSize, '\0');
+  for (size_t i{0}; i < data.size(); ++i) {
+    data[i] = static_cast<char>((i * 131) % 251);
+  }
+  auto tempFile = velox::common::testutil::TempFilePath::create();
+  {
+    velox::LocalWriteFile writeFile(
+        tempFile->getPath(),
+        /*shouldCreateParentDirectories=*/false,
+        /*shouldThrowOnFileAlreadyExists=*/false);
+    writeFile.append(data);
+    writeFile.close();
+  }
+
+  velox::ThreadLocalIoUringReader::testingClear();
+  auto file = std::make_unique<velox::LocalReadFile>(
+      tempFile->getPath(),
+      /*executor=*/nullptr,
+      readMode.bufferIo,
+      readMode.useIoUring);
+  auto cache = velox::cache::AsyncDataCache::create(
+      velox::memory::memoryManager()->allocator());
+  velox::StringIdLease fileId{
+      velox::fileIds(),
+      fmt::format("CachedDataInputLocalFileTest.{}", readMode.name)};
+
+  constexpr uint64_t kCachedBytes = 1'000 + 700 + kPageSize;
+  constexpr uint64_t kPayloadBytes = 80 + 50 + 100 + 256;
+  CachedDataInput::Options options{
+      .pool = pool_.get(),
+      .cache = cache.get(),
+      .fileId = fileId.id(),
+      .ioStats = ioStats_,
+  };
+  {
+    CachedDataInput input{file.get(), options};
+    for (int32_t cycle{0}; cycle < 2; ++cycle) {
+      SCOPED_TRACE(fmt::format("cycle={}", cycle));
+      input.reserve(5);
+      input.startGroup(DataInput::Region{100, 1'000});
+      const auto first = input.enqueue(DataInput::Region{180, 80});
+      const auto duplicate = input.enqueue(DataInput::Region{180, 80});
+      const auto second = input.enqueue(DataInput::Region{500, 50});
+      input.startGroup(DataInput::Region{2 * kPageSize + 200, 700});
+      const auto third =
+          input.enqueue(DataInput::Region{2 * kPageSize + 300, 100});
+      input.startGroup(DataInput::Region{5 * kPageSize, kPageSize});
+      const auto fourth =
+          input.enqueue(DataInput::Region{5 * kPageSize + 300, 256});
+
+      auto handle = input.load();
+      const auto cacheStats = cache->refreshStats();
+      EXPECT_EQ(cacheStats.numEntries, 3);
+      EXPECT_EQ(cacheStats.numShared, 3);
+      EXPECT_EQ(cacheStats.numExclusive, 0);
+      EXPECT_EQ(refData(input.bufferRef(first)), data.substr(180, 80));
+      EXPECT_EQ(refData(input.bufferRef(duplicate)), data.substr(180, 80));
+      EXPECT_EQ(refData(input.bufferRef(second)), data.substr(500, 50));
+      EXPECT_EQ(
+          refData(input.bufferRef(third)),
+          data.substr(2 * kPageSize + 300, 100));
+      EXPECT_EQ(
+          refData(input.bufferRef(fourth)),
+          data.substr(5 * kPageSize + 300, 256));
+      EXPECT_EQ(input.bufferRef(duplicate).canonicalIndex, first);
+      EXPECT_EQ(input.bufferRef(first).data, input.bufferRef(duplicate).data);
+
+      EXPECT_EQ(file->bytesRead(), readMode.expectedReadBytes);
+      EXPECT_EQ(ioStats_->read().count(), 3);
+      EXPECT_EQ(ioStats_->read().sum(), readMode.expectedReadBytes);
+      EXPECT_EQ(ioStats_->rawBytesRead(), (cycle + 1) * kPayloadBytes);
+      EXPECT_EQ(
+          ioStats_->rawOverreadBytes(),
+          readMode.expectedReadBytes - kPayloadBytes);
+      EXPECT_EQ(ioStats_->ramHit().count(), cycle * 3);
+      EXPECT_EQ(ioStats_->ramHit().sum(), cycle * kCachedBytes);
+
+      uint64_t numIoUringReaders{0};
+      const auto ioUringStats = velox::getIoUringReaderStats(numIoUringReaders);
+      if (readMode.useIoUring) {
+        EXPECT_EQ(numIoUringReaders, 1);
+        EXPECT_EQ(ioUringStats.readCalls, 1);
+        EXPECT_EQ(ioUringStats.regions, 3);
+        EXPECT_EQ(ioUringStats.batches, 1);
+      } else {
+        EXPECT_EQ(numIoUringReaders, 0);
+        EXPECT_EQ(ioUringStats.readCalls, 0);
+      }
+
+      handle.reset();
+      input.clear();
+    }
+  }
+  cache->shutdown();
+  velox::ThreadLocalIoUringReader::testingClear();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LocalReadModes,
+    CachedDataInputLocalFileTest,
+    ::testing::Values(
+        CachedLocalReadMode{
+            "buffered",
+            /*bufferIo=*/true,
+            /*useIoUring=*/false,
+            /*expectedReadBytes=*/1'000 + 700 +
+                velox::memory::AllocationTraits::kPageSize,
+        },
+        CachedLocalReadMode{
+            "direct",
+            /*bufferIo=*/false,
+            /*useIoUring=*/false,
+            /*expectedReadBytes=*/
+            3 * velox::memory::AllocationTraits::kPageSize,
+        },
+        CachedLocalReadMode{
+            "directIoUring",
+            /*bufferIo=*/false,
+            /*useIoUring=*/true,
+            /*expectedReadBytes=*/
+            3 * velox::memory::AllocationTraits::kPageSize,
+        }),
+    [](const auto& info) { return info.param.name; });
 
 TEST_F(DataInputTest, alignment) {
   std::string data(16'384, '\0');


### PR DESCRIPTION
Summary:

Allows Nimble readers to retain an entire data group in AsyncDataCache and return zero-copy slices for requested streams. Repeated projections reuse the group without storage I/O.

Cache misses are submitted as one positioned read batch. Direct-I/O files use aligned staging storage before copying bytes into cache entries, so the same path supports O_DIRECT and io_uring.

Differential Revision: D119123774


