### PR TITLE
docs(nimble): Explain encoded stream slicing

### DIFF
--- a/website/blog/2026-09-08-nimble-stream-slicing.mdx
+++ b/website/blog/2026-09-08-nimble-stream-slicing.mdx
@@ -1,0 +1,170 @@
+---
+slug: nimble-stream-slicing
+title: "Slicing Encoded Streams Efficiently in Velox Nimble"
+authors: [xiaoxmeng, tanjialiang]
+tags: [tech-blog, nimble, performance]
+---
+
+## Introduction
+
+On serving paths, indexed reads such as prefix scans often need a small row
+range from a much larger stripe. Fetching the full stripe creates row-level
+over-fetch: it wastes network bandwidth in NIC-bound workloads, while decoding
+it into Velox vectors, selecting rows, and serializing again incurs significant
+CPU, allocation, and data-copy costs.
+
+Nimble's
+[`StreamSlicer`](https://github.com/facebookincubator/velox/blob/main/velox/dwio/nimble/serializer/StreamSlicer.h)
+leverages white-box knowledge of each stream's encoding structure. It maps the
+requested top-level row range to the corresponding range in each nested stream
+and slices encoded bytes directly. For a compressed chunk, it decompresses the
+chunk before applying encoding-level slicing.
+
+This article explains how `StreamSlicer` maps nested row ranges and slices
+encoded streams without decoding and re-encoding the full batch.
+
+<!-- truncate -->
+
+## Nested stream mapping
+
+For a flat scalar stream, `[offset, offset + length)` maps directly to encoded
+positions. Nested streams require translation:
+
+- For nullable data, count non-null bits before and within the requested row
+  range. These counts define the offset and length in the values stream.
+- For arrays and maps, sum lengths before and within the requested row range.
+  The sums define the element-stream offset and length.
+- For flat maps, count each key's set in-map bits before and within the requested
+  row range. The counts define that key's value-stream offset and length.
+
+`StreamSlicer` applies these translations recursively.
+
+<figure style={{textAlign: 'center'}}>
+  <img
+    src="/img/nimble-stream-slicer-range-mapping.svg"
+    alt="Flow from requested top-level rows through schema-aware range mapping for null, length, and in-map streams into EncodingFactory slicing and compact Nimble output."
+    width="95%"
+  />
+  <figcaption>
+    <em>
+      A top-level row range is translated into each nested stream's range
+      before encoding-level slicing.
+    </em>
+  </figcaption>
+</figure>
+
+This avoids constructing a complete `RowVector`. If an encoding has no native
+slice implementation, the fallback decodes only the requested values and
+re-encodes them using the source encoding layout.
+
+## Slicing methods
+
+Nimble supports four slicing methods:
+
+| Method | What it does | When it applies |
+| --- | --- | --- |
+| Full-range copy | Copies the original encoded stream | The request covers every row and the stream is self-contained |
+| Native slice | Rewrites metadata and copies only the required encoded payload | The encoding has a format-aware slice implementation |
+| Slice wrapper | Keeps complete structural units and records the requested sub-range in `SliceEncoding` | Trimming boundary units would require re-encoding |
+| Re-encode fallback | Materializes the requested range and re-encodes it using the source layout | No native slice implementation is available |
+
+Native slicing avoids the re-encode fallback. For example, FixedBitWidth copies
+packed bits while preserving its baseline and width; Dictionary preserves its
+alphabet and slices indices; nested encodings slice their children recursively.
+
+## Boolean range operations
+
+Null and in-map metadata streams determine how top-level rows map to child
+values. Nimble extends boolean decoders with range operations that extract a
+bit range and count its set bits in one pass. `StreamSlicer` uses those counts
+to retrieve child offsets and lengths without materializing or scanning the
+metadata stream twice.
+
+`SliceEncoding` supports two modes used below: row offset retains complete
+runs or blocks, while value delta rebases encoded positions.
+
+## Row-offset mode: avoiding boundary re-encoding
+
+RLE and BlockBitPacking are cheap to slice except when a range starts or ends
+inside a run or packed block. Trimming those units would require rewriting run
+lengths or unpacking and repacking boundary blocks.
+
+The row-offset mode stores a logical view over complete structural units:
+
+```text
+[slice prefix: logical row count]
+[row offset into inner encoding]
+[inner encoding bytes]
+```
+
+At read time, the wrapper skips the stored offset and stops at the logical
+length. RLE keeps complete touched runs; BlockBitPacking keeps complete touched
+blocks and rebases block offsets. This trades a small payload overhang and one
+decoder layer for avoiding boundary re-encoding.
+
+## Value-delta mode: rebasing encoded position streams
+
+SparseBool stores the positions of true values, while PFOR stores the positions
+of exceptions. Neither has one entry per logical row. For example, a SparseBool
+stream can be represented as:
+
+```text
+row:                0 1 2 3 4 5 6 7 8 9 10 ... 18
+logical value:      F F T F F F F T F F  T ...  T
+encoded positions: [2, 7, 10, 18]
+```
+
+For position stream `[2, 7, 10, 18]` and row range `[6, 13)`, slicing
+proceeds as follows:
+
+1. Find the first position at or after `6`: zero-based slot `1`, which
+   contains `7`.
+2. Find the first position at or after `13`: slot `3`, which contains
+   `18`.
+3. `EncodingFactory::slice` slices slots `[1, 3)`, producing positions
+   `[7, 10]`.
+4. Apply a delta of `-6`, producing positions `[1, 4]` relative to the
+   sliced row range.
+
+`EncodingView` finds the two slot boundaries directly in the encoded
+positions. Without a view, the fallback materializes the position stream once
+to find them.
+
+After slicing the position stream, the value-delta mode stores a delta that
+rebases positions relative to the requested range:
+
+```text
+[slice prefix]
+[inner row offset]
+[value delta]
+[inner encoding bytes]
+```
+
+`SliceEncoding` records this delta so readers interpret the sliced positions
+relative to the new row range.
+
+## Reducing per-stream overhead
+
+After removing most decode-and-re-encode work, smaller costs became visible:
+
+- `StreamSlicer` reuses Velox and encoding scratch pools.
+- Projected streams sharing physical bytes reuse stripped tablet chunks.
+- `NimbleIndexProjector` fetches selected stream locations in one pass.
+- One output arena serves all partial stripes and transfers its chunks into the
+  returned `IOBuf` chain without copying the completed body.
+
+The `maxOverfetchRowsRatio` option controls the tradeoff between network bytes
+and slicing CPU. For each stripe, the projector computes the fraction of stripe
+rows that were not requested. If this ratio exceeds the configured value, it
+uses `StreamSlicer`; otherwise, it directly packs the full stripe. A value of
+`0.0` slices whenever avoidable row over-fetch exists, while `1.0` disables
+slicing.
+
+## Summary
+
+`StreamSlicer` addresses row-level over-fetch on serving paths by translating a
+top-level range through nested metadata and slicing each encoded stream. Native
+slices, boolean range utilities, `SliceEncoding`'s row-offset and value-delta
+modes, and buffer reuse minimize the CPU, temporary allocations, and copies
+required to return the requested row range. This technique helps Meta's serving
+workloads reduce network bandwidth consumption with minimal CPU cost.

--- a/website/static/img/nimble-stream-slicer-range-mapping.svg
+++ b/website/static/img/nimble-stream-slicer-range-mapping.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 800 540" role="img" aria-labelledby="title description">
+  <title id="title">Nimble StreamSlicer range mapping</title>
+  <desc id="description">A requested top-level row range flows through schema-aware mapping of null, in-map, and length streams. EncodingFactory then creates a compact serialized output without re-encoding the full batch.</desc>
+  <defs>
+    <style>
+      text { font-family: 'Comic Sans MS', 'Segoe Print', cursive; fill: #172033; }
+      .heading { font-size: 21px; font-weight: 700; }
+      .label { font-size: 18px; font-weight: 700; }
+      .detail { font-size: 14px; }
+      .box { stroke-width: 2; }
+      .arrow { fill: none; stroke: #334155; stroke-width: 2.5; }
+    </style>
+    <filter id="sketch" x="-8%" y="-12%" width="116%" height="124%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.018" numOctaves="2" seed="7" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4"/>
+    </filter>
+    <marker id="arrowhead" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 Z" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <rect width="800" height="540" fill="#ffffff"/>
+
+  <rect filter="url(#sketch)" x="260" y="25" width="280" height="62" rx="8" fill="#dae8fc" stroke="#6c8ebf" class="box"/>
+  <text x="400" y="51" text-anchor="middle" class="label">Requested top-level row range</text>
+  <text x="400" y="74" text-anchor="middle" class="detail">[offset, offset + length)</text>
+
+  <rect filter="url(#sketch)" x="40" y="125" width="720" height="180" rx="10" fill="#fafafa" stroke="#64748b" class="box"/>
+  <rect filter="url(#sketch)" x="47" y="132" width="706" height="166" rx="8" fill="none" stroke="#94a3b8" stroke-width="1"/>
+  <text x="400" y="157" text-anchor="middle" class="heading">Schema-aware range mapping</text>
+  <text x="400" y="180" text-anchor="middle" class="detail">Translate top-level rows into nested child ranges</text>
+
+  <rect filter="url(#sketch)" x="75" y="215" width="180" height="64" rx="10" fill="#fff2cc" stroke="#d6b656" class="box"/>
+  <text x="165" y="241" text-anchor="middle" class="label">Null streams</text>
+  <text x="165" y="264" text-anchor="middle" class="detail">Track present values</text>
+
+  <rect filter="url(#sketch)" x="310" y="215" width="180" height="64" rx="10" fill="#f8cecc" stroke="#b85450" class="box"/>
+  <text x="400" y="241" text-anchor="middle" class="label">In-map streams</text>
+  <text x="400" y="264" text-anchor="middle" class="detail">Track values for each key</text>
+
+  <rect filter="url(#sketch)" x="545" y="215" width="180" height="64" rx="10" fill="#e1d5e7" stroke="#9673a6" class="box"/>
+  <text x="635" y="241" text-anchor="middle" class="label">Length streams</text>
+  <text x="635" y="264" text-anchor="middle" class="detail">Count child elements</text>
+
+  <path filter="url(#sketch)" d="M400 87 V108 H165 V208" class="arrow" marker-end="url(#arrowhead)"/>
+  <path filter="url(#sketch)" d="M400 87 V208" class="arrow" marker-end="url(#arrowhead)"/>
+  <path filter="url(#sketch)" d="M400 108 H635 V208" class="arrow" marker-end="url(#arrowhead)"/>
+
+  <path filter="url(#sketch)" d="M400 305 V337" class="arrow" marker-end="url(#arrowhead)"/>
+  <rect filter="url(#sketch)" x="250" y="345" width="300" height="66" rx="8" fill="#d5e8d4" stroke="#82b366" class="box"/>
+  <text x="400" y="372" text-anchor="middle" class="label">EncodingFactory::slice</text>
+  <text x="400" y="396" text-anchor="middle" class="detail">Native slice or SliceEncoding</text>
+
+  <path filter="url(#sketch)" d="M400 411 V446" class="arrow" marker-end="url(#arrowhead)"/>
+  <rect filter="url(#sketch)" x="265" y="454" width="270" height="62" rx="10" fill="#dae8fc" stroke="#6c8ebf" class="box"/>
+  <text x="400" y="480" text-anchor="middle" class="label">Compact serialized output</text>
+  <text x="400" y="503" text-anchor="middle" class="detail">Without re-encoding the full batch</text>
+</svg>


### PR DESCRIPTION
Summary:
Adds a technical blog post explaining how Nimble produces compact serialized row windows without deserializing complete batches. A requested `[offset, offset + length)` window is translated through null, length, and in-map streams before each encoded leaf is sliced.

Describes the progression from native and deferred structural slicing through buffer reuse, sorted-position rebasing, and value-delta push-down. The article focuses on mechanisms and tradeoffs without publishing benchmark measurements.

Differential Revision: D119200726


