### PR TITLE
feat(nimble): Add FAISS-backed vector search indexes (#18894)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,7 @@ if(${VELOX_ENABLE_DUCKDB})
   velox_resolve_dependency(DuckDB)
 endif()
 
-if(VELOX_ENABLE_FAISS)
+if(VELOX_ENABLE_FAISS OR VELOX_ENABLE_NIMBLE)
   velox_set_source(faiss)
   velox_resolve_dependency(faiss)
   if(NOT TARGET FAISS::faiss)

--- a/velox/dwio/nimble/common/Exceptions.h
+++ b/velox/dwio/nimble/common/Exceptions.h
@@ -330,6 +330,13 @@ NIMBLE_DECLARE_CHECK_FAIL_TEMPLATES(::facebook::nimble::NimbleInternalError);
       /* retryable */ false,                           \
       __VA_ARGS__)
 
+#define NIMBLE_FILE_FAIL(...)                        \
+  NIMBLE_RAISE_USER_ERROR(                           \
+      "",                                            \
+      ::facebook::nimble::error_code::CorruptedFile, \
+      /* retryable */ false,                         \
+      __VA_ARGS__)
+
 // Debug variants
 #ifndef NDEBUG
 #define NIMBLE_DCHECK(condition, ...) NIMBLE_CHECK(condition, ##__VA_ARGS__)

--- a/velox/dwio/nimble/common/tests/ExceptionTests.cpp
+++ b/velox/dwio/nimble/common/tests/ExceptionTests.cpp
@@ -473,5 +473,18 @@ TEST(ExceptionTests, failMacros) {
   }
 }
 
+TEST(ExceptionTests, fileFail) {
+  try {
+    NIMBLE_FILE_FAIL("Corrupted data at offset: {}", 42);
+    FAIL() << "Should have thrown";
+  } catch (const nimble::NimbleUserError& exception) {
+    EXPECT_EQ(exception.errorCode(), "CORRUPTED_FILE");
+    EXPECT_EQ(exception.errorSource(), "USER");
+    EXPECT_FALSE(exception.retryable());
+    EXPECT_EQ(exception.failingExpression(), "");
+    EXPECT_EQ(exception.errorMessage(), "Corrupted data at offset: 42");
+  }
+}
+
 } // namespace
 } // namespace facebook

--- a/velox/dwio/nimble/index/CMakeLists.txt
+++ b/velox/dwio/nimble/index/CMakeLists.txt
@@ -86,6 +86,30 @@ target_link_libraries(
   Folly::folly
 )
 
+add_library(
+  nimble_vector_index
+  VectorIndex.cpp
+  VectorIndexWriter.cpp
+  VectorIndexUtility.cpp
+  VectorIndex.h
+  VectorIndexWriter.h
+  VectorIndexUtility.h
+  VectorIndexConfig.h
+)
+target_link_libraries(
+  nimble_vector_index
+  nimble_index
+  nimble_common
+  nimble_tablet_common
+  nimble_vector_index_fb
+  velox_buffer
+  velox_memory
+  velox_type
+  velox_vector
+  FAISS::faiss
+  Folly::folly
+)
+
 if(NIMBLE_BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/velox/dwio/nimble/index/VectorIndex.cpp
+++ b/velox/dwio/nimble/index/VectorIndex.cpp
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/index/VectorIndex.h"
+
+#include <algorithm>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <optional>
+#include <variant>
+
+#include <faiss/Index.h>
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexHNSW.h>
+#include <faiss/IndexIVF.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/IndexIVFPQ.h>
+#include <faiss/IndexIVFRaBitQ.h>
+#include <faiss/IndexScalarQuantizer.h>
+#include <faiss/impl/io.h>
+#include <faiss/index_io.h>
+#include <flatbuffers/flatbuffers.h>
+#include <folly/Synchronized.h>
+
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/index/VectorIndexUtility.h"
+#include "velox/dwio/nimble/tablet/MetadataInput.h"
+#include "velox/dwio/nimble/tablet/VectorIndexGenerated.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+// Adapts an in-memory metadata section to the FAISS streaming reader API.
+struct VectorIndexReader : public faiss::IOReader {
+  // Points into a MetadataBuffer retained by the caller during deserialization.
+  const uint8_t* const serializedData;
+
+  // Bounds all reads requested by FAISS.
+  const size_t dataBytes;
+
+  // Tracks the next unread byte.
+  size_t position{0};
+
+  VectorIndexReader(const uint8_t* serializedData, size_t dataBytes)
+      : serializedData{serializedData}, dataBytes{dataBytes} {
+    NIMBLE_CHECK_NOT_NULL(serializedData);
+    NIMBLE_CHECK_GT(dataBytes, 0);
+  }
+
+  size_t operator()(void* destination, size_t itemSize, size_t numItems)
+      override {
+    // FAISS reads zero items for absent optional data such as direct maps.
+    if (numItems == 0) {
+      return 0;
+    }
+
+    NIMBLE_CHECK_GT(itemSize, 0, "FAISS read item size must be positive");
+    NIMBLE_CHECK_NOT_NULL(destination);
+    NIMBLE_CHECK_LE(position, dataBytes);
+    const auto numItemsToRead =
+        std::min(numItems, (dataBytes - position) / itemSize);
+    const auto numBytesToRead = numItemsToRead * itemSize;
+    if (numBytesToRead == 0) {
+      // Returning zero reports EOF so FAISS rejects a truncated index.
+      return 0;
+    }
+    std::memcpy(destination, serializedData + position, numBytesToRead);
+    position += numBytesToRead;
+    return numItemsToRead;
+  }
+};
+
+// Deserializes one FAISS index while its metadata buffer remains alive.
+std::unique_ptr<faiss::Index> readFaissIndex(std::string_view serializedIndex) {
+  NIMBLE_CHECK_FILE(
+      !serializedIndex.empty(), "FAISS index data must not be empty");
+  VectorIndexReader reader(
+      reinterpret_cast<const uint8_t*>(serializedIndex.data()),
+      serializedIndex.size());
+  try {
+    return std::unique_ptr<faiss::Index>(faiss::read_index(&reader));
+  } catch (const std::exception& error) {
+    NIMBLE_FILE_FAIL("Failed to deserialize FAISS index: {}", error.what());
+  }
+}
+
+// Verifies that the serialized implementation agrees with Nimble metadata.
+bool checkIndexType(const faiss::Index& index, VectorIndexType indexType) {
+  switch (indexType) {
+    case VectorIndexType::kIvfFlat:
+      return dynamic_cast<const faiss::IndexIVFFlat*>(&index) != nullptr;
+    case VectorIndexType::kIvfSq8:
+      return dynamic_cast<const faiss::IndexIVFScalarQuantizer*>(&index) !=
+          nullptr;
+    case VectorIndexType::kIvfPq:
+      return dynamic_cast<const faiss::IndexIVFPQ*>(&index) != nullptr;
+    case VectorIndexType::kIvfRaBitQ:
+      return dynamic_cast<const faiss::IndexIVFRaBitQ*>(&index) != nullptr;
+    case VectorIndexType::kHnswSq8:
+      return dynamic_cast<const faiss::IndexHNSWSQ*>(&index) != nullptr;
+    default:
+      NIMBLE_UNREACHABLE(
+          "Unknown vector index type: {}", static_cast<int>(indexType));
+  }
+}
+
+// Copies a query and normalizes it when FAISS uses inner product for cosine.
+std::vector<float> prepareQueryVector(
+    const std::vector<float>& queryVector,
+    VectorDistanceMetric metric) {
+  auto preparedQuery = queryVector;
+  normalizeVectors(
+      metric,
+      /*numVectors=*/1,
+      static_cast<uint32_t>(preparedQuery.size()),
+      preparedQuery.data());
+  return preparedQuery;
+}
+
+// Serializes HNSW searches because FAISS updates process-global statistics.
+folly::Synchronized<std::monostate>& hnswSearchGuard() {
+  static auto* guard = new folly::Synchronized<std::monostate>();
+  return *guard;
+}
+
+// VectorIndex::search accepts one query vector per call.
+constexpr faiss::idx_t kNumQueriesPerSearch{1};
+
+// Runs one search without mutating shared request parameters or IVF statistics.
+void searchFaissIndex(
+    const faiss::Index& index,
+    VectorIndexType indexType,
+    const VectorIndex::SearchConfig& config,
+    const float* queryVector,
+    faiss::idx_t maxNumNeighbors,
+    float* scores,
+    faiss::idx_t* labels) {
+  if (indexType == VectorIndexType::kHnswSq8) {
+    NIMBLE_CHECK_NOT_NULL(
+        dynamic_cast<const faiss::IndexHNSW*>(&index),
+        "FAISS index metadata requires an HNSW index");
+    NIMBLE_USER_CHECK_GT(
+        config.hnswSearchDepth, 0, "HNSW search depth must be positive");
+    NIMBLE_USER_CHECK_LE(
+        config.hnswSearchDepth,
+        static_cast<uint32_t>(std::numeric_limits<int>::max()),
+        "HNSW search depth exceeds the FAISS limit");
+    faiss::SearchParametersHNSW searchParameters;
+    searchParameters.efSearch = static_cast<int>(config.hnswSearchDepth);
+    // FAISS updates process-global HNSW statistics during search.
+    const auto hnswSearchLock = hnswSearchGuard().wlock();
+    index.search(
+        kNumQueriesPerSearch,
+        queryVector,
+        maxNumNeighbors,
+        scores,
+        labels,
+        &searchParameters);
+    return;
+  }
+
+  const auto* ivfIndex = dynamic_cast<const faiss::IndexIVF*>(&index);
+  NIMBLE_CHECK_NOT_NULL(ivfIndex, "FAISS index metadata requires an IVF index");
+  NIMBLE_CHECK_NOT_NULL(ivfIndex->quantizer);
+  NIMBLE_CHECK_NOT_NULL(
+      dynamic_cast<const faiss::IndexFlat*>(ivfIndex->quantizer),
+      "FAISS IVF index requires a flat quantizer");
+  NIMBLE_USER_CHECK_GT(
+      config.numProbes, 0, "Number of probed partitions must be positive");
+  faiss::SearchParametersIVF searchParameters;
+  const auto numProbes = static_cast<faiss::idx_t>(
+      std::min(ivfIndex->nlist, static_cast<size_t>(config.numProbes)));
+  NIMBLE_CHECK_GT(numProbes, 0);
+  searchParameters.nprobe = static_cast<size_t>(numProbes);
+  std::vector<float> centroidScores(static_cast<size_t>(numProbes));
+  std::vector<faiss::idx_t> partitionLabels(static_cast<size_t>(numProbes));
+
+  // IVF search first finds the nearest coarse partitions, then scans vectors
+  // assigned to those partitions. Keeping the stages explicit lets the second
+  // pass use request-local statistics instead of FAISS's process-global state.
+  ivfIndex->quantizer->search(
+      kNumQueriesPerSearch,
+      queryVector,
+      numProbes,
+      centroidScores.data(),
+      partitionLabels.data(),
+      searchParameters.quantizer_params);
+
+  // Pass request-local statistics to avoid FAISS's process-global
+  // indexIVF_stats, which is not safe for concurrent searches.
+  //
+  // TODO: Aggregate per-search FAISS statistics in VectorIndex for
+  // observability.
+  faiss::IndexIVFStats searchStats;
+  ivfIndex->search_preassigned(
+      kNumQueriesPerSearch,
+      queryVector,
+      maxNumNeighbors,
+      partitionLabels.data(),
+      centroidScores.data(),
+      scores,
+      labels,
+      /*store_pairs=*/false,
+      &searchParameters,
+      &searchStats);
+}
+
+// Validates metadata before allocating or deserializing a FAISS index.
+void validateVectorIndexMetadata(const VectorIndex::Metadata& metadata) {
+  NIMBLE_CHECK_FILE(
+      !metadata.columnName.empty(),
+      "VectorIndex column name must not be empty");
+  NIMBLE_CHECK_FILE_GT(
+      metadata.dimensions, 0, "VectorIndex dimensions must be positive");
+  NIMBLE_CHECK_FILE_LE(
+      metadata.dimensions,
+      static_cast<uint32_t>(std::numeric_limits<int>::max()),
+      "VectorIndex dimensions exceed the FAISS limit");
+  NIMBLE_CHECK_FILE_GT(
+      metadata.numVectors, 0, "VectorIndex vector count must be positive");
+  NIMBLE_CHECK_FILE_LE(
+      metadata.numVectors,
+      static_cast<uint64_t>(std::numeric_limits<faiss::idx_t>::max()),
+      "VectorIndex vector count exceeds the FAISS limit");
+}
+
+// Parses and validates one vector index descriptor's logical metadata.
+VectorIndex::Metadata parseVectorIndexMetadata(
+    const serialization::VectorIndexMeta& config) {
+  NIMBLE_CHECK_FILE_NOT_NULL(
+      config.column_name(), "VectorIndex column name is missing");
+  const auto* configTable =
+      reinterpret_cast<const flatbuffers::Table*>(&config);
+  const auto serializedMetric = configTable->GetField<int8_t>(
+      serialization::VectorIndexMeta::VT_METRIC,
+      static_cast<int8_t>(serialization::VectorDistanceMetric_L2));
+  const auto serializedIndexType = configTable->GetField<int8_t>(
+      serialization::VectorIndexMeta::VT_INDEX_TYPE,
+      static_cast<int8_t>(serialization::VectorIndexType_IVF_FLAT));
+
+  VectorIndex::Metadata metadata{
+      .columnName = config.column_name()->str(),
+      .dimensions = config.dimensions(),
+      .metric = fromSerializedMetric(serializedMetric),
+      .indexType = fromSerializedIndexType(serializedIndexType),
+      .numVectors = config.num_vectors(),
+  };
+  validateVectorIndexMetadata(metadata);
+  return metadata;
+}
+
+// Parses and validates one vector index data section.
+MetadataSection parseVectorIndexSection(
+    const serialization::MetadataSection& section) {
+  NIMBLE_CHECK_FILE_GT(
+      section.size(), 0, "VectorIndex index data must not be empty");
+  NIMBLE_CHECK_FILE_LE(
+      section.size(),
+      kMaxVectorIndexSizeBytes,
+      "VectorIndex index data exceeds the supported limit");
+  const auto uncompressedSize = section.uncompressed_size();
+  NIMBLE_CHECK_FILE_GT(
+      uncompressedSize,
+      0,
+      "VectorIndex uncompressed data size must be recorded");
+  NIMBLE_CHECK_FILE_LE(
+      uncompressedSize,
+      kMaxVectorIndexSizeBytes,
+      "VectorIndex uncompressed data exceeds the supported limit");
+
+  const auto* sectionTable =
+      reinterpret_cast<const flatbuffers::Table*>(&section);
+  const auto serializedCompressionType = sectionTable->GetField<uint8_t>(
+      serialization::MetadataSection::VT_COMPRESSION_TYPE,
+      static_cast<uint8_t>(serialization::CompressionType_Uncompressed));
+  NIMBLE_CHECK_FILE_LE(
+      serializedCompressionType,
+      static_cast<uint8_t>(serialization::CompressionType_MAX),
+      "VectorIndex compression type is invalid");
+  const auto compressionType =
+      static_cast<CompressionType>(serializedCompressionType);
+  if (compressionType == CompressionType::Uncompressed) {
+    NIMBLE_CHECK_FILE_EQ(
+        uncompressedSize,
+        section.size(),
+        "VectorIndex uncompressed data size must equal its section size");
+  } else {
+    NIMBLE_CHECK_FILE_GE(
+        uncompressedSize,
+        section.size(),
+        "VectorIndex uncompressed data must not be smaller than its section");
+  }
+
+  return MetadataSection{
+      section.offset(),
+      section.size(),
+      compressionType,
+      uncompressedSize,
+  };
+}
+
+} // namespace
+
+VectorIndexDirectory VectorIndexDirectory::create(Section directorySection) {
+  const auto directoryData = directorySection.content();
+  NIMBLE_CHECK_FILE(
+      !directoryData.empty(), "Vector index directory must not be empty");
+  flatbuffers::Verifier verifier(
+      reinterpret_cast<const uint8_t*>(directoryData.data()),
+      directoryData.size());
+  NIMBLE_CHECK_FILE(
+      serialization::VerifyVectorIndexDirectoryBuffer(verifier),
+      "Invalid VectorIndexDirectory FlatBuffer");
+
+  const auto* root = flatbuffers::GetRoot<serialization::VectorIndexDirectory>(
+      directoryData.data());
+  NIMBLE_CHECK_FILE_NOT_NULL(root, "VectorIndexDirectory root is missing");
+  const auto* descriptors = root->indices();
+  NIMBLE_CHECK_FILE_NOT_NULL(
+      descriptors, "VectorIndexDirectory indices are missing");
+  NIMBLE_CHECK_FILE_GT(
+      descriptors->size(), 0, "VectorIndexDirectory must contain an index");
+
+  folly::F14FastMap<std::string, Entry> entries;
+  entries.reserve(descriptors->size());
+  for (const auto* descriptor : *descriptors) {
+    NIMBLE_CHECK_FILE_NOT_NULL(descriptor, "VectorIndex descriptor is missing");
+    const auto* config = descriptor->config();
+    NIMBLE_CHECK_FILE_NOT_NULL(config, "VectorIndex config is missing");
+    auto metadata = parseVectorIndexMetadata(*config);
+    NIMBLE_CHECK_FILE(
+        !entries.contains(metadata.columnName),
+        "VectorIndex column name is duplicated: {}",
+        metadata.columnName);
+    const auto* section = descriptor->index_data();
+    NIMBLE_CHECK_FILE_NOT_NULL(
+        section, "VectorIndex index data section is missing");
+    const auto columnName = metadata.columnName;
+    entries.emplace(
+        columnName,
+        Entry{
+            .metadata = std::move(metadata),
+            .indexSection = parseVectorIndexSection(*section),
+        });
+  }
+
+  return VectorIndexDirectory{std::move(entries)};
+}
+
+VectorIndexDirectory::VectorIndexDirectory(
+    folly::F14FastMap<std::string, Entry> entries)
+    : entries_{std::move(entries)} {}
+
+size_t VectorIndexDirectory::numIndexes() const {
+  return entries_.size();
+}
+
+bool VectorIndexDirectory::contains(std::string_view columnName) const {
+  return entries_.contains(std::string{columnName});
+}
+
+std::shared_ptr<const VectorIndex> VectorIndexDirectory::load(
+    std::string_view columnName,
+    MetadataInput& metadataInput) const {
+  const auto entry = entries_.find(std::string{columnName});
+  NIMBLE_USER_CHECK(
+      entry != entries_.end(),
+      "Vector index column does not exist: {}",
+      columnName);
+
+  const auto indexData = metadataInput.load({&entry->second.indexSection, 1});
+  NIMBLE_CHECK_EQ(indexData.size(), 1);
+  NIMBLE_CHECK_NOT_NULL(indexData.front().get());
+  return VectorIndex::create(
+      entry->second.metadata, indexData.front()->content());
+}
+
+std::shared_ptr<const VectorIndex> VectorIndex::create(
+    Metadata metadata,
+    std::string_view serializedIndex) {
+  validateVectorIndexMetadata(metadata);
+  return std::shared_ptr<const VectorIndex>(
+      new VectorIndex(std::move(metadata), serializedIndex));
+}
+
+VectorIndex::VectorIndex(Metadata metadata, std::string_view serializedIndex)
+    : columnName_{std::move(metadata.columnName)},
+      dimensions_{metadata.dimensions},
+      metric_{metadata.metric},
+      indexType_{metadata.indexType},
+      numVectors_{metadata.numVectors},
+      faissIndex_{readFaissIndex(serializedIndex)} {
+  NIMBLE_CHECK_FILE_EQ(
+      faissIndex_->d,
+      static_cast<int>(dimensions_),
+      "FAISS index dimensions disagree with its metadata");
+  NIMBLE_CHECK_FILE_EQ(
+      faissIndex_->ntotal,
+      static_cast<faiss::idx_t>(numVectors_),
+      "FAISS vector count disagrees with its metadata");
+  NIMBLE_CHECK_FILE_EQ(
+      static_cast<int>(faissIndex_->metric_type),
+      static_cast<int>(toFaissMetric(metric_)),
+      "FAISS index metric disagrees with its metadata");
+  NIMBLE_CHECK_FILE(
+      checkIndexType(*faissIndex_, indexType_),
+      "FAISS index type disagrees with its metadata");
+}
+
+VectorIndex::~VectorIndex() = default;
+
+std::vector<VectorIndex::SearchResult> VectorIndex::search(
+    const SearchConfig& config) const {
+  NIMBLE_USER_CHECK_EQ(
+      config.queryVector.size(),
+      static_cast<size_t>(dimensions_),
+      "Query vector dimensions do not match the index");
+  NIMBLE_USER_CHECK_GT(
+      config.numNeighbors, 0, "Number of neighbors must be positive");
+
+  const auto queryVector = prepareQueryVector(config.queryVector, metric_);
+
+  const auto maxNumNeighbors = static_cast<faiss::idx_t>(
+      std::min<uint64_t>(config.numNeighbors, numVectors_));
+  std::vector<float> scores(static_cast<size_t>(maxNumNeighbors));
+  std::vector<faiss::idx_t> labels(static_cast<size_t>(maxNumNeighbors));
+
+  searchFaissIndex(
+      *faissIndex_,
+      indexType_,
+      config,
+      queryVector.data(),
+      maxNumNeighbors,
+      scores.data(),
+      labels.data());
+
+  std::vector<SearchResult> results;
+  results.reserve(static_cast<size_t>(maxNumNeighbors));
+  for (faiss::idx_t i = 0; i < maxNumNeighbors; ++i) {
+    if (labels[i] == -1) {
+      // FAISS uses -1 for unfilled slots when the probed partitions contain
+      // fewer candidates than requested. All later slots are also unfilled.
+      break;
+    }
+    NIMBLE_CHECK_LT(
+        static_cast<uint64_t>(labels[i]),
+        numVectors_,
+        "FAISS returned an out-of-range row ID");
+    results.push_back(
+        SearchResult{
+            .rowId = labels[i],
+            .score = scores[i],
+        });
+  }
+
+  return results;
+}
+
+const std::string& VectorIndex::columnName() const {
+  return columnName_;
+}
+
+uint32_t VectorIndex::dimensions() const {
+  return dimensions_;
+}
+
+VectorDistanceMetric VectorIndex::metric() const {
+  return metric_;
+}
+
+VectorIndexType VectorIndex::indexType() const {
+  return indexType_;
+}
+
+uint64_t VectorIndex::numVectors() const {
+  return numVectors_;
+}
+
+} // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/VectorIndex.h
+++ b/velox/dwio/nimble/index/VectorIndex.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+
+#include "velox/dwio/nimble/index/VectorIndexConfig.h"
+#include "velox/dwio/nimble/tablet/MetadataBuffer.h"
+
+namespace faiss {
+struct Index;
+} // namespace faiss
+
+namespace facebook::nimble {
+class MetadataInput;
+} // namespace facebook::nimble
+
+namespace facebook::nimble::index {
+
+/// Reads a FAISS-based vector similarity search index from a Nimble file.
+///
+/// The FAISS index is immutable after construction. Concurrent searches use
+/// request-local parameters and synchronize FAISS global statistics when
+/// necessary.
+class VectorIndex {
+ public:
+  /// Configures one nearest-neighbor query.
+  struct SearchConfig {
+    /// Supplies a query with the same dimensionality as the indexed vectors.
+    std::vector<float> queryVector;
+
+    /// Sets the maximum number of nearest neighbors to return.
+    uint32_t numNeighbors{10};
+
+    /// Sets the number of IVF partitions to probe. IVF first assigns the query
+    /// to its nearest partitions, then searches vectors only within them.
+    /// Higher values generally improve recall at the cost of more work.
+    uint32_t numProbes{32};
+
+    /// Sets the HNSW candidate-list size used while traversing the graph.
+    /// Higher values generally improve recall at the cost of more work.
+    uint32_t hnswSearchDepth{32};
+  };
+
+  /// Identifies one nearest-neighbor match and its metric-specific score.
+  struct SearchResult {
+    /// Identifies the zero-based row in the file.
+    int64_t rowId{0};
+
+    /// Contains squared Euclidean distance for L2, where smaller is better.
+    /// Contains similarity for cosine and dot product, where larger is better.
+    float score{0};
+  };
+
+  /// Describes the logical vector index stored in a Nimble file.
+  struct Metadata {
+    /// Identifies the indexed top-level column.
+    std::string columnName;
+
+    /// Defines the required width of indexed and query vectors.
+    uint32_t dimensions{0};
+
+    /// Determines whether search scores are distances or similarities.
+    VectorDistanceMetric metric{VectorDistanceMetric::kL2};
+
+    /// Selects the concrete FAISS implementation to validate and query.
+    VectorIndexType indexType{VectorIndexType::kIvfSq8};
+
+    /// Bounds the valid row labels returned by FAISS.
+    uint64_t numVectors{0};
+  };
+
+  /// Deserializes and validates one FAISS index.
+  static std::shared_ptr<const VectorIndex> create(
+      Metadata metadata,
+      std::string_view serializedIndex);
+
+  ~VectorIndex();
+
+  /// Searches for nearest neighbors in score order. Row IDs are not
+  /// numerically ordered.
+  std::vector<SearchResult> search(const SearchConfig& config) const;
+
+  /// Returns the column name this index was built on.
+  const std::string& columnName() const;
+
+  /// Returns the vector dimensionality.
+  uint32_t dimensions() const;
+
+  /// Returns the distance metric.
+  VectorDistanceMetric metric() const;
+
+  /// Returns the index type.
+  VectorIndexType indexType() const;
+
+  /// Returns the number of indexed vectors.
+  uint64_t numVectors() const;
+
+ private:
+  // Constructs and validates one eagerly deserialized FAISS index.
+  VectorIndex(Metadata metadata, std::string_view serializedIndex);
+
+  // Identifies the indexed top-level column.
+  const std::string columnName_;
+
+  // Defines the required width of search queries.
+  const uint32_t dimensions_;
+
+  // Determines how FAISS scores candidate vectors.
+  const VectorDistanceMetric metric_;
+
+  // Identifies the serialized FAISS index implementation.
+  const VectorIndexType indexType_;
+
+  // Bounds valid row IDs returned by FAISS.
+  const uint64_t numVectors_;
+
+  // Remains immutable so concurrent searches only read shared state.
+  const std::unique_ptr<faiss::Index> faissIndex_;
+};
+
+/// Describes the vector indexes in a Nimble file without loading their data.
+///
+/// Call load() to materialize only the index needed for a query.
+class VectorIndexDirectory {
+ public:
+  /// Parses a vector-index directory and validates its descriptors.
+  static VectorIndexDirectory create(Section directorySection);
+
+  /// Returns the number of indexes described by the directory.
+  size_t numIndexes() const;
+
+  /// Returns whether the directory describes an index for the column.
+  bool contains(std::string_view columnName) const;
+
+  /// Loads an immutable index that callers may retain and reuse.
+  std::shared_ptr<const VectorIndex> load(
+      std::string_view columnName,
+      MetadataInput& metadataInput) const;
+
+ private:
+  struct Entry {
+    // Defines the index and validates its serialized FAISS representation.
+    VectorIndex::Metadata metadata;
+
+    // Locates the serialized FAISS representation in the Nimble file.
+    MetadataSection indexSection;
+  };
+
+  explicit VectorIndexDirectory(folly::F14FastMap<std::string, Entry> entries);
+
+  // Keys descriptors by top-level column name for direct lookup.
+  folly::F14FastMap<std::string, Entry> entries_;
+};
+
+} // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/VectorIndexConfig.h
+++ b/velox/dwio/nimble/index/VectorIndexConfig.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace facebook::nimble {
+
+/// Caps index sections at 1 GiB, within MetadataSection's uint32_t size limit.
+inline constexpr uint64_t kMaxVectorIndexSizeBytes{1ULL << 30};
+
+/// Distance metric for vector similarity search.
+enum class VectorDistanceMetric : uint8_t {
+  /// Squared Euclidean distance.
+  kL2,
+  /// Cosine similarity over normalized vectors.
+  kCosine,
+  /// Inner-product similarity over unnormalized vectors.
+  kDotProduct,
+};
+
+/// Vector index types.
+/// IVF partitioning with configurable quantization or sub-index acceleration.
+enum class VectorIndexType : uint8_t {
+  /// IVF + brute-force scan (no compression).
+  kIvfFlat,
+  /// IVF + 8-bit scalar quantization.
+  kIvfSq8,
+  /// IVF + product quantization.
+  kIvfPq,
+  /// IVF + RaBitQ binary quantization.
+  kIvfRaBitQ,
+  /// HNSW graph with SQ8 quantization.
+  kHnswSq8,
+};
+
+/// Configuration for building a vector search index during file writes.
+struct VectorIndexConfig {
+  /// Selects a direct child of the top-level row with type ARRAY<REAL>.
+  /// Nested columns are not supported.
+  std::string columnName;
+
+  /// Sets the number of elements in each vector.
+  uint32_t dimensions{0};
+
+  /// Selects the distance metric used for training and search.
+  VectorDistanceMetric metric{VectorDistanceMetric::kL2};
+
+  /// Selects the FAISS index implementation.
+  VectorIndexType indexType{VectorIndexType::kIvfSq8};
+
+  /// Sets the IVF partition count. Zero derives it from the number of vectors.
+  uint32_t numPartitions{0};
+
+  /// Sets the number of PQ sub-quantizers.
+  uint32_t pqSubQuantizers{8};
+
+  /// Sets the number of bits per PQ code.
+  uint8_t pqBits{8};
+
+  /// Sets the number of bidirectional HNSW links per node.
+  uint32_t hnswNumConnections{32};
+
+  /// Rejects input when buffered vectors exceed this many bytes.
+  uint64_t maxBufferedVectorSizeBytes{kMaxVectorIndexSizeBytes};
+
+  /// Rejects close() when the serialized index exceeds this many bytes.
+  uint64_t maxIndexSizeBytes{kMaxVectorIndexSizeBytes};
+};
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/index/VectorIndexUtility.cpp
+++ b/velox/dwio/nimble/index/VectorIndexUtility.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/index/VectorIndexUtility.h"
+
+#include <cmath>
+
+#include "velox/dwio/nimble/common/Exceptions.h"
+
+namespace facebook::nimble::index {
+
+faiss::MetricType toFaissMetric(VectorDistanceMetric metric) {
+  switch (metric) {
+    case VectorDistanceMetric::kL2:
+      return faiss::METRIC_L2;
+    case VectorDistanceMetric::kCosine:
+    case VectorDistanceMetric::kDotProduct:
+      return faiss::METRIC_INNER_PRODUCT;
+    default:
+      NIMBLE_UNREACHABLE(
+          "Unknown distance metric: {}", static_cast<int>(metric));
+  }
+}
+
+void normalizeVectors(
+    VectorDistanceMetric metric,
+    uint64_t numVectors,
+    uint32_t dimensions,
+    float* vectors) {
+  NIMBLE_CHECK_NOT_NULL(vectors, "Vector data must not be null");
+  if (metric != VectorDistanceMetric::kCosine) {
+    return;
+  }
+
+  for (uint64_t i = 0; i < numVectors; ++i) {
+    float* vector = vectors + i * dimensions;
+    float squaredNorm{0};
+    for (uint32_t j = 0; j < dimensions; ++j) {
+      squaredNorm += vector[j] * vector[j];
+    }
+    const auto norm = std::sqrt(squaredNorm);
+    if (norm > 0) {
+      for (uint32_t j = 0; j < dimensions; ++j) {
+        vector[j] /= norm;
+      }
+    }
+  }
+}
+
+serialization::VectorDistanceMetric toSerializedMetric(
+    VectorDistanceMetric metric) {
+  switch (metric) {
+    case VectorDistanceMetric::kL2:
+      return serialization::VectorDistanceMetric_L2;
+    case VectorDistanceMetric::kCosine:
+      return serialization::VectorDistanceMetric_Cosine;
+    case VectorDistanceMetric::kDotProduct:
+      return serialization::VectorDistanceMetric_DotProduct;
+    default:
+      NIMBLE_UNREACHABLE(
+          "Unknown distance metric: {}", static_cast<int>(metric));
+  }
+}
+
+VectorDistanceMetric fromSerializedMetric(int8_t metric) {
+  switch (metric) {
+    case static_cast<int8_t>(serialization::VectorDistanceMetric_L2):
+      return VectorDistanceMetric::kL2;
+    case static_cast<int8_t>(serialization::VectorDistanceMetric_Cosine):
+      return VectorDistanceMetric::kCosine;
+    case static_cast<int8_t>(serialization::VectorDistanceMetric_DotProduct):
+      return VectorDistanceMetric::kDotProduct;
+    default:
+      NIMBLE_CHECK_FILE(
+          false,
+          "Unknown FlatBuffer distance metric: {}",
+          static_cast<int>(metric));
+      return VectorDistanceMetric::kL2;
+  }
+}
+
+serialization::VectorIndexType toSerializedIndexType(
+    VectorIndexType indexType) {
+  switch (indexType) {
+    case VectorIndexType::kIvfFlat:
+      return serialization::VectorIndexType_IVF_FLAT;
+    case VectorIndexType::kIvfSq8:
+      return serialization::VectorIndexType_IVF_SQ8;
+    case VectorIndexType::kIvfPq:
+      return serialization::VectorIndexType_IVF_PQ;
+    case VectorIndexType::kIvfRaBitQ:
+      return serialization::VectorIndexType_IVF_RABITQ;
+    case VectorIndexType::kHnswSq8:
+      return serialization::VectorIndexType_HNSW_SQ8;
+    default:
+      NIMBLE_UNREACHABLE(
+          "Unknown vector index type: {}", static_cast<int>(indexType));
+  }
+}
+
+VectorIndexType fromSerializedIndexType(int8_t indexType) {
+  switch (indexType) {
+    case static_cast<int8_t>(serialization::VectorIndexType_IVF_FLAT):
+      return VectorIndexType::kIvfFlat;
+    case static_cast<int8_t>(serialization::VectorIndexType_IVF_SQ8):
+      return VectorIndexType::kIvfSq8;
+    case static_cast<int8_t>(serialization::VectorIndexType_IVF_PQ):
+      return VectorIndexType::kIvfPq;
+    case static_cast<int8_t>(serialization::VectorIndexType_IVF_RABITQ):
+      return VectorIndexType::kIvfRaBitQ;
+    case static_cast<int8_t>(serialization::VectorIndexType_HNSW_SQ8):
+      return VectorIndexType::kHnswSq8;
+    default:
+      NIMBLE_CHECK_FILE(
+          false,
+          "Unknown FlatBuffer index type: {}",
+          static_cast<int>(indexType));
+      return VectorIndexType::kIvfFlat;
+  }
+}
+
+} // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/VectorIndexUtility.h
+++ b/velox/dwio/nimble/index/VectorIndexUtility.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include <faiss/MetricType.h>
+
+#include "velox/dwio/nimble/index/VectorIndexConfig.h"
+#include "velox/dwio/nimble/tablet/VectorIndexGenerated.h"
+
+namespace facebook::nimble::index {
+
+/// Converts a Nimble vector distance metric to its FAISS representation.
+faiss::MetricType toFaissMetric(VectorDistanceMetric metric);
+
+/// Normalizes vectors in place when cosine similarity is configured.
+void normalizeVectors(
+    VectorDistanceMetric metric,
+    uint64_t numVectors,
+    uint32_t dimensions,
+    float* vectors);
+
+/// Converts a Nimble vector distance metric to its serialized representation.
+serialization::VectorDistanceMetric toSerializedMetric(
+    VectorDistanceMetric metric);
+
+/// Validates and converts a serialized vector distance metric byte.
+VectorDistanceMetric fromSerializedMetric(int8_t metric);
+
+/// Converts a Nimble vector index type to its serialized representation.
+serialization::VectorIndexType toSerializedIndexType(VectorIndexType indexType);
+
+/// Validates and converts a serialized vector index type byte.
+VectorIndexType fromSerializedIndexType(int8_t indexType);
+
+} // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/VectorIndexWriter.cpp
+++ b/velox/dwio/nimble/index/VectorIndexWriter.cpp
@@ -1,0 +1,645 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/index/VectorIndexWriter.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <set>
+#include <span>
+
+#include <faiss/Clustering.h>
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexHNSW.h>
+#include <faiss/IndexIVF.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/IndexIVFPQ.h>
+#include <faiss/IndexIVFRaBitQ.h>
+#include <faiss/IndexScalarQuantizer.h>
+#include <faiss/impl/io.h>
+#include <faiss/index_io.h>
+#include <flatbuffers/flatbuffers.h>
+
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/index/VectorIndexUtility.h"
+#include "velox/dwio/nimble/tablet/Constants.h"
+#include "velox/dwio/nimble/tablet/VectorIndexGenerated.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+// Bounds graph fanout to prevent pathological memory and build costs.
+constexpr uint32_t kMaxHnswNumConnections{512};
+
+constexpr int kHnswConstructionSearchDepth{200};
+
+constexpr uint8_t kMaxPqBits{24};
+
+// Clamps the requested partition count to the available training data.
+uint32_t calculateNumPartitions(
+    uint64_t numVectors,
+    uint32_t requestedNumPartitions) {
+  const auto desiredNumPartitions = requestedNumPartitions > 0
+      ? static_cast<uint64_t>(requestedNumPartitions)
+      : std::max<uint64_t>(
+            1,
+            static_cast<uint64_t>(std::sqrt(static_cast<double>(numVectors))));
+  const auto minVectorsPerPartition = static_cast<uint64_t>(
+      faiss::ClusteringParameters{}.min_points_per_centroid);
+  const auto maximumNumPartitions =
+      std::max<uint64_t>(1, numVectors / minVectorsPerPartition);
+  return static_cast<uint32_t>(
+      std::min(desiredNumPartitions, maximumNumPartitions));
+}
+
+// Collects FAISS serialization output in a contiguous pool-tracked buffer.
+struct SerializedIndexWriter : public faiss::IOWriter {
+  SerializedIndexWriter(
+      velox::memory::MemoryPool* pool,
+      size_t maxSerializedSize)
+      : pool{pool}, maxSerializedSize{maxSerializedSize} {
+    NIMBLE_CHECK_NOT_NULL(pool);
+    NIMBLE_CHECK_GT(maxSerializedSize, 0);
+  }
+
+  // Appends one FAISS write and returns the number of items consumed.
+  size_t operator()(const void* source, size_t itemSize, size_t numItems)
+      override {
+    // FAISS emits zero-item writes for absent optional data such as direct
+    // maps.
+    if (numItems == 0) {
+      return 0;
+    }
+    NIMBLE_CHECK_GT(itemSize, 0, "FAISS write item size must be positive");
+    NIMBLE_CHECK_NOT_NULL(source, "FAISS write buffer must not be null");
+    NIMBLE_CHECK_LE(
+        numItems,
+        std::numeric_limits<size_t>::max() / itemSize,
+        "FAISS write size exceeds the platform limit");
+    const auto numBytes = itemSize * numItems;
+    NIMBLE_USER_CHECK_LE(
+        numBytes,
+        maxSerializedSize - serializedSize,
+        "Serialized vector index exceeds the configured limit");
+    const auto requiredSize = serializedSize + numBytes;
+    ensureCapacity(requiredSize);
+    serializedData->setSize(requiredSize);
+    std::memcpy(
+        serializedData->asMutable<char>() + serializedSize, source, numBytes);
+    serializedSize = requiredSize;
+    return numItems;
+  }
+
+  // Grows storage geometrically without exceeding the configured limit.
+  void ensureCapacity(size_t requiredSize) {
+    const auto currentCapacity =
+        serializedData == nullptr ? 0 : serializedData->capacity();
+    if (currentCapacity >= requiredSize) {
+      return;
+    }
+    const auto doubledCapacity = currentCapacity > maxSerializedSize / 2
+        ? maxSerializedSize
+        : currentCapacity * 2;
+    const auto newCapacity = std::max(requiredSize, doubledCapacity);
+    if (serializedData == nullptr) {
+      serializedData = velox::AlignedBuffer::allocate<char>(newCapacity, pool);
+    } else {
+      velox::AlignedBuffer::reallocate<char>(&serializedData, newCapacity);
+    }
+  }
+
+  // Accounts serialized bytes against the writer pool.
+  velox::memory::MemoryPool* const pool;
+
+  // Prevents serialization from exceeding the caller's configured bound.
+  const size_t maxSerializedSize;
+
+  // Owns all bytes emitted by faiss::write_index().
+  velox::BufferPtr serializedData;
+
+  // Tracks initialized bytes separately from allocated capacity.
+  size_t serializedSize{0};
+};
+
+// Constructs the configured index and transfers IVF quantizer ownership.
+std::unique_ptr<faiss::Index> createFaissIndex(
+    const VectorIndexConfig& config,
+    uint32_t numPartitions) {
+  const auto dimensions = static_cast<int>(config.dimensions);
+  const auto faissMetric = toFaissMetric(config.metric);
+
+  if (config.indexType == VectorIndexType::kHnswSq8) {
+    auto index = std::make_unique<faiss::IndexHNSWSQ>(
+        dimensions,
+        faiss::ScalarQuantizer::QT_8bit,
+        static_cast<int>(config.hnswNumConnections),
+        faissMetric);
+    index->hnsw.efConstruction = kHnswConstructionSearchDepth;
+    return index;
+  }
+
+  auto quantizer = std::make_unique<faiss::IndexFlat>(dimensions, faissMetric);
+  std::unique_ptr<faiss::IndexIVF> index;
+  switch (config.indexType) {
+    case VectorIndexType::kIvfFlat:
+      index = std::make_unique<faiss::IndexIVFFlat>(
+          quantizer.get(), dimensions, numPartitions, faissMetric);
+      break;
+    case VectorIndexType::kIvfSq8:
+      index = std::make_unique<faiss::IndexIVFScalarQuantizer>(
+          quantizer.get(),
+          dimensions,
+          numPartitions,
+          faiss::ScalarQuantizer::QT_8bit,
+          faissMetric);
+      break;
+    case VectorIndexType::kIvfPq:
+      index = std::make_unique<faiss::IndexIVFPQ>(
+          quantizer.get(),
+          dimensions,
+          numPartitions,
+          static_cast<size_t>(config.pqSubQuantizers),
+          static_cast<size_t>(config.pqBits),
+          faissMetric);
+      break;
+    case VectorIndexType::kIvfRaBitQ:
+      index = std::make_unique<faiss::IndexIVFRaBitQ>(
+          quantizer.get(), dimensions, numPartitions, faissMetric);
+      break;
+    case VectorIndexType::kHnswSq8:
+      NIMBLE_UNREACHABLE("HNSW index must be created before IVF dispatch");
+    default:
+      NIMBLE_UNREACHABLE(
+          "Unsupported vector index type: {}",
+          static_cast<int>(config.indexType));
+  }
+
+  NIMBLE_CHECK_NOT_NULL(
+      index.get(), "IVF index construction produced no index");
+  index->own_fields = true;
+  (void)quantizer.release();
+  index->cp.spherical = config.metric == VectorDistanceMetric::kCosine;
+  return index;
+}
+
+// Validates one index configuration and resolves its input column.
+velox::column_index_t validateConfig(
+    const VectorIndexConfig& config,
+    const velox::RowTypePtr& inputType) {
+  NIMBLE_USER_CHECK(
+      !config.columnName.empty(), "Vector index column name must not be empty");
+  NIMBLE_USER_CHECK_GT(
+      config.dimensions, 0, "Vector dimensions must be positive");
+  NIMBLE_USER_CHECK_LE(
+      config.dimensions,
+      static_cast<uint32_t>(std::numeric_limits<int>::max()),
+      "Vector dimensions exceed the FAISS limit");
+  NIMBLE_USER_CHECK_LE(
+      config.numPartitions,
+      static_cast<uint32_t>(std::numeric_limits<int>::max()),
+      "Number of partitions exceeds the FAISS limit");
+  NIMBLE_USER_CHECK_GT(
+      config.maxBufferedVectorSizeBytes,
+      0,
+      "Vector buffer size limit must be positive");
+  NIMBLE_USER_CHECK_LE(
+      config.maxBufferedVectorSizeBytes,
+      kMaxVectorIndexSizeBytes,
+      "Vector buffer size limit exceeds the supported maximum");
+  NIMBLE_USER_CHECK_GT(
+      config.maxIndexSizeBytes, 0, "Vector index size limit must be positive");
+  NIMBLE_USER_CHECK_LE(
+      config.maxIndexSizeBytes,
+      kMaxVectorIndexSizeBytes,
+      "Vector index size limit exceeds the supported maximum");
+
+  if (config.indexType == VectorIndexType::kIvfPq) {
+    NIMBLE_USER_CHECK_GT(
+        config.pqSubQuantizers,
+        0,
+        "Number of PQ sub-quantizers must be positive");
+    NIMBLE_USER_CHECK_EQ(
+        config.dimensions % config.pqSubQuantizers,
+        0,
+        "Vector dimensions must be divisible by the number of PQ "
+        "sub-quantizers");
+    NIMBLE_USER_CHECK_GE(
+        config.pqBits, 1, "PQ bits per code must be at least one");
+    NIMBLE_USER_CHECK_LE(
+        config.pqBits, kMaxPqBits, "PQ bits per code exceed the FAISS limit");
+  }
+
+  if (config.indexType == VectorIndexType::kHnswSq8) {
+    NIMBLE_USER_CHECK_GT(
+        config.hnswNumConnections,
+        0,
+        "Number of HNSW connections must be positive");
+    NIMBLE_USER_CHECK_LE(
+        config.hnswNumConnections,
+        kMaxHnswNumConnections,
+        "Number of HNSW connections is too large");
+  }
+
+  const auto columnIndex = inputType->getChildIdx(config.columnName);
+  const auto& columnType = inputType->childAt(columnIndex);
+  NIMBLE_USER_CHECK_EQ(
+      static_cast<int>(columnType->kind()),
+      static_cast<int>(velox::TypeKind::ARRAY),
+      "Vector index column must be an array: {}",
+      columnType->toString());
+  NIMBLE_USER_CHECK_EQ(
+      static_cast<int>(columnType->childAt(0)->kind()),
+      static_cast<int>(velox::TypeKind::REAL),
+      "Vector index elements must be REAL: {}",
+      columnType->toString());
+  return columnIndex;
+}
+
+// Rejects top-level nulls before any column accumulator is mutated.
+void validateTopLevelRows(const velox::RowVector& input, uint64_t fileRow) {
+  if (!input.mayHaveNulls()) {
+    return;
+  }
+  for (velox::vector_size_t row = 0; row < input.size(); ++row) {
+    NIMBLE_USER_CHECK(
+        !input.isNullAt(row),
+        "Input contains a null top-level row: {}",
+        fileRow + static_cast<uint64_t>(row));
+  }
+}
+
+} // namespace
+
+std::unique_ptr<VectorIndexWriter> VectorIndexWriter::create(
+    std::span<const VectorIndexConfig> configs,
+    const velox::RowTypePtr& inputType,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_USER_CHECK(!configs.empty(), "Vector index configs must not be empty");
+  NIMBLE_USER_CHECK_NOT_NULL(inputType, "Input type must not be null");
+  NIMBLE_USER_CHECK_NOT_NULL(pool, "Memory pool must not be null");
+
+  std::set<std::string> columnNames;
+  std::vector<Accumulator> accumulators;
+  accumulators.reserve(configs.size());
+  for (const auto& config : configs) {
+    NIMBLE_USER_CHECK(
+        columnNames.emplace(config.columnName).second,
+        "Duplicate vector index column: {}",
+        config.columnName);
+    accumulators.emplace_back(
+        Accumulator{
+            .config = config,
+            .columnIndex = validateConfig(config, inputType),
+            .vectors = nullptr,
+            .numVectors = 0,
+        });
+  }
+
+  return std::unique_ptr<VectorIndexWriter>(
+      new VectorIndexWriter(std::move(accumulators), pool));
+}
+
+VectorIndexWriter::VectorIndexWriter(
+    std::vector<Accumulator> accumulators,
+    velox::memory::MemoryPool* pool)
+    : pool_{pool}, accumulators_{std::move(accumulators)} {
+  NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool must not be null");
+  NIMBLE_CHECK(
+      !accumulators_.empty(), "Vector index configs must not be empty");
+}
+
+VectorIndexWriter::~VectorIndexWriter() = default;
+
+namespace {
+
+// Returns the decoded array base after checked type conversion.
+const velox::ArrayVector& decodedArrayVector(
+    const velox::DecodedVector& decodedArrays) {
+  const auto* baseVector = decodedArrays.base();
+  if (baseVector == nullptr) {
+    NIMBLE_FAIL("Decoded vector base must not be null");
+  }
+  return *baseVector->asChecked<velox::ArrayVector>();
+}
+
+// Keeps decoded array and element mappings alive across validation and append.
+struct DecodedVectorColumn {
+  explicit DecodedVectorColumn(const velox::VectorPtr& column)
+      : decodedArrays{*column},
+        arrayVector{decodedArrayVector(decodedArrays)},
+        decodedElements{*arrayVector.elements()} {}
+
+  velox::DecodedVector decodedArrays;
+  const velox::ArrayVector& arrayVector;
+  velox::DecodedVector decodedElements;
+};
+
+// Validates one decoded vector column and returns its new value count.
+size_t validateVectors(
+    velox::vector_size_t numRows,
+    uint64_t fileRowOffset,
+    const VectorIndexConfig& config,
+    const DecodedVectorColumn& input) {
+  for (velox::vector_size_t rowOffset = 0; rowOffset < numRows; ++rowOffset) {
+    const auto row = fileRowOffset + static_cast<uint64_t>(rowOffset);
+    if (input.decodedArrays.mayHaveNulls()) {
+      NIMBLE_USER_CHECK(
+          !input.decodedArrays.isNullAt(rowOffset),
+          "Vector index column contains a null row: {}",
+          row);
+    }
+    const auto arrayRow = input.decodedArrays.index(rowOffset);
+    const auto offset = input.arrayVector.offsetAt(arrayRow);
+    const auto size = input.arrayVector.sizeAt(arrayRow);
+    NIMBLE_USER_CHECK_EQ(
+        static_cast<uint32_t>(size),
+        config.dimensions,
+        "Vector dimension mismatch at row: {}",
+        row);
+    if (input.decodedElements.mayHaveNulls()) {
+      for (velox::vector_size_t i = 0; i < size; ++i) {
+        NIMBLE_USER_CHECK(
+            !input.decodedElements.isNullAt(offset + i),
+            "Vector index column contains a null element at row: {}",
+            row);
+      }
+    }
+  }
+
+  const auto numVectors = fileRowOffset + static_cast<uint64_t>(numRows);
+  NIMBLE_USER_CHECK_LE(
+      numVectors,
+      static_cast<uint64_t>(std::numeric_limits<faiss::idx_t>::max()),
+      "Number of vectors exceeds the FAISS limit");
+  NIMBLE_USER_CHECK_LE(
+      numVectors,
+      std::numeric_limits<size_t>::max() / config.dimensions,
+      "Vector buffer size exceeds the platform limit");
+  return static_cast<size_t>(numVectors * config.dimensions);
+}
+
+// Appends one validated vector column to its pool-tracked buffer.
+void appendVectors(
+    velox::vector_size_t numRows,
+    uint64_t fileRowOffset,
+    const VectorIndexConfig& config,
+    const DecodedVectorColumn& input,
+    velox::Buffer& output) {
+  auto* outputData = output.asMutable<float>();
+  NIMBLE_CHECK_NOT_NULL(outputData);
+  const std::span<float> outputValues{
+      outputData, output.size() / sizeof(float)};
+  const auto outputStart =
+      static_cast<size_t>(fileRowOffset) * config.dimensions;
+  for (velox::vector_size_t rowOffset = 0; rowOffset < numRows; ++rowOffset) {
+    const auto arrayRow = input.decodedArrays.index(rowOffset);
+    const auto offset = input.arrayVector.offsetAt(arrayRow);
+    const auto outputOffset =
+        outputStart + static_cast<size_t>(rowOffset) * config.dimensions;
+    const auto outputVector =
+        outputValues.subspan(outputOffset, config.dimensions);
+    if (input.decodedElements.isIdentityMapping()) {
+      const auto* contiguousInputData = input.decodedElements.data<float>();
+      NIMBLE_CHECK_NOT_NULL(contiguousInputData);
+      const std::span<const float> inputValues{
+          contiguousInputData,
+          static_cast<size_t>(input.arrayVector.elements()->size())};
+      std::copy_n(
+          inputValues.begin() + offset,
+          config.dimensions,
+          outputVector.begin());
+      continue;
+    }
+    // Dictionary and constant encodings require decoded value access.
+    for (velox::vector_size_t i = 0;
+         i < static_cast<velox::vector_size_t>(config.dimensions);
+         ++i) {
+      outputVector[i] = input.decodedElements.valueAt<float>(offset + i);
+    }
+  }
+}
+
+} // namespace
+
+void VectorIndexWriter::write(const velox::VectorPtr& input) {
+  NIMBLE_CHECK(!closed_, "VectorIndexWriter has been closed");
+  NIMBLE_USER_CHECK_NOT_NULL(input, "Input vector must not be null");
+  if (input->size() == 0) {
+    return;
+  }
+
+  const auto* rowVector = input->asChecked<velox::RowVector>();
+  const auto fileRowOffset = accumulators_.front().numVectors;
+  validateTopLevelRows(*rowVector, fileRowOffset);
+
+  std::vector<std::unique_ptr<DecodedVectorColumn>> decodedColumns;
+  decodedColumns.reserve(accumulators_.size());
+  std::vector<size_t> numValues;
+  numValues.reserve(accumulators_.size());
+  for (const auto& accumulator : accumulators_) {
+    auto decodedColumn = std::make_unique<DecodedVectorColumn>(
+        rowVector->childAt(accumulator.columnIndex));
+    numValues.emplace_back(validateVectors(
+        rowVector->size(),
+        accumulator.numVectors,
+        accumulator.config,
+        *decodedColumn));
+    decodedColumns.emplace_back(std::move(decodedColumn));
+  }
+  for (size_t i = 0; i < accumulators_.size(); ++i) {
+    ensureVectorCapacity(accumulators_.at(i), numValues.at(i));
+  }
+  for (size_t i = 0; i < accumulators_.size(); ++i) {
+    auto& accumulator = accumulators_.at(i);
+    NIMBLE_CHECK_NOT_NULL(accumulator.vectors.get());
+    appendVectors(
+        rowVector->size(),
+        accumulator.numVectors,
+        accumulator.config,
+        *decodedColumns.at(i),
+        *accumulator.vectors);
+    accumulator.numVectors += static_cast<uint64_t>(rowVector->size());
+  }
+}
+
+void VectorIndexWriter::ensureVectorCapacity(
+    Accumulator& accumulator,
+    size_t numValues) const {
+  const auto maxValues = static_cast<size_t>(
+      accumulator.config.maxBufferedVectorSizeBytes / sizeof(float));
+  NIMBLE_USER_CHECK_LE(
+      numValues,
+      maxValues,
+      "Buffered vector data exceeds the configured limit for column: {}",
+      accumulator.config.columnName);
+
+  const auto currentCapacity = accumulator.vectors == nullptr
+      ? 0
+      : accumulator.vectors->capacity() / sizeof(float);
+  if (currentCapacity < numValues) {
+    const auto doubledCapacity =
+        currentCapacity > maxValues / 2 ? maxValues : currentCapacity * 2;
+    const auto newCapacity = std::max(numValues, doubledCapacity);
+    if (accumulator.vectors == nullptr) {
+      accumulator.vectors =
+          velox::AlignedBuffer::allocate<float>(newCapacity, pool_);
+    } else {
+      velox::AlignedBuffer::reallocate<float>(
+          &accumulator.vectors, newCapacity);
+    }
+  }
+  NIMBLE_CHECK_NOT_NULL(accumulator.vectors.get());
+  accumulator.vectors->setSize(numValues * sizeof(float));
+}
+
+VectorIndexWriter::SerializedIndex VectorIndexWriter::buildIndex(
+    Accumulator& accumulator) const {
+  const auto& config = accumulator.config;
+  NIMBLE_CHECK_GT(accumulator.numVectors, 0, "No vectors to index");
+  NIMBLE_USER_CHECK_NOT_NULL(
+      accumulator.vectors.get(), "Vector data must be buffered before close");
+
+  auto* vectorData = accumulator.vectors->asMutable<float>();
+  NIMBLE_CHECK_NOT_NULL(vectorData);
+  normalizeVectors(
+      config.metric, accumulator.numVectors, config.dimensions, vectorData);
+
+  const auto numPartitions = config.indexType == VectorIndexType::kHnswSq8
+      ? 0
+      : calculateNumPartitions(accumulator.numVectors, config.numPartitions);
+  auto ownedIndex = createFaissIndex(config, numPartitions);
+  NIMBLE_CHECK_NOT_NULL(ownedIndex.get());
+  // @lint-ignore NULLSAFECLANG nullable-dereference
+  auto& faissIndex = *ownedIndex;
+
+  const auto faissNumVectors =
+      static_cast<faiss::idx_t>(accumulator.numVectors);
+  // Some FAISS implementations are initialized as trained, while others must
+  // learn their quantization state from the input vectors.
+  if (!faissIndex.is_trained) {
+    faissIndex.train(faissNumVectors, vectorData);
+  }
+  faissIndex.add(faissNumVectors, vectorData);
+
+  SerializedIndexWriter writer{
+      pool_, static_cast<size_t>(config.maxIndexSizeBytes)};
+  faiss::write_index(&faissIndex, &writer);
+  return SerializedIndex{
+      .serializedData = std::move(writer.serializedData),
+      .serializedSize = writer.serializedSize,
+      .numPartitions = numPartitions,
+  };
+}
+
+std::string VectorIndexWriter::serializeDirectory(
+    std::span<const PersistedIndex> indexes) const {
+  NIMBLE_CHECK(!indexes.empty(), "Persisted vector indexes must not be empty");
+  flatbuffers::FlatBufferBuilder builder;
+  std::vector<flatbuffers::Offset<serialization::VectorIndex>> descriptors;
+  descriptors.reserve(indexes.size());
+  for (const auto& index : indexes) {
+    const auto& accumulator = accumulators_[index.accumulatorIndex];
+    const auto& config = accumulator.config;
+    const auto configOffset = serialization::CreateVectorIndexMeta(
+        builder,
+        builder.CreateString(config.columnName),
+        config.dimensions,
+        toSerializedMetric(config.metric),
+        toSerializedIndexType(config.indexType),
+        index.numPartitions,
+        accumulator.numVectors);
+    const auto sectionOffset = serialization::CreateMetadataSection(
+        builder,
+        index.indexSection.offset(),
+        index.indexSection.size(),
+        static_cast<serialization::CompressionType>(
+            index.indexSection.compressionType()),
+        index.indexSection.uncompressedSize().value());
+    descriptors.emplace_back(
+        serialization::CreateVectorIndex(builder, configOffset, sectionOffset));
+  }
+
+  builder.Finish(
+      serialization::CreateVectorIndexDirectory(
+          builder, builder.CreateVector(descriptors)));
+
+  return {
+      reinterpret_cast<const char*>(builder.GetBufferPointer()),
+      builder.GetSize(),
+  };
+}
+
+void VectorIndexWriter::close(
+    const CreateMetadataSectionFn& createMetadataFn,
+    const WriteOptionalSectionFn& writeMetadataFn) {
+  NIMBLE_CHECK(!closed_, "close() already called");
+  closed_ = true;
+
+  if (accumulators_.front().numVectors == 0) {
+    for (const auto& accumulator : accumulators_) {
+      NIMBLE_CHECK_EQ(accumulator.numVectors, 0);
+    }
+    return;
+  }
+
+  std::vector<PersistedIndex> persistedIndexes;
+  persistedIndexes.reserve(accumulators_.size());
+  for (size_t i = 0; i < accumulators_.size(); ++i) {
+    auto& accumulator = accumulators_[i];
+    NIMBLE_CHECK_GT(accumulator.numVectors, 0);
+    auto serializedIndex = buildIndex(accumulator);
+    accumulator.vectors.reset();
+
+    NIMBLE_CHECK_NOT_NULL(serializedIndex.serializedData.get());
+    NIMBLE_USER_CHECK_LE(
+        serializedIndex.serializedSize,
+        accumulator.config.maxIndexSizeBytes,
+        "Serialized vector index exceeds the configured limit for column: {}",
+        accumulator.config.columnName);
+
+    const std::string_view serializedData{
+        serializedIndex.serializedData->as<char>(),
+        serializedIndex.serializedSize};
+    auto indexSection = createMetadataFn(serializedData);
+    NIMBLE_CHECK_GT(
+        indexSection.size(), 0, "Persisted vector index must not be empty");
+    NIMBLE_CHECK(
+        indexSection.uncompressedSize().has_value(),
+        "Persisted vector index must record its uncompressed size");
+    NIMBLE_CHECK_EQ(
+        indexSection.uncompressedSize().value(),
+        serializedIndex.serializedSize,
+        "Persisted vector index uncompressed size is incorrect");
+
+    persistedIndexes.emplace_back(
+        PersistedIndex{
+            .accumulatorIndex = i,
+            .numPartitions = serializedIndex.numPartitions,
+            .indexSection = std::move(indexSection),
+        });
+  }
+
+  NIMBLE_CHECK_EQ(persistedIndexes.size(), accumulators_.size());
+  writeMetadataFn(
+      std::string(kVectorIndexSection), serializeDirectory(persistedIndexes));
+}
+
+} // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/VectorIndexWriter.h
+++ b/velox/dwio/nimble/index/VectorIndexWriter.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/index/VectorIndexConfig.h"
+#include "velox/dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::nimble::index {
+
+/// Builds a FAISS-based vector similarity search index during file writes.
+///
+/// Accumulates float vectors from each configured column during write() calls,
+/// then trains and serializes the FAISS indexes during close(). Each FAISS blob
+/// is stored in a metadata section referenced by one optional directory.
+class VectorIndexWriter {
+ public:
+  /// Creates a VectorIndexWriter from one or more index configurations.
+  static std::unique_ptr<VectorIndexWriter> create(
+      std::span<const VectorIndexConfig> configs,
+      const velox::RowTypePtr& inputType,
+      velox::memory::MemoryPool* pool);
+
+  ~VectorIndexWriter();
+
+  /// Extracts float vectors from the configured column and buffers them.
+  void write(const velox::VectorPtr& input);
+
+  /// Writes each FAISS blob as a metadata section and their directory as an
+  /// optional section.
+  void close(
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn);
+
+ private:
+  // Collects all state required to build one configured index.
+  struct Accumulator {
+    // Defines how vectors are encoded and indexed.
+    VectorIndexConfig config;
+
+    // Locates the vector column in each top-level row batch.
+    velox::column_index_t columnIndex{0};
+
+    // Stores vectors contiguously in file-row order. The values for row i
+    // occupy [i * dimensions, (i + 1) * dimensions) until close() builds the
+    // index and releases this pool-tracked buffer.
+    velox::BufferPtr vectors;
+
+    // Tracks the number of top-level rows represented in vectors.
+    uint64_t numVectors{0};
+  };
+
+  // Owns an index between FAISS serialization and metadata-section persistence.
+  struct SerializedIndex {
+    // Contains the complete pool-tracked FAISS index representation.
+    velox::BufferPtr serializedData;
+
+    // Limits the view to bytes emitted by FAISS rather than buffer capacity.
+    size_t serializedSize{0};
+
+    // Records the effective IVF partition count after data-size clamping.
+    uint32_t numPartitions{0};
+  };
+
+  // Describes a persisted index while assembling the output directory.
+  struct PersistedIndex {
+    // Identifies the matching accumulator.
+    size_t accumulatorIndex{0};
+
+    // Records the effective IVF partition count after data-size clamping.
+    uint32_t numPartitions{0};
+
+    // Locates the serialized FAISS blob in the Nimble file.
+    MetadataSection indexSection;
+  };
+
+  VectorIndexWriter(
+      std::vector<Accumulator> accumulators,
+      velox::memory::MemoryPool* pool);
+
+  // Builds the FAISS index from accumulated vectors.
+  SerializedIndex buildIndex(Accumulator& accumulator) const;
+
+  // Grows an accumulator geometrically while enforcing its configured limit.
+  void ensureVectorCapacity(Accumulator& accumulator, size_t numValues) const;
+
+  // Serializes descriptors for every successfully built vector index.
+  std::string serializeDirectory(std::span<const PersistedIndex> indexes) const;
+
+  // Accounts for the potentially large vector accumulation buffer.
+  velox::memory::MemoryPool* const pool_;
+
+  // Holds one independent accumulator per configured vector index.
+  std::vector<Accumulator> accumulators_;
+
+  // Prevents writes and duplicate finalization after close().
+  bool closed_{false};
+};
+
+} // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/index/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ add_executable(
   ClusterIndexTest.cpp
   KeyChunkDecoderTest.cpp
   ClusterIndexTestBase.cpp
+  VectorIndexTest.cpp
+  VectorIndexUtilityTest.cpp
   SortedIndexTestUtils.h
   HashIndexTestUtils.h
 )
@@ -55,6 +57,7 @@ add_test(nimble_index_tests nimble_index_tests)
 target_link_libraries(
   nimble_index_tests
   nimble_index
+  nimble_vector_index
   nimble_index_test_utils
   nimble_tablet_reader
   nimble_tablet_writer

--- a/velox/dwio/nimble/index/tests/VectorIndexTest.cpp
+++ b/velox/dwio/nimble/index/tests/VectorIndexTest.cpp
@@ -1,0 +1,1508 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <faiss/IndexFlat.h>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <barrier>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <future>
+#include <limits>
+#include <memory>
+#include <random>
+#include <set>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "velox/common/file/File.h"
+#include "velox/common/io/Options.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/index/VectorIndex.h"
+#include "velox/dwio/nimble/index/VectorIndexWriter.h"
+#include "velox/dwio/nimble/tablet/Constants.h"
+#include "velox/dwio/nimble/tablet/MetadataInput.h"
+#include "velox/dwio/nimble/tablet/TabletReader.h"
+#include "velox/dwio/nimble/tablet/VectorIndexGenerated.h"
+#include "velox/dwio/nimble/writer/Writer.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble::index::test {
+namespace {
+
+// Recall metrics for comparing ANN results against brute-force ground truth.
+struct RecallMetrics {
+  float recallAt1{0};
+  float recallAt5{0};
+  float recallAt10{0};
+
+  std::string debugString() const {
+    return fmt::format(
+        "recall@1={:.1f}%, recall@5={:.1f}%, recall@10={:.1f}%",
+        recallAt1 * 100,
+        recallAt5 * 100,
+        recallAt10 * 100);
+  }
+};
+
+// Captures the two physical layers emitted by VectorIndexWriter.
+struct WrittenIndexes {
+  // Stores all FAISS data sections at their recorded offsets.
+  std::string indexData;
+
+  // Stores the optional VectorIndexDirectory section.
+  std::string directoryData;
+};
+
+class VectorIndexTest : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+ protected:
+  static constexpr uint32_t kDimensions = 32;
+  static constexpr int kSeed = 42;
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addRootPool("VectorIndexTest");
+    leafPool_ = pool_->addLeafChild("leaf");
+  }
+
+  velox::memory::MemoryPool* pool() {
+    return leafPool_.get();
+  }
+
+  velox::RowTypePtr createType() {
+    return velox::ROW(
+        {{"id", velox::INTEGER()}, {"embedding", velox::ARRAY(velox::REAL())}});
+  }
+
+  // Generates uniform random vectors in [0, 1].
+  std::vector<float> generateRandomVectors(
+      size_t numVectors,
+      uint32_t dimensions,
+      int seed = kSeed) {
+    std::mt19937 randomGenerator(seed);
+    std::uniform_real_distribution<float> distribution(0.0f, 1.0f);
+    std::vector<float> vectors(numVectors * dimensions);
+    for (auto& value : vectors) {
+      value = distribution(randomGenerator);
+    }
+    return vectors;
+  }
+
+  // Creates a RowVector with id + embedding columns from a flat float array.
+  velox::RowVectorPtr makeInputFromVectors(
+      const std::vector<float>& vectors,
+      uint32_t dimensions,
+      int32_t startId = 0) {
+    const auto numRows =
+        static_cast<velox::vector_size_t>(vectors.size() / dimensions);
+
+    auto idsVector =
+        velox::BaseVector::create(velox::INTEGER(), numRows, pool());
+    auto* rawIds = idsVector->asFlatVector<int32_t>()->mutableRawValues();
+    for (int32_t i = 0; i < numRows; ++i) {
+      rawIds[i] = startId + i;
+    }
+
+    const auto totalElements =
+        numRows * static_cast<velox::vector_size_t>(dimensions);
+    auto elementsVector =
+        velox::BaseVector::create(velox::REAL(), totalElements, pool());
+    auto* rawElements =
+        elementsVector->asFlatVector<float>()->mutableRawValues();
+    std::memcpy(rawElements, vectors.data(), vectors.size() * sizeof(float));
+
+    auto arrayVector = std::make_shared<velox::ArrayVector>(
+        pool(),
+        velox::ARRAY(velox::REAL()),
+        nullptr,
+        numRows,
+        velox::allocateOffsets(numRows, pool()),
+        velox::allocateSizes(numRows, pool()),
+        elementsVector);
+
+    auto* rawOffsets =
+        arrayVector->mutableOffsets(numRows)->asMutable<velox::vector_size_t>();
+    auto* rawSizes =
+        arrayVector->mutableSizes(numRows)->asMutable<velox::vector_size_t>();
+    for (int32_t i = 0; i < numRows; ++i) {
+      rawOffsets[i] = i * static_cast<velox::vector_size_t>(dimensions);
+      rawSizes[i] = static_cast<velox::vector_size_t>(dimensions);
+    }
+
+    return std::make_shared<velox::RowVector>(
+        pool(),
+        createType(),
+        nullptr,
+        numRows,
+        std::vector<velox::VectorPtr>{idsVector, arrayVector});
+  }
+
+  // Creates a single-index writer for focused unit tests.
+  std::unique_ptr<VectorIndexWriter> createWriter(
+      const VectorIndexConfig& config,
+      const velox::RowTypePtr& type) {
+    const std::array configs{config};
+    return VectorIndexWriter::create(configs, type, pool());
+  }
+
+  // Closes a writer and captures its directory and data sections.
+  WrittenIndexes closeWriter(VectorIndexWriter& writer) {
+    WrittenIndexes written;
+    const CreateMetadataSectionFn createMetadataFn =
+        [&written](std::string_view content) {
+          const auto offset = written.indexData.size();
+          written.indexData.append(content);
+          return MetadataSection{
+              offset,
+              static_cast<uint32_t>(content.size()),
+              CompressionType::Uncompressed,
+              static_cast<uint32_t>(content.size()),
+          };
+        };
+    const WriteOptionalSectionFn writeMetadataFn =
+        [&written](const std::string& name, std::string_view content) {
+          EXPECT_EQ(name, kVectorIndexSection);
+          written.directoryData = std::string(content);
+        };
+    writer.close(createMetadataFn, writeMetadataFn);
+    return written;
+  }
+
+  // Writes vectors and captures the directory and referenced data sections.
+  WrittenIndexes writeIndex(
+      const VectorIndexConfig& config,
+      const std::vector<velox::RowVectorPtr>& batches) {
+    auto type = createType();
+    auto writer = createWriter(config, type);
+    EXPECT_NE(writer, nullptr);
+
+    for (const auto& batch : batches) {
+      writer->write(batch);
+    }
+
+    return closeWriter(*writer);
+  }
+
+  // Parses the directory from the captured optional section.
+  VectorIndexDirectory readDirectory(const WrittenIndexes& written) {
+    auto directoryBuffer = MetadataBuffer::decompress(
+        written.directoryData, CompressionType::Uncompressed, pool());
+    return VectorIndexDirectory::create(
+        Section{MetadataBuffer{std::move(directoryBuffer)}});
+  }
+
+  // Materializes the single index expected by most focused tests.
+  std::shared_ptr<const VectorIndex> readIndex(const WrittenIndexes& written) {
+    const auto directory = readDirectory(written);
+    NIMBLE_CHECK_EQ(directory.numIndexes(), 1);
+    auto readFile =
+        std::make_unique<velox::InMemoryReadFile>(written.indexData);
+    auto metadataInput = MetadataInput::create(
+        readFile.get(),
+        MetadataInput::Options{
+            .pool = pool(),
+            .ioStats = std::make_shared<velox::io::IoStatistics>(),
+        });
+    return directory.load("embedding", *metadataInput);
+  }
+
+  // Returns one descriptor from the captured directory FlatBuffer.
+  const serialization::VectorIndex* serializedIndex(
+      const WrittenIndexes& written,
+      uint32_t index = 0) {
+    const auto* directory =
+        flatbuffers::GetRoot<serialization::VectorIndexDirectory>(
+            written.directoryData.data());
+    NIMBLE_CHECK_NOT_NULL(directory);
+    NIMBLE_CHECK_NOT_NULL(directory->indices());
+    NIMBLE_CHECK_LT(index, directory->indices()->size());
+    const auto* descriptor = directory->indices()->Get(index);
+    NIMBLE_CHECK_NOT_NULL(descriptor);
+    return descriptor;
+  }
+
+  // Computes recall by comparing ANN results against brute-force ground truth.
+  // Uses FAISS IndexFlat as the exact search baseline.
+  RecallMetrics computeRecall(
+      const WrittenIndexes& written,
+      const std::vector<float>& dataVectors,
+      const std::vector<float>& queryVectors,
+      uint32_t dimensions,
+      uint32_t numNeighbors,
+      uint32_t numProbes,
+      VectorDistanceMetric metric) {
+    const auto numData = dataVectors.size() / dimensions;
+    const auto numQueries = queryVectors.size() / dimensions;
+
+    // Build brute-force ground truth.
+    const auto faissMetric = (metric == VectorDistanceMetric::kL2)
+        ? faiss::METRIC_L2
+        : faiss::METRIC_INNER_PRODUCT;
+    faiss::IndexFlat groundTruth(dimensions, faissMetric);
+
+    // For cosine, normalize data vectors before adding to ground truth.
+    std::vector<float> normalizedData;
+    if (metric == VectorDistanceMetric::kCosine) {
+      normalizedData = dataVectors;
+      for (size_t i = 0; i < numData; ++i) {
+        float norm = 0;
+        for (uint32_t j = 0; j < dimensions; ++j) {
+          norm += normalizedData[i * dimensions + j] *
+              normalizedData[i * dimensions + j];
+        }
+        norm = std::sqrt(norm);
+        if (norm > 0) {
+          for (uint32_t j = 0; j < dimensions; ++j) {
+            normalizedData[i * dimensions + j] /= norm;
+          }
+        }
+      }
+      groundTruth.add(
+          static_cast<faiss::idx_t>(numData), normalizedData.data());
+    } else {
+      groundTruth.add(static_cast<faiss::idx_t>(numData), dataVectors.data());
+    }
+
+    // Search ground truth.
+    std::vector<float> expectedDistances(numQueries * numNeighbors);
+    std::vector<faiss::idx_t> expectedLabels(numQueries * numNeighbors);
+
+    // For cosine, normalize query vectors too.
+    std::vector<float> normalizedQueries;
+    const float* queryData = queryVectors.data();
+    if (metric == VectorDistanceMetric::kCosine) {
+      normalizedQueries = queryVectors;
+      for (size_t i = 0; i < numQueries; ++i) {
+        float norm = 0;
+        for (uint32_t j = 0; j < dimensions; ++j) {
+          norm += normalizedQueries[i * dimensions + j] *
+              normalizedQueries[i * dimensions + j];
+        }
+        norm = std::sqrt(norm);
+        if (norm > 0) {
+          for (uint32_t j = 0; j < dimensions; ++j) {
+            normalizedQueries[i * dimensions + j] /= norm;
+          }
+        }
+      }
+      queryData = normalizedQueries.data();
+    }
+
+    groundTruth.search(
+        static_cast<faiss::idx_t>(numQueries),
+        queryData,
+        static_cast<faiss::idx_t>(numNeighbors),
+        expectedDistances.data(),
+        expectedLabels.data());
+
+    // Search via VectorIndex.
+    auto reader = readIndex(written);
+
+    uint32_t recallAt1Matches{0};
+    uint32_t recallAt5Matches{0};
+    uint32_t recallAt10Matches{0};
+
+    for (size_t queryIndex = 0; queryIndex < numQueries; ++queryIndex) {
+      const auto queryOffset = static_cast<std::ptrdiff_t>(
+          queryIndex * static_cast<size_t>(dimensions));
+      const auto nextQueryOffset = static_cast<std::ptrdiff_t>(
+          (queryIndex + 1) * static_cast<size_t>(dimensions));
+      std::vector<float> queryVector(
+          queryVectors.begin() + queryOffset,
+          queryVectors.begin() + nextQueryOffset);
+
+      VectorIndex::SearchConfig searchConfig{
+          .queryVector = queryVector,
+          .numNeighbors = numNeighbors,
+          .numProbes = numProbes,
+      };
+      const auto results = reader->search(searchConfig);
+
+      const auto countMatches = [&](uint32_t requestedNeighbors) {
+        const auto resultWidth = std::min(requestedNeighbors, numNeighbors);
+        const auto numComparedResults =
+            std::min(resultWidth, static_cast<uint32_t>(results.size()));
+        uint32_t numMatches{0};
+        for (uint32_t resultIndex = 0; resultIndex < numComparedResults;
+             ++resultIndex) {
+          for (uint32_t expectedIndex = 0; expectedIndex < resultWidth;
+               ++expectedIndex) {
+            if (results[resultIndex].rowId ==
+                expectedLabels[queryIndex * numNeighbors + expectedIndex]) {
+              ++numMatches;
+              break;
+            }
+          }
+        }
+        return numMatches;
+      };
+
+      recallAt1Matches += countMatches(1);
+      recallAt5Matches += countMatches(5);
+      recallAt10Matches += countMatches(10);
+    }
+
+    RecallMetrics metrics;
+    metrics.recallAt1 =
+        static_cast<float>(recallAt1Matches) / static_cast<float>(numQueries);
+    metrics.recallAt5 = static_cast<float>(recallAt5Matches) /
+        static_cast<float>(numQueries * std::min(5U, numNeighbors));
+    metrics.recallAt10 = static_cast<float>(recallAt10Matches) /
+        static_cast<float>(numQueries * std::min(10U, numNeighbors));
+    return metrics;
+  }
+
+  VectorIndexConfig makeConfig(
+      VectorIndexType indexType,
+      VectorDistanceMetric metric = VectorDistanceMetric::kL2,
+      uint32_t dimensions = kDimensions,
+      uint32_t numPartitions = 8) {
+    return VectorIndexConfig{
+        .columnName = "embedding",
+        .dimensions = dimensions,
+        .metric = metric,
+        .indexType = indexType,
+        .numPartitions = numPartitions,
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+};
+
+TEST_F(VectorIndexTest, recallNumProbesEffect) {
+  const uint32_t numVectors = 1'000;
+  const uint32_t numQueries = 20;
+  const uint32_t numNeighbors = 10;
+
+  auto data = generateRandomVectors(numVectors, kDimensions);
+  auto queries = generateRandomVectors(numQueries, kDimensions, /*seed=*/99);
+
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  auto batch = makeInputFromVectors(data, kDimensions);
+  auto written = writeIndex(config, {batch});
+  ASSERT_FALSE(written.directoryData.empty());
+
+  // Low numProbes: lower recall.
+  auto metricsLow = computeRecall(
+      written,
+      data,
+      queries,
+      kDimensions,
+      numNeighbors,
+      1,
+      VectorDistanceMetric::kL2);
+  // High numProbes (all partitions): should approach 100% recall.
+  auto metricsHigh = computeRecall(
+      written,
+      data,
+      queries,
+      kDimensions,
+      numNeighbors,
+      8,
+      VectorDistanceMetric::kL2);
+
+  LOG(INFO) << "numProbes=1: " << metricsLow.debugString();
+  LOG(INFO) << "numProbes=8: " << metricsHigh.debugString();
+
+  // Higher numProbes should yield equal or better recall.
+  EXPECT_GE(metricsHigh.recallAt1, metricsLow.recallAt1);
+  EXPECT_GE(metricsHigh.recallAt10, metricsLow.recallAt10);
+}
+
+TEST_F(VectorIndexTest, concurrentSearchUsesPerRequestNumProbes) {
+  const uint32_t numVectors = 1'000;
+  const uint32_t numNeighbors = 50;
+  const auto data = generateRandomVectors(numVectors, kDimensions);
+  const auto batch = makeInputFromVectors(data, kDimensions);
+  const auto written =
+      writeIndex(makeConfig(VectorIndexType::kIvfFlat), {batch});
+  const auto query = generateRandomVectors(1, kDimensions, /*seed=*/99);
+
+  const auto searchRows = [&query](
+                              const VectorIndex& index, uint32_t numProbes) {
+    const auto results = index.search(
+        {.queryVector = query,
+         .numNeighbors = numNeighbors,
+         .numProbes = numProbes});
+    std::vector<int64_t> rows;
+    rows.reserve(results.size());
+    for (const auto& result : results) {
+      rows.emplace_back(result.rowId);
+    }
+    return rows;
+  };
+
+  const auto expectedReader = readIndex(written);
+  const auto expectedNarrow = searchRows(*expectedReader, 1);
+  const auto expectedWide = searchRows(*expectedReader, 8);
+  ASSERT_NE(expectedNarrow, expectedWide);
+
+  constexpr uint32_t kNumConcurrentSearches = 16;
+  std::barrier start{kNumConcurrentSearches};
+  const auto concurrentReader = readIndex(written);
+  std::vector<std::future<std::vector<int64_t>>> searches;
+  searches.reserve(kNumConcurrentSearches);
+  for (uint32_t i = 0; i < kNumConcurrentSearches; ++i) {
+    const uint32_t numProbes = i % 2 == 0 ? 1 : 8;
+    searches.emplace_back(std::async(std::launch::async, [&, numProbes] {
+      start.arrive_and_wait();
+      return searchRows(*concurrentReader, numProbes);
+    }));
+  }
+
+  for (uint32_t i = 0; i < searches.size(); ++i) {
+    SCOPED_TRACE(fmt::format("search={}", i));
+    EXPECT_EQ(searches[i].get(), i % 2 == 0 ? expectedNarrow : expectedWide);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exact match tests: deterministic vectors where the answer is known.
+// ---------------------------------------------------------------------------
+
+TEST_F(VectorIndexTest, exactMatchIvfFlat) {
+  const uint32_t dimensions = 8;
+  const int32_t numRows = 200;
+
+  // Deterministic vectors use i * 0.1 + j * 0.01 for element j in row i.
+  std::vector<float> vectors(numRows * dimensions);
+  for (int32_t i = 0; i < numRows; ++i) {
+    for (uint32_t j = 0; j < dimensions; ++j) {
+      vectors[i * dimensions + j] =
+          static_cast<float>(i) * 0.1f + static_cast<float>(j) * 0.01f;
+    }
+  }
+
+  auto config = makeConfig(
+      VectorIndexType::kIvfFlat, VectorDistanceMetric::kL2, dimensions, 4);
+  auto batch = makeInputFromVectors(vectors, dimensions);
+  auto written = writeIndex(config, {batch});
+  ASSERT_FALSE(written.directoryData.empty());
+
+  auto reader = readIndex(written);
+  ASSERT_NE(reader, nullptr);
+
+  // Query with exact vector for row 42.
+  std::vector<float> queryVector(dimensions);
+  for (uint32_t j = 0; j < dimensions; ++j) {
+    queryVector[j] = 42 * 0.1f + static_cast<float>(j) * 0.01f;
+  }
+
+  VectorIndex::SearchConfig searchConfig{
+      .queryVector = queryVector,
+      .numNeighbors = 5,
+      .numProbes = 4,
+  };
+  auto results = reader->search(searchConfig);
+
+  ASSERT_FALSE(results.empty());
+  EXPECT_EQ(results[0].rowId, 42);
+  EXPECT_NEAR(results[0].score, 0.0f, 1e-4f);
+
+  // Neighbors should be row 41 and 43.
+  ASSERT_GE(results.size(), 3);
+  std::set<int64_t> neighborIds;
+  for (size_t i = 1; i < results.size(); ++i) {
+    neighborIds.insert(results[i].rowId);
+  }
+  EXPECT_TRUE(neighborIds.count(41) > 0 || neighborIds.count(43) > 0);
+}
+
+TEST_F(VectorIndexTest, l2ScoreOrdering) {
+  const uint32_t dimensions = 8;
+  const int32_t numRows = 200;
+
+  std::vector<float> vectors(numRows * dimensions);
+  for (int32_t i = 0; i < numRows; ++i) {
+    for (uint32_t j = 0; j < dimensions; ++j) {
+      vectors[i * dimensions + j] =
+          static_cast<float>(i) * 0.1f + static_cast<float>(j) * 0.01f;
+    }
+  }
+
+  auto config = makeConfig(
+      VectorIndexType::kIvfFlat, VectorDistanceMetric::kL2, dimensions, 4);
+  auto batch = makeInputFromVectors(vectors, dimensions);
+  auto written = writeIndex(config, {batch});
+
+  auto reader = readIndex(written);
+
+  std::vector<float> queryVector(dimensions, 0.5f);
+  VectorIndex::SearchConfig searchConfig{
+      .queryVector = queryVector,
+      .numNeighbors = 10,
+      .numProbes = 4,
+  };
+  auto results = reader->search(searchConfig);
+
+  // Squared L2 scores are monotonically non-decreasing.
+  for (size_t i = 1; i < results.size(); ++i) {
+    EXPECT_GE(results[i].score, results[i - 1].score)
+        << "Score not sorted at position " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialization round-trip tests.
+// ---------------------------------------------------------------------------
+
+TEST_F(VectorIndexTest, serializationRoundTrip) {
+  const uint32_t numVectors = 500;
+  auto data = generateRandomVectors(numVectors, kDimensions);
+
+  auto config = makeConfig(VectorIndexType::kIvfSq8);
+  auto batch = makeInputFromVectors(data, kDimensions);
+  auto written = writeIndex(config, {batch});
+  ASSERT_FALSE(written.directoryData.empty());
+
+  // Deserialize and verify metadata.
+  auto reader = readIndex(written);
+  ASSERT_NE(reader, nullptr);
+  EXPECT_EQ(reader->columnName(), "embedding");
+  EXPECT_EQ(reader->dimensions(), kDimensions);
+  EXPECT_EQ(reader->metric(), VectorDistanceMetric::kL2);
+  EXPECT_EQ(reader->indexType(), VectorIndexType::kIvfSq8);
+  EXPECT_EQ(reader->numVectors(), numVectors);
+
+  // Search should return valid results.
+  auto queries = generateRandomVectors(5, kDimensions, /*seed=*/77);
+  for (size_t queryIndex = 0; queryIndex < 5; ++queryIndex) {
+    const auto queryOffset = static_cast<std::ptrdiff_t>(
+        queryIndex * static_cast<size_t>(kDimensions));
+    const auto nextQueryOffset = static_cast<std::ptrdiff_t>(
+        (queryIndex + 1) * static_cast<size_t>(kDimensions));
+    std::vector<float> queryVector(
+        queries.begin() + queryOffset, queries.begin() + nextQueryOffset);
+    VectorIndex::SearchConfig searchConfig{
+        .queryVector = queryVector,
+        .numNeighbors = 5,
+        .numProbes = 8,
+    };
+    auto results = reader->search(searchConfig);
+    ASSERT_FALSE(results.empty());
+    for (const auto& result : results) {
+      EXPECT_GE(result.rowId, 0);
+      EXPECT_LT(result.rowId, static_cast<int64_t>(numVectors));
+      EXPECT_GE(result.score, 0.0f);
+    }
+  }
+}
+
+TEST_F(VectorIndexTest, truncatedFaissIndexRejected) {
+  constexpr uint32_t kNumVectors{100};
+  auto written = writeIndex(
+      makeConfig(VectorIndexType::kIvfFlat),
+      {makeInputFromVectors(
+          generateRandomVectors(kNumVectors, kDimensions), kDimensions)});
+  ASSERT_GT(written.indexData.size(), 1);
+  written.indexData.resize(written.indexData.size() / 2);
+
+  EXPECT_THROW(
+      VectorIndex::create(
+          VectorIndex::Metadata{
+              .columnName = "embedding",
+              .dimensions = kDimensions,
+              .metric = VectorDistanceMetric::kL2,
+              .indexType = VectorIndexType::kIvfFlat,
+              .numVectors = kNumVectors,
+          },
+          written.indexData),
+      NimbleUserError);
+}
+
+TEST_F(VectorIndexTest, mismatchedFaissMetadataRejected) {
+  constexpr uint32_t kNumVectors{200};
+  const auto written = writeIndex(
+      makeConfig(VectorIndexType::kIvfFlat),
+      {makeInputFromVectors(
+          generateRandomVectors(kNumVectors, kDimensions), kDimensions)});
+  const auto* original = serializedIndex(written);
+  ASSERT_NE(original->config(), nullptr);
+  ASSERT_NE(original->index_data(), nullptr);
+
+  struct TestCase {
+    serialization::VectorDistanceMetric metric;
+    serialization::VectorIndexType indexType;
+  };
+  const std::array testCases{
+      TestCase{
+          serialization::VectorDistanceMetric_Cosine,
+          serialization::VectorIndexType_IVF_FLAT,
+      },
+      TestCase{
+          serialization::VectorDistanceMetric_L2,
+          serialization::VectorIndexType_IVF_SQ8,
+      },
+  };
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "metric={}, indexType={}",
+            static_cast<int>(testCase.metric),
+            static_cast<int>(testCase.indexType)));
+    flatbuffers::FlatBufferBuilder builder;
+    const auto config = serialization::CreateVectorIndexMeta(
+        builder,
+        builder.CreateString(original->config()->column_name()->string_view()),
+        original->config()->dimensions(),
+        testCase.metric,
+        testCase.indexType,
+        original->config()->num_partitions(),
+        original->config()->num_vectors());
+    const auto originalSection = original->index_data();
+    const auto section = serialization::CreateMetadataSection(
+        builder,
+        originalSection->offset(),
+        originalSection->size(),
+        originalSection->compression_type(),
+        originalSection->uncompressed_size());
+    const auto descriptor =
+        serialization::CreateVectorIndex(builder, config, section);
+    builder.Finish(
+        serialization::CreateVectorIndexDirectory(
+            builder, builder.CreateVector(&descriptor, 1)));
+
+    auto mismatched = written;
+    mismatched.directoryData.assign(
+        reinterpret_cast<const char*>(builder.GetBufferPointer()),
+        builder.GetSize());
+    NIMBLE_ASSERT_THROW(readIndex(mismatched), "FAISS index");
+  }
+}
+
+TEST_F(VectorIndexTest, zeroVectorMetadataRejected) {
+  constexpr uint32_t kNumVectors{100};
+  const auto written = writeIndex(
+      makeConfig(VectorIndexType::kIvfFlat),
+      {makeInputFromVectors(
+          generateRandomVectors(kNumVectors, kDimensions), kDimensions)});
+
+  NIMBLE_ASSERT_THROW(
+      VectorIndex::create(
+          VectorIndex::Metadata{
+              .columnName = "embedding",
+              .dimensions = kDimensions,
+              .metric = VectorDistanceMetric::kL2,
+              .indexType = VectorIndexType::kIvfFlat,
+              .numVectors = 0,
+          },
+          written.indexData),
+      "VectorIndex vector count must be positive");
+}
+
+TEST_F(VectorIndexTest, writerRoundTripWithMultipleIndexes) {
+  constexpr uint32_t kNumVectors{200};
+  constexpr uint32_t kQueryRow{42};
+  const auto firstData = generateRandomVectors(kNumVectors, kDimensions);
+  const auto secondData =
+      generateRandomVectors(kNumVectors, kDimensions, /*seed=*/99);
+  const auto firstInput = makeInputFromVectors(firstData, kDimensions);
+  const auto secondInput = makeInputFromVectors(secondData, kDimensions);
+  const auto type = velox::ROW({
+      {"id", velox::INTEGER()},
+      {"first_embedding", velox::ARRAY(velox::REAL())},
+      {"second_embedding", velox::ARRAY(velox::REAL())},
+  });
+  const auto input = std::make_shared<velox::RowVector>(
+      pool(),
+      type,
+      nullptr,
+      kNumVectors,
+      std::vector<velox::VectorPtr>{
+          firstInput->childAt(0),
+          firstInput->childAt(1),
+          secondInput->childAt(1),
+      });
+
+  auto firstConfig = makeConfig(VectorIndexType::kIvfFlat);
+  firstConfig.columnName = "first_embedding";
+  auto secondConfig = makeConfig(VectorIndexType::kIvfSq8);
+  secondConfig.columnName = "second_embedding";
+  WriterOptions writerOptions;
+  writerOptions.vectorIndexConfigs = {firstConfig, secondConfig};
+
+  std::string fileData;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
+  Writer writer(type, std::move(writeFile), *pool_, std::move(writerOptions));
+  writer.write(input);
+  writer.close();
+
+  auto readFile =
+      std::make_shared<velox::InMemoryReadFile>(std::string_view{fileData});
+  TabletReader::Options readerOptions;
+  readerOptions.ioOptions.emplace(pool())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
+      .setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+  const auto tablet = TabletReader::create(readFile, pool(), readerOptions);
+  auto directory =
+      tablet->loadOptionalSection(std::string{kVectorIndexSection});
+  ASSERT_TRUE(directory.has_value());
+
+  auto metadataInput = MetadataInput::create(
+      readFile.get(),
+      MetadataInput::Options{
+          .pool = pool(),
+          .ioStats = std::make_shared<velox::io::IoStatistics>(),
+      });
+  const auto vectorIndexDirectory =
+      VectorIndexDirectory::create(std::move(directory.value()));
+  ASSERT_EQ(vectorIndexDirectory.numIndexes(), 2);
+
+  const std::array expectedColumns{"first_embedding", "second_embedding"};
+  const std::array<const std::vector<float>*, 2> data{
+      &firstData,
+      &secondData,
+  };
+  for (size_t i = 0; i < expectedColumns.size(); ++i) {
+    SCOPED_TRACE(fmt::format("column={}", expectedColumns[i]));
+    EXPECT_TRUE(vectorIndexDirectory.contains(expectedColumns[i]));
+    const auto vectorIndex =
+        vectorIndexDirectory.load(expectedColumns[i], *metadataInput);
+    const auto queryBegin = data[i]->begin() + kQueryRow * kDimensions;
+    const std::vector<float> query(queryBegin, queryBegin + kDimensions);
+    const auto results = vectorIndex->search({
+        .queryVector = query,
+        .numNeighbors = 1,
+        .numProbes = 8,
+    });
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results.front().rowId, kQueryRow);
+  }
+
+  EXPECT_FALSE(vectorIndexDirectory.contains("missing"));
+  NIMBLE_ASSERT_THROW(
+      vectorIndexDirectory.load("missing", *metadataInput),
+      "Vector index column does not exist");
+}
+
+TEST_F(VectorIndexTest, partitionMetadataMatchesBuiltIndex) {
+  constexpr uint32_t kNumVectors = 100;
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  config.numPartitions = 8;
+  const auto data = generateRandomVectors(kNumVectors, kDimensions);
+  const auto written =
+      writeIndex(config, {makeInputFromVectors(data, kDimensions)});
+
+  const auto* index = serializedIndex(written);
+  ASSERT_NE(index, nullptr);
+  ASSERT_NE(index->config(), nullptr);
+  EXPECT_EQ(index->config()->num_partitions(), 2);
+}
+
+TEST_F(VectorIndexTest, hnswMetadataHasNoIvfPartitions) {
+  constexpr uint32_t kNumVectors = 100;
+  auto config = makeConfig(VectorIndexType::kHnswSq8);
+  config.numPartitions = 8;
+  const auto data = generateRandomVectors(kNumVectors, kDimensions);
+  const auto written =
+      writeIndex(config, {makeInputFromVectors(data, kDimensions)});
+
+  const auto* index = serializedIndex(written);
+  ASSERT_NE(index, nullptr);
+  ASSERT_NE(index->config(), nullptr);
+  EXPECT_EQ(index->config()->num_partitions(), 0);
+}
+
+TEST_F(VectorIndexTest, hnswSearchDepth) {
+  constexpr uint32_t kNumVectors{200};
+  const auto data = generateRandomVectors(kNumVectors, kDimensions);
+  const auto written = writeIndex(
+      makeConfig(VectorIndexType::kHnswSq8),
+      {makeInputFromVectors(data, kDimensions)});
+  const auto reader = readIndex(written);
+
+  auto searchConfig = VectorIndex::SearchConfig{
+      .queryVector =
+          std::vector<float>(data.begin(), data.begin() + kDimensions),
+      .numNeighbors = 1,
+      .hnswSearchDepth = 16,
+  };
+  const auto results = reader->search(searchConfig);
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results.front().rowId, 0);
+
+  searchConfig.hnswSearchDepth = 0;
+  NIMBLE_ASSERT_THROW(
+      reader->search(searchConfig), "HNSW search depth must be positive");
+}
+
+TEST_F(VectorIndexTest, metadataAllIndexTypes) {
+  struct TestParam {
+    VectorIndexType indexType;
+    VectorDistanceMetric metric;
+    std::string debugString() const {
+      return fmt::format(
+          "indexType={}, metric={}",
+          static_cast<int>(indexType),
+          static_cast<int>(metric));
+    }
+  };
+
+  std::vector<TestParam> testParams = {
+      {VectorIndexType::kIvfFlat, VectorDistanceMetric::kL2},
+      {VectorIndexType::kIvfSq8, VectorDistanceMetric::kCosine},
+      {VectorIndexType::kIvfPq, VectorDistanceMetric::kDotProduct},
+      {VectorIndexType::kIvfRaBitQ, VectorDistanceMetric::kL2},
+      {VectorIndexType::kHnswSq8, VectorDistanceMetric::kL2},
+  };
+
+  for (const auto& param : testParams) {
+    SCOPED_TRACE(param.debugString());
+
+    auto config = makeConfig(param.indexType, param.metric);
+    if (param.indexType == VectorIndexType::kIvfPq) {
+      config.pqSubQuantizers = 8;
+    }
+    auto data = generateRandomVectors(500, kDimensions);
+    auto batch = makeInputFromVectors(data, kDimensions);
+    auto written = writeIndex(config, {batch});
+    ASSERT_FALSE(written.directoryData.empty());
+
+    auto reader = readIndex(written);
+    ASSERT_NE(reader, nullptr);
+    EXPECT_EQ(reader->indexType(), param.indexType);
+    EXPECT_EQ(reader->metric(), param.metric);
+    EXPECT_EQ(reader->dimensions(), kDimensions);
+    EXPECT_EQ(reader->numVectors(), 500);
+
+    const auto results = reader->search({
+        .queryVector =
+            std::vector<float>(data.begin(), data.begin() + kDimensions),
+        .numNeighbors = 10,
+        .numProbes = 8,
+        .hnswSearchDepth = 32,
+    });
+    ASSERT_FALSE(results.empty());
+    EXPECT_LE(results.size(), 10);
+    for (const auto& result : results) {
+      EXPECT_GE(result.rowId, 0);
+      EXPECT_LT(result.rowId, 500);
+      EXPECT_TRUE(std::isfinite(result.score));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Multiple batch / incremental write tests.
+// ---------------------------------------------------------------------------
+
+TEST_F(VectorIndexTest, multipleBatchesAccumulate) {
+  const uint32_t numVectorsPerBatch = 200;
+  const uint32_t numBatches = 5;
+  const uint32_t totalVectors = numVectorsPerBatch * numBatches;
+
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+
+  std::vector<velox::RowVectorPtr> batches;
+  for (uint32_t batchIndex = 0; batchIndex < numBatches; ++batchIndex) {
+    auto data = generateRandomVectors(
+        numVectorsPerBatch, kDimensions, kSeed + static_cast<int>(batchIndex));
+    batches.push_back(makeInputFromVectors(
+        data,
+        kDimensions,
+        static_cast<int32_t>(batchIndex * numVectorsPerBatch)));
+  }
+
+  auto written = writeIndex(config, batches);
+  ASSERT_FALSE(written.directoryData.empty());
+
+  auto reader = readIndex(written);
+  ASSERT_NE(reader, nullptr);
+  EXPECT_EQ(reader->numVectors(), totalVectors);
+
+  // Search should find vectors from any batch.
+  auto queries = generateRandomVectors(10, kDimensions, /*seed=*/77);
+  for (size_t queryIndex = 0; queryIndex < 10; ++queryIndex) {
+    const auto queryOffset = static_cast<std::ptrdiff_t>(
+        queryIndex * static_cast<size_t>(kDimensions));
+    const auto nextQueryOffset = static_cast<std::ptrdiff_t>(
+        (queryIndex + 1) * static_cast<size_t>(kDimensions));
+    std::vector<float> queryVector(
+        queries.begin() + queryOffset, queries.begin() + nextQueryOffset);
+    VectorIndex::SearchConfig searchConfig{
+        .queryVector = queryVector,
+        .numNeighbors = 5,
+        .numProbes = 8,
+    };
+    auto results = reader->search(searchConfig);
+    ASSERT_FALSE(results.empty());
+    for (const auto& result : results) {
+      EXPECT_GE(result.rowId, 0);
+      EXPECT_LT(result.rowId, static_cast<int64_t>(totalVectors));
+    }
+  }
+}
+
+TEST_F(VectorIndexTest, invalidBatchDoesNotMutateOtherIndexes) {
+  constexpr velox::vector_size_t kNumVectors{100};
+  const auto firstInput = makeInputFromVectors(
+      generateRandomVectors(kNumVectors, kDimensions), kDimensions);
+  const auto secondInput = makeInputFromVectors(
+      generateRandomVectors(kNumVectors, kDimensions, /*seed=*/99),
+      kDimensions);
+  const auto type = velox::ROW({
+      {"id", velox::INTEGER()},
+      {"first_embedding", velox::ARRAY(velox::REAL())},
+      {"second_embedding", velox::ARRAY(velox::REAL())},
+  });
+  const auto input = std::make_shared<velox::RowVector>(
+      pool(),
+      type,
+      nullptr,
+      kNumVectors,
+      std::vector<velox::VectorPtr>{
+          firstInput->childAt(0),
+          firstInput->childAt(1),
+          secondInput->childAt(1),
+      });
+
+  auto firstConfig = makeConfig(VectorIndexType::kIvfFlat);
+  firstConfig.columnName = "first_embedding";
+  auto secondConfig = makeConfig(VectorIndexType::kIvfSq8);
+  secondConfig.columnName = "second_embedding";
+  const std::array configs{firstConfig, secondConfig};
+  auto writer = VectorIndexWriter::create(configs, type, pool());
+
+  input->childAt(2)->setNull(0, true);
+  NIMBLE_ASSERT_THROW(
+      writer->write(input), "Vector index column contains a null row");
+  input->childAt(2)->setNull(0, false);
+  writer->write(input);
+
+  const auto written = closeWriter(*writer);
+  const auto* directory =
+      flatbuffers::GetRoot<serialization::VectorIndexDirectory>(
+          written.directoryData.data());
+  ASSERT_NE(directory, nullptr);
+  ASSERT_NE(directory->indices(), nullptr);
+  ASSERT_EQ(directory->indices()->size(), configs.size());
+  for (const auto* descriptor : *directory->indices()) {
+    ASSERT_NE(descriptor, nullptr);
+    ASSERT_NE(descriptor->config(), nullptr);
+    EXPECT_EQ(descriptor->config()->num_vectors(), kNumVectors);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases and error handling.
+// ---------------------------------------------------------------------------
+
+TEST_F(VectorIndexTest, emptyInputOmitsSections) {
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  auto type = createType();
+  auto writer = createWriter(config, type);
+
+  bool dataSectionWritten = false;
+  bool sectionWritten = false;
+  const CreateMetadataSectionFn createMetadataFn =
+      [&dataSectionWritten](std::string_view) {
+        dataSectionWritten = true;
+        return MetadataSection{};
+      };
+  auto writeMetadataFn = [&sectionWritten](
+                             const std::string&, std::string_view) {
+    sectionWritten = true;
+  };
+  writer->close(createMetadataFn, writeMetadataFn);
+  EXPECT_FALSE(dataSectionWritten);
+  EXPECT_FALSE(sectionWritten);
+}
+
+TEST_F(VectorIndexTest, emptyFileOmitsVectorIndex) {
+  const auto type = createType();
+  WriterOptions writerOptions;
+  writerOptions.vectorIndexConfigs = {makeConfig(VectorIndexType::kIvfFlat)};
+
+  std::string fileData;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
+  Writer writer(type, std::move(writeFile), *pool(), std::move(writerOptions));
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileData);
+  TabletReader::Options readerOptions;
+  readerOptions.ioOptions.emplace(pool())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
+      .setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+  const auto tablet = TabletReader::create(readFile, pool(), readerOptions);
+  EXPECT_FALSE(tablet->hasOptionalSection(std::string{kVectorIndexSection}));
+}
+
+TEST_F(VectorIndexTest, noConfig) {
+  auto type = createType();
+  NIMBLE_ASSERT_THROW(
+      VectorIndexWriter::create(
+          std::span<const VectorIndexConfig>{}, type, pool()),
+      "Vector index configs must not be empty");
+}
+
+TEST_F(VectorIndexTest, nullVectorRejected) {
+  auto writer =
+      createWriter(makeConfig(VectorIndexType::kIvfFlat), createType());
+  const auto data = generateRandomVectors(10, kDimensions);
+  const auto batch = makeInputFromVectors(data, kDimensions);
+  batch->childAt(1)->setNull(3, true);
+
+  NIMBLE_ASSERT_THROW(
+      writer->write(batch), "Vector index column contains a null row");
+}
+
+TEST_F(VectorIndexTest, topLevelNullRejected) {
+  auto writer =
+      createWriter(makeConfig(VectorIndexType::kIvfFlat), createType());
+  const auto data = generateRandomVectors(10, kDimensions);
+  const auto batch = makeInputFromVectors(data, kDimensions);
+  batch->setNull(3, true);
+
+  NIMBLE_ASSERT_THROW(
+      writer->write(batch), "Input contains a null top-level row");
+}
+
+TEST_F(VectorIndexTest, usesTopLevelRowCount) {
+  constexpr velox::vector_size_t kNumRows{5};
+  const auto data = generateRandomVectors(10, kDimensions);
+  const auto batch = makeInputFromVectors(data, kDimensions);
+  const auto shorterBatch = std::make_shared<velox::RowVector>(
+      pool(), createType(), nullptr, kNumRows, batch->children());
+
+  const auto written =
+      writeIndex(makeConfig(VectorIndexType::kIvfFlat), {shorterBatch});
+  const auto* index = serializedIndex(written);
+  ASSERT_NE(index, nullptr);
+  ASSERT_NE(index->config(), nullptr);
+  EXPECT_EQ(index->config()->num_vectors(), kNumRows);
+}
+
+TEST_F(VectorIndexTest, dictionaryEncodedVectors) {
+  constexpr velox::vector_size_t kNumVectors{100};
+  const auto data = generateRandomVectors(kNumVectors, kDimensions);
+  const auto input = makeInputFromVectors(data, kDimensions);
+  const auto* arrayVector = input->childAt(1)->as<velox::ArrayVector>();
+  ASSERT_NE(arrayVector, nullptr);
+
+  const auto numElements = kNumVectors * kDimensions;
+  auto elementIndices =
+      velox::AlignedBuffer::allocate<velox::vector_size_t>(numElements, pool());
+  auto* rawElementIndices = elementIndices->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t i = 0; i < numElements; ++i) {
+    rawElementIndices[i] = i;
+  }
+  const auto encodedElements = velox::BaseVector::wrapInDictionary(
+      nullptr, elementIndices, numElements, arrayVector->elements());
+  const auto encodedArray = std::make_shared<velox::ArrayVector>(
+      pool(),
+      velox::ARRAY(velox::REAL()),
+      nullptr,
+      kNumVectors,
+      arrayVector->offsets(),
+      arrayVector->sizes(),
+      encodedElements);
+
+  auto rowIndices =
+      velox::AlignedBuffer::allocate<velox::vector_size_t>(kNumVectors, pool());
+  auto* rawRowIndices = rowIndices->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t row = 0; row < kNumVectors; ++row) {
+    rawRowIndices[row] = kNumVectors - row - 1;
+  }
+  const auto encodedEmbedding = velox::BaseVector::wrapInDictionary(
+      nullptr, rowIndices, kNumVectors, encodedArray);
+  const auto encodedInput = std::make_shared<velox::RowVector>(
+      pool(),
+      createType(),
+      nullptr,
+      kNumVectors,
+      std::vector<velox::VectorPtr>{input->childAt(0), encodedEmbedding});
+
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  config.numPartitions = 2;
+  const auto written = writeIndex(config, {encodedInput});
+  const auto reader = readIndex(written);
+  const auto queryBegin = data.end() - kDimensions;
+  const auto results = reader->search({
+      .queryVector = std::vector<float>(queryBegin, data.end()),
+      .numNeighbors = 1,
+      .numProbes = 2,
+  });
+
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results.front().rowId, 0);
+}
+
+TEST_F(VectorIndexTest, nullVectorElementRejected) {
+  auto writer =
+      createWriter(makeConfig(VectorIndexType::kIvfFlat), createType());
+  const auto data = generateRandomVectors(10, kDimensions);
+  const auto batch = makeInputFromVectors(data, kDimensions);
+  batch->childAt(1)->as<velox::ArrayVector>()->elements()->setNull(
+      kDimensions + 1, true);
+
+  NIMBLE_ASSERT_THROW(
+      writer->write(batch), "Vector index column contains a null element");
+}
+
+TEST_F(VectorIndexTest, invalidPqConfigurationRejected) {
+  auto config = makeConfig(VectorIndexType::kIvfPq);
+
+  for (const uint32_t numSubQuantizers : {0, 3}) {
+    SCOPED_TRACE(fmt::format("numSubQuantizers={}", numSubQuantizers));
+    config.pqSubQuantizers = numSubQuantizers;
+    NIMBLE_ASSERT_THROW(createWriter(config, createType()), "PQ");
+  }
+
+  config.pqSubQuantizers = 8;
+  for (const uint8_t bitsPerCode : {0, 25}) {
+    SCOPED_TRACE(fmt::format("bitsPerCode={}", bitsPerCode));
+    config.pqBits = bitsPerCode;
+    NIMBLE_ASSERT_THROW(createWriter(config, createType()), "PQ bits per code");
+  }
+}
+
+TEST_F(VectorIndexTest, invalidIndexSizeLimitRejected) {
+  for (const uint64_t maxIndexSizeBytes :
+       std::array<uint64_t, 2>{0, kMaxVectorIndexSizeBytes + 1}) {
+    SCOPED_TRACE(fmt::format("maxIndexSizeBytes={}", maxIndexSizeBytes));
+    auto config = makeConfig(VectorIndexType::kIvfFlat);
+    config.maxIndexSizeBytes = maxIndexSizeBytes;
+    NIMBLE_ASSERT_THROW(
+        createWriter(config, createType()), "Vector index size limit");
+  }
+}
+
+TEST_F(VectorIndexTest, bufferedVectorSizeLimitExceeded) {
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  config.maxBufferedVectorSizeBytes = 9 * kDimensions * sizeof(float);
+  auto writer = createWriter(config, createType());
+  const auto input =
+      makeInputFromVectors(generateRandomVectors(10, kDimensions), kDimensions);
+
+  NIMBLE_ASSERT_THROW(writer->write(input), "Buffered vector data exceeds");
+}
+
+TEST_F(VectorIndexTest, dimensionMismatchOnSearch) {
+  auto data = generateRandomVectors(200, kDimensions);
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  auto batch = makeInputFromVectors(data, kDimensions);
+  auto written = writeIndex(config, {batch});
+
+  auto reader = readIndex(written);
+  ASSERT_NE(reader, nullptr);
+
+  VectorIndex::SearchConfig searchConfig{
+      .queryVector = std::vector<float>(kDimensions + 1, 0.0f),
+      .numNeighbors = 5,
+  };
+  NIMBLE_ASSERT_THROW(
+      reader->search(searchConfig),
+      "Query vector dimensions do not match the index");
+}
+
+TEST_F(VectorIndexTest, emptyDirectoryRejected) {
+  NIMBLE_ASSERT_THROW(
+      readDirectory({}), "Vector index directory must not be empty");
+}
+
+TEST_F(VectorIndexTest, invalidDirectoryLimitsRejected) {
+  constexpr uint32_t kNumVectors{100};
+  const auto written = writeIndex(
+      makeConfig(VectorIndexType::kIvfFlat),
+      {makeInputFromVectors(
+          generateRandomVectors(kNumVectors, kDimensions), kDimensions)});
+  const auto* original = serializedIndex(written);
+  ASSERT_NE(original->config(), nullptr);
+  ASSERT_NE(original->index_data(), nullptr);
+
+  struct TestCase {
+    uint32_t dimensions;
+    uint64_t numVectors;
+    uint32_t indexSize;
+    uint32_t uncompressedSize;
+  };
+  const auto* originalSection = original->index_data();
+  const auto originalUncompressedSize = originalSection->uncompressed_size();
+  const std::array testCases{
+      TestCase{
+          0,
+          kNumVectors,
+          originalSection->size(),
+          originalUncompressedSize,
+      },
+      TestCase{
+          static_cast<uint32_t>(std::numeric_limits<int>::max()) + 1,
+          kNumVectors,
+          originalSection->size(),
+          originalUncompressedSize,
+      },
+      TestCase{
+          kDimensions,
+          0,
+          originalSection->size(),
+          originalUncompressedSize,
+      },
+      TestCase{
+          kDimensions,
+          static_cast<uint64_t>(std::numeric_limits<faiss::idx_t>::max()) + 1,
+          originalSection->size(),
+          originalUncompressedSize,
+      },
+      TestCase{
+          kDimensions,
+          kNumVectors,
+          0,
+          originalUncompressedSize,
+      },
+      TestCase{
+          kDimensions,
+          kNumVectors,
+          static_cast<uint32_t>(kMaxVectorIndexSizeBytes + 1),
+          originalUncompressedSize,
+      },
+      TestCase{
+          kDimensions,
+          kNumVectors,
+          originalSection->size(),
+          static_cast<uint32_t>(kMaxVectorIndexSizeBytes + 1),
+      },
+      TestCase{kDimensions, kNumVectors, originalSection->size(), 0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "dimensions={}, numVectors={}, indexSize={}, uncompressedSize={}",
+            testCase.dimensions,
+            testCase.numVectors,
+            testCase.indexSize,
+            testCase.uncompressedSize));
+    flatbuffers::FlatBufferBuilder builder;
+    const auto config = serialization::CreateVectorIndexMeta(
+        builder,
+        builder.CreateString(original->config()->column_name()->string_view()),
+        testCase.dimensions,
+        original->config()->metric(),
+        original->config()->index_type(),
+        original->config()->num_partitions(),
+        testCase.numVectors);
+    const auto section = serialization::CreateMetadataSection(
+        builder,
+        originalSection->offset(),
+        testCase.indexSize,
+        originalSection->compression_type(),
+        testCase.uncompressedSize);
+    const auto descriptor =
+        serialization::CreateVectorIndex(builder, config, section);
+    builder.Finish(
+        serialization::CreateVectorIndexDirectory(
+            builder, builder.CreateVector(&descriptor, 1)));
+
+    auto invalid = written;
+    invalid.directoryData.assign(
+        reinterpret_cast<const char*>(builder.GetBufferPointer()),
+        builder.GetSize());
+    NIMBLE_ASSERT_THROW(readDirectory(invalid), "VectorIndex");
+  }
+}
+
+TEST_F(VectorIndexTest, invalidDirectoryEnumsRejectedAsCorruptFile) {
+  constexpr uint32_t kNumVectors{100};
+  const auto written = writeIndex(
+      makeConfig(VectorIndexType::kIvfFlat),
+      {makeInputFromVectors(
+          generateRandomVectors(kNumVectors, kDimensions), kDimensions)});
+  const auto* original = serializedIndex(written);
+  ASSERT_NE(original->config(), nullptr);
+  ASSERT_NE(original->index_data(), nullptr);
+
+  enum class Field {
+    kMetric,
+    kIndexType,
+    kCompressionType,
+  };
+  const std::array fields{
+      Field::kMetric,
+      Field::kIndexType,
+      Field::kCompressionType,
+  };
+
+  for (const auto field : fields) {
+    SCOPED_TRACE(fmt::format("field={}", static_cast<int>(field)));
+    flatbuffers::FlatBufferBuilder builder;
+    builder.ForceDefaults(true);
+    const auto config = serialization::CreateVectorIndexMeta(
+        builder,
+        builder.CreateString(original->config()->column_name()->string_view()),
+        original->config()->dimensions(),
+        serialization::VectorDistanceMetric_Cosine,
+        serialization::VectorIndexType_IVF_SQ8,
+        original->config()->num_partitions(),
+        original->config()->num_vectors());
+    const auto section = serialization::CreateMetadataSection(
+        builder,
+        original->index_data()->offset(),
+        original->index_data()->size(),
+        serialization::CompressionType_Zstd,
+        original->index_data()->uncompressed_size());
+    const auto descriptorOffset =
+        serialization::CreateVectorIndex(builder, config, section);
+    builder.Finish(
+        serialization::CreateVectorIndexDirectory(
+            builder, builder.CreateVector(&descriptorOffset, 1)));
+
+    WrittenIndexes invalid{
+        .indexData = written.indexData,
+        .directoryData = std::string(
+            reinterpret_cast<const char*>(builder.GetBufferPointer()),
+            builder.GetSize()),
+    };
+    const auto* directory =
+        flatbuffers::GetRoot<serialization::VectorIndexDirectory>(
+            invalid.directoryData.data());
+    auto* descriptor =
+        const_cast<serialization::VectorIndex*>(directory->indices()->Get(0));
+    if (field == Field::kCompressionType) {
+      auto* sectionTable = reinterpret_cast<flatbuffers::Table*>(
+          const_cast<serialization::MetadataSection*>(
+              descriptor->index_data()));
+      ASSERT_TRUE(sectionTable->SetField<uint8_t>(
+          serialization::MetadataSection::VT_COMPRESSION_TYPE, 255));
+    } else {
+      auto* configTable = reinterpret_cast<flatbuffers::Table*>(
+          const_cast<serialization::VectorIndexMeta*>(descriptor->config()));
+      const auto fieldOffset = field == Field::kMetric
+          ? serialization::VectorIndexMeta::VT_METRIC
+          : serialization::VectorIndexMeta::VT_INDEX_TYPE;
+      ASSERT_TRUE(configTable->SetField<int8_t>(fieldOffset, 127));
+    }
+    EXPECT_THROW(readDirectory(invalid), NimbleUserError);
+  }
+}
+
+TEST_F(VectorIndexTest, numNeighborsLargerThanDataset) {
+  auto data = generateRandomVectors(50, kDimensions);
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  config.numPartitions = 2;
+  auto batch = makeInputFromVectors(data, kDimensions);
+  auto written = writeIndex(config, {batch});
+
+  auto reader = readIndex(written);
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<float> queryVector(kDimensions, 0.5f);
+  VectorIndex::SearchConfig searchConfig{
+      .queryVector = queryVector,
+      .numNeighbors = 100,
+      .numProbes = 2,
+  };
+  auto results = reader->search(searchConfig);
+
+  // Should return at most the number of vectors in the dataset.
+  EXPECT_LE(results.size(), 50);
+  EXPECT_FALSE(results.empty());
+}
+
+TEST_F(VectorIndexTest, singleVector) {
+  std::vector<float> data(kDimensions, 1.0f);
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  config.numPartitions = 1;
+  auto batch = makeInputFromVectors(data, kDimensions);
+  auto written = writeIndex(config, {batch});
+  ASSERT_FALSE(written.directoryData.empty());
+
+  auto reader = readIndex(written);
+  ASSERT_NE(reader, nullptr);
+  EXPECT_EQ(reader->numVectors(), 1);
+
+  VectorIndex::SearchConfig searchConfig{
+      .queryVector = std::vector<float>(kDimensions, 1.0f),
+      .numNeighbors = 1,
+      .numProbes = 1,
+  };
+  auto results = reader->search(searchConfig);
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0].rowId, 0);
+  EXPECT_NEAR(results[0].score, 0.0f, 1e-6f);
+}
+
+TEST_F(VectorIndexTest, maxIndexSizeExceeded) {
+  auto data = generateRandomVectors(500, kDimensions);
+  auto config = makeConfig(VectorIndexType::kIvfFlat);
+  config.maxIndexSizeBytes = 1;
+
+  auto type = createType();
+  auto writer = createWriter(config, type);
+  auto batch = makeInputFromVectors(data, kDimensions);
+  writer->write(batch);
+
+  bool dataSectionWritten = false;
+  bool sectionWritten = false;
+  const CreateMetadataSectionFn createMetadataFn =
+      [&dataSectionWritten](std::string_view) {
+        dataSectionWritten = true;
+        return MetadataSection{};
+      };
+  auto writeMetadataFn = [&sectionWritten](
+                             const std::string&, std::string_view) {
+    sectionWritten = true;
+  };
+  NIMBLE_ASSERT_THROW(
+      writer->close(createMetadataFn, writeMetadataFn),
+      "Serialized vector index exceeds the configured limit");
+  EXPECT_FALSE(dataSectionWritten);
+  EXPECT_FALSE(sectionWritten);
+}
+
+TEST_F(VectorIndexTest, missingUncompressedIndexSizeRejected) {
+  constexpr uint32_t kNumVectors{100};
+  auto writer =
+      createWriter(makeConfig(VectorIndexType::kIvfFlat), createType());
+  writer->write(makeInputFromVectors(
+      generateRandomVectors(kNumVectors, kDimensions), kDimensions));
+
+  bool sectionWritten{false};
+  const CreateMetadataSectionFn createMetadataFn =
+      [](std::string_view content) {
+        return MetadataSection{
+            0,
+            static_cast<uint32_t>(content.size()),
+            CompressionType::Uncompressed,
+        };
+      };
+  const WriteOptionalSectionFn writeMetadataFn =
+      [&sectionWritten](const std::string&, std::string_view) {
+        sectionWritten = true;
+      };
+
+  NIMBLE_ASSERT_THROW(
+      writer->close(createMetadataFn, writeMetadataFn),
+      "Persisted vector index must record its uncompressed size");
+  EXPECT_FALSE(sectionWritten);
+}
+
+} // namespace
+} // namespace facebook::nimble::index::test

--- a/velox/dwio/nimble/index/tests/VectorIndexUtilityTest.cpp
+++ b/velox/dwio/nimble/index/tests/VectorIndexUtilityTest.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/index/VectorIndexUtility.h"
+
+#include <array>
+
+#include <gtest/gtest.h>
+
+namespace facebook::nimble::index::test {
+namespace {
+
+TEST(VectorIndexUtilityTest, metricConversions) {
+  struct TestCase {
+    VectorDistanceMetric metric;
+    faiss::MetricType faissMetric;
+    serialization::VectorDistanceMetric serializedMetric;
+  };
+  constexpr std::array testCases{
+      TestCase{
+          VectorDistanceMetric::kL2,
+          faiss::METRIC_L2,
+          serialization::VectorDistanceMetric_L2,
+      },
+      TestCase{
+          VectorDistanceMetric::kCosine,
+          faiss::METRIC_INNER_PRODUCT,
+          serialization::VectorDistanceMetric_Cosine,
+      },
+      TestCase{
+          VectorDistanceMetric::kDotProduct,
+          faiss::METRIC_INNER_PRODUCT,
+          serialization::VectorDistanceMetric_DotProduct,
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        ::testing::Message() << "metric=" << static_cast<int>(testCase.metric));
+    EXPECT_EQ(toFaissMetric(testCase.metric), testCase.faissMetric);
+    EXPECT_EQ(toSerializedMetric(testCase.metric), testCase.serializedMetric);
+    EXPECT_EQ(
+        fromSerializedMetric(static_cast<int8_t>(testCase.serializedMetric)),
+        testCase.metric);
+  }
+}
+
+TEST(VectorIndexUtilityTest, indexTypeConversions) {
+  struct TestCase {
+    VectorIndexType indexType;
+    serialization::VectorIndexType serializedIndexType;
+  };
+  constexpr std::array testCases{
+      TestCase{
+          VectorIndexType::kIvfFlat,
+          serialization::VectorIndexType_IVF_FLAT,
+      },
+      TestCase{
+          VectorIndexType::kIvfSq8,
+          serialization::VectorIndexType_IVF_SQ8,
+      },
+      TestCase{
+          VectorIndexType::kIvfPq,
+          serialization::VectorIndexType_IVF_PQ,
+      },
+      TestCase{
+          VectorIndexType::kIvfRaBitQ,
+          serialization::VectorIndexType_IVF_RABITQ,
+      },
+      TestCase{
+          VectorIndexType::kHnswSq8,
+          serialization::VectorIndexType_HNSW_SQ8,
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        ::testing::Message()
+        << "indexType=" << static_cast<int>(testCase.indexType));
+    EXPECT_EQ(
+        toSerializedIndexType(testCase.indexType),
+        testCase.serializedIndexType);
+    EXPECT_EQ(
+        fromSerializedIndexType(
+            static_cast<int8_t>(testCase.serializedIndexType)),
+        testCase.indexType);
+  }
+}
+
+TEST(VectorIndexUtilityTest, normalizeVectors) {
+  const std::array<float, 4> input{3, 4, 0, 0};
+  for (const auto metric :
+       {VectorDistanceMetric::kL2, VectorDistanceMetric::kDotProduct}) {
+    SCOPED_TRACE(::testing::Message() << "metric=" << static_cast<int>(metric));
+    auto vectors = input;
+    normalizeVectors(
+        metric, /*numVectors=*/2, /*dimensions=*/2, vectors.data());
+    EXPECT_EQ(vectors, input);
+  }
+
+  auto vectors = input;
+  normalizeVectors(
+      VectorDistanceMetric::kCosine,
+      /*numVectors=*/2,
+      /*dimensions=*/2,
+      vectors.data());
+  EXPECT_FLOAT_EQ(vectors[0], 0.6f);
+  EXPECT_FLOAT_EQ(vectors[1], 0.8f);
+  EXPECT_FLOAT_EQ(vectors[2], 0);
+  EXPECT_FLOAT_EQ(vectors[3], 0);
+}
+
+} // namespace
+} // namespace facebook::nimble::index::test

--- a/velox/dwio/nimble/tablet/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/CMakeLists.txt
@@ -144,6 +144,22 @@ target_include_directories(
 )
 add_dependencies(nimble_sorted_index_fb nimble_sorted_index_schema_fb)
 
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/VectorIndex.fbs"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  nimble_vector_index_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  ""
+)
+add_library(nimble_vector_index_fb INTERFACE)
+target_include_directories(
+  nimble_vector_index_fb
+  INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
+)
+add_dependencies(nimble_vector_index_fb nimble_vector_index_schema_fb)
+
 add_library(
   nimble_tablet_common
   Compression.cpp

--- a/velox/dwio/nimble/tablet/Constants.h
+++ b/velox/dwio/nimble/tablet/Constants.h
@@ -40,5 +40,6 @@ constexpr std::string_view kIndexSection = "columnar.indexes";
 constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
 constexpr std::string_view kPropertiesSection = "columnar.properties";
 constexpr std::string_view kDictionarySection = "columnar.dictionaries";
+constexpr std::string_view kVectorIndexSection = "columnar.vector.index";
 
 } // namespace facebook::nimble

--- a/velox/dwio/nimble/tablet/VectorIndex.fbs
+++ b/velox/dwio/nimble/tablet/VectorIndex.fbs
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+include "Footer.fbs";
+
+namespace facebook.nimble.serialization;
+
+/// Distance metric for vector similarity search.
+enum VectorDistanceMetric : byte {
+  /// Squared Euclidean distance, where smaller scores are closer.
+  L2,
+  /// Cosine similarity over normalized vectors, where larger scores are closer.
+  Cosine,
+  /// Inner-product similarity over unnormalized vectors, where larger scores
+  /// are closer.
+  DotProduct,
+}
+
+/// Vector index types supported.
+/// IVF partitioning with configurable quantization or sub-index.
+enum VectorIndexType : byte {
+  IVF_FLAT,
+  IVF_SQ8,
+  IVF_PQ,
+  IVF_RABITQ,
+  HNSW_SQ8,
+}
+
+/// Serialized configuration for the vector index.
+table VectorIndexMeta {
+  /// Name of the indexed vector column.
+  column_name:string;
+  /// Fixed width of every indexed vector, measured in floating-point
+  /// coordinates (for example, 768 for a 768-dimensional embedding). Readers
+  /// require query vectors to have the same width before passing them to FAISS.
+  dimensions:uint32;
+  /// Distance metric used for similarity search.
+  metric:VectorDistanceMetric;
+  /// Index type (partitioning + compression/sub-index).
+  index_type:VectorIndexType;
+  /// Number of IVF partitions (clusters), or zero for non-IVF indexes.
+  num_partitions:uint32;
+  /// Number of top-level file rows represented by the index. The writer
+  /// requires one non-null vector per row, so this is also the vector column's
+  /// row count. FAISS labels are file row numbers in [0, num_vectors).
+  num_vectors:uint64;
+}
+
+/// Describes one vector index stored in a separate metadata section.
+table VectorIndex {
+  /// Index configuration metadata.
+  config:VectorIndexMeta (required);
+  /// Section containing the trained and populated FAISS index blob. Readers
+  /// pass its contents to faiss::read_index().
+  index_data:MetadataSection (required);
+}
+
+/// Root table for the vector index optional section.
+/// Supports independent vector indexes on multiple columns in one file.
+table VectorIndexDirectory {
+  /// Descriptors for all vector indexes stored in the file.
+  indices:[VectorIndex] (required);
+}
+
+root_type VectorIndexDirectory;

--- a/velox/dwio/nimble/writer/CMakeLists.txt
+++ b/velox/dwio/nimble/writer/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(
   nimble_common
   nimble_encodings
   nimble_index
+  nimble_vector_index
   nimble_tablet_writer
   nimble_velox_field_writer
   nimble_velox_layout_planner

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -47,6 +47,7 @@
 #include "velox/dwio/nimble/index/HashIndexWriter.h"
 #include "velox/dwio/nimble/index/IndexSerialization.h"
 #include "velox/dwio/nimble/index/SortedIndexWriter.h"
+#include "velox/dwio/nimble/index/VectorIndexWriter.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/tablet/FileProperties.h"
 #include "velox/dwio/nimble/tablet/IndexGenerated.h"
@@ -1889,6 +1890,13 @@ Writer::Writer(
           context_->options(),
           type,
           &(*context_->bufferMemoryPool()))},
+      vectorIndexWriter_{
+          context_->options().vectorIndexConfigs.empty()
+              ? nullptr
+              : index::VectorIndexWriter::create(
+                    context_->options().vectorIndexConfigs,
+                    velox::asRowType(type),
+                    &(*context_->bufferMemoryPool()))},
       tabletWriter_{TabletWriter::create(
           file_.get(),
           *encodingMemoryPool_,
@@ -2268,6 +2276,9 @@ void Writer::addIndexKey(const velox::VectorPtr& input) {
   for (const auto& denseIndex : denseIndexWriters_) {
     denseIndex.writer->write(input);
   }
+  if (vectorIndexWriter_ != nullptr) {
+    vectorIndexWriter_->write(input);
+  }
 }
 
 void Writer::writeProperties(const WriteOptionalSectionFn& writeMetadataFn) {
@@ -2333,6 +2344,9 @@ void Writer::writeIndexes(
     }
   }
   writeIndexSection(descriptors, writeMetadataFn);
+  if (vectorIndexWriter_ != nullptr) {
+    vectorIndexWriter_->close(createMetadataFn, writeMetadataFn);
+  }
 }
 
 bool Writer::shouldFlush(FlushPolicy* policy) const {

--- a/velox/dwio/nimble/writer/Writer.h
+++ b/velox/dwio/nimble/writer/Writer.h
@@ -25,6 +25,7 @@
 #include "velox/dwio/common/Writer.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/index/IndexWriter.h"
+#include "velox/dwio/nimble/index/VectorIndexWriter.h"
 #include "velox/dwio/nimble/tablet/TabletWriter.h"
 #include "velox/dwio/nimble/velox/FieldWriter.h"
 #include "velox/dwio/nimble/velox/SharedDictionaryWriter.h"
@@ -358,6 +359,8 @@ class Writer : public velox::dwio::common::Writer {
   std::unique_ptr<velox::WriteFile> file_;
   const std::unique_ptr<index::IndexWriter> clusterIndexWriter_;
   const std::vector<DenseIndexWriter> denseIndexWriters_;
+  // Accumulates vectors for all configured similarity-search indexes.
+  const std::unique_ptr<index::VectorIndexWriter> vectorIndexWriter_;
   const std::unique_ptr<TabletWriter> tabletWriter_;
   // Built once at construction from `options.bufferPolicyFactory`; null if
   // the caller didn't set the factory (legacy FlushPolicy path).

--- a/velox/dwio/nimble/writer/WriterOptions.h
+++ b/velox/dwio/nimble/writer/WriterOptions.h
@@ -23,6 +23,7 @@
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/index/IndexConfig.h"
+#include "velox/dwio/nimble/index/VectorIndexConfig.h"
 #include "velox/dwio/nimble/tablet/StripeGroup.h"
 #include "velox/dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "velox/dwio/nimble/velox/NimbleConfig.h"
@@ -136,6 +137,14 @@ struct WriterOptions {
   /// EXPERIMENTAL: Dense indexes are not production-ready. Do not enable for
   /// production tables without consulting the Nimble team (oncall: dwios).
   std::vector<std::shared_ptr<const index::IndexConfig>> denseIndexConfigs{};
+
+  /// Vector index configurations. Each entry builds a FAISS similarity index
+  /// over a top-level ARRAY<REAL> column, where each row contains one vector of
+  /// floating-point values. Every array must have exactly the configured
+  /// dimensions; null rows and null elements are rejected.
+  /// EXPERIMENTAL: Vector indexes are not production-ready. Do not enable for
+  /// production tables without consulting the Nimble team (oncall: dwios).
+  std::vector<VectorIndexConfig> vectorIndexConfigs{};
 
   /// Columns that should be encoded as flat maps. Maps column name to a set
   /// of predefined key strings. When the set is empty, the column is


### PR DESCRIPTION
Summary:

Nimble files can persist FAISS indexes for multiple ARRAY<REAL> columns and reuse them across queries. Each FAISS blob is stored in a bounded metadata section referenced by a compact directory.

Readers parse the directory without loading index data and deserialize only the selected column index on demand. Each loaded index is validated against its stored dimensions, row count, metric, and implementation type. Searches use request-local IVF or HNSW tuning, and IVF searches keep statistics local so concurrent queries remain race-free.

Writers reject null or malformed vectors, grow pool-backed buffers geometrically, and enforce a configured memory bound before building each index.

Reviewed By: duxiao1212

Differential Revision: D102743610


