### PR TITLE
build(ci): Run the fuzzers on the Debug dependency image

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -95,7 +95,7 @@ jobs:
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 32-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     timeout-minutes: 120
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
@@ -457,7 +457,7 @@ jobs:
     name: Build LocalRunnerService
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 32-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     timeout-minutes: 120
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
@@ -600,7 +600,7 @@ jobs:
     name: Presto Fuzzer
     if: ${{ needs.compile.outputs.presto_bias  != 'true' }}
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     timeout-minutes: 30
     steps:
@@ -682,7 +682,7 @@ jobs:
   presto-fuzzer-with-local-runner-run:
     name: Regression Fuzzer
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: [compile, compile-baseline-local-runner]
     timeout-minutes: 120
     # Soft launch: this job is being monitored for signal quality and must not
@@ -867,7 +867,7 @@ jobs:
   presto-bias-fuzzer:
     name: Presto Bias Fuzzer
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     if: ${{ needs.compile.outputs.presto_bias  == 'true' }}
     timeout-minutes: 120
@@ -1046,7 +1046,7 @@ jobs:
   spark-bias-fuzzer:
     name: Spark Bias Fuzzer
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     if: ${{ needs.compile.outputs.spark_bias  == 'true' }}
     timeout-minutes: 120
@@ -1105,7 +1105,7 @@ jobs:
     name: Spark Fuzzer
     if: ${{ needs.compile.outputs.spark_bias  != 'true' }}
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     timeout-minutes: 30
     steps:
@@ -1226,7 +1226,7 @@ jobs:
   exchange-fuzzer-run:
     name: Exchange Fuzzer
     runs-on: ubuntu-latest
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     timeout-minutes: 30
     steps:
@@ -1410,7 +1410,7 @@ jobs:
   cache-fuzzer-run:
     name: Cache Fuzzer
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     timeout-minutes: 30
     # Temporarily disable on PRs till flakiness is fixed #12167
@@ -1454,7 +1454,7 @@ jobs:
   table-evolution-fuzzer-run:
     name: Table Evolution Fuzzer
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     timeout-minutes: 30
     steps:
@@ -1496,7 +1496,7 @@ jobs:
   memory-arbitration-fuzzer-run:
     name: Memory Arbitration Fuzzer
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     timeout-minutes: 30
     steps:
@@ -1969,7 +1969,7 @@ jobs:
   spatial-join-fuzzer-run:
     name: Spatial Join Fuzzer
     runs-on: 4-core-ubuntu
-    container: ghcr.io/facebookincubator/velox-dev:centos9
+    container: ghcr.io/facebookincubator/velox-dev:centos9-debug
     needs: compile
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Fixes #18793. Stacked on #18904 — **do not merge until that has landed and the
`centos9-debug` image has actually been pushed to ghcr.**

## What this does

Points the 12 fuzzer jobs in `scheduled.yml` at
`ghcr.io/facebookincubator/velox-dev:centos9-debug`, the image added in #18904,
whose bundled dependencies are compiled Debug.

The fuzzers build Velox with `BUILD_TYPE=Debug`. Against the Release dependency
image the Presto expression fuzzer aborts inside folly:

```
Assertion failure: hp.second == srcChunk->tag(srcI)
File: /deps/include/folly/container/detail/F14Table.h
Function: rehashImpl
```

`folly::kIsDebug` is `!NDEBUG`, `F14Table.h` branches on it in the insert and
rehash path, and the FBOS static archives in the image carry their own F14
instantiations compiled with `NDEBUG`. Those have vague linkage, so a single
definition per symbol survives across `libvelox.so` and the archives. Full
analysis in #18904 and in the issue.

## Why the run jobs move too, not just the compile jobs

The fuzzer binaries load `libfolly.so` from the image at runtime. Leaving the
run jobs on the Release image would reintroduce the mismatch after the build,
so all 12 have to move together.

## Why this is a separate PR

`docker.yml` pushes images only on merge to main. A single PR that both adds
the image and points jobs at it cannot pass its own CI: the container pull
fails with `manifest unknown` before any step runs, which is exactly what
happened on the first revision of #18904.

For the same reason, the fuzzer checks on *this* PR will fail until #18904 is
merged and the image is published. Keeping it in draft until then.
