### PR TITLE
fix(ci): Update recent blog posts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ of available functions [can be found here.](https://facebookincubator.github.io/
 
 Recent blog posts ([all posts](https://velox-lib.io/blog)):
 
+- [Slicing Encoded Streams Efficiently in Velox Nimble](https://velox-lib.io/blog/nimble-stream-slicing) (2026-09-08)
 - [Native Delta Statistics with Velox Task Barriers](https://velox-lib.io/blog/native-delta-statistics) (2026-08-25)
 - [Build Once, Probe Many: Hash Table Caching in Velox](https://velox-lib.io/blog/hash-table-caching) (2026-08-03)
-- [War of the Allocators](https://velox-lib.io/blog/war-of-the-allocators) (2026-07-27)
 
 ## Community
 


### PR DESCRIPTION
The blog post added in #18919 was merged without updating the
"Recent blog posts" list, so the check-readme-blogs pre-commit hook
now fails on every pull request with "Updated recent blog posts in
README.md". This change is the exact output of the hook's auto-fix.