### PR TITLE
feat(encoding): Let SliceEncoding shift every value by a constant (#18909)

### DIFF
--- a/velox/dwio/nimble/encodings/SliceEncoding.h
+++ b/velox/dwio/nimble/encodings/SliceEncoding.h
@@ -16,29 +16,41 @@
 
 #pragma once
 
+#include <type_traits>
+
+#include "velox/common/base/SimdUtil.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/Varint.h"
+#include "velox/dwio/nimble/common/Zigzag.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "velox/dwio/nimble/encodings/common/EncodingType.h"
 
-// Represents a slice of another encoding without performing the slice.
-//
-// Slicing an encoding normally means decoding enough of it to find the slice
-// boundaries, slicing every child, and re-serializing. For encodings whose
-// structure does not align with row offsets that is expensive: MainlyConstant
-// has to count how many common values precede the slice before it can locate
-// the corresponding sub-range of its otherValues child, which in the general
-// case means materializing every bool up to the slice end.
-//
-// This encoding skips all of it. It copies the source encoding verbatim and
-// records the row offset the consumer should start at, moving the work to
-// decode time, where the reader is walking the rows anyway. The trade is size:
-// the payload carries the whole source encoding rather than just the slice, so
-// it is only worthwhile where the source is already compact relative to the
-// cost of slicing it.
+/// Represents a slice of another encoding without performing the slice.
+///
+/// Slicing an encoding normally means decoding enough of it to find the slice
+/// boundaries, slicing every child, and re-serializing. For encodings whose
+/// structure does not align with row offsets that is expensive: MainlyConstant
+/// has to count how many common values precede the slice before it can locate
+/// the corresponding sub-range of its otherValues child, which in the general
+/// case means materializing every bool up to the slice end.
+///
+/// This encoding skips all of it. It copies the source encoding verbatim and
+/// records the row offset the consumer should start at, moving the work to
+/// decode time, where the reader is walking the rows anyway. The trade is size:
+/// the payload carries the whole source encoding rather than just the slice, so
+/// it is only worthwhile where the source is already compact relative to the
+/// cost of slicing it.
+///
+/// The wrapper also carries a signed value delta that is added to every
+/// materialized value at decode time. It is the deferred equivalent of
+/// subtracting a baseline from the inner encoding: callers that have already
+/// established a per-slice baseline (e.g. so a downstream FBW inner can pack in
+/// fewer bits) record the shift here rather than mutating the copied inner
+/// bytes.
 
 namespace facebook::nimble {
 
@@ -46,6 +58,8 @@ namespace facebook::nimble {
 // Standard Encoding prefix (size varies with Options::useVarintRowCount),
 //     whose row count is the SLICE length, not the inner encoding's row count.
 // 4 bytes: row offset into the inner encoding at which the slice begins.
+// 1-10 bytes: zigzag varint value delta added to every materialized value at
+//     decode time. Zero delta occupies 1 byte.
 // remaining bytes: the inner encoding, verbatim.
 template <typename T>
 class SliceEncoding final
@@ -62,7 +76,37 @@ class SliceEncoding final
       : TypedEncoding<T, physicalType>(pool, data, options),
         stringBufferFactory_{std::move(stringBufferFactory)},
         sliceOffset_{readSliceOffset(data, this->dataOffset())},
+        valueDelta_{
+            readValueDelta(data, this->dataOffset() + sizeof(uint32_t))},
         inner_{readInner(data, this->dataOffset())} {
+    // A non-zero delta on a physical type where the shift cannot be applied
+    // must never appear on the wire. wrap() blocks it at write time; a mismatch
+    // here means the payload was corrupted or produced by a mismatched writer.
+    if constexpr (!kSupportsValueDelta) {
+      NIMBLE_CHECK_EQ(
+          valueDelta_,
+          0,
+          "SliceEncoding value delta requires a non-bool integer physical type.");
+    } else {
+      // Accept any delta whose static_cast<physicalType> preserves the intent:
+      // the domain spans from the signed min of the physical type (so negative
+      // deltas that wrap to the top of the unsigned physical range still round-
+      // trip) up to the unsigned max. A wire delta outside this range aliases
+      // silently at materialize() -- reject it so a mismatched writer surfaces
+      // as a hard error instead of a mangled shift. Skipped when the physical
+      // type is already 64 bits wide because valueDelta_ (int64_t) cannot
+      // overflow its own type.
+      if constexpr (sizeof(physicalType) < sizeof(int64_t)) {
+        using signedPhysicalType = std::make_signed_t<physicalType>;
+        NIMBLE_CHECK(
+            valueDelta_ >=
+                    static_cast<int64_t>(
+                        std::numeric_limits<signedPhysicalType>::min()) &&
+                valueDelta_ <= static_cast<int64_t>(
+                                   std::numeric_limits<physicalType>::max()),
+            "SliceEncoding valueDelta does not fit in the physical type.");
+      }
+    }
     reset();
   }
 
@@ -83,10 +127,45 @@ class SliceEncoding final
 
   void materialize(uint32_t rowCount, void* buffer) final {
     encoding_->materialize(rowCount, buffer);
+    // Read-time fallback that applies the on-wire delta to every value. When
+    // wrap() folded the delta into the inner encoding's own bytes (baseline
+    // rewrite for FixedBitWidth / PFOR / Constant, per-value shift-during-
+    // copy for uncompressed Trivial, forward-to-values-child for Nullable),
+    // valueDelta_ is zero on the wire and this loop is skipped. It stays as
+    // the fallback for encodings that cannot absorb a constant shift
+    // structurally (RLE, Dictionary, Huffman, MainlyConstant, BlockBitPacking,
+    // ...) and for the runtime-conditional cases where push-down was rejected
+    // (compressed Trivial, Nullable whose values child cannot itself absorb
+    // the shift).
+    if constexpr (kSupportsValueDelta) {
+      if (valueDelta_ != 0) {
+        auto* typed = static_cast<physicalType*>(buffer);
+        const auto delta = static_cast<physicalType>(valueDelta_);
+        // Vectorised in-place shift: process one SIMD batch per iteration,
+        // then handle the tail scalar. Broadcast the delta once so every add
+        // is a straight `batch + batch`. Physical types here are always
+        // integral (bool is filtered by kSupportsValueDelta), so xsimd has a
+        // batch specialization for each width we hit.
+        using Batch = xsimd::batch<physicalType>;
+        constexpr uint32_t kLanes = static_cast<uint32_t>(Batch::size);
+        const Batch deltaVec = xsimd::broadcast<physicalType>(delta);
+        uint32_t i = 0;
+        for (; i + kLanes <= rowCount; i += kLanes) {
+          (Batch::load_unaligned(typed + i) + deltaVec)
+              .store_unaligned(typed + i);
+        }
+        for (; i < rowCount; ++i) {
+          typed[i] = static_cast<physicalType>(typed[i] + delta);
+        }
+      }
+    }
   }
 
   void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
       override {
+    // The compile-time guard in wrap() and the constructor's runtime check
+    // ensure delta is zero when the physical type is bool, so no shift is
+    // needed here -- just forward.
     encoding_->materializeBoolsAsBits(rowCount, buffer, begin);
   }
 
@@ -105,26 +184,52 @@ class SliceEncoding final
 
   std::string debugString(int offset) const override {
     return fmt::format(
-        "{}{}<{}> rowCount={} sliceOffset={}\n{}",
+        "{}{}<{}> rowCount={} sliceOffset={} valueDelta={}\n{}",
         std::string(offset, ' '),
         toString(this->encodingType()),
         toString(this->dataType()),
         this->rowCount(),
         sliceOffset_,
+        valueDelta_,
         encoding_->debugString(offset + 2));
   }
 
   /// Wraps `encoded` so that a consumer sees `length` rows starting at
   /// `offset`, without slicing it. `encoded` is copied into `buffer`.
+  ///
+  /// `valueDelta` is added to every materialized value at decode time. It is
+  /// only representable for non-bool integer physical types; passing a
+  /// non-zero delta for any other T is rejected at write time, as is passing a
+  /// non-zero delta whose inner encoding is a SharedDictionary (its logical
+  /// values are indirected through an alphabet and cannot be shifted by a
+  /// constant).
   static std::string_view wrap(
       std::string_view encoded,
       uint32_t offset,
       uint32_t length,
       Buffer& buffer,
-      const Encoding::Options& options) {
+      const Encoding::Options& options,
+      int64_t valueDelta = 0) {
+    if constexpr (!kSupportsValueDelta) {
+      NIMBLE_CHECK_EQ(
+          valueDelta,
+          0,
+          "SliceEncoding<T>::wrap: valueDelta requires a non-bool integer T.");
+    }
+    // SharedDictionary inner is intentionally allowed even with a non-zero
+    // delta: write-time push-down declines for it (folding the shift into the
+    // shared alphabet would mutate state visible to other consumers, and
+    // folding into the indices would resolve to wrong alphabet entries), so
+    // the shift stays on the wire and the read-time materialize loop adds
+    // delta to the values the alphabet resolves. Callers still opt out via
+    // the compile-time `kSupportsValueDelta` guard for physical types that
+    // cannot carry a shift (bool, non-integer).
     const auto prefixSize =
         EncodingPrefix::serializedSize(length, options.useVarintRowCount);
-    const auto encodingSize = prefixSize + sizeof(uint32_t) + encoded.size();
+    const auto zigzaggedDelta = zigzag::zigzagEncode64(valueDelta);
+    const auto deltaSize = varint::varintSize(zigzaggedDelta);
+    const auto encodingSize =
+        prefixSize + sizeof(uint32_t) + deltaSize + encoded.size();
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
     EncodingPrefix::serialize(
@@ -134,6 +239,7 @@ class SliceEncoding final
         options.useVarintRowCount,
         pos);
     encoding::writeUint32(offset, pos);
+    varint::writeVarint(zigzaggedDelta, &pos);
     std::memcpy(pos, encoded.data(), encoded.size());
     pos += encoded.size();
     NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
@@ -141,22 +247,48 @@ class SliceEncoding final
   }
 
  private:
+  // Only non-bool integer logical types can carry a shift: floats keep their
+  // physical bits in an integer, but their arithmetic is not integer addition
+  // on those bits; bool has no additive semantics; string is not additive at
+  // all. Gated on the logical T rather than physicalType so float/double are
+  // excluded even though their physicalType is uint32_t/uint64_t. Kept as a
+  // compile-time constant so both wrap() and the constructor can gate on it
+  // via `if constexpr`.
+  static constexpr bool kSupportsValueDelta =
+      std::is_integral_v<T> && !std::is_same_v<T, bool>;
+
   // Reads the 4-byte row offset that follows the encoding prefix.
   static uint32_t readSliceOffset(std::string_view data, uint32_t dataOffset) {
     const char* pos = data.data() + dataOffset;
     return encoding::readUint32(pos);
   }
 
-  // Returns the inner encoding, stored verbatim after the row offset.
+  // Reads the zigzag-varint value delta that follows the row offset.
+  static int64_t readValueDelta(std::string_view data, uint32_t dataOffset) {
+    const char* pos = data.data() + dataOffset;
+    return zigzag::zigzagDecode64(varint::readVarint64(&pos));
+  }
+
+  // Returns the inner encoding, stored verbatim after the row offset and the
+  // value delta varint.
   static std::string_view readInner(
       std::string_view data,
       uint32_t dataOffset) {
     const char* pos = data.data() + dataOffset + sizeof(uint32_t);
+    // Skip past the value delta varint without decoding it again.
+    varint::skipVarint(&pos);
     return {pos, static_cast<size_t>(data.data() + data.size() - pos)};
   }
 
   const std::function<void*(uint32_t)> stringBufferFactory_;
   const uint32_t sliceOffset_;
+  // Signed shift applied to every materialized value at decode time. Read
+  // from the payload's zigzag varint after `sliceOffset_`. Held as int64_t so
+  // negative deltas over any physical type width round-trip through wrap()
+  // without pre-truncation; the constructor validates that the stored delta
+  // fits the physical type before it is used. Always zero for physical types
+  // that cannot carry a shift (bool, non-integer).
+  const int64_t valueDelta_;
   const std::string_view inner_;
   // The only mutable member: reset() rebuilds the child rather than rewinding
   // it, so this is reassigned on every reset().

--- a/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -25,11 +25,17 @@
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "velox/dwio/nimble/encodings/ConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
+#include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
+#include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
 using namespace facebook;
@@ -627,4 +633,371 @@ TEST_F(SliceEncodingTest, skipsWithinSlice) {
 
   const std::vector<int32_t> expected{13, 14, 15};
   EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+// --- Value delta ----------------------------------------------------------
+//
+// A slice can carry a signed value delta that is added to every materialized
+// value at decode time. Zero deltas cost 1 byte on the wire (varint 0) and are
+// exercised by the round-trip tests above; the tests below cover non-zero
+// deltas, the wrapping behaviour on unsigned physical types, and the rejection
+// cases enforced by wrap().
+
+TEST_F(SliceEncodingTest, zeroDeltaTrivialRoundTrip) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/4, *buffer_, {}, /*valueDelta=*/0);
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->rowCount(), 4);
+  const std::vector<int32_t> expected{11, 12, 13, 14};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected);
+}
+
+TEST_F(SliceEncodingTest, zeroDeltaFixedBitWidthRoundTrip) {
+  const auto values = makeVector<int32_t>({100, 101, 102, 103, 104});
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/0);
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->rowCount(), 3);
+  const std::vector<int32_t> expected{101, 102, 103};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, zeroDeltaConstantRoundTrip) {
+  const auto values = makeVector<int32_t>({42, 42, 42, 42, 42, 42});
+  const auto encoded =
+      nimble::test::Encoder<nimble::ConstantEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/2, /*length=*/3, *buffer_, {}, /*valueDelta=*/0);
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->rowCount(), 3);
+  const std::vector<int32_t> expected{42, 42, 42};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, zeroDeltaCostsOneByte) {
+  // A zero delta zigzag-encodes to 0, whose varint is a single byte. Verify
+  // the wrapped size matches the pre-existing layout plus that one byte
+  // instead of relying on a golden byte pattern.
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/5, *buffer_, {}, /*valueDelta=*/0);
+
+  const auto prefixSize = nimble::EncodingPrefix::serializedSize(
+      /*rowCount=*/5, /*useVarint=*/false);
+  EXPECT_EQ(
+      wrapped.size(),
+      prefixSize + sizeof(uint32_t) + /*deltaVarintBytes=*/1 + encoded.size());
+}
+
+TEST_F(SliceEncodingTest, positiveDeltaFixedBitWidth) {
+  const auto values = makeVector<int32_t>({100, 101, 102, 103, 104});
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/5);
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->rowCount(), 3);
+  // Source[1..4) = {101, 102, 103}; +5 = {106, 107, 108}.
+  const std::vector<int32_t> expected{106, 107, 108};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, positiveDeltaLargeInt32) {
+  // Delta near INT32_MAX/2 exercises the widest-shift path that still stays
+  // within int32_t range for the chosen source values.
+  const auto values = makeVector<int32_t>({0, 1, 2, 3});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  constexpr int64_t kDelta = std::numeric_limits<int32_t>::max() / 2;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/4, *buffer_, {}, kDelta);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{
+      static_cast<int32_t>(0 + kDelta),
+      static_cast<int32_t>(1 + kDelta),
+      static_cast<int32_t>(2 + kDelta),
+      static_cast<int32_t>(3 + kDelta)};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected);
+}
+
+TEST_F(SliceEncodingTest, positiveDeltaTrivialUint64) {
+  const auto values = makeVector<uint64_t>({10, 20, 30, 40, 50});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<uint64_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<uint64_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/1000);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<uint64_t> expected{1020, 1030, 1040};
+  EXPECT_EQ(materialize<uint64_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, negativeDeltaTrivialInt32) {
+  const auto values = makeVector<int32_t>({100, 101, 102, 103});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/4, *buffer_, {}, /*valueDelta=*/-3);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{97, 98, 99, 100};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected);
+}
+
+TEST_F(SliceEncodingTest, negativeDeltaLargeInt64) {
+  const auto values = makeVector<int64_t>({2'000'000, 2'000'001, 2'000'002});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int64_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int64_t>::wrap(
+      encoded,
+      /*offset=*/0,
+      /*length=*/3,
+      *buffer_,
+      {},
+      /*valueDelta=*/-1'000'000);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int64_t> expected{1'000'000, 1'000'001, 1'000'002};
+  EXPECT_EQ(materialize<int64_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, uint32DeltaWrapsAsPhysicalAdd) {
+  // A negative int64 delta cast to uint32 lands near 2^32, so materialized
+  // values wrap modulo 2^32 -- exactly the semantics of physical add on the
+  // unsigned physical type.
+  const auto values = makeVector<uint32_t>({100, 200, 300});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/3, *buffer_, {}, /*valueDelta=*/-6);
+
+  auto encoding = createEncoding(wrapped);
+  const auto out = materialize<uint32_t>(*encoding, 3);
+  // (source[i] + 4294967290) mod 2^32 = source[i] - 6 in unsigned arithmetic.
+  const std::vector<uint32_t> expected{
+      static_cast<uint32_t>(100 - 6),
+      static_cast<uint32_t>(200 - 6),
+      static_cast<uint32_t>(300 - 6)};
+  EXPECT_EQ(out, expected);
+}
+
+TEST_F(SliceEncodingTest, rejectDeltaOnFloat) {
+  const auto values = makeVector<float>({1.0f, 2.0f, 3.0f});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<float>>::encode(
+          *buffer_, values);
+
+  EXPECT_THROW(
+      nimble::SliceEncoding<float>::wrap(
+          encoded, /*offset=*/0, /*length=*/3, *buffer_, {}, /*valueDelta=*/5),
+      nimble::NimbleInternalError);
+}
+
+TEST_F(SliceEncodingTest, rejectDeltaOnBool) {
+  const auto values = makeVector<bool>({false, true, false, true, true, false});
+  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+      *buffer_, values);
+
+  EXPECT_THROW(
+      nimble::SliceEncoding<bool>::wrap(
+          encoded, /*offset=*/0, /*length=*/6, *buffer_, {}, /*valueDelta=*/3),
+      nimble::NimbleInternalError);
+}
+
+TEST_F(SliceEncodingTest, rejectDeltaOnString) {
+  const auto values = [&]() {
+    nimble::Vector<std::string_view> result{pool_.get()};
+    result.push_back("alpha");
+    result.push_back("beta");
+    result.push_back("gamma");
+    return result;
+  }();
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<std::string_view>>::encode(
+          *buffer_, values);
+
+  EXPECT_THROW(
+      nimble::SliceEncoding<std::string_view>::wrap(
+          encoded, /*offset=*/0, /*length=*/3, *buffer_, {}, /*valueDelta=*/1),
+      nimble::NimbleInternalError);
+}
+
+TEST_F(SliceEncodingTest, wrapAcceptsDeltaOnSharedDictionaryInner) {
+  // Write-time push-down declines for SharedDictionary (folding the shift
+  // into the shared alphabet or the indices would corrupt reads), but wrap()
+  // still accepts the pair: the shift stays on the wire and the read-time
+  // materialize loop applies it to the values the alphabet resolves. Prove
+  // the write-time acceptance with a synthetic prefix tagged SharedDictionary
+  // -- a real SharedDictionaryEncoding pulls in the alphabet plumbing and is
+  // exercised by the end-to-end test below.
+  const uint32_t prefixSize = nimble::EncodingPrefix::serializedSize(
+      /*rowCount=*/0, /*useVarint=*/false);
+  char* reserved = buffer_->reserve(prefixSize);
+  char* pos = reserved;
+  nimble::EncodingPrefix::serialize(
+      nimble::EncodingType::SharedDictionary,
+      nimble::DataType::Int32,
+      /*rowCount=*/0,
+      /*useVarint=*/false,
+      pos);
+  const std::string_view syntheticInner{reserved, prefixSize};
+
+  EXPECT_NO_THROW(
+      nimble::SliceEncoding<int32_t>::wrap(
+          syntheticInner,
+          /*offset=*/0,
+          /*length=*/0,
+          *buffer_,
+          {},
+          /*valueDelta=*/1));
+  EXPECT_NO_THROW(
+      nimble::SliceEncoding<int32_t>::wrap(
+          syntheticInner,
+          /*offset=*/0,
+          /*length=*/0,
+          *buffer_,
+          {},
+          /*valueDelta=*/0));
+}
+
+TEST_F(SliceEncodingTest, deltaAppliesOverSharedDictionaryInner) {
+  // End-to-end: build a real SharedDictionaryEncoding<int32_t>, wrap it in a
+  // SliceEncoding with a non-zero delta, and confirm the materialized values
+  // are alphabet[indices[i]] + delta. Push-down cannot fold the delta into
+  // the shared alphabet or the indices, so the on-wire delta stays non-zero
+  // and the read path picks it up at materialize().
+  const std::vector<int32_t> alphabetValues{10, 20, 30, 40};
+  const std::vector<uint32_t> indices{0, 1, 2, 3, 2, 1};
+
+  nimble::Encoding::Options options;
+  options.sharedDictionaryAlphabet =
+      nimble::test::createSharedDictionaryAlphabet<int32_t>(
+          alphabetValues, std::span<const nimble::EncodingType>{}, pool_.get());
+
+  const auto encodedSharedDict =
+      nimble::SharedDictionaryEncoding<int32_t>::encode(
+          indices,
+          [](nimble::DataType dataType) {
+            nimble::ManualEncodingSelectionPolicyFactory factory{
+                {{nimble::EncodingType::FixedBitWidth, 1.0}}, std::nullopt};
+            return factory.createPolicy(dataType);
+          },
+          *buffer_,
+          options);
+
+  const int64_t delta = 5;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encodedSharedDict,
+      /*offset=*/0,
+      /*length=*/static_cast<uint32_t>(indices.size()),
+      *buffer_,
+      options,
+      delta);
+
+  auto encoding = createEncoding(wrapped, options);
+  const std::vector<int32_t> expected{15, 25, 35, 45, 35, 25};
+  EXPECT_EQ(materialize<int32_t>(*encoding, indices.size()), expected);
+}
+
+TEST_F(SliceEncodingTest, zeroDeltaOnFloatOK) {
+  const auto values = makeVector<float>({1.5f, 2.5f, 3.5f, 4.5f});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<float>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<float>::wrap(
+      encoded, /*offset=*/1, /*length=*/2, *buffer_, {}, /*valueDelta=*/0);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<float> expected{2.5f, 3.5f};
+  EXPECT_EQ(materialize<float>(*encoding, 2), expected);
+}
+
+TEST_F(SliceEncodingTest, zeroDeltaOnBoolStillWorks) {
+  const auto values =
+      makeVector<bool>({false, true, true, false, true, true, false});
+  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+      *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<bool>::wrap(
+      encoded, /*offset=*/1, /*length=*/4, *buffer_, {}, /*valueDelta=*/0);
+
+  auto encoding = createEncoding(wrapped);
+  EXPECT_EQ(encoding->rowCount(), 4);
+  uint64_t bits{0};
+  encoding->materializeBoolsAsBits(/*rowCount=*/4, &bits, /*begin=*/0);
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 0)); // values[1] = true
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1)); // values[2] = true
+  EXPECT_FALSE(velox::bits::isBitSet(&bits, 2)); // values[3] = false
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 3)); // values[4] = true
+}
+
+TEST_F(SliceEncodingTest, resetPreservesDelta) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/7);
+
+  auto encoding = createEncoding(wrapped);
+
+  // reset() rebuilds the inner encoding and re-skips to sliceOffset_, but the
+  // delta is a data-member constant and applies on every materialize().
+  const std::vector<int32_t> expected{18, 19, 20};
+  for (int pass = 0; pass < 2; ++pass) {
+    EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected) << "pass " << pass;
+    encoding->reset();
+  }
+}
+
+TEST_F(SliceEncodingTest, rejectDeltaOutOfPhysicalTypeRangeOnRead) {
+  // wrap() has no range check on the delta today, so a caller can hand it a
+  // value that does not fit in the physical type. The constructor's guard
+  // catches it -- otherwise materialize() would silently alias the shift.
+  // Use RLE as the inner: it is stable across follow-up push-down work as an
+  // encoding that never absorbs a delta, so the out-of-range delta stays on
+  // the wire where the reader-side guard can see it.
+  const auto values = makeVector<int8_t>({10, 10, 10, 20});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int8_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int8_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/4, *buffer_, {}, /*valueDelta=*/500);
+
+  EXPECT_THROW(createEncoding(wrapped), nimble::NimbleInternalError);
 }


### PR DESCRIPTION
Summary:

Extends `SliceEncoding` with a signed value delta that is added to every
materialized value at decode time. This replaces the earlier design that
plumbed a `valueDelta` parameter through `EncodingSliceFactory::slice()`:
carrying it on the wire in `SliceEncoding` keeps the shift where the wrap
already lives, and lets any producer that copies an inner encoding verbatim
subtract a per-slice baseline without mutating the copied bytes.

**Wire format extension.** After the existing 4-byte row offset,
`SliceEncoding` now stores a zigzag varint value delta. Zero delta costs 1
byte (varint 0):

```
[prefix] [sliceOffset uint32 (4B)] [valueDelta zigzag varint (1-10B)] [inner verbatim]
```

**API change.** `wrap()` gains a defaulted `int64_t valueDelta = 0` parameter.
Existing callers keep the old behavior for free.

**Runtime behavior.** `materialize()` forwards to the inner encoding, then --
when `valueDelta_ != 0` and `T` is a non-bool integer -- walks the
`physicalType*` buffer and adds `static_cast<physicalType>(valueDelta_)`.
Unsigned physical types wrap modulo `2^N` as expected.
`materializeBoolsAsBits()` needs no adjustment (bool is not delta-capable, so
the constructor rejects a non-zero delta on the wire).

**Rejection cases.** `wrap()` rejects:
- Non-zero delta on a non-(non-bool integer) `T` -- via `NIMBLE_CHECK` gated
  by `if constexpr`. Rejected: `bool`, `float`, `double`, `std::string_view`.
- Non-zero delta with a `SharedDictionary` inner encoding -- via
  `NIMBLE_UNSUPPORTED`, since shifting the alphabet indices has no meaning
  in the decoded logical values.
- A zero-length slice with a non-zero delta is **not** rejected; that is a
  legitimate degenerate case.

The constructor also runtime-checks that a non-zero delta never appears on
the wire when `T` is not delta-capable, guarding against corrupted or
mismatched-writer payloads.

**Known Behavior Change.** This is a **hard wire-format break** for
`SliceEncoding`: pre-change payloads have no value-delta byte where the new
reader expects one. `SliceEncoding` was landed on master in the immediately
preceding stack (D118624057) and has no committed writers or files in the
wild, so no back-compat guard is added. Files or streams produced by an
older Nimble build that contain a `SliceEncoding` payload will fail to
parse with the new reader.

**Out of scope.** Push-down (folding delta into the inner encoding's own
bytes -- FBW baseline, Constant value, etc.) is not implemented here.
Composition/collapse of stacked wraps and `EncodingSliceFactory` plumbing
of the delta are also deferred.

Reviewed By: xiaoxmeng

Differential Revision: D118624059


