### PR TITLE
feat(nimble): Integrate vector indexes with TabletReader (#18895)

### DIFF
--- a/velox/dwio/nimble/index/VectorIndex.cpp
+++ b/velox/dwio/nimble/index/VectorIndex.cpp
@@ -35,7 +35,9 @@
 #include <faiss/index_io.h>
 #include <flatbuffers/flatbuffers.h>
 #include <folly/Synchronized.h>
+#include <folly/synchronization/CallOnce.h>
 
+#include "velox/common/io/Options.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/index/VectorIndexUtility.h"
 #include "velox/dwio/nimble/tablet/MetadataInput.h"
@@ -316,7 +318,50 @@ MetadataSection parseVectorIndexSection(
 
 } // namespace
 
-VectorIndexDirectory VectorIndexDirectory::create(Section directorySection) {
+// Owns the state required to create the index input on first use.
+struct VectorIndexDirectory::InputState {
+  explicit InputState(const IndexLookup::Options& sourceOptions)
+      : ioOptions{[&] {
+          NIMBLE_CHECK_NOT_NULL(sourceOptions.ioOptions);
+          return std::make_shared<velox::io::ReaderOptions>(
+              *sourceOptions.ioOptions);
+        }()},
+        options{
+            .file = sourceOptions.file,
+            .ioOptions = ioOptions.get(),
+            .fileHandle = sourceOptions.fileHandle,
+            .cache = sourceOptions.cache,
+            .pinIndex = sourceOptions.pinIndex,
+            .preloadIndex = sourceOptions.preloadIndex,
+        } {
+    NIMBLE_CHECK_NOT_NULL(options.file);
+  }
+
+  std::shared_ptr<MetadataInput> input() {
+    folly::call_once(initializeOnce, [this] {
+      options.validate();
+      metadataInput = createIndexMetadataInput(options);
+    });
+    NIMBLE_CHECK_NOT_NULL(metadataInput);
+    return metadataInput;
+  }
+
+  // Keeps the ReaderOptions referenced by options alive.
+  std::shared_ptr<velox::io::ReaderOptions> ioOptions;
+
+  // Preserves index-specific statistics and cache behavior.
+  IndexLookup::Options options;
+
+  // Serializes construction while allowing concurrent reads afterward.
+  folly::once_flag initializeOnce;
+
+  // Remains null until the first vector index is materialized.
+  std::shared_ptr<MetadataInput> metadataInput;
+};
+
+VectorIndexDirectory VectorIndexDirectory::create(
+    Section directorySection,
+    const IndexLookup::Options& options) {
   const auto directoryData = directorySection.content();
   NIMBLE_CHECK_FILE(
       !directoryData.empty(), "Vector index directory must not be empty");
@@ -359,31 +404,35 @@ VectorIndexDirectory VectorIndexDirectory::create(Section directorySection) {
         });
   }
 
-  return VectorIndexDirectory{std::move(entries)};
+  return VectorIndexDirectory{
+      std::move(entries), std::make_shared<InputState>(options)};
 }
 
 VectorIndexDirectory::VectorIndexDirectory(
-    folly::F14FastMap<std::string, Entry> entries)
-    : entries_{std::move(entries)} {}
+    folly::F14FastMap<std::string, Entry> entries,
+    std::shared_ptr<InputState> inputState)
+    : entries_{std::move(entries)}, inputState_{std::move(inputState)} {
+  NIMBLE_CHECK_NOT_NULL(inputState_);
+}
 
 size_t VectorIndexDirectory::numIndexes() const {
   return entries_.size();
 }
 
 bool VectorIndexDirectory::contains(std::string_view columnName) const {
-  return entries_.contains(std::string{columnName});
+  return entries_.contains(columnName);
 }
 
 std::shared_ptr<const VectorIndex> VectorIndexDirectory::load(
-    std::string_view columnName,
-    MetadataInput& metadataInput) const {
-  const auto entry = entries_.find(std::string{columnName});
+    std::string_view columnName) const {
+  const auto entry = entries_.find(columnName);
   NIMBLE_USER_CHECK(
       entry != entries_.end(),
       "Vector index column does not exist: {}",
       columnName);
 
-  const auto indexData = metadataInput.load({&entry->second.indexSection, 1});
+  const auto indexData =
+      inputState_->input()->load({&entry->second.indexSection, 1});
   NIMBLE_CHECK_EQ(indexData.size(), 1);
   NIMBLE_CHECK_NOT_NULL(indexData.front().get());
   return VectorIndex::create(

--- a/velox/dwio/nimble/index/VectorIndex.h
+++ b/velox/dwio/nimble/index/VectorIndex.h
@@ -24,6 +24,7 @@
 
 #include <folly/container/F14Map.h>
 
+#include "velox/dwio/nimble/index/IndexLookup.h"
 #include "velox/dwio/nimble/index/VectorIndexConfig.h"
 #include "velox/dwio/nimble/tablet/MetadataBuffer.h"
 
@@ -144,8 +145,11 @@ class VectorIndex {
 /// Call load() to materialize only the index needed for a query.
 class VectorIndexDirectory {
  public:
-  /// Parses a vector-index directory and validates its descriptors.
-  static VectorIndexDirectory create(Section directorySection);
+  /// Parses a vector-index directory and captures options used to create its
+  /// index data input on the first load.
+  static VectorIndexDirectory create(
+      Section directorySection,
+      const IndexLookup::Options& options);
 
   /// Returns the number of indexes described by the directory.
   size_t numIndexes() const;
@@ -154,11 +158,11 @@ class VectorIndexDirectory {
   bool contains(std::string_view columnName) const;
 
   /// Loads an immutable index that callers may retain and reuse.
-  std::shared_ptr<const VectorIndex> load(
-      std::string_view columnName,
-      MetadataInput& metadataInput) const;
+  std::shared_ptr<const VectorIndex> load(std::string_view columnName) const;
 
  private:
+  struct InputState;
+
   struct Entry {
     // Defines the index and validates its serialized FAISS representation.
     VectorIndex::Metadata metadata;
@@ -167,10 +171,15 @@ class VectorIndexDirectory {
     MetadataSection indexSection;
   };
 
-  explicit VectorIndexDirectory(folly::F14FastMap<std::string, Entry> entries);
+  VectorIndexDirectory(
+      folly::F14FastMap<std::string, Entry> entries,
+      std::shared_ptr<InputState> inputState);
 
   // Keys descriptors by top-level column name for direct lookup.
   folly::F14FastMap<std::string, Entry> entries_;
+
+  // Lazily creates and owns the index-specific metadata input.
+  std::shared_ptr<InputState> inputState_;
 };
 
 } // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/tests/VectorIndexTest.cpp
+++ b/velox/dwio/nimble/index/tests/VectorIndexTest.cpp
@@ -43,7 +43,6 @@
 #include "velox/dwio/nimble/index/VectorIndex.h"
 #include "velox/dwio/nimble/index/VectorIndexWriter.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
-#include "velox/dwio/nimble/tablet/MetadataInput.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
 #include "velox/dwio/nimble/tablet/VectorIndexGenerated.h"
 #include "velox/dwio/nimble/writer/Writer.h"
@@ -214,23 +213,21 @@ class VectorIndexTest : public ::testing::Test {
   VectorIndexDirectory readDirectory(const WrittenIndexes& written) {
     auto directoryBuffer = MetadataBuffer::decompress(
         written.directoryData, CompressionType::Uncompressed, pool());
+    velox::io::ReaderOptions ioOptions(pool());
+    ioOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+    IndexLookup::Options indexOptions{
+        .file = std::make_shared<velox::InMemoryReadFile>(written.indexData),
+        .ioOptions = &ioOptions,
+    };
     return VectorIndexDirectory::create(
-        Section{MetadataBuffer{std::move(directoryBuffer)}});
+        Section{MetadataBuffer{std::move(directoryBuffer)}}, indexOptions);
   }
 
   // Materializes the single index expected by most focused tests.
   std::shared_ptr<const VectorIndex> readIndex(const WrittenIndexes& written) {
     const auto directory = readDirectory(written);
     NIMBLE_CHECK_EQ(directory.numIndexes(), 1);
-    auto readFile =
-        std::make_unique<velox::InMemoryReadFile>(written.indexData);
-    auto metadataInput = MetadataInput::create(
-        readFile.get(),
-        MetadataInput::Options{
-            .pool = pool(),
-            .ioStats = std::make_shared<velox::io::IoStatistics>(),
-        });
-    return directory.load("embedding", *metadataInput);
+    return directory.load("embedding");
   }
 
   // Returns one descriptor from the captured directory FlatBuffer.
@@ -766,14 +763,14 @@ TEST_F(VectorIndexTest, writerRoundTripWithMultipleIndexes) {
       tablet->loadOptionalSection(std::string{kVectorIndexSection});
   ASSERT_TRUE(directory.has_value());
 
-  auto metadataInput = MetadataInput::create(
-      readFile.get(),
-      MetadataInput::Options{
-          .pool = pool(),
-          .ioStats = std::make_shared<velox::io::IoStatistics>(),
-      });
+  velox::io::ReaderOptions indexIoOptions(pool());
+  indexIoOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+  IndexLookup::Options indexOptions{
+      .file = readFile,
+      .ioOptions = &indexIoOptions,
+  };
   const auto vectorIndexDirectory =
-      VectorIndexDirectory::create(std::move(directory.value()));
+      VectorIndexDirectory::create(std::move(directory.value()), indexOptions);
   ASSERT_EQ(vectorIndexDirectory.numIndexes(), 2);
 
   const std::array expectedColumns{"first_embedding", "second_embedding"};
@@ -784,8 +781,7 @@ TEST_F(VectorIndexTest, writerRoundTripWithMultipleIndexes) {
   for (size_t i = 0; i < expectedColumns.size(); ++i) {
     SCOPED_TRACE(fmt::format("column={}", expectedColumns[i]));
     EXPECT_TRUE(vectorIndexDirectory.contains(expectedColumns[i]));
-    const auto vectorIndex =
-        vectorIndexDirectory.load(expectedColumns[i], *metadataInput);
+    const auto vectorIndex = vectorIndexDirectory.load(expectedColumns[i]);
     const auto queryBegin = data[i]->begin() + kQueryRow * kDimensions;
     const std::vector<float> query(queryBegin, queryBegin + kDimensions);
     const auto results = vectorIndex->search({
@@ -799,7 +795,7 @@ TEST_F(VectorIndexTest, writerRoundTripWithMultipleIndexes) {
 
   EXPECT_FALSE(vectorIndexDirectory.contains("missing"));
   NIMBLE_ASSERT_THROW(
-      vectorIndexDirectory.load("missing", *metadataInput),
+      vectorIndexDirectory.load("missing"),
       "Vector index column does not exist");
 }
 
@@ -1226,6 +1222,26 @@ TEST_F(VectorIndexTest, dimensionMismatchOnSearch) {
 TEST_F(VectorIndexTest, emptyDirectoryRejected) {
   NIMBLE_ASSERT_THROW(
       readDirectory({}), "Vector index directory must not be empty");
+}
+
+TEST_F(VectorIndexTest, missingIoStatsDeferredUntilLoad) {
+  constexpr uint32_t kNumVectors{100};
+  const auto written = writeIndex(
+      makeConfig(VectorIndexType::kIvfFlat),
+      {makeInputFromVectors(
+          generateRandomVectors(kNumVectors, kDimensions), kDimensions)});
+  auto directoryBuffer = MetadataBuffer::decompress(
+      written.directoryData, CompressionType::Uncompressed, pool());
+  velox::io::ReaderOptions ioOptions(pool());
+  IndexLookup::Options indexOptions{
+      .file = std::make_shared<velox::InMemoryReadFile>(written.indexData),
+      .ioOptions = &ioOptions,
+  };
+
+  const auto directory = VectorIndexDirectory::create(
+      Section{MetadataBuffer{std::move(directoryBuffer)}}, indexOptions);
+  EXPECT_TRUE(directory.contains("embedding"));
+  NIMBLE_ASSERT_THROW(directory.load("embedding"), "indexIoStats must be set");
 }
 
 TEST_F(VectorIndexTest, invalidDirectoryLimitsRejected) {

--- a/velox/dwio/nimble/tablet/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/CMakeLists.txt
@@ -214,6 +214,7 @@ target_link_libraries(
   PUBLIC
     nimble_encodings
     nimble_index
+    nimble_vector_index
     nimble_tablet_common
     nimble_cluster_index_fb
     nimble_chunk_stats_fb

--- a/velox/dwio/nimble/tablet/TabletReader.cpp
+++ b/velox/dwio/nimble/tablet/TabletReader.cpp
@@ -21,6 +21,7 @@
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/index/ClusterIndexFactory.h"
 #include "velox/dwio/nimble/index/IndexSerialization.h"
+#include "velox/dwio/nimble/index/VectorIndex.h"
 #include "velox/dwio/nimble/tablet/ChunkStatsGenerated.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/tablet/FooterGenerated.h"
@@ -254,6 +255,11 @@ TabletReader::TabletReader(
             return loadStripeGroup(stripeGroupIndex);
           },
           options.pinMetadata},
+      vectorIndexCache_{
+          [this](const std::string& columnName) {
+            return loadVectorIndex(columnName);
+          },
+          /*pinEntries=*/true},
       chunkStatsCache_{
           [this](uint32_t stripeGroupIndex) {
             return loadChunkStatsGroup(stripeGroupIndex);
@@ -341,6 +347,7 @@ void TabletReader::init(const Options& options) {
   initClusterIndex();
   initChunkStats(footerView, footerOffset);
   initDenseIndexes();
+  initVectorIndexes();
 
   cacheMetadata(footerView, footerOffset);
 }
@@ -468,6 +475,7 @@ bool TabletReader::initFromCache(const Options& options) {
   initClusterIndex();
   initChunkStats();
   initDenseIndexes();
+  initVectorIndexes();
   return true;
 }
 
@@ -775,7 +783,7 @@ void TabletReader::initSharedDictionaries(const Options& options) {
 std::vector<std::string> TabletReader::preloadSectionNames(
     const Options& options) const {
   std::vector<std::string> names;
-  names.reserve(options.preloadOptionalSections.size() + 3);
+  names.reserve(options.preloadOptionalSections.size() + 4);
   auto addName = [&names](std::string name) {
     if (std::find(names.begin(), names.end(), name) == names.end()) {
       names.emplace_back(std::move(name));
@@ -789,6 +797,7 @@ std::vector<std::string> TabletReader::preloadSectionNames(
   }
   addName(std::string{kPropertiesSection});
   addName(std::string{kDictionarySection});
+  addName(std::string{kVectorIndexSection});
   return names;
 }
 
@@ -1262,6 +1271,39 @@ const index::IndexLookup* TabletReader::denseIndex(
     return nullptr;
   }
   return denseIndexRegistry_->findIndex(name, columns);
+}
+
+void TabletReader::initVectorIndexes() {
+  auto section = loadOptionalSection(std::string{kVectorIndexSection});
+  if (!section.has_value()) {
+    return;
+  }
+  NIMBLE_CHECK_NULL(
+      vectorIndexDirectory_, "Vector indexes already initialized");
+  vectorIndexDirectory_ = std::make_unique<index::VectorIndexDirectory>(
+      index::VectorIndexDirectory::create(
+          std::move(section.value()), indexOptions_));
+}
+
+bool TabletReader::hasVectorIndex(std::string_view columnName) const {
+  return vectorIndexDirectory_ != nullptr &&
+      vectorIndexDirectory_->contains(columnName);
+}
+
+std::shared_ptr<const index::VectorIndex> TabletReader::vectorIndex(
+    std::string_view columnName) const {
+  if (vectorIndexDirectory_ == nullptr ||
+      !vectorIndexDirectory_->contains(columnName)) {
+    return nullptr;
+  }
+
+  return vectorIndexCache_.getOrCreate(std::string{columnName});
+}
+
+std::shared_ptr<const index::VectorIndex> TabletReader::loadVectorIndex(
+    const std::string& columnName) const {
+  NIMBLE_CHECK_NOT_NULL(vectorIndexDirectory_);
+  return vectorIndexDirectory_->load(columnName);
 }
 
 void TabletReader::initDenseIndexes() {

--- a/velox/dwio/nimble/tablet/TabletReader.h
+++ b/velox/dwio/nimble/tablet/TabletReader.h
@@ -68,6 +68,11 @@ class SharedDictionaryReaderFactory;
 class SharedDictionaryAlphabet;
 class ExternalDictionaryResolver;
 
+namespace index {
+class VectorIndex;
+class VectorIndexDirectory;
+} // namespace index
+
 /// Nimble-specific reader options carried through Velox common ReaderOptions.
 class NimbleReaderOptions : public velox::dwio::common::FormatSpecificOptions {
  public:
@@ -296,6 +301,14 @@ class TabletReader {
   const index::IndexLookup* denseIndex(
       std::string_view name,
       const std::vector<std::string>& columns) const;
+
+  /// Returns whether the file contains a vector index for the column.
+  bool hasVectorIndex(std::string_view columnName) const;
+
+  /// Loads the immutable vector index on first use and reuses it thereafter.
+  /// Returns nullptr if the column has no vector index.
+  std::shared_ptr<const index::VectorIndex> vectorIndex(
+      std::string_view columnName) const;
 
   uint64_t fileSize() const {
     return fileSize_;
@@ -559,6 +572,13 @@ class TabletReader {
 
   void initDenseIndexes();
 
+  // Parses vector index descriptors and configures their index data input.
+  void initVectorIndexes();
+
+  // Loads one vector index for insertion into the metadata cache.
+  std::shared_ptr<const index::VectorIndex> loadVectorIndex(
+      const std::string& columnName) const;
+
   // Loads chunk stats and preloads the first group from footerBuf
   // when available.
   void initChunkStats(
@@ -618,6 +638,12 @@ class TabletReader {
   FileProperties properties_{false, false, {}};
 
   std::unique_ptr<index::DenseIndexRegistry> denseIndexRegistry_;
+
+  // Describes available indexes without materializing their FAISS data.
+  std::unique_ptr<index::VectorIndexDirectory> vectorIndexDirectory_;
+  // Keeps immutable indexes strongly cached for the reader lifetime.
+  mutable MetadataCache<std::string, const index::VectorIndex>
+      vectorIndexCache_;
 
   // Chunk stats root, loaded from the "columnar.chunk.stats" optional section.
   std::unique_ptr<ChunkStats> chunkStats_;

--- a/velox/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -29,11 +29,15 @@ target_link_libraries(
   nimble_tablet_reader
   nimble_tablet_writer
   nimble_index
+  nimble_vector_index
   nimble_index_test_utils
   nimble_common
+  nimble_writer
   velox_dwio_common
   velox_memory
   velox_file
+  velox_vector
+  gmock
   gtest
   gtest_main
   glog::glog

--- a/velox/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/velox/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <fmt/format.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
@@ -40,6 +41,7 @@
 #include "velox/dwio/nimble/index/HashIndexConfig.h"
 #include "velox/dwio/nimble/index/IndexLookup.h"
 #include "velox/dwio/nimble/index/SortedIndexConfig.h"
+#include "velox/dwio/nimble/index/VectorIndex.h"
 #include "velox/dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "velox/dwio/nimble/tablet/Compression.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
@@ -1049,6 +1051,146 @@ TEST_P(TabletTest, hasOptionalSectionEmpty) {
   EXPECT_FALSE(tablet->hasOptionalSection("section1"));
   EXPECT_FALSE(tablet->hasOptionalSection(""));
   EXPECT_FALSE(tablet->hasOptionalSection("any_name"));
+}
+
+TEST_P(TabletTest, vectorIndex) {
+  constexpr velox::vector_size_t kNumVectors{4};
+  constexpr velox::vector_size_t kDimensions{2};
+  constexpr std::array<float, kNumVectors * kDimensions> kValues{
+      0.0,
+      0.0,
+      1.0,
+      1.0,
+      2.0,
+      2.0,
+      3.0,
+      3.0,
+  };
+
+  auto elements =
+      velox::BaseVector::create(velox::REAL(), kValues.size(), pool_.get());
+  auto* flatElements = elements->asFlatVector<float>();
+  for (velox::vector_size_t i = 0; i < kValues.size(); ++i) {
+    flatElements->set(i, kValues[i]);
+  }
+  auto embeddings = std::make_shared<velox::ArrayVector>(
+      pool_.get(),
+      velox::ARRAY(velox::REAL()),
+      nullptr,
+      kNumVectors,
+      velox::allocateOffsets(kNumVectors, pool_.get()),
+      velox::allocateSizes(kNumVectors, pool_.get()),
+      elements);
+  auto* offsets = embeddings->mutableOffsets(kNumVectors)
+                      ->asMutable<velox::vector_size_t>();
+  auto* sizes =
+      embeddings->mutableSizes(kNumVectors)->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t i = 0; i < kNumVectors; ++i) {
+    offsets[i] = i * kDimensions;
+    sizes[i] = kDimensions;
+  }
+  const auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      velox::ROW({{"embedding", velox::ARRAY(velox::REAL())}}),
+      nullptr,
+      kNumVectors,
+      std::vector<velox::VectorPtr>{std::move(embeddings)});
+
+  for (const bool withVectorIndex : {false, true}) {
+    SCOPED_TRACE(fmt::format("withVectorIndex={}", withVectorIndex));
+    nimble::WriterOptions writerOptions;
+    if (withVectorIndex) {
+      writerOptions.vectorIndexConfigs.push_back(
+          nimble::VectorIndexConfig{
+              .columnName = "embedding",
+              .dimensions = kDimensions,
+              .metric = nimble::VectorDistanceMetric::kL2,
+              .indexType = nimble::VectorIndexType::kIvfFlat,
+              .numPartitions = 1,
+          });
+    }
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::Writer writer(
+        input->type(), std::move(writeFile), *pool_, std::move(writerOptions));
+    writer.write(input);
+    writer.close();
+
+    const auto tablet = createTabletReader(file);
+    EXPECT_EQ(tablet->hasVectorIndex("embedding"), withVectorIndex);
+    const auto indexBytesBeforeLoad = indexIoStats_->rawBytesRead();
+    const auto indexReadsBeforeLoad = indexIoStats_->read().count();
+    uint64_t numCacheEntriesBeforeLoad{0};
+    uint64_t numCacheInsertionsBeforeLoad{0};
+    if (expectHasCache()) {
+      const auto cacheStats = cache_->refreshStats();
+      numCacheEntriesBeforeLoad = cacheStats.numEntries;
+      numCacheInsertionsBeforeLoad = cacheStats.numNew;
+    }
+
+    const auto vectorIndex = tablet->vectorIndex("embedding");
+    if (!withVectorIndex) {
+      EXPECT_EQ(vectorIndex, nullptr);
+      EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesBeforeLoad);
+      EXPECT_EQ(indexIoStats_->read().count(), indexReadsBeforeLoad);
+      continue;
+    }
+
+    ASSERT_NE(vectorIndex, nullptr);
+    EXPECT_GT(indexIoStats_->rawBytesRead(), indexBytesBeforeLoad);
+    EXPECT_GT(indexIoStats_->read().count(), indexReadsBeforeLoad);
+    EXPECT_EQ(vectorIndex->columnName(), "embedding");
+    EXPECT_EQ(vectorIndex->dimensions(), kDimensions);
+    EXPECT_EQ(vectorIndex->numVectors(), kNumVectors);
+    const auto indexBytesAfterLoad = indexIoStats_->rawBytesRead();
+    const auto indexReadsAfterLoad = indexIoStats_->read().count();
+    EXPECT_EQ(tablet->vectorIndex("embedding"), vectorIndex);
+    EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesAfterLoad);
+    EXPECT_EQ(indexIoStats_->read().count(), indexReadsAfterLoad);
+    const auto results = vectorIndex->search({
+        .queryVector = {2.0, 2.0},
+        .numNeighbors = 1,
+        .numProbes = 1,
+    });
+    EXPECT_THAT(
+        results,
+        testing::ElementsAre(
+            testing::Field(
+                &nimble::index::VectorIndex::SearchResult::rowId, 2)));
+    EXPECT_FALSE(tablet->hasVectorIndex("missing"));
+    EXPECT_EQ(tablet->vectorIndex("missing"), nullptr);
+    EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesAfterLoad);
+    EXPECT_EQ(indexIoStats_->read().count(), indexReadsAfterLoad);
+
+    if (expectHasCache()) {
+      const auto coldCacheStats = cache_->refreshStats();
+      EXPECT_GT(coldCacheStats.numEntries, numCacheEntriesBeforeLoad);
+      EXPECT_GT(coldCacheStats.numNew, numCacheInsertionsBeforeLoad);
+
+      dataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+      metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+      indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+      readerOptions_.reset();
+
+      const auto warmTablet = createTabletReader(file);
+      const auto warmCacheStatsBeforeLoad = cache_->refreshStats();
+      const auto warmIndexBytesBeforeLoad = indexIoStats_->rawBytesRead();
+      const auto warmIndexReadsBeforeLoad = indexIoStats_->read().count();
+      const auto warmVectorIndex = warmTablet->vectorIndex("embedding");
+
+      ASSERT_NE(warmVectorIndex, nullptr);
+      EXPECT_EQ(warmVectorIndex->numVectors(), kNumVectors);
+      EXPECT_EQ(indexIoStats_->rawBytesRead(), warmIndexBytesBeforeLoad);
+      EXPECT_EQ(indexIoStats_->read().count(), warmIndexReadsBeforeLoad);
+      EXPECT_GT(indexIoStats_->ramHit().count(), 0);
+
+      const auto warmCacheStats = cache_->refreshStats();
+      EXPECT_EQ(warmCacheStats.numEntries, warmCacheStatsBeforeLoad.numEntries);
+      EXPECT_EQ(warmCacheStats.numNew, warmCacheStatsBeforeLoad.numNew);
+      EXPECT_GT(warmCacheStats.numHit, warmCacheStatsBeforeLoad.numHit);
+    }
+  }
 }
 
 TEST_P(TabletTest, optionalSectionsPreload) {


### PR DESCRIPTION
Summary:

Callers can now ask a `TabletReader` whether a column has a vector index and load it directly. Repeated requests for `embedding` return the same immutable index instead of reading and deserializing its FAISS data again.

The reader parses the vector-index directory on first use and keeps loaded indexes in a synchronized cache. Index payload reads use the configured index I/O path and statistics.

Reviewed By: duxiao1212

Differential Revision: D119124584


