### PR TITLE
fix(spill): Avoid dropping distinct rows after merging spill files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ of available functions [can be found here.](https://facebookincubator.github.io/
 
 Recent blog posts ([all posts](https://velox-lib.io/blog)):
 
+- [Slicing Encoded Streams Efficiently in Velox Nimble](https://velox-lib.io/blog/nimble-stream-slicing) (2026-09-08)
 - [Native Delta Statistics with Velox Task Barriers](https://velox-lib.io/blog/native-delta-statistics) (2026-08-25)
 - [Build Once, Probe Many: Hash Table Caching in Velox](https://velox-lib.io/blog/hash-table-caching) (2026-08-03)
-- [War of the Allocators](https://velox-lib.io/blog/war-of-the-allocators) (2026-07-27)
 
 ## Community
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1247,7 +1247,14 @@ bool GroupingSet::prepareNextSpillPartitionOutput() {
   auto it = spillPartitionSet_.begin();
   VELOX_CHECK_NE(outputSpillPartition_, it->first.partitionNumber());
   outputSpillPartition_ = it->first.partitionNumber();
-  merge_ = it->second->createOrderedReader(*spillConfig_, pool_, spillStats_);
+  merge_ = it->second->createOrderedReader(
+      *spillConfig_,
+      pool_,
+      spillStats_,
+      isDistinct()
+          ? std::optional<size_t>(
+                numDistinctSpillFilesPerPartition_[outputSpillPartition_])
+          : std::nullopt);
   spillPartitionSet_.erase(it);
   return true;
 }

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -543,7 +543,9 @@ SpillPartition::createOrderedReader(
     VELOX_CHECK_GT(orderedFiles.size(), 1);
     const uint64_t numMergeFiles = std::min(
         static_cast<uint64_t>(numMaxMergeFiles),
-        std::min(orderedFiles.size(), totalFiles + 1 - numMaxMergeFiles));
+        std::min(
+            static_cast<uint64_t>(orderedFiles.size()),
+            totalFiles + 1 - numMaxMergeFiles));
     // Choose the top 'numMergeFiles' smallest files for merging to minimize IO.
     for (uint32_t i = 0; i < numMergeFiles; i++) {
       files.push_back(orderedFiles.top());

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -485,6 +485,12 @@ SpillFileInfo mergeSpillFiles(
   }
   auto resultFiles = writer->finish();
   VELOX_CHECK_EQ(resultFiles.size(), 1);
+  // Release input readers before removing their files.
+  mergeTree.reset();
+  for (const auto& fileInfo : files) {
+    auto fs = filesystems::getFileSystem(fileInfo.path, nullptr);
+    fs->remove(fileInfo.path);
+  }
   return std::move(resultFiles[0]);
 }
 
@@ -501,7 +507,8 @@ std::unique_ptr<TreeOfLosers<SpillMergeStream>>
 SpillPartition::createOrderedReader(
     const common::SpillConfig& spillConfig,
     memory::MemoryPool* pool,
-    exec::SpillStats* spillStats) {
+    exec::SpillStats* spillStats,
+    const std::optional<size_t> initDistinctFiles) {
   const auto numMaxMergeFiles = spillConfig.numMaxMergeFiles;
   VELOX_CHECK_NE(numMaxMergeFiles, 1);
   if (numMaxMergeFiles == 0 || files_.size() <= numMaxMergeFiles) {
@@ -509,22 +516,45 @@ SpillPartition::createOrderedReader(
         spillConfig.readBufferSize, pool, spillStats);
   }
 
-  SpillFileHeap orderedFiles(files_.begin(), files_.end());
+  SpillFileHeap distinctFiles;
+  SpillFileHeap nonDistinctFiles;
+  for (const auto& file : files_) {
+    if (initDistinctFiles.has_value() && file.id < initDistinctFiles.value()) {
+      distinctFiles.push(file);
+    } else {
+      nonDistinctFiles.push(file);
+    }
+  }
   SpillFiles files;
   files.reserve(numMaxMergeFiles);
   const auto mergeFilePathPrefix = files_[0].path;
   SpillFileMergeParams mergeParams(files_[0].type, pool);
 
-  // Recursively merge the files.
-  for (uint32_t round = 0; orderedFiles.size() > numMaxMergeFiles; ++round) {
+  // Recursively merge files until the final reader observes no more than the
+  // configured number of streams. When a DISTINCT boundary is specified,
+  // merge only within a provenance group.
+  uint64_t totalFiles = distinctFiles.size() + nonDistinctFiles.size();
+  for (uint32_t round = 0; totalFiles > numMaxMergeFiles; ++round) {
+    auto& orderedFiles = distinctFiles.size() > 1 &&
+            (nonDistinctFiles.size() <= 1 ||
+             distinctFiles.top().size < nonDistinctFiles.top().size)
+        ? distinctFiles
+        : nonDistinctFiles;
+    VELOX_CHECK_GT(orderedFiles.size(), 1);
     const uint64_t numMergeFiles = std::min(
         static_cast<uint64_t>(numMaxMergeFiles),
-        static_cast<uint64_t>(orderedFiles.size() + 1 - numMaxMergeFiles));
+        std::min(orderedFiles.size(), totalFiles + 1 - numMaxMergeFiles));
     // Choose the top 'numMergeFiles' smallest files for merging to minimize IO.
     for (uint32_t i = 0; i < numMergeFiles; i++) {
       files.push_back(orderedFiles.top());
       orderedFiles.pop();
     }
+    const auto mergedFileId =
+        std::min_element(
+            files.begin(),
+            files.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs.id < rhs.id; })
+            ->id;
     auto mergedFile = mergeSpillFiles(
         files,
         fmt::format("{}-merge-round-{}", mergeFilePathPrefix, round),
@@ -535,14 +565,18 @@ SpillPartition::createOrderedReader(
         mergeParams,
         pool,
         spillStats);
-    orderedFiles.push(mergedFile);
+    mergedFile.id = mergedFileId;
+    orderedFiles.push(std::move(mergedFile));
     files.clear();
+    totalFiles = distinctFiles.size() + nonDistinctFiles.size();
   }
 
   files_.clear();
-  while (!orderedFiles.empty()) {
-    files_.push_back(orderedFiles.top());
-    orderedFiles.pop();
+  for (auto* orderedFiles : {&distinctFiles, &nonDistinctFiles}) {
+    while (!orderedFiles->empty()) {
+      files_.push_back(orderedFiles->top());
+      orderedFiles->pop();
+    }
   }
   return createOrderedReaderInternal(
       spillConfig.readBufferSize, pool, spillStats);

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -511,10 +511,15 @@ class SpillPartition {
   /// more than numMaxMergeFiles files. This behavior is to avoid OOM problem
   /// when opening and reading too many files at the same time. If
   /// numMaxMergeFiles < 2, the merge way is unlimited.
+  ///
+  /// If 'initDistinctFiles' is specified, identifies the initial spill files of
+  /// a distinct aggregation. These files contain rows that have already been
+  /// emitted and must not be pre-merged with subsequently spilled input.
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> createOrderedReader(
       const common::SpillConfig& spillConfig,
       memory::MemoryPool* pool,
-      exec::SpillStats* spillStats);
+      exec::SpillStats* spillStats,
+      std::optional<size_t> initDistinctFiles = std::nullopt);
 
   std::string toString() const;
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -5346,4 +5346,37 @@ TEST_F(
           .copyResults(pool());
   EXPECT_EQ(result->size(), totalRows);
 }
+
+// Regression test for distinct aggregation with spilling merge enabled:
+// The first spill contains the distinct hash table, which has already been
+// output. The second and third spills are smaller and will be pre-merged.
+TEST_F(AggregationTest, distinctWithSpillingAndPreMerge) {
+  const std::vector<RowVectorPtr> inputs{
+      makeRowVector({makeFlatVector<int64_t>(
+          100, [](vector_size_t row) { return row; })}),
+      makeRowVector({makeFlatVector<int64_t>(
+          1, [](vector_size_t /* row */) { return 100; })}),
+      makeRowVector({makeFlatVector<int64_t>(
+          1, [](vector_size_t /* row */) { return 101; })}),
+  };
+  createDuckDbTable(inputs);
+
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  TestScopedSpillInjection scopedSpillInjection(100);
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .spillDirectory(spillDirectory->getPath())
+                  .config(QueryConfig::kSpillEnabled, true)
+                  .config(QueryConfig::kAggregationSpillEnabled, true)
+                  .config(QueryConfig::kSpillNumPartitionBits, "0")
+                  .config(QueryConfig::kSpillNumMaxMergeFiles, "2")
+                  .maxDrivers(1)
+                  .plan(
+                      PlanBuilder()
+                          .values(inputs)
+                          .singleAggregation({"c0"}, {}, {})
+                          .planNode())
+                  .assertResults("SELECT distinct c0 FROM tmp");
+
+  OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+}
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -586,9 +586,19 @@ class SpillTest : public ::testing::TestWithParam<uint32_t>,
             finalStats.spillReads,
             succinctNanos(finalStats.spillReadTimeNanos),
             succinctNanos(finalStats.spillDeserializationTimeNanos)));
-    // Verify the spilled files are still there after spill state destruction.
-    for (const auto& spilledFile : spilledFileSet) {
-      ASSERT_TRUE(fs->exists(spilledFile));
+    if (!usePreMerge) {
+      // Verify the spilled files are still there after spill state destruction.
+      for (const auto& spilledFile : spilledFileSet) {
+        ASSERT_TRUE(fs->exists(spilledFile));
+      }
+    } else {
+      uint32_t numRemovedFiles{0};
+      for (const auto& spilledFile : spilledFileSet) {
+        if (!fs->exists(spilledFile)) {
+          ++numRemovedFiles;
+        }
+      }
+      ASSERT_GT(numRemovedFiles, 0);
     }
     // Verify stats.
     const auto spillFileSizeCount =


### PR DESCRIPTION
## Context
When enable merging spill files, the new `SpillWriter` will generate file ID from 0. For distinct aggregation, the new merged spill file id is smaller than first spilled distinct file number, so all the data in new merged spill file will be thought as already output distinct data, and be ignored.

Fix https://github.com/facebookincubator/velox/pull/14143.

## Change
- Pass the initial DISTINCT spill file count into ordered spill reading, only merge files in the same boundary
- Preserves the source group’s logical file ID on merged output
- Remove the merged old spill files after merge success to reduce the disk usage