### PR TITLE
perf(nimble): Reduce FSST encoding buffer allocations

### DIFF
--- a/velox/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/velox/dwio/nimble/encodings/FsstEncoding.cpp
@@ -581,12 +581,13 @@ std::string_view FsstEncoding::encode(
   {
     auto compressedValues = compressValues(values, &buffer.getMemoryPool());
 
-    Buffer lengthsBuffer{buffer.getMemoryPool()};
+    ScopedEncodingBuffer lengthsBuffer{
+        &buffer.getMemoryPool(), options.encodingBufferPool};
     const std::string_view serializedLengths = encodeCompressedLengths(
         selection,
         {compressedValues.compressedLengths.data(),
          compressedValues.compressedLengths.size()},
-        lengthsBuffer,
+        lengthsBuffer.get(),
         options);
 
     const bool useVarint = options.useVarintRowCount;
@@ -602,8 +603,7 @@ std::string_view FsstEncoding::encode(
             compressedValues.totalInputSize,
             encodingSize,
             options.fsstCompressionTargetRatio)) {
-      Buffer fsstBuffer{buffer.getMemoryPool()};
-      char* reserved = fsstBuffer.reserve(encodingSize);
+      char* reserved = buffer.reserve(encodingSize);
       char* pos = reserved;
       Encoding::serializePrefix(
           EncodingType::Fsst, DataType::String, valueCount, useVarint, pos);
@@ -620,14 +620,11 @@ std::string_view FsstEncoding::encode(
       }
 
       NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
-      std::string_view fsstEncoded{reserved, encodingSize};
-      return buffer.writeString(fsstEncoded);
+      return {reserved, encodingSize};
     }
   }
 
-  Buffer trivialBuffer{buffer.getMemoryPool()};
-  return buffer.writeString(
-      encodeTrivialFallback(selection, values, trivialBuffer, options));
+  return encodeTrivialFallback(selection, values, buffer, options);
 }
 
 std::string_view FsstEncoding::slice(

--- a/velox/dwio/nimble/encodings/benchmarks/FsstEncodingBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/FsstEncodingBenchmark.cpp
@@ -291,6 +291,69 @@ BENCHMARK(FSST_Encode_String_SortedStructuredTextMixedLengths, iterations) {
   }
 }
 
+void benchmarkEncodeBuffers(
+    uint32_t iterations,
+    uint32_t rowCount,
+    bool useBufferPool,
+    bool fallback) {
+  folly::BenchmarkSuspender suspender;
+  const auto corpus = makeFsstBenchmarkCorpus(rowCount);
+  Buffer buffer{*benchmarkPool()};
+  EncodingBufferPool bufferPool{benchmarkPool().get()};
+  auto options = fsstOptions();
+  if (fallback) {
+    options.fsstCompressionTargetRatio = 0;
+  }
+  const auto encode = [&] {
+    buffer.reset();
+    return EncodingFactory::encode<std::string_view>(
+        fsstPolicy(), corpus.values, buffer, options);
+  };
+  const std::string expected{encode()};
+  if (useBufferPool) {
+    options.encodingBufferPool = &bufferPool;
+  }
+  // Exclude the initial output and scratch allocations from the steady-state
+  // measurement. The baseline uses the same setup without a scratch pool.
+  auto encoded = encode();
+  suspender.dismiss();
+  while (iterations--) {
+    encoded = encode();
+    folly::doNotOptimizeAway(encoded);
+  }
+  suspender.rehire();
+  if (encoded != expected) {
+    throw std::runtime_error{"FSST buffer benchmark timed encode mismatch"};
+  }
+}
+
+BENCHMARK(FSST_Encode_SmallChunk, iterations) {
+  benchmarkEncodeBuffers(iterations, 64, false, false);
+}
+
+BENCHMARK_RELATIVE(FSST_Encode_SmallChunk_Pooled, iterations) {
+  benchmarkEncodeBuffers(iterations, 64, true, false);
+}
+
+BENCHMARK(FSST_Encode_LargeChunk, iterations) {
+  benchmarkEncodeBuffers(
+      iterations, kFsstBenchmarkDefaultRowCount, false, false);
+}
+
+BENCHMARK_RELATIVE(FSST_Encode_LargeChunk_Pooled, iterations) {
+  benchmarkEncodeBuffers(
+      iterations, kFsstBenchmarkDefaultRowCount, true, false);
+}
+
+BENCHMARK(FSST_Encode_TrivialFallback, iterations) {
+  benchmarkEncodeBuffers(
+      iterations, kFsstBenchmarkDefaultRowCount, false, true);
+}
+
+BENCHMARK_RELATIVE(FSST_Encode_TrivialFallback_Pooled, iterations) {
+  benchmarkEncodeBuffers(iterations, kFsstBenchmarkDefaultRowCount, true, true);
+}
+
 BENCHMARK(
     FSST_DecodeDense_String_SortedStructuredTextMixedLengths,
     iterations) {
@@ -325,15 +388,16 @@ BENCHMARK(FSST_SkipSeek_String_SortedStructuredTextMixedLengths, iterations) {
 }
 
 void printArtifactRatio() {
-  const FsstBenchmarkFixture fixture;
+  // Keep shared setup encode-only. Decode benchmarks validate their fixtures.
+  const auto corpus = makeFsstBenchmarkCorpus();
+  const auto encoded = encodeFsstFixture(corpus.values);
   fmt::print(
       "FSST full artifact: raw={} encoded={} encoded_to_raw={:.6f} "
       "raw_to_encoded={:.6f}\n",
-      fixture.corpus().rawBytes,
-      fixture.encoded().size(),
-      static_cast<double>(fixture.encoded().size()) / fixture.corpus().rawBytes,
-      static_cast<double>(fixture.corpus().rawBytes) /
-          fixture.encoded().size());
+      corpus.rawBytes,
+      encoded.size(),
+      static_cast<double>(encoded.size()) / corpus.rawBytes,
+      static_cast<double>(corpus.rawBytes) / encoded.size());
 }
 
 } // namespace

--- a/velox/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
@@ -18,6 +18,7 @@
 #include <fmt/core.h>
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <random>
 
@@ -60,12 +61,14 @@ class FsstEncodingTest : public ::testing::Test {
   std::unique_ptr<EncodingSelectionPolicy<std::string_view>>
   createSelectionPolicy(
       CompressionOptions compressionOptions = {},
-      CompressionType compressionType = CompressionType::Uncompressed) {
+      CompressionType compressionType = CompressionType::Uncompressed,
+      EncodingLayout lengthsLayout = {
+          EncodingType::Trivial,
+          {},
+          CompressionType::Uncompressed}) {
     // FSST has one nested child encoding for compressed string lengths.
     std::vector<std::optional<const EncodingLayout>> children;
-    children.emplace_back(
-        EncodingLayout{
-            EncodingType::Trivial, {}, CompressionType::Uncompressed});
+    children.emplace_back(std::move(lengthsLayout));
     EncodingLayout layout{
         EncodingType::Fsst, {}, compressionType, std::move(children)};
     return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
@@ -1009,6 +1012,183 @@ TEST_F(FsstEncodingTest, fsstCompressionTargetRatioFallsBackToTrivial) {
   std::vector<std::string_view> decoded(values.size());
   strictTargetEncoding->materialize(values.size(), decoded.data());
   EXPECT_EQ(decoded, values);
+}
+
+TEST_F(FsstEncodingTest, encodeWithReusableBuffers) {
+  std::vector<std::string> storage;
+  for (int i = 0; i < 256; ++i) {
+    storage.push_back(
+        fmt::format("common/prefix/{}/{}", i, std::string(i % 31, 'x')));
+  }
+  std::vector<std::string_view> values(storage.begin(), storage.end());
+  values[0] = "";
+  values[1] = std::string_view("embedded\0null", 13);
+
+  const EncodingLayout trivial{
+      EncodingType::Trivial, {}, CompressionType::Uncompressed};
+  const EncodingLayout dictionaryLengths{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {trivial, trivial}};
+
+  for (const auto& lengthsLayout :
+       {trivial,
+        EncodingLayout{
+            EncodingType::FixedBitWidth, {}, CompressionType::Uncompressed},
+        dictionaryLengths}) {
+    for (const bool useVarint : {false, true}) {
+      for (const bool fallback : {false, true}) {
+        for (const auto compressionType :
+             {CompressionType::Uncompressed, CompressionType::Zstd}) {
+          SCOPED_TRACE(
+              fmt::format(
+                  "lengths={}, varint={}, fallback={}, compression={}",
+                  lengthsLayout.encodingType(),
+                  useVarint,
+                  fallback,
+                  compressionType));
+          Encoding::Options options;
+          options.useVarintRowCount = useVarint;
+          options.fsstCompressionTargetRatio =
+              fallback ? 0 : std::numeric_limits<double>::max();
+          CompressionOptions compressionOptions;
+          compressionOptions.zstdMinCompressionSize = 0;
+          const auto encode = [&](auto input, Buffer& buffer) {
+            return EncodingFactory::encode<std::string_view>(
+                createSelectionPolicy(
+                    compressionOptions, compressionType, lengthsLayout),
+                input,
+                buffer,
+                options);
+          };
+
+          Buffer expectedBuffer{*pool_};
+          Buffer output{*pool_};
+          const auto prefix = output.writeString("previous output");
+          std::vector<std::string_view> expected;
+          std::vector<std::string_view> encoded;
+          const std::vector<uint32_t> batchSizes{256, 64, 192};
+          for (const auto size : batchSizes) {
+            expected.push_back(encode(
+                std::span<const std::string_view>(values.data(), size),
+                expectedBuffer));
+          }
+
+          {
+            EncodingBufferPool bufferPool{pool_.get()};
+            options.encodingBufferPool = &bufferPool;
+            for (const auto size : batchSizes) {
+              encoded.push_back(encode(
+                  std::span<const std::string_view>(values.data(), size),
+                  output));
+              // Force the next result into a different output chunk and keep
+              // all earlier results alive while scratch buffers are reused.
+              output.reserve(1 << 20);
+            }
+            auto scratch = bufferPool.acquire();
+            std::memset(scratch->reserve(8192), 0xa5, 8192);
+          }
+          options.encodingBufferPool = nullptr;
+
+          EXPECT_EQ(prefix, "previous output");
+          EXPECT_EQ(encoded, expected);
+          for (size_t i = 0; i < encoded.size(); ++i) {
+            auto decoder = EncodingFactory().create(
+                *pool_, encoded[i], createStringBufferFactory(), options);
+            EXPECT_EQ(
+                decoder->encodingType(),
+                fallback ? EncodingType::Trivial : EncodingType::Fsst);
+            std::vector<std::string_view> decoded(batchSizes[i]);
+            decoder->materialize(decoded.size(), decoded.data());
+            EXPECT_EQ(
+                decoded,
+                std::vector<std::string_view>(
+                    values.begin(), values.begin() + batchSizes[i]));
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST_F(FsstEncodingTest, encodesLengthsIntoPooledBuffer) {
+  const std::vector<std::string_view> values{
+      "common/prefix/one", "common/prefix/two", "common/prefix/three"};
+  Buffer output{*pool_};
+  EncodingBufferPool bufferPool{pool_.get(), /*maxCachedBuffers=*/1};
+  auto cachedBuffer = bufferPool.acquire();
+  auto* cachedAddress = cachedBuffer.get();
+  // A returned buffer must be reset before FSST writes its lengths into it.
+  std::memset(cachedBuffer->reserve(128), 0xa5, 128);
+  bufferPool.release(std::move(cachedBuffer));
+
+  const auto encoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(),
+      values,
+      output,
+      {.encodingBufferPool = &bufferPool,
+       .fsstCompressionTargetRatio = std::numeric_limits<double>::max()});
+  const auto lengths = FsstEncoding::lengthsEncoding(encoded);
+  auto reusedBuffer = bufferPool.acquire();
+  ASSERT_EQ(reusedBuffer.get(), cachedAddress);
+  EXPECT_EQ(
+      (std::string_view{reusedBuffer->reserve(lengths.size()), lengths.size()}),
+      lengths);
+}
+
+TEST_F(FsstEncodingTest, pooledDictionaryAlphabet) {
+  const EncodingLayout trivial{
+      EncodingType::Trivial, {}, CompressionType::Uncompressed};
+  const EncodingLayout fsst{
+      EncodingType::Fsst, {}, CompressionType::Uncompressed, {trivial}};
+  const EncodingLayout dictionary{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {fsst, trivial}};
+  const std::vector<std::string_view> values{
+      "common/prefix/one",
+      "common/prefix/two",
+      "common/prefix/one",
+      "common/prefix/three"};
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(useVarint);
+    Encoding::Options options;
+    options.useVarintRowCount = useVarint;
+    options.fsstCompressionTargetRatio = std::numeric_limits<double>::max();
+    const auto encode = [&](Buffer& buffer) {
+      return EncodingFactory::encode<std::string_view>(
+          std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+              dictionary, std::nullopt, encodingSelectionPolicyCreator_),
+          values,
+          buffer,
+          options);
+    };
+    Buffer expectedBuffer{*pool_};
+    const auto expected = encode(expectedBuffer);
+    Buffer output{*pool_};
+    std::vector<std::string_view> encoded;
+    {
+      // The dictionary output scratch arena must remain checked out while
+      // FSST acquires and releases a separate arena for its lengths.
+      EncodingBufferPool bufferPool{pool_.get(), /*maxCachedBuffers=*/1};
+      options.encodingBufferPool = &bufferPool;
+      for (int i = 0; i < 3; ++i) {
+        encoded.push_back(encode(output));
+      }
+    }
+    options.encodingBufferPool = nullptr;
+    for (const auto data : encoded) {
+      EXPECT_EQ(data, expected);
+      auto decoder = EncodingFactory().create(
+          *pool_, data, createStringBufferFactory(), options);
+      std::vector<std::string_view> decoded(values.size());
+      decoder->materialize(decoded.size(), decoded.data());
+      EXPECT_EQ(decoded, values);
+    }
+  }
 }
 
 TEST_F(FsstEncodingTest, skipAndMaterialize) {


### PR DESCRIPTION
Serialize FSST and Trivial fallback results directly into the output buffer and reuse the optional encoding scratch pool for lengths. Add coverage for buffer reuse and nested dictionaries, plus encoding benchmarks with and without scratch pooling.