### PR TITLE
refactor(nimble): Reuse sorted-input statistics (#18896)

### DIFF
--- a/velox/dwio/nimble/encodings/EliasFanoEncoding.h
+++ b/velox/dwio/nimble/encodings/EliasFanoEncoding.h
@@ -100,9 +100,12 @@ class EliasFanoEncoding final
       Buffer& buffer,
       const Encoding::Options& options = {});
 
-  /// Estimates encoded bytes or returns nullopt for unsupported input.
+  /// Estimates encoded size, or returns nullopt for empty, unsorted, or
+  /// oversized input. Requires 'statistics' derived from 'values'.
   static std::optional<uint64_t> estimateSize(
-      std::span<const physicalType> values);
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {});
 
   /// Returns a human-readable description of the encoded layout.
   std::string debugString(int offset) const final;
@@ -112,8 +115,19 @@ class EliasFanoEncoding final
       std::is_integral_v<T> && !std::is_same_v<T, bool>,
       "EliasFanoEncoding only supports non-bool integer types.");
 
-  using Encoder =
-      folly::compression::EliasFanoEncoder<uint64_t, uint64_t, 128, 256>;
+  // The wire layout is [prefix][base][lower bit count][upper byte count]
+  // [alignment padding][skip pointers][forward pointers][lower bits]
+  // [upper bits][trailing padding]. The constants below define this layout and
+  // must remain stable unless the Nimble wire format is versioned.
+  static constexpr size_t kSkipQuantum{128};
+  static constexpr size_t kForwardQuantum{256};
+  static constexpr bool kUpperFirst{false};
+  using Encoder = folly::compression::EliasFanoEncoder<
+      uint64_t,
+      uint64_t,
+      kSkipQuantum,
+      kForwardQuantum,
+      kUpperFirst>;
   using Reader = folly::compression::EliasFanoReader<Encoder>;
 
   // Number of bytes between the common prefix and the Folly payload.
@@ -123,7 +137,8 @@ class EliasFanoEncoding final
 
   // Makes Folly's word-at-a-time payload reads safe at the end of the stream.
   static constexpr size_t kPayloadPaddingBytes{
-      folly::compression::kUpperTrailingBytes};
+      kUpperFirst ? folly::compression::kLowerTrailingBytes
+                  : folly::compression::kUpperTrailingBytes};
 
   // Aligns Folly's uint64 pointer tables while encoding into the arena.
   static constexpr size_t kPayloadAlignment{alignof(uint64_t)};
@@ -158,10 +173,19 @@ class EliasFanoEncoding final
     }
   }
 
-  // Validates monotonicity and derives the Folly payload layout.
-  static std::optional<Encoder::Layout> layoutForValues(
+  // Holds the normalized base and the corresponding Folly payload layout.
+  struct ValueLayout {
+    // Absolute value represented by relative value zero in the payload.
+    uint64_t base{0};
+
+    // Describes the byte layout of the base-relative values.
+    Encoder::Layout payload;
+  };
+
+  // Returns the normalized base and payload layout for valid input.
+  static std::optional<ValueLayout> layoutForValues(
       std::span<const physicalType> values,
-      uint64_t& base);
+      const Statistics<physicalType>& statistics);
 
   // Returns the format-defined payload offset for the selected prefix size.
   static constexpr size_t payloadOffset(uint32_t prefixSize) {
@@ -225,6 +249,25 @@ class EliasFanoEncoding final
   // Next logical row consumed by the stateful Encoding interface.
   uint32_t row_{0};
 };
+
+namespace detail::elias_fano {
+
+// Returns nullopt so encoding selection can skip oversized streams. encode()
+// turns nullopt into an exception if the selected encoding exceeds the limit.
+constexpr std::optional<uint32_t> trySerializedSize(
+    uint64_t payloadOffset,
+    uint64_t payloadBytes,
+    uint64_t paddingBytes) noexcept {
+  constexpr uint64_t kMaxSerializedSize{std::numeric_limits<uint32_t>::max()};
+  if (payloadOffset > kMaxSerializedSize ||
+      paddingBytes > kMaxSerializedSize - payloadOffset ||
+      payloadBytes > kMaxSerializedSize - payloadOffset - paddingBytes) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(payloadOffset + payloadBytes + paddingBytes);
+}
+
+} // namespace detail::elias_fano
 
 template <typename T>
 EliasFanoEncoding<T>::EliasFanoEncoding(
@@ -420,41 +463,40 @@ void EliasFanoEncoding<T>::readWithVisitor(
 }
 
 template <typename T>
-std::optional<typename EliasFanoEncoding<T>::Encoder::Layout> EliasFanoEncoding<
-    T>::layoutForValues(std::span<const physicalType> values, uint64_t& base) {
-  if (values.empty()) {
+std::optional<typename EliasFanoEncoding<T>::ValueLayout>
+EliasFanoEncoding<T>::layoutForValues(
+    std::span<const physicalType> values,
+    const Statistics<physicalType>& statistics) {
+  if (values.empty() || !statistics.template isNonDecreasing<T>()) {
     return std::nullopt;
   }
 
-  base = toOrdered(values.front());
-  uint64_t previous = base;
-  for (size_t i = 1; i < values.size(); ++i) {
-    const auto current = toOrdered(values[i]);
-    if (current < previous) {
-      return std::nullopt;
-    }
-    previous = current;
-  }
-  return Encoder::Layout::fromUpperBoundAndSize(previous - base, values.size());
+  const auto base = toOrdered(values.front());
+  return ValueLayout{
+      .base = base,
+      .payload = Encoder::Layout::fromUpperBoundAndSize(
+          toOrdered(values.back()) - base, values.size()),
+  };
 }
 
 template <typename T>
 std::optional<uint64_t> EliasFanoEncoding<T>::estimateSize(
-    std::span<const physicalType> values) {
+    std::span<const physicalType> values,
+    const Statistics<physicalType>& statistics,
+    const Encoding::Options& options) {
   if (values.size() > std::numeric_limits<uint32_t>::max()) {
     return std::nullopt;
   }
-  uint64_t base;
-  const auto layout = layoutForValues(values, base);
+  const auto layout = layoutForValues(values, statistics);
   if (!layout.has_value()) {
     return std::nullopt;
   }
   const auto rowCount = static_cast<uint32_t>(values.size());
-  const auto maxPayloadOffset = std::max(
-      payloadOffset(EncodingPrefix::kFixedPrefixSize),
-      payloadOffset(
-          EncodingPrefix::serializedSize(rowCount, /*useVarint=*/true)));
-  return maxPayloadOffset + layout->bytes() + kPayloadPaddingBytes;
+  const auto prefixSize =
+      EncodingPrefix::serializedSize(rowCount, options.useVarintRowCount);
+  const auto encodingSize = detail::elias_fano::trySerializedSize(
+      payloadOffset(prefixSize), layout->payload.bytes(), kPayloadPaddingBytes);
+  return encodingSize;
 }
 
 template <typename T>
@@ -470,20 +512,18 @@ std::string_view EliasFanoEncoding<T>::encode(
   const auto prefixSize =
       Encoding::serializePrefixSize(rowCount, options.useVarintRowCount);
   const auto encodedPayloadOffset = payloadOffset(prefixSize);
-  const uint64_t encodingSize =
-      encodedPayloadOffset + payloadBytes + kPayloadPaddingBytes;
-  NIMBLE_CHECK_LE(
-      encodingSize,
-      std::numeric_limits<uint32_t>::max(),
-      "EliasFano encoding exceeds uint32 size.");
+  const auto encodingSize = detail::elias_fano::trySerializedSize(
+      encodedPayloadOffset, payloadBytes, kPayloadPaddingBytes);
+  NIMBLE_CHECK(
+      encodingSize.has_value(), "EliasFano encoding exceeds uint32 size.");
 
-  const auto allocationSize = encodingSize + kPayloadAlignment - 1;
+  const auto allocationSize = *encodingSize + kPayloadAlignment - 1;
   void* reserved = buffer.reserve(allocationSize);
   auto availableBytes = static_cast<size_t>(allocationSize);
   NIMBLE_CHECK_NOT_NULL(
       std::align(
           kPayloadAlignment,
-          static_cast<size_t>(encodingSize),
+          static_cast<size_t>(*encodingSize),
           reserved,
           availableBytes));
   auto* const encodedBegin = static_cast<char*>(reserved);
@@ -517,13 +557,13 @@ std::string_view EliasFanoEncoding<T>::encode(
   std::memset(position, 0, kPayloadPaddingBytes);
   position += kPayloadPaddingBytes;
   NIMBLE_CHECK_EQ(
-      position - encodedBegin, encodingSize, "Encoding size mismatch.");
-  return {encodedBegin, static_cast<size_t>(encodingSize)};
+      position - encodedBegin, *encodingSize, "Encoding size mismatch.");
+  return {encodedBegin, static_cast<size_t>(*encodingSize)};
 }
 
 template <typename T>
 std::string_view EliasFanoEncoding<T>::encode(
-    EncodingSelection<physicalType>& /*selection*/,
+    EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
     Buffer& buffer,
     const Encoding::Options& options) {
@@ -531,8 +571,7 @@ std::string_view EliasFanoEncoding<T>::encode(
       values.size(),
       std::numeric_limits<uint32_t>::max(),
       "EliasFano row count exceeds uint32.");
-  uint64_t base;
-  const auto layout = layoutForValues(values, base);
+  const auto layout = layoutForValues(values, selection.statistics());
   if (!layout.has_value()) {
     NIMBLE_INCOMPATIBLE_ENCODING(
         "EliasFano requires non-empty non-decreasing values.");
@@ -540,9 +579,9 @@ std::string_view EliasFanoEncoding<T>::encode(
 
   return encode(
       static_cast<uint32_t>(values.size()),
-      base,
-      *layout,
-      [&](uint32_t row) { return toOrdered(values[row]) - base; },
+      layout->base,
+      layout->payload,
+      [&](uint32_t row) { return toOrdered(values[row]) - layout->base; },
       buffer,
       options);
 }

--- a/velox/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/velox/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -186,7 +186,8 @@ struct EncodingSizeEstimation {
       }
       case EncodingType::EliasFano: {
         if constexpr (isIntegralType<T>()) {
-          return EliasFanoEncoding<T>::estimateSize(values);
+          return EliasFanoEncoding<T>::estimateSize(
+              values, statistics, options);
         } else {
           return std::nullopt;
         }

--- a/velox/dwio/nimble/encodings/selection/Statistics.cpp
+++ b/velox/dwio/nimble/encodings/selection/Statistics.cpp
@@ -208,6 +208,25 @@ void Statistics<T, InputType>::populateMinMax() const {
 }
 
 template <typename T, typename InputType>
+void Statistics<T, InputType>::populatePhysicalOrderNonDecreasing()
+    const noexcept {
+  physicalOrderNonDecreasing_ = std::is_sorted(data_.begin(), data_.end());
+}
+
+template <typename T, typename InputType>
+void Statistics<T, InputType>::populateSignedOrderNonDecreasing()
+    const noexcept {
+  using UnsignedInputType = std::make_unsigned_t<InputType>;
+  constexpr auto signMask = UnsignedInputType{1}
+      << (std::numeric_limits<UnsignedInputType>::digits - 1);
+  signedOrderNonDecreasing_ = std::is_sorted(
+      data_.begin(), data_.end(), [](const auto lhs, const auto rhs) {
+        return (static_cast<UnsignedInputType>(lhs) ^ signMask) <
+            (static_cast<UnsignedInputType>(rhs) ^ signMask);
+      });
+}
+
+template <typename T, typename InputType>
 void Statistics<T, InputType>::populateUniques() const {
   MapType<T, InputType> uniqueCounts;
   if constexpr (nimble::isBoolType<T>()) {
@@ -329,6 +348,8 @@ Statistics<T, InputType> Statistics<T, InputType>::create(
     statistics.totalStringsRepeatLength_ = 0;
     statistics.min_ = T();
     statistics.max_ = T();
+    statistics.physicalOrderNonDecreasing_ = true;
+    statistics.signedOrderNonDecreasing_ = true;
 
     statistics.bucketCounts_ = {};
     statistics.uniqueCounts_ = std::make_optional(
@@ -412,6 +433,35 @@ template void Statistics<float>::populateMinMax() const;
 template void Statistics<double>::populateMinMax() const;
 template void Statistics<std::string_view>::populateMinMax() const;
 template void Statistics<std::string_view, std::string>::populateMinMax() const;
+
+// populatePhysicalOrderNonDecreasing works on integral types only.
+template void Statistics<int8_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+template void Statistics<uint8_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+template void Statistics<int16_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+template void Statistics<uint16_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+template void Statistics<int32_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+template void Statistics<uint32_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+template void Statistics<int64_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+template void Statistics<uint64_t>::populatePhysicalOrderNonDecreasing()
+    const noexcept;
+
+// populateSignedOrderNonDecreasing is used when signed logical values are
+// represented by unsigned physical values.
+template void Statistics<uint8_t>::populateSignedOrderNonDecreasing()
+    const noexcept;
+template void Statistics<uint16_t>::populateSignedOrderNonDecreasing()
+    const noexcept;
+template void Statistics<uint32_t>::populateSignedOrderNonDecreasing()
+    const noexcept;
+template void Statistics<uint64_t>::populateSignedOrderNonDecreasing()
+    const noexcept;
 
 // populateMinMaxBlocks is used through the estimation path where T is always
 // the unsigned physicalType.

--- a/velox/dwio/nimble/encodings/selection/Statistics.h
+++ b/velox/dwio/nimble/encodings/selection/Statistics.h
@@ -179,6 +179,30 @@ class Statistics {
     return max_.value();
   }
 
+  /// Returns whether integral input values are non-decreasing when interpreted
+  /// as LogicalType. LogicalType must be explicit because signed values use
+  /// unsigned physical storage.
+  template <typename LogicalType>
+  bool isNonDecreasing() const noexcept {
+    static_assert(nimble::isIntegralType<LogicalType>());
+    static_assert(nimble::isIntegralType<InputType>());
+    static_assert(sizeof(LogicalType) == sizeof(InputType));
+    if constexpr (
+        std::is_signed_v<LogicalType> == std::is_signed_v<InputType>) {
+      if (!physicalOrderNonDecreasing_.has_value()) {
+        populatePhysicalOrderNonDecreasing();
+      }
+      return physicalOrderNonDecreasing_.value();
+    } else {
+      static_assert(
+          std::is_signed_v<LogicalType> && std::is_unsigned_v<InputType>);
+      if (!signedOrderNonDecreasing_.has_value()) {
+        populateSignedOrderNonDecreasing();
+      }
+      return signedOrderNonDecreasing_.value();
+    }
+  }
+
   const std::vector<uint64_t>& bucketCounts() const noexcept {
     static_assert(nimble::isIntegralType<T>());
     if (!bucketCounts_.has_value()) {
@@ -246,6 +270,11 @@ class Statistics {
   void populateMinMax() const;
   void populateBucketCounts() const;
   void populateMinMaxBlocks(uint16_t blockSize) const;
+  // Checks the order of the physical input values.
+  void populatePhysicalOrderNonDecreasing() const noexcept;
+
+  // Checks signed logical order over unsigned physical input values.
+  void populateSignedOrderNonDecreasing() const noexcept;
   void populateStringLength() const;
 
   mutable std::optional<uint64_t> consecutiveRepeatCount_;
@@ -255,6 +284,12 @@ class Statistics {
   mutable std::optional<uint64_t> totalStringsRepeatLength_;
   mutable std::optional<T> min_;
   mutable std::optional<T> max_;
+
+  // Caches the physical input order independently from signed logical order.
+  mutable std::optional<bool> physicalOrderNonDecreasing_;
+
+  // Caches signed logical order for unsigned physical input.
+  mutable std::optional<bool> signedOrderNonDecreasing_;
   mutable std::optional<std::vector<uint64_t>> bucketCounts_;
   mutable std::optional<std::vector<BlockStats>> minMaxBlocks_;
   mutable uint16_t minMaxBlockSize_{0};

--- a/velox/dwio/nimble/encodings/tests/EliasFanoEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EliasFanoEncodingTest.cpp
@@ -239,16 +239,96 @@ TEST_F(EliasFanoEncodingTest, factoryRoundTrip) {
   EXPECT_NE(encoding->debugString(0).find("lowerBits="), std::string::npos);
 }
 
-TEST_F(EliasFanoEncodingTest, estimateRejectsEmptyAndUnsortedValues) {
+TEST_F(EliasFanoEncodingTest, factoryRoundTripSignedLogicalOrder) {
+  const std::vector<int64_t> input{
+      std::numeric_limits<int64_t>::min(),
+      -7,
+      -7,
+      0,
+      9,
+      std::numeric_limits<int64_t>::max()};
+  auto values = toVector(input);
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<int64_t>>(
+          std::vector<std::pair<nimble::EncodingType, float>>{
+              {nimble::EncodingType::EliasFano, 1.0}},
+          std::nullopt,
+          std::nullopt);
+  const auto encoded = nimble::EncodingFactory::encode<int64_t>(
+      std::move(policy), values, *buffer_);
+  auto encoding = nimble::EncodingFactory{}.create(
+      *pool_, encoded, /*stringBufferFactory=*/nullptr);
+  std::vector<int64_t> output(input.size());
+  encoding->materialize(static_cast<uint32_t>(input.size()), output.data());
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::EliasFano);
+  EXPECT_EQ(output, input);
+}
+
+TEST_F(EliasFanoEncodingTest, estimateMatchesEncodedSize) {
+  for (const uint32_t rowCount : {1, 127, 128, 255, 256, 257}) {
+    std::vector<uint64_t> input(rowCount);
+    for (uint32_t row{0}; row < rowCount; ++row) {
+      input[row] = row / 2;
+    }
+    const auto values = toVector(input);
+    const auto physicalValues =
+        std::span<const uint64_t>{values.data(), values.size()};
+    const auto statistics =
+        nimble::Statistics<uint64_t>::create(physicalValues);
+    for (const bool useVarintRowCount : {false, true}) {
+      SCOPED_TRACE(
+          ::testing::Message() << "rowCount=" << rowCount
+                               << ", useVarintRowCount=" << useVarintRowCount);
+      const nimble::Encoding::Options options{
+          .useVarintRowCount = useVarintRowCount};
+      const auto estimate = nimble::EliasFanoEncoding<uint64_t>::estimateSize(
+          physicalValues, statistics, options);
+      ASSERT_TRUE(estimate.has_value());
+      buffer_->reset();
+      const auto encoded =
+          nimble::test::Encoder<nimble::EliasFanoEncoding<uint64_t>>::encode(
+              *buffer_, values, nimble::CompressionType::Uncompressed, options);
+      EXPECT_EQ(*estimate, encoded.size());
+    }
+  }
+}
+
+TEST_F(EliasFanoEncodingTest, rejectsSerializedSizeAboveUint32) {
+  constexpr uint64_t kPayloadOffset{24};
+  constexpr uint64_t kPaddingSize{7};
+  constexpr uint64_t kMaxPayloadSize{
+      std::numeric_limits<uint32_t>::max() - kPayloadOffset - kPaddingSize};
+
   EXPECT_EQ(
-      nimble::EliasFanoEncoding<uint64_t>::estimateSize({}), std::nullopt);
+      nimble::detail::elias_fano::trySerializedSize(
+          kPayloadOffset, kMaxPayloadSize, kPaddingSize),
+      std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(
+      nimble::detail::elias_fano::trySerializedSize(
+          kPayloadOffset, kMaxPayloadSize + 1, kPaddingSize),
+      std::nullopt);
+  EXPECT_EQ(
+      nimble::detail::elias_fano::trySerializedSize(
+          kPayloadOffset, std::numeric_limits<uint64_t>::max(), kPaddingSize),
+      std::nullopt);
+}
+
+TEST_F(EliasFanoEncodingTest, estimateRejectsEmptyAndUnsortedValues) {
+  const auto emptyStatistics =
+      nimble::Statistics<uint64_t>::create(std::span<const uint64_t>{});
+  EXPECT_EQ(
+      nimble::EliasFanoEncoding<uint64_t>::estimateSize({}, emptyStatistics),
+      std::nullopt);
 
   const std::vector<uint32_t> input{1, 5, 4, 8};
   const auto values = toVector(input);
   const auto physicalValues = std::span<const uint32_t>{
       reinterpret_cast<const uint32_t*>(values.data()), values.size()};
+  const auto statistics = nimble::Statistics<uint32_t>::create(physicalValues);
   EXPECT_EQ(
-      nimble::EliasFanoEncoding<uint32_t>::estimateSize(physicalValues),
+      nimble::EliasFanoEncoding<uint32_t>::estimateSize(
+          physicalValues, statistics),
       std::nullopt);
 }
 
@@ -317,10 +397,10 @@ TEST_F(EliasFanoEncodingTest, rejectsMissingUpperBits) {
       "Invalid EliasFano upper bits.");
 }
 
-TEST_F(EliasFanoEncodingTest, alignsFollyPointerTables) {
-  std::vector<uint64_t> input(300);
+TEST_F(EliasFanoEncodingTest, alignsAndReadsFollyPointerTables) {
+  std::vector<uint64_t> input(600);
   for (size_t i{0}; i < input.size(); ++i) {
-    input[i] = i;
+    input[i] = i / 2;
   }
   for (const bool useVarint : {false, true}) {
     SCOPED_TRACE(::testing::Message() << "useVarint=" << useVarint);
@@ -349,6 +429,21 @@ TEST_F(EliasFanoEncodingTest, alignsFollyPointerTables) {
     for (size_t offset{headerEndOffset}; offset < payloadOffset; ++offset) {
       SCOPED_TRACE(::testing::Message() << "offset=" << offset);
       EXPECT_EQ(encoded[offset], 0);
+    }
+
+    auto encoding = nimble::EncodingFactory{}.create(
+        *pool_, encoded, /*stringBufferFactory=*/nullptr, options);
+    std::vector<uint64_t> output(input.size());
+    encoding->materialize(static_cast<uint32_t>(input.size()), output.data());
+    EXPECT_EQ(output, input);
+
+    const auto* eliasFano =
+        dynamic_cast<const nimble::EliasFanoEncoding<uint64_t>*>(
+            encoding.get());
+    ASSERT_NE(eliasFano, nullptr);
+    for (const uint32_t row : {127, 128, 255, 256, 511, 512}) {
+      EXPECT_EQ(eliasFano->valueAt(row), input[row]);
+      EXPECT_EQ(eliasFano->lowerBound(input[row]), row - row % 2);
     }
   }
 }

--- a/velox/dwio/nimble/encodings/tests/StatisticsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/StatisticsTest.cpp
@@ -62,6 +62,63 @@ class StatisticsBoolTests : public ::testing::Test {};
 template <typename C>
 class StatisticsStringTests : public ::testing::Test {};
 
+TYPED_TEST(StatisticsIntegerTests, isNonDecreasing) {
+  using ValueType = typename TypeParam::valueType;
+
+  const std::vector<ValueType> sorted{
+      static_cast<ValueType>(1),
+      static_cast<ValueType>(1),
+      static_cast<ValueType>(3),
+  };
+  const std::vector<ValueType> unsorted{
+      static_cast<ValueType>(1),
+      static_cast<ValueType>(3),
+      static_cast<ValueType>(2),
+  };
+
+  EXPECT_TRUE(TypeParam::create(sorted).template isNonDecreasing<ValueType>());
+  EXPECT_FALSE(
+      TypeParam::create(unsorted).template isNonDecreasing<ValueType>());
+  EXPECT_TRUE(
+      TypeParam::create(std::span<const ValueType>{})
+          .template isNonDecreasing<ValueType>());
+}
+
+template <typename SignedType>
+void testNaturalAndSignedOrderCachesAreIndependent() {
+  using UnsignedType = std::make_unsigned_t<SignedType>;
+  const std::vector<UnsignedType> signedSorted{
+      static_cast<UnsignedType>(std::numeric_limits<SignedType>::min()),
+      static_cast<UnsignedType>(-1),
+      static_cast<UnsignedType>(0),
+      static_cast<UnsignedType>(std::numeric_limits<SignedType>::max()),
+  };
+  const auto signedFirst =
+      nimble::Statistics<UnsignedType>::create(signedSorted);
+  EXPECT_TRUE(signedFirst.template isNonDecreasing<SignedType>());
+  EXPECT_FALSE(signedFirst.template isNonDecreasing<UnsignedType>());
+
+  const auto naturalFirst =
+      nimble::Statistics<UnsignedType>::create(signedSorted);
+  EXPECT_FALSE(naturalFirst.template isNonDecreasing<UnsignedType>());
+  EXPECT_TRUE(naturalFirst.template isNonDecreasing<SignedType>());
+
+  const std::vector<UnsignedType> signedUnsorted{
+      static_cast<UnsignedType>(-1),
+      static_cast<UnsignedType>(-2),
+  };
+  EXPECT_FALSE(
+      nimble::Statistics<UnsignedType>::create(signedUnsorted)
+          .template isNonDecreasing<SignedType>());
+}
+
+TEST(StatisticsTest, naturalAndSignedOrderCachesAreIndependent) {
+  testNaturalAndSignedOrderCachesAreIndependent<int8_t>();
+  testNaturalAndSignedOrderCachesAreIndependent<int16_t>();
+  testNaturalAndSignedOrderCachesAreIndependent<int32_t>();
+  testNaturalAndSignedOrderCachesAreIndependent<int64_t>();
+}
+
 TEST(StatisticsTest, runValues) {
   const std::vector<int32_t> data = {1, 1, 2, 2, 1, 3, 3};
   const std::vector<int32_t> expected = {1, 2, 1, 3};


### PR DESCRIPTION
Summary:

Cache Elias-Fano monotonicity in `Statistics` and reuse it during encoding. The normal estimate-and-encode path now performs two full input traversals instead of three (-33.3% traversals, not CPU); forced encoding remains two-pass. Separate natural and signed-logical caches preserve ordering for signed values stored as unsigned physical types.

Make estimates exact for the configured row-count prefix and reject results above Nimble’s `uint32` size limit. Explicitly freeze Folly’s persisted skip quantum 128, forward quantum 256, and `kUpperFirst=false`; encoded bytes are unchanged.

Reviewed By: xiaoxmeng

Differential Revision: D119029677


