### PR TITLE
perf: Read preferredOutputBatchBytes once in HashProbe

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -141,6 +141,8 @@ HashProbe::HashProbe(
               ? driverCtx->makeSpillConfig(operatorId, OperatorType::kHashProbe)
               : std::nullopt),
       outputBatchSize_{outputBatchRows()},
+      preferredOutputBatchBytes_{
+          driverCtx->queryConfig().preferredOutputBatchBytes()},
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
       nullAware_{joinNode_->isNullAware()},
@@ -1373,7 +1375,7 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
           joinIncludesMissesFromLeft(joinType_),
           folly::Range(mapping.data(), outputBatchSize),
           folly::Range(outputTableRows, outputBatchSize),
-          operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes());
+          preferredOutputBatchBytes_);
     }
 
     // We are done processing the input batch if there are no more joined rows
@@ -2062,10 +2064,7 @@ void HashProbe::ensureOutputFits() {
   }
 
   const uint64_t bytesToReserve = static_cast<uint64_t>(
-      static_cast<double>(operatorCtx_->driverCtx()
-                              ->queryConfig()
-                              .preferredOutputBatchBytes()) *
-      1.2);
+      static_cast<double>(preferredOutputBatchBytes_) * 1.2);
   if (pool()->availableReservation() >= bytesToReserve) {
     return;
   }

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -409,6 +409,9 @@ class HashProbe : public Operator {
   // TODO: Define batch size as bytes based on RowContainer row sizes.
   const vector_size_t outputBatchSize_;
 
+  // QueryConfig is fixed for the life of the query.
+  const uint64_t preferredOutputBatchBytes_;
+
   const std::shared_ptr<const core::HashJoinNode> joinNode_;
 
   const core::JoinType joinType_;


### PR DESCRIPTION
HashProbe read `preferredOutputBatchBytes` out of `QueryConfig` on every output batch, in `getOutputInternal` and again in `ensureOutputFits`.

`ConfigBase::access` takes a `std::shared_lock`, so every driver thread contended on the same lock and went into the kernel to wait for it.

Profiling shows that 1574 of getOutputInternal's 1598 samples are inside that one config read, and 1008 of those are blocked in __psynch_mutexwait:
```
2196 facebook::velox::exec::HashProbe::getOutput()
1598  facebook::velox::exec::HashProbe::getOutputInternal(bool)
1574   facebook::velox::core::QueryConfig::preferredOutputBatchBytes() const
1544    <deduplicated_symbol>
1219     facebook::velox::config::ConfigBase::access(std::basic_string<char> const&) const
1025      std::__shared_mutex_base::lock_shared()
1025       std::mutex::lock()
1016        _pthread_mutex_firstfit_lock_slow
1008         _pthread_mutex_firstfit_lock_wait
1008          __psynch_mutexwait
```



QueryConfig is fixed for the life of a query, so the value can be read once in the constructor and used at both call sites.

Result shows 1.33x improvement for tpch Q21.

Follow-up: Other operators: HashAggregation, GroupingSet, Window, Merge, MergeJoin, MixedUnion call the same accessor outside their constructors and are worth refactor as well. 