### PR TITLE
feat(cudf): Add split batching support

### DIFF
--- a/docs/designs/cudf-split-batching.md
+++ b/docs/designs/cudf-split-batching.md
@@ -40,6 +40,18 @@ The datasource checks whole-file coverage against actual file sizes. Incompatibl
 splits retain their original per-file processing and metadata. The existing cuDF
 file-list split constructors also remain available for direct reader callers.
 
+## Iceberg scope
+
+Iceberg combines a vector only for the experimental reader when all children
+are unpartitioned Parquet files without deletes, have identical physical schemas
+and column-mapping metadata, and read ordinary data columns present in each file.
+Bounded splits must cover the actual size of their files.
+
+Other cases run through the existing per-file Iceberg reader. This includes
+deletes, partition values, file metadata columns, missing columns, differing
+schemas, and byte ranges. No multi-file delete processing or schema
+reconciliation is introduced.
+
 ## Integration and observation
 
 Presto collects the splits accepted from each TaskSource update into a vector

--- a/docs/designs/cudf-split-batching.md
+++ b/docs/designs/cudf-split-batching.md
@@ -1,0 +1,55 @@
+# cuDF Parquet split batching
+
+Submit original splits together using the vector overload:
+
+```cpp
+std::vector<exec::Split> splits;
+splits.emplace_back(std::move(firstFileSplit));
+splits.emplace_back(std::move(secondFileSplit));
+task->addSplit(scanNodeId, std::move(splits));
+```
+
+Task preserves the vector as one scheduled batch for connectors that enable
+`supportsSplitBatch()`. TableScan passes the original connector splits to
+`DataSource::addSplit(vector<shared_ptr<ConnectorSplit>>)`. Other connectors
+receive individually queued splits. Existing single-split APIs remain supported.
+Grouped, barrier, and mixed-connector submissions use individual delivery.
+
+The queue uses a generic `ConnectorSplitBatch` internally to retain each child's
+metadata and the total split weight. Callers do not construct this wrapper.
+Task and operator split counts count scheduled batches; the original files are
+available through reader counters. Trace capture writes the original splits.
+
+## cuDF reader
+
+cuDF connectors enable batch delivery when `cudf.batch_splits_enabled=true`.
+With `cudf.hive.use-experimental-reader=true`, compatible complete Parquet files
+initialize one `cudf::io::parquet::experimental::hybrid_scan_multifile` with all
+of their metadata. Single-file splits use `hybrid_scan_reader`, including its
+byte-range filtering. The regular reader supports compatible file vectors
+through `chunked_parquet_reader`.
+
+Row-group statistics pruning returns column ranges with source indices. Velox
+fetches each source through its existing datasource and restores cuDF's flattened
+range order. Fetched device buffers live until the reader is destroyed. Chunk and
+pass limits bound decoding/output; they do not cap compressed input retained by a
+batch. Callers must bound their vectors and submit enough batches to occupy their
+scan drivers. Task does not regroup or resize a vector.
+
+The datasource checks whole-file coverage against actual file sizes. Incompatible
+splits retain their original per-file processing and metadata. The existing cuDF
+file-list split constructors also remain available for direct reader callers.
+
+## Integration and observation
+
+Presto collects the splits accepted from each TaskSource update into a vector
+and calls Task's vector overload. It reads Task's existing sequence watermark to
+exclude retried deliveries before submission, then advances that watermark.
+Delivery remains serialized by the existing Presto task lock. There is no
+Presto cuDF batcher, duplicate sequence state, or connector-specific grouping
+policy. Each update defines its batch boundary; there is no worker byte cap.
+
+Scan runtime statistics expose `parquet.cudfMultiFileReaders` and
+`parquet.cudfBatchedFiles`. They count actual hybrid multi-file reader
+constructions and their input files, including files subsequently pruned by
+statistics. Batches that fall back per file do not increment them.

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -18,6 +18,8 @@
 
 #include "velox/common/EnumDefine.h"
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -26,6 +28,83 @@
 #include "velox/connectors/ConnectorRegistryInternal.h"
 
 namespace facebook::velox::connector {
+
+namespace {
+int64_t totalSplitWeight(
+    const std::vector<std::shared_ptr<ConnectorSplit>>& splits) {
+  int64_t total = 0;
+  for (const auto& split : splits) {
+    VELOX_USER_CHECK_NOT_NULL(split);
+    VELOX_USER_CHECK_GE(split->splitWeight, 0);
+    if (total < std::numeric_limits<int64_t>::max()) {
+      total = split->splitWeight > std::numeric_limits<int64_t>::max() - total
+          ? std::numeric_limits<int64_t>::max()
+          : total + split->splitWeight;
+    }
+  }
+  return total;
+}
+
+bool allSplitsCacheable(
+    const std::vector<std::shared_ptr<ConnectorSplit>>& splits) {
+  return std::all_of(splits.begin(), splits.end(), [](const auto& split) {
+    return split != nullptr && split->cacheable;
+  });
+}
+} // namespace
+
+ConnectorSplitBatch::ConnectorSplitBatch(
+    const std::string& connectorId,
+    std::vector<std::shared_ptr<ConnectorSplit>> _splits)
+    : ConnectorSplit(
+          connectorId,
+          totalSplitWeight(_splits),
+          allSplitsCacheable(_splits)),
+      splits(std::move(_splits)) {
+  VELOX_USER_CHECK(!splits.empty(), "A split batch must not be empty");
+  for (const auto& split : splits) {
+    VELOX_USER_CHECK_NOT_NULL(split);
+    VELOX_USER_CHECK(
+        dynamic_cast<const ConnectorSplitBatch*>(split.get()) == nullptr,
+        "Nested split batches are not supported");
+    VELOX_USER_CHECK(
+        split->dataSource == nullptr,
+        "Preloaded splits cannot be added to a split batch");
+    VELOX_USER_CHECK_EQ(
+        split->connectorId,
+        connectorId,
+        "All splits in a batch must use the same connector ID");
+  }
+  const auto hint = splits.front()->batchSizeHint;
+  if (std::all_of(splits.begin(), splits.end(), [hint](const auto& split) {
+        return split->batchSizeHint == hint;
+      })) {
+    batchSizeHint = hint;
+  }
+}
+
+std::string ConnectorSplitBatch::toString() const {
+  return fmt::format("Split batch: {} splits", splits.size());
+}
+
+uint64_t ConnectorSplitBatch::size() const {
+  uint64_t total = 0;
+  for (const auto& split : splits) {
+    const auto splitSize = split->size();
+    if (splitSize > std::numeric_limits<uint64_t>::max() - total) {
+      return std::numeric_limits<uint64_t>::max();
+    }
+    total += splitSize;
+  }
+  return total;
+}
+
+void DataSource::addSplit(
+    const std::vector<std::shared_ptr<ConnectorSplit>>& splits) {
+  VELOX_CHECK_EQ(
+      splits.size(), 1, "Data source does not support split batches");
+  addSplit(splits.front());
+}
 
 ScopedRegistry<std::string, Connector>& connectors() {
   static ScopedRegistry<std::string, Connector> instance;

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -127,6 +127,26 @@ struct ConnectorSplit : public ISerializable {
   }
 };
 
+/// Carries the splits submitted together through Task::addSplit(). TableScan
+/// unwraps these into DataSource's vector overload. Counts as one scheduled
+/// split with the combined weight of its children.
+struct ConnectorSplitBatch : public ConnectorSplit {
+  ConnectorSplitBatch(
+      const std::string& connectorId,
+      std::vector<std::shared_ptr<ConnectorSplit>> splits);
+
+  std::string toString() const override;
+  uint64_t size() const override;
+
+  folly::dynamic serialize() const override {
+    VELOX_UNSUPPORTED(
+        "ConnectorSplitBatch is process-local and cannot be serialized");
+    return nullptr;
+  }
+
+  const std::vector<std::shared_ptr<ConnectorSplit>> splits;
+};
+
 class ColumnHandle : public ISerializable {
  public:
   virtual ~ColumnHandle() = default;
@@ -345,6 +365,11 @@ class DataSource {
   /// added. Next returns nullptr to indicate that current split is fully
   /// processed.
   virtual void addSplit(std::shared_ptr<ConnectorSplit> split) = 0;
+
+  /// Processes a batch until next() reports completion of all its splits.
+  /// Used only when Connector::supportsSplitBatch() returns true.
+  virtual void addSplit(
+      const std::vector<std::shared_ptr<ConnectorSplit>>& splits);
 
   /// Process a split added via addSplit. Returns nullptr if split has been
   /// fully processed. Returns std::nullopt and sets the 'future' if started
@@ -746,6 +771,12 @@ class Connector {
   /// so that file opening and metadata operations are off the Driver'
   /// thread.
   virtual bool supportsSplitPreload() const {
+    return false;
+  }
+
+  /// Returns true if this connector accepts batches through DataSource's
+  /// vector addSplit overload. Otherwise Task queues each split separately.
+  virtual bool supportsSplitBatch() const {
     return false;
   }
 

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -342,7 +342,14 @@ bool TableScan::getSplit() {
   }
 
   if (FOLLY_UNLIKELY(splitTracer_ != nullptr)) {
-    splitTracer_->write(split);
+    if (const auto* batch = dynamic_cast<const connector::ConnectorSplitBatch*>(
+            split.connectorSplit.get())) {
+      for (const auto& child : batch->splits) {
+        splitTracer_->write(Split(folly::copy(child)));
+      }
+    } else {
+      splitTracer_->write(split);
+    }
   }
 
   stats_.wlock()->addRuntimeStat(
@@ -416,7 +423,13 @@ bool TableScan::getSplit() {
     {
       MicrosecondWallTimer timer(&addSplitTimeUs);
       auto lk = driverCtx_->driver->pushdownFilters()->at(0).rlock();
-      dataSource_->addSplit(connectorSplit);
+      if (const auto* batch =
+              dynamic_cast<const connector::ConnectorSplitBatch*>(
+                  connectorSplit.get())) {
+        dataSource_->addSplit(batch->splits);
+      } else {
+        dataSource_->addSplit(connectorSplit);
+      }
     }
     stats_.wlock()->addRuntimeStat(
         std::string(TableScan::kDataSourceAddSplitWallNanos),
@@ -489,7 +502,13 @@ void TableScan::preload(
         }
         {
           auto lk = pushdownFilters->at(0).rlock();
-          dataSource->addSplit(split);
+          if (const auto* batch =
+                  dynamic_cast<const connector::ConnectorSplitBatch*>(
+                      split.get())) {
+            dataSource->addSplit(batch->splits);
+          } else {
+            dataSource->addSplit(split);
+          }
         }
         return dataSource;
       });

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -27,6 +27,7 @@
 #include "velox/common/memory/CustomMemoryResourceRegistry.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
+#include "velox/connectors/ConnectorRegistry.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/HashJoinBridge.h"
 #include "velox/exec/IndexLookupJoinBridge.h"
@@ -1697,9 +1698,27 @@ void Task::setMaxSplitSequenceId(
   }
 }
 
+long Task::maxSplitSequenceId(const core::PlanNodeId& planNodeId) {
+  std::lock_guard<std::timed_mutex> l(mutex_);
+  // Finished tasks still accept remote splits to clean up upstream buffers.
+  return isRunningLocked()
+      ? getPlanNodeSplitsStateLocked(planNodeId).maxSequenceId
+      : std::numeric_limits<long>::min();
+}
+
 void Task::onAddSplit(
     const core::PlanNodeId& planNodeId,
     const exec::Split& split) {
+  if (splitListeners_.empty()) {
+    return;
+  }
+  if (const auto* batch = dynamic_cast<const connector::ConnectorSplitBatch*>(
+          split.connectorSplit.get())) {
+    for (const auto& child : batch->splits) {
+      onAddSplit(planNodeId, Split(folly::copy(child)));
+    }
+    return;
+  }
   for (auto& listener : splitListeners_) {
     listener->onAddSplit(planNodeId, split);
   }
@@ -1774,6 +1793,52 @@ void Task::addSplit(const core::PlanNodeId& planNodeId, exec::Split&& split) {
   if (shouldLogSplit) {
     onAddSplit(planNodeId, split);
   }
+}
+
+void Task::addSplitBatch(
+    const core::PlanNodeId& planNodeId,
+    std::vector<exec::Split>&& splits) {
+  bool canBatch = splits.size() > 1;
+  if (canBatch) {
+    std::lock_guard<std::timed_mutex> l(mutex_);
+    canBatch = isRunningLocked() &&
+        getPlanNodeSplitsStateLocked(planNodeId).sourceIsTableScan;
+  }
+  if (canBatch) {
+    const auto& first = splits.front().connectorSplit;
+    canBatch =
+        first &&
+        std::all_of(splits.begin(), splits.end(), [&](const auto& split) {
+          return split.hasConnectorSplit() && !split.hasGroup() &&
+              !split.isBarrier() && !split.connectorSplit->dataSource &&
+              split.connectorSplit->splitWeight >= 0 &&
+              split.connectorSplit->connectorId == first->connectorId &&
+              split.connectorSplit->batchSizeHint == first->batchSizeHint;
+        });
+    if (canBatch) {
+      const auto connector =
+          connector::ConnectorRegistry::tryGet(*queryCtx_, first->connectorId);
+      canBatch = connector && connector->supportsSplitBatch();
+    }
+  }
+  if (!canBatch) {
+    for (auto& split : splits) {
+      addSplit(planNodeId, std::move(split));
+    }
+    return;
+  }
+
+  const auto connectorId = splits.front().connectorSplit->connectorId;
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> children;
+  children.reserve(splits.size());
+  for (auto& split : splits) {
+    children.push_back(std::move(split.connectorSplit));
+  }
+  addSplit(
+      planNodeId,
+      Split(
+          std::make_shared<connector::ConnectorSplitBatch>(
+              connectorId, std::move(children))));
 }
 
 void Task::addRemoteSplit(

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <folly/container/IntrusiveList.h>
+#include <concepts>
 
 #include "velox/common/base/SkewedPartitionBalancer.h"
 #include "velox/core/PlanFragment.h"
@@ -249,6 +250,11 @@ class Task : public std::enable_shared_from_this<Task> {
       const core::PlanNodeId& planNodeId,
       long maxSequenceId);
 
+  /// Returns the watermark used to discard re-delivered splits. Callers that
+  /// filter a vector using this snapshot must serialize delivery and watermark
+  /// updates, just as callers of addSplitWithSequence() do.
+  long maxSplitSequenceId(const core::PlanNodeId& planNodeId);
+
   /// Adds split for a source operator corresponding to plan node with
   /// specified ID.
   /// It requires sequential id of the split and, when that id is NOT greater
@@ -266,6 +272,19 @@ class Task : public std::enable_shared_from_this<Task> {
   /// specified ID. Does not require sequential id.
   /// Note that, the operation is silently ignored if Task is not running.
   void addSplit(const core::PlanNodeId& planNodeId, exec::Split&& split);
+
+  /// Adds a batch for a table scan. A connector that supports batching receives
+  /// the vector together; other sources receive individual splits. Grouped,
+  /// barrier, preloaded, or mixed-connector splits are queued individually.
+  /// Callers bound batch sizes and submit enough batches for their drivers.
+  /// An empty vector is a no-op. Existing single-split APIs are unchanged.
+  /// Uses vector type deduction to keep addSplit(planNodeId, {}) unambiguous.
+  template <std::same_as<exec::Split> SplitType>
+  void addSplit(
+      const core::PlanNodeId& planNodeId,
+      std::vector<SplitType>&& splits) {
+    addSplitBatch(planNodeId, std::move(splits));
+  }
 
   /// We mark that for the given group there would be no more splits coming.
   void noMoreSplitsForGroup(
@@ -1091,7 +1110,13 @@ class Task : public std::enable_shared_from_this<Task> {
   // Notifies listeners that the task is now complete.
   void onTaskCompletion();
 
+  // Notifies listeners once per original split, unwrapping scheduled batches.
   void onAddSplit(const core::PlanNodeId& planNodeId, const exec::Split& split);
+
+  // Queues a vector as one batch when the source and splits support batching.
+  void addSplitBatch(
+      const core::PlanNodeId& planNodeId,
+      std::vector<exec::Split>&& splits);
 
   // Returns true if all splits are finished processing and there are no more
   // splits coming for the task.

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/Task.h"
+#include <gmock/gmock.h>
 #include "folly/OperationCancelled.h"
 #include "folly/synchronization/Baton.h"
 #include "folly/synchronization/EventCount.h"
@@ -26,6 +27,8 @@
 #include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/exec/Cursor.h"
 #include "velox/exec/DefaultOutputBufferManager.h"
@@ -729,6 +732,353 @@ TEST_F(TaskTest, stateChangeFutureNotFiredWhenNoMoreSplits) {
   task->requestCancel().wait();
 }
 
+TEST_F(TaskTest, splitVectorDelivery) {
+  // Serialize each notification as an existing connector-specific listener
+  // does.
+  class RecordingListener : public SplitListener {
+   public:
+    RecordingListener(
+        const std::string& taskId,
+        const std::string& taskUuid,
+        std::vector<std::shared_ptr<connector::ConnectorSplit>>& observed)
+        : SplitListener(taskId, taskUuid), observed_(observed) {}
+
+    void onAddSplit(const core::PlanNodeId& planNodeId, const Split& split)
+        override {
+      EXPECT_EQ(planNodeId, "0");
+      split.connectorSplit->serialize();
+      observed_.push_back(split.connectorSplit);
+    }
+
+    void onTaskCompletion() override {}
+
+   private:
+    // Original objects delivered to the listener, in notification order.
+    std::vector<std::shared_ptr<connector::ConnectorSplit>>& observed_;
+  };
+
+  // Attach the recording listener to the task created by this test.
+  class RecordingListenerFactory : public SplitListenerFactory {
+   public:
+    explicit RecordingListenerFactory(
+        std::vector<std::shared_ptr<connector::ConnectorSplit>>& observed)
+        : observed_(observed) {}
+
+    std::unique_ptr<SplitListener> create(
+        const std::string& taskId,
+        const std::string& taskUuid,
+        const core::QueryConfig& /*config*/) override {
+      return std::make_unique<RecordingListener>(taskId, taskUuid, observed_);
+    }
+
+   private:
+    std::vector<std::shared_ptr<connector::ConnectorSplit>>& observed_;
+  };
+
+  class BatchConnector : public connector::hive::HiveConnector {
+   public:
+    using HiveConnector::HiveConnector;
+
+    bool supportsSplitBatch() const override {
+      return true;
+    }
+  };
+
+  for (const bool batching : {false, true}) {
+    SCOPED_TRACE(batching);
+    std::vector<std::shared_ptr<connector::ConnectorSplit>> observed;
+    auto listenerFactory = std::make_shared<RecordingListenerFactory>(observed);
+    ASSERT_TRUE(registerSplitListenerFactory(listenerFactory));
+    SCOPE_EXIT {
+      unregisterSplitListenerFactory(listenerFactory);
+    };
+    auto queryCtx = core::QueryCtx::create();
+    if (batching) {
+      // The global connector remains the CPU Hive connector. Batch support
+      // must be resolved through the same query override as TableScan.
+      auto registry = connector::ConnectorRegistry::create();
+      registry->insert(
+          kHiveConnectorId,
+          std::make_shared<BatchConnector>(
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(
+                  std::unordered_map<std::string, std::string>{}),
+              ioExecutor_.get()));
+      queryCtx->setRegistry(
+          connector::ConnectorRegistry::kRegistryKey, registry);
+    }
+    auto task = Task::create(
+        "vector-splits",
+        PlanBuilder().tableScan(ROW({"c0"}, {BIGINT()})).planFragment(),
+        0,
+        queryCtx,
+        Task::ExecutionMode::kSerial,
+        exec::Consumer{});
+    SCOPE_EXIT {
+      task->requestCancel().wait();
+    };
+    task->addSplit("0", std::vector<Split>{});
+    EXPECT_EQ(task->taskStats().numTotalSplits, 0);
+    std::vector<std::shared_ptr<connector::ConnectorSplit>> children;
+    std::vector<Split> splits;
+    for (int i = 0; i < 3; ++i) {
+      auto child = connector::hive::HiveConnectorSplitBuilder(
+                       fmt::format("file{}.parquet", i))
+                       .connectorId(kHiveConnectorId)
+                       .splitWeight(10)
+                       .build();
+      children.push_back(child);
+      splits.emplace_back(std::move(child));
+    }
+    task->addSplit("0", std::move(splits));
+    EXPECT_THAT(observed, testing::ElementsAreArray(children));
+    EXPECT_EQ(task->taskStats().numTotalSplits, batching ? 1 : 3);
+    EXPECT_EQ(task->taskStats().queuedTableScanSplitWeights, 30);
+    task->noMoreSplits("0");
+    for (int i = 0; i < (batching ? 1 : 3); ++i) {
+      Split split;
+      ContinueFuture future;
+      ASSERT_EQ(
+          task->getSplitOrFuture(
+              0, kUngroupedGroupId, "0", 0, nullptr, split, future),
+          BlockingReason::kNotBlocked);
+      if (batching) {
+        const auto batch =
+            std::dynamic_pointer_cast<connector::ConnectorSplitBatch>(
+                split.connectorSplit);
+        ASSERT_NE(batch, nullptr);
+        EXPECT_EQ(batch->splits, children);
+        EXPECT_EQ(batch->splitWeight, 30);
+      } else {
+        EXPECT_EQ(split.connectorSplit, children[i]);
+      }
+    }
+    EXPECT_EQ(task->taskStats().numQueuedSplits, 0);
+    EXPECT_EQ(task->taskStats().queuedTableScanSplitWeights, 0);
+  }
+}
+
+TEST_F(TaskTest, splitVectorScan) {
+  using ConnectorSplits =
+      std::vector<std::shared_ptr<connector::ConnectorSplit>>;
+
+  // Collect calls from the driver and the preload executor.
+  struct ScanState {
+    folly::Synchronized<std::vector<ConnectorSplits>> received;
+    std::atomic<int32_t> numTransfers{0};
+  };
+
+  // Produce one row per non-empty child and finish only after the whole batch.
+  class BatchDataSource : public connector::DataSource {
+   public:
+    BatchDataSource(
+        RowTypePtr outputType,
+        memory::MemoryPool* pool,
+        std::shared_ptr<ScanState> state)
+        : outputType_(std::move(outputType)),
+          pool_(pool),
+          state_(std::move(state)) {}
+
+    void addSplit(std::shared_ptr<connector::ConnectorSplit> split) override {
+      addSplit(ConnectorSplits{std::move(split)});
+    }
+
+    void addSplit(const ConnectorSplits& splits) override {
+      splits_ = splits;
+      nextChild_ = 0;
+      state_->received.wlock()->push_back(splits);
+    }
+
+    std::optional<RowVectorPtr> next(
+        uint64_t /*size*/,
+        ContinueFuture& /*future*/) override {
+      if (nextChild_ == splits_.size()) {
+        return nullptr;
+      }
+      const auto split =
+          std::dynamic_pointer_cast<connector::hive::HiveConnectorSplit>(
+              splits_[nextChild_++]);
+      VELOX_CHECK_NOT_NULL(split);
+      const vector_size_t numRows = split->start == 0 ? 0 : 1;
+      auto result = BaseVector::create<RowVector>(outputType_, numRows, pool_);
+      if (numRows != 0) {
+        result->childAt(0)->asFlatVector<int64_t>()->set(0, split->start);
+      }
+      completedRows_ += numRows;
+      return result;
+    }
+
+    void addDynamicFilter(
+        column_index_t /*outputChannel*/,
+        const std::shared_ptr<common::Filter>& /*filter*/) override {
+      VELOX_UNSUPPORTED();
+    }
+
+    uint64_t getCompletedBytes() override {
+      return completedRows_ * sizeof(int64_t);
+    }
+
+    uint64_t getCompletedRows() override {
+      return completedRows_;
+    }
+
+    bool allPrefetchIssued() const override {
+      return true;
+    }
+
+    void setFromDataSource(
+        std::unique_ptr<connector::DataSource> source) override {
+      auto* prepared = dynamic_cast<BatchDataSource*>(source.get());
+      VELOX_CHECK_NOT_NULL(prepared);
+      splits_ = std::move(prepared->splits_);
+      nextChild_ = prepared->nextChild_;
+      completedRows_ += prepared->completedRows_;
+      ++state_->numTransfers;
+    }
+
+   private:
+    const RowTypePtr outputType_;
+    memory::MemoryPool* const pool_;
+    const std::shared_ptr<ScanState> state_;
+    // Retain the original children until the batch has been consumed.
+    ConnectorSplits splits_;
+    size_t nextChild_{0};
+    uint64_t completedRows_{0};
+  };
+
+  // Supply a batch-capable source while retaining Hive's executor for preload.
+  class BatchConnector : public connector::hive::HiveConnector {
+   public:
+    BatchConnector(folly::Executor* executor, std::shared_ptr<ScanState> state)
+        : HiveConnector(
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(
+                  std::unordered_map<std::string, std::string>{}),
+              executor),
+          state_(std::move(state)) {}
+
+    bool canAddDynamicFilter() const override {
+      return false;
+    }
+
+    bool supportsSplitBatch() const override {
+      return true;
+    }
+
+    std::unique_ptr<connector::DataSource> createDataSource(
+        const RowTypePtr& outputType,
+        const connector::ConnectorTableHandlePtr& /*tableHandle*/,
+        const connector::ColumnHandleMap& /*columnHandles*/,
+        connector::ConnectorQueryCtx* context) override {
+      return std::make_unique<BatchDataSource>(
+          outputType, context->memoryPool(), state_);
+    }
+
+   private:
+    const std::shared_ptr<ScanState> state_;
+  };
+
+  for (const bool batching : {false, true}) {
+    for (const bool preload : {false, true}) {
+      SCOPED_TRACE(fmt::format("batching={}, preload={}", batching, preload));
+      auto state = std::make_shared<ScanState>();
+      auto registry = connector::ConnectorRegistry::create();
+      registry->insert(
+          kHiveConnectorId,
+          std::make_shared<BatchConnector>(ioExecutor_.get(), state));
+      auto queryCtx = core::QueryCtx::create();
+      queryCtx->setRegistry(
+          connector::ConnectorRegistry::kRegistryKey, registry);
+      queryCtx->testingOverrideConfigUnsafe({
+          {core::QueryConfig::kMaxSplitPreloadPerDriver, preload ? "3" : "0"},
+      });
+      auto task = Task::create(
+          "vector-scan",
+          PlanBuilder().tableScan(ROW({"c0"}, {BIGINT()})).planFragment(),
+          0,
+          queryCtx,
+          Task::ExecutionMode::kSerial,
+          Consumer{});
+      SCOPE_EXIT {
+        task->requestCancel().wait();
+      };
+      ConnectorSplits children;
+      std::vector<Split> splits;
+      for (int i = 0; i < 3; ++i) {
+        auto child =
+            connector::hive::HiveConnectorSplitBuilder(fmt::format("file{}", i))
+                .connectorId(kHiveConnectorId)
+                .start(i)
+                .splitWeight(10)
+                .build();
+        children.push_back(child);
+        splits.emplace_back(std::move(child));
+      }
+      if (batching) {
+        task->addSplit("0", std::move(splits));
+      } else {
+        for (auto& split : splits) {
+          task->addSplit("0", std::move(split));
+        }
+      }
+      task->noMoreSplits("0");
+      std::vector<int64_t> values;
+      while (auto result = task->next()) {
+        ASSERT_EQ(result->size(), 1);
+        values.push_back(
+            result->childAt(0)->asFlatVector<int64_t>()->valueAt(0));
+        if (batching) {
+          EXPECT_EQ(task->taskStats().numRunningTableScanSplits, 1);
+          EXPECT_EQ(task->taskStats().runningTableScanSplitWeights, 30);
+          EXPECT_EQ(task->taskStats().numFinishedSplits, 0);
+        }
+      }
+      EXPECT_THAT(values, testing::UnorderedElementsAre(1, 2));
+      EXPECT_TRUE(task->isFinished());
+      const auto stats = task->taskStats();
+      EXPECT_EQ(stats.numFinishedSplits, batching ? 1 : 3);
+      EXPECT_EQ(stats.numRunningSplits, 0);
+      EXPECT_EQ(stats.numQueuedSplits, 0);
+      EXPECT_EQ(stats.runningTableScanSplitWeights, 0);
+      EXPECT_EQ(stats.queuedTableScanSplitWeights, 0);
+      const auto received = state->received.copy();
+      if (batching) {
+        ASSERT_THAT(received, testing::SizeIs(1));
+        EXPECT_THAT(received.front(), testing::ElementsAreArray(children));
+      } else {
+        ConnectorSplits observed;
+        for (const auto& batch : received) {
+          ASSERT_THAT(batch, testing::SizeIs(1));
+          observed.push_back(batch.front());
+        }
+        EXPECT_THAT(observed, testing::UnorderedElementsAreArray(children));
+      }
+      EXPECT_EQ(state->numTransfers.load(), preload ? (batching ? 1 : 3) : 0);
+    }
+  }
+}
+
+TEST_F(TaskTest, splitSequenceWatermark) {
+  auto task = Task::create(
+      "split-watermark",
+      PlanBuilder().tableScan(ROW({"c0"}, {BIGINT()})).planFragment(),
+      0,
+      core::QueryCtx::create(),
+      Task::ExecutionMode::kSerial,
+      exec::Consumer{});
+  EXPECT_EQ(task->maxSplitSequenceId("0"), std::numeric_limits<long>::min());
+  task->setMaxSplitSequenceId("0", 10);
+  task->setMaxSplitSequenceId("0", 5);
+  EXPECT_EQ(task->maxSplitSequenceId("0"), 10);
+  EXPECT_FALSE(task->addSplitWithSequence(
+      "0", Split(makeHiveConnectorSplit("duplicate")), 10));
+  EXPECT_TRUE(task->addSplitWithSequence(
+      "0", Split(makeHiveConnectorSplit("new")), 11));
+  EXPECT_EQ(task->maxSplitSequenceId("0"), 10);
+  task->requestCancel().wait();
+  EXPECT_EQ(task->maxSplitSequenceId("0"), std::numeric_limits<long>::min());
+}
+
 TEST_F(TaskTest, wrongPlanNodeForSplit) {
   auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
       "test",
@@ -754,7 +1104,7 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
   task->addSplit("0", exec::Split(folly::copy(connectorSplit)));
 
   // Add an empty split.
-  task->addSplit("0", exec::Split());
+  task->addSplit("0", {});
 
   // Try to add split for a non-source node.
   auto errorMessage =

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -54,6 +54,8 @@ struct CudfConfig {
   static constexpr const char* kCudfStreamingGroupbyCapacityMultiplier{
       "cudf.streaming_groupby_capacity_multiplier"};
   static constexpr const char* kCudfTimestampUnit{"cudf.timestamp_unit"};
+  static constexpr const char* kCudfBatchSplitsEnabled{
+      "cudf.batch_splits_enabled"};
   /// Query session configs for the cuDF Operators.
   static constexpr const char* kCudfTopNBatchSize{"cudf.topk_batch_size"};
 
@@ -144,6 +146,9 @@ struct CudfConfig {
   /// "s" (seconds), "ms" (milliseconds), "us" (microseconds), "ns"
   /// (nanoseconds).
   cudf::type_id timestampUnit = cudf::type_id::TIMESTAMP_NANOSECONDS;
+
+  /// Whether cuDF connectors accept Task's vector submissions as batches.
+  bool batchSplitsEnabled{false};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnector.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h"
@@ -32,6 +33,10 @@ CudfHiveConnector::CudfHiveConnector(
     : ::facebook::velox::connector::hive::HiveConnector(id, config, executor),
       cudfHiveConfig_(std::make_shared<CudfHiveConfig>(config)) {
   VLOG(1) << "cuDF Hive connector created";
+}
+
+bool CudfHiveConnector::supportsSplitBatch() const {
+  return cudfIsRegistered() && CudfConfig::getInstance().batchSplitsEnabled;
 }
 
 std::unique_ptr<DataSource> CudfHiveConnector::createDataSource(

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
@@ -47,6 +47,9 @@ class CudfHiveConnector final
     return false;
   }
 
+  /// Accepts split vectors when cuDF split batching is enabled.
+  bool supportsSplitBatch() const override;
+
   bool supportsSplitPreload() const override {
     return false;
   }

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.cpp
@@ -19,8 +19,11 @@
 
 #include <cudf/io/types.hpp>
 
+#include <algorithm>
 #include <string>
+#include <string_view>
 #include <unordered_map>
+#include <vector>
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
@@ -32,10 +35,38 @@ std::string stripFilePrefix(const std::string& targetPath) {
   }
   return targetPath;
 }
+
+std::string normalizeBatchedFilePath(const std::string& targetPath) {
+  auto path = stripFilePrefix(targetPath);
+  constexpr std::string_view kS3APrefix{"s3a:"};
+  if (path.starts_with(kS3APrefix)) {
+    path.erase(kS3APrefix.size() - 2, 1);
+  }
+  return path;
+}
+
+std::vector<std::string> stripFilePrefixes(
+    const std::vector<std::string>& paths) {
+  VELOX_USER_CHECK(!paths.empty(), "A batched split must contain a file");
+  std::vector<std::string> result;
+  result.reserve(paths.size());
+  for (const auto& p : paths) {
+    result.push_back(normalizeBatchedFilePath(p));
+  }
+  return result;
+}
+
 } // namespace
 
 std::string CudfHiveConnectorSplit::toString() const {
-  return fmt::format("CudfHive: {}", filePath);
+  if (filePaths.size() <= 1) {
+    return fmt::format("CudfHive: {}", filePath);
+  }
+  return fmt::format(
+      "CudfHive: {} files [{}..{}]",
+      filePaths.size(),
+      filePaths.front(),
+      filePaths.back());
 }
 
 std::string CudfHiveConnectorSplit::getFileName() const {
@@ -55,20 +86,84 @@ CudfHiveConnectorSplit::CudfHiveConnectorSplit(
     int64_t _splitWeight,
     const std::unordered_map<std::string, std::string>& _infoColumns)
     : facebook::velox::connector::ConnectorSplit(connectorId, _splitWeight),
-      filePath(stripFilePrefix(_filePath)),
+      filePaths({stripFilePrefix(_filePath)}),
+      filePath(filePaths.front()),
       start(_start),
       length(_length),
       cudfSourceInfo(std::make_unique<cudf::io::source_info>(filePath)),
       infoColumns(_infoColumns) {}
 
+CudfHiveConnectorSplit::CudfHiveConnectorSplit(
+    BatchTag,
+    const std::string& connectorId,
+    const std::vector<std::string>& paths,
+    int64_t splitWeight)
+    : facebook::velox::connector::ConnectorSplit(connectorId, splitWeight),
+      filePaths(stripFilePrefixes(paths)),
+      filePath(filePaths.front()),
+      start(0),
+      length(std::numeric_limits<uint64_t>::max()),
+      cudfSourceInfo(std::make_unique<cudf::io::source_info>(filePaths)) {}
+
+// static
+std::shared_ptr<CudfHiveConnectorSplit> CudfHiveConnectorSplit::makeBatch(
+    const std::string& connectorId,
+    const std::vector<std::string>& filePaths,
+    int64_t splitWeight) {
+  return std::shared_ptr<CudfHiveConnectorSplit>(new CudfHiveConnectorSplit(
+      BatchTag{}, connectorId, filePaths, splitWeight));
+}
+
+// static
+CudfHiveConnectorSplitBuilder CudfHiveConnectorSplitBuilder::forFilePaths(
+    std::vector<std::string> filePaths) {
+  return CudfHiveConnectorSplitBuilder(BatchTag{}, std::move(filePaths));
+}
+
+std::vector<std::shared_ptr<CudfHiveConnectorSplit>>
+makeCudfHiveConnectorSplitBatches(
+    const std::string& connectorId,
+    const std::vector<std::string>& filePaths,
+    size_t maxFilesPerBatch,
+    int64_t splitWeight) {
+  if (filePaths.empty()) {
+    return {};
+  }
+  const auto batchSize =
+      maxFilesPerBatch == 0 ? filePaths.size() : maxFilesPerBatch;
+  std::vector<std::shared_ptr<CudfHiveConnectorSplit>> result;
+  result.reserve((filePaths.size() + batchSize - 1) / batchSize);
+  for (size_t start = 0; start < filePaths.size(); start += batchSize) {
+    const auto end = std::min(start + batchSize, filePaths.size());
+    result.push_back(
+        CudfHiveConnectorSplit::makeBatch(
+            connectorId,
+            std::vector<std::string>(
+                filePaths.begin() + start, filePaths.begin() + end),
+            splitWeight));
+  }
+  return result;
+}
+
 // static
 std::shared_ptr<CudfHiveConnectorSplit> CudfHiveConnectorSplit::create(
     const folly::dynamic& obj) {
   const auto connectorId = obj["connectorId"].asString();
+  const auto splitWeight = obj["splitWeight"].asInt();
+
+  if (obj.count("filePaths")) {
+    std::vector<std::string> filePaths;
+    filePaths.reserve(obj["filePaths"].size());
+    for (const auto& path : obj["filePaths"]) {
+      filePaths.push_back(path.asString());
+    }
+    return CudfHiveConnectorSplit::makeBatch(
+        connectorId, filePaths, splitWeight);
+  }
+
   const auto filePath = obj["filePath"].asString();
   const auto start = static_cast<uint64_t>(obj["start"].asInt());
   const auto length = static_cast<uint64_t>(obj["length"].asInt());
-  const auto splitWeight = obj["splitWeight"].asInt();
 
   std::unordered_map<std::string, std::string> infoColumns;
   for (const auto& [key, value] : obj["infoColumns"].items()) {
@@ -86,6 +181,14 @@ folly::dynamic CudfHiveConnectorSplit::serialize() const {
   obj["start"] = start;
   obj["length"] = length;
   obj["splitWeight"] = splitWeight;
+
+  if (filePaths.size() > 1) {
+    folly::dynamic paths = folly::dynamic::array;
+    for (const auto& path : filePaths) {
+      paths.push_back(path);
+    }
+    obj["filePaths"] = std::move(paths);
+  }
 
   folly::dynamic infoColumnsObj = folly::dynamic::object;
   for (const auto& [key, value] : infoColumns) {

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
@@ -28,11 +28,17 @@ struct source_info;
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <variant>
+#include <vector>
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
 struct CudfHiveConnectorSplit
     : public facebook::velox::connector::ConnectorSplit {
+  /// Paths in this split. Batched splits contain more than one full file.
+  const std::vector<std::string> filePaths;
+
+  /// First path, retained for source compatibility with single-file callers.
   const std::string filePath;
   const uint64_t start;
   const uint64_t length;
@@ -44,6 +50,7 @@ struct CudfHiveConnectorSplit
   /// associated with the CudfHiveConnectorSplit.
   std::unordered_map<std::string, std::string> infoColumns = {};
 
+  /// Constructs a single-file (or byte-range) split.
   CudfHiveConnectorSplit(
       const std::string& connectorId,
       const std::string& _filePath,
@@ -51,6 +58,12 @@ struct CudfHiveConnectorSplit
       uint64_t _length = std::numeric_limits<uint64_t>::max(),
       int64_t _splitWeight = 0,
       const std::unordered_map<std::string, std::string>& _infoColumns = {});
+
+  /// Constructs a batch of full-file splits.
+  static std::shared_ptr<CudfHiveConnectorSplit> makeBatch(
+      const std::string& connectorId,
+      const std::vector<std::string>& filePaths,
+      int64_t splitWeight);
 
   std::string toString() const override;
   std::string getFileName() const;
@@ -65,12 +78,33 @@ struct CudfHiveConnectorSplit
 
   static std::shared_ptr<CudfHiveConnectorSplit> create(
       const folly::dynamic& obj);
+
+ private:
+  struct BatchTag {};
+
+  CudfHiveConnectorSplit(
+      BatchTag,
+      const std::string& connectorId,
+      const std::vector<std::string>& filePaths,
+      int64_t splitWeight);
 };
+
+/// Groups paths into native cuDF multi-file splits. A maximum of zero places
+/// all paths in one split.
+std::vector<std::shared_ptr<CudfHiveConnectorSplit>>
+makeCudfHiveConnectorSplitBatches(
+    const std::string& connectorId,
+    const std::vector<std::string>& filePaths,
+    size_t maxFilesPerBatch,
+    int64_t splitWeight = 0);
 
 class CudfHiveConnectorSplitBuilder {
  public:
   explicit CudfHiveConnectorSplitBuilder(std::string filePath)
-      : filePath_{std::move(filePath)} {}
+      : filePaths_{std::move(filePath)} {}
+
+  static CudfHiveConnectorSplitBuilder forFilePaths(
+      std::vector<std::string> filePaths);
 
   CudfHiveConnectorSplitBuilder& start(uint64_t start) {
     start_ = start;
@@ -100,12 +134,34 @@ class CudfHiveConnectorSplitBuilder {
   }
 
   std::shared_ptr<CudfHiveConnectorSplit> build() const {
-    return std::make_shared<CudfHiveConnectorSplit>(
-        connectorId_, filePath_, start_, length_, splitWeight_, infoColumns_);
+    if (auto* single = std::get_if<std::string>(&filePaths_)) {
+      return std::make_shared<CudfHiveConnectorSplit>(
+          connectorId_, *single, start_, length_, splitWeight_, infoColumns_);
+    }
+    VELOX_USER_CHECK_EQ(
+        start_, 0, "Batched splits do not support a non-zero start offset");
+    VELOX_USER_CHECK_EQ(
+        length_,
+        std::numeric_limits<uint64_t>::max(),
+        "Batched splits do not support byte-range lengths");
+    VELOX_USER_CHECK(
+        infoColumns_.empty(),
+        "Batched splits cannot share per-file info columns");
+    return CudfHiveConnectorSplit::makeBatch(
+        connectorId_,
+        std::get<std::vector<std::string>>(filePaths_),
+        splitWeight_);
   }
 
  private:
-  const std::string filePath_;
+  struct BatchTag {};
+
+  explicit CudfHiveConnectorSplitBuilder(
+      BatchTag,
+      std::vector<std::string> filePaths)
+      : filePaths_{std::move(filePaths)} {}
+
+  const std::variant<std::string, std::vector<std::string>> filePaths_;
   uint64_t start_{0};
   uint64_t length_{std::numeric_limits<uint64_t>::max()};
   std::string connectorId_;

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -215,29 +215,106 @@ void CudfHiveDataSource::convertSplit(std::shared_ptr<ConnectorSplit> split) {
   VLOG(1) << "Adding split " << split_->toString();
 }
 
+std::unique_ptr<CudfSplitReader> CudfHiveDataSource::createBatchedSplitReader(
+    const std::vector<std::shared_ptr<ConnectorSplit>>& batch,
+    dwio::common::RuntimeStats& runtimeStats) {
+  std::vector<std::string> paths;
+  std::vector<uint64_t> lengths;
+  for (const auto& child : batch) {
+    if (!child->cacheable || child->batchSizeHint != 0) {
+      return nullptr;
+    }
+    if (const auto* hiveSplit =
+            dynamic_cast<const hive::HiveConnectorSplit*>(child.get())) {
+      if (typeid(*hiveSplit) != typeid(hive::HiveConnectorSplit) ||
+          !hiveSplit->partitionKeys.empty() ||
+          !hiveSplit->customSplitInfo.empty() || hiveSplit->columnMappingMode ||
+          hiveSplit->tableBucketNumber || hiveSplit->bucketConversion ||
+          hiveSplit->rowIdProperties || hiveSplit->extraFileInfo ||
+          hiveSplit->properties ||
+          hiveSplit->fileFormat != dwio::common::FileFormat::PARQUET) {
+        return nullptr;
+      }
+    } else if (!dynamic_cast<const CudfHiveConnectorSplit*>(child.get())) {
+      return nullptr;
+    }
+    convertSplit(child);
+    if (split_->start != 0 || split_->filePaths.size() != 1) {
+      return nullptr;
+    }
+    for (const auto& name : readColumnNames_) {
+      if (split_->infoColumns.contains(name)) {
+        return nullptr;
+      }
+    }
+    paths.push_back(split_->filePath);
+    lengths.push_back(split_->length);
+  }
+  split_ =
+      CudfHiveConnectorSplit::makeBatch(batch.front()->connectorId, paths, 0);
+  auto reader = createCudfSplitReader();
+  return reader->tryPrepareBatch(lengths, runtimeStats) ? std::move(reader)
+                                                        : nullptr;
+}
+
 void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
-  // Virtual method for class-specific conversion of the split
-  convertSplit(split);
+  addSplit(std::vector<std::shared_ptr<ConnectorSplit>>{std::move(split)});
+}
+
+void CudfHiveDataSource::addSplit(
+    const std::vector<std::shared_ptr<ConnectorSplit>>& splits) {
+  cudfSplitReader_.reset();
+  splitBatch_ = splits;
+  nextSplitIndex_ = 0;
+  if (splits.size() > 1) {
+    if (auto reader = createBatchedSplitReader(splits, runtimeStats_)) {
+      cudfSplitReader_ = std::move(reader);
+      nextSplitIndex_ = splits.size();
+      updateCompletedBytes();
+      return;
+    }
+  }
+  VELOX_CHECK(prepareNextSplit(), "Cannot add an empty split batch");
+}
+
+bool CudfHiveDataSource::prepareNextSplit() {
+  if (nextSplitIndex_ >= splitBatch_.size()) {
+    return false;
+  }
+
+  auto connectorSplit = splitBatch_.at(nextSplitIndex_++);
+
+  // Virtual methods preserve connector-specific per-file state. In
+  // particular, the Iceberg data source refreshes delete, partition and schema
+  // metadata for every child.
+  convertSplit(connectorSplit);
 
   cudfSplitReader_ = createCudfSplitReader();
   cudfSplitReader_->prepareSplit(runtimeStats_);
 
+  updateCompletedBytes();
+  return true;
+}
+
+void CudfHiveDataSource::updateCompletedBytes() {
   // TODO: `completedBytes_` should be updated in `next()` as we read more and
   // more table bytes
-  try {
-    const auto fileHandleKey = FileHandleKey{
-        .filename = split_->filePath,
-        .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
-    auto fileProperties = FileProperties{};
-    auto const fileHandleCachePtr = fileHandleFactory_->generate(
-        fileHandleKey, &fileProperties, ioStats_ ? ioStats_.get() : nullptr);
-    if (fileHandleCachePtr.get() and fileHandleCachePtr.get()->file) {
-      completedBytes_ += fileHandleCachePtr->file->size();
+  for (const auto& path : split_->filePaths) {
+    try {
+      const auto fileHandleKey = FileHandleKey{
+          .filename = path,
+          .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
+      auto fileProperties = FileProperties{};
+      auto const fileHandleCachePtr = fileHandleFactory_->generate(
+          fileHandleKey, &fileProperties, ioStats_ ? ioStats_.get() : nullptr);
+      if (fileHandleCachePtr.get() and fileHandleCachePtr.get()->file) {
+        completedBytes_ += fileHandleCachePtr->file->size();
+      }
+    } catch (const std::exception& e) {
+      // Unable to get the file size, log a warning and continue.
+      LOG(WARNING) << "Failed to get file size for " << path << ": "
+                   << e.what();
     }
-  } catch (const std::exception& e) {
-    // Unable to get the file size, log a warning and continue
-    LOG(WARNING) << "Failed to get file size for " << split_->filePath << ": "
-                 << e.what();
   }
 }
 
@@ -246,9 +323,15 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     velox::ContinueFuture& /* future */) {
   VELOX_CHECK_NOT_NULL(split_, "No split present. Call addSplit() first.");
   VELOX_CHECK_NOT_NULL(cudfSplitReader_, "No split to process.");
-  auto chunkOpt = cudfSplitReader_->next(size);
-  if (!chunkOpt.has_value()) {
-    return nullptr;
+  std::optional<std::unique_ptr<cudf::table>> chunkOpt;
+  while (true) {
+    chunkOpt = cudfSplitReader_->next(size);
+    if (chunkOpt.has_value()) {
+      break;
+    }
+    if (not prepareNextSplit()) {
+      return nullptr;
+    }
   }
   auto cudfTable = std::move(chunkOpt.value());
   auto stream = cudfSplitReader_->stream();

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
@@ -53,6 +53,10 @@ class CudfHiveDataSource : public DataSource, public NvtxHelper {
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
 
+  /// Initializes one reader for compatible files, with per-file fallback.
+  void addSplit(
+      const std::vector<std::shared_ptr<ConnectorSplit>>& splits) override;
+
   void addDynamicFilter(
       column_index_t /*outputChannel*/,
       const std::shared_ptr<facebook::velox::common::Filter>& /*filter*/)
@@ -80,6 +84,13 @@ class CudfHiveDataSource : public DataSource, public NvtxHelper {
   std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override;
 
  protected:
+  // Returns a prepared multi-file reader when the batch's per-file state is
+  // compatible, or nullptr to retain sequential processing of its children.
+  virtual std::unique_ptr<CudfSplitReader> createBatchedSplitReader(
+      const std::vector<
+          std::shared_ptr<facebook::velox::connector::ConnectorSplit>>& batch,
+      dwio::common::RuntimeStats& runtimeStats);
+
   // Virtual method to create a `CudfSplitReader` or subclass for the data
   // source.
   virtual std::unique_ptr<CudfSplitReader> createCudfSplitReader();
@@ -112,6 +123,12 @@ class CudfHiveDataSource : public DataSource, public NvtxHelper {
   cudf::ast::expression const* subfieldFilterExpr_{nullptr};
 
  private:
+  // Activates the next child of the current logical split batch.
+  bool prepareNextSplit();
+
+  // Accounts for the files represented by the current reader.
+  void updateCompletedBytes();
+
   // Construct and cache a RowTypePtr for the table column names and types.
   const RowTypePtr getTableRowType();
   RowTypePtr cachedTableRowType_{};
@@ -124,6 +141,9 @@ class CudfHiveDataSource : public DataSource, public NvtxHelper {
   dwio::common::RuntimeStats runtimeStats_;
 
   std::unique_ptr<CudfSplitReader> cudfSplitReader_;
+
+  std::vector<std::shared_ptr<ConnectorSplit>> splitBatch_;
+  size_t nextSplitIndex_{0};
 
   // Optimized remaining-filter expression, or null when there is no remaining
   // filter. Gates remaining-filter evaluation in next().

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -42,6 +42,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/error.hpp>
 
 #include <cuda_runtime.h>
 #include <nvtx3/nvtx3.hpp>
@@ -208,18 +209,52 @@ void CudfSplitReader::prepareSplitInternal(
   setupReader();
 }
 
-void CudfSplitReader::prepareSplit(dwio::common::RuntimeStats& runtimeStats) {
-  // Reset existing split and split readers, if any
+CudfSplitReader::~CudfSplitReader() {
   resetSplit();
+}
 
-  // Acquire a stream from the global stream pool
+void CudfSplitReader::initializeSplit() {
+  resetSplit();
   stream_ = cudfGlobalStreamPool().get_stream();
+}
 
-  // Perform split-specific setup.
+void CudfSplitReader::recordPreparedSplit(
+    dwio::common::RuntimeStats& runtimeStats) const {
+  ++runtimeStats.processedSplits;
+  if (multiFileReader_) {
+    auto& metrics =
+        runtimeStats.formatSpecificStats[dwio::common::FileFormat::PARQUET];
+    metrics["cudfMultiFileReaders"].addValue(1);
+    metrics["cudfBatchedFiles"].addValue(split_->filePaths.size());
+  }
+}
+
+bool CudfSplitReader::tryPrepareBatch(
+    const std::vector<uint64_t>& lengths,
+    dwio::common::RuntimeStats& runtimeStats) {
+  initializeSplit();
+  try {
+    fileMetaDatas();
+  } catch (const cudf::logic_error&) {
+    // cuDF rejects incompatible schemas while reading the footer vector.
+    // Let individual readers perform their usual validation and adaptation.
+    return false;
+  }
+  VELOX_CHECK_EQ(lengths.size(), fileMetaData_.size());
+  for (size_t i = 0; i < lengths.size(); ++i) {
+    if (lengths[i] < fileSize(i)) {
+      return false;
+    }
+  }
   prepareSplitInternal(runtimeStats);
+  recordPreparedSplit(runtimeStats);
+  return true;
+}
 
-  // Update runtime stats
-  runtimeStats.processedSplits++;
+void CudfSplitReader::prepareSplit(dwio::common::RuntimeStats& runtimeStats) {
+  initializeSplit();
+  prepareSplitInternal(runtimeStats);
+  recordPreparedSplit(runtimeStats);
 }
 
 std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::next(
@@ -260,6 +295,10 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk() {
         std::move(tableWithMetadata.tbl), outputType_, stream_, output_mr);
   }
 
+  if (multiFileReader_) {
+    return readMultiFileChunk();
+  }
+
   // Read table using the experimental parquet reader
   VELOX_CHECK_NOT_NULL(exptSplitReader_, "cuDF hybrid scan reader not present");
   VELOX_CHECK_NOT_NULL(hybridScanState_, "hybrid scan state not present");
@@ -292,7 +331,7 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk() {
     // for each input byte range, and a future to wait for all reads to
     // complete
     auto ioData = fetchByteRangesAsync(
-        dataSource_, columnChunkByteRanges, stream_, get_temp_mr());
+        dataSources_.front(), columnChunkByteRanges, stream_, get_temp_mr());
 
     // Wait for all pending reads to complete
     std::get<2>(ioData).wait();
@@ -323,11 +362,79 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk() {
       std::move(tableWithMetadata.tbl), outputType_, stream_, output_mr);
 }
 
+std::optional<std::unique_ptr<cudf::table>>
+CudfSplitReader::readMultiFileChunk() {
+  const auto outputMemoryResource = determineCudfMemoryResource();
+  std::call_once(*hybridScanState_->isHybridScanSetup_, [&]() {
+    auto rowGroups = multiFileReader_->all_row_groups(readerOptions_);
+    if (readerOptions_.get_filter().has_value()) {
+      rowGroups = multiFileReader_->filter_row_groups_with_stats(
+          rowGroups, readerOptions_, stream_);
+    }
+
+    // cuDF returns flattened column ranges and the source of each range.
+    // Read each source through its own datasource, then restore cuDF's order.
+    const auto [ranges, sources] =
+        multiFileReader_->all_column_chunks_byte_ranges(
+            rowGroups, readerOptions_);
+    VELOX_CHECK_EQ(ranges.size(), sources.size());
+    std::vector<std::vector<cudf::io::text::byte_range_info>> rangesBySource(
+        dataSources_.size());
+    std::vector<std::vector<size_t>> positionsBySource(dataSources_.size());
+    for (size_t i = 0; i < ranges.size(); ++i) {
+      VELOX_CHECK_GE(sources[i], 0);
+      const auto source = static_cast<size_t>(sources[i]);
+      VELOX_CHECK_LT(source, dataSources_.size());
+      rangesBySource[source].push_back(ranges[i]);
+      positionsBySource[source].push_back(i);
+    }
+
+    hybridScanState_->columnChunkData_.resize(ranges.size());
+    for (size_t source = 0; source < dataSources_.size(); ++source) {
+      if (rangesBySource[source].empty()) {
+        continue;
+      }
+      auto [buffers, spans, completion] = fetchByteRangesAsync(
+          dataSources_[source], rangesBySource[source], stream_, get_temp_mr());
+      // Finish the read before releasing its buffers or switching sources.
+      // This retains the existing I/O ownership model without a new executor.
+      completion.get();
+      VELOX_CHECK_EQ(spans.size(), positionsBySource[source].size());
+      for (size_t i = 0; i < spans.size(); ++i) {
+        hybridScanState_->columnChunkData_[positionsBySource[source][i]] =
+            spans[i];
+      }
+      for (auto& buffer : buffers) {
+        hybridScanState_->columnChunkBuffers_.push_back(std::move(buffer));
+      }
+    }
+
+    multiFileReader_->setup_chunking_for_all_columns(
+        cudfHiveConfig_->maxChunkReadLimitSession(
+            connectorQueryCtx_->sessionProperties()),
+        cudfHiveConfig_->maxPassReadLimitSession(
+            connectorQueryCtx_->sessionProperties()),
+        rowGroups,
+        hybridScanState_->columnChunkData_,
+        readerOptions_,
+        stream_,
+        outputMemoryResource);
+  });
+
+  if (!multiFileReader_->has_next_table_chunk()) {
+    return std::nullopt;
+  }
+  auto result = multiFileReader_->materialize_all_columns_chunk();
+  return castDecimalColumnsToVeloxTypes(
+      std::move(result.tbl), outputType_, stream_, outputMemoryResource);
+}
+
 void CudfSplitReader::resetSplit() {
   splitReader_.reset();
   exptSplitReader_.reset();
+  multiFileReader_.reset();
   hybridScanState_.reset();
-  dataSource_.reset();
+  dataSources_.clear();
   fileMetaData_.clear();
   pushdownFilterExpr_ = subfieldFilterExpr_;
   hasSplitSpecificPushdownFilter_ = false;
@@ -346,104 +453,111 @@ bool CudfSplitReader::hasSplitSpecificPushdownFilter() const {
 }
 
 void CudfSplitReader::setupCudfDataSource() {
-  if (dataSource_) {
+  if (not dataSources_.empty()) {
     return;
   }
 
   const auto useBufferedInput = cudfHiveConfig_->useBufferedInputSession(
       connectorQueryCtx_->sessionProperties());
 
-  VELOX_CHECK(
-      not isAbfsPath(split_->filePath) or useBufferedInput,
-      "ABFS blobs require buffered input data source. "
-      "Set the session property '{}' (or connector property '{}') to 'true'. "
-      "Blob Path: {}.",
-      CudfHiveConfig::kUseBufferedInputSession,
-      CudfHiveConfig::kUseBufferedInput,
-      split_->filePath);
+  for (const auto& path : split_->filePaths) {
+    VELOX_CHECK(
+        not isAbfsPath(path) or useBufferedInput,
+        "ABFS blobs require buffered input data source. "
+        "Set the session property '{}' (or connector property '{}') to 'true'. "
+        "Blob Path: {}.",
+        CudfHiveConfig::kUseBufferedInputSession,
+        CudfHiveConfig::kUseBufferedInput,
+        path);
+  }
 
   // Use KvikIO data source if we don't want to use the BufferedInput source
   if (not useBufferedInput) {
     VLOG(1) << fmt::format(
-        "Using KvikIO data source for file: {}", split_->filePath);
-    dataSource_ = std::move(
-        cudf::io::make_datasources(cudf::io::source_info{split_->filePath})
-            .front());
+        "Using KvikIO data sources for {} file(s)", split_->filePaths.size());
+    auto sources =
+        cudf::io::make_datasources(cudf::io::source_info{split_->filePaths});
+    dataSources_.reserve(sources.size());
+    for (auto& source : sources) {
+      dataSources_.push_back(std::move(source));
+    }
     return;
   }
 
-  auto fileHandleCachePtr = FileHandleCachedPtr{};
-  try {
-    const auto fileHandleKey = FileHandleKey{
-        .filename = split_->filePath,
-        .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
-    auto fileProperties = FileProperties{};
-    fileHandleCachePtr = fileHandleFactory_->generate(
-        fileHandleKey, &fileProperties, ioStats_ ? ioStats_.get() : nullptr);
-    VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
-  } catch (const VeloxRuntimeError& e) {
-    // ABFS blobs can not fall back to KvikIO. Throw the original error.
-    if (isAbfsPath(split_->filePath)) {
-      VELOX_USER_FAIL(
-          "Failed to generate file handle cache for ABFS blob. Ensure "
-          "registerAbfsFileSystem() and registerAzureClientProvider() have "
-          "been called and the connector config provides Azure credentials. "
-          "Blob path: {}. Error: {}.",
-          split_->filePath,
-          e.what());
+  dataSources_.reserve(split_->filePaths.size());
+  for (const auto& path : split_->filePaths) {
+    auto fileHandleCachePtr = FileHandleCachedPtr{};
+    try {
+      const auto fileHandleKey = FileHandleKey{
+          .filename = path,
+          .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
+      auto fileProperties = FileProperties{};
+      fileHandleCachePtr = fileHandleFactory_->generate(
+          fileHandleKey, &fileProperties, ioStats_ ? ioStats_.get() : nullptr);
+      VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
+    } catch (const VeloxRuntimeError& e) {
+      if (isAbfsPath(path)) {
+        VELOX_USER_FAIL(
+            "Failed to generate file handle cache for ABFS blob. Ensure "
+            "registerAbfsFileSystem() and registerAzureClientProvider() have "
+            "been called and the connector config provides Azure credentials. "
+            "Blob path: {}. Error: {}.",
+            path,
+            e.what());
+      }
+
+      LOG(WARNING) << fmt::format(
+          "Failed to generate file handle cache for file. Falling back to KvikIO. Path: {}",
+          path);
+      dataSources_.push_back(
+          std::move(
+              cudf::io::make_datasources(cudf::io::source_info{path}).front()));
+      continue;
     }
 
-    LOG(WARNING) << fmt::format(
-        "Failed to generate file handle cache for file. Falling back to KvikIO. Path: {}",
-        split_->filePath);
-    dataSource_ = std::move(
-        cudf::io::make_datasources(cudf::io::source_info{split_->filePath})
-            .front());
-    return;
-  }
-
-  // Here we keep adding new entries to CacheTTLController when new
-  // fileHandles are generated, if CacheTTLController was created. Creator of
-  // CacheTTLController needs to make sure a size control strategy was
-  // available such as removing aged out entries.
-  if (auto* cacheTTLController = cache::CacheTTLController::getInstance()) {
-    cacheTTLController->addOpenFileInfo(fileHandleCachePtr->uuid.id());
-  }
-
-  auto bufferedInput =
-      velox::connector::hive::BufferedInputBuilder::getInstance()->create(
-          *fileHandleCachePtr,
-          baseReaderOpts_,
-          connectorQueryCtx_,
-          ioStatistics_,
-          ioStats_,
-          executor_);
-  if (not bufferedInput) {
-    // ABFS blobs can not fall back to KvikIO
-    if (isAbfsPath(split_->filePath)) {
-      VELOX_USER_FAIL(
-          "Failed to create buffered input data source for the ABFS blob. Ensure that the registered "
-          "BufferedInputBuilder is ABFS-aware. Blob path: {}.",
-          split_->filePath);
+    if (auto* cacheTTLController = cache::CacheTTLController::getInstance()) {
+      cacheTTLController->addOpenFileInfo(fileHandleCachePtr->uuid.id());
     }
 
-    LOG(WARNING) << fmt::format(
-        "Failed to create buffered input data source for file. Falling back to the KvikIO. Path: {}",
-        split_->filePath);
-    dataSource_ = std::move(
-        cudf::io::make_datasources(cudf::io::source_info{split_->filePath})
-            .front());
-    return;
+    auto bufferedInput =
+        velox::connector::hive::BufferedInputBuilder::getInstance()->create(
+            *fileHandleCachePtr,
+            baseReaderOpts_,
+            connectorQueryCtx_,
+            ioStatistics_,
+            ioStats_,
+            executor_);
+    if (not bufferedInput) {
+      if (isAbfsPath(path)) {
+        VELOX_USER_FAIL(
+            "Failed to create buffered input data source for the ABFS blob. Ensure that the registered "
+            "BufferedInputBuilder is ABFS-aware. Blob path: {}.",
+            path);
+      }
+
+      LOG(WARNING) << fmt::format(
+          "Failed to create buffered input data source for file. Falling back to KvikIO. Path: {}",
+          path);
+      dataSources_.push_back(
+          std::move(
+              cudf::io::make_datasources(cudf::io::source_info{path}).front()));
+      continue;
+    }
+    dataSources_.push_back(
+        std::make_unique<BufferedInputDataSource>(std::move(bufferedInput)));
   }
-  dataSource_ =
-      std::make_unique<BufferedInputDataSource>(std::move(bufferedInput));
 }
 
 void CudfSplitReader::setupReaderOptions() {
-  VELOX_CHECK_NOT_NULL(
-      dataSource_,
+  VELOX_CHECK(
+      not dataSources_.empty(),
       "CudfSplitReader does not have a datasource. Call setupCudfDataSource() first");
-  auto sourceInfo = cudf::io::source_info{dataSource_.get()};
+  std::vector<cudf::io::datasource*> sources;
+  sources.reserve(dataSources_.size());
+  for (const auto& source : dataSources_) {
+    sources.push_back(source.get());
+  }
+  auto sourceInfo = cudf::io::source_info{sources};
 
   // Reader options
   readerOptions_ =
@@ -482,6 +596,10 @@ rmm::device_async_resource_ref CudfSplitReader::determineCudfMemoryResource()
   return get_output_mr();
 }
 
+uint64_t CudfSplitReader::fileSize(size_t index) const {
+  return dataSources_.at(index)->size();
+}
+
 void CudfSplitReader::fileMetaDatas() {
   if (not fileMetaData_.empty()) {
     return;
@@ -491,13 +609,16 @@ void CudfSplitReader::fileMetaDatas() {
   setupCudfDataSource();
 
   // Check that the datasource is set up
-  VELOX_CHECK_NOT_NULL(
-      dataSource_,
+  VELOX_CHECK(
+      not dataSources_.empty(),
       "CudfSplitReader does not have a datasource. Call setupCudfDataSource() first");
 
-  // Wrap the existing datasource without transferring ownership.
+  // Wrap the existing datasources without transferring ownership.
   std::vector<std::unique_ptr<cudf::io::datasource>> sources;
-  sources.push_back(cudf::io::datasource::create(dataSource_.get()));
+  sources.reserve(dataSources_.size());
+  for (const auto& source : dataSources_) {
+    sources.push_back(cudf::io::datasource::create(source.get()));
+  }
   fileMetaData_ = cudf::io::read_parquet_footers(sources);
   VELOX_CHECK_GE(
       fileMetaData_.size(),
@@ -525,7 +646,10 @@ void CudfSplitReader::createCudfReader() {
   setupReaderOptions();
 
   std::vector<std::unique_ptr<cudf::io::datasource>> sources;
-  sources.push_back(cudf::io::datasource::create(dataSource_.get()));
+  sources.reserve(dataSources_.size());
+  for (const auto& source : dataSources_) {
+    sources.push_back(cudf::io::datasource::create(source.get()));
+  }
 
   // Create a parquet reader
   splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(
@@ -547,25 +671,23 @@ void CudfSplitReader::createExperimentalReader() {
   // Read file metadatas
   fileMetaDatas();
 
-  // Setup reader options
-  setupReaderOptions();
-
   VELOX_CHECK_EQ(
       fileMetaData_.size(),
-      1,
-      "cuDF experimental reader requires exactly one parquet metadata");
+      dataSources_.size(),
+      "Expected one parquet metadata per data source");
 
-  // Create a hybrid scan reader
-  nvtxRangePush("hybridScanReader");
-  auto reader = std::make_unique<CudfHybridScanReader>(
-      std::move(fileMetaData_.front()), readerOptions_);
-  nvtxRangePop();
-
-  exptSplitReader_ = std::move(reader);
+  setupReaderOptions();
+  if (dataSources_.size() > 1) {
+    multiFileReader_ = std::make_unique<
+        cudf::io::parquet::experimental::hybrid_scan_multifile>(
+        cudf::host_span<const cudf::io::parquet::FileMetaData>{
+            fileMetaData_.data(), fileMetaData_.size()},
+        readerOptions_);
+  } else {
+    exptSplitReader_ = std::make_unique<CudfHybridScanReader>(
+        std::move(fileMetaData_.front()), readerOptions_);
+  }
   hybridScanState_ = std::make_unique<HybridScanState>();
-
-  // Metadata ingested
-  fileMetaData_.clear();
 }
 
 void CudfSplitReader::totalScanTimeCalculator(void* userData) {

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -31,11 +31,13 @@
 
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/experimental/hybrid_scan_multifile.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/io/types.hpp>
 
 #include <functional>
+#include <optional>
 #include <utility>
 
 namespace facebook::velox::cudf_velox::connector::hive {
@@ -66,7 +68,7 @@ class CudfSplitReader : public NvtxHelper {
       bool useExperimentalCudfReader,
       cudf::ast::expression const* subfieldFilterExpr);
 
-  virtual ~CudfSplitReader() = default;
+  virtual ~CudfSplitReader();
 
   using PushdownFilterBuilder = std::function<cudf::ast::expression const*(
       const cudf::io::parquet::FileMetaData&)>;
@@ -83,6 +85,12 @@ class CudfSplitReader : public NvtxHelper {
   /// @param runtimeStats Reference to the DataSource's runtime statistics
   void prepareSplit(dwio::common::RuntimeStats& runtimeStats);
 
+  /// Prepares a batch if each range covers its whole file and cuDF accepts
+  /// their footers together. Otherwise the datasource retains per-file reads.
+  bool tryPrepareBatch(
+      const std::vector<uint64_t>& lengths,
+      dwio::common::RuntimeStats& runtimeStats);
+
   /// Read the next raw cudf table chunk. Returns nullopt when done.
   virtual std::optional<std::unique_ptr<cudf::table>> next(uint64_t size);
 
@@ -92,6 +100,12 @@ class CudfSplitReader : public NvtxHelper {
   }
 
  protected:
+  // Resets reader state and acquires the stream for a new split.
+  void initializeSplit();
+
+  // Records successful reader preparation, including the selected batch path.
+  void recordPreparedSplit(dwio::common::RuntimeStats& runtimeStats) const;
+
   // Performs split-specific setup after base reader state is reset.
   virtual void prepareSplitInternal(dwio::common::RuntimeStats& runtimeStats);
 
@@ -113,6 +127,9 @@ class CudfSplitReader : public NvtxHelper {
 
   // Read file metadatas.
   void fileMetaDatas();
+
+  // File size after the data sources have been opened.
+  uint64_t fileSize(size_t index) const;
 
   // Return the logical subfield filter used after reading.
   cudf::ast::expression const* subfieldFilter() const;
@@ -145,7 +162,7 @@ class CudfSplitReader : public NvtxHelper {
   // Clear splitReaders and datasources after split has been fully processed.
   void resetSplit();
 
-  // Setup the cuDF reader options
+  // Setup cuDF reader options for all sources.
   void setupReaderOptions();
 
   // Create the chunked parquet reader.
@@ -154,14 +171,21 @@ class CudfSplitReader : public NvtxHelper {
   // Create the experimental hybrid scan reader.
   void createExperimentalReader();
 
+  // Reads one chunk with a single hybrid reader spanning every file.
+  std::optional<std::unique_ptr<cudf::table>> readMultiFileChunk();
+
   std::shared_ptr<CudfHiveConfig> cudfHiveConfig_;
   memory::MemoryPool* pool_;
 
   // cuDF split reader stuff.
-  std::shared_ptr<cudf::io::datasource> dataSource_;
+  std::vector<std::shared_ptr<cudf::io::datasource>> dataSources_;
   cudf::io::parquet_reader_options readerOptions_;
   CudfParquetReaderPtr splitReader_;
   CudfHybridScanReaderPtr exptSplitReader_;
+  // Keeps one reader for a native batch; options and metadata outlive it.
+  std::unique_ptr<cudf::io::parquet::experimental::hybrid_scan_multifile>
+      multiFileReader_;
+
   std::unique_ptr<HybridScanState> hybridScanState_;
   bool useExperimentalCudfReader_;
 

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h"
 #include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.h"
@@ -54,6 +55,10 @@ CudfIcebergConnector::CudfIcebergConnector(
               connectorConfig())) {
   registerIcebergInternalFunctions(icebergConfig_->functionPrefix());
   VLOG(1) << "cuDF Iceberg connector created";
+}
+
+bool CudfIcebergConnector::supportsSplitBatch() const {
+  return cudfIsRegistered() && CudfConfig::getInstance().batchSplitsEnabled;
 }
 
 std::unique_ptr<DataSource> CudfIcebergConnector::createDataSource(

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
@@ -54,6 +54,9 @@ class CudfIcebergConnector final
     return false;
   }
 
+  /// Accepts split vectors when cuDF split batching is enabled.
+  bool supportsSplitBatch() const override;
+
   bool supportsSplitPreload() const override {
     return false;
   }

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
@@ -48,6 +48,55 @@ CudfIcebergDataSource::CudfIcebergDataSource(
           cudfHiveConfig),
       hiveConfig_(hiveConfig) {}
 
+std::unique_ptr<CudfSplitReader>
+CudfIcebergDataSource::createBatchedSplitReader(
+    const std::vector<
+        std::shared_ptr<facebook::velox::connector::ConnectorSplit>>& batch,
+    dwio::common::RuntimeStats& runtimeStats) {
+  if (!useExperimentalCudfReader_) {
+    return nullptr;
+  }
+
+  std::vector<std::string> paths;
+  std::shared_ptr<const velox_iceberg::HiveIcebergSplit> first;
+  for (const auto& child : batch) {
+    auto split =
+        std::dynamic_pointer_cast<const velox_iceberg::HiveIcebergSplit>(child);
+    if (!split || !split->deleteFiles.empty() ||
+        !split->partitionKeys.empty() ||
+        !split->identityPartitionKeys.empty() || split->start != 0 ||
+        split->fileFormat != dwio::common::FileFormat::PARQUET ||
+        split->tableBucketNumber || split->bucketConversion ||
+        split->rowIdProperties || split->extraFileInfo ||
+        split->batchSizeHint != 0 || !split->cacheable || split->properties) {
+      return nullptr;
+    }
+    // Per-file information columns cannot be injected as one batch constant.
+    for (const auto& name : readColumnNames_) {
+      if (split->infoColumns.contains(name)) {
+        return nullptr;
+      }
+    }
+    if (!first) {
+      first = split;
+    } else if (
+        split->customSplitInfo != first->customSplitInfo ||
+        split->columnMappingMode != first->columnMappingMode) {
+      return nullptr;
+    }
+    paths.push_back(split->filePath);
+  }
+
+  icebergSplit_ = first;
+  split_ = CudfHiveConnectorSplit::makeBatch(first->connectorId, paths, 0);
+  auto reader = createCudfSplitReader();
+  if (!checkedPointerCast<CudfIcebergSplitReader>(reader.get())
+           ->tryPrepareBatch(batch, runtimeStats)) {
+    return nullptr;
+  }
+  return reader;
+}
+
 void CudfIcebergDataSource::convertSplit(
     std::shared_ptr<velox_connector::ConnectorSplit> split) {
   // Convert `ConnectorSplit` to `HiveIcebergSplit`

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.h
@@ -55,6 +55,11 @@ class CudfIcebergDataSource : public ::facebook::velox::cudf_velox::connector::
       const std::shared_ptr<const velox_hive::HiveConfig>& hiveConfig);
 
  protected:
+  std::unique_ptr<CudfSplitReader> createBatchedSplitReader(
+      const std::vector<
+          std::shared_ptr<facebook::velox::connector::ConnectorSplit>>& batch,
+      dwio::common::RuntimeStats& runtimeStats) override;
+
   // Override to create `CudfIcebergSplitReader` instead of
   // `CudfHiveSplitReader`
   std::unique_ptr<CudfSplitReader> createCudfSplitReader() override;

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -59,6 +59,51 @@ namespace velox_iceberg = ::facebook::velox::connector::hive::iceberg;
 
 namespace {
 
+bool sameLogicalType(
+    const cudf::io::parquet::LogicalType& left,
+    const cudf::io::parquet::LogicalType& right) {
+  const auto sameOptional = [](const auto& a, const auto& b, auto equal) {
+    return a.has_value() == b.has_value() && (!a || equal(*a, *b));
+  };
+  const auto sameTime = [](const auto& a, const auto& b) {
+    return a.isAdjustedToUTC == b.isAdjustedToUTC && a.unit.type == b.unit.type;
+  };
+  return left.type == right.type &&
+      sameOptional(
+             left.decimal_type,
+             right.decimal_type,
+             [](const auto& a, const auto& b) {
+               return a.scale == b.scale && a.precision == b.precision;
+             }) &&
+      sameOptional(left.time_type, right.time_type, sameTime) &&
+      sameOptional(left.timestamp_type, right.timestamp_type, sameTime) &&
+      sameOptional(
+             left.int_type, right.int_type, [](const auto& a, const auto& b) {
+               return a.bitWidth == b.bitWidth && a.isSigned == b.isSigned;
+             });
+}
+
+// Iceberg adapts columns once for a native batch. Require identical physical
+// schemas, including annotations omitted by cuDF's SchemaElement::operator==,
+// so files needing different schema evolution retain their individual readers.
+bool sameBatchSchema(
+    const std::vector<cudf::io::parquet::SchemaElement>& left,
+    const std::vector<cudf::io::parquet::SchemaElement>& right) {
+  return left.size() == right.size() &&
+      std::equal(
+             left.begin(),
+             left.end(),
+             right.begin(),
+             [](const auto& a, const auto& b) {
+               return a == b && a.repetition_type == b.repetition_type &&
+                   a.arrow_type == b.arrow_type &&
+                   a.output_as_byte_array == b.output_as_byte_array &&
+                   a.logical_type.has_value() == b.logical_type.has_value() &&
+                   (!a.logical_type ||
+                    sameLogicalType(*a.logical_type, *b.logical_type));
+             });
+}
+
 // Returns true if a delete/update file should be skipped based on sequence
 // number conflict resolution. Per the Iceberg spec (V2+):
 //   - Equality deletes apply when deleteSeqNum > dataSeqNum (i.e., skip when
@@ -111,6 +156,49 @@ CudfIcebergSplitReader::CudfIcebergSplitReader(
           subfieldFilterExpr),
       icebergSplit_(std::move(icebergSplit)),
       hiveConfig_(hiveConfig) {}
+
+bool CudfIcebergSplitReader::tryPrepareBatch(
+    const std::vector<
+        std::shared_ptr<facebook::velox::connector::ConnectorSplit>>& batch,
+    dwio::common::RuntimeStats& runtimeStats) {
+  initializeSplit();
+  try {
+    fileMetaDatas();
+  } catch (const cudf::logic_error&) {
+    // cuDF's footer loader can reject different schemas before returning
+    // metadata. Let the per-file reader perform validation and adaptation;
+    // errors in an individual file still propagate through that path.
+    return false;
+  }
+  const auto& schema = fileMetaData_.front().schema;
+  if (schema.empty() || readColumnNames_.empty()) {
+    return false;
+  }
+  // Keep batching to ordinary columns present in every file. Missing columns
+  // and synthesized metadata retain the established per-file adaptation.
+  for (const auto& name : readColumnNames_) {
+    if (std::none_of(
+            schema.front().children_idx.begin(),
+            schema.front().children_idx.end(),
+            [&](auto i) { return schema.at(i).name == name; })) {
+      return false;
+    }
+  }
+  VELOX_CHECK_EQ(batch.size(), fileMetaData_.size());
+  for (size_t i = 0; i < batch.size(); ++i) {
+    // Iceberg does not always send a file size in split metadata. Check the
+    // open datasource before treating a bounded split as a full file.
+    const auto& child =
+        static_cast<const velox_iceberg::HiveIcebergSplit&>(*batch[i]);
+    if (child.length < fileSize(i) ||
+        !sameBatchSchema(schema, fileMetaData_[i].schema)) {
+      return false;
+    }
+  }
+  prepareSplitInternal(runtimeStats);
+  recordPreparedSplit(runtimeStats);
+  return true;
+}
 
 void CudfIcebergSplitReader::resetSplit() {
   deletionVectorReader_.reset();
@@ -737,10 +825,7 @@ void CudfIcebergSplitReader::cacheSchemaFromMetadata() {
   // Read file metadatas if not already
   fileMetaDatas();
 
-  VELOX_CHECK_EQ(
-      fileMetaData_.size(),
-      1,
-      "Expected a single parquet footer for Iceberg data file");
+  VELOX_CHECK_EQ(fileMetaData_.size(), split_->filePaths.size());
   const auto& meta = fileMetaData_.front();
   VELOX_CHECK(not meta.schema.empty(), "Parquet footer schema is empty");
   VELOX_CHECK_GE(meta.num_rows, 0, "Parquet footer reports negative row count");
@@ -777,12 +862,14 @@ CudfIcebergSplitReader::computeSplitRowRange() const {
 
   std::size_t startRow{0};
   std::size_t numRows{0};
-  for (const auto& rowGroup : fileMetaData_.front().row_groups) {
-    const auto offset = rowGroupOffset(rowGroup);
-    if (offset < split_->start) {
-      startRow += rowGroup.num_rows;
-    } else if (offset - split_->start < split_->size()) {
-      numRows += rowGroup.num_rows;
+  for (const auto& metadata : fileMetaData_) {
+    for (const auto& rowGroup : metadata.row_groups) {
+      const auto offset = rowGroupOffset(rowGroup);
+      if (offset < split_->start) {
+        startRow += rowGroup.num_rows;
+      } else if (offset - split_->start < split_->size()) {
+        numRows += rowGroup.num_rows;
+      }
     }
   }
   return {startRow, numRows};

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -65,6 +65,14 @@ class CudfIcebergSplitReader : public CudfSplitReader {
       bool useExperimentalCudfReader,
       cudf::ast::expression const* subfieldFilterExpr);
 
+  /// Prepares compatible full files with one multi-file hybrid reader.
+  /// Returns false for different physical schemas so the data source can
+  /// retain the original per-file readers and schema adaptation.
+  bool tryPrepareBatch(
+      const std::vector<
+          std::shared_ptr<facebook::velox::connector::ConnectorSplit>>& batch,
+      dwio::common::RuntimeStats& runtimeStats);
+
  protected:
   // Sets up delete file readers and column projection after base state reset.
   void prepareSplitInternal(dwio::common::RuntimeStats& runtimeStats) override;

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -436,6 +436,9 @@ void CudfConfig::initialize(
           "Invalid timestamp unit: {}. Valid values are: s, ms, us, ns", unit);
     }
   }
+  if (config.find(kCudfBatchSplitsEnabled) != config.end()) {
+    batchSplitsEnabled = folly::to<bool>(config[kCudfBatchSplitsEnabled]);
+  }
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -29,7 +29,8 @@ TEST(ConfigTest, cudfConfig) {
       {CudfConfig::kCudfFunctionNamePrefix, "presto"},
       {CudfConfig::kCudfStreamingGroupbyEnabled, "true"},
       {CudfConfig::kCudfStreamingGroupbyCapacityMultiplier, "3.5"},
-      {CudfConfig::kCudfAllowCpuFallback, "false"}};
+      {CudfConfig::kCudfAllowCpuFallback, "false"},
+      {CudfConfig::kCudfBatchSplitsEnabled, "true"}};
 
   CudfConfig config;
   ASSERT_FALSE(config.streamingGroupbyEnabled);
@@ -43,5 +44,6 @@ TEST(ConfigTest, cudfConfig) {
   ASSERT_EQ(config.streamingGroupbyEnabled, true);
   ASSERT_EQ(config.streamingGroupbyCapacityMultiplier, 3.5);
   ASSERT_EQ(config.allowCpuFallback, false);
+  ASSERT_EQ(config.batchSplitsEnabled, true);
 }
 } // namespace facebook::velox::cudf_velox::test

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConfig.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnector.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h"
@@ -30,6 +31,7 @@
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/FileSink.h"
@@ -49,6 +51,9 @@
 #include <cudf/io/parquet.hpp>
 
 #include <fmt/ranges.h>
+#include <folly/ScopeGuard.h>
+
+#include <atomic>
 
 using namespace facebook::velox;
 using namespace facebook::velox::common::testutil;
@@ -95,6 +100,53 @@ StatsFilterMetrics readParquetWithStatsFilter(
 
 class TableScanTest : public virtual CudfHiveConnectorTestBase {
  protected:
+  struct BatchedFiles {
+    std::vector<std::shared_ptr<TempFilePath>> files;
+    std::vector<RowVectorPtr> vectors;
+    std::vector<std::string> paths;
+  };
+
+  class SuccessfulBufferedInputBuilder final
+      : public facebook::velox::connector::hive::BufferedInputBuilder {
+   public:
+    explicit SuccessfulBufferedInputBuilder(
+        std::shared_ptr<facebook::velox::connector::hive::BufferedInputBuilder>
+            delegate)
+        : delegate_(std::move(delegate)) {}
+
+    std::unique_ptr<dwio::common::BufferedInput> create(
+        const FileHandle& fileHandle,
+        const dwio::common::ReaderOptions& readerOptions,
+        const ConnectorQueryCtx* connectorQueryCtx,
+        std::shared_ptr<io::IoStatistics> ioStatistics,
+        std::shared_ptr<IoStats> ioStats,
+        folly::Executor* executor,
+        const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
+        override {
+      auto input = delegate_->create(
+          fileHandle,
+          readerOptions,
+          connectorQueryCtx,
+          std::move(ioStatistics),
+          std::move(ioStats),
+          executor,
+          fileReadOps);
+      if (input) {
+        successfulCreateCount_.fetch_add(1, std::memory_order_relaxed);
+      }
+      return input;
+    }
+
+    uint64_t successfulCreateCount() const {
+      return successfulCreateCount_.load(std::memory_order_relaxed);
+    }
+
+   private:
+    std::shared_ptr<facebook::velox::connector::hive::BufferedInputBuilder>
+        delegate_;
+    std::atomic_uint64_t successfulCreateCount_{0};
+  };
+
   void SetUp() override {
     CudfHiveConnectorTestBase::SetUp();
     ExchangeSource::factories().clear();
@@ -115,6 +167,28 @@ class TableScanTest : public virtual CudfHiveConnectorTestBase {
 
   Split makeCudfHiveSplit(std::string path, int64_t splitWeight = 0) {
     return Split(makeCudfHiveConnectorSplit(std::move(path), splitWeight));
+  }
+
+  BatchedFiles makeBatchedFiles(int32_t count, int32_t rowsPerFile = 1'000) {
+    BatchedFiles data;
+    data.files = makeFilePaths(count);
+    data.vectors.reserve(count);
+    data.paths.reserve(count);
+    for (size_t fileIndex = 0; fileIndex < data.files.size(); ++fileIndex) {
+      const auto& file = data.files[fileIndex];
+      auto vector = makeVectors(1, rowsPerFile).front();
+      vector->children()[0] = makeFlatVector<int32_t>(
+          rowsPerFile, [fileIndex, rowsPerFile](auto row) {
+            const auto magnitude =
+                static_cast<int32_t>(fileIndex) * rowsPerFile + row + 1;
+            return row % 2 == 0 ? -magnitude : magnitude;
+          });
+      writeToFile(file->getPath(), vector);
+      data.vectors.push_back(std::move(vector));
+      data.paths.push_back(file->getPath());
+    }
+    createDuckDbTable(data.vectors);
+    return data;
   }
 
   std::shared_ptr<Task> assertQuery(
@@ -590,7 +664,8 @@ TEST_F(TableScanTest, DISABLED_decimalFilterPushdown) {
           .add(
               "c1",
               common::createHugeintValues(
-                  {int128_t{200}, int128_t{700}}, /*nullAllowed*/ false))
+                  {int128_t{200}, int128_t{700}},
+                  /*nullAllowed*/ false))
           .build();
 
   auto tableHandle = makeTableHandle(
@@ -787,6 +862,295 @@ TEST_F(TableScanTest, remainingFilterExtraction) {
   ASSERT_NE(it, scanStats.customStats.end());
   EXPECT_EQ(it->second.sum, 0)
       << "Expected no remaining filter time when filter is fully extracted";
+}
+
+TEST_F(TableScanTest, batchedMultiFileSplitReaderModes) {
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  config.batchSplitsEnabled = true;
+  auto data = makeBatchedFiles(5);
+  auto originalBuilder =
+      facebook::velox::connector::hive::BufferedInputBuilder::getInstance();
+  auto countingBuilder =
+      std::make_shared<SuccessfulBufferedInputBuilder>(originalBuilder);
+  facebook::velox::connector::hive::BufferedInputBuilder::registerBuilder(
+      countingBuilder);
+  SCOPE_EXIT {
+    facebook::velox::connector::hive::BufferedInputBuilder::registerBuilder(
+        originalBuilder);
+  };
+
+  for (const bool useExperimentalReader : {false, true}) {
+    for (const bool useBufferedInput : {false, true}) {
+      SCOPED_TRACE(
+          fmt::format(
+              "experimental={}, buffered={}",
+              useExperimentalReader,
+              useBufferedInput));
+      resetCudfHiveConnector(
+          std::make_shared<
+              config::ConfigBase>(std::unordered_map<std::string, std::string>{
+              {cudf_velox::connector::hive::CudfHiveConfig::
+                   kUseExperimentalCudfReader,
+               useExperimentalReader ? "true" : "false"},
+              {cudf_velox::connector::hive::CudfHiveConfig::kUseBufferedInput,
+               useBufferedInput ? "true" : "false"},
+              {cudf_velox::connector::hive::CudfHiveConfig::kMaxChunkReadLimit,
+               "16384"}}));
+
+      std::vector<Split> splits;
+      for (const auto& path : data.paths) {
+        splits.emplace_back(
+            facebook::velox::connector::hive::HiveConnectorSplitBuilder(path)
+                .connectorId(kCudfHiveConnectorId)
+                .fileFormat(dwio::common::FileFormat::PARQUET)
+                .build());
+      }
+      const auto successfulCreatesBefore =
+          countingBuilder->successfulCreateCount();
+      auto plan = tableScanNode();
+      auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                      .plan(plan)
+                      .beforeTaskStart([&](Task& task) {
+                        task.addSplit(plan->id(), std::move(splits));
+                        task.noMoreSplits(plan->id());
+                      })
+                      .assertResults("SELECT * FROM tmp");
+      const auto stats = toPlanStats(task->taskStats());
+      EXPECT_GT(stats.at(plan->id()).outputVectors, 2);
+      const auto& metrics = stats.at(plan->id()).customStats;
+      const auto multiFileReaders =
+          metrics.find("parquet.cudfMultiFileReaders");
+      if (useExperimentalReader) {
+        ASSERT_NE(multiFileReaders, metrics.end());
+        EXPECT_EQ(multiFileReaders->second.sum, 1);
+        EXPECT_EQ(metrics.at("parquet.cudfBatchedFiles").sum, 5);
+      } else {
+        EXPECT_EQ(multiFileReaders, metrics.end());
+      }
+      EXPECT_EQ(
+          countingBuilder->successfulCreateCount() - successfulCreatesBefore,
+          useBufferedInput ? data.paths.size() : 0);
+    }
+  }
+}
+
+TEST_F(TableScanTest, batchedMultiFileSplitWithFilter) {
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  config.batchSplitsEnabled = true;
+  auto data = makeBatchedFiles(4);
+  auto outputType = ROW({"c0", "c4"}, {INTEGER(), BIGINT()});
+  auto filters = common::test::SubfieldFiltersBuilder()
+                     .add("c0", greaterThan(0, false))
+                     .build();
+  auto tableHandle =
+      makeTableHandle("parquet_table", nullptr, std::move(filters));
+  auto plan = PlanBuilder(pool_.get())
+                  .startTableScan()
+                  .outputType(outputType)
+                  .tableHandle(tableHandle)
+                  .assignments(
+                      facebook::velox::exec::test::HiveConnectorTestBase::
+                          allRegularColumns(rowType_))
+                  .endTableScan()
+                  .planNode();
+  for (const bool useExperimentalReader : {false, true}) {
+    for (const bool useBufferedInput : {false, true}) {
+      SCOPED_TRACE(
+          fmt::format(
+              "experimental={}, buffered={}",
+              useExperimentalReader,
+              useBufferedInput));
+      resetCudfHiveConnector(
+          std::make_shared<
+              config::ConfigBase>(std::unordered_map<std::string, std::string>{
+              {cudf_velox::connector::hive::CudfHiveConfig::
+                   kUseExperimentalCudfReader,
+               useExperimentalReader ? "true" : "false"},
+              {cudf_velox::connector::hive::CudfHiveConfig::kUseBufferedInput,
+               useBufferedInput ? "true" : "false"}}));
+
+      std::vector<Split> splits;
+      for (const auto& path : data.paths) {
+        splits.emplace_back(
+            facebook::velox::connector::hive::HiveConnectorSplitBuilder(path)
+                .connectorId(kCudfHiveConnectorId)
+                .fileFormat(dwio::common::FileFormat::PARQUET)
+                .build());
+      }
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .plan(plan)
+          .beforeTaskStart([&](Task& task) {
+            task.addSplit(plan->id(), std::move(splits));
+            task.noMoreSplits(plan->id());
+          })
+          .assertResults("SELECT c0, c4 FROM tmp WHERE c0 > 0");
+    }
+  }
+}
+
+TEST_F(TableScanTest, splitVectorPreservesByteRangesAndDisabledMode) {
+  using cudf_velox::connector::hive::CudfHiveConfig;
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  auto data = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  auto firstFile = TempFilePath::create();
+  auto secondFile = TempFilePath::create();
+  writeToFile(firstFile->getPath(), data);
+  writeToFile(secondFile->getPath(), data);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(asRowType(data->type()))
+                  .tableHandle(makeTableHandle("parquet_table"))
+                  .endTableScan()
+                  .planNode();
+  for (const bool enabled : {false, true}) {
+    config.batchSplitsEnabled = enabled;
+    for (const bool wholeFile : {false, true}) {
+      SCOPED_TRACE(fmt::format("enabled={}, wholeFile={}", enabled, wholeFile));
+      std::vector<Split> splits;
+      for (const auto& file : {firstFile, secondFile}) {
+        splits.emplace_back(
+            facebook::velox::connector::hive::HiveConnectorSplitBuilder(
+                file->getPath())
+                .connectorId(kCudfHiveConnectorId)
+                .fileFormat(dwio::common::FileFormat::PARQUET)
+                .length(wholeFile ? std::numeric_limits<uint64_t>::max() : 1)
+                .build());
+      }
+      std::vector<RowVectorPtr> expected = wholeFile
+          ? std::vector<RowVectorPtr>{data, data}
+          : std::vector<RowVectorPtr>{makeRowVector(
+                {makeFlatVector<int64_t>(std::vector<int64_t>{})})};
+      auto task = AssertQueryBuilder(plan)
+                      .connectorSessionProperty(
+                          kCudfHiveConnectorId,
+                          CudfHiveConfig::kUseExperimentalCudfReaderSession,
+                          "true")
+                      .beforeTaskStart([&](Task& task) {
+                        task.addSplit(plan->id(), std::move(splits));
+                        task.noMoreSplits(plan->id());
+                      })
+                      .assertResults(expected);
+      EXPECT_EQ(task->taskStats().numTotalSplits, enabled ? 1 : 2);
+      EXPECT_EQ(
+          toPlanStats(task->taskStats())
+              .at(plan->id())
+              .customStats.contains("parquet.cudfMultiFileReaders"),
+          enabled && wholeFile);
+    }
+  }
+}
+
+TEST_F(TableScanTest, multiFileHybridEmptyAndPrunedSources) {
+  using cudf_velox::connector::hive::CudfHiveConfig;
+  using cudf_velox::connector::hive::CudfHiveConnectorSplit;
+  std::vector<std::shared_ptr<TempFilePath>> files;
+  std::vector<std::string> paths;
+  for (const auto& values : {std::vector<int64_t>{}, {1, 2, 3}, {}, {10, 11}}) {
+    auto file = TempFilePath::create();
+    writeToFile(
+        file->getPath(), makeRowVector({makeFlatVector<int64_t>(values)}));
+    paths.push_back(file->getPath());
+    files.push_back(std::move(file));
+  }
+  auto type = ROW({"c0"}, {BIGINT()});
+  for (const auto threshold : {5, 100}) {
+    SCOPED_TRACE(threshold);
+    auto filters = common::test::SubfieldFiltersBuilder()
+                       .add("c0", greaterThan(threshold, false))
+                       .build();
+    auto plan = PlanBuilder(pool_.get())
+                    .startTableScan()
+                    .outputType(type)
+                    .tableHandle(makeTableHandle(
+                        "parquet_table", nullptr, std::move(filters)))
+                    .endTableScan()
+                    .planNode();
+    auto expected = makeRowVector({makeFlatVector<int64_t>(
+        threshold == 5 ? std::vector<int64_t>{10, 11}
+                       : std::vector<int64_t>{})});
+    auto task = AssertQueryBuilder(plan)
+                    .connectorSessionProperty(
+                        kCudfHiveConnectorId,
+                        CudfHiveConfig::kUseExperimentalCudfReaderSession,
+                        "true")
+                    .connectorSessionProperty(
+                        kCudfHiveConnectorId,
+                        CudfHiveConfig::kMaxChunkReadLimitSession,
+                        "1024")
+                    .split(Split(
+                        CudfHiveConnectorSplit::makeBatch(
+                            kCudfHiveConnectorId, paths, 0)))
+                    .assertResults({expected});
+    const auto stats = toPlanStats(task->taskStats());
+    EXPECT_EQ(
+        stats.at(plan->id()).customStats.at("parquet.cudfMultiFileReaders").sum,
+        1);
+  }
+}
+
+TEST_F(TableScanTest, batchedSplitValidationAndSerialization) {
+  using cudf_velox::connector::hive::CudfHiveConnectorSplit;
+  using cudf_velox::connector::hive::CudfHiveConnectorSplitBuilder;
+  using facebook::velox::connector::ConnectorSplitBatch;
+
+  CudfHiveConnectorSplit singleSplit(
+      kCudfHiveConnectorId, {"file:/tmp/single.parquet"}, 123);
+  EXPECT_EQ(singleSplit.filePath, "/tmp/single.parquet");
+  EXPECT_EQ(singleSplit.start, 123);
+  auto builtSingle = CudfHiveConnectorSplitBuilder{"file:/tmp/single.parquet"}
+                         .connectorId(kCudfHiveConnectorId)
+                         .start(123)
+                         .build();
+  EXPECT_EQ(builtSingle->filePath, "/tmp/single.parquet");
+  EXPECT_EQ(builtSingle->start, 123);
+
+  EXPECT_THROW(
+      CudfHiveConnectorSplit::makeBatch(
+          kCudfHiveConnectorId, std::vector<std::string>{}, 0),
+      VeloxUserError);
+  EXPECT_THROW(
+      CudfHiveConnectorSplitBuilder::forFilePaths(
+          std::vector<std::string>{"a", "b"})
+          .connectorId(kCudfHiveConnectorId)
+          .start(1)
+          .build(),
+      VeloxUserError);
+
+  const auto makeWeightedChild = [](std::string path, int64_t weight) {
+    return CudfHiveConnectorSplitBuilder(std::move(path))
+        .connectorId(kCudfHiveConnectorId)
+        .splitWeight(weight)
+        .build();
+  };
+  std::vector<std::shared_ptr<ConnectorSplit>> weightedChildren{
+      makeWeightedChild("a", std::numeric_limits<int64_t>::max() - 1),
+      makeWeightedChild("b", 2),
+      makeWeightedChild("c", -1)};
+  EXPECT_THROW(
+      ConnectorSplitBatch(kCudfHiveConnectorId, std::move(weightedChildren)),
+      VeloxUserError);
+
+  auto split = CudfHiveConnectorSplit::makeBatch(
+      kCudfHiveConnectorId,
+      std::vector<std::string>{"file:/tmp/a.parquet", "s3a://bucket/b.parquet"},
+      7);
+  auto copy = CudfHiveConnectorSplit::create(split->serialize());
+  EXPECT_EQ(copy->filePaths, split->filePaths);
+  EXPECT_EQ(copy->splitWeight, 7);
+  EXPECT_EQ(copy->start, 0);
+  EXPECT_EQ(copy->size(), std::numeric_limits<uint64_t>::max());
 }
 
 TEST_F(TableScanTest, decimalSubfieldFilter) {

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -16,6 +16,7 @@
 
 /// Basic end-to-end read tests for the cudf Iceberg connector.
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/tests/iceberg/CudfDeletionVectorTestUtils.h"
 #include "velox/experimental/cudf/tests/iceberg/CudfIcebergTestBase.h"
 
@@ -2478,6 +2479,329 @@ TEST_F(CudfIcebergReadTest, partitionColumnsFromHive) {
                   .endTableScan()
                   .planNode();
   AssertQueryBuilder(plan).splits(icebergSplits).assertResults({expected});
+}
+
+TEST_F(CudfIcebergReadTest, splitBatchUsesMultiFileHybridReader) {
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  config.batchSplitsEnabled = true;
+  auto firstData = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  auto secondData = makeRowVector({makeFlatVector<int64_t>({3, 4, 5})});
+  auto firstFile = TempFilePath::create();
+  auto secondFile = TempFilePath::create();
+  writeToFile(firstFile->getPath(), firstData);
+  writeToFile(secondFile->getPath(), secondData);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(asRowType(firstData->type()))
+                  .endTableScan()
+                  .planNode();
+  for (const bool experimental : {false, true}) {
+    for (const bool buffered : {false, true}) {
+      SCOPED_TRACE(
+          fmt::format("experimental={}, buffered={}", experimental, buffered));
+      std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
+          children{
+              makeIcebergSplits(firstFile->getPath()).front(),
+              makeIcebergSplits(secondFile->getPath()).front()};
+      auto task =
+          AssertQueryBuilder(plan)
+              .connectorSessionProperty(
+                  kCudfIcebergConnectorId,
+                  connector::hive::CudfHiveConfig::
+                      kUseExperimentalCudfReaderSession,
+                  experimental ? "true" : "false")
+              .connectorSessionProperty(
+                  kCudfIcebergConnectorId,
+                  connector::hive::CudfHiveConfig::kUseBufferedInputSession,
+                  buffered ? "true" : "false")
+              .beforeTaskStart([&](Task& task) {
+                std::vector<Split> splits;
+                for (auto child : children) {
+                  splits.emplace_back(std::move(child));
+                }
+                task.addSplit(plan->id(), std::move(splits));
+                task.noMoreSplits(plan->id());
+              })
+              .assertResults({firstData, secondData});
+      const auto stats = toPlanStats(task->taskStats());
+      const auto& metrics = stats.at(plan->id()).customStats;
+      if (experimental) {
+        ASSERT_TRUE(metrics.contains("parquet.cudfMultiFileReaders"));
+        EXPECT_EQ(metrics.at("parquet.cudfMultiFileReaders").sum, 1);
+        EXPECT_EQ(metrics.at("parquet.cudfBatchedFiles").sum, 2);
+      } else {
+        EXPECT_FALSE(metrics.contains("parquet.cudfMultiFileReaders"));
+      }
+    }
+  }
+}
+
+TEST_F(CudfIcebergReadTest, splitBatchDoesNotExpandByteRanges) {
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  config.batchSplitsEnabled = true;
+  auto data = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  auto firstFile = TempFilePath::create();
+  auto secondFile = TempFilePath::create();
+  std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
+      children;
+  for (const auto& file : {firstFile, secondFile}) {
+    writeToFile(file->getPath(), data);
+    children.push_back(IcebergSplitBuilder(file->getPath())
+                           .connectorId(kCudfIcebergConnectorId)
+                           .fileFormat(dwio::common::FileFormat::PARQUET)
+                           // Covers the file header, without any row groups.
+                           .length(1)
+                           .build());
+  }
+  auto plan = makeTableScanPlan(asRowType(data->type()));
+  auto empty = makeRowVector({makeFlatVector<int64_t>(std::vector<int64_t>{})});
+  auto task = AssertQueryBuilder(plan)
+                  .connectorSessionProperty(
+                      kCudfIcebergConnectorId,
+                      connector::hive::CudfHiveConfig::
+                          kUseExperimentalCudfReaderSession,
+                      "true")
+                  .beforeTaskStart([&](Task& task) {
+                    std::vector<Split> splits;
+                    for (auto child : children) {
+                      splits.emplace_back(std::move(child));
+                    }
+                    task.addSplit(plan->id(), std::move(splits));
+                    task.noMoreSplits(plan->id());
+                  })
+                  .assertResults({empty});
+  EXPECT_FALSE(toPlanStats(task->taskStats())
+                   .at(plan->id())
+                   .customStats.contains("parquet.cudfMultiFileReaders"));
+}
+
+TEST_F(CudfIcebergReadTest, splitBatchFallsBackForSchemaEvolution) {
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  config.batchSplitsEnabled = true;
+  auto firstData = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  auto secondData = makeRowVector(
+      {makeFlatVector<int64_t>({3, 4}), makeFlatVector<int64_t>({30, 40})});
+  auto firstFile = TempFilePath::create();
+  auto secondFile = TempFilePath::create();
+  writeToFile(firstFile->getPath(), firstData);
+  writeToFile(secondFile->getPath(), secondData);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(asRowType(secondData->type()))
+                  .endTableScan()
+                  .planNode();
+  std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
+      children{
+          makeIcebergSplits(firstFile->getPath()).front(),
+          makeIcebergSplits(secondFile->getPath()).front()};
+  auto expected = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4}),
+       makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt, 30, 40})});
+  auto task = AssertQueryBuilder(plan)
+                  .connectorSessionProperty(
+                      kCudfIcebergConnectorId,
+                      connector::hive::CudfHiveConfig::
+                          kUseExperimentalCudfReaderSession,
+                      "true")
+                  .beforeTaskStart([&](Task& task) {
+                    std::vector<Split> splits;
+                    for (auto child : children) {
+                      splits.emplace_back(std::move(child));
+                    }
+                    task.addSplit(plan->id(), std::move(splits));
+                    task.noMoreSplits(plan->id());
+                  })
+                  .assertResults({expected});
+  EXPECT_FALSE(toPlanStats(task->taskStats())
+                   .at(plan->id())
+                   .customStats.contains("parquet.cudfMultiFileReaders"));
+}
+
+TEST_F(CudfIcebergReadTest, splitBatchFallsBackForFileMetadata) {
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  config.batchSplitsEnabled = true;
+  auto data = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  auto firstFile = TempFilePath::create();
+  auto secondFile = TempFilePath::create();
+  writeToFile(firstFile->getPath(), data);
+  writeToFile(secondFile->getPath(), data);
+  auto type = ROW({"c0", "$path"}, {BIGINT(), VARCHAR()});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(type)
+                  .endTableScan()
+                  .planNode();
+  std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
+      children;
+  std::vector<RowVectorPtr> expected;
+  for (const auto& file : {firstFile, secondFile}) {
+    auto split = makeIcebergSplits(file->getPath()).front();
+    std::static_pointer_cast<HiveIcebergSplit>(split)->infoColumns["$path"] =
+        file->getPath();
+    children.push_back(std::move(split));
+    expected.push_back(makeRowVector(
+        type->names(),
+        {data->childAt(0), makeFlatVector<std::string>(2, [&](auto) {
+           return file->getPath();
+         })}));
+  }
+  auto task = AssertQueryBuilder(plan)
+                  .connectorSessionProperty(
+                      kCudfIcebergConnectorId,
+                      connector::hive::CudfHiveConfig::
+                          kUseExperimentalCudfReaderSession,
+                      "true")
+                  .beforeTaskStart([&](Task& task) {
+                    std::vector<Split> splits;
+                    for (auto child : children) {
+                      splits.emplace_back(std::move(child));
+                    }
+                    task.addSplit(plan->id(), std::move(splits));
+                    task.noMoreSplits(plan->id());
+                  })
+                  .assertResults(expected);
+  EXPECT_FALSE(toPlanStats(task->taskStats())
+                   .at(plan->id())
+                   .customStats.contains("parquet.cudfMultiFileReaders"));
+}
+
+TEST_F(
+    CudfIcebergReadTest,
+    splitBatchPreservesPerFilePartitionAndDeleteMetadata) {
+  auto& config = CudfConfig::getInstance();
+  const auto oldConfig = config;
+  SCOPE_EXIT {
+    config = oldConfig;
+  };
+  config.batchSplitsEnabled = true;
+  auto firstData = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  auto secondData = makeRowVector({makeFlatVector<int64_t>({3, 4})});
+  auto firstFile = TempFilePath::create();
+  auto secondFile = TempFilePath::create();
+  writeToFile(firstFile->getPath(), firstData);
+  writeToFile(secondFile->getPath(), secondData);
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+
+  auto firstDeleteFile = TempFilePath::create();
+  auto firstDelete = makeRowVector(
+      {pathColumn->name, posColumn->name},
+      {
+          makeFlatVector<std::string>(
+              1, [&](vector_size_t) { return firstFile->getPath(); }),
+          makeFlatVector<int64_t>({0}),
+      });
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, firstDeleteFile->getPath(), {firstDelete});
+  IcebergDeleteFile firstDeleteMetadata(
+      FileContent::kPositionalDeletes,
+      firstDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(firstDeleteFile->getPath()));
+
+  auto secondDeleteFile = TempFilePath::create();
+  auto secondDelete = makeRowVector(
+      {pathColumn->name, posColumn->name},
+      {
+          makeFlatVector<std::string>(
+              1, [&](vector_size_t) { return secondFile->getPath(); }),
+          makeFlatVector<int64_t>({1}),
+      });
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, secondDeleteFile->getPath(), {secondDelete});
+  IcebergDeleteFile secondDeleteMetadata(
+      FileContent::kPositionalDeletes,
+      secondDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(secondDeleteFile->getPath()));
+
+  auto firstSplits = makeIcebergSplits(
+      firstFile->getPath(), {firstDeleteMetadata}, {{"region", "US"}});
+  auto secondSplits = makeIcebergSplits(
+      secondFile->getPath(), {secondDeleteMetadata}, {{"region", "EU"}});
+  ASSERT_EQ(firstSplits.size(), 1);
+  ASSERT_EQ(secondSplits.size(), 1);
+  ASSERT_NE(
+      std::dynamic_pointer_cast<HiveIcebergSplit>(firstSplits.front()),
+      nullptr);
+  ASSERT_NE(
+      std::dynamic_pointer_cast<HiveIcebergSplit>(secondSplits.front()),
+      nullptr);
+
+  std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
+      children{firstSplits.front(), secondSplits.front()};
+
+  auto tableType = ROW({"c0", "region"}, {BIGINT(), VARCHAR()});
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["region"] = std::make_shared<HiveColumnHandle>(
+      "region",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      VARCHAR(),
+      VARCHAR(),
+      std::vector<common::Subfield>{});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(tableType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+  auto expected = makeRowVector(
+      tableType->names(),
+      {
+          makeFlatVector<int64_t>({2, 3}),
+          makeFlatVector<std::string>({"US", "EU"}),
+      });
+
+  AssertQueryBuilder(plan).splits(children).assertResults({expected});
+  auto task = AssertQueryBuilder(plan)
+                  .connectorSessionProperty(
+                      kCudfIcebergConnectorId,
+                      cudf_velox::connector::hive::CudfHiveConfig::
+                          kUseExperimentalCudfReaderSession,
+                      "true")
+                  .beforeTaskStart([&](Task& task) {
+                    std::vector<Split> splits;
+                    for (auto child : children) {
+                      splits.emplace_back(std::move(child));
+                    }
+                    task.addSplit(plan->id(), std::move(splits));
+                    task.noMoreSplits(plan->id());
+                  })
+                  .assertResults({expected});
+  EXPECT_FALSE(toPlanStats(task->taskStats())
+                   .at(plan->id())
+                   .customStats.contains("parquet.cudfMultiFileReaders"));
 }
 
 // Test reading a DATE identity partition column. DATE partition values arrive


### PR DESCRIPTION
Adds a vector overload of Task::addSplit() while preserving existing single-split APIs. cuDF uses the supplied batches to initialize hybrid_scan_multifile for Hive and compatible unpartitioned, delete-free Iceberg files.

  Benchmarked through Presto master plus the vector-delivery patch: SF10 Hive Q1, one GPU, one driver, median of three warm runs.
```
   Files    Batching off    Batching on    Speedup
  ━━━━━━━  ━━━━━━━━━━━━━━  ━━━━━━━━━━━━━  ━━━━━━━━━
       1          221 ms         233 ms      0.95×
  ───────  ──────────────  ─────────────  ─────────
       4          221 ms         199 ms      1.11×
  ───────  ──────────────  ─────────────  ─────────
      16          263 ms         210 ms      1.26×
  ───────  ──────────────  ─────────────  ─────────
      64          554 ms         272 ms      2.04×
  ───────  ──────────────  ─────────────  ─────────
     256        1,540 ms         282 ms      5.46×
```
  Counters confirmed one multifile reader per batch. All 40 query results matched a CPU reference within numeric tolerance.