### PR TITLE
refactor(nimble): Decouple the writer from FAISS (#18913)

### DIFF
--- a/velox/dwio/nimble/index/CMakeLists.txt
+++ b/velox/dwio/nimble/index/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(
   IndexLookup.cpp
   IndexWriter.cpp
   SortOrder.cpp
+  VectorIndexWriter.h
+  VectorIndexConfig.h
   SortedIndexWriter.h
   SortedIndexConfig.h
   SortedIndex.h
@@ -89,12 +91,11 @@ target_link_libraries(
 add_library(
   nimble_vector_index
   VectorIndex.cpp
-  VectorIndexWriter.cpp
+  FaissVectorIndexWriter.cpp
   VectorIndexUtility.cpp
   VectorIndex.h
-  VectorIndexWriter.h
+  FaissVectorIndexWriter.h
   VectorIndexUtility.h
-  VectorIndexConfig.h
 )
 target_link_libraries(
   nimble_vector_index

--- a/velox/dwio/nimble/index/FaissVectorIndexWriter.cpp
+++ b/velox/dwio/nimble/index/FaissVectorIndexWriter.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/nimble/index/VectorIndexWriter.h"
+#include "velox/dwio/nimble/index/FaissVectorIndexWriter.h"
 
 #include <algorithm>
 #include <cmath>
@@ -288,7 +288,7 @@ void validateTopLevelRows(const velox::RowVector& input, uint64_t fileRow) {
 
 } // namespace
 
-std::unique_ptr<VectorIndexWriter> VectorIndexWriter::create(
+std::unique_ptr<FaissVectorIndexWriter> FaissVectorIndexWriter::create(
     std::span<const VectorIndexConfig> configs,
     const velox::RowTypePtr& inputType,
     velox::memory::MemoryPool* pool) {
@@ -313,11 +313,11 @@ std::unique_ptr<VectorIndexWriter> VectorIndexWriter::create(
         });
   }
 
-  return std::unique_ptr<VectorIndexWriter>(
-      new VectorIndexWriter(std::move(accumulators), pool));
+  return std::unique_ptr<FaissVectorIndexWriter>(
+      new FaissVectorIndexWriter(std::move(accumulators), pool));
 }
 
-VectorIndexWriter::VectorIndexWriter(
+FaissVectorIndexWriter::FaissVectorIndexWriter(
     std::vector<Accumulator> accumulators,
     velox::memory::MemoryPool* pool)
     : pool_{pool}, accumulators_{std::move(accumulators)} {
@@ -326,7 +326,7 @@ VectorIndexWriter::VectorIndexWriter(
       !accumulators_.empty(), "Vector index configs must not be empty");
 }
 
-VectorIndexWriter::~VectorIndexWriter() = default;
+FaissVectorIndexWriter::~FaissVectorIndexWriter() = default;
 
 namespace {
 
@@ -439,8 +439,8 @@ void appendVectors(
 
 } // namespace
 
-void VectorIndexWriter::write(const velox::VectorPtr& input) {
-  NIMBLE_CHECK(!closed_, "VectorIndexWriter has been closed");
+void FaissVectorIndexWriter::write(const velox::VectorPtr& input) {
+  NIMBLE_CHECK(!closed_, "FaissVectorIndexWriter has been closed");
   NIMBLE_USER_CHECK_NOT_NULL(input, "Input vector must not be null");
   if (input->size() == 0) {
     return;
@@ -480,7 +480,7 @@ void VectorIndexWriter::write(const velox::VectorPtr& input) {
   }
 }
 
-void VectorIndexWriter::ensureVectorCapacity(
+void FaissVectorIndexWriter::ensureVectorCapacity(
     Accumulator& accumulator,
     size_t numValues) const {
   const auto maxValues = static_cast<size_t>(
@@ -510,7 +510,7 @@ void VectorIndexWriter::ensureVectorCapacity(
   accumulator.vectors->setSize(numValues * sizeof(float));
 }
 
-VectorIndexWriter::SerializedIndex VectorIndexWriter::buildIndex(
+FaissVectorIndexWriter::SerializedIndex FaissVectorIndexWriter::buildIndex(
     Accumulator& accumulator) const {
   const auto& config = accumulator.config;
   NIMBLE_CHECK_GT(accumulator.numVectors, 0, "No vectors to index");
@@ -549,7 +549,7 @@ VectorIndexWriter::SerializedIndex VectorIndexWriter::buildIndex(
   };
 }
 
-std::string VectorIndexWriter::serializeDirectory(
+std::string FaissVectorIndexWriter::serializeDirectory(
     std::span<const PersistedIndex> indexes) const {
   NIMBLE_CHECK(!indexes.empty(), "Persisted vector indexes must not be empty");
   flatbuffers::FlatBufferBuilder builder;
@@ -587,7 +587,7 @@ std::string VectorIndexWriter::serializeDirectory(
   };
 }
 
-void VectorIndexWriter::close(
+void FaissVectorIndexWriter::close(
     const CreateMetadataSectionFn& createMetadataFn,
     const WriteOptionalSectionFn& writeMetadataFn) {
   NIMBLE_CHECK(!closed_, "close() already called");
@@ -640,6 +640,15 @@ void VectorIndexWriter::close(
   NIMBLE_CHECK_EQ(persistedIndexes.size(), accumulators_.size());
   writeMetadataFn(
       std::string(kVectorIndexSection), serializeDirectory(persistedIndexes));
+}
+
+VectorIndexWriterFactory faissVectorIndexWriterFactory() {
+  return [](std::span<const VectorIndexConfig> configs,
+            const velox::RowTypePtr& inputType,
+            velox::memory::MemoryPool* pool)
+             -> std::unique_ptr<VectorIndexWriter> {
+    return FaissVectorIndexWriter::create(configs, inputType, pool);
+  };
 }
 
 } // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/FaissVectorIndexWriter.h
+++ b/velox/dwio/nimble/index/FaissVectorIndexWriter.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/index/VectorIndexConfig.h"
+#include "velox/dwio/nimble/index/VectorIndexWriter.h"
+#include "velox/dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::nimble::index {
+
+/// Builds a FAISS-based vector similarity search index during file writes.
+///
+/// Accumulates float vectors from each configured column during write() calls,
+/// then trains and serializes the FAISS indexes during close(). Each FAISS blob
+/// is stored in a metadata section referenced by one optional directory.
+class FaissVectorIndexWriter : public VectorIndexWriter {
+ public:
+  /// Creates a FaissVectorIndexWriter from one or more index configurations.
+  static std::unique_ptr<FaissVectorIndexWriter> create(
+      std::span<const VectorIndexConfig> configs,
+      const velox::RowTypePtr& inputType,
+      velox::memory::MemoryPool* pool);
+
+  ~FaissVectorIndexWriter() override;
+
+  void write(const velox::VectorPtr& input) override;
+
+  void close(
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn) override;
+
+ private:
+  // Collects all state required to build one configured index.
+  struct Accumulator {
+    // Defines how vectors are encoded and indexed.
+    VectorIndexConfig config;
+
+    // Locates the vector column in each top-level row batch.
+    velox::column_index_t columnIndex{0};
+
+    // Stores vectors contiguously in file-row order. The values for row i
+    // occupy [i * dimensions, (i + 1) * dimensions) until close() builds the
+    // index and releases this pool-tracked buffer.
+    velox::BufferPtr vectors;
+
+    // Tracks the number of top-level rows represented in vectors.
+    uint64_t numVectors{0};
+  };
+
+  // Owns an index between FAISS serialization and metadata-section persistence.
+  struct SerializedIndex {
+    // Contains the complete pool-tracked FAISS index representation.
+    velox::BufferPtr serializedData;
+
+    // Limits the view to bytes emitted by FAISS rather than buffer capacity.
+    size_t serializedSize{0};
+
+    // Records the effective IVF partition count after data-size clamping.
+    uint32_t numPartitions{0};
+  };
+
+  // Describes a persisted index while assembling the output directory.
+  struct PersistedIndex {
+    // Identifies the matching accumulator.
+    size_t accumulatorIndex{0};
+
+    // Records the effective IVF partition count after data-size clamping.
+    uint32_t numPartitions{0};
+
+    // Locates the serialized FAISS blob in the Nimble file.
+    MetadataSection indexSection;
+  };
+
+  FaissVectorIndexWriter(
+      std::vector<Accumulator> accumulators,
+      velox::memory::MemoryPool* pool);
+
+  // Builds the FAISS index from accumulated vectors.
+  SerializedIndex buildIndex(Accumulator& accumulator) const;
+
+  // Grows an accumulator geometrically while enforcing its configured limit.
+  void ensureVectorCapacity(Accumulator& accumulator, size_t numValues) const;
+
+  // Serializes descriptors for every successfully built vector index.
+  std::string serializeDirectory(std::span<const PersistedIndex> indexes) const;
+
+  // Accounts for the potentially large vector accumulation buffer.
+  velox::memory::MemoryPool* const pool_;
+
+  // Holds one independent accumulator per configured vector index.
+  std::vector<Accumulator> accumulators_;
+
+  // Prevents writes and duplicate finalization after close().
+  bool closed_{false};
+};
+
+/// Returns a factory that builds FaissVectorIndexWriter. Assign it to
+/// WriterOptions::vectorIndexWriterFactory to build FAISS vector indexes.
+VectorIndexWriterFactory faissVectorIndexWriterFactory();
+
+} // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/VectorIndexWriter.h
+++ b/velox/dwio/nimble/index/VectorIndexWriter.h
@@ -15,14 +15,10 @@
  */
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+#include <functional>
 #include <memory>
 #include <span>
-#include <string>
-#include <vector>
 
-#include "velox/buffer/Buffer.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/index/VectorIndexConfig.h"
 #include "velox/dwio/nimble/tablet/MetadataBuffer.h"
@@ -31,93 +27,36 @@
 
 namespace facebook::nimble::index {
 
-/// Builds a FAISS-based vector similarity search index during file writes.
+/// Builds a vector similarity search index during file writes.
 ///
-/// Accumulates float vectors from each configured column during write() calls,
-/// then trains and serializes the FAISS indexes during close(). Each FAISS blob
-/// is stored in a metadata section referenced by one optional directory.
+/// Accumulates vectors from each configured column during write() calls, then
+/// trains and serializes the indexes during close().
 class VectorIndexWriter {
  public:
-  /// Creates a VectorIndexWriter from one or more index configurations.
-  static std::unique_ptr<VectorIndexWriter> create(
-      std::span<const VectorIndexConfig> configs,
-      const velox::RowTypePtr& inputType,
-      velox::memory::MemoryPool* pool);
+  virtual ~VectorIndexWriter() = default;
 
-  ~VectorIndexWriter();
+  /// Extracts vectors from the configured column and buffers them.
+  virtual void write(const velox::VectorPtr& input) = 0;
 
-  /// Extracts float vectors from the configured column and buffers them.
-  void write(const velox::VectorPtr& input);
-
-  /// Writes each FAISS blob as a metadata section and their directory as an
+  /// Writes each index blob as a metadata section and their directory as an
   /// optional section.
-  void close(
+  virtual void close(
       const CreateMetadataSectionFn& createMetadataFn,
-      const WriteOptionalSectionFn& writeMetadataFn);
-
- private:
-  // Collects all state required to build one configured index.
-  struct Accumulator {
-    // Defines how vectors are encoded and indexed.
-    VectorIndexConfig config;
-
-    // Locates the vector column in each top-level row batch.
-    velox::column_index_t columnIndex{0};
-
-    // Stores vectors contiguously in file-row order. The values for row i
-    // occupy [i * dimensions, (i + 1) * dimensions) until close() builds the
-    // index and releases this pool-tracked buffer.
-    velox::BufferPtr vectors;
-
-    // Tracks the number of top-level rows represented in vectors.
-    uint64_t numVectors{0};
-  };
-
-  // Owns an index between FAISS serialization and metadata-section persistence.
-  struct SerializedIndex {
-    // Contains the complete pool-tracked FAISS index representation.
-    velox::BufferPtr serializedData;
-
-    // Limits the view to bytes emitted by FAISS rather than buffer capacity.
-    size_t serializedSize{0};
-
-    // Records the effective IVF partition count after data-size clamping.
-    uint32_t numPartitions{0};
-  };
-
-  // Describes a persisted index while assembling the output directory.
-  struct PersistedIndex {
-    // Identifies the matching accumulator.
-    size_t accumulatorIndex{0};
-
-    // Records the effective IVF partition count after data-size clamping.
-    uint32_t numPartitions{0};
-
-    // Locates the serialized FAISS blob in the Nimble file.
-    MetadataSection indexSection;
-  };
-
-  VectorIndexWriter(
-      std::vector<Accumulator> accumulators,
-      velox::memory::MemoryPool* pool);
-
-  // Builds the FAISS index from accumulated vectors.
-  SerializedIndex buildIndex(Accumulator& accumulator) const;
-
-  // Grows an accumulator geometrically while enforcing its configured limit.
-  void ensureVectorCapacity(Accumulator& accumulator, size_t numValues) const;
-
-  // Serializes descriptors for every successfully built vector index.
-  std::string serializeDirectory(std::span<const PersistedIndex> indexes) const;
-
-  // Accounts for the potentially large vector accumulation buffer.
-  velox::memory::MemoryPool* const pool_;
-
-  // Holds one independent accumulator per configured vector index.
-  std::vector<Accumulator> accumulators_;
-
-  // Prevents writes and duplicate finalization after close().
-  bool closed_{false};
+      const WriteOptionalSectionFn& writeMetadataFn) = 0;
 };
+
+/// Creates a non-null writer for one or more index configurations. The
+/// implementation must consume or copy configs during the call and must not
+/// retain the span storage.
+///
+/// Injected through WriterOptions rather than resolved from a global so that a
+/// writer which never configures a vector index does not have to link an index
+/// implementation, and the heavyweight similarity-search libraries it depends
+/// on.
+using VectorIndexWriterFactory =
+    std::function<std::unique_ptr<VectorIndexWriter>(
+        std::span<const VectorIndexConfig> configs,
+        const velox::RowTypePtr& inputType,
+        velox::memory::MemoryPool* pool)>;
 
 } // namespace facebook::nimble::index

--- a/velox/dwio/nimble/index/tests/VectorIndexTest.cpp
+++ b/velox/dwio/nimble/index/tests/VectorIndexTest.cpp
@@ -40,8 +40,8 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Exceptions.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/index/FaissVectorIndexWriter.h"
 #include "velox/dwio/nimble/index/VectorIndex.h"
-#include "velox/dwio/nimble/index/VectorIndexWriter.h"
 #include "velox/dwio/nimble/tablet/Constants.h"
 #include "velox/dwio/nimble/tablet/MetadataInput.h"
 #include "velox/dwio/nimble/tablet/TabletReader.h"
@@ -169,7 +169,7 @@ class VectorIndexTest : public ::testing::Test {
       const VectorIndexConfig& config,
       const velox::RowTypePtr& type) {
     const std::array configs{config};
-    return VectorIndexWriter::create(configs, type, pool());
+    return FaissVectorIndexWriter::create(configs, type, pool());
   }
 
   // Closes a writer and captures its directory and data sections.
@@ -748,6 +748,7 @@ TEST_F(VectorIndexTest, writerRoundTripWithMultipleIndexes) {
   secondConfig.columnName = "second_embedding";
   WriterOptions writerOptions;
   writerOptions.vectorIndexConfigs = {firstConfig, secondConfig};
+  writerOptions.vectorIndexWriterFactory = faissVectorIndexWriterFactory();
 
   std::string fileData;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
@@ -989,7 +990,7 @@ TEST_F(VectorIndexTest, invalidBatchDoesNotMutateOtherIndexes) {
   auto secondConfig = makeConfig(VectorIndexType::kIvfSq8);
   secondConfig.columnName = "second_embedding";
   const std::array configs{firstConfig, secondConfig};
-  auto writer = VectorIndexWriter::create(configs, type, pool());
+  auto writer = FaissVectorIndexWriter::create(configs, type, pool());
 
   input->childAt(2)->setNull(0, true);
   NIMBLE_ASSERT_THROW(
@@ -1036,10 +1037,24 @@ TEST_F(VectorIndexTest, emptyInputOmitsSections) {
   EXPECT_FALSE(sectionWritten);
 }
 
+TEST_F(VectorIndexTest, configuredWithoutWriterFactoryFails) {
+  const auto type = createType();
+  WriterOptions writerOptions;
+  writerOptions.vectorIndexConfigs = {makeConfig(VectorIndexType::kIvfFlat)};
+  // vectorIndexWriterFactory deliberately left unset.
+
+  std::string fileData;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
+  NIMBLE_ASSERT_USER_THROW(
+      Writer(type, std::move(writeFile), *pool(), std::move(writerOptions)),
+      "WriterOptions::vectorIndexWriterFactory must be set");
+}
+
 TEST_F(VectorIndexTest, emptyFileOmitsVectorIndex) {
   const auto type = createType();
   WriterOptions writerOptions;
   writerOptions.vectorIndexConfigs = {makeConfig(VectorIndexType::kIvfFlat)};
+  writerOptions.vectorIndexWriterFactory = faissVectorIndexWriterFactory();
 
   std::string fileData;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
@@ -1058,7 +1073,7 @@ TEST_F(VectorIndexTest, emptyFileOmitsVectorIndex) {
 TEST_F(VectorIndexTest, noConfig) {
   auto type = createType();
   NIMBLE_ASSERT_THROW(
-      VectorIndexWriter::create(
+      FaissVectorIndexWriter::create(
           std::span<const VectorIndexConfig>{}, type, pool()),
       "Vector index configs must not be empty");
 }

--- a/velox/dwio/nimble/writer/CMakeLists.txt
+++ b/velox/dwio/nimble/writer/CMakeLists.txt
@@ -43,7 +43,6 @@ target_link_libraries(
   nimble_common
   nimble_encodings
   nimble_index
-  nimble_vector_index
   nimble_tablet_writer
   nimble_velox_field_writer
   nimble_velox_layout_planner

--- a/velox/dwio/nimble/writer/Writer.cpp
+++ b/velox/dwio/nimble/writer/Writer.cpp
@@ -1765,6 +1765,28 @@ void configureAddedFlatMapField(
         context.schemaBuilder());
   }
 }
+
+// Returns nullptr when no vector index is configured. The implementation comes
+// from the caller so that this target links no similarity-search library.
+std::unique_ptr<index::VectorIndexWriter> createVectorIndexWriter(
+    const WriterOptions& options,
+    const velox::TypePtr& type,
+    velox::memory::MemoryPool* pool) {
+  if (options.vectorIndexConfigs.empty()) {
+    return nullptr;
+  }
+  NIMBLE_USER_CHECK(
+      options.vectorIndexWriterFactory != nullptr,
+      "WriterOptions::vectorIndexWriterFactory must be set when "
+      "vectorIndexConfigs is not empty. Depend on "
+      "//velox/dwio/nimble/index:vector_index and use "
+      "index::faissVectorIndexWriterFactory().");
+  auto writer = options.vectorIndexWriterFactory(
+      options.vectorIndexConfigs, velox::asRowType(type), pool);
+  NIMBLE_CHECK_NOT_NULL(
+      writer, "Vector index writer factory returned a null writer");
+  return writer;
+}
 } // namespace
 
 std::unique_ptr<index::IndexWriter> Writer::createClusterIndexWriter(
@@ -1890,13 +1912,10 @@ Writer::Writer(
           context_->options(),
           type,
           &(*context_->bufferMemoryPool()))},
-      vectorIndexWriter_{
-          context_->options().vectorIndexConfigs.empty()
-              ? nullptr
-              : index::VectorIndexWriter::create(
-                    context_->options().vectorIndexConfigs,
-                    velox::asRowType(type),
-                    &(*context_->bufferMemoryPool()))},
+      vectorIndexWriter_{createVectorIndexWriter(
+          context_->options(),
+          type,
+          &(*context_->bufferMemoryPool()))},
       tabletWriter_{TabletWriter::create(
           file_.get(),
           *encodingMemoryPool_,

--- a/velox/dwio/nimble/writer/WriterOptions.h
+++ b/velox/dwio/nimble/writer/WriterOptions.h
@@ -24,6 +24,7 @@
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/index/IndexConfig.h"
 #include "velox/dwio/nimble/index/VectorIndexConfig.h"
+#include "velox/dwio/nimble/index/VectorIndexWriter.h"
 #include "velox/dwio/nimble/tablet/StripeGroup.h"
 #include "velox/dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "velox/dwio/nimble/velox/NimbleConfig.h"
@@ -145,6 +146,13 @@ struct WriterOptions {
   /// EXPERIMENTAL: Vector indexes are not production-ready. Do not enable for
   /// production tables without consulting the Nimble team (oncall: dwios).
   std::vector<VectorIndexConfig> vectorIndexConfigs{};
+
+  /// Builds the writer for vectorIndexConfigs. Required when
+  /// vectorIndexConfigs is non-empty. Set it to
+  /// index::faissVectorIndexWriterFactory() and depend on
+  /// //velox/dwio/nimble/index:vector_index to build FAISS indexes; the writer
+  /// itself links no similarity-search library.
+  index::VectorIndexWriterFactory vectorIndexWriterFactory{};
 
   /// Columns that should be encoded as flat maps. Maps column name to a set
   /// of predefined key strings. When the set is empty, the column is


### PR DESCRIPTION
Summary:

Every binary that links the Nimble writer also links FAISS, because the writer depends on `//velox/dwio/nimble/index:vector_index` to build vector indexes. FAISS ships several build flavors compiled from the same sources with different flags, so a binary that already links one of the others now fails to link at all:

```
ld.lld: error: duplicate symbol: faiss::fvecs_maybe_subsample(unsigned long, unsigned long*, unsigned long, float const*, bool, long)
>>> defined at utils.cpp:470 (__faiss__/.../utils/utils.cpp.pic.o)
>>> defined at utils.cpp:470 (__faiss_omp_mock__/.../utils/utils.cpp.pic.o)
```

`VectorIndexWriter` is now an interface in `:index` and the FAISS implementation moved to `FaissVectorIndexWriter` in `:vector_index`. The caller supplies the implementation through a new `WriterOptions::vectorIndexWriterFactory`, next to the `vectorIndexConfigs` it already sets, so the writer target no longer depends on `:vector_index` and links no similarity-search library. Enabling FAISS indexes is two adjacent lines: `options.vectorIndexConfigs = {config};` and `options.vectorIndexWriterFactory = index::faissVectorIndexWriterFactory();`.

The factory is required whenever `vectorIndexConfigs` is non-empty. A writer configured without one fails at construction rather than silently producing a file with no index. Vector indexes remain experimental and the only callers today are the tests.

Reviewed By: duxiao1212, xiaoxmeng

Differential Revision: D119196342
