### PR TITLE
fix(iceberg): Fall back to name mapping when field IDs are unavailable

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -171,6 +171,9 @@ void IcebergSplitReader::configureBaseReaderOptions() {
       baseReaderOpts_.setColumnMappingMode(
           dwio::common::ColumnMappingMode::kParquetFieldId);
       baseReaderOpts_.setFieldIds(std::move(fieldIds));
+    } else {
+      baseReaderOpts_.setColumnMappingMode(
+          dwio::common::ColumnMappingMode::kName);
     }
     return;
   }
@@ -181,6 +184,8 @@ void IcebergSplitReader::configureBaseReaderOptions() {
   }
   auto fieldIds = buildFieldIds();
   if (fieldIds.empty()) {
+    baseReaderOpts_.setColumnMappingMode(
+        dwio::common::ColumnMappingMode::kName);
     return;
   }
   baseReaderOpts_.setColumnMappingMode(
@@ -205,8 +210,19 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
   // data-column name so we can align to dataColumns() order.
   const auto handleByName =
       buildIcebergHandleByName(columnHandles_.get(), tableHandle_.get());
-  if (handleByName.empty() &&
-      (dataColumnFieldIds == nullptr || dataColumnFieldIds->empty())) {
+
+  // Field-ID column mapping is only meaningful when the table handle carries
+  // explicit Iceberg field IDs, OR when the caller supplied explicit
+  // IcebergColumnHandle assignments with real (positive) field IDs.
+  // Without either, the file was written with positional/name mapping, so
+  // activating kParquetFieldId mode would produce wrong results (e.g. crash
+  // on nested structs with no embedded field IDs).
+  const bool hasExplicitHandleFieldIds =
+      std::any_of(handleByName.begin(), handleByName.end(), [](const auto& kv) {
+        return kv.second->field().fieldId > 0;
+      });
+  if ((dataColumnFieldIds == nullptr || dataColumnFieldIds->empty()) &&
+      !hasExplicitHandleFieldIds) {
     return fieldIds;
   }
 

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -60,8 +60,6 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_vector_test_lib
     velox_exec
     velox_exec_test_lib
-    Folly::folly
-    Folly::follybenchmark
     GTest::gtest
     GTest::gtest_main
   )

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -494,6 +494,46 @@ TEST_F(IcebergReadTest, readParquetFilterOnlyColumnByFieldId) {
       .assertResults({makeRowVector({makeFlatVector<int64_t>({20})})});
 }
 
+// Regression test for the guard in buildFieldIds(): field-ID column mapping
+// must NOT be activated when all IcebergColumnHandle assignments carry only
+// sentinel (≤ 0) field IDs. Before the fix, a non-empty handleByName was
+// sufficient to activate kParquetFieldId mode regardless of the actual IDs,
+// causing the reader to return wrong results or crash.
+TEST_F(IcebergReadTest, testNoFieldIdMappingWithSentinelHandles) {
+  const auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  // Writing the columns in different order to verify that column
+  // mapping is done by name.
+  const std::vector<RowVectorPtr> data = {makeRowVector(
+      {"c1", "c0"},
+      {makeFlatVector<std::string>({"a", "b", "c"}),
+       makeFlatVector<int64_t>({1, 2, 3})})};
+
+  // Write Parquet via the Iceberg sink (stamps 1-based field IDs on columns).
+  // writeParquetData also sets fileFormat_ = PARQUET so splits are correct.
+  const auto outputDirectory = writeParquetData(data);
+
+  // Build assignments with sentinel field IDs (≤ 0). These must NOT activate
+  // kParquetFieldId mode; the reader must fall back to name-based mapping.
+  ColumnHandleMap assignments;
+  assignments["c0"] = makeIcebergHandle("c0", BIGINT(), /*fieldId=*/-1);
+  assignments["c1"] = makeIcebergHandle("c1", VARCHAR(), /*fieldId=*/-1);
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(rowType)
+                  .dataColumns(rowType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  exec::test::AssertQueryBuilder(plan)
+      .splits(createSplitsForDirectory(outputDirectory->getPath()))
+      .assertResults({makeRowVector(
+          rowType->names(),
+          {makeFlatVector<int64_t>({1, 2, 3}),
+           makeFlatVector<std::string>({"a", "b", "c"})})});
+}
+
 TEST_F(IcebergReadTest, readParquetNestedStructByFieldId) {
   const auto addressWriteType = ROW({"city", "zip"}, {VARCHAR(), VARCHAR()});
   const auto profileWriteType =


### PR DESCRIPTION
Making checks in `IcebergSplitReader::buildFieldIds()` stricter to use field id based mapping only when valid field ids are available. Fall back to name based mapping otherwise for PARQUET/DWRF/ORC. No change for other formats.


