### PR TITLE
docs(style): Scope "why, not what" to the code

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -136,7 +136,7 @@ are summarized below.
 - Comment every class, every non-trivial method, every member variable.
 - Do not restate the variable name. Either explain the semantic meaning or omit the comment.
   - ❌ `// A simple counter.` above `size_t count_{0};`
-- Avoid redundant comments that repeat what the code already says. Comments should explain *why*, not *what*.
+- Avoid redundant comments that repeat what the code already says. Comments should explain *why*, not *what*. "Why" means why the code is the way it is — the constraint or tradeoff a reader must respect. Not how it got that way: what the code used to be, why that was wrong, and which alternative was rejected belong in the commit message.
 - Use `// TODO: Description.` for future work. Do not include author's username.
 - Do not duplicate comments between `.h` and `.cpp`. Document the function in the header; the implementation should not repeat the same comment. Duplicated comments diverge over time.
 

--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -213,6 +213,12 @@ About comment style:
 
 * **Avoid redundant comments** that simply repeat what the code already says.
   Comments should explain *why*, not *what*.
+  * "Why" means why the code is the way it is: the constraint, invariant or
+    tradeoff a reader must respect to change it safely. Not how it got that
+    way. What the code used to be, why that was wrong, and which alternative
+    was rejected describe the change, not the code, and belong in the commit
+    message, which `git blame` will find. A comment is read every time; a
+    commit message is read once, by whoever asks.
 
 ```cpp
 // ❌ Avoid - comment just repeats the code
@@ -230,6 +236,17 @@ return result;
 // ✅ Prefer - comment explains WHY, not WHAT
 // Use a larger buffer to avoid repeated reallocations for typical queries.
 buffer.reserve(1024);
+
+// ❌ Avoid - comment explains the change, not the code
+/// Was a std::string, which forced a JSON round-trip per row. Replaced with
+/// an opaque payload so the framework never parses it. Deriving a response
+/// type per function was rejected because it makes a missing response
+/// representable.
+std::shared_ptr<const Payload> payload;
+
+// ✅ Prefer - comment explains the constraint the reader must respect
+/// Opaque to the framework. Only the function that produced it may read it.
+std::shared_ptr<const Payload> payload;
 ```
 
 * **Do not reference other implementations** in comments ("like Java Presto",


### PR DESCRIPTION
Summary:
CODING_STYLE.md tells authors that comments should explain why, not what, and every example under that bullet is a one-liner like `++counter;`. Nothing says which "why" is meant. A header comment that narrates the change reads as compliant: what the member used to be, why that shape was wrong, which alternative was rejected. That material is about the diff, not the code, and every future reader pays for it. Reviewers ask for it to be cut and have no bullet to point at.

A sub-bullet now defines "why" as the constraint, invariant or tradeoff a reader must respect in order to change the code safely, and sends the change history to the commit message, which `git blame` will find. The example block gains a member-variable pair, since the existing examples are all too small for this habit to appear in. The OSS `CLAUDE.md` and the internal coding-style rule carry the same sentence, per the keep-in-sync note in the latter.

Differential Revision: D119266238


