### PR TITLE
build(ci): Add a centos9 image with Debug dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,13 @@ jobs:
         os:
           - {runner: ubuntu-24.04-arm, platform: arm64}
           - {runner: ubuntu-24.04, platform: amd64}
-        target: [ci, pyvelox, ubuntu, fedora]
+        target: [ci, centos9-debug, pyvelox, ubuntu, fedora]
+        exclude:
+          # Only x86 jobs use this image, so don't take an arm runner to build
+          # nothing. ubuntu and fedora skip arm with an empty bake group
+          # instead; that works too but still allocates the runner.
+          - os: {runner: ubuntu-24.04-arm, platform: arm64}
+            target: centos9-debug
 
     steps:
       - name: Free Disk Space
@@ -145,10 +151,12 @@ jobs:
           mkdir -p "$DIGEST_DIR"
           cd "$DIGEST_DIR" || exit 1
           # Add the target for any images that shouldn't be build as multi-platform
-          # into the skip list
-          echo "$METADATA" | jq -r 'def skip: ["ubuntu", "fedora"];
+          # into the skip list.
+          # Strip only the trailing architecture rather than everything after the
+          # first dash, so names that contain a dash (centos9-debug) survive.
+          echo "$METADATA" | jq -r 'def skip: ["ubuntu", "fedora", "centos9-debug"];
             . | to_entries[] | select(.value | has("image.name")) |
-            .key | split("-")[0] |
+            .key | sub("-(amd64|arm64)$"; "") |
             if . as $name | skip | index($name) != null then empty else . end' | \
             while read -r image_name; do
               touch "$image_name"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -109,6 +109,15 @@ target "centos9" {
   cache-from = cache-from-arch("centos9", "${arch}")
 }
 
+# Debug-dependency twin of centos9, for jobs that build Velox Debug. It gets
+# its own cache keys because DEPS_BUILD_TYPE invalidates the base-build stage,
+# so it shares no layers with centos9.
+target "centos9-debug-amd64" {
+  inherits   = ["base","centos-cpp-debug"]
+  cache-to   = cache-to-arch("centos9-debug", "amd64")
+  cache-from = cache-from-arch("centos9-debug", "amd64")
+}
+
 target "ubuntu-amd64" {
   inherits   = ["base","ubuntu-cpp"]
   cache-to   = cache-to-arch("ubuntu", "amd64")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,17 @@ services:
         image: quay.io/centos/centos:stream9
         VELOX_BUILD_SHARED: "ON"
 
+  # Same image as centos-cpp but with the bundled dependencies built Debug, so
+  # they match a Debug Velox. Used by the fuzzer jobs. See issue #18793.
+  centos-cpp-debug:
+    extends: centos-cpp
+    image: ghcr.io/facebookincubator/velox-dev:centos9-debug
+    build:
+      args:
+        image: quay.io/centos/centos:stream9
+        VELOX_BUILD_SHARED: "ON"
+        DEPS_BUILD_TYPE: Debug
+
   adapters-cpp:
     extends: centos-cpp
     image: ghcr.io/facebookincubator/velox-dev:adapters

--- a/scripts/docker/centos-multi.dockerfile
+++ b/scripts/docker/centos-multi.dockerfile
@@ -54,6 +54,12 @@ ENV VELOX_BUILD_SHARED=${VELOX_BUILD_SHARED}
 ARG ARM_BUILD_TARGET=local
 ENV ARM_BUILD_TARGET=${ARM_BUILD_TARGET}
 
+# Build type for the bundled dependencies. Must match the build type of the
+# Velox that links against them, or folly's F14 hash table breaks at runtime.
+# See https://github.com/facebookincubator/velox/issues/18793.
+ARG DEPS_BUILD_TYPE=Release
+ENV BUILD_TYPE=${DEPS_BUILD_TYPE}
+
 RUN mkdir build
 WORKDIR /build
 
@@ -156,6 +162,10 @@ COPY scripts/setup-centos-adapters.sh /
 
 ARG ARM_BUILD_TARGET=local
 ENV ARM_BUILD_TARGET=${ARM_BUILD_TARGET}
+
+# Keep the adapter dependencies on the same build type as the base ones.
+ARG DEPS_BUILD_TYPE=Release
+ENV BUILD_TYPE=${DEPS_BUILD_TYPE}
 
 RUN mkdir build
 WORKDIR /build


### PR DESCRIPTION
Part of #18793. This PR only publishes the image; a follow-up moves the fuzzer
jobs onto it.

## Problem

The Presto expression fuzzer aborts inside folly:

```
Assertion failure: hp.second == srcChunk->tag(srcI)
File: /deps/include/folly/container/detail/F14Table.h
Line: 2487
Function: rehashImpl
```

Velox fuzzers are built `BUILD_TYPE=Debug`, but the dependencies in
`velox-dev:centos9` are built Release. `folly::kIsDebug` is `!NDEBUG`, and
`F14Table.h` branches on it in five places, four of them in the insert and
rehash path. The FBOS static archives in the image (`libfizz.a`,
`libmvfst*.a`, `libconcurrency.a` and others) carry their own F14 template
instantiations compiled with `NDEBUG`. Those have vague linkage, so one
definition per symbol survives across `libvelox.so` and the archives. A table
populated with the debug hooks active then gets rehashed by code compiled
without them.

The `/deps` path in the assertion is the giveaway: `/deps` does not exist in
the image, it is the `INSTALL_PREFIX` of the dockerfile's `base-build` stage,
so that string is `__FILE__` frozen into those archives at image build time.

This is not memory corruption. An ASAN build reaches the same assertion with no
sanitizer report beforehand.

## Evidence

Per seed the failure is deterministic. The day-to-day variation in CI is only
because `run-fuzzer-parallel.sh` draws random seeds.

| build | seed 496198449 | seed 688600297 |
| --- | --- | --- |
| Debug Velox + Release deps (today) | abort at iteration 2032 | abort at iteration 5987 |
| Debug Velox + **Debug** deps | clean, reached iteration 8392 | clean, reached iteration 8946 |
| **NDEBUG** Velox + Release deps | clean | clean |
| `-DFOLLY_F14_PERTURB_INSERTION_ORDER=0` on Velox only | still aborts | still aborts |

Matching either side fixes it. The last row does not, because it only changes
Velox's own translation units while the aborting code lives in the prebuilt
Release archives.

## Change

- `DEPS_BUILD_TYPE` build argument on the `base-build` and `adapters-build`
  stages, defaulting to `Release`. `scripts/setup-common.sh` already reads
  `BUILD_TYPE`, so no script change was needed.
- `centos9-debug` bake target and matrix entry, with its own cache keys since
  changing the argument invalidates `base-build` entirely.
- The new image is amd64 only. Multi-arch has been the shape for `centos9`
  since #14046, but every job that will use this image runs on x86 and nothing
  in the repo pulls an arm64 CI image today, so skipping arm halves the cost
  below. The combination is dropped with a matrix `exclude` rather than the
  empty bake group that `ubuntu` and `fedora` use, so no arm runner is
  allocated to build nothing. Those two could get the same treatment, but that
  is out of scope here.
- The manifest merge step derived the image name with `split("-")[0]`, which
  turns `centos9-debug-amd64` into `centos9` and would have clobbered the
  release manifest. Changed to strip only the trailing architecture.

`centos9` and `adapters` are unchanged. `adapters` derives `FROM centos9` and
builds Velox Release, so flipping the shared base would fix the fuzzers and
create the same mismatch in the opposite direction there.

## Why this is split from the job switch

`docker.yml` pushes images only on merge to main
(`push: ... github.event_name != 'pull_request'`). A PR that both adds the
image and points jobs at it cannot pass its own CI, because the container pull
fails with `manifest unknown` before any step runs. So the image lands first,
and the fuzzer jobs move over once the tag exists.

## Cost

The Debug dependency libraries are 3.4 GB against 240 MB for Release, so about
+3.2 GB on the image, and roughly 25 minutes of extra image build time. Paid
when images are built and pulled, not in every PR compile.

## Note for reviewers

The same mismatch exists today, unnoticed, wherever Velox is built Debug
against a Release dependency image: `Ubuntu debug with system dependencies`,
`Fedora debug`, and `Linux ASAN/UBSAN`. They do not exercise F14 hard enough to
trip the check. Worth deciding separately whether those should get Debug
dependency images too.
