### PR TITLE
fix(cudf): Preserve null semantics in subfield filters

### DIFF
--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
@@ -333,10 +333,7 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerInListExpr(
   }
 }
 
-} // namespace
-
-// Convert subfield filters to cudf AST
-cudf::ast::expression const& createAstFromSubfieldFilter(
+cudf::ast::expression const& createAstFromSubfieldFilterImpl(
     const common::Subfield& subfield,
     const common::Filter& filter,
     cudf::ast::tree& tree,
@@ -494,7 +491,7 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
       std::vector<const cudf::ast::expression*> exprRefs;
       exprRefs.reserve(subFilters.size());
       for (const auto* subFilter : subFilters) {
-        auto const& subExpr = createAstFromSubfieldFilter(
+        auto const& subExpr = createAstFromSubfieldFilterImpl(
             subfield, *subFilter, tree, scalars, inputRowSchema);
         exprRefs.push_back(&subExpr);
       }
@@ -535,6 +532,31 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
           "Filter type {} not yet supported for subfield filter conversion",
           static_cast<int>(filter.kind()));
   }
+}
+
+} // namespace
+
+// Convert subfield filters to cudf AST
+cudf::ast::expression const& createAstFromSubfieldFilter(
+    const common::Subfield& subfield,
+    const common::Filter& filter,
+    cudf::ast::tree& tree,
+    std::vector<std::unique_ptr<cudf::scalar>>& scalars,
+    const RowTypePtr& inputRowSchema) {
+  auto const& expression = createAstFromSubfieldFilterImpl(
+      subfield, filter, tree, scalars, inputRowSchema);
+  if (filter.testNull() && filter.kind() != common::FilterKind::kIsNull &&
+      filter.kind() != common::FilterKind::kIsNotNull) {
+    using Op = cudf::ast::ast_operator;
+    using Operation = cudf::ast::operation;
+
+    auto const& columnRef = tree.push(
+        cudf::ast::column_reference(
+            inputRowSchema->getChildIdx(subfield.toString())));
+    auto const& isNull = tree.push(Operation{Op::IS_NULL, columnRef});
+    return tree.push(Operation{Op::NULL_LOGICAL_OR, isNull, expression});
+  }
+  return expression;
 }
 
 // Create a combined AST from a set of subfield filters by chaining them with

--- a/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
+++ b/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
@@ -102,7 +102,11 @@ class SubfieldFilterAstTest : public OperatorTestBase {
 
       for (int i = 0; i < vector->size(); ++i) {
         if (fieldVec->isNullAt(i)) {
-          continue; // skip null comparison
+          if (filter.testNull()) {
+            EXPECT_FALSE(boolVector->isNullAt(i)) << "Mismatch at row " << i;
+            EXPECT_TRUE(boolVector->valueAt(i)) << "Mismatch at row " << i;
+          }
+          continue;
         }
 
         bool veloxExpected = false;
@@ -182,6 +186,42 @@ TEST_F(SubfieldFilterAstTest, int32RangeInclusive) {
   // Execution validation
   auto vec = makeTestVector(rowType, 100);
   testFilterExecution(rowType, columnName, *filter, vec, expr);
+}
+
+TEST_F(SubfieldFilterAstTest, nullAllowed) {
+  const std::string columnName = "c0";
+  auto rowType = ROW({{columnName, BIGINT()}});
+  auto vector = makeRowVector(
+      {columnName},
+      {makeNullableFlatVector<int64_t>({std::nullopt, 10, 15, 20, 30})});
+
+  std::vector<std::unique_ptr<common::Filter>> filters;
+  filters.push_back(
+      std::make_unique<common::BigintRange>(10, 20, /*nullAllowed*/ true));
+  filters.push_back(
+      common::createBigintValues(
+          std::vector<int64_t>{10, 20}, /*nullAllowed*/ true));
+  filters.push_back(
+      std::make_unique<common::NegatedBigintRange>(
+          10, 20, /*nullAllowed*/ true));
+
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(10, 12, /*nullAllowed*/ false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(18, 20, /*nullAllowed*/ false));
+  filters.push_back(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed*/ true));
+
+  for (const auto& filter : filters) {
+    common::Subfield subfield(columnName);
+    cudf::ast::tree tree;
+    std::vector<std::unique_ptr<cudf::scalar>> scalars;
+    const auto& expr =
+        createAstFromSubfieldFilter(subfield, *filter, tree, scalars, rowType);
+    testFilterExecution(rowType, columnName, *filter, vector, expr);
+  }
 }
 
 TEST_F(SubfieldFilterAstTest, doubleRange) {

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -491,7 +491,7 @@ TEST_F(TableScanTest, filterPushdown) {
           .endTableScan()
           .planNode(),
       filePaths,
-      "SELECT c1, c3, c0 FROM tmp WHERE (c1 >= 0 ) AND c3");
+      "SELECT c1, c3, c0 FROM tmp WHERE (c1 >= 0 OR c1 IS NULL) AND c3");
 
   auto tableScanStats = getTableScanStats(task);
   // EXPECT_EQ(tableScanStats.rawInputRows, 10'000);


### PR DESCRIPTION
Preserve `Filter::testNull()` when converting subfield filters to cuDF AST expressions.

For null-allowing filters, combine the generated predicate with an `IS NULL` check. Apply this only at the top level so multi-range child filters are not wrapped repeatedly. 

Fixes https://github.com/facebookincubator/velox/issues/18911

