### PR TITLE
feat(json) Json file format reader 

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -212,6 +212,13 @@ class SerDeOptions {
   ~SerDeOptions() = default;
 };
 
+/// Parse options for the JSON reader (JSON Lines, matching Hive
+/// org.apache.hive.hcatalog.data.JsonSerDe). Intentionally empty for now: the
+/// reader has no lenient mode — every parse error throws, and leaf type
+/// mismatches coerce silently — so no toggle is needed yet. Date and timestamp
+/// format strings are added when temporal types land.
+struct JsonSerDeOptions {};
+
 struct TableParameter {
   /// If present in the table parameters, the option is passed to the row reader
   /// to instruct it to skip the number of rows from the current position. Used

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -213,11 +213,20 @@ class SerDeOptions {
 };
 
 /// Parse options for the JSON reader (JSON Lines, matching Hive
-/// org.apache.hive.hcatalog.data.JsonSerDe). Intentionally empty for now: the
-/// reader has no lenient mode — every parse error throws, and leaf type
-/// mismatches coerce silently — so no toggle is needed yet. Date and timestamp
-/// format strings are added when temporal types land.
-struct JsonSerDeOptions {};
+/// org.apache.hive.hcatalog.data.JsonSerDe). The reader has no lenient mode —
+/// every parse error throws, and leaf type mismatches coerce silently — so no
+/// toggle is needed there. The temporal format strings below are Joda-style
+/// patterns (see velox/functions/lib/DateTimeFormatter.h); SimpleDateFormat
+/// parity is intentionally out of scope for v1.
+struct JsonSerDeOptions {
+  /// Joda-style pattern used to parse DATE columns from JSON string values.
+  std::string dateFormat{"yyyy-MM-dd"};
+
+  /// Joda-style pattern used to parse TIMESTAMP columns from JSON string
+  /// values. A trailing timezone token (e.g. ` ZZ`) is honored when present;
+  /// inputs without one are interpreted as UTC.
+  std::string timestampFormat{"yyyy-MM-dd HH:mm:ss"};
+};
 
 struct TableParameter {
   /// If present in the table parameters, the option is passed to the row reader
@@ -755,6 +764,13 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  /// Modifies the JSON serialization-deserialization options (temporal
+  /// format strings). Only consulted by the JSON reader.
+  ReaderOptions& setJsonSerDeOptions(const JsonSerDeOptions& serdeOpts) {
+    jsonSerDeOptions_ = serdeOpts;
+    return *this;
+  }
+
   ReaderOptions& setDecrypterFactory(
       const std::shared_ptr<encryption::DecrypterFactory>& factory) {
     decrypterFactory_ = factory;
@@ -853,6 +869,10 @@ class ReaderOptions : public io::ReaderOptions {
 
   const SerDeOptions& serDeOptions() const {
     return serDeOptions_;
+  }
+
+  const JsonSerDeOptions& jsonSerDeOptions() const {
+    return jsonSerDeOptions_;
   }
 
   const std::shared_ptr<encryption::DecrypterFactory> decrypterFactory() const {
@@ -1057,6 +1077,7 @@ class ReaderOptions : public io::ReaderOptions {
   std::vector<ParquetFieldId> fieldIds_;
   std::string fieldIdAttributeKey_;
   SerDeOptions serDeOptions_;
+  JsonSerDeOptions jsonSerDeOptions_;
   std::unordered_map<std::string, std::string> properties_{};
   std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -218,14 +218,18 @@ class SerDeOptions {
 /// toggle is needed there. The temporal format strings below are Joda-style
 /// patterns (see velox/functions/lib/DateTimeFormatter.h); SimpleDateFormat
 /// parity is intentionally out of scope for v1.
+/// The format strings are owned rather than viewed: these options are stored in
+/// ReaderOptions, which outlives the call that sets them, so a caller passing a
+/// pattern computed at runtime (a connector reading it out of table properties,
+/// say) must not have to keep the source string alive until the read.
 struct JsonSerDeOptions {
   /// Joda-style pattern used to parse DATE columns from JSON string values.
-  std::string_view dateFormat{"yyyy-MM-dd"};
+  std::string dateFormat{"yyyy-MM-dd"};
 
   /// Joda-style pattern used to parse TIMESTAMP columns from JSON string
   /// values. A trailing timezone token (e.g. ` ZZ`) is honored when present;
   /// inputs without one are interpreted as UTC.
-  std::string_view timestampFormat{"yyyy-MM-dd HH:mm:ss"};
+  std::string timestampFormat{"yyyy-MM-dd HH:mm:ss"};
 };
 
 struct TableParameter {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -212,20 +212,20 @@ class SerDeOptions {
   ~SerDeOptions() = default;
 };
 
-/// Parse options for the JSON reader (JSON Lines, matching Hive
-/// org.apache.hive.hcatalog.data.JsonSerDe). The reader has no lenient mode —
+/// Parse options for the JSON reader (JSON Lines, matching Hive 4.0.0
+/// org.apache.hadoop.hive.serde2.JsonSerDe). The reader has no lenient mode —
 /// every parse error throws, and leaf type mismatches coerce silently — so no
 /// toggle is needed there. The temporal format strings below are Joda-style
 /// patterns (see velox/functions/lib/DateTimeFormatter.h); SimpleDateFormat
 /// parity is intentionally out of scope for v1.
 struct JsonSerDeOptions {
   /// Joda-style pattern used to parse DATE columns from JSON string values.
-  std::string dateFormat{"yyyy-MM-dd"};
+  std::string_view dateFormat{"yyyy-MM-dd"};
 
   /// Joda-style pattern used to parse TIMESTAMP columns from JSON string
   /// values. A trailing timezone token (e.g. ` ZZ`) is honored when present;
   /// inputs without one are interpreted as UTC.
-  std::string timestampFormat{"yyyy-MM-dd HH:mm:ss"};
+  std::string_view timestampFormat{"yyyy-MM-dd HH:mm:ss"};
 };
 
 struct TableParameter {

--- a/velox/dwio/json/CMakeLists.txt
+++ b/velox/dwio/json/CMakeLists.txt
@@ -11,34 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(velox_link_libs INTERFACE)
-velox_link_libraries(
-  velox_link_libs
-  INTERFACE
-    velox_caching
-    velox_dwio_catalog_fbhive
-    velox_dwio_common
-    velox_dwio_common_exception
-    velox_encode
-    velox_exception
-    velox_memory
-    velox_process
-    velox_serialization
-    velox_type
-    velox_type_fbhive
-    velox_vector
-    Folly::folly
-    fmt::fmt
-)
 
-add_subdirectory(common)
-add_subdirectory(catalog)
-add_subdirectory(dwrf)
-add_subdirectory(json)
-add_subdirectory(orc)
-add_subdirectory(parquet)
-add_subdirectory(text)
-
-if(VELOX_ENABLE_NIMBLE)
-  add_subdirectory(nimble)
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
 endif()
+
+add_subdirectory(reader)
+
+velox_add_library(velox_dwio_json_reader_register RegisterJsonReader.cpp)
+
+velox_link_libraries(velox_dwio_json_reader_register velox_dwio_json_reader)

--- a/velox/dwio/json/RegisterJsonReader.cpp
+++ b/velox/dwio/json/RegisterJsonReader.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/json/RegisterJsonReader.h"
+#include "velox/dwio/json/reader/JsonReader.h"
+
+namespace facebook::velox::json {
+
+std::unique_ptr<dwio::common::Reader> JsonReaderFactory::createReader(
+    std::unique_ptr<dwio::common::BufferedInput> input,
+    const dwio::common::ReaderOptions& options) {
+  return std::make_unique<JsonReader>(options, std::move(input));
+}
+
+void registerJsonReaderFactory() {
+  dwio::common::registerReaderFactory(std::make_shared<JsonReaderFactory>());
+}
+
+void unregisterJsonReaderFactory() {
+  dwio::common::unregisterReaderFactory(dwio::common::FileFormat::JSON);
+}
+
+} // namespace facebook::velox::json

--- a/velox/dwio/json/RegisterJsonReader.h
+++ b/velox/dwio/json/RegisterJsonReader.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/ReaderFactory.h"
+
+namespace facebook::velox::json {
+
+class JsonReaderFactory : public dwio::common::ReaderFactory {
+ public:
+  JsonReaderFactory() : ReaderFactory(dwio::common::FileFormat::JSON) {}
+
+  std::unique_ptr<dwio::common::Reader> createReader(
+      std::unique_ptr<dwio::common::BufferedInput> input,
+      const dwio::common::ReaderOptions& options) override;
+};
+
+void registerJsonReaderFactory();
+
+void unregisterJsonReaderFactory();
+
+} // namespace facebook::velox::json

--- a/velox/dwio/json/reader/CMakeLists.txt
+++ b/velox/dwio/json/reader/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(velox_dwio_json_reader JsonReader.cpp HEADERS JsonReader.h)
 velox_link_libraries(
   velox_dwio_json_reader
   velox_dwio_common
+  velox_encode
   velox_type
   velox_vector
   Folly::folly

--- a/velox/dwio/json/reader/CMakeLists.txt
+++ b/velox/dwio/json/reader/CMakeLists.txt
@@ -20,4 +20,5 @@ velox_link_libraries(
   velox_type
   velox_vector
   Folly::folly
-  fmt::fmt)
+  fmt::fmt
+  simdjson::simdjson)

--- a/velox/dwio/json/reader/CMakeLists.txt
+++ b/velox/dwio/json/reader/CMakeLists.txt
@@ -19,6 +19,7 @@ velox_link_libraries(
   velox_dwio_common
   velox_encode
   velox_functions_lib_date_time_formatter
+  velox_functions_string
   velox_type
   velox_vector
   Folly::folly

--- a/velox/dwio/json/reader/CMakeLists.txt
+++ b/velox/dwio/json/reader/CMakeLists.txt
@@ -18,6 +18,7 @@ velox_link_libraries(
   velox_dwio_json_reader
   velox_dwio_common
   velox_encode
+  velox_functions_lib_date_time_formatter
   velox_type
   velox_vector
   Folly::folly

--- a/velox/dwio/json/reader/CMakeLists.txt
+++ b/velox/dwio/json/reader/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(velox_dwio_json_reader JsonReader.cpp HEADERS JsonReader.h)
 velox_link_libraries(
   velox_dwio_json_reader
   velox_dwio_common
+  velox_dwio_common_compression
   velox_encode
   velox_functions_lib_date_time_formatter
   velox_functions_string

--- a/velox/dwio/json/reader/CMakeLists.txt
+++ b/velox/dwio/json/reader/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+velox_add_library(velox_dwio_json_reader JsonReader.cpp HEADERS JsonReader.h)
+
+velox_link_libraries(
+  velox_dwio_json_reader
+  velox_dwio_common
+  velox_type
+  velox_vector
+  Folly::folly
+  fmt::fmt)

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -25,6 +25,7 @@
 #include "velox/dwio/common/exception/Exceptions.h"
 #include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
 #include "velox/type/DecimalUtil.h"
+#include "velox/type/Timestamp.h"
 
 namespace facebook::velox::json {
 namespace {
@@ -433,13 +434,71 @@ std::string coerceToVarbinary(simdjson::ondemand::value& value) {
   return out;
 }
 
+// Extracts the JSON string a temporal column expects. DATE and TIMESTAMP are
+// parsed from string values only; any other JSON type (number, boolean,
+// object, array) is a shape mismatch and throws. typeName labels the error.
+std::string_view temporalStringOrThrow(
+    simdjson::ondemand::value& value,
+    const char* typeName) {
+  if (unwrap(value.type()) != simdjson::ondemand::json_type::string) {
+    VELOX_USER_FAIL(
+        "Shape mismatch: {} column expects a JSON string value.", typeName);
+  }
+  return unwrap(value.get_string());
+}
+
+// Parses a JSON string into a Timestamp using the configured Joda formatter.
+// When the input carries a timezone (the format has a timezone token and the
+// value supplies an offset), the wall-clock time is normalized to UTC. Inputs
+// without a timezone are interpreted as UTC. A string the format cannot parse
+// throws — unlike numeric/boolean coercion, malformed temporal input is an
+// error, not a silent default (per json-reader-pr-roadmap.md PR-5).
+Timestamp coerceToTimestamp(
+    simdjson::ondemand::value& value,
+    const functions::DateTimeFormatter& formatter) {
+  auto str = temporalStringOrThrow(value, "TIMESTAMP");
+  auto result = formatter.parse(str);
+  if (result.hasError()) {
+    VELOX_USER_FAIL(
+        "Failed to parse TIMESTAMP from JSON string: '{}'", std::string{str});
+  }
+  auto parsed = result.value();
+  Timestamp timestamp = parsed.timestamp;
+  if (parsed.timezone != nullptr) {
+    timestamp.toGMT(*parsed.timezone);
+  }
+  return timestamp;
+}
+
+// Parses a JSON string into a DATE (days since the epoch) using the configured
+// Joda formatter. The parsed timestamp lands at midnight of the date; flooring
+// its UTC seconds by the seconds-per-day count yields the day number, correct
+// for pre-epoch dates where integer division alone would round toward zero.
+int32_t coerceToDate(
+    simdjson::ondemand::value& value,
+    const functions::DateTimeFormatter& formatter) {
+  auto str = temporalStringOrThrow(value, "DATE");
+  auto result = formatter.parse(str);
+  if (result.hasError()) {
+    VELOX_USER_FAIL(
+        "Failed to parse DATE from JSON string: '{}'", std::string{str});
+  }
+  const int64_t seconds = result.value().timestamp.getSeconds();
+  int64_t days = seconds / Timestamp::kSecondsInDay;
+  if (seconds < 0 && seconds % Timestamp::kSecondsInDay != 0) {
+    --days;
+  }
+  return static_cast<int32_t>(days);
+}
+
 // Writes one JSON value into a FlatVector cell. The caller has verified
 // that the JSON value is not `null` (it set the cell to NULL beforehand).
 void writeValue(
     simdjson::ondemand::value& value,
     const TypePtr& type,
     BaseVector& column,
-    vector_size_t rowIndex) {
+    vector_size_t rowIndex,
+    const FileContents& contents) {
   // DECIMAL is read from the raw lexeme, not coerced through a numeric kind.
   // It must be intercepted before the kind switch because a short decimal's
   // TypeKind is BIGINT and a long decimal's is HUGEINT — the switch would
@@ -466,6 +525,13 @@ void writeValue(
       return;
     }
     case TypeKind::INTEGER: {
+      // DATE is an INTEGER-kinded logical type storing days since the epoch;
+      // it must be dispatched before the plain integer coercion below.
+      if (type->isDate()) {
+        column.asUnchecked<FlatVector<int32_t>>()->set(
+            rowIndex, coerceToDate(value, *contents.dateFormatter));
+        return;
+      }
       // Narrowing wrap from int64 follows the empirical table.
       column.asUnchecked<FlatVector<int32_t>>()->set(
           rowIndex, static_cast<int32_t>(coerceToInt64(value)));
@@ -512,6 +578,11 @@ void writeValue(
           rowIndex, StringView(bytes.data(), bytes.size()));
       return;
     }
+    case TypeKind::TIMESTAMP: {
+      column.asUnchecked<FlatVector<Timestamp>>()->set(
+          rowIndex, coerceToTimestamp(value, *contents.timestampFormatter));
+      return;
+    }
     default:
       VELOX_NYI(
           "JSON reader does not yet support column type: {}",
@@ -529,6 +600,26 @@ FileContents::FileContents(
       schema{std::move(schema)},
       serDeOptions{serDeOptions},
       input{nullptr} {
+  // Compile the temporal formatters once. Joda-style patterns only — the
+  // reader does not implement SimpleDateFormat parity.
+  auto dateFormatterOrError =
+      functions::buildJodaDateTimeFormatter(this->serDeOptions.dateFormat);
+  VELOX_USER_CHECK(
+      !dateFormatterOrError.hasError(),
+      "Invalid JSON date format '{}': {}",
+      this->serDeOptions.dateFormat,
+      dateFormatterOrError.error().message());
+  dateFormatter = dateFormatterOrError.value();
+
+  auto timestampFormatterOrError =
+      functions::buildJodaDateTimeFormatter(this->serDeOptions.timestampFormat);
+  VELOX_USER_CHECK(
+      !timestampFormatterOrError.hasError(),
+      "Invalid JSON timestamp format '{}': {}",
+      this->serDeOptions.timestampFormat,
+      timestampFormatterOrError.error().message());
+  timestampFormatter = timestampFormatterOrError.value();
+
   fieldIndex.reserve(this->schema->size());
   for (size_t i = 0; i < this->schema->size(); ++i) {
     // Last-write-wins on case-collision: a schema with both `x` and `X`
@@ -547,7 +638,9 @@ JsonReader::JsonReader(
   VELOX_USER_CHECK(schema->isRow(), "File schema for JSON must be a ROW type.");
 
   contents_ = std::make_shared<FileContents>(
-      options_.memoryPool(), std::move(schema), dwio::common::JsonSerDeOptions{});
+      options_.memoryPool(),
+      std::move(schema),
+      options_.jsonSerDeOptions());
   contents_->input = std::move(input);
 }
 
@@ -680,7 +773,12 @@ void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
       // Already NULL from the per-row initialization above.
       continue;
     }
-    writeValue(value, contents_->schema->childAt(it->second), *child, rowIndex);
+    writeValue(
+        value,
+        contents_->schema->childAt(it->second),
+        *child,
+        rowIndex,
+        *contents_);
   }
 }
 

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -18,11 +18,13 @@
 
 #include <cctype>
 #include <cstring>
+#include <limits>
 
 #include <folly/Conv.h>
 #include <folly/container/F14Map.h>
 
 #include "velox/common/encode/Base64.h"
+#include "velox/dwio/common/compression/Compression.h"
 #include "velox/dwio/common/exception/Exceptions.h"
 #include "velox/functions/lib/string/StringImpl.h"
 #include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
@@ -32,6 +34,21 @@
 namespace facebook::velox::json {
 namespace {
 
+// File name suffixes that signal a compressed JSON Lines file, matching the
+// Hive text-file convention (see TextReader). Compression is inferred from the
+// name because JSON carries no embedded codec marker.
+constexpr std::string_view kCompressionExtensionGzip{".gz"};
+constexpr std::string_view kCompressionExtensionDeflate{".deflate"};
+constexpr std::string_view kCompressionExtensionZstd{".zst"};
+constexpr std::string_view kCompressionExtensionLz4{".lz4"};
+constexpr std::string_view kCompressionExtensionLzo{".lzo"};
+constexpr std::string_view kCompressionExtensionSnappy{".snappy"};
+
+// Multiplier applied to the compressed file length to size the zlib output
+// buffer (and the fallback decompressed-length estimate for other codecs).
+// Mirrors TextReader's kDecompressionBufferFactor.
+constexpr int32_t kDecompressionBufferFactor = 3;
+
 // Unwraps a simdjson_result, throwing VELOX_USER_FAIL on error.
 template <typename T>
 T unwrap(simdjson::simdjson_result<T> result) {
@@ -40,6 +57,65 @@ T unwrap(simdjson::simdjson_result<T> result) {
         "JSON parse error: {}", simdjson::error_message(result.error()));
   }
   return std::move(result).value_unsafe();
+}
+
+// Infers the compression codec from a file name extension. GZIP uses a 2^15
+// window with gzip framing; the .deflate convention is raw deflate (negative
+// window bits, no header); .zst is zstd. LZ4/LZO/Snappy carry framing the
+// reader's decompressor does not support and fail fast, matching TextReader.
+// An unrecognized extension means the file is uncompressed.
+void setCompressionFromName(
+    std::string_view name,
+    common::CompressionKind& kind,
+    dwio::common::compression::CompressionOptions& options) {
+  if (name.ends_with(kCompressionExtensionLz4) ||
+      name.ends_with(kCompressionExtensionLzo) ||
+      name.ends_with(kCompressionExtensionSnappy)) {
+    VELOX_FAIL("Unsupported compression extension for JSON file: {}", name);
+  }
+  if (name.ends_with(kCompressionExtensionGzip)) {
+    kind = common::CompressionKind::CompressionKind_GZIP;
+    options.format.zlib.windowBits = 15;
+  } else if (name.ends_with(kCompressionExtensionDeflate)) {
+    kind = common::CompressionKind::CompressionKind_ZLIB;
+    options.format.zlib.windowBits = -15; // Raw deflate, no zlib header.
+  } else if (name.ends_with(kCompressionExtensionZstd)) {
+    kind = common::CompressionKind::CompressionKind_ZSTD;
+  } else {
+    kind = common::CompressionKind::CompressionKind_NONE;
+  }
+}
+
+// Decompresses the whole file into buffer, padded with SIMDJSON_PADDING zero
+// bytes, and returns the decompressed length. Compressed JSON files are not
+// byte-addressable, so the entire file is materialized at once. Mirrors
+// TextReader's whole-file, raw decompression via createDecompressor.
+size_t decompressWholeFile(FileContents& contents, std::string& buffer) {
+  const size_t compressedLength = contents.input->getReadFile()->size();
+  auto decompressed = dwio::common::compression::createDecompressor(
+      contents.compression,
+      contents.input->loadCompleteFile(),
+      kDecompressionBufferFactor * compressedLength,
+      contents.pool,
+      contents.compressionOptions,
+      "JSON Reader",
+      /*decryptr=*/nullptr,
+      /*useRawDecompression=*/true,
+      compressedLength);
+
+  std::string decoded;
+  const void* chunk = nullptr;
+  int32_t length = 0;
+  while (decompressed->Next(&chunk, &length)) {
+    if (length > 0) {
+      decoded.append(static_cast<const char*>(chunk), length);
+    }
+  }
+
+  const size_t decodedLength = decoded.size();
+  buffer.assign(decodedLength + simdjson::SIMDJSON_PADDING, '\0');
+  std::memcpy(buffer.data(), decoded.data(), decodedLength);
+  return decodedLength;
 }
 
 // Lowercases an ASCII string byte by byte.
@@ -900,6 +976,12 @@ JsonReader::JsonReader(
       std::move(schema),
       options_.jsonSerDeOptions());
   contents_->input = std::move(input);
+  // Infer the compression codec from the file name. Unsupported codecs throw
+  // here, so an unsupported file fails at reader creation rather than mid-read.
+  setCompressionFromName(
+      contents_->input->getName(),
+      contents_->compression,
+      contents_->compressionOptions);
 }
 
 std::optional<uint64_t> JsonReader::numberOfRows() const {
@@ -935,6 +1017,23 @@ JsonRowReader::JsonRowReader(
       options_{options},
       splitStart_{options.offset()},
       splitEnd_{options.limit()} {
+  if (contents_->compression != common::CompressionKind::CompressionKind_NONE) {
+    // Compressed files are not byte-addressable and so cannot be split: the
+    // split that starts at offset 0 decompresses and reads the whole file,
+    // while every other split reads nothing. Matches TextReader's convention.
+    if (splitStart_ != 0) {
+      fileLength_ = 0;
+      pos_ = 0; // pos_ >= fileLength_ makes next() return zero rows.
+      return;
+    }
+    fileLength_ = decompressWholeFile(*contents_, fileBuffer_);
+    pos_ = 0;
+    // The requested byte length refers to compressed bytes and is meaningless
+    // after decompression; this split owns every decompressed record.
+    splitEnd_ = std::numeric_limits<size_t>::max();
+    return;
+  }
+
   const auto& readFile = contents_->input->getReadFile();
   fileLength_ = readFile->size();
   // Pad the buffer so the last line can be parsed by simdjson without

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 
 #include <folly/Conv.h>
+#include <folly/container/F14Map.h>
 
 #include "velox/common/encode/Base64.h"
 #include "velox/dwio/common/exception/Exceptions.h"
@@ -569,6 +570,76 @@ void writeArray(
   arrayVector->setNull(rowIndex, false);
 }
 
+// Writes one JSON object into a MapVector cell. simdjson On-Demand is
+// forward-only, so the object is iterated exactly once: keys and values are
+// appended to the tail of the MapVector's shared keys/values vectors. JSON
+// object keys are data (MAP<VARCHAR, V>) and pass through with case preserved
+// — unlike ROW field names, they are never case-folded.
+//
+// Velox MapVectors require unique keys per row, so duplicate keys are deduped
+// with insertion-order + last-write-wins (JsonSerDe LinkedHashMap semantics):
+// a repeated key overwrites the value at its first position and does not grow
+// the map. A non-object, non-null JSON value is a container-shape mismatch and
+// throws; value-level type mismatches coerce rather than throw.
+void writeMap(
+    simdjson::ondemand::value& value,
+    const TypePtr& type,
+    BaseVector& column,
+    vector_size_t rowIndex,
+    const FileContents& contents) {
+  const auto jsonType = unwrap(value.type());
+  if (jsonType != simdjson::ondemand::json_type::object) {
+    VELOX_USER_FAIL(
+        "Container shape mismatch: expected object for MAP, got JSON {}.",
+        jsonTypeName(jsonType));
+  }
+
+  auto* mapVector = column.asUnchecked<MapVector>();
+  auto& keys = mapVector->mapKeys();
+  auto& values = mapVector->mapValues();
+  const auto& keyType = type->childAt(0);
+  const auto& valueType = type->childAt(1);
+  // JSON object keys are strings; only VARCHAR-keyed maps are in scope.
+  VELOX_USER_CHECK(
+      keyType->kind() == TypeKind::VARCHAR,
+      "JSON reader supports only VARCHAR map keys, got: {}",
+      keyType->toString());
+  auto* keyVector = keys->asUnchecked<FlatVector<StringView>>();
+
+  const vector_size_t offset = values->size();
+  // Maps each key seen in this object to its element index in the shared
+  // keys/values vectors, giving O(1) last-write-wins on duplicate keys.
+  folly::F14FastMap<std::string, vector_size_t> keyToIndex;
+  vector_size_t count{0};
+
+  auto jsonObject = unwrap(value.get_object());
+  for (auto fieldResult : jsonObject) {
+    auto field = unwrap(fieldResult);
+    std::string key{unwrap(field.unescaped_key())};
+    simdjson::ondemand::value fieldValue = field.value();
+
+    auto [it, inserted] = keyToIndex.emplace(key, offset + count);
+    const vector_size_t elementIndex = it->second;
+    if (inserted) {
+      keys->resize(elementIndex + 1);
+      values->resize(elementIndex + 1);
+      keyVector->set(elementIndex, StringView(key.data(), key.size()));
+      ++count;
+    }
+
+    if (fieldValue.is_null()) {
+      values->setNull(elementIndex, true);
+    } else {
+      writeValue(fieldValue, valueType, *values, elementIndex, contents);
+    }
+  }
+
+  mapVector->setOffsetAndSize(rowIndex, offset, count);
+  // setOffsetAndSize does not touch the null flag; clear it so an empty object
+  // ({} -> cardinality 0) is distinct from a JSON null (SQL NULL).
+  mapVector->setNull(rowIndex, false);
+}
+
 // Writes one JSON value into a FlatVector cell. The caller has verified
 // that the JSON value is not `null` (it set the cell to NULL beforehand).
 void writeValue(
@@ -663,6 +734,10 @@ void writeValue(
     }
     case TypeKind::ARRAY: {
       writeArray(value, type, column, rowIndex, contents);
+      return;
+    }
+    case TypeKind::MAP: {
+      writeMap(value, type, column, rowIndex, contents);
       return;
     }
     default:

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -491,6 +491,84 @@ int32_t coerceToDate(
   return static_cast<int32_t>(days);
 }
 
+// Returns a human-readable name for a JSON value's type, used in
+// container-shape mismatch error messages.
+const char* jsonTypeName(simdjson::ondemand::json_type type) {
+  switch (type) {
+    case simdjson::ondemand::json_type::array:
+      return "array";
+    case simdjson::ondemand::json_type::object:
+      return "object";
+    case simdjson::ondemand::json_type::number:
+      return "number";
+    case simdjson::ondemand::json_type::string:
+      return "string";
+    case simdjson::ondemand::json_type::boolean:
+      return "boolean";
+    case simdjson::ondemand::json_type::null:
+      return "null";
+    case simdjson::ondemand::json_type::unknown:
+      return "unknown";
+  }
+  return "unknown";
+}
+
+// Forward declaration: writeArray recurses through writeValue for per-element
+// coercion, and writeValue dispatches arrays to writeArray.
+void writeValue(
+    simdjson::ondemand::value& value,
+    const TypePtr& type,
+    BaseVector& column,
+    vector_size_t rowIndex,
+    const FileContents& contents);
+
+// Writes one JSON array into an ArrayVector cell. simdjson On-Demand is
+// forward-only, so the array is iterated exactly once: each element is
+// appended to the tail of the ArrayVector's shared elements vector and
+// recursed through writeValue for per-element coercion. Because rows are
+// written in order, the current element count is this array's offset.
+//
+// A non-array, non-null JSON value is a container-shape mismatch and throws,
+// matching Presto. Element-level type mismatches coerce rather than
+// throw.
+void writeArray(
+    simdjson::ondemand::value& value,
+    const TypePtr& type,
+    BaseVector& column,
+    vector_size_t rowIndex,
+    const FileContents& contents) {
+  const auto jsonType = unwrap(value.type());
+  if (jsonType != simdjson::ondemand::json_type::array) {
+    VELOX_USER_FAIL(
+        "Container shape mismatch: expected array, got JSON {}.",
+        jsonTypeName(jsonType));
+  }
+
+  auto* arrayVector = column.asUnchecked<ArrayVector>();
+  auto& elements = arrayVector->elements();
+  const auto& elementType = type->childAt(0);
+
+  const vector_size_t offset = elements->size();
+  vector_size_t count{0};
+  auto jsonArray = unwrap(value.get_array());
+  for (auto elementResult : jsonArray) {
+    auto element = unwrap(elementResult);
+    const vector_size_t elementIndex = offset + count;
+    elements->resize(elementIndex + 1);
+    if (element.is_null()) {
+      elements->setNull(elementIndex, true);
+    } else {
+      writeValue(element, elementType, *elements, elementIndex, contents);
+    }
+    ++count;
+  }
+
+  arrayVector->setOffsetAndSize(rowIndex, offset, count);
+  // setOffsetAndSize does not touch the null flag; clear it so an empty array
+  // ([] -> cardinality 0) is distinct from a JSON null (SQL NULL).
+  arrayVector->setNull(rowIndex, false);
+}
+
 // Writes one JSON value into a FlatVector cell. The caller has verified
 // that the JSON value is not `null` (it set the cell to NULL beforehand).
 void writeValue(
@@ -581,6 +659,10 @@ void writeValue(
     case TypeKind::TIMESTAMP: {
       column.asUnchecked<FlatVector<Timestamp>>()->set(
           rowIndex, coerceToTimestamp(value, *contents.timestampFormatter));
+      return;
+    }
+    case TypeKind::ARRAY: {
+      writeArray(value, type, column, rowIndex, contents);
       return;
     }
     default:

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -16,9 +16,181 @@
 
 #include "velox/dwio/json/reader/JsonReader.h"
 
+#include <cctype>
+#include <cstring>
+
+#include <folly/Conv.h>
+
 #include "velox/dwio/common/exception/Exceptions.h"
+#include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
 
 namespace facebook::velox::json {
+namespace {
+
+// Unwraps a simdjson_result, throwing VELOX_USER_FAIL on error.
+template <typename T>
+T unwrap(simdjson::simdjson_result<T>&& result) {
+  if (result.error() != simdjson::SUCCESS) {
+    VELOX_USER_FAIL(
+        "JSON parse error: {}", simdjson::error_message(result.error()));
+  }
+  return std::move(result).value_unsafe();
+}
+
+// Lowercases an ASCII string. JSON field names that fall outside ASCII go
+// through unchanged; full Unicode folding lands with nested ROW support
+// (see json-reader-pr-roadmap.md PR-6c).
+std::string asciiLower(std::string_view s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  }
+  return out;
+}
+
+// Casts a JSON-parsed double to int64, wrapping through uint64 for values
+// in [2^63, 2^64). Values outside [-2^63, 2^64) are out of representable
+// range and diverge from Presto/Jackson for inputs that exceed 2^64 in
+// magnitude. The v1 contract is "no
+// throw", not "bit-for-bit parity".
+int64_t doubleToInt64Truncating(double d) {
+  constexpr double kInt64MinAsDouble = -9.2233720368547758e18; // -2^63
+  constexpr double kInt64MaxPlusOne = 9.2233720368547758e18; // 2^63
+  constexpr double kUint64MaxPlusOne = 1.8446744073709552e19; // 2^64
+  if (d >= kInt64MinAsDouble && d < kInt64MaxPlusOne) {
+    return static_cast<int64_t>(d);
+  }
+  if (d >= kInt64MaxPlusOne && d < kUint64MaxPlusOne) {
+    return static_cast<int64_t>(static_cast<uint64_t>(d));
+  }
+  // Out-of-range input. Velox v1 diverges from Presto/Jackson here.
+  // The test contract is "does not throw".
+  return 0;
+}
+
+// Returns the int64 coercion of a JSON scalar value per the empirical table.
+// Throws VELOX_USER_FAIL on container-shape
+// mismatch (object or array). null becomes SQL NULL via the caller's
+// is_null() check before this function is called.
+int64_t coerceToInt64(simdjson::ondemand::value& value) {
+  auto type = unwrap(value.type());
+  switch (type) {
+    case simdjson::ondemand::json_type::number: {
+      auto num = unwrap(value.get_number());
+      switch (num.get_number_type()) {
+        case simdjson::ondemand::number_type::signed_integer:
+          return num.get_int64();
+        case simdjson::ondemand::number_type::unsigned_integer:
+          // [2^63, 2^64) wraps via two's complement to match Presto/Jackson.
+          return static_cast<int64_t>(num.get_uint64());
+        case simdjson::ondemand::number_type::floating_point_number:
+          // -3.7 -> -3 (truncate toward zero, not floor).
+          return doubleToInt64Truncating(num.get_double());
+        case simdjson::ondemand::number_type::big_integer:
+          // simdjson reports big_integer for integer literals beyond
+          // uint64. value.get_number() returns NUMBER_OUT_OF_RANGE in
+          // that case, so the unwrap above already threw. Floating
+          // forms like 1e20 (the test's overflow case) parse as
+          // floating_point_number above and diverge from
+          // Presto/Jackson.
+          VELOX_UNREACHABLE();
+      }
+      VELOX_UNREACHABLE();
+    }
+    case simdjson::ondemand::json_type::boolean:
+      return unwrap(value.get_bool()) ? 1 : 0;
+    case simdjson::ondemand::json_type::string: {
+      auto s = unwrap(value.get_string());
+      // Full-fail to 0 — NOT partial-parse.
+      // "12abc" -> 0, not 12.
+      auto parsed = folly::tryTo<int64_t>(s);
+      return parsed.hasValue() ? parsed.value() : 0;
+    }
+    case simdjson::ondemand::json_type::object:
+    case simdjson::ondemand::json_type::array:
+      VELOX_USER_FAIL(
+          "Container shape mismatch: integer column received a JSON object or array.");
+    case simdjson::ondemand::json_type::null:
+      // Caller checks is_null() before invoking; reaching here is a bug.
+      VELOX_UNREACHABLE();
+    case simdjson::ondemand::json_type::unknown:
+      VELOX_USER_FAIL("Unrecognized JSON value type.");
+  }
+  VELOX_UNREACHABLE();
+}
+
+double coerceToDouble(simdjson::ondemand::value& value) {
+  auto type = unwrap(value.type());
+  switch (type) {
+    case simdjson::ondemand::json_type::number:
+      return unwrap(value.get_double());
+    case simdjson::ondemand::json_type::boolean:
+      return unwrap(value.get_bool()) ? 1.0 : 0.0;
+    case simdjson::ondemand::json_type::string: {
+      auto s = unwrap(value.get_string());
+      auto parsed = folly::tryTo<double>(s);
+      return parsed.hasValue() ? parsed.value() : 0.0;
+    }
+    case simdjson::ondemand::json_type::object:
+    case simdjson::ondemand::json_type::array:
+      VELOX_USER_FAIL(
+          "Container shape mismatch: floating-point column received a JSON object or array.");
+    case simdjson::ondemand::json_type::null:
+      VELOX_UNREACHABLE();
+    case simdjson::ondemand::json_type::unknown:
+      VELOX_USER_FAIL("Unrecognized JSON value type.");
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Writes one JSON value into a FlatVector cell. The caller has verified
+// that the JSON value is not `null` (it set the cell to NULL beforehand).
+void writeValue(
+    simdjson::ondemand::value& value,
+    const TypePtr& type,
+    BaseVector& column,
+    vector_size_t rowIndex) {
+  switch (type->kind()) {
+    case TypeKind::BIGINT: {
+      column.asUnchecked<FlatVector<int64_t>>()->set(
+          rowIndex, coerceToInt64(value));
+      return;
+    }
+    case TypeKind::INTEGER: {
+      // Narrowing wrap from int64 follows the empirical table.
+      column.asUnchecked<FlatVector<int32_t>>()->set(
+          rowIndex, static_cast<int32_t>(coerceToInt64(value)));
+      return;
+    }
+    case TypeKind::SMALLINT: {
+      column.asUnchecked<FlatVector<int16_t>>()->set(
+          rowIndex, static_cast<int16_t>(coerceToInt64(value)));
+      return;
+    }
+    case TypeKind::TINYINT: {
+      column.asUnchecked<FlatVector<int8_t>>()->set(
+          rowIndex, static_cast<int8_t>(coerceToInt64(value)));
+      return;
+    }
+    case TypeKind::DOUBLE: {
+      column.asUnchecked<FlatVector<double>>()->set(
+          rowIndex, coerceToDouble(value));
+      return;
+    }
+    case TypeKind::REAL: {
+      column.asUnchecked<FlatVector<float>>()->set(
+          rowIndex, static_cast<float>(coerceToDouble(value)));
+      return;
+    }
+    default:
+      VELOX_NYI(
+          "JSON reader does not yet support column type: {}",
+          type->toString());
+  }
+}
+
+} // namespace
 
 FileContents::FileContents(
     memory::MemoryPool& pool,
@@ -26,8 +198,16 @@ FileContents::FileContents(
     dwio::common::JsonSerDeOptions serDeOptions)
     : pool{pool},
       schema{std::move(schema)},
-      serDeOptions{std::move(serDeOptions)},
-      input{nullptr} {}
+      serDeOptions{serDeOptions},
+      input{nullptr} {
+  fieldIndex.reserve(this->schema->size());
+  for (size_t i = 0; i < this->schema->size(); ++i) {
+    // Last-write-wins on case-collision: a schema with both `x` and `X`
+    // produces a single index entry pointing to the second field. JSON
+    // field matching is case-insensitive.
+    fieldIndex[asciiLower(this->schema->nameOf(i))] = i;
+  }
+}
 
 JsonReader::JsonReader(
     const dwio::common::ReaderOptions& options,
@@ -38,9 +218,7 @@ JsonReader::JsonReader(
   VELOX_USER_CHECK(schema->isRow(), "File schema for JSON must be a ROW type.");
 
   contents_ = std::make_shared<FileContents>(
-      options_.memoryPool(),
-      std::move(schema),
-      dwio::common::JsonSerDeOptions{});
+      options_.memoryPool(), std::move(schema), dwio::common::JsonSerDeOptions{});
   contents_->input = std::move(input);
 }
 
@@ -73,14 +251,130 @@ std::unique_ptr<dwio::common::RowReader> JsonReader::createRowReader(
 JsonRowReader::JsonRowReader(
     std::shared_ptr<FileContents> contents,
     const dwio::common::RowReaderOptions& options)
-    : contents_{std::move(contents)}, options_{options} {}
+    : contents_{std::move(contents)}, options_{options} {
+  const auto& readFile = contents_->input->getReadFile();
+  fileLength_ = readFile->size();
+  // Pad the buffer so the last line can be parsed by simdjson without
+  // copying. Lines other than the last are still copied into lineBuffer_
+  // because simdjson requires padding bytes after the parsed region.
+  fileBuffer_.assign(fileLength_ + simdjson::SIMDJSON_PADDING, '\0');
+  if (fileLength_ > 0) {
+    readFile->pread(0, fileLength_, fileBuffer_.data());
+  }
+}
+
+bool JsonRowReader::readNextLine() {
+  if (pos_ >= fileLength_) {
+    return false;
+  }
+  const char* start = fileBuffer_.data() + pos_;
+  size_t remaining = fileLength_ - pos_;
+  const char* nl = static_cast<const char*>(std::memchr(start, '\n', remaining));
+  size_t length = (nl == nullptr) ? remaining : static_cast<size_t>(nl - start);
+
+  // Reserve enough room for the line plus simdjson's required trailing
+  // padding. Reuse the buffer across rows; std::string keeps capacity.
+  if (lineBuffer_.size() < length + simdjson::SIMDJSON_PADDING) {
+    lineBuffer_.assign(length + simdjson::SIMDJSON_PADDING, '\0');
+  } else {
+    // Zero the padding region in case the previous line was longer.
+    std::memset(lineBuffer_.data() + length, 0, simdjson::SIMDJSON_PADDING);
+  }
+  std::memcpy(lineBuffer_.data(), start, length);
+  lineLength_ = length;
+  pos_ += length + (nl == nullptr ? 0 : 1);
+  return true;
+}
+
+void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
+  // Initialize every column at this row to NULL. Fields absent from the
+  // JSON object stay NULL; present fields overwrite below.
+  for (size_t i = 0; i < row.childrenSize(); ++i) {
+    auto* child = row.childAt(i).get();
+    if (child != nullptr) {
+      child->setNull(rowIndex, true);
+    }
+  }
+
+  simdjson::padded_string_view padded(
+      lineBuffer_.data(),
+      lineLength_,
+      lineLength_ + simdjson::SIMDJSON_PADDING);
+  thread_local simdjson::ondemand::parser parser;
+  auto docResult = parser.iterate(padded);
+  if (docResult.error() != simdjson::SUCCESS) {
+    VELOX_USER_FAIL(
+        "JSON parse error: {}",
+        simdjson::error_message(docResult.error()));
+  }
+  simdjson::ondemand::document doc = std::move(docResult).value_unsafe();
+
+  auto objResult = doc.get_object();
+  if (objResult.error() != simdjson::SUCCESS) {
+    VELOX_USER_FAIL(
+        "JSON record is not an object: {}",
+        simdjson::error_message(objResult.error()));
+  }
+  simdjson::ondemand::object obj = objResult.value_unsafe();
+
+  // Iterate-once dispatch. simdjson On-Demand is forward-only — we
+  // cannot stash ondemand::value handles for later association with a
+  // column. Instead, look each field up in the schema's lowercase-name
+  // -> column-index map and dispatch directly into the matching column.
+  // Last-write-wins on case-duplicate keys falls out for free.
+  for (auto field : obj) {
+    auto keyResult = field.unescaped_key();
+    if (keyResult.error() != simdjson::SUCCESS) {
+      VELOX_USER_FAIL(
+          "JSON parse error: {}",
+          simdjson::error_message(keyResult.error()));
+    }
+    std::string_view key = keyResult.value_unsafe();
+    auto it = contents_->fieldIndex.find(asciiLower(key));
+    if (it == contents_->fieldIndex.end()) {
+      // Extra field — silently ignored.
+      continue;
+    }
+
+    auto valueResult = field.value();
+    if (valueResult.error() != simdjson::SUCCESS) {
+      VELOX_USER_FAIL(
+          "JSON parse error: {}",
+          simdjson::error_message(valueResult.error()));
+    }
+    simdjson::ondemand::value value = valueResult.value_unsafe();
+    auto* child = row.childAt(it->second).get();
+    if (child == nullptr) {
+      continue;
+    }
+    if (value.is_null()) {
+      // Already NULL from the per-row initialization above.
+      continue;
+    }
+    writeValue(value, contents_->schema->childAt(it->second), *child, rowIndex);
+  }
+}
 
 uint64_t JsonRowReader::next(
-    uint64_t /*size*/,
-    VectorPtr& /*result*/,
+    uint64_t size,
+    VectorPtr& result,
     const dwio::common::Mutation* /*mutation*/) {
-  // Phase 1 stub: no parsing yet.
-  return 0;
+  if (size == 0 || pos_ >= fileLength_) {
+    return 0;
+  }
+
+  auto rowVector = BaseVector::create<RowVector>(
+      contents_->schema, static_cast<vector_size_t>(size), &contents_->pool);
+
+  vector_size_t rowsRead = 0;
+  while (rowsRead < static_cast<vector_size_t>(size) && readNextLine()) {
+    writeRow(*rowVector, rowsRead);
+    ++rowsRead;
+  }
+
+  rowVector->resize(rowsRead);
+  result = rowVector;
+  return static_cast<uint64_t>(rowsRead);
 }
 
 int64_t JsonRowReader::nextRowNumber() {

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -24,6 +24,7 @@
 
 #include "velox/common/encode/Base64.h"
 #include "velox/dwio/common/exception/Exceptions.h"
+#include "velox/functions/lib/string/StringImpl.h"
 #include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/Timestamp.h"
@@ -41,9 +42,7 @@ T unwrap(simdjson::simdjson_result<T> result) {
   return std::move(result).value_unsafe();
 }
 
-// Lowercases an ASCII string. JSON field names that fall outside ASCII go
-// through unchanged; full Unicode folding lands with nested ROW support
-// (see json-reader-pr-roadmap.md PR-6c).
+// Lowercases an ASCII string byte by byte.
 std::string asciiLower(std::string_view s) {
   std::string out;
   out.reserve(s.size());
@@ -51,6 +50,20 @@ std::string asciiLower(std::string_view s) {
     out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
   }
   return out;
+}
+
+// Lowercases a JSON field name for case-insensitive ROW field matching.
+// Pure-ASCII names take a fast byte-wise
+// path; names carrying non-ASCII bytes fall back to full Unicode lowercasing
+// to match JsonSerDe's String.toLowerCase() semantics. MAP keys do NOT go
+// through here — they are data and pass through with case preserved.
+std::string toLowerKey(std::string_view key) {
+  for (char c : key) {
+    if (static_cast<unsigned char>(c) >= 0x80) {
+      return functions::stringImpl::utf8StrToLowerCopy(std::string{key});
+    }
+  }
+  return asciiLower(key);
 }
 
 // Trims trailing ASCII whitespace from a raw simdjson token. raw_json_token()
@@ -523,6 +536,15 @@ void writeValue(
     vector_size_t rowIndex,
     const FileContents& contents);
 
+// Forward declaration: writeValue dispatches nested ROWs to writeRowObject,
+// which recurses back through writeValue for each field.
+void writeRowObject(
+    simdjson::ondemand::object& object,
+    const RowType& rowType,
+    RowVector& row,
+    vector_size_t rowIndex,
+    const FileContents& contents);
+
 // Writes one JSON array into an ArrayVector cell. simdjson On-Demand is
 // forward-only, so the array is iterated exactly once: each element is
 // appended to the tail of the ArrayVector's shared elements vector and
@@ -740,10 +762,95 @@ void writeValue(
       writeMap(value, type, column, rowIndex, contents);
       return;
     }
+    case TypeKind::ROW: {
+      const auto jsonType = unwrap(value.type());
+      if (jsonType != simdjson::ondemand::json_type::object) {
+        VELOX_USER_FAIL(
+            "Container shape mismatch: expected object for ROW, got JSON {}.",
+            jsonTypeName(jsonType));
+      }
+      auto object = unwrap(value.get_object());
+      writeRowObject(
+          object,
+          type->asRow(),
+          *column.asUnchecked<RowVector>(),
+          rowIndex,
+          contents);
+      return;
+    }
     default:
       VELOX_NYI(
           "JSON reader does not yet support column type: {}",
           type->toString());
+  }
+}
+
+// Writes the fields of one JSON object into a RowVector cell at rowIndex.
+// simdjson On-Demand is forward-only, so the object is iterated exactly once:
+// each field name is lowercased and looked up in rowType's field index, then
+// dispatched directly into the matching child column. Fields absent from the
+// object stay NULL; fields not in the schema are silently ignored. Iteration
+// does not short-circuit on first match, so case-duplicate keys resolve
+// last-write-wins. An empty object {}
+// produces a non-null row whose every field is NULL — distinct from a JSON
+// null, which the caller maps to SQL NULL before reaching here.
+void writeRowObject(
+    simdjson::ondemand::object& object,
+    const RowType& rowType,
+    RowVector& row,
+    vector_size_t rowIndex,
+    const FileContents& contents) {
+  // The object exists, so the row cell is non-null even when it has no fields.
+  row.setNull(rowIndex, false);
+  // Initialize every column at this row to NULL; present fields overwrite.
+  for (size_t i = 0; i < row.childrenSize(); ++i) {
+    auto* child = row.childAt(i).get();
+    if (child != nullptr) {
+      child->setNull(rowIndex, true);
+    }
+  }
+
+  const auto& fieldIndex = contents.fieldIndexes.at(&rowType);
+  for (auto fieldResult : object) {
+    auto field = unwrap(fieldResult);
+    auto it = fieldIndex.find(toLowerKey(unwrap(field.unescaped_key())));
+    if (it == fieldIndex.end()) {
+      // Extra field — silently ignored.
+      continue;
+    }
+    auto* child = row.childAt(it->second).get();
+    if (child == nullptr) {
+      continue;
+    }
+    simdjson::ondemand::value fieldValue = field.value();
+    if (fieldValue.is_null()) {
+      // Already NULL from the per-row initialization above.
+      continue;
+    }
+    writeValue(
+        fieldValue, rowType.childAt(it->second), *child, rowIndex, contents);
+  }
+}
+
+// Recursively builds a lowercased-field-name -> child-index map for every ROW
+// type reachable from type — the type itself, ROWs nested in its ARRAY
+// elements and MAP values, and ROWs nested in its fields — keyed by RowType
+// identity. Called once per file so per-row dispatch is a hash lookup. Field
+// names collide last-write-wins on case:
+// a ROW with both `x` and `X` keeps a single entry pointing at the later field.
+void collectFieldIndexes(
+    const TypePtr& type,
+    std::unordered_map<const RowType*, std::unordered_map<std::string, uint32_t>>&
+        out) {
+  if (type->isRow()) {
+    const auto& rowType = type->asRow();
+    auto& index = out[&rowType];
+    for (uint32_t i = 0; i < rowType.size(); ++i) {
+      index[toLowerKey(rowType.nameOf(i))] = i;
+    }
+  }
+  for (uint32_t i = 0; i < type->size(); ++i) {
+    collectFieldIndexes(type->childAt(i), out);
   }
 }
 
@@ -777,13 +884,7 @@ FileContents::FileContents(
       timestampFormatterOrError.error().message());
   timestampFormatter = timestampFormatterOrError.value();
 
-  fieldIndex.reserve(this->schema->size());
-  for (size_t i = 0; i < this->schema->size(); ++i) {
-    // Last-write-wins on case-collision: a schema with both `x` and `X`
-    // produces a single index entry pointing to the second field. JSON
-    // field matching is case-insensitive.
-    fieldIndex[asciiLower(this->schema->nameOf(i))] = i;
-  }
+  collectFieldIndexes(this->schema, fieldIndexes);
 }
 
 JsonReader::JsonReader(
@@ -866,15 +967,6 @@ bool JsonRowReader::readNextLine() {
 }
 
 void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
-  // Initialize every column at this row to NULL. Fields absent from the
-  // JSON object stay NULL; present fields overwrite below.
-  for (size_t i = 0; i < row.childrenSize(); ++i) {
-    auto* child = row.childAt(i).get();
-    if (child != nullptr) {
-      child->setNull(rowIndex, true);
-    }
-  }
-
   simdjson::padded_string_view padded(
       lineBuffer_.data(),
       lineLength_,
@@ -896,47 +988,10 @@ void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
   }
   simdjson::ondemand::object obj = objResult.value_unsafe();
 
-  // Iterate-once dispatch. simdjson On-Demand is forward-only — we
-  // cannot stash ondemand::value handles for later association with a
-  // column. Instead, look each field up in the schema's lowercase-name
-  // -> column-index map and dispatch directly into the matching column.
-  // Last-write-wins on case-duplicate keys falls out for free.
-  for (auto field : obj) {
-    auto keyResult = field.unescaped_key();
-    if (keyResult.error() != simdjson::SUCCESS) {
-      VELOX_USER_FAIL(
-          "JSON parse error: {}",
-          simdjson::error_message(keyResult.error()));
-    }
-    std::string_view key = keyResult.value_unsafe();
-    auto it = contents_->fieldIndex.find(asciiLower(key));
-    if (it == contents_->fieldIndex.end()) {
-      // Extra field — silently ignored.
-      continue;
-    }
-
-    auto valueResult = field.value();
-    if (valueResult.error() != simdjson::SUCCESS) {
-      VELOX_USER_FAIL(
-          "JSON parse error: {}",
-          simdjson::error_message(valueResult.error()));
-    }
-    simdjson::ondemand::value value = valueResult.value_unsafe();
-    auto* child = row.childAt(it->second).get();
-    if (child == nullptr) {
-      continue;
-    }
-    if (value.is_null()) {
-      // Already NULL from the per-row initialization above.
-      continue;
-    }
-    writeValue(
-        value,
-        contents_->schema->childAt(it->second),
-        *child,
-        rowIndex,
-        *contents_);
-  }
+  // The top-level record dispatches through the same iterate-once writer as
+  // nested ROWs: simdjson On-Demand is forward-only, so each field is looked
+  // up in the schema's lowercase-name -> column-index map and written directly.
+  writeRowObject(obj, *contents_->schema, row, rowIndex, *contents_);
 }
 
 uint64_t JsonRowReader::next(

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -21,8 +21,10 @@
 
 #include <folly/Conv.h>
 
+#include "velox/common/encode/Base64.h"
 #include "velox/dwio/common/exception/Exceptions.h"
 #include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::json {
 namespace {
@@ -351,6 +353,86 @@ double coerceToDouble(simdjson::ondemand::value& value) {
   VELOX_UNREACHABLE();
 }
 
+// Parses a JSON value into a decimal of the given precision and scale from
+// the original lexeme, NOT through double. Routing a high-precision number
+// through double silently rounds away digits a double cannot hold (a double
+// carries ~15-16 significant decimal digits); the raw lexeme preserves them.
+// Numbers use the raw token; strings use the decoded contents. Throws on a
+// container-shape mismatch or a lexeme the decimal parser rejects.
+template <typename T>
+T coerceToDecimal(
+    simdjson::ondemand::value& value,
+    uint8_t precision,
+    uint8_t scale) {
+  std::string_view lexeme;
+  // Backs lexeme when the source is a JSON string; must outlive the parse.
+  std::string decoded;
+  auto type = unwrap(value.type());
+  switch (type) {
+    case simdjson::ondemand::json_type::number:
+      lexeme = trimTrailingWhitespace(value.raw_json_token());
+      break;
+    case simdjson::ondemand::json_type::string:
+      decoded = std::string{unwrap(value.get_string())};
+      lexeme = decoded;
+      break;
+    case simdjson::ondemand::json_type::object:
+    case simdjson::ondemand::json_type::array:
+      VELOX_USER_FAIL(
+          "Container shape mismatch: decimal column received a JSON object or array.");
+    case simdjson::ondemand::json_type::boolean:
+      VELOX_USER_FAIL("Cannot coerce a JSON boolean to a decimal column.");
+    case simdjson::ondemand::json_type::null:
+      VELOX_UNREACHABLE();
+    case simdjson::ondemand::json_type::unknown:
+      VELOX_USER_FAIL("Unrecognized JSON value type.");
+  }
+
+  T out{0};
+  const auto status = DecimalUtil::castFromString<T>(
+      StringView(lexeme.data(), static_cast<int32_t>(lexeme.size())),
+      precision,
+      scale,
+      out);
+  if (!status.ok()) {
+    VELOX_USER_FAIL(
+        "Cannot parse decimal from JSON lexeme: {} ({})",
+        lexeme,
+        status.message());
+  }
+  return out;
+}
+
+// Base64-decodes a JSON string into raw bytes for a VARBINARY column. Presto
+// carries binary data base64-encoded in JSON text, so the reader decodes on
+// the way in. Throws on a non-string value or invalid base64.
+std::string coerceToVarbinary(simdjson::ondemand::value& value) {
+  auto type = unwrap(value.type());
+  if (type != simdjson::ondemand::json_type::string) {
+    VELOX_USER_FAIL("VARBINARY column requires a base64-encoded JSON string.");
+  }
+  auto encoded = unwrap(value.get_string());
+  // calculateDecodedSize adjusts inputSize for padding; the adjusted value
+  // must be the one passed to decode.
+  size_t inputSize = encoded.size();
+  auto decodedSize =
+      encoding::Base64::calculateDecodedSize(encoded.data(), inputSize);
+  if (decodedSize.hasError()) {
+    VELOX_USER_FAIL(
+        "Invalid base64 in VARBINARY column: {}",
+        decodedSize.error().message());
+  }
+  std::string out;
+  out.resize(decodedSize.value());
+  const auto status = encoding::Base64::decode(
+      encoded.data(), inputSize, out.data(), out.size());
+  if (!status.ok()) {
+    VELOX_USER_FAIL(
+        "Invalid base64 in VARBINARY column: {}", status.message());
+  }
+  return out;
+}
+
 // Writes one JSON value into a FlatVector cell. The caller has verified
 // that the JSON value is not `null` (it set the cell to NULL beforehand).
 void writeValue(
@@ -358,6 +440,25 @@ void writeValue(
     const TypePtr& type,
     BaseVector& column,
     vector_size_t rowIndex) {
+  // DECIMAL is read from the raw lexeme, not coerced through a numeric kind.
+  // It must be intercepted before the kind switch because a short decimal's
+  // TypeKind is BIGINT and a long decimal's is HUGEINT — the switch would
+  // otherwise misroute them. JSON-typed columns are not handled here: the
+  // Hive connector does not accept JSON column declarations today, so
+  // JSON-shaped data flows through VARCHAR. If
+  // a future Presto adds JSON columns to the Hive path, this dispatch reopens.
+  if (type->isDecimal()) {
+    const auto [precision, scale] = getDecimalPrecisionScale(*type);
+    if (type->isShortDecimal()) {
+      column.asUnchecked<FlatVector<int64_t>>()->set(
+          rowIndex, coerceToDecimal<int64_t>(value, precision, scale));
+    } else {
+      column.asUnchecked<FlatVector<int128_t>>()->set(
+          rowIndex, coerceToDecimal<int128_t>(value, precision, scale));
+    }
+    return;
+  }
+
   switch (type->kind()) {
     case TypeKind::BIGINT: {
       column.asUnchecked<FlatVector<int64_t>>()->set(
@@ -401,6 +502,14 @@ void writeValue(
       // owned string buffer, so the temporary str can safely go out of scope.
       column.asUnchecked<FlatVector<StringView>>()->set(
           rowIndex, StringView(str.data(), str.size()));
+      return;
+    }
+    case TypeKind::VARBINARY: {
+      auto bytes = coerceToVarbinary(value);
+      // FlatVector::set() copies the bytes into the vector's owned string
+      // buffer, so the temporary can safely go out of scope.
+      column.asUnchecked<FlatVector<StringView>>()->set(
+          rowIndex, StringView(bytes.data(), bytes.size()));
       return;
     }
     default:

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/json/reader/JsonReader.h"
+
+#include "velox/dwio/common/exception/Exceptions.h"
+
+namespace facebook::velox::json {
+
+FileContents::FileContents(
+    memory::MemoryPool& pool,
+    std::shared_ptr<const RowType> schema,
+    dwio::common::JsonSerDeOptions serDeOptions)
+    : pool{pool},
+      schema{std::move(schema)},
+      serDeOptions{std::move(serDeOptions)},
+      input{nullptr} {}
+
+JsonReader::JsonReader(
+    const dwio::common::ReaderOptions& options,
+    std::unique_ptr<dwio::common::BufferedInput> input)
+    : options_{options} {
+  auto schema = options_.fileSchema();
+  VELOX_USER_CHECK_NOT_NULL(schema, "File schema for JSON must be set.");
+  VELOX_USER_CHECK(schema->isRow(), "File schema for JSON must be a ROW type.");
+
+  contents_ = std::make_shared<FileContents>(
+      options_.memoryPool(),
+      std::move(schema),
+      dwio::common::JsonSerDeOptions{});
+  contents_->input = std::move(input);
+}
+
+std::optional<uint64_t> JsonReader::numberOfRows() const {
+  return std::nullopt;
+}
+
+std::unique_ptr<dwio::common::ColumnStatistics> JsonReader::columnStatistics(
+    uint32_t /*index*/) const {
+  return nullptr;
+}
+
+const RowTypePtr& JsonReader::rowType() const {
+  return contents_->schema;
+}
+
+const std::shared_ptr<const dwio::common::TypeWithId>& JsonReader::typeWithId()
+    const {
+  if (typeWithId_ == nullptr) {
+    typeWithId_ = dwio::common::TypeWithId::create(rowType());
+  }
+  return typeWithId_;
+}
+
+std::unique_ptr<dwio::common::RowReader> JsonReader::createRowReader(
+    const dwio::common::RowReaderOptions& options) const {
+  return std::make_unique<JsonRowReader>(contents_, options);
+}
+
+JsonRowReader::JsonRowReader(
+    std::shared_ptr<FileContents> contents,
+    const dwio::common::RowReaderOptions& options)
+    : contents_{std::move(contents)}, options_{options} {}
+
+uint64_t JsonRowReader::next(
+    uint64_t /*size*/,
+    VectorPtr& /*result*/,
+    const dwio::common::Mutation* /*mutation*/) {
+  // Phase 1 stub: no parsing yet.
+  return 0;
+}
+
+int64_t JsonRowReader::nextRowNumber() {
+  return kAtEnd;
+}
+
+int64_t JsonRowReader::nextReadSize(uint64_t /*size*/) {
+  return kAtEnd;
+}
+
+void JsonRowReader::updateRuntimeStats(
+    dwio::common::RuntimeStatistics& /*stats*/) const {
+  // The JSON reader produces no runtime statistics. There is no
+  // parse-error counter because there is no lenient mode: every parse
+  // error throws.
+}
+
+void JsonRowReader::resetFilterCaches() {
+  // No filter caches; the JSON reader does not use ScanSpec filters.
+}
+
+std::optional<size_t> JsonRowReader::estimatedRowSize() const {
+  // JSON Lines has no cheap size estimate without a sampling pass.
+  return std::nullopt;
+}
+
+} // namespace facebook::velox::json

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -931,7 +931,10 @@ std::unique_ptr<dwio::common::RowReader> JsonReader::createRowReader(
 JsonRowReader::JsonRowReader(
     std::shared_ptr<FileContents> contents,
     const dwio::common::RowReaderOptions& options)
-    : contents_{std::move(contents)}, options_{options} {
+    : contents_{std::move(contents)},
+      options_{options},
+      splitStart_{options.offset()},
+      splitEnd_{options.limit()} {
   const auto& readFile = contents_->input->getReadFile();
   fileLength_ = readFile->size();
   // Pad the buffer so the last line can be parsed by simdjson without
@@ -941,10 +944,29 @@ JsonRowReader::JsonRowReader(
   if (fileLength_ > 0) {
     readFile->pread(0, fileLength_, fileBuffer_.data());
   }
+
+  // Position at the first record this split owns. A nonzero split offset
+  // generally lands inside a record; that record belongs to the previous
+  // split, so scan forward to the byte after the next newline and start
+  // there. The first split (offset 0) starts at byte 0 and skips nothing.
+  pos_ = splitStart_;
+  if (splitStart_ != 0 && splitStart_ < fileLength_) {
+    const char* from = fileBuffer_.data() + splitStart_;
+    const char* nl = static_cast<const char*>(
+        std::memchr(from, '\n', fileLength_ - splitStart_));
+    // No newline at or after the offset means the offset falls in the
+    // file's final (unterminated) record, which the previous split owns.
+    pos_ = (nl == nullptr) ? fileLength_
+                           : static_cast<size_t>(nl - fileBuffer_.data()) + 1;
+  }
 }
 
 bool JsonRowReader::readNextLine() {
-  if (pos_ >= fileLength_) {
+  // Stop at end of file, or once a record would start past this split's
+  // boundary. A record starting at exactly splitEnd_ is still read (the
+  // straddling record); the next split skips it via the constructor's
+  // first-line skip. This is the Presto/Hive line-split convention.
+  if (pos_ >= fileLength_ || pos_ > splitEnd_) {
     return false;
   }
   const char* start = fileBuffer_.data() + pos_;
@@ -967,6 +989,16 @@ bool JsonRowReader::readNextLine() {
 }
 
 void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
+  // A blank line — empty or whitespace only — is never a valid JSON
+  // record. JsonSerDe rejects these as empty rows; surface a clear error
+  // rather than simdjson's lower-level diagnostic. Blank lines turn up at
+  // split boundaries (leading, trailing, or between records), so the
+  // behavior is pinned here.
+  std::string_view line(lineBuffer_.data(), lineLength_);
+  if (line.find_first_not_of(" \t\r\n") == std::string_view::npos) {
+    VELOX_USER_FAIL("JSON parse error: encountered an empty row.");
+  }
+
   simdjson::padded_string_view padded(
       lineBuffer_.data(),
       lineLength_,
@@ -998,7 +1030,7 @@ uint64_t JsonRowReader::next(
     uint64_t size,
     VectorPtr& result,
     const dwio::common::Mutation* /*mutation*/) {
-  if (size == 0 || pos_ >= fileLength_) {
+  if (size == 0 || pos_ >= fileLength_ || pos_ > splitEnd_) {
     return 0;
   }
 

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -29,7 +29,7 @@ namespace {
 
 // Unwraps a simdjson_result, throwing VELOX_USER_FAIL on error.
 template <typename T>
-T unwrap(simdjson::simdjson_result<T>&& result) {
+T unwrap(simdjson::simdjson_result<T> result) {
   if (result.error() != simdjson::SUCCESS) {
     VELOX_USER_FAIL(
         "JSON parse error: {}", simdjson::error_message(result.error()));
@@ -47,6 +47,21 @@ std::string asciiLower(std::string_view s) {
     out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
   }
   return out;
+}
+
+// Trims trailing ASCII whitespace from a raw simdjson token. raw_json_token()
+// returns the value's bytes up to (but not including) the next structural
+// character, which can leave trailing spaces or newlines for scalars.
+std::string_view trimTrailingWhitespace(std::string_view token) {
+  size_t size = token.size();
+  while (size > 0) {
+    char c = token[size - 1];
+    if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+      break;
+    }
+    --size;
+  }
+  return token.substr(0, size);
 }
 
 // Casts a JSON-parsed double to int64, wrapping through uint64 for values
@@ -120,6 +135,198 @@ int64_t coerceToInt64(simdjson::ondemand::value& value) {
   VELOX_UNREACHABLE();
 }
 
+// Returns the boolean coercion of a JSON scalar.
+// Numbers coerce by nonzero (any nonzero, including negatives, is true).
+// Strings match the strict literal "true" (lowercase, exactly four bytes);
+// everything else — "True", "TRUE", "yes", "", "false" — is false. Throws on
+// container-shape mismatch. null is handled by the caller's is_null() check.
+bool coerceToBool(simdjson::ondemand::value& value) {
+  auto type = unwrap(value.type());
+  switch (type) {
+    case simdjson::ondemand::json_type::boolean:
+      return unwrap(value.get_bool());
+    case simdjson::ondemand::json_type::number: {
+      auto num = unwrap(value.get_number());
+      switch (num.get_number_type()) {
+        case simdjson::ondemand::number_type::signed_integer:
+          return num.get_int64() != 0;
+        case simdjson::ondemand::number_type::unsigned_integer:
+          return num.get_uint64() != 0;
+        case simdjson::ondemand::number_type::floating_point_number:
+          return num.get_double() != 0.0;
+        case simdjson::ondemand::number_type::big_integer:
+          // get_number() already returned NUMBER_OUT_OF_RANGE and threw.
+          VELOX_UNREACHABLE();
+      }
+      VELOX_UNREACHABLE();
+    }
+    case simdjson::ondemand::json_type::string: {
+      auto s = unwrap(value.get_string());
+      // Strict literal match — case-sensitive — per the probe: only the
+      // exact lowercase "true" is true. "True"/"TRUE" are false.
+      return s.size() == 4 && std::memcmp(s.data(), "true", 4) == 0;
+    }
+    case simdjson::ondemand::json_type::object:
+    case simdjson::ondemand::json_type::array:
+      VELOX_USER_FAIL(
+          "Container shape mismatch: boolean column received a JSON object or array.");
+    case simdjson::ondemand::json_type::null:
+      VELOX_UNREACHABLE();
+    case simdjson::ondemand::json_type::unknown:
+      VELOX_USER_FAIL("Unrecognized JSON value type.");
+  }
+  VELOX_UNREACHABLE();
+}
+
+// JSON-escapes str into out, emitting compact escapes for the mandatory
+// characters (quote, backslash, control bytes). Forward slash is left bare
+// because Jackson's compact serialization does not escape it — this is what
+// makes "http:\/\/x" re-serialize as http://x. The surrounding quotes are
+// the caller's responsibility.
+void appendEscapedJsonString(std::string_view str, std::string& out) {
+  for (char c : str) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\b':
+        out += "\\b";
+        break;
+      case '\f':
+        out += "\\f";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        const auto byte = static_cast<unsigned int>(static_cast<unsigned char>(c));
+        if (byte < 0x20) {
+          constexpr char kHex[] = "0123456789abcdef";
+          out += "\\u00";
+          out += kHex[(byte >> 4U) & 0xFU];
+          out += kHex[byte & 0xFU];
+        } else {
+          out += c;
+        }
+    }
+  }
+}
+
+// Forward declaration: serializeJsonValue and serializeJsonObject/Array
+// recurse into one another.
+void serializeJsonValue(simdjson::ondemand::value& value, std::string& out);
+
+// Minifies a JSON object into out: whitespace stripped, escapes decoded then
+// re-encoded, input key order preserved (NOT canonicalized — distinct from
+// the JSON-typed-column rule). simdjson On-Demand
+// is forward-only, so each field is visited exactly once in document order.
+void serializeJsonObject(simdjson::ondemand::object& obj, std::string& out) {
+  out += '{';
+  bool first = true;
+  for (auto field : obj) {
+    if (!first) {
+      out += ',';
+    }
+    first = false;
+    out += '"';
+    appendEscapedJsonString(unwrap(field.unescaped_key()), out);
+    out += "\":";
+    auto value = unwrap(field.value());
+    serializeJsonValue(value, out);
+  }
+  out += '}';
+}
+
+// Minifies a JSON array into out, preserving element order.
+void serializeJsonArray(simdjson::ondemand::array& arr, std::string& out) {
+  out += '[';
+  bool first = true;
+  for (auto element : arr) {
+    if (!first) {
+      out += ',';
+    }
+    first = false;
+    auto value = unwrap(element);
+    serializeJsonValue(value, out);
+  }
+  out += ']';
+}
+
+void serializeJsonValue(simdjson::ondemand::value& value, std::string& out) {
+  auto type = unwrap(value.type());
+  switch (type) {
+    case simdjson::ondemand::json_type::object: {
+      auto obj = unwrap(value.get_object());
+      serializeJsonObject(obj, out);
+      return;
+    }
+    case simdjson::ondemand::json_type::array: {
+      auto arr = unwrap(value.get_array());
+      serializeJsonArray(arr, out);
+      return;
+    }
+    case simdjson::ondemand::json_type::string:
+      out += '"';
+      appendEscapedJsonString(unwrap(value.get_string()), out);
+      out += '"';
+      return;
+    case simdjson::ondemand::json_type::number:
+    case simdjson::ondemand::json_type::boolean:
+    case simdjson::ondemand::json_type::null:
+      // Scalars carry no whitespace within the token; emit the lexeme as-is
+      // (trailing whitespace before the next structural char is trimmed).
+      out += trimTrailingWhitespace(value.raw_json_token());
+      return;
+    case simdjson::ondemand::json_type::unknown:
+      VELOX_USER_FAIL("Unrecognized JSON value type.");
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Returns the VARCHAR coercion of a JSON value.
+// Strings pass through with escapes decoded by the parser; booleans become
+// the lowercase literals; objects and arrays are re-serialized minified with
+// key order preserved; numbers use a best-effort lexeme. null is handled by
+// the caller's is_null() check.
+//
+// VARCHAR-from-number is a known v1 divergence: Presto/Jackson formats via
+// BigDecimal(input).stripTrailingZeros().toString(), which C++ has no
+// standard equivalent for. v1 emits the original lexeme, so the semantic
+// value is preserved but the exact textual form (trailing zeros, scientific
+// notation case/threshold) may differ. This is the documented
+// VARCHAR-from-number v1 divergence.
+std::string coerceToString(simdjson::ondemand::value& value) {
+  auto type = unwrap(value.type());
+  switch (type) {
+    case simdjson::ondemand::json_type::string:
+      return std::string{unwrap(value.get_string())};
+    case simdjson::ondemand::json_type::boolean:
+      return unwrap(value.get_bool()) ? "true" : "false";
+    case simdjson::ondemand::json_type::number:
+      return std::string{trimTrailingWhitespace(value.raw_json_token())};
+    case simdjson::ondemand::json_type::object:
+    case simdjson::ondemand::json_type::array: {
+      std::string out;
+      serializeJsonValue(value, out);
+      return out;
+    }
+    case simdjson::ondemand::json_type::null:
+      VELOX_UNREACHABLE();
+    case simdjson::ondemand::json_type::unknown:
+      VELOX_USER_FAIL("Unrecognized JSON value type.");
+  }
+  VELOX_UNREACHABLE();
+}
+
 double coerceToDouble(simdjson::ondemand::value& value) {
   auto type = unwrap(value.type());
   switch (type) {
@@ -181,6 +388,19 @@ void writeValue(
     case TypeKind::REAL: {
       column.asUnchecked<FlatVector<float>>()->set(
           rowIndex, static_cast<float>(coerceToDouble(value)));
+      return;
+    }
+    case TypeKind::BOOLEAN: {
+      column.asUnchecked<FlatVector<bool>>()->set(
+          rowIndex, coerceToBool(value));
+      return;
+    }
+    case TypeKind::VARCHAR: {
+      auto str = coerceToString(value);
+      // FlatVector::set() copies the StringView's data into the vector's
+      // owned string buffer, so the temporary str can safely go out of scope.
+      column.asUnchecked<FlatVector<StringView>>()->set(
+          rowIndex, StringView(str.data(), str.size()));
       return;
     }
     default:

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -25,6 +25,8 @@
 #include <folly/container/F14Map.h>
 
 #include "velox/common/encode/Base64.h"
+#include "velox/dwio/common/Mutation.h"
+#include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/compression/Compression.h"
 #include "velox/dwio/common/exception/Exceptions.h"
 #include "velox/functions/lib/string/StringImpl.h"
@@ -612,6 +614,8 @@ Timestamp coerceToTimestamp(
 // Joda formatter. The parsed timestamp lands at midnight of the date; flooring
 // its UTC seconds by the seconds-per-day count yields the day number, correct
 // for pre-epoch dates where integer division alone would round toward zero.
+// A format carrying a timezone token names an instant rather than a wall-clock
+// date, so it is normalized to UTC first, matching coerceToTimestamp.
 int32_t coerceToDate(
     simdjson::ondemand::value& value,
     const functions::DateTimeFormatter& formatter) {
@@ -621,7 +625,11 @@ int32_t coerceToDate(
     VELOX_USER_FAIL(
         "Failed to parse DATE from JSON string: '{}'", std::string{str});
   }
-  const int64_t seconds = result.value().timestamp.getSeconds();
+  auto parsed = result.value();
+  if (parsed.timezone != nullptr) {
+    parsed.timestamp.toGMT(*parsed.timezone);
+  }
+  const int64_t seconds = parsed.timestamp.getSeconds();
   int64_t days = seconds / Timestamp::kSecondsInDay;
   if (seconds < 0 && seconds % Timestamp::kSecondsInDay != 0) {
     --days;
@@ -1064,6 +1072,17 @@ JsonRowReader::JsonRowReader(
       options_{options},
       splitStart_{options.offset()},
       splitEnd_{options.limit()} {
+  // Refuse a filter rather than ignore one. Connectors attach a scan spec to
+  // every scan, so its mere presence says nothing; a filter on it does, and
+  // reading past it would return rows the caller asked to have removed with no
+  // indication that the filter went unapplied. Column projection carried by the
+  // spec is ignored rather than refused: next() materializes the full file
+  // schema, which a caller can see in the result's type.
+  const auto& scanSpec = options_.scanSpec();
+  VELOX_USER_CHECK(
+      scanSpec == nullptr || !scanSpec->hasFilter(),
+      "JSON reader does not support filter pushdown.");
+
   if (contents_->compression != common::CompressionKind::CompressionKind_NONE) {
     // Compressed files are not byte-addressable and so cannot be split: the
     // split that starts at offset 0 decompresses and reads the whole file,
@@ -1188,7 +1207,14 @@ void JsonRowReader::parseRecord(RowVector& row, vector_size_t rowIndex) {
 uint64_t JsonRowReader::next(
     uint64_t size,
     VectorPtr& result,
-    const dwio::common::Mutation* /*mutation*/) {
+    const dwio::common::Mutation* mutation) {
+  // As with a filter, a delete that goes unapplied hands back rows the caller
+  // asked to have removed. A mutation with nothing deleted asks for nothing, so
+  // it is the deletions rather than the mutation that are refused.
+  VELOX_USER_CHECK(
+      !dwio::common::hasDeletion(mutation),
+      "JSON reader does not support row-level deletes.");
+
   // Guard, not boundary enforcement: readNextLine() would return 0 rows
   // anyway. Returning early avoids allocating a RowVector and leaves result
   // untouched at end of split, matching TextRowReader and DwrfRowReader.
@@ -1205,6 +1231,17 @@ uint64_t JsonRowReader::next(
     ++rowsRead;
   }
 
+  // The batch was sized to the caller's request, which is an upper bound; trim
+  // it to what was actually read. RowVector::resize deliberately does not
+  // propagate a shrink to its children, so trim them first: otherwise a short
+  // batch leaves each child holding trailing rows that were never written and
+  // are not marked null, which a consumer iterating a child by its own size()
+  // would read as real data.
+  for (auto& child : rowVector->children()) {
+    if (child != nullptr) {
+      child->resize(rowsRead);
+    }
+  }
   rowVector->resize(rowsRead);
   result = rowVector;
   return static_cast<uint64_t>(rowsRead);

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -49,12 +49,13 @@ constexpr std::string_view kCompressionExtensionSnappy{".snappy"};
 // Mirrors TextReader's kDecompressionBufferFactor.
 constexpr int32_t kDecompressionBufferFactor = 3;
 
-// Unwraps a simdjson_result, throwing VELOX_USER_FAIL on error.
+// Unwraps a simdjson_result, throwing VELOX_USER_FAIL on error. The simdjson
+// diagnostic is thrown bare; JsonRowReader::writeRow catches it and prepends
+// the record's byte offset so every parse error carries a location.
 template <typename T>
 T unwrap(simdjson::simdjson_result<T> result) {
   if (result.error() != simdjson::SUCCESS) {
-    VELOX_USER_FAIL(
-        "JSON parse error: {}", simdjson::error_message(result.error()));
+    VELOX_USER_FAIL("{}", simdjson::error_message(result.error()));
   }
   return std::move(result).value_unsafe();
 }
@@ -1068,6 +1069,9 @@ bool JsonRowReader::readNextLine() {
   if (pos_ >= fileLength_ || pos_ > splitEnd_) {
     return false;
   }
+  // Capture where this record begins before pos_ advances, so a parse error
+  // can report the record's byte offset.
+  recordStartOffset_ = pos_;
   const char* start = fileBuffer_.data() + pos_;
   size_t remaining = fileLength_ - pos_;
   const char* nl = static_cast<const char*>(std::memchr(start, '\n', remaining));
@@ -1088,6 +1092,23 @@ bool JsonRowReader::readNextLine() {
 }
 
 void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
+  try {
+    parseRecord(row, rowIndex);
+  } catch (const VeloxUserError& error) {
+    // Every parse error path throws a VeloxUserError with a bare description;
+    // catch it here, the one place that knows where the record began, and
+    // prepend the byte offset. Splits make line numbers ambiguous, so the
+    // offset into the (decompressed) file is the stable locator.
+    // Internal errors (VELOX_CHECK / VELOX_NYI)
+    // are not user-facing parse failures and propagate unwrapped.
+    VELOX_USER_FAIL(
+        "JSON parse error at byte offset {}: {}",
+        recordStartOffset_,
+        error.message());
+  }
+}
+
+void JsonRowReader::parseRecord(RowVector& row, vector_size_t rowIndex) {
   // A blank line — empty or whitespace only — is never a valid JSON
   // record. JsonSerDe rejects these as empty rows; surface a clear error
   // rather than simdjson's lower-level diagnostic. Blank lines turn up at
@@ -1095,7 +1116,7 @@ void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
   // behavior is pinned here.
   std::string_view line(lineBuffer_.data(), lineLength_);
   if (line.find_first_not_of(" \t\r\n") == std::string_view::npos) {
-    VELOX_USER_FAIL("JSON parse error: encountered an empty row.");
+    VELOX_USER_FAIL("encountered an empty row.");
   }
 
   simdjson::padded_string_view padded(
@@ -1103,18 +1124,12 @@ void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
       lineLength_,
       lineLength_ + simdjson::SIMDJSON_PADDING);
   thread_local simdjson::ondemand::parser parser;
-  auto docResult = parser.iterate(padded);
-  if (docResult.error() != simdjson::SUCCESS) {
-    VELOX_USER_FAIL(
-        "JSON parse error: {}",
-        simdjson::error_message(docResult.error()));
-  }
-  simdjson::ondemand::document doc = std::move(docResult).value_unsafe();
+  auto doc = unwrap(parser.iterate(padded));
 
   auto objResult = doc.get_object();
   if (objResult.error() != simdjson::SUCCESS) {
     VELOX_USER_FAIL(
-        "JSON record is not an object: {}",
+        "record is not a JSON object: {}",
         simdjson::error_message(objResult.error()));
   }
   simdjson::ondemand::object obj = objResult.value_unsafe();

--- a/velox/dwio/json/reader/JsonReader.cpp
+++ b/velox/dwio/json/reader/JsonReader.cpp
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <cstring>
 #include <limits>
+#include <optional>
 
 #include <folly/Conv.h>
 #include <folly/container/F14Map.h>
@@ -87,11 +88,12 @@ void setCompressionFromName(
   }
 }
 
-// Decompresses the whole file into buffer, padded with SIMDJSON_PADDING zero
-// bytes, and returns the decompressed length. Compressed JSON files are not
-// byte-addressable, so the entire file is materialized at once. Mirrors
-// TextReader's whole-file, raw decompression via createDecompressor.
-size_t decompressWholeFile(FileContents& contents, std::string& buffer) {
+// Decompresses the whole file into a pool-owned AlignedBuffer padded with
+// SIMDJSON_PADDING zero bytes, and returns it. The decompressed length is
+// written into decodedLength. Compressed JSON files are not byte-addressable,
+// so the entire file is materialized at once. Mirrors TextReader's whole-file,
+// raw decompression via createDecompressor.
+BufferPtr decompressWholeFile(FileContents& contents, size_t& decodedLength) {
   const size_t compressedLength = contents.input->getReadFile()->size();
   auto decompressed = dwio::common::compression::createDecompressor(
       contents.compression,
@@ -104,6 +106,9 @@ size_t decompressWholeFile(FileContents& contents, std::string& buffer) {
       /*useRawDecompression=*/true,
       compressedLength);
 
+  // Accumulate chunks into a temporary string — chunks are pointers into the
+  // decompressor's internal buffer and are only valid until the next Next()
+  // call, so they must be copied out immediately.
   std::string decoded;
   const void* chunk = nullptr;
   int32_t length = 0;
@@ -113,34 +118,29 @@ size_t decompressWholeFile(FileContents& contents, std::string& buffer) {
     }
   }
 
-  const size_t decodedLength = decoded.size();
-  buffer.assign(decodedLength + simdjson::SIMDJSON_PADDING, '\0');
-  std::memcpy(buffer.data(), decoded.data(), decodedLength);
-  return decodedLength;
-}
-
-// Lowercases an ASCII string byte by byte.
-std::string asciiLower(std::string_view s) {
-  std::string out;
-  out.reserve(s.size());
-  for (char c : s) {
-    out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
-  }
-  return out;
+  // Now the full size is known: allocate a single pool-owned buffer at the
+  // right size and copy in one shot.
+  decodedLength = decoded.size();
+  auto buffer = AlignedBuffer::allocate<char>(
+      decodedLength + simdjson::SIMDJSON_PADDING, &contents.pool);
+  std::memcpy(buffer->asMutable<char>(), decoded.data(), decodedLength);
+  return buffer;
 }
 
 // Lowercases a JSON field name for case-insensitive ROW field matching.
 // Pure-ASCII names take a fast byte-wise
 // path; names carrying non-ASCII bytes fall back to full Unicode lowercasing
-// to match JsonSerDe's String.toLowerCase() semantics. MAP keys do NOT go
-// through here — they are data and pass through with case preserved.
+// to match the serde2 JsonSerDe's String.toLowerCase() semantics. MAP keys do
+// NOT go through here — they are data and pass through with case preserved.
 std::string toLowerKey(std::string_view key) {
   for (char c : key) {
     if (static_cast<unsigned char>(c) >= 0x80) {
       return functions::stringImpl::utf8StrToLowerCopy(std::string{key});
     }
   }
-  return asciiLower(key);
+  std::string out{key};
+  folly::toLowerAscii(out);
+  return out;
 }
 
 // Trims trailing ASCII whitespace from a raw simdjson token. raw_json_token()
@@ -160,7 +160,7 @@ std::string_view trimTrailingWhitespace(std::string_view token) {
 
 // Casts a JSON-parsed double to int64, wrapping through uint64 for values
 // in [2^63, 2^64). Values outside [-2^63, 2^64) are out of representable
-// range and diverge from Presto/Jackson for inputs that exceed 2^64 in
+// range and diverge from Jackson for inputs that exceed 2^64 in
 // magnitude. The v1 contract is "no
 // throw", not "bit-for-bit parity".
 int64_t doubleToInt64Truncating(double d) {
@@ -173,15 +173,16 @@ int64_t doubleToInt64Truncating(double d) {
   if (d >= kInt64MaxPlusOne && d < kUint64MaxPlusOne) {
     return static_cast<int64_t>(static_cast<uint64_t>(d));
   }
-  // Out-of-range input. Velox v1 diverges from Presto/Jackson here.
+  // Out-of-range input. Velox v1 diverges from Jackson here.
   // The test contract is "does not throw".
   return 0;
 }
 
-// Returns the int64 coercion of a JSON scalar value per the empirical table.
-// Throws VELOX_USER_FAIL on container-shape
-// mismatch (object or array). null becomes SQL NULL via the caller's
-// is_null() check before this function is called.
+// Returns the int64 coercion of a JSON scalar value, following the serde2
+// JsonSerDe's leaf handling (Jackson's JsonNode.asLong(), which defaults on a
+// value it cannot convert rather than throwing). Throws VELOX_USER_FAIL on
+// container-shape mismatch (object or array). null becomes SQL NULL via the
+// caller's is_null() check before this function is called.
 int64_t coerceToInt64(simdjson::ondemand::value& value) {
   auto type = unwrap(value.type());
   switch (type) {
@@ -191,7 +192,7 @@ int64_t coerceToInt64(simdjson::ondemand::value& value) {
         case simdjson::ondemand::number_type::signed_integer:
           return num.get_int64();
         case simdjson::ondemand::number_type::unsigned_integer:
-          // [2^63, 2^64) wraps via two's complement to match Presto/Jackson.
+          // [2^63, 2^64) wraps via two's complement to match Jackson.
           return static_cast<int64_t>(num.get_uint64());
         case simdjson::ondemand::number_type::floating_point_number:
           // -3.7 -> -3 (truncate toward zero, not floor).
@@ -201,8 +202,7 @@ int64_t coerceToInt64(simdjson::ondemand::value& value) {
           // uint64. value.get_number() returns NUMBER_OUT_OF_RANGE in
           // that case, so the unwrap above already threw. Floating
           // forms like 1e20 (the test's overflow case) parse as
-          // floating_point_number above and diverge from
-          // Presto/Jackson.
+          // floating_point_number above and diverge from Jackson.
           VELOX_UNREACHABLE();
       }
       VELOX_UNREACHABLE();
@@ -211,10 +211,20 @@ int64_t coerceToInt64(simdjson::ondemand::value& value) {
       return unwrap(value.get_bool()) ? 1 : 0;
     case simdjson::ondemand::json_type::string: {
       auto s = unwrap(value.get_string());
-      // Full-fail to 0 — NOT partial-parse.
-      // "12abc" -> 0, not 12.
       auto parsed = folly::tryTo<int64_t>(s);
-      return parsed.hasValue() ? parsed.value() : 0;
+      if (parsed.hasValue()) {
+        return parsed.value();
+      }
+      // Jackson's NumberInput.parseAsLong is a two-stage parse: when the
+      // integer scan hits a character it cannot use, it retries the whole
+      // string as a double and casts, reaching its default only if that fails
+      // too. So a quoted float truncates toward zero ("12.5" -> 12, "1e3" ->
+      // 1000) instead of defaulting.
+      auto viaDouble = folly::tryTo<double>(s);
+      // Full-fail to 0 — NOT partial-parse. "12abc" is neither integer nor
+      // float syntax, so it yields 0, not 12.
+      return viaDouble.hasValue() ? doubleToInt64Truncating(viaDouble.value())
+                                  : 0;
     }
     case simdjson::ondemand::json_type::object:
     case simdjson::ondemand::json_type::array:
@@ -256,8 +266,12 @@ bool coerceToBool(simdjson::ondemand::value& value) {
     }
     case simdjson::ondemand::json_type::string: {
       auto s = unwrap(value.get_string());
-      // Strict literal match — case-sensitive — per the probe: only the
-      // exact lowercase "true" is true. "True"/"TRUE" are false.
+      // Strict literal match — case-sensitive — matching Hive 4.0.0's
+      // Boolean.valueOf(leafNode.asBoolean()), where TextNode.asBoolean()
+      // defaults to false: only the exact lowercase "true" is true.
+      // "True"/"TRUE" are false. Hive later changed this to asBoolean(true),
+      // which turns every non-"false" string into true; that is a divergence
+      // from post-4.0.0 Hive, not from the pinned reference.
       return s.size() == 4 && std::memcmp(s.data(), "true", 4) == 0;
     }
     case simdjson::ondemand::json_type::object:
@@ -392,12 +406,11 @@ void serializeJsonValue(simdjson::ondemand::value& value, std::string& out) {
 // key order preserved; numbers use a best-effort lexeme. null is handled by
 // the caller's is_null() check.
 //
-// VARCHAR-from-number is a known v1 divergence: Presto/Jackson formats via
-// BigDecimal(input).stripTrailingZeros().toString(), which C++ has no
-// standard equivalent for. v1 emits the original lexeme, so the semantic
-// value is preserved but the exact textual form (trailing zeros, scientific
-// notation case/threshold) may differ. This is the documented
-// VARCHAR-from-number v1 divergence.
+// Numbers emit the original lexeme rather than reformatting, which is the
+// VARCHAR-from-number divergence documented on JsonReader. The reference routes
+// a JSON float through Java's String.valueOf(double), and C++ has no standard
+// equivalent, so the semantic value is preserved but trailing zeros and
+// scientific-notation thresholds may differ.
 std::string coerceToString(simdjson::ondemand::value& value) {
   auto type = unwrap(value.type());
   switch (type) {
@@ -421,6 +434,10 @@ std::string coerceToString(simdjson::ondemand::value& value) {
   VELOX_UNREACHABLE();
 }
 
+// Returns the double coercion of a JSON scalar. The serde2 JsonSerDe reads both
+// DOUBLE and REAL through JsonNode.asDouble(), the same defaulting accessor
+// family the integer types use, so a numeric string coerces and an
+// unconvertible one lands on 0.0 rather than throwing.
 double coerceToDouble(simdjson::ondemand::value& value) {
   auto type = unwrap(value.type());
   switch (type) {
@@ -449,10 +466,24 @@ double coerceToDouble(simdjson::ondemand::value& value) {
 // the original lexeme, NOT through double. Routing a high-precision number
 // through double silently rounds away digits a double cannot hold (a double
 // carries ~15-16 significant decimal digits); the raw lexeme preserves them.
-// Numbers use the raw token; strings use the decoded contents. Throws on a
-// container-shape mismatch or a lexeme the decimal parser rejects.
+// Numbers use the raw token; strings use the decoded contents.
+//
+// Returns nullopt — SQL NULL for the cell — when the lexeme is not a decimal
+// the declared precision and scale can hold. The serde2 JsonSerDe builds
+// decimals with HiveDecimal.create(asText()), which returns null instead of
+// raising on text it cannot parse, and enforcePrecisionScale likewise returns
+// null for a value too large for the declared precision. A boolean takes the
+// same path: asText() on a boolean node yields "true"/"false", which
+// HiveDecimal.create rejects. So a bad decimal leaf is NULL and the row
+// survives, the same coerce-do-not-throw rule the integer leaves follow —
+// decimals just have no zero-like fallback to land on. Only a container-shape
+// mismatch throws.
+//
+// Enforcing precision and scale at all matches Hive's development branch, which
+// wraps the decimal in HiveDecimalUtils.enforcePrecisionScale; 4.0.0 does not
+// enforce either, so an out-of-range value is NULL here and retained there.
 template <typename T>
-T coerceToDecimal(
+std::optional<T> coerceToDecimal(
     simdjson::ondemand::value& value,
     uint8_t precision,
     uint8_t scale) {
@@ -473,7 +504,7 @@ T coerceToDecimal(
       VELOX_USER_FAIL(
           "Container shape mismatch: decimal column received a JSON object or array.");
     case simdjson::ondemand::json_type::boolean:
-      VELOX_USER_FAIL("Cannot coerce a JSON boolean to a decimal column.");
+      return std::nullopt;
     case simdjson::ondemand::json_type::null:
       VELOX_UNREACHABLE();
     case simdjson::ondemand::json_type::unknown:
@@ -487,17 +518,33 @@ T coerceToDecimal(
       scale,
       out);
   if (!status.ok()) {
-    VELOX_USER_FAIL(
-        "Cannot parse decimal from JSON lexeme: {} ({})",
-        lexeme,
-        status.message());
+    return std::nullopt;
   }
   return out;
 }
 
-// Base64-decodes a JSON string into raw bytes for a VARBINARY column. Presto
-// carries binary data base64-encoded in JSON text, so the reader decodes on
-// the way in. Throws on a non-string value or invalid base64.
+// Parses a decimal leaf and writes it into column at rowIndex, mapping an
+// unparseable or out-of-range lexeme to SQL NULL. Shared by the short-decimal
+// (int64) and long-decimal (int128) paths.
+template <typename T>
+void writeDecimal(
+    simdjson::ondemand::value& value,
+    uint8_t precision,
+    uint8_t scale,
+    BaseVector& column,
+    vector_size_t rowIndex) {
+  const auto parsed = coerceToDecimal<T>(value, precision, scale);
+  if (parsed.has_value()) {
+    column.asUnchecked<FlatVector<T>>()->set(rowIndex, parsed.value());
+  } else {
+    column.setNull(rowIndex, true);
+  }
+}
+
+// Base64-decodes a JSON string into raw bytes for a VARBINARY column. JSON text
+// carries binary data base64-encoded, which the serde2 JsonSerDe decodes via
+// Jackson's JsonNode.binaryValue(), so the reader decodes on the way in. Throws
+// on a non-string value or invalid base64.
 std::string coerceToVarbinary(simdjson::ondemand::value& value) {
   auto type = unwrap(value.type());
   if (type != simdjson::ondemand::json_type::string) {
@@ -629,8 +676,8 @@ void writeRowObject(
 // written in order, the current element count is this array's offset.
 //
 // A non-array, non-null JSON value is a container-shape mismatch and throws,
-// matching Presto. Element-level type mismatches coerce rather than
-// throw.
+// matching the serde2 JsonSerDe. Element-level type mismatches coerce rather
+// than throw.
 void writeArray(
     simdjson::ondemand::value& value,
     const TypePtr& type,
@@ -676,7 +723,8 @@ void writeArray(
 // — unlike ROW field names, they are never case-folded.
 //
 // Velox MapVectors require unique keys per row, so duplicate keys are deduped
-// with insertion-order + last-write-wins (JsonSerDe LinkedHashMap semantics):
+// with insertion-order + last-write-wins (the serde2 JsonSerDe builds maps in a
+// LinkedHashMap, which has the same semantics):
 // a repeated key overwrites the value at its first position and does not grow
 // the map. A non-object, non-null JSON value is a container-shape mismatch and
 // throws; value-level type mismatches coerce rather than throw.
@@ -757,11 +805,9 @@ void writeValue(
   if (type->isDecimal()) {
     const auto [precision, scale] = getDecimalPrecisionScale(*type);
     if (type->isShortDecimal()) {
-      column.asUnchecked<FlatVector<int64_t>>()->set(
-          rowIndex, coerceToDecimal<int64_t>(value, precision, scale));
+      writeDecimal<int64_t>(value, precision, scale, column, rowIndex);
     } else {
-      column.asUnchecked<FlatVector<int128_t>>()->set(
-          rowIndex, coerceToDecimal<int128_t>(value, precision, scale));
+      writeDecimal<int128_t>(value, precision, scale, column, rowIndex);
     }
     return;
   }
@@ -1027,7 +1073,7 @@ JsonRowReader::JsonRowReader(
       pos_ = 0; // pos_ >= fileLength_ makes next() return zero rows.
       return;
     }
-    fileLength_ = decompressWholeFile(*contents_, fileBuffer_);
+    fileBuffer_ = decompressWholeFile(*contents_, fileLength_);
     pos_ = 0;
     // The requested byte length refers to compressed bytes and is meaningless
     // after decompression; this split owns every decompressed record.
@@ -1037,12 +1083,13 @@ JsonRowReader::JsonRowReader(
 
   const auto& readFile = contents_->input->getReadFile();
   fileLength_ = readFile->size();
-  // Pad the buffer so the last line can be parsed by simdjson without
-  // copying. Lines other than the last are still copied into lineBuffer_
-  // because simdjson requires padding bytes after the parsed region.
-  fileBuffer_.assign(fileLength_ + simdjson::SIMDJSON_PADDING, '\0');
+  // Allocate a pool-owned buffer so the file bytes are memory-accounted.
+  // Padded with SIMDJSON_PADDING zero bytes so the last line can be parsed
+  // by simdjson in place without an extra copy.
+  fileBuffer_ = AlignedBuffer::allocate<char>(
+      fileLength_ + simdjson::SIMDJSON_PADDING, &contents_->pool);
   if (fileLength_ > 0) {
-    readFile->pread(0, fileLength_, fileBuffer_.data());
+    readFile->pread(0, fileLength_, fileBuffer_->asMutable<char>());
   }
 
   // Position at the first record this split owns. A nonzero split offset
@@ -1051,31 +1098,29 @@ JsonRowReader::JsonRowReader(
   // there. The first split (offset 0) starts at byte 0 and skips nothing.
   pos_ = splitStart_;
   if (splitStart_ != 0 && splitStart_ < fileLength_) {
-    const char* from = fileBuffer_.data() + splitStart_;
-    const char* nl = static_cast<const char*>(
+    const char* from = fileBuffer_->as<char>() + splitStart_;
+    const char* newline = static_cast<const char*>(
         std::memchr(from, '\n', fileLength_ - splitStart_));
     // No newline at or after the offset means the offset falls in the
     // file's final (unterminated) record, which the previous split owns.
-    pos_ = (nl == nullptr) ? fileLength_
-                           : static_cast<size_t>(nl - fileBuffer_.data()) + 1;
+    pos_ = (newline == nullptr) ? fileLength_
+                           : static_cast<size_t>(newline - fileBuffer_->as<char>()) + 1;
   }
 }
 
 bool JsonRowReader::readNextLine() {
-  // Stop at end of file, or once a record would start past this split's
-  // boundary. A record starting at exactly splitEnd_ is still read (the
-  // straddling record); the next split skips it via the constructor's
-  // first-line skip. This is the Presto/Hive line-split convention.
-  if (pos_ >= fileLength_ || pos_ > splitEnd_) {
+  // The one place the split boundary is enforced per record: a batch almost
+  // always crosses it mid-read. Follows the Presto/Hive line-split convention.
+  if (atSplitEnd()) {
     return false;
   }
   // Capture where this record begins before pos_ advances, so a parse error
   // can report the record's byte offset.
   recordStartOffset_ = pos_;
-  const char* start = fileBuffer_.data() + pos_;
+  const char* start = fileBuffer_->as<char>() + pos_;
   size_t remaining = fileLength_ - pos_;
-  const char* nl = static_cast<const char*>(std::memchr(start, '\n', remaining));
-  size_t length = (nl == nullptr) ? remaining : static_cast<size_t>(nl - start);
+  const char* newline = static_cast<const char*>(std::memchr(start, '\n', remaining));
+  size_t length = (newline == nullptr) ? remaining : static_cast<size_t>(newline - start);
 
   // Reserve enough room for the line plus simdjson's required trailing
   // padding. Reuse the buffer across rows; std::string keeps capacity.
@@ -1087,7 +1132,7 @@ bool JsonRowReader::readNextLine() {
   }
   std::memcpy(lineBuffer_.data(), start, length);
   lineLength_ = length;
-  pos_ += length + (nl == nullptr ? 0 : 1);
+  pos_ += length + (newline == nullptr ? 0 : 1);
   return true;
 }
 
@@ -1110,9 +1155,9 @@ void JsonRowReader::writeRow(RowVector& row, vector_size_t rowIndex) {
 
 void JsonRowReader::parseRecord(RowVector& row, vector_size_t rowIndex) {
   // A blank line — empty or whitespace only — is never a valid JSON
-  // record. JsonSerDe rejects these as empty rows; surface a clear error
-  // rather than simdjson's lower-level diagnostic. Blank lines turn up at
-  // split boundaries (leading, trailing, or between records), so the
+  // record. The serde2 JsonSerDe rejects these as empty rows; surface a clear
+  // error rather than simdjson's lower-level diagnostic. Blank lines turn up
+  // at split boundaries (leading, trailing, or between records), so the
   // behavior is pinned here.
   std::string_view line(lineBuffer_.data(), lineLength_);
   if (line.find_first_not_of(" \t\r\n") == std::string_view::npos) {
@@ -1144,7 +1189,10 @@ uint64_t JsonRowReader::next(
     uint64_t size,
     VectorPtr& result,
     const dwio::common::Mutation* /*mutation*/) {
-  if (size == 0 || pos_ >= fileLength_ || pos_ > splitEnd_) {
+  // Guard, not boundary enforcement: readNextLine() would return 0 rows
+  // anyway. Returning early avoids allocating a RowVector and leaves result
+  // untouched at end of split, matching TextRowReader and DwrfRowReader.
+  if (size == 0 || atSplitEnd()) {
     return 0;
   }
 

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -23,6 +23,7 @@
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
 #include "velox/dwio/common/TypeWithId.h"
+#include "velox/functions/lib/DateTimeFormatter.h"
 
 namespace facebook::velox::json {
 
@@ -42,9 +43,18 @@ struct FileContents {
   /// schema; this comes from the connector.
   const std::shared_ptr<const RowType> schema;
 
-  /// SerDe options controlling parse behavior. Empty in this phase; later
-  /// phases add date/timestamp format strings.
+  /// SerDe options controlling parse behavior, including the Joda-style
+  /// format strings used to parse DATE and TIMESTAMP columns.
   dwio::common::JsonSerDeOptions serDeOptions;
+
+  /// Formatter compiled once from serDeOptions.dateFormat, reused across
+  /// rows to parse DATE columns. simdjson hands us the JSON string; this
+  /// turns it into days since the epoch.
+  std::shared_ptr<functions::DateTimeFormatter> dateFormatter;
+
+  /// Formatter compiled once from serDeOptions.timestampFormat, reused
+  /// across rows to parse TIMESTAMP columns.
+  std::shared_ptr<functions::DateTimeFormatter> timestampFormatter;
 
   /// Decompressed byte stream for the file. Owned here so JsonRowReader
   /// can read from it without taking ownership.

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -61,6 +61,12 @@ struct FileContents {
 /// Reader for the JSON file format (JSON Lines, matching Hive
 /// org.apache.hive.hcatalog.data.JsonSerDe). Constructs JsonRowReader
 /// instances that parse records out of the underlying stream.
+///
+/// Known v1 divergence: VARCHAR-formatted JSON numbers may differ in exact
+/// string form from Presto's Hive JSON connector for edge cases involving
+/// trailing zeros and scientific notation (Presto canonicalizes via
+/// BigDecimal; v1 emits the original lexeme). The semantic numeric value is
+/// preserved; only the textual representation may diverge.
 class JsonReader : public dwio::common::Reader {
  public:
   JsonReader(

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -117,8 +117,11 @@ class JsonReader : public dwio::common::Reader {
 
 /// Row reader for the JSON file format. Reads one JSON object per line,
 /// dispatching each field to the matching column via the schema field
-/// index. The whole file is loaded into memory at construction; split
-/// support is deferred (see json-reader-pr-roadmap.md PR-7).
+/// index. The whole file is loaded into memory at construction. Reads are
+/// split-aware: a row reader created for the byte range [offset, offset +
+/// length) processes exactly the records whose starting byte falls in that
+/// range, so concatenating the output of splits that tile the file
+/// reproduces a whole-file read with no dropped or duplicated records.
 class JsonRowReader : public dwio::common::RowReader {
  public:
   JsonRowReader(
@@ -159,14 +162,27 @@ class JsonRowReader : public dwio::common::RowReader {
   // Caller-supplied row reader options (range, selector, scan spec).
   dwio::common::RowReaderOptions options_;
 
-  // Entire file contents loaded at construction. Split support
-  // is deferred to a later PR.
+  // Entire file contents loaded at construction. Reads are restricted to
+  // this reader's split via splitStart_ and splitEnd_ below.
   std::string fileBuffer_;
 
   // Length of valid bytes in fileBuffer_. fileBuffer_ has additional
   // SIMDJSON_PADDING bytes of zeroes after fileLength_ so the last
   // line can be parsed in place.
   size_t fileLength_{0};
+
+  // First byte of this reader's split (RowReaderOptions::offset()). When
+  // nonzero, the record straddling this offset belongs to the previous
+  // split, so the constructor skips it by scanning forward to the byte
+  // after the next newline.
+  size_t splitStart_{0};
+
+  // One past the last byte this reader claims (RowReaderOptions::limit(),
+  // i.e. offset + length saturated). A record is read while its starting
+  // byte is <= splitEnd_, so the record straddling the boundary is read
+  // in full here and skipped by the next split. Matches the Presto/Hive
+  // line-split convention (see TextReader).
+  size_t splitEnd_{0};
 
   // Current read offset into fileBuffer_. Records start at this position.
   size_t pos_{0};

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -23,6 +23,7 @@
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
 #include "velox/dwio/common/TypeWithId.h"
+#include "velox/dwio/common/compression/Compression.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 
 namespace facebook::velox::json {
@@ -56,9 +57,20 @@ struct FileContents {
   /// across rows to parse TIMESTAMP columns.
   std::shared_ptr<functions::DateTimeFormatter> timestampFormatter;
 
-  /// Decompressed byte stream for the file. Owned here so JsonRowReader
-  /// can read from it without taking ownership.
+  /// Byte stream for the file. Owned here so JsonRowReader can read from it
+  /// without taking ownership. May hold compressed bytes; see compression.
   std::unique_ptr<dwio::common::BufferedInput> input;
+
+  /// Compression codec inferred once from the file name extension (.gz,
+  /// .deflate, .zst). JSON Lines files are decompressed whole at row-reader
+  /// construction; they are not byte-addressable, so a compressed file cannot
+  /// be split (the first split reads it all, the rest read nothing).
+  common::CompressionKind compression{
+      common::CompressionKind::CompressionKind_NONE};
+
+  /// Format-specific decompression options (e.g. zlib window bits) paired with
+  /// compression. Empty for uncompressed files.
+  dwio::common::compression::CompressionOptions compressionOptions{};
 
   /// For every ROW type reachable from the schema (the top-level row and
   /// any ROW nested inside ARRAY elements, MAP values, or other ROWs), maps

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
+
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
@@ -46,6 +49,13 @@ struct FileContents {
   /// Decompressed byte stream for the file. Owned here so JsonRowReader
   /// can read from it without taking ownership.
   std::unique_ptr<dwio::common::BufferedInput> input;
+
+  /// Lowercased top-level field name to column index in the schema.
+  /// Built once from the schema; reused across rows. The iterate-once
+  /// dispatch pattern requires
+  /// a fast name lookup because simdjson On-Demand is forward-only and
+  /// values cannot be stashed for later association with a column.
+  std::unordered_map<std::string, size_t> fieldIndex;
 };
 
 /// Reader for the JSON file format (JSON Lines, matching Hive
@@ -86,8 +96,10 @@ class JsonReader : public dwio::common::Reader {
   std::shared_ptr<FileContents> contents_;
 };
 
-/// Row reader for the JSON file format. Phase 1 stub: implements the
-/// full RowReader interface but produces no rows.
+/// Row reader for the JSON file format. Reads one JSON object per line,
+/// dispatching each field to the matching column via the schema field
+/// index. The whole file is loaded into memory at construction; split
+/// support is deferred (see json-reader-pr-roadmap.md PR-7).
 class JsonRowReader : public dwio::common::RowReader {
  public:
   JsonRowReader(
@@ -111,11 +123,41 @@ class JsonRowReader : public dwio::common::RowReader {
   std::optional<size_t> estimatedRowSize() const override;
 
  private:
+  // Reads the next newline-terminated line from the file buffer into
+  // lineBuffer_, padded with SIMDJSON_PADDING zero bytes for safe
+  // simdjson parsing. Returns false when there are no more lines.
+  bool readNextLine();
+
+  // Parses lineBuffer_ as a single JSON object and writes its fields
+  // into the corresponding columns of row at rowIndex. Fields not in
+  // the schema are silently ignored; fields in the schema but absent
+  // from the JSON object remain NULL.
+  void writeRow(RowVector& row, vector_size_t rowIndex);
+
   // Per-file shared state (input stream, schema, options).
   const std::shared_ptr<FileContents> contents_;
 
   // Caller-supplied row reader options (range, selector, scan spec).
   dwio::common::RowReaderOptions options_;
+
+  // Entire file contents loaded at construction. Split support
+  // is deferred to a later PR.
+  std::string fileBuffer_;
+
+  // Length of valid bytes in fileBuffer_. fileBuffer_ has additional
+  // SIMDJSON_PADDING bytes of zeroes after fileLength_ so the last
+  // line can be parsed in place.
+  size_t fileLength_{0};
+
+  // Current read offset into fileBuffer_. Records start at this position.
+  size_t pos_{0};
+
+  // Reusable padded buffer holding the current line. Sized to fit the
+  // longest line seen so far plus SIMDJSON_PADDING.
+  std::string lineBuffer_;
+
+  // Length of valid line content in lineBuffer_ (excluding padding).
+  size_t lineLength_{0};
 };
 
 } // namespace facebook::velox::json

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -60,12 +60,15 @@ struct FileContents {
   /// can read from it without taking ownership.
   std::unique_ptr<dwio::common::BufferedInput> input;
 
-  /// Lowercased top-level field name to column index in the schema.
-  /// Built once from the schema; reused across rows. The iterate-once
-  /// dispatch pattern requires
-  /// a fast name lookup because simdjson On-Demand is forward-only and
-  /// values cannot be stashed for later association with a column.
-  std::unordered_map<std::string, size_t> fieldIndex;
+  /// For every ROW type reachable from the schema (the top-level row and
+  /// any ROW nested inside ARRAY elements, MAP values, or other ROWs), maps
+  /// its lowercased field names to child indices, keyed by RowType identity.
+  /// Built once at construction; reused across rows. The iterate-once dispatch
+  /// pattern requires a fast name
+  /// lookup because simdjson On-Demand is forward-only and values cannot be
+  /// stashed for later association with a column.
+  std::unordered_map<const RowType*, std::unordered_map<std::string, uint32_t>>
+      fieldIndexes;
 };
 
 /// Reader for the JSON file format (JSON Lines, matching Hive

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Reader.h"
+#include "velox/dwio/common/TypeWithId.h"
+
+namespace facebook::velox::json {
+
+/// Shared state for a JSON file between JsonReader and the JsonRowReader
+/// instances it spawns. Holds the input stream, schema, and SerDe options
+/// so they are not duplicated across readers.
+struct FileContents {
+  FileContents(
+      memory::MemoryPool& pool,
+      std::shared_ptr<const RowType> schema,
+      dwio::common::JsonSerDeOptions serDeOptions);
+
+  /// Memory pool used for vector allocations during reads.
+  memory::MemoryPool& pool;
+
+  /// Top-level row schema requested by the caller. JSON has no embedded
+  /// schema; this comes from the connector.
+  const std::shared_ptr<const RowType> schema;
+
+  /// SerDe options controlling parse behavior. Empty in this phase; later
+  /// phases add date/timestamp format strings.
+  dwio::common::JsonSerDeOptions serDeOptions;
+
+  /// Decompressed byte stream for the file. Owned here so JsonRowReader
+  /// can read from it without taking ownership.
+  std::unique_ptr<dwio::common::BufferedInput> input;
+};
+
+/// Reader for the JSON file format (JSON Lines, matching Hive
+/// org.apache.hive.hcatalog.data.JsonSerDe). Constructs JsonRowReader
+/// instances that parse records out of the underlying stream.
+class JsonReader : public dwio::common::Reader {
+ public:
+  JsonReader(
+      const dwio::common::ReaderOptions& options,
+      std::unique_ptr<dwio::common::BufferedInput> input);
+
+  /// JSON Lines has no record count metadata; always returns nullopt.
+  std::optional<uint64_t> numberOfRows() const override;
+
+  /// JSON Lines has no per-column statistics; always returns nullptr.
+  std::unique_ptr<dwio::common::ColumnStatistics> columnStatistics(
+      uint32_t index) const override;
+
+  /// Returns the schema supplied via ReaderOptions::fileSchema().
+  const RowTypePtr& rowType() const override;
+
+  /// Returns the schema with node identifiers attached.
+  const std::shared_ptr<const dwio::common::TypeWithId>& typeWithId()
+      const override;
+
+  /// Creates a row reader for the given range and column selection.
+  std::unique_ptr<dwio::common::RowReader> createRowReader(
+      const dwio::common::RowReaderOptions& options) const override;
+
+ private:
+  // Reader-level options (memory pool, file schema, SerDe options).
+  dwio::common::ReaderOptions options_;
+
+  // Lazily computed schema with node identifiers.
+  mutable std::shared_ptr<const dwio::common::TypeWithId> typeWithId_;
+
+  // Per-file shared state passed to every row reader this reader creates.
+  std::shared_ptr<FileContents> contents_;
+};
+
+/// Row reader for the JSON file format. Phase 1 stub: implements the
+/// full RowReader interface but produces no rows.
+class JsonRowReader : public dwio::common::RowReader {
+ public:
+  JsonRowReader(
+      std::shared_ptr<FileContents> contents,
+      const dwio::common::RowReaderOptions& options);
+
+  uint64_t next(
+      uint64_t size,
+      VectorPtr& result,
+      const dwio::common::Mutation* mutation = nullptr) override;
+
+  int64_t nextRowNumber() override;
+
+  int64_t nextReadSize(uint64_t size) override;
+
+  void updateRuntimeStats(
+      dwio::common::RuntimeStatistics& stats) const override;
+
+  void resetFilterCaches() override;
+
+  std::optional<size_t> estimatedRowSize() const override;
+
+ private:
+  // Per-file shared state (input stream, schema, options).
+  const std::shared_ptr<FileContents> contents_;
+
+  // Caller-supplied row reader options (range, selector, scan spec).
+  dwio::common::RowReaderOptions options_;
+};
+
+} // namespace facebook::velox::json

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "velox/buffer/Buffer.h"
+
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
@@ -83,15 +85,35 @@ struct FileContents {
       fieldIndexes;
 };
 
-/// Reader for the JSON file format (JSON Lines, matching Hive
-/// org.apache.hive.hcatalog.data.JsonSerDe). Constructs JsonRowReader
-/// instances that parse records out of the underlying stream.
+/// Reader for the JSON file format (JSON Lines, matching Hive 4.0.0
+/// org.apache.hadoop.hive.serde2.JsonSerDe and its HiveJsonReader).
+/// Constructs JsonRowReader instances that parse records out of the underlying
+/// stream.
+///
+/// The reference implementation is specifically the serde2 SerDe, not the
+/// legacy org.apache.hive.hcatalog.data.JsonSerDe. Through Hive 3.1 the two
+/// differ on type mismatch: HCatalog's reads the token stream with Jackson's
+/// strict numeric accessors, which throw when a column's JSON value has the
+/// wrong token type, whereas serde2's builds a Jackson document and coerces
+/// through JsonNode.asLong()/asBoolean()/asText(), which fall back to a default
+/// instead of throwing. (From Hive 4.0.0 the HCatalog class is a thin wrapper
+/// that delegates to serde2, so both SerDe names behave the same there.) This
+/// reader follows serde2: a leaf whose JSON type does not match its column type
+/// coerces silently (a non-numeric string into BIGINT becomes 0, and a DECIMAL
+/// that has no such default value becomes NULL), and only a container-shape
+/// mismatch — a scalar or the wrong container where ARRAY, MAP, or ROW is
+/// declared — is an error. There is no lenient mode that skips bad records;
+/// every error that is raised throws.
+///
+/// The pin to 4.0.0 matters: Hive has since changed the BOOLEAN and BINARY leaf
+/// rules on its development branch. Divergences are tracked against 4.0.0.
 ///
 /// Known v1 divergence: VARCHAR-formatted JSON numbers may differ in exact
-/// string form from Presto's Hive JSON connector for edge cases involving
-/// trailing zeros and scientific notation (Presto canonicalizes via
-/// BigDecimal; v1 emits the original lexeme). The semantic numeric value is
-/// preserved; only the textual representation may diverge.
+/// string form from the reference for edge cases involving trailing zeros and
+/// scientific notation. The reference stringifies a JSON float through
+/// JsonNode.asText() on a DoubleNode, i.e. Java's String.valueOf(double), so
+/// 1e3 reads back as "1000.0"; v1 emits the original lexeme. The semantic
+/// numeric value is preserved; only the textual representation may diverge.
 class JsonReader : public dwio::common::Reader {
  public:
   JsonReader(
@@ -157,6 +179,14 @@ class JsonRowReader : public dwio::common::RowReader {
   std::optional<size_t> estimatedRowSize() const override;
 
  private:
+  // True once this split is exhausted: past the end of the file, or the next
+  // record would start beyond the split boundary. Note '>' rather than '>=':
+  // a record starting exactly at splitEnd_ is still read in full here, and
+  // the next split skips it via the constructor's first-line skip.
+  bool atSplitEnd() const {
+    return pos_ >= fileLength_ || pos_ > splitEnd_;
+  }
+
   // Reads the next newline-terminated line from the file buffer into
   // lineBuffer_, padded with SIMDJSON_PADDING zero bytes for safe
   // simdjson parsing. Returns false when there are no more lines.
@@ -179,9 +209,10 @@ class JsonRowReader : public dwio::common::RowReader {
   // Caller-supplied row reader options (range, selector, scan spec).
   dwio::common::RowReaderOptions options_;
 
-  // Entire file contents loaded at construction. Reads are restricted to
-  // this reader's split via splitStart_ and splitEnd_ below.
-  std::string fileBuffer_;
+  // Entire file contents loaded at construction, allocated from the memory
+  // pool so bytes are accounted. Reads are restricted to this reader's split
+  // via splitStart_ and splitEnd_ below.
+  BufferPtr fileBuffer_;
 
   // Length of valid bytes in fileBuffer_. fileBuffer_ has additional
   // SIMDJSON_PADDING bytes of zeroes after fileLength_ so the last

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -165,8 +165,13 @@ class JsonRowReader : public dwio::common::RowReader {
   // Parses lineBuffer_ as a single JSON object and writes its fields
   // into the corresponding columns of row at rowIndex. Fields not in
   // the schema are silently ignored; fields in the schema but absent
-  // from the JSON object remain NULL.
+  // from the JSON object remain NULL. Wraps parseRecord so any parse
+  // error is reported with the record's byte offset.
   void writeRow(RowVector& row, vector_size_t rowIndex);
+
+  // Parses and dispatches the record in lineBuffer_ into row at rowIndex,
+  // throwing a VeloxUserError (without location) on any malformed input.
+  void parseRecord(RowVector& row, vector_size_t rowIndex);
 
   // Per-file shared state (input stream, schema, options).
   const std::shared_ptr<FileContents> contents_;
@@ -198,6 +203,12 @@ class JsonRowReader : public dwio::common::RowReader {
 
   // Current read offset into fileBuffer_. Records start at this position.
   size_t pos_{0};
+
+  // Byte offset into the file (decompressed bytes, for a compressed file) at
+  // which the line currently held in lineBuffer_ begins. Used to locate parse
+  // errors; line numbers are ambiguous under splits, so errors report the byte
+  // offset instead.
+  size_t recordStartOffset_{0};
 
   // Reusable padded buffer holding the current line. Sized to fit the
   // longest line seen so far plus SIMDJSON_PADDING.

--- a/velox/dwio/json/reader/JsonReader.h
+++ b/velox/dwio/json/reader/JsonReader.h
@@ -162,6 +162,16 @@ class JsonRowReader : public dwio::common::RowReader {
       std::shared_ptr<FileContents> contents,
       const dwio::common::RowReaderOptions& options);
 
+  /// Reads up to size records from this reader's split into result.
+  ///
+  /// Column projection and filter pushdown are not implemented. Projection is
+  /// ignored: every column of the file schema is materialized regardless of
+  /// what the scan spec selects, which a caller can see in the result's type. A
+  /// filter or a row-level delete cannot be ignored the same way — the rows it
+  /// asked to remove would come back with nothing to say the request was
+  /// dropped — so a scan spec carrying a filter is refused when the reader is
+  /// built, and a mutation carrying deletions throws here. Callers needing
+  /// either must apply them above this reader.
   uint64_t next(
       uint64_t size,
       VectorPtr& result,

--- a/velox/dwio/json/tests/CMakeLists.txt
+++ b/velox/dwio/json/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(TEST_LINK_LIBS
+    velox_dwio_common_test_utils
+    velox_vector_test_lib
+    velox_exec_test_lib
+    velox_test_util
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+    gflags::gflags
+    glog::glog)
+
+add_subdirectory(reader)

--- a/velox/dwio/json/tests/reader/CMakeLists.txt
+++ b/velox/dwio/json/tests/reader/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_json_reader_test JsonReaderTest.cpp)
+
+add_test(
+  NAME velox_json_reader_test
+  COMMAND velox_json_reader_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(velox_json_reader_test velox_dwio_json_reader_register
+                      ${TEST_LINK_LIBS})

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -600,5 +600,134 @@ TEST_F(JsonReaderTest, mapShapeMismatchArrayThrows) {
       "expected object");
 }
 
+TEST_F(JsonReaderTest, nestedRowBaseline) {
+  auto schema =
+      ROW({{"u", ROW({{"id", BIGINT()}, {"name", VARCHAR()}})}});
+  auto row = read("{\"u\":{\"id\":123,\"name\":\"Alice\"}}\n", schema);
+  auto inner = makeRowVector(
+      {makeFlatVector<int64_t>({123}),
+       makeFlatVector<StringView>({"Alice"_sv})});
+  test::assertEqualVectors(makeRowVector({inner}), row);
+}
+
+TEST_F(JsonReaderTest, rowFieldMatchCaseInsensitive) {
+  // {"X":1,"y":"hi"} matches ROW(x BIGINT, y VARCHAR) — field names are
+  // folded for matching.
+  auto schema = ROW({{"u", ROW({{"x", BIGINT()}, {"y", VARCHAR()}})}});
+  auto row = read("{\"u\":{\"X\":1,\"y\":\"hi\"}}\n", schema);
+  auto inner = makeRowVector(
+      {makeFlatVector<int64_t>({1}), makeFlatVector<StringView>({"hi"_sv})});
+  test::assertEqualVectors(makeRowVector({inner}), row);
+}
+
+TEST_F(JsonReaderTest, rowFieldLastWriteWins) {
+  // {"X":1,"x":2} both fold to x; the later assignment wins.
+  auto schema = ROW({{"u", ROW({{"x", BIGINT()}})}});
+  auto row = read("{\"u\":{\"X\":1,\"x\":2}}\n", schema);
+  auto inner = makeRowVector({makeFlatVector<int64_t>({2})});
+  test::assertEqualVectors(makeRowVector({inner}), row);
+}
+
+TEST_F(JsonReaderTest, rowFieldNestedCaseInsensitive) {
+  // Case-folding applies at every nesting level.
+  auto schema = ROW(
+      {{"u", ROW({{"profile", ROW({{"name", VARCHAR()}})}})}});
+  auto row = read("{\"U\":{\"Profile\":{\"NAME\":\"Bob\"}}}\n", schema);
+  auto profile = makeRowVector({makeFlatVector<StringView>({"Bob"_sv})});
+  test::assertEqualVectors(makeRowVector({makeRowVector({profile})}), row);
+}
+
+TEST_F(JsonReaderTest, rowMissingFieldYieldsNull) {
+  auto schema =
+      ROW({{"u", ROW({{"id", BIGINT()}, {"name", VARCHAR()}})}});
+  auto row = read("{\"u\":{\"id\":1}}\n", schema);
+  auto* inner = row->childAt(0)->as<RowVector>();
+  EXPECT_FALSE(inner->isNullAt(0));
+  EXPECT_EQ(inner->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 1);
+  EXPECT_TRUE(inner->childAt(1)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, rowExtraInnerFieldIgnored) {
+  auto schema = ROW({{"u", ROW({{"id", BIGINT()}})}});
+  auto row = read("{\"u\":{\"id\":1,\"extra\":99}}\n", schema);
+  auto inner = makeRowVector({makeFlatVector<int64_t>({1})});
+  test::assertEqualVectors(makeRowVector({inner}), row);
+}
+
+TEST_F(JsonReaderTest, rowExtraOuterFieldIgnored) {
+  auto schema = ROW({{"u", ROW({{"id", BIGINT()}})}});
+  auto row = read("{\"u\":{\"id\":1},\"junk\":2}\n", schema);
+  auto inner = makeRowVector({makeFlatVector<int64_t>({1})});
+  test::assertEqualVectors(makeRowVector({inner}), row);
+}
+
+TEST_F(JsonReaderTest, rowJsonNullProducesSqlNull) {
+  // JSON null for the whole ROW is SQL NULL.
+  auto schema = ROW({{"u", ROW({{"id", BIGINT()}})}});
+  auto row = read("{\"u\":null}\n", schema);
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_TRUE(row->childAt(0)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, rowEmptyObjectAllFieldsNullButRowNotNull) {
+  // {} is a non-null ROW whose every field is NULL — distinct from JSON null.
+  auto schema =
+      ROW({{"u", ROW({{"id", BIGINT()}, {"name", VARCHAR()}})}});
+  auto row = read("{\"u\":{}}\n", schema);
+  auto* inner = row->childAt(0)->as<RowVector>();
+  EXPECT_FALSE(inner->isNullAt(0));
+  EXPECT_TRUE(inner->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(inner->childAt(1)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, rowFieldTypeMismatchCoerces) {
+  // A leaf type mismatch coerces (per the leaf table), it does not throw:
+  // "abc" into BIGINT -> 0.
+  auto schema = ROW({{"u", ROW({{"x", BIGINT()}, {"y", VARCHAR()}})}});
+  auto row = read("{\"u\":{\"x\":\"abc\",\"y\":\"hi\"}}\n", schema);
+  auto inner = makeRowVector(
+      {makeFlatVector<int64_t>({0}), makeFlatVector<StringView>({"hi"_sv})});
+  test::assertEqualVectors(makeRowVector({inner}), row);
+}
+
+TEST_F(JsonReaderTest, rowShapeMismatchScalarThrows) {
+  // A scalar where a ROW is expected is a container-shape mismatch.
+  VELOX_ASSERT_THROW(
+      read("{\"u\":5}\n", ROW({{"u", ROW({{"id", BIGINT()}})}})),
+      "expected object");
+}
+
+TEST_F(JsonReaderTest, rowShapeMismatchArrayThrows) {
+  // An array where a ROW is expected is a container-shape mismatch.
+  VELOX_ASSERT_THROW(
+      read("{\"u\":[1,2]}\n", ROW({{"u", ROW({{"id", BIGINT()}})}})),
+      "expected object");
+}
+
+TEST_F(JsonReaderTest, arrayOfRow) {
+  // ROW reachable through an ARRAY element exercises the recursive field-index
+  // walk: the element ROW's field map must be built even though no top-level
+  // column has that ROW type directly.
+  auto schema =
+      ROW({{"items", ARRAY(ROW({{"id", BIGINT()}, {"qty", BIGINT()}}))}});
+  auto row = read(
+      "{\"items\":[{\"id\":10,\"qty\":2},{\"id\":20,\"qty\":1}]}\n", schema);
+  auto elements = makeRowVector(
+      {makeFlatVector<int64_t>({10, 20}), makeFlatVector<int64_t>({2, 1})});
+  auto expected = makeRowVector({makeArrayVector({0}, elements)});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, mapValueRow) {
+  // ROW reachable through a MAP value exercises the same recursive walk.
+  auto schema =
+      ROW({{"m", MAP(VARCHAR(), ROW({{"n", BIGINT()}}))}});
+  auto row = read("{\"m\":{\"a\":{\"n\":1}}}\n", schema);
+  auto values = makeRowVector({makeFlatVector<int64_t>({1})});
+  auto keys = makeFlatVector<StringView>({"a"_sv});
+  auto expected = makeRowVector({makeMapVector({0}, keys, values)});
+  test::assertEqualVectors(expected, row);
+}
+
 } // namespace
 } // namespace facebook::velox::json

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/file/File.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/json/RegisterJsonReader.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::json {
+namespace {
+
+class JsonReaderTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    registerJsonReaderFactory();
+  }
+
+  void TearDown() override {
+    unregisterJsonReaderFactory();
+  }
+};
+
+TEST_F(JsonReaderTest, factoryRegistration) {
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+  ASSERT_NE(factory, nullptr);
+  EXPECT_EQ(factory->fileFormat(), dwio::common::FileFormat::JSON);
+}
+
+TEST_F(JsonReaderTest, emptyFileReturnsZeroRows) {
+  auto type = ROW({{"a", BIGINT()}});
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileSchema(type);
+
+  auto readFile = std::make_shared<InMemoryReadFile>(std::string{});
+  auto input =
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool());
+  auto reader = factory->createReader(std::move(input), readerOptions);
+  auto rowReader = reader->createRowReader(dwio::common::RowReaderOptions{});
+
+  VectorPtr result;
+  EXPECT_EQ(rowReader->next(10, result), 0);
+}
+
+} // namespace
+} // namespace facebook::velox::json

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -477,5 +477,128 @@ TEST_F(JsonReaderTest, arrayShapeMismatchObjectThrows) {
       "expected array");
 }
 
+TEST_F(JsonReaderTest, mapVarcharVarcharBaseline) {
+  auto row = read(
+      "{\"m\":{\"k1\":\"v1\",\"k2\":\"v2\"}}\n",
+      ROW({{"m", MAP(VARCHAR(), VARCHAR())}}));
+  auto expected = makeRowVector({makeMapVector<StringView, StringView>(
+      {{{"k1"_sv, "v1"_sv}, {"k2"_sv, "v2"_sv}}})});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, mapVarcharVarcharStringifiesNonStrings) {
+  // Non-string values stringify into VARCHAR per the leaf coercion rules:
+  // numbers via lexeme, booleans as lowercase literals, objects re-serialized
+  // minified with key order preserved.
+  auto row = read(
+      "{\"m\":{\"a\":1,\"b\":true,\"c\":{\"x\":1}}}\n",
+      ROW({{"m", MAP(VARCHAR(), VARCHAR())}}));
+  auto expected = makeRowVector({makeMapVector<StringView, StringView>(
+      {{{"a"_sv, "1"_sv},
+        {"b"_sv, "true"_sv},
+        {"c"_sv, "{\"x\":1}"_sv}}})});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, mapVarcharBigintCoercesValues) {
+  // Values coerce into BIGINT per the leaf table: "abc" -> 0, true -> 1,
+  // -3.7 -> -3 (truncate toward zero).
+  auto row = read(
+      "{\"m\":{\"a\":\"abc\",\"b\":true,\"c\":-3.7}}\n",
+      ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  auto expected = makeRowVector({makeMapVector<StringView, int64_t>(
+      {{{"a"_sv, 0}, {"b"_sv, 1}, {"c"_sv, -3}}})});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, mapBadValueDoesNotDropRowOrEntry) {
+  // A value that fails to coerce becomes 0 (full-fail to zero) — the entry is
+  // kept and the row stays. Both keys remain.
+  auto row = read(
+      "{\"m\":{\"k1\":100,\"k2\":\"abc\"}}\n",
+      ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  auto expected = makeRowVector({makeMapVector<StringView, int64_t>(
+      {{{"k1"_sv, 100}, {"k2"_sv, 0}}})});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, mapKeysPassThroughCaseUnchanged) {
+  // MAP keys are data, NOT schema — they are never case-folded. "K" and "k"
+  // are two distinct keys (contrast with ROW field matching, which folds).
+  auto row = read(
+      "{\"m\":{\"K\":1,\"k\":2}}\n", ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  auto* map = row->childAt(0)->as<MapVector>();
+  ASSERT_FALSE(map->isNullAt(0));
+  EXPECT_EQ(map->sizeAt(0), 2);
+  auto keys = map->mapKeys()->asFlatVector<StringView>();
+  auto values = map->mapValues()->asFlatVector<int64_t>();
+  const auto offset = map->offsetAt(0);
+  EXPECT_EQ(keys->valueAt(offset), "K"_sv);
+  EXPECT_EQ(values->valueAt(offset), 1);
+  EXPECT_EQ(keys->valueAt(offset + 1), "k"_sv);
+  EXPECT_EQ(values->valueAt(offset + 1), 2);
+}
+
+TEST_F(JsonReaderTest, mapDuplicateKeysLastWriteWinsInsertionOrderPreserved) {
+  // {"a":1,"b":2,"a":3} -> {a=3, b=2} with "a" first, cardinality 2. A naive
+  // append would produce a malformed MapVector with a duplicate "a" key.
+  auto row = read(
+      "{\"m\":{\"a\":1,\"b\":2,\"a\":3}}\n",
+      ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  auto* map = row->childAt(0)->as<MapVector>();
+  ASSERT_FALSE(map->isNullAt(0));
+  EXPECT_EQ(map->sizeAt(0), 2);
+  auto keys = map->mapKeys()->asFlatVector<StringView>();
+  auto values = map->mapValues()->asFlatVector<int64_t>();
+  const auto offset = map->offsetAt(0);
+  EXPECT_EQ(keys->valueAt(offset), "a"_sv);
+  EXPECT_EQ(values->valueAt(offset), 3);
+  EXPECT_EQ(keys->valueAt(offset + 1), "b"_sv);
+  EXPECT_EQ(values->valueAt(offset + 1), 2);
+}
+
+TEST_F(JsonReaderTest, mapDuplicateKeysCaseSensitive) {
+  // {"k":1,"K":2} -> two distinct entries, cardinality 2. Distinct from ROW
+  // case-insensitive matching: MAP keys are not folded.
+  auto row = read(
+      "{\"m\":{\"k\":1,\"K\":2}}\n", ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  auto* map = row->childAt(0)->as<MapVector>();
+  EXPECT_EQ(map->sizeAt(0), 2);
+  auto keys = map->mapKeys()->asFlatVector<StringView>();
+  const auto offset = map->offsetAt(0);
+  EXPECT_EQ(keys->valueAt(offset), "k"_sv);
+  EXPECT_EQ(keys->valueAt(offset + 1), "K"_sv);
+}
+
+TEST_F(JsonReaderTest, mapJsonNullProducesSqlNull) {
+  // JSON null for the whole map is SQL NULL, not an empty map.
+  auto row =
+      read("{\"m\":null}\n", ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_TRUE(row->childAt(0)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, mapJsonEmptyObjectIsNotNull) {
+  // JSON {} is a non-null map of cardinality 0, distinct from SQL NULL.
+  auto row = read("{\"m\":{}}\n", ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  auto* map = row->childAt(0)->as<MapVector>();
+  EXPECT_FALSE(map->isNullAt(0));
+  EXPECT_EQ(map->sizeAt(0), 0);
+}
+
+TEST_F(JsonReaderTest, mapShapeMismatchScalarThrows) {
+  // A scalar where an object is expected is a container-shape mismatch.
+  VELOX_ASSERT_THROW(
+      read("{\"m\":5}\n", ROW({{"m", MAP(VARCHAR(), BIGINT())}})),
+      "expected object");
+}
+
+TEST_F(JsonReaderTest, mapShapeMismatchArrayThrows) {
+  // An array where an object is expected is a container-shape mismatch.
+  VELOX_ASSERT_THROW(
+      read("{\"m\":[1,2]}\n", ROW({{"m", MAP(VARCHAR(), BIGINT())}})),
+      "expected object");
+}
+
 } // namespace
 } // namespace facebook::velox::json

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+#include <folly/compression/Compression.h>
+#include <folly/compression/Zlib.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/json/RegisterJsonReader.h"
 #include "velox/type/Timestamp.h"
@@ -25,6 +28,31 @@
 
 namespace facebook::velox::json {
 namespace {
+
+// Compresses data into a gzip-framed stream (.gz convention: zlib deflate with
+// a 2^15 window and gzip header/trailer), matching what the reader's GZIP
+// decompressor expects.
+std::string gzipCompress(const std::string& data) {
+  auto codec = folly::compression::zlib::getCodec(folly::compression::zlib::Options(
+      folly::compression::zlib::Options::Format::GZIP));
+  return codec->compress(folly::StringPiece(data));
+}
+
+// Compresses data into a raw deflate stream (.deflate convention: no zlib
+// header, negative window bits), matching the reader's ZLIB decompressor.
+std::string deflateCompress(const std::string& data) {
+  auto codec = folly::compression::zlib::getCodec(folly::compression::zlib::Options(
+      folly::compression::zlib::Options::Format::RAW));
+  return codec->compress(folly::StringPiece(data));
+}
+
+// Compresses data with zstd (.zst convention), matching the reader's ZSTD
+// decompressor.
+std::string zstdCompress(const std::string& data) {
+  auto codec =
+      folly::compression::getCodec(folly::compression::CodecType::ZSTD);
+  return codec->compress(folly::StringPiece(data));
+}
 
 class JsonReaderTest : public testing::Test, public test::VectorTestBase {
  protected:
@@ -34,10 +62,51 @@ class JsonReaderTest : public testing::Test, public test::VectorTestBase {
 
   void SetUp() override {
     registerJsonReaderFactory();
+    tempDir_ = common::testutil::TempDirectoryPath::create();
   }
 
   void TearDown() override {
     unregisterJsonReaderFactory();
+  }
+
+  // Writes bytes to a fresh file under the test's temp directory whose name
+  // ends in extension (e.g. ".gz"), and returns its path. The extension drives
+  // the reader's filename-based compression detection.
+  std::string writeTempFile(
+      const std::string& bytes,
+      const std::string& extension) {
+    auto path =
+        fmt::format("{}/data{}{}", tempDir_->getPath(), fileCounter_++, extension);
+    LocalWriteFile writeFile(path);
+    writeFile.append(bytes);
+    writeFile.close();
+    return path;
+  }
+
+  // Reads an on-disk file through the JSON reader against schema and returns
+  // the resulting RowVector. The file name's extension selects the codec; bytes
+  // must already be encoded with that codec.
+  RowVectorPtr readFromFile(
+      const std::string& bytes,
+      const std::string& extension,
+      const RowTypePtr& schema) {
+    auto path = writeTempFile(bytes, extension);
+    auto factory =
+        dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+    dwio::common::ReaderOptions readerOptions{pool()};
+    readerOptions.setFileSchema(schema);
+
+    auto readFile = std::make_shared<LocalReadFile>(path);
+    auto bufferedInput =
+        std::make_unique<dwio::common::BufferedInput>(readFile, *pool());
+    auto reader =
+        factory->createReader(std::move(bufferedInput), readerOptions);
+    auto rowReader = reader->createRowReader(dwio::common::RowReaderOptions{});
+
+    VectorPtr result;
+    rowReader->next(1'000, result);
+    return std::dynamic_pointer_cast<RowVector>(result);
   }
 
   // Reads the entire input string through the JSON reader against the
@@ -109,6 +178,13 @@ class JsonReaderTest : public testing::Test, public test::VectorTestBase {
     }
     return out;
   }
+
+  // Temp directory backing on-disk fixtures for compression tests. Lives for
+  // the whole test so files written under it outlast each read.
+  std::shared_ptr<common::testutil::TempDirectoryPath> tempDir_;
+
+  // Distinguishes temp file names within a single test.
+  int fileCounter_{0};
 };
 
 TEST_F(JsonReaderTest, factoryRegistration) {
@@ -902,6 +978,112 @@ TEST_F(JsonReaderTest, splitFileWithWhitespaceOnlyLineThrows) {
   auto schema = ROW({{"id", BIGINT()}});
   std::string file = "{\"id\":0}\n   \n{\"id\":1}\n";
   VELOX_ASSERT_USER_THROW(readRange(file, schema, 0, file.size()), "empty row");
+}
+
+// Records exercising several leaf types so decompression is verified to feed
+// the parser byte-identical input, not just simple scalars.
+const std::string kCompressionJson =
+    "{\"id\":0,\"name\":\"alice\",\"score\":1.5,\"ok\":true}\n"
+    "{\"id\":1,\"name\":\"bob\",\"score\":-2.25,\"ok\":false}\n"
+    "{\"id\":2,\"name\":\"carol\",\"score\":3.75,\"ok\":true}\n";
+
+const RowTypePtr kCompressionSchema = ROW(
+    {{"id", BIGINT()},
+     {"name", VARCHAR()},
+     {"score", DOUBLE()},
+     {"ok", BOOLEAN()}});
+
+TEST_F(JsonReaderTest, compressionGzipIdentical) {
+  // A gzip-compressed file produces the same vector as the uncompressed bytes.
+  auto expected = read(kCompressionJson, kCompressionSchema);
+  auto actual = readFromFile(
+      gzipCompress(kCompressionJson), ".gz", kCompressionSchema);
+  test::assertEqualVectors(expected, actual);
+}
+
+TEST_F(JsonReaderTest, compressionDeflateIdentical) {
+  // A raw-deflate (.deflate) file decompresses to the same vector.
+  auto expected = read(kCompressionJson, kCompressionSchema);
+  auto actual = readFromFile(
+      deflateCompress(kCompressionJson), ".deflate", kCompressionSchema);
+  test::assertEqualVectors(expected, actual);
+}
+
+TEST_F(JsonReaderTest, compressionZstdIdentical) {
+  // A zstd-compressed (.zst) file decompresses to the same vector.
+  auto expected = read(kCompressionJson, kCompressionSchema);
+  auto actual = readFromFile(
+      zstdCompress(kCompressionJson), ".zst", kCompressionSchema);
+  test::assertEqualVectors(expected, actual);
+}
+
+TEST_F(JsonReaderTest, compressionLz4Throws) {
+  // LZ4/LZO/Snappy carry framing the reader's decompressor does not support.
+  // Detection is name-based and fails at reader creation, so the payload bytes
+  // are irrelevant.
+  auto schema = ROW({{"id", BIGINT()}});
+  VELOX_ASSERT_THROW(
+      readFromFile("{\"id\":0}\n", ".lz4", schema),
+      "Unsupported compression extension");
+}
+
+TEST_F(JsonReaderTest, compressionLzoThrows) {
+  auto schema = ROW({{"id", BIGINT()}});
+  VELOX_ASSERT_THROW(
+      readFromFile("{\"id\":0}\n", ".lzo", schema),
+      "Unsupported compression extension");
+}
+
+TEST_F(JsonReaderTest, compressionSnappyThrows) {
+  auto schema = ROW({{"id", BIGINT()}});
+  VELOX_ASSERT_THROW(
+      readFromFile("{\"id\":0}\n", ".snappy", schema),
+      "Unsupported compression extension");
+}
+
+TEST_F(JsonReaderTest, compressionSplitReadsAllAtOffsetZeroNothingAfter) {
+  // Compressed files are not byte-addressable, so they cannot be split. The
+  // split starting at offset 0 reads the whole decompressed file; any later
+  // split reads nothing. Without this carve-out the split's byte length (which
+  // refers to compressed bytes) would truncate the decompressed stream.
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string json = "{\"id\":0}\n{\"id\":1}\n{\"id\":2}\n";
+  auto compressed = gzipCompress(json);
+  auto path = writeTempFile(compressed, ".gz");
+
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileSchema(schema);
+
+  auto makeReader = [&]() {
+    auto readFile = std::make_shared<LocalReadFile>(path);
+    auto bufferedInput =
+        std::make_unique<dwio::common::BufferedInput>(readFile, *pool());
+    return factory->createReader(std::move(bufferedInput), readerOptions);
+  };
+
+  // Split at offset 0 covering only the first compressed byte still reads the
+  // entire file.
+  {
+    dwio::common::RowReaderOptions rowReaderOptions;
+    rowReaderOptions.range(0, 1);
+    auto rowReader = makeReader()->createRowReader(rowReaderOptions);
+    VectorPtr result;
+    rowReader->next(1'000, result);
+    EXPECT_EQ(
+        ids(std::dynamic_pointer_cast<RowVector>(result)),
+        (std::vector<int64_t>{0, 1, 2}));
+  }
+
+  // Any split that does not start at offset 0 reads nothing.
+  {
+    dwio::common::RowReaderOptions rowReaderOptions;
+    rowReaderOptions.range(1, compressed.size());
+    auto rowReader = makeReader()->createRowReader(rowReaderOptions);
+    VectorPtr result;
+    EXPECT_EQ(rowReader->next(1'000, result), 0);
+  }
 }
 
 } // namespace

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -197,5 +197,122 @@ TEST_F(JsonReaderTest, parseDoubleAndReal) {
   EXPECT_FLOAT_EQ(row->childAt(1)->asFlatVector<float>()->valueAt(0), 2.5f);
 }
 
+TEST_F(JsonReaderTest, parseString) {
+  auto row = read("{\"a\":\"hello\"}\n", ROW({{"a", VARCHAR()}}));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0), "hello"_sv);
+}
+
+TEST_F(JsonReaderTest, parseBoolean) {
+  auto row =
+      read("{\"a\":true}\n{\"a\":false}\n", ROW({{"a", BOOLEAN()}}));
+  ASSERT_EQ(row->size(), 2);
+  auto col = row->childAt(0)->asFlatVector<bool>();
+  EXPECT_TRUE(col->valueAt(0));
+  EXPECT_FALSE(col->valueAt(1));
+}
+
+TEST_F(JsonReaderTest, booleanFromStringStrictLiteral) {
+  // Only the exact lowercase "true" is true. "True"/"TRUE" are false —
+  // case-sensitive per the probe.
+  auto row = read(
+      "{\"a\":\"true\"}\n{\"a\":\"True\"}\n{\"a\":\"TRUE\"}\n",
+      ROW({{"a", BOOLEAN()}}));
+  ASSERT_EQ(row->size(), 3);
+  auto col = row->childAt(0)->asFlatVector<bool>();
+  EXPECT_TRUE(col->valueAt(0));
+  EXPECT_FALSE(col->valueAt(1));
+  EXPECT_FALSE(col->valueAt(2));
+}
+
+TEST_F(JsonReaderTest, booleanFromNumberNonzero) {
+  // Any nonzero number — including negatives — is true; 0 is false.
+  auto row = read(
+      "{\"a\":-1}\n{\"a\":2}\n{\"a\":0}\n", ROW({{"a", BOOLEAN()}}));
+  ASSERT_EQ(row->size(), 3);
+  auto col = row->childAt(0)->asFlatVector<bool>();
+  EXPECT_TRUE(col->valueAt(0));
+  EXPECT_TRUE(col->valueAt(1));
+  EXPECT_FALSE(col->valueAt(2));
+}
+
+TEST_F(JsonReaderTest, varcharFromIntegerStringifies) {
+  auto row = read("{\"a\":123}\n", ROW({{"a", VARCHAR()}}));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0), "123"_sv);
+}
+
+TEST_F(JsonReaderTest, varcharFromSimpleFloatStringifies) {
+  auto row = read("{\"a\":123.45}\n", ROW({{"a", VARCHAR()}}));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0), "123.45"_sv);
+}
+
+TEST_F(JsonReaderTest, varcharFromNumberV1DivergenceDocumented) {
+  // v1 emits the original lexeme rather than Presto's BigDecimal-canonical
+  // form. The semantic value is preserved; the exact textual form may
+  // differ (trailing zeros, scientific notation). We assert each output is
+  // a valid string parseable back to the input number, NOT bit-for-bit
+  // Presto parity. This is the documented "VARCHAR-from-number v1
+  // divergence".
+  auto row = read(
+      "{\"a\":1.20}\n{\"a\":1e3}\n{\"a\":100.0}\n", ROW({{"a", VARCHAR()}}));
+  ASSERT_EQ(row->size(), 3);
+  auto col = row->childAt(0)->asFlatVector<StringView>();
+  EXPECT_DOUBLE_EQ(folly::to<double>(std::string(col->valueAt(0))), 1.20);
+  EXPECT_DOUBLE_EQ(folly::to<double>(std::string(col->valueAt(1))), 1e3);
+  EXPECT_DOUBLE_EQ(folly::to<double>(std::string(col->valueAt(2))), 100.0);
+}
+
+TEST_F(JsonReaderTest, varcharFromBooleanStringifiesLowercase) {
+  auto row =
+      read("{\"a\":true}\n{\"a\":false}\n", ROW({{"a", VARCHAR()}}));
+  ASSERT_EQ(row->size(), 2);
+  auto col = row->childAt(0)->asFlatVector<StringView>();
+  EXPECT_EQ(col->valueAt(0), "true"_sv);
+  EXPECT_EQ(col->valueAt(1), "false"_sv);
+}
+
+TEST_F(JsonReaderTest, varcharFromNestedObjectReSerializes) {
+  // Whitespace stripped, key order preserved (NOT canonicalized). Asserted
+  // byte-for-byte against the probe's observed minified output.
+  auto row =
+      read("{\"a\":{\"a\"  :  1 , \"b\" : 2}}\n", ROW({{"a", VARCHAR()}}));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0),
+      "{\"a\":1,\"b\":2}"_sv);
+}
+
+TEST_F(JsonReaderTest, varcharFromArrayReSerializes) {
+  auto row = read("{\"a\":[1 ,  2,3]}\n", ROW({{"a", VARCHAR()}}));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0), "[1,2,3]"_sv);
+}
+
+TEST_F(JsonReaderTest, varcharStringDecodesEscapes) {
+  // simdjson decodes the \/ escape; passthrough yields the bare slash.
+  auto row =
+      read("{\"a\":\"http:\\/\\/example.com\"}\n", ROW({{"a", VARCHAR()}}));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0),
+      "http://example.com"_sv);
+}
+
+TEST_F(JsonReaderTest, varcharFromExplicitJsonNull) {
+  // Unquoted null is SQL NULL.
+  auto row = read("{\"a\":null}\n", ROW({{"a", VARCHAR()}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_TRUE(row->childAt(0)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, varcharFromQuotedNullString) {
+  // Quoted "null" is the 4-char string null, distinct from SQL NULL.
+  auto row = read("{\"a\":\"null\"}\n", ROW({{"a", VARCHAR()}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_FALSE(row->childAt(0)->isNullAt(0));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0), "null"_sv);
+}
+
 } // namespace
 } // namespace facebook::velox::json

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/file/File.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/json/RegisterJsonReader.h"
+#include "velox/type/Timestamp.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::json {
@@ -41,13 +42,18 @@ class JsonReaderTest : public testing::Test, public test::VectorTestBase {
 
   // Reads the entire input string through the JSON reader against the
   // given schema and returns the resulting RowVector. The input is
-  // interpreted as JSON Lines (one record per newline).
-  RowVectorPtr read(const std::string& input, const RowTypePtr& schema) {
+  // interpreted as JSON Lines (one record per newline). serDeOptions
+  // supplies the temporal format strings used for DATE/TIMESTAMP columns.
+  RowVectorPtr read(
+      const std::string& input,
+      const RowTypePtr& schema,
+      const dwio::common::JsonSerDeOptions& serDeOptions = {}) {
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
 
     dwio::common::ReaderOptions readerOptions{pool()};
     readerOptions.setFileSchema(schema);
+    readerOptions.setJsonSerDeOptions(serDeOptions);
 
     auto readFile = std::make_shared<InMemoryReadFile>(input);
     auto bufferedInput =
@@ -354,6 +360,66 @@ TEST_F(JsonReaderTest, varbinaryInvalidBase64Throws) {
   VELOX_ASSERT_THROW(
       read("{\"a\":\"@@@@\"}\n", ROW({{"a", VARBINARY()}})),
       "Invalid base64 in VARBINARY column");
+}
+
+TEST_F(JsonReaderTest, parseDateDefaultFormat) {
+  // Default Joda pattern is yyyy-MM-dd. 2021-03-15 is day 18701 since the
+  // epoch; 1969-12-31 is -1, exercising pre-epoch floor division.
+  auto row = read(
+      "{\"a\":\"2021-03-15\"}\n{\"a\":\"1969-12-31\"}\n",
+      ROW({{"a", DATE()}}));
+  ASSERT_EQ(row->size(), 2);
+  auto col = row->childAt(0)->asFlatVector<int32_t>();
+  EXPECT_EQ(col->valueAt(0), 18701);
+  EXPECT_EQ(col->valueAt(1), -1);
+}
+
+TEST_F(JsonReaderTest, parseDateCustomFormat) {
+  dwio::common::JsonSerDeOptions options;
+  options.dateFormat = "MM/dd/yyyy";
+  auto row = read("{\"a\":\"03/15/2021\"}\n", ROW({{"a", DATE()}}), options);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int32_t>()->valueAt(0), 18701);
+}
+
+TEST_F(JsonReaderTest, parseDateMalformedThrows) {
+  // Unlike numeric coercion (which silently defaults), a temporal string the
+  // format cannot parse is an error.
+  VELOX_ASSERT_THROW(
+      read("{\"a\":\"not-a-date\"}\n", ROW({{"a", DATE()}})),
+      "Failed to parse DATE");
+}
+
+TEST_F(JsonReaderTest, parseTimestampDefaultFormat) {
+  // Default Joda pattern is yyyy-MM-dd HH:mm:ss, interpreted as UTC.
+  auto row =
+      read("{\"a\":\"2021-03-15 12:34:56\"}\n", ROW({{"a", TIMESTAMP()}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<Timestamp>()->valueAt(0),
+      Timestamp(1615811696, 0));
+}
+
+TEST_F(JsonReaderTest, parseTimestampWithTimezone) {
+  // TZ behavior pinned here: a timezone token in the format consumes the
+  // input's offset, and the wall-clock time is normalized to UTC. So
+  // 12:34:56 at +05:00 stores as 07:34:56 UTC (seconds 1615793696). Inputs
+  // without a timezone token are interpreted as UTC (see the default-format
+  // test above).
+  dwio::common::JsonSerDeOptions options;
+  options.timestampFormat = "yyyy-MM-dd HH:mm:ss ZZ";
+  auto row = read(
+      "{\"a\":\"2021-03-15 12:34:56 +05:00\"}\n",
+      ROW({{"a", TIMESTAMP()}}),
+      options);
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<Timestamp>()->valueAt(0),
+      Timestamp(1615793696, 0));
+}
+
+TEST_F(JsonReaderTest, parseTimestampMalformedThrows) {
+  VELOX_ASSERT_THROW(
+      read("{\"a\":\"2021-13-99 99:99:99\"}\n", ROW({{"a", TIMESTAMP()}})),
+      "Failed to parse TIMESTAMP");
 }
 
 } // namespace

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -422,5 +422,60 @@ TEST_F(JsonReaderTest, parseTimestampMalformedThrows) {
       "Failed to parse TIMESTAMP");
 }
 
+TEST_F(JsonReaderTest, arrayOfBigint) {
+  auto row = read("{\"a\":[1,2,3]}\n", ROW({{"a", ARRAY(BIGINT())}}));
+  // Compare the whole row: next() leaves child vectors at their batch
+  // capacity, so comparing the array child directly would mismatch on size.
+  auto expected = makeRowVector({makeArrayVector<int64_t>({{1, 2, 3}})});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, arrayOfString) {
+  auto row =
+      read("{\"a\":[\"x\",\"y\",\"z\"]}\n", ROW({{"a", ARRAY(VARCHAR())}}));
+  auto expected =
+      makeRowVector({makeArrayVector<StringView>({{"x"_sv, "y"_sv, "z"_sv}})});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, arrayElementTypeMismatchCoerces) {
+  // [1, "abc", 3] into ARRAY<BIGINT>: the element "abc" coerces to 0 (full-
+  // fail to zero) rather than throwing or
+  // producing a NULL element.
+  auto row = read("{\"a\":[1,\"abc\",3]}\n", ROW({{"a", ARRAY(BIGINT())}}));
+  auto expected = makeRowVector({makeArrayVector<int64_t>({{1, 0, 3}})});
+  test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, arrayNullProducesSqlNull) {
+  // JSON null for the whole array is SQL NULL, not an empty array.
+  auto row = read("{\"a\":null}\n", ROW({{"a", ARRAY(BIGINT())}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_TRUE(row->childAt(0)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, arrayEmptyIsNotNull) {
+  // JSON [] is a non-null array of cardinality 0, distinct from SQL NULL.
+  auto row = read("{\"a\":[]}\n", ROW({{"a", ARRAY(BIGINT())}}));
+  ASSERT_EQ(row->size(), 1);
+  auto arrays = row->childAt(0)->as<ArrayVector>();
+  EXPECT_FALSE(arrays->isNullAt(0));
+  EXPECT_EQ(arrays->sizeAt(0), 0);
+}
+
+TEST_F(JsonReaderTest, arrayShapeMismatchScalarThrows) {
+  // A scalar where an array is expected is a container-shape mismatch.
+  VELOX_ASSERT_THROW(
+      read("{\"a\":5}\n", ROW({{"a", ARRAY(BIGINT())}})),
+      "expected array");
+}
+
+TEST_F(JsonReaderTest, arrayShapeMismatchObjectThrows) {
+  // An object where an array is expected is a container-shape mismatch.
+  VELOX_ASSERT_THROW(
+      read("{\"a\":{\"k\":1}}\n", ROW({{"a", ARRAY(BIGINT())}})),
+      "expected array");
+}
+
 } // namespace
 } // namespace facebook::velox::json

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/json/RegisterJsonReader.h"
@@ -312,6 +313,47 @@ TEST_F(JsonReaderTest, varcharFromQuotedNullString) {
   EXPECT_FALSE(row->childAt(0)->isNullAt(0));
   EXPECT_EQ(
       row->childAt(0)->asFlatVector<StringView>()->valueAt(0), "null"_sv);
+}
+
+TEST_F(JsonReaderTest, decimalPreservesPrecisionViaLexeme) {
+  // 123456789.0123456789 has more significant digits than a double can hold
+  // exactly. Routing through double would round the trailing digits away;
+  // reading from the lexeme preserves them. DECIMAL(38, 10) scales by 10^10,
+  // so the exact unscaled value is 1234567890123456789.
+  auto row = read("{\"a\":123456789.0123456789}\n", ROW({{"a", DECIMAL(38, 10)}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<int128_t>()->valueAt(0),
+      static_cast<int128_t>(1234567890123456789LL));
+}
+
+TEST_F(JsonReaderTest, decimalScaleAndPrecision) {
+  // A short decimal (precision <= 18) is stored as int64. "3.14" at scale 4
+  // scales to the unscaled value 31400. The string and number forms parse
+  // identically since both go through the lexeme.
+  auto row = read(
+      "{\"a\":3.14,\"b\":\"3.14\"}\n",
+      ROW({{"a", DECIMAL(10, 4)}, {"b", DECIMAL(10, 4)}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 31400);
+  EXPECT_EQ(row->childAt(1)->asFlatVector<int64_t>()->valueAt(0), 31400);
+}
+
+TEST_F(JsonReaderTest, varbinaryFromBase64) {
+  // "SGVsbG8gV29ybGQ=" is the base64 encoding of "Hello World".
+  auto row =
+      read("{\"a\":\"SGVsbG8gV29ybGQ=\"}\n", ROW({{"a", VARBINARY()}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<StringView>()->valueAt(0),
+      "Hello World"_sv);
+}
+
+TEST_F(JsonReaderTest, varbinaryInvalidBase64Throws) {
+  // '@' is outside the base64 alphabet, so decoding must fail.
+  VELOX_ASSERT_THROW(
+      read("{\"a\":\"@@@@\"}\n", ROW({{"a", VARBINARY()}})),
+      "Invalid base64 in VARBINARY column");
 }
 
 } // namespace

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -66,6 +66,49 @@ class JsonReaderTest : public testing::Test, public test::VectorTestBase {
     rowReader->next(1'000, result);
     return std::dynamic_pointer_cast<RowVector>(result);
   }
+
+  // Reads the byte range [offset, offset + length) of the input through
+  // the JSON reader and returns the resulting RowVector, or nullptr when
+  // the split contains no whole records.
+  RowVectorPtr readRange(
+      const std::string& input,
+      const RowTypePtr& schema,
+      uint64_t offset,
+      uint64_t length) {
+    auto factory =
+        dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+    dwio::common::ReaderOptions readerOptions{pool()};
+    readerOptions.setFileSchema(schema);
+
+    auto readFile = std::make_shared<InMemoryReadFile>(input);
+    auto bufferedInput =
+        std::make_unique<dwio::common::BufferedInput>(readFile, *pool());
+    auto reader =
+        factory->createReader(std::move(bufferedInput), readerOptions);
+
+    dwio::common::RowReaderOptions rowReaderOptions;
+    rowReaderOptions.range(offset, length);
+    auto rowReader = reader->createRowReader(rowReaderOptions);
+
+    VectorPtr result;
+    rowReader->next(1'000, result);
+    return std::dynamic_pointer_cast<RowVector>(result);
+  }
+
+  // Collects the first (BIGINT) column of a read result into a vector,
+  // treating a null result as no records.
+  std::vector<int64_t> ids(const RowVectorPtr& row) {
+    std::vector<int64_t> out;
+    if (row == nullptr) {
+      return out;
+    }
+    auto* col = row->childAt(0)->asFlatVector<int64_t>();
+    for (vector_size_t i = 0; i < row->size(); ++i) {
+      out.push_back(col->valueAt(i));
+    }
+    return out;
+  }
 };
 
 TEST_F(JsonReaderTest, factoryRegistration) {
@@ -727,6 +770,138 @@ TEST_F(JsonReaderTest, mapValueRow) {
   auto keys = makeFlatVector<StringView>({"a"_sv});
   auto expected = makeRowVector({makeMapVector({0}, keys, values)});
   test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, splitFromOffsetZero) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file = "{\"id\":0}\n{\"id\":1}\n{\"id\":2}\n";
+  EXPECT_EQ(
+      ids(readRange(file, schema, 0, file.size())),
+      (std::vector<int64_t>{0, 1, 2}));
+}
+
+TEST_F(JsonReaderTest, splitExhaustiveSweep) {
+  auto schema = ROW({{"id", BIGINT()}});
+  // Twenty records of varying length. "pad" is not in the schema, so it
+  // is ignored — its only purpose is to shift record boundaries.
+  std::string file;
+  std::vector<int64_t> expected;
+  for (int i = 0; i < 20; ++i) {
+    file += "{\"id\":" + std::to_string(i) + ",\"pad\":\"" +
+        std::string(i % 7, 'x') + "\"}\n";
+    expected.push_back(i);
+  }
+
+  // Whole-file read sanity check.
+  EXPECT_EQ(ids(readRange(file, schema, 0, file.size())), expected);
+
+  // Partition the file into [0, p) and [p, fileSize) at every byte
+  // offset p. The concatenation must equal the whole-file read with no
+  // dropped or duplicated records. This is the only test that exercises
+  // off-by-one errors at every byte position.
+  for (uint64_t p = 1; p <= file.size(); ++p) {
+    auto left = ids(readRange(file, schema, 0, p));
+    auto right = ids(readRange(file, schema, p, file.size() - p));
+    std::vector<int64_t> combined = left;
+    combined.insert(combined.end(), right.begin(), right.end());
+    EXPECT_EQ(combined, expected) << "split point " << p;
+  }
+}
+
+TEST_F(JsonReaderTest, splitInsideMultibyteUtf8) {
+  auto schema = ROW({{"id", BIGINT()}});
+  // String value holds "ñ" (0xC3 0xB1) and "€" (0xE2 0x82 0xAC). None of
+  // those bytes is 0x0A, so newline scanning must not be confused.
+  std::string r0 = "{\"id\":0,\"s\":\"\xC3\xB1\xE2\x82\xAC\"}\n";
+  std::string file = r0 + "{\"id\":1}\n";
+  // Split one byte into the multibyte run of the first record.
+  uint64_t p = r0.find("\xC3\xB1") + 1;
+  auto left = ids(readRange(file, schema, 0, p));
+  auto right = ids(readRange(file, schema, p, file.size() - p));
+  std::vector<int64_t> combined = left;
+  combined.insert(combined.end(), right.begin(), right.end());
+  EXPECT_EQ(combined, (std::vector<int64_t>{0, 1}));
+}
+
+TEST_F(JsonReaderTest, splitInsideJsonStringLiteral) {
+  auto schema = ROW({{"id", BIGINT()}});
+  // The string value contains braces and an escaped newline (backslash
+  // 'n', two bytes — not a real 0x0A line terminator).
+  std::string r0 = "{\"id\":0,\"s\":\"a{b}c\\nd efgh\"}\n";
+  std::string file = r0 + "{\"id\":1}\n";
+  uint64_t p = r0.find("b}c");
+  auto left = ids(readRange(file, schema, 0, p));
+  auto right = ids(readRange(file, schema, p, file.size() - p));
+  std::vector<int64_t> combined = left;
+  combined.insert(combined.end(), right.begin(), right.end());
+  EXPECT_EQ(combined, (std::vector<int64_t>{0, 1}));
+}
+
+TEST_F(JsonReaderTest, splitAtExactlyNewline) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file = "{\"id\":0}\n{\"id\":1}\n{\"id\":2}\n";
+  // Split exactly at the newline ending the first record. That record
+  // belongs to the left split; the right split skips from the newline
+  // forward to the start of the second record.
+  uint64_t nl = file.find('\n');
+  auto left = ids(readRange(file, schema, 0, nl));
+  auto right = ids(readRange(file, schema, nl, file.size() - nl));
+  std::vector<int64_t> combined = left;
+  combined.insert(combined.end(), right.begin(), right.end());
+  EXPECT_EQ(combined, (std::vector<int64_t>{0, 1, 2}));
+}
+
+TEST_F(JsonReaderTest, splitPastEof) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file = "{\"id\":0}\n{\"id\":1}\n";
+  // Offset beyond the end of the file yields no records.
+  EXPECT_TRUE(ids(readRange(file, schema, file.size() + 10, 100)).empty());
+  // Offset exactly at EOF yields no records.
+  EXPECT_TRUE(ids(readRange(file, schema, file.size(), 100)).empty());
+}
+
+TEST_F(JsonReaderTest, splitWith20RecordsVaryingLength) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file;
+  std::vector<int64_t> expected;
+  for (int i = 0; i < 20; ++i) {
+    file += "{\"id\":" + std::to_string(i) + ",\"pad\":\"" +
+        std::string(i, 'x') + "\"}\n";
+    expected.push_back(i);
+  }
+  // Three adjacent splits tiling the file end to end.
+  uint64_t third = file.size() / 3;
+  auto a = ids(readRange(file, schema, 0, third));
+  auto b = ids(readRange(file, schema, third, third));
+  auto c = ids(readRange(file, schema, 2 * third, file.size() - 2 * third));
+  std::vector<int64_t> combined = a;
+  combined.insert(combined.end(), b.begin(), b.end());
+  combined.insert(combined.end(), c.begin(), c.end());
+  EXPECT_EQ(combined, expected);
+}
+
+TEST_F(JsonReaderTest, splitFileWithLeadingBlankLineThrows) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file = "\n{\"id\":0}\n";
+  VELOX_ASSERT_USER_THROW(readRange(file, schema, 0, file.size()), "empty row");
+}
+
+TEST_F(JsonReaderTest, splitFileWithBlankLineBetweenRecordsThrows) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file = "{\"id\":0}\n\n{\"id\":1}\n";
+  VELOX_ASSERT_USER_THROW(readRange(file, schema, 0, file.size()), "empty row");
+}
+
+TEST_F(JsonReaderTest, splitFileWithTrailingBlankLineThrows) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file = "{\"id\":0}\n\n";
+  VELOX_ASSERT_USER_THROW(readRange(file, schema, 0, file.size()), "empty row");
+}
+
+TEST_F(JsonReaderTest, splitFileWithWhitespaceOnlyLineThrows) {
+  auto schema = ROW({{"id", BIGINT()}});
+  std::string file = "{\"id\":0}\n   \n{\"id\":1}\n";
+  VELOX_ASSERT_USER_THROW(readRange(file, schema, 0, file.size()), "empty row");
 }
 
 } // namespace

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -37,6 +37,28 @@ class JsonReaderTest : public testing::Test, public test::VectorTestBase {
   void TearDown() override {
     unregisterJsonReaderFactory();
   }
+
+  // Reads the entire input string through the JSON reader against the
+  // given schema and returns the resulting RowVector. The input is
+  // interpreted as JSON Lines (one record per newline).
+  RowVectorPtr read(const std::string& input, const RowTypePtr& schema) {
+    auto factory =
+        dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+    dwio::common::ReaderOptions readerOptions{pool()};
+    readerOptions.setFileSchema(schema);
+
+    auto readFile = std::make_shared<InMemoryReadFile>(input);
+    auto bufferedInput =
+        std::make_unique<dwio::common::BufferedInput>(readFile, *pool());
+    auto reader =
+        factory->createReader(std::move(bufferedInput), readerOptions);
+    auto rowReader = reader->createRowReader(dwio::common::RowReaderOptions{});
+
+    VectorPtr result;
+    rowReader->next(1'000, result);
+    return std::dynamic_pointer_cast<RowVector>(result);
+  }
 };
 
 TEST_F(JsonReaderTest, factoryRegistration) {
@@ -62,6 +84,117 @@ TEST_F(JsonReaderTest, emptyFileReturnsZeroRows) {
 
   VectorPtr result;
   EXPECT_EQ(rowReader->next(10, result), 0);
+}
+
+TEST_F(JsonReaderTest, parseSingleBigint) {
+  auto schema = ROW({{"a", BIGINT()}});
+  auto row = read("{\"a\":42}\n", schema);
+
+  ASSERT_EQ(row->size(), 1);
+  auto col = row->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(col->valueAt(0), 42);
+}
+
+TEST_F(JsonReaderTest, parseAllNumericTypes) {
+  auto schema = ROW(
+      {{"t", TINYINT()},
+       {"s", SMALLINT()},
+       {"i", INTEGER()},
+       {"b", BIGINT()},
+       {"r", REAL()},
+       {"d", DOUBLE()}});
+  auto row = read("{\"t\":1,\"s\":2,\"i\":3,\"b\":4,\"r\":1.5,\"d\":2.5}\n", schema);
+
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int8_t>()->valueAt(0), 1);
+  EXPECT_EQ(row->childAt(1)->asFlatVector<int16_t>()->valueAt(0), 2);
+  EXPECT_EQ(row->childAt(2)->asFlatVector<int32_t>()->valueAt(0), 3);
+  EXPECT_EQ(row->childAt(3)->asFlatVector<int64_t>()->valueAt(0), 4);
+  EXPECT_FLOAT_EQ(row->childAt(4)->asFlatVector<float>()->valueAt(0), 1.5f);
+  EXPECT_DOUBLE_EQ(row->childAt(5)->asFlatVector<double>()->valueAt(0), 2.5);
+}
+
+TEST_F(JsonReaderTest, bigintFromString) {
+  auto row = read("{\"a\":\"100\"}\n", ROW({{"a", BIGINT()}}));
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 100);
+}
+
+TEST_F(JsonReaderTest, bigintFromNonNumericString) {
+  // Full-fail to 0, NOT partial-parse.
+  // "12abc" -> 0, not 12.
+  auto row = read(
+      "{\"a\":\"abc\"}\n{\"a\":\"12abc\"}\n", ROW({{"a", BIGINT()}}));
+  ASSERT_EQ(row->size(), 2);
+  auto col = row->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(col->valueAt(0), 0);
+  EXPECT_EQ(col->valueAt(1), 0);
+}
+
+TEST_F(JsonReaderTest, bigintFromBoolean) {
+  auto row =
+      read("{\"a\":true}\n{\"a\":false}\n", ROW({{"a", BIGINT()}}));
+  ASSERT_EQ(row->size(), 2);
+  auto col = row->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(col->valueAt(0), 1);
+  EXPECT_EQ(col->valueAt(1), 0);
+}
+
+TEST_F(JsonReaderTest, bigintFromFloatTruncatesTowardZero) {
+  // -3.7 -> -3 (truncate toward zero, NOT floor which would be -4).
+  auto row = read("{\"a\":-3.7}\n", ROW({{"a", BIGINT()}}));
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int64_t>()->valueAt(0), -3);
+}
+
+TEST_F(JsonReaderTest, bigintOverflowWrapsUint64) {
+  // 9223372036854775808 = 2^63: simdjson parses as unsigned_integer,
+  // two's-complement wrap to int64 yields Long.MIN_VALUE.
+  auto row =
+      read("{\"a\":9223372036854775808}\n", ROW({{"a", BIGINT()}}));
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<int64_t>()->valueAt(0),
+      std::numeric_limits<int64_t>::min());
+}
+
+TEST_F(JsonReaderTest, bigintExtremeOverflowDiverges) {
+  // 1e20 is outside [INT64_MIN, 2^64). v1 diverges from Presto/Jackson
+  // here. The contract is only "does
+  // not throw"; the exact wrap value is intentionally not asserted.
+  EXPECT_NO_THROW(read("{\"a\":1e20}\n", ROW({{"a", BIGINT()}})));
+}
+
+TEST_F(JsonReaderTest, bigintFromEmptyString) {
+  auto row = read("{\"a\":\"\"}\n", ROW({{"a", BIGINT()}}));
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 0);
+}
+
+TEST_F(JsonReaderTest, missingFieldYieldsNull) {
+  // Field "b" is in the schema but absent from the JSON record.
+  auto row = read("{\"a\":1}\n", ROW({{"a", BIGINT()}, {"b", BIGINT()}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_FALSE(row->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(row->childAt(1)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, extraFieldIgnored) {
+  // Field "extra" is in the JSON record but not in the schema. Should
+  // be silently ignored.
+  auto row = read("{\"a\":1,\"extra\":99}\n", ROW({{"a", BIGINT()}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 1);
+}
+
+TEST_F(JsonReaderTest, tinyintRangeOverflow) {
+  // 255 narrows to int8 via two's-complement wrap: 255 -> -1.
+  auto row = read("{\"a\":255}\n", ROW({{"a", TINYINT()}}));
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int8_t>()->valueAt(0), -1);
+}
+
+TEST_F(JsonReaderTest, parseDoubleAndReal) {
+  auto row = read(
+      "{\"d\":3.14,\"r\":2.5}\n",
+      ROW({{"d", DOUBLE()}, {"r", REAL()}}));
+  EXPECT_DOUBLE_EQ(row->childAt(0)->asFlatVector<double>()->valueAt(0), 3.14);
+  EXPECT_FLOAT_EQ(row->childAt(1)->asFlatVector<float>()->valueAt(0), 2.5f);
 }
 
 } // namespace

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -18,6 +18,7 @@
 
 #include <folly/compression/Compression.h>
 #include <folly/compression/Zlib.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -248,6 +249,12 @@ TEST_F(JsonReaderTest, bigintFromString) {
 }
 
 TEST_F(JsonReaderTest, bigintFromNonNumericString) {
+  // A leaf whose JSON type does not match its column type coerces silently
+  // rather than throwing, following org.apache.hadoop.hive.serde2.JsonSerDe
+  // (Jackson's JsonNode.asLong(), which defaults on an unconvertible value).
+  // Through Hive 3.1 the legacy org.apache.hive.hcatalog.data.JsonSerDe would
+  // fail the query here instead — it is not the reference.
+  //
   // Full-fail to 0, NOT partial-parse.
   // "12abc" -> 0, not 12.
   auto row = read(
@@ -256,6 +263,35 @@ TEST_F(JsonReaderTest, bigintFromNonNumericString) {
   auto col = row->childAt(0)->asFlatVector<int64_t>();
   EXPECT_EQ(col->valueAt(0), 0);
   EXPECT_EQ(col->valueAt(1), 0);
+}
+
+TEST_F(JsonReaderTest, bigintFromFloatingPointString) {
+  // Jackson's NumberInput.parseAsLong is a two-stage parse: on the first
+  // non-digit it retries the whole string as a double and casts, reaching its
+  // default only when that fails too. So a quoted float truncates toward zero
+  // rather than defaulting to 0, and only a string that is not valid float
+  // syntax either (see bigintFromNonNumericString) lands on 0.
+  auto row = read(
+      "{\"a\":\"12.5\"}\n{\"a\":\"-12.5\"}\n{\"a\":\"1e3\"}\n",
+      ROW({{"a", BIGINT()}}));
+  ASSERT_EQ(row->size(), 3);
+  auto col = row->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(col->valueAt(0), 12);
+  EXPECT_EQ(col->valueAt(1), -12);
+  EXPECT_EQ(col->valueAt(2), 1000);
+}
+
+TEST_F(JsonReaderTest, narrowIntegerFromFloatingPointString) {
+  // The narrower widths share the same coercion, then wrap. The reference
+  // reaches them through NumberInput.parseAsInt, which has the identical
+  // double fallback.
+  auto row = read(
+      "{\"t\":\"1.9\",\"s\":\"2.9\",\"i\":\"3.9\"}\n",
+      ROW({{"t", TINYINT()}, {"s", SMALLINT()}, {"i", INTEGER()}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int8_t>()->valueAt(0), 1);
+  EXPECT_EQ(row->childAt(1)->asFlatVector<int16_t>()->valueAt(0), 2);
+  EXPECT_EQ(row->childAt(2)->asFlatVector<int32_t>()->valueAt(0), 3);
 }
 
 TEST_F(JsonReaderTest, bigintFromBoolean) {
@@ -284,7 +320,7 @@ TEST_F(JsonReaderTest, bigintOverflowWrapsUint64) {
 }
 
 TEST_F(JsonReaderTest, bigintExtremeOverflowDiverges) {
-  // 1e20 is outside [INT64_MIN, 2^64). v1 diverges from Presto/Jackson
+  // 1e20 is outside [INT64_MIN, 2^64). v1 diverges from Jackson
   // here. The contract is only "does
   // not throw"; the exact wrap value is intentionally not asserted.
   EXPECT_NO_THROW(read("{\"a\":1e20}\n", ROW({{"a", BIGINT()}})));
@@ -342,7 +378,7 @@ TEST_F(JsonReaderTest, parseBoolean) {
 
 TEST_F(JsonReaderTest, booleanFromStringStrictLiteral) {
   // Only the exact lowercase "true" is true. "True"/"TRUE" are false —
-  // case-sensitive per the probe.
+  // case-sensitive, matching Jackson's TextNode.asBoolean().
   auto row = read(
       "{\"a\":\"true\"}\n{\"a\":\"True\"}\n{\"a\":\"TRUE\"}\n",
       ROW({{"a", BOOLEAN()}}));
@@ -377,12 +413,13 @@ TEST_F(JsonReaderTest, varcharFromSimpleFloatStringifies) {
 }
 
 TEST_F(JsonReaderTest, varcharFromNumberV1DivergenceDocumented) {
-  // v1 emits the original lexeme rather than Presto's BigDecimal-canonical
-  // form. The semantic value is preserved; the exact textual form may
+  // v1 emits the original lexeme rather than the String.valueOf(double) form
+  // the reference produces via JsonNode.asText() on a DoubleNode, so 1e3 reads
+  // back as "1000.0" there. The semantic value is preserved; the textual may
   // differ (trailing zeros, scientific notation). We assert each output is
   // a valid string parseable back to the input number, NOT bit-for-bit
-  // Presto parity. This is the documented "VARCHAR-from-number v1
-  // divergence".
+  // parity with the reference SerDe. This is the documented
+  // "VARCHAR-from-number v1 divergence".
   auto row = read(
       "{\"a\":1.20}\n{\"a\":1e3}\n{\"a\":100.0}\n", ROW({{"a", VARCHAR()}}));
   ASSERT_EQ(row->size(), 3);
@@ -464,6 +501,70 @@ TEST_F(JsonReaderTest, decimalScaleAndPrecision) {
   ASSERT_EQ(row->size(), 1);
   EXPECT_EQ(row->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 31400);
   EXPECT_EQ(row->childAt(1)->asFlatVector<int64_t>()->valueAt(0), 31400);
+}
+
+TEST_F(JsonReaderTest, decimalUnparseableValueYieldsNull) {
+  // The reference builds decimals with HiveDecimal.create(asText()), which
+  // returns null rather than raising when the text is not a decimal, so an
+  // unparseable leaf is SQL NULL and the row survives. This is the same
+  // coerce-do-not-throw rule the integer leaves follow, except that decimals
+  // have no zero-like fallback value to land on.
+  auto row = read(
+      "{\"a\":\"abc\"}\n{\"a\":\"\"}\n{\"a\":\"12abc\"}\n",
+      ROW({{"a", DECIMAL(10, 2)}}));
+  ASSERT_EQ(row->size(), 3);
+  const auto& column = row->childAt(0);
+  EXPECT_TRUE(column->isNullAt(0));
+  EXPECT_TRUE(column->isNullAt(1));
+  EXPECT_TRUE(column->isNullAt(2));
+}
+
+TEST_F(JsonReaderTest, decimalFromBooleanYieldsNull) {
+  // asText() on a boolean node gives "true"/"false", which HiveDecimal.create
+  // rejects — so a boolean is NULL, not an error.
+  auto row =
+      read("{\"a\":true}\n{\"a\":false}\n", ROW({{"a", DECIMAL(10, 2)}}));
+  ASSERT_EQ(row->size(), 2);
+  EXPECT_TRUE(row->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(row->childAt(0)->isNullAt(1));
+}
+
+TEST_F(JsonReaderTest, decimalExceedingPrecisionYieldsNull) {
+  // 12345 does not fit DECIMAL(3, 0). enforcePrecisionScale returns null for a
+  // value the declared precision cannot hold, so this is NULL rather than an
+  // error or a truncation. Long-decimal (int128) columns take the same path.
+  auto row = read(
+      "{\"a\":12345,\"b\":123456789012345678901234567890123456789}\n",
+      ROW({{"a", DECIMAL(3, 0)}, {"b", DECIMAL(38, 10)}}));
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_TRUE(row->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(row->childAt(1)->isNullAt(0));
+}
+
+TEST_F(JsonReaderTest, decimalNestedInArrayYieldsNullElement) {
+  // A decimal element inside a container follows the same rule, but reaches
+  // NULL through the element vector rather than the pre-nulled top-level cell.
+  auto row =
+      read("{\"a\":[1.5,\"abc\",2.5]}\n", ROW({{"a", ARRAY(DECIMAL(10, 2))}}));
+  ASSERT_EQ(row->size(), 1);
+  auto* array = row->childAt(0)->as<ArrayVector>();
+  ASSERT_EQ(array->sizeAt(0), 3);
+  const auto& elements = array->elements();
+  auto* values = elements->asFlatVector<int64_t>();
+  EXPECT_EQ(values->valueAt(0), 150);
+  EXPECT_TRUE(elements->isNullAt(1));
+  EXPECT_EQ(values->valueAt(2), 250);
+}
+
+TEST_F(JsonReaderTest, decimalShapeMismatchThrows) {
+  // Unparseable scalars degrade to NULL, but a container where a scalar column
+  // is declared stays an error — the same rule every other leaf type follows.
+  VELOX_ASSERT_USER_THROW(
+      read("{\"a\":[1]}\n", ROW({{"a", DECIMAL(10, 2)}})),
+      "JSON parse error at byte offset 0");
+  VELOX_ASSERT_USER_THROW(
+      read("{\"a\":{\"k\":1}}\n", ROW({{"a", DECIMAL(10, 2)}})),
+      "JSON parse error at byte offset 0");
 }
 
 TEST_F(JsonReaderTest, varbinaryFromBase64) {
@@ -566,6 +667,24 @@ TEST_F(JsonReaderTest, arrayElementTypeMismatchCoerces) {
   auto row = read("{\"a\":[1,\"abc\",3]}\n", ROW({{"a", ARRAY(BIGINT())}}));
   auto expected = makeRowVector({makeArrayVector<int64_t>({{1, 0, 3}})});
   test::assertEqualVectors(expected, row);
+}
+
+TEST_F(JsonReaderTest, arrayNullElementIsNullNotZero) {
+  // A JSON null *element* is a NULL element, distinct from the 0 an
+  // unconvertible element coerces to (see arrayElementTypeMismatchCoerces).
+  // The elements vector is grown one slot at a time and has no nulls buffer
+  // until something asks for one, so this NULL has to be written explicitly —
+  // growing the vector does not leave new slots null on its own.
+  auto row = read("{\"a\":[1,null,3]}\n", ROW({{"a", ARRAY(BIGINT())}}));
+  ASSERT_EQ(row->size(), 1);
+  auto* arrays = row->childAt(0)->as<ArrayVector>();
+  ASSERT_EQ(arrays->sizeAt(0), 3);
+  const auto& elements = arrays->elements();
+  EXPECT_FALSE(elements->isNullAt(0));
+  EXPECT_TRUE(elements->isNullAt(1));
+  EXPECT_FALSE(elements->isNullAt(2));
+  EXPECT_EQ(elements->asFlatVector<int64_t>()->valueAt(0), 1);
+  EXPECT_EQ(elements->asFlatVector<int64_t>()->valueAt(2), 3);
 }
 
 TEST_F(JsonReaderTest, arrayNullProducesSqlNull) {
@@ -678,6 +797,40 @@ TEST_F(JsonReaderTest, mapDuplicateKeysLastWriteWinsInsertionOrderPreserved) {
   EXPECT_EQ(values->valueAt(offset + 1), 2);
 }
 
+TEST_F(JsonReaderTest, mapDuplicateKeysNullInterplay) {
+  // Last-write-wins holds across the null boundary in both directions. Null
+  // first then a value un-nulls the slot; a value then null re-nulls it. Both
+  // keep the key at its first-seen position and cardinality 2. The two
+  // directions are carried by different code: the re-null by writeMap's
+  // setNull, which sits outside the inserted-only guard, and the un-null by
+  // FlatVector::set clearing the flag on write.
+  auto row = read(
+      "{\"m\":{\"a\":null,\"b\":2,\"a\":3}}\n"
+      "{\"m\":{\"a\":1,\"b\":2,\"a\":null}}\n",
+      ROW({{"m", MAP(VARCHAR(), BIGINT())}}));
+  ASSERT_EQ(row->size(), 2);
+  auto* map = row->childAt(0)->as<MapVector>();
+  auto keys = map->mapKeys()->asFlatVector<StringView>();
+  auto values = map->mapValues()->asFlatVector<int64_t>();
+
+  ASSERT_FALSE(map->isNullAt(0));
+  EXPECT_EQ(map->sizeAt(0), 2);
+  const auto first = map->offsetAt(0);
+  EXPECT_EQ(keys->valueAt(first), "a"_sv);
+  EXPECT_FALSE(values->isNullAt(first));
+  EXPECT_EQ(values->valueAt(first), 3);
+  EXPECT_EQ(keys->valueAt(first + 1), "b"_sv);
+  EXPECT_EQ(values->valueAt(first + 1), 2);
+
+  ASSERT_FALSE(map->isNullAt(1));
+  EXPECT_EQ(map->sizeAt(1), 2);
+  const auto second = map->offsetAt(1);
+  EXPECT_EQ(keys->valueAt(second), "a"_sv);
+  EXPECT_TRUE(values->isNullAt(second));
+  EXPECT_EQ(keys->valueAt(second + 1), "b"_sv);
+  EXPECT_EQ(values->valueAt(second + 1), 2);
+}
+
 TEST_F(JsonReaderTest, mapDuplicateKeysCaseSensitive) {
   // {"k":1,"K":2} -> two distinct entries, cardinality 2. Distinct from ROW
   // case-insensitive matching: MAP keys are not folded.
@@ -689,6 +842,136 @@ TEST_F(JsonReaderTest, mapDuplicateKeysCaseSensitive) {
   const auto offset = map->offsetAt(0);
   EXPECT_EQ(keys->valueAt(offset), "k"_sv);
   EXPECT_EQ(keys->valueAt(offset + 1), "K"_sv);
+}
+
+TEST_F(JsonReaderTest, mapDuplicateKeysArrayValueGrows) {
+  // A duplicate key whose ARRAY value grows. writeArray takes its offset from
+  // the current tail of the shared elements vector on every call, so the second
+  // occurrence appends past "b" — appended between the two "a"s — and re-points
+  // the entry. An implementation that instead wrote the new elements in place
+  // at "a"'s old offset would run past its old cardinality and corrupt "b",
+  // leaving "a" itself correct. That is why the sibling is asserted here.
+  auto row = read(
+      "{\"m\":{\"a\":[1],\"b\":[9],\"a\":[1,2,3,4,5]}}\n",
+      ROW({{"m", MAP(VARCHAR(), ARRAY(BIGINT()))}}));
+  auto* map = row->childAt(0)->as<MapVector>();
+  auto keys = map->mapKeys()->asFlatVector<StringView>();
+  auto* arrays = map->mapValues()->as<ArrayVector>();
+  auto elements = arrays->elements()->asFlatVector<int64_t>();
+  // Reads an entry's array through its offset and size, which is the only
+  // reachable view: elements orphaned by an overwrite are invisible here.
+  auto arrayAt = [&](vector_size_t entry) {
+    std::vector<int64_t> out;
+    const auto begin = arrays->offsetAt(entry);
+    for (vector_size_t i = 0; i < arrays->sizeAt(entry); ++i) {
+      out.push_back(elements->valueAt(begin + i));
+    }
+    return out;
+  };
+
+  ASSERT_FALSE(map->isNullAt(0));
+  ASSERT_EQ(map->sizeAt(0), 2);
+  const auto offset = map->offsetAt(0);
+  EXPECT_EQ(keys->valueAt(offset), "a"_sv);
+  EXPECT_THAT(arrayAt(offset), testing::ElementsAre(1, 2, 3, 4, 5));
+  EXPECT_EQ(keys->valueAt(offset + 1), "b"_sv);
+  EXPECT_THAT(arrayAt(offset + 1), testing::ElementsAre(9));
+}
+
+TEST_F(JsonReaderTest, mapDuplicateKeysArrayValueShrinks) {
+  // The opposite direction. Asserting the full contents and not just the first
+  // element is what matters here: reusing the old offset without updating the
+  // size would leave "a" reading [7, 2, 3, 4, 5] instead of [7].
+  auto row = read(
+      "{\"m\":{\"a\":[1,2,3,4,5],\"b\":[9],\"a\":[7]}}\n",
+      ROW({{"m", MAP(VARCHAR(), ARRAY(BIGINT()))}}));
+  auto* map = row->childAt(0)->as<MapVector>();
+  auto keys = map->mapKeys()->asFlatVector<StringView>();
+  auto* arrays = map->mapValues()->as<ArrayVector>();
+  auto elements = arrays->elements()->asFlatVector<int64_t>();
+  auto arrayAt = [&](vector_size_t entry) {
+    std::vector<int64_t> out;
+    const auto begin = arrays->offsetAt(entry);
+    for (vector_size_t i = 0; i < arrays->sizeAt(entry); ++i) {
+      out.push_back(elements->valueAt(begin + i));
+    }
+    return out;
+  };
+
+  ASSERT_EQ(map->sizeAt(0), 2);
+  const auto offset = map->offsetAt(0);
+  EXPECT_EQ(keys->valueAt(offset), "a"_sv);
+  EXPECT_EQ(arrays->sizeAt(offset), 1);
+  EXPECT_THAT(arrayAt(offset), testing::ElementsAre(7));
+  EXPECT_EQ(keys->valueAt(offset + 1), "b"_sv);
+  EXPECT_THAT(arrayAt(offset + 1), testing::ElementsAre(9));
+}
+
+TEST_F(JsonReaderTest, mapDuplicateKeysArrayValueEmptyAndNull) {
+  // An overwrite must keep [] and JSON null distinguishable, as a first write
+  // does: [] is a non-null array of cardinality 0, null is SQL NULL. The null
+  // case leaves the entry's stale offset and size in place, so it is the null
+  // flag alone that carries the meaning.
+  auto row = read(
+      "{\"m\":{\"a\":[1,2],\"a\":[]}}\n"
+      "{\"m\":{\"a\":[1,2],\"a\":null}}\n",
+      ROW({{"m", MAP(VARCHAR(), ARRAY(BIGINT()))}}));
+  ASSERT_EQ(row->size(), 2);
+  auto* map = row->childAt(0)->as<MapVector>();
+  auto* arrays = map->mapValues()->as<ArrayVector>();
+
+  ASSERT_EQ(map->sizeAt(0), 1);
+  const auto emptied = map->offsetAt(0);
+  EXPECT_FALSE(arrays->isNullAt(emptied));
+  EXPECT_EQ(arrays->sizeAt(emptied), 0);
+
+  ASSERT_EQ(map->sizeAt(1), 1);
+  const auto nulled = map->offsetAt(1);
+  EXPECT_TRUE(arrays->isNullAt(nulled));
+}
+
+TEST_F(JsonReaderTest, mapDuplicateKeysRowValueRenullsAbsentField) {
+  // ROW values do not append. writeRowObject writes children in place at the
+  // entry index, after setting every child at that index to NULL. That
+  // initialization is what makes an overwrite a replacement rather than a
+  // merge: "y" is present in the first occurrence and absent from the second,
+  // so it must come back NULL. Without it the entry would read {x=9, y=2}.
+  // Jackson replaces the whole ObjectNode, so NULL is the reference behavior.
+  auto row = read(
+      "{\"m\":{\"a\":{\"x\":1,\"y\":2},\"a\":{\"x\":9}}}\n",
+      ROW({{"m", MAP(VARCHAR(), ROW({{"x", BIGINT()}, {"y", BIGINT()}}))}}));
+  auto* map = row->childAt(0)->as<MapVector>();
+  ASSERT_EQ(map->sizeAt(0), 1);
+  const auto offset = map->offsetAt(0);
+  EXPECT_EQ(
+      map->mapKeys()->asFlatVector<StringView>()->valueAt(offset), "a"_sv);
+  auto* rows = map->mapValues()->as<RowVector>();
+  ASSERT_FALSE(rows->isNullAt(offset));
+  EXPECT_EQ(rows->childAt(0)->asFlatVector<int64_t>()->valueAt(offset), 9);
+  EXPECT_TRUE(rows->childAt(1)->isNullAt(offset));
+}
+
+TEST_F(JsonReaderTest, mapDuplicateKeysMapValueReplacedNotMerged) {
+  // A MAP-valued duplicate is replaced whole rather than merged. The nested
+  // writeMap builds a fresh key index per call, so the first occurrence's keys
+  // cannot survive into the second: {"p","q"} then {"r"} yields just {"r"}.
+  auto row = read(
+      "{\"m\":{\"a\":{\"p\":1,\"q\":2},\"a\":{\"r\":3}}}\n",
+      ROW({{"m", MAP(VARCHAR(), MAP(VARCHAR(), BIGINT()))}}));
+  auto* outer = row->childAt(0)->as<MapVector>();
+  ASSERT_EQ(outer->sizeAt(0), 1);
+  const auto offset = outer->offsetAt(0);
+  EXPECT_EQ(
+      outer->mapKeys()->asFlatVector<StringView>()->valueAt(offset), "a"_sv);
+  auto* inner = outer->mapValues()->as<MapVector>();
+  ASSERT_FALSE(inner->isNullAt(offset));
+  ASSERT_EQ(inner->sizeAt(offset), 1);
+  const auto innerOffset = inner->offsetAt(offset);
+  EXPECT_EQ(
+      inner->mapKeys()->asFlatVector<StringView>()->valueAt(innerOffset),
+      "r"_sv);
+  EXPECT_EQ(
+      inner->mapValues()->asFlatVector<int64_t>()->valueAt(innerOffset), 3);
 }
 
 TEST_F(JsonReaderTest, mapJsonNullProducesSqlNull) {
@@ -873,16 +1156,16 @@ TEST_F(JsonReaderTest, splitExhaustiveSweep) {
   // Whole-file read sanity check.
   EXPECT_EQ(ids(readRange(file, schema, 0, file.size())), expected);
 
-  // Partition the file into [0, p) and [p, fileSize) at every byte
-  // offset p. The concatenation must equal the whole-file read with no
-  // dropped or duplicated records. This is the only test that exercises
-  // off-by-one errors at every byte position.
-  for (uint64_t p = 1; p <= file.size(); ++p) {
-    auto left = ids(readRange(file, schema, 0, p));
-    auto right = ids(readRange(file, schema, p, file.size() - p));
+  // Partition the file into [0, splitPoint) and [splitPoint, fileSize) at
+  // every byte offset splitPoint. The concatenation must equal the whole-file
+  // read with no dropped or duplicated records. This is the only test that
+  // exercises off-by-one errors at every byte position.
+  for (uint64_t splitPoint = 1; splitPoint <= file.size(); ++splitPoint) {
+    auto left = ids(readRange(file, schema, 0, splitPoint));
+    auto right = ids(readRange(file, schema, splitPoint, file.size() - splitPoint));
     std::vector<int64_t> combined = left;
     combined.insert(combined.end(), right.begin(), right.end());
-    EXPECT_EQ(combined, expected) << "split point " << p;
+    EXPECT_EQ(combined, expected) << "split point " << splitPoint;
   }
 }
 
@@ -893,9 +1176,9 @@ TEST_F(JsonReaderTest, splitInsideMultibyteUtf8) {
   std::string r0 = "{\"id\":0,\"s\":\"\xC3\xB1\xE2\x82\xAC\"}\n";
   std::string file = r0 + "{\"id\":1}\n";
   // Split one byte into the multibyte run of the first record.
-  uint64_t p = r0.find("\xC3\xB1") + 1;
-  auto left = ids(readRange(file, schema, 0, p));
-  auto right = ids(readRange(file, schema, p, file.size() - p));
+  uint64_t splitPoint = r0.find("\xC3\xB1") + 1;
+  auto left = ids(readRange(file, schema, 0, splitPoint));
+  auto right = ids(readRange(file, schema, splitPoint, file.size() - splitPoint));
   std::vector<int64_t> combined = left;
   combined.insert(combined.end(), right.begin(), right.end());
   EXPECT_EQ(combined, (std::vector<int64_t>{0, 1}));
@@ -907,9 +1190,9 @@ TEST_F(JsonReaderTest, splitInsideJsonStringLiteral) {
   // 'n', two bytes — not a real 0x0A line terminator).
   std::string r0 = "{\"id\":0,\"s\":\"a{b}c\\nd efgh\"}\n";
   std::string file = r0 + "{\"id\":1}\n";
-  uint64_t p = r0.find("b}c");
-  auto left = ids(readRange(file, schema, 0, p));
-  auto right = ids(readRange(file, schema, p, file.size() - p));
+  uint64_t splitPoint = r0.find("b}c");
+  auto left = ids(readRange(file, schema, 0, splitPoint));
+  auto right = ids(readRange(file, schema, splitPoint, file.size() - splitPoint));
   std::vector<int64_t> combined = left;
   combined.insert(combined.end(), right.begin(), right.end());
   EXPECT_EQ(combined, (std::vector<int64_t>{0, 1}));
@@ -921,9 +1204,9 @@ TEST_F(JsonReaderTest, splitAtExactlyNewline) {
   // Split exactly at the newline ending the first record. That record
   // belongs to the left split; the right split skips from the newline
   // forward to the start of the second record.
-  uint64_t nl = file.find('\n');
-  auto left = ids(readRange(file, schema, 0, nl));
-  auto right = ids(readRange(file, schema, nl, file.size() - nl));
+  uint64_t newline = file.find('\n');
+  auto left = ids(readRange(file, schema, 0, newline));
+  auto right = ids(readRange(file, schema, newline, file.size() - newline));
   std::vector<int64_t> combined = left;
   combined.insert(combined.end(), right.begin(), right.end());
   EXPECT_EQ(combined, (std::vector<int64_t>{0, 1, 2}));
@@ -1039,8 +1322,9 @@ TEST_F(JsonReaderTest, errorShapeMismatchThrowsForEachContainer) {
 
 TEST_F(JsonReaderTest, errorTopLevelNonObjectThrows) {
   // A top-level value that is not an object throws a clean user error for every
-  // non-object JSON shape — including null, which Hive's JsonSerDe turns into a
-  // NullPointerException. We match the spec (a clean parse error), not the bug.
+  // non-object JSON shape, including null. This is a deliberate spec choice:
+  // the contract is a clean parse error carrying a byte offset, independent of
+  // how the reference SerDe happens to fail on each shape.
   auto schema = ROW({{"a", BIGINT()}});
   for (const auto* input : {"5\n", "[1,2]\n", "\"str\"\n", "null\n"}) {
     VELOX_ASSERT_USER_THROW(read(input, schema), "JSON parse error at byte offset 0");

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <limits>
+
 #include <folly/compression/Compression.h>
 #include <folly/compression/Zlib.h>
 #include <gtest/gtest.h>
@@ -978,6 +980,88 @@ TEST_F(JsonReaderTest, splitFileWithWhitespaceOnlyLineThrows) {
   auto schema = ROW({{"id", BIGINT()}});
   std::string file = "{\"id\":0}\n   \n{\"id\":1}\n";
   VELOX_ASSERT_USER_THROW(readRange(file, schema, 0, file.size()), "empty row");
+}
+
+TEST_F(JsonReaderTest, errorMessageIncludesByteOffset) {
+  // The failing record is the third one. Each of the first two is 8 bytes
+  // ("{\"a\":N}\n"), so the third begins at byte 16. An array where BIGINT is
+  // expected is a shape mismatch, and the error must name that offset.
+  auto schema = ROW({{"a", BIGINT()}});
+  VELOX_ASSERT_USER_THROW(
+      read("{\"a\":1}\n{\"a\":2}\n{\"a\":[3]}\n", schema),
+      "JSON parse error at byte offset 16");
+}
+
+TEST_F(JsonReaderTest, errorMalformedJsonSyntax) {
+  // Malformed JSON on the second record (offset 8) surfaces simdjson's
+  // diagnostic, prefixed with the byte offset.
+  auto schema = ROW({{"a", BIGINT()}});
+  VELOX_ASSERT_USER_THROW(
+      read("{\"a\":1}\n{\"a\":}\n", schema),
+      "JSON parse error at byte offset 8");
+}
+
+TEST_F(JsonReaderTest, errorIntegerOverflowInRangeDoesNotThrow) {
+  // Coercion, not an error path: 2^63 wraps via two's complement to
+  // Long.MIN_VALUE. A regression that routed overflow to the error path
+  // would throw here.
+  auto schema = ROW({{"a", BIGINT()}});
+  auto row = read("{\"a\":9223372036854775808}\n", schema);
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(
+      row->childAt(0)->asFlatVector<int64_t>()->valueAt(0),
+      std::numeric_limits<int64_t>::min());
+}
+
+TEST_F(JsonReaderTest, errorTypeMismatchDoesNotThrow) {
+  // Coercion, not an error path: a non-numeric string into BIGINT becomes 0
+  // (full-fail to zero). A regression that threw on leaf type mismatch would
+  // fail here.
+  auto schema = ROW({{"a", BIGINT()}});
+  auto row = read("{\"a\":\"abc\"}\n", schema);
+  ASSERT_EQ(row->size(), 1);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 0);
+}
+
+TEST_F(JsonReaderTest, errorShapeMismatchThrowsForEachContainer) {
+  // A scalar where a container is expected throws for ARRAY, MAP, and ROW
+  // alike, and each error carries the byte offset.
+  VELOX_ASSERT_USER_THROW(
+      read("{\"v\":5}\n", ROW({{"v", ARRAY(BIGINT())}})),
+      "JSON parse error at byte offset 0");
+  VELOX_ASSERT_USER_THROW(
+      read("{\"v\":5}\n", ROW({{"v", MAP(VARCHAR(), BIGINT())}})),
+      "JSON parse error at byte offset 0");
+  VELOX_ASSERT_USER_THROW(
+      read("{\"v\":5}\n", ROW({{"v", ROW({{"id", BIGINT()}})}})),
+      "JSON parse error at byte offset 0");
+}
+
+TEST_F(JsonReaderTest, errorTopLevelNonObjectThrows) {
+  // A top-level value that is not an object throws a clean user error for every
+  // non-object JSON shape — including null, which Hive's JsonSerDe turns into a
+  // NullPointerException. We match the spec (a clean parse error), not the bug.
+  auto schema = ROW({{"a", BIGINT()}});
+  for (const auto* input : {"5\n", "[1,2]\n", "\"str\"\n", "null\n"}) {
+    VELOX_ASSERT_USER_THROW(read(input, schema), "JSON parse error at byte offset 0");
+  }
+}
+
+TEST_F(JsonReaderTest, errorBlankLineThrows) {
+  // A blank line after a valid record throws with the blank line's byte offset
+  // (8 — the length of the first record including its newline).
+  auto schema = ROW({{"a", BIGINT()}});
+  VELOX_ASSERT_USER_THROW(
+      read("{\"a\":1}\n\n", schema),
+      "JSON parse error at byte offset 8: encountered an empty row");
+}
+
+TEST_F(JsonReaderTest, errorWhitespaceOnlyLineThrows) {
+  // A whitespace-only line is rejected as an empty row, with its byte offset.
+  auto schema = ROW({{"a", BIGINT()}});
+  VELOX_ASSERT_USER_THROW(
+      read("{\"a\":1}\n   \n", schema),
+      "JSON parse error at byte offset 8: encountered an empty row");
 }
 
 // Records exercising several leaf types so decompression is verified to feed

--- a/velox/dwio/json/tests/reader/JsonReaderTest.cpp
+++ b/velox/dwio/json/tests/reader/JsonReaderTest.cpp
@@ -25,7 +25,10 @@
 #include "velox/common/file/File.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/Mutation.h"
+#include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/json/RegisterJsonReader.h"
+#include "velox/type/Filter.h"
 #include "velox/type/Timestamp.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -213,6 +216,117 @@ TEST_F(JsonReaderTest, emptyFileReturnsZeroRows) {
 
   VectorPtr result;
   EXPECT_EQ(rowReader->next(10, result), 0);
+}
+
+TEST_F(JsonReaderTest, scanSpecWithoutFilterIsAccepted) {
+  // Connectors attach a scan spec to every scan. One that only names columns
+  // asks for nothing the reader cannot do, so it must not be rejected.
+  auto schema = ROW({{"a", BIGINT()}});
+  auto factory = dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileSchema(schema);
+
+  auto readFile =
+      std::make_shared<InMemoryReadFile>(std::string{"{\"a\":1}\n{\"a\":2}\n"});
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      readerOptions);
+
+  auto spec = std::make_shared<velox::common::ScanSpec>("<root>");
+  spec->addFieldRecursively("a", *BIGINT(), 0);
+  dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(spec);
+
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+  VectorPtr result;
+  EXPECT_EQ(rowReader->next(10, result), 2);
+}
+
+TEST_F(JsonReaderTest, scanSpecWithFilterThrows) {
+  // Filter pushdown is not implemented. Accepting a filter and then not
+  // applying it would hand back rows the caller asked to have removed, with
+  // nothing to signal it, so an unhonored filter is refused instead.
+  auto schema = ROW({{"a", BIGINT()}});
+  auto factory = dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileSchema(schema);
+
+  auto readFile =
+      std::make_shared<InMemoryReadFile>(std::string{"{\"a\":1}\n{\"a\":2}\n"});
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      readerOptions);
+
+  auto spec = std::make_shared<velox::common::ScanSpec>("<root>");
+  spec->addFieldRecursively("a", *BIGINT(), 0);
+  spec->childByName("a")->setFilter(
+      velox::common::createBigintValues({2}, false));
+  dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(spec);
+
+  VELOX_ASSERT_USER_THROW(
+      reader->createRowReader(rowReaderOptions),
+      "JSON reader does not support filter pushdown");
+}
+
+TEST_F(JsonReaderTest, mutationWithDeletedRowsThrows) {
+  // Row-level deletes are not honored. As with a filter, silently returning a
+  // deleted row is worse than refusing the read.
+  auto schema = ROW({{"a", BIGINT()}});
+  auto factory = dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileSchema(schema);
+
+  auto readFile =
+      std::make_shared<InMemoryReadFile>(std::string{"{\"a\":1}\n{\"a\":2}\n"});
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      readerOptions);
+  auto rowReader = reader->createRowReader(dwio::common::RowReaderOptions{});
+
+  // Marks row 0 deleted.
+  uint64_t deletedRows{1};
+  dwio::common::Mutation mutation;
+  mutation.deletedRows = &deletedRows;
+
+  VectorPtr result;
+  VELOX_ASSERT_USER_THROW(
+      rowReader->next(10, result, &mutation),
+      "JSON reader does not support row-level deletes");
+
+  // A mutation carrying no deletions asks for nothing and is accepted.
+  dwio::common::Mutation empty;
+  EXPECT_EQ(rowReader->next(10, result, &empty), 2);
+}
+
+TEST_F(JsonReaderTest, shortBatchShrinksChildVectors) {
+  // next() is asked for more rows than the file holds. Every child must be
+  // trimmed to the number of rows actually read; leaving children at the
+  // requested batch size exposes trailing rows that were never written but
+  // are not marked null, which any consumer iterating a child by its own
+  // size() would read as real data.
+  auto schema = ROW({{"a", BIGINT()}, {"b", ARRAY(BIGINT())}});
+  auto factory = dwio::common::getReaderFactory(dwio::common::FileFormat::JSON);
+
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setFileSchema(schema);
+
+  auto readFile = std::make_shared<InMemoryReadFile>(
+      std::string{"{\"a\":1,\"b\":[1,2]}\n{\"a\":2,\"b\":[3]}\n"});
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      readerOptions);
+  auto rowReader = reader->createRowReader(dwio::common::RowReaderOptions{});
+
+  VectorPtr result;
+  ASSERT_EQ(rowReader->next(1'000, result), 2);
+  auto* row = result->as<RowVector>();
+  ASSERT_EQ(row->size(), 2);
+  EXPECT_EQ(row->childAt(0)->size(), 2);
+  EXPECT_EQ(row->childAt(1)->size(), 2);
 }
 
 TEST_F(JsonReaderTest, parseSingleBigint) {
@@ -599,6 +713,32 @@ TEST_F(JsonReaderTest, parseDateDefaultFormat) {
 TEST_F(JsonReaderTest, parseDateCustomFormat) {
   dwio::common::JsonSerDeOptions options;
   options.dateFormat = "MM/dd/yyyy";
+  auto row = read("{\"a\":\"03/15/2021\"}\n", ROW({{"a", DATE()}}), options);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int32_t>()->valueAt(0), 18701);
+}
+
+TEST_F(JsonReaderTest, parseDateHonorsTimezoneOffset) {
+  // A format carrying a timezone token means the value names an instant, not a
+  // wall-clock date, so it must be normalized to UTC before the day number is
+  // taken — exactly as the TIMESTAMP path does. Local midnight at +14:00 is
+  // 10:00 UTC on the *previous* day, so this is 2021-03-14 (18700), not
+  // 2021-03-15 (18701).
+  dwio::common::JsonSerDeOptions options;
+  options.dateFormat = "yyyy-MM-dd ZZ";
+  auto row =
+      read("{\"a\":\"2021-03-15 +14:00\"}\n", ROW({{"a", DATE()}}), options);
+  EXPECT_EQ(row->childAt(0)->asFlatVector<int32_t>()->valueAt(0), 18700);
+}
+
+TEST_F(JsonReaderTest, parseDateComputedFormatOutlivesItsSource) {
+  // A caller that builds the pattern at runtime — as a connector reading it
+  // out of table properties does — must not have to keep the source string
+  // alive until the read. JsonSerDeOptions has to own its format strings.
+  dwio::common::JsonSerDeOptions options;
+  {
+    std::string computed = fmt::format("{}/dd/{}", "MM", "yyyy");
+    options.dateFormat = computed;
+  }
   auto row = read("{\"a\":\"03/15/2021\"}\n", ROW({{"a", DATE()}}), options);
   EXPECT_EQ(row->childAt(0)->asFlatVector<int32_t>()->valueAt(0), 18701);
 }


### PR DESCRIPTION
Json reader support split into 13 commits (11 main commits and 2 coverage + bug fixes)

## Summary

Adds a reader for the JSON file format to the `dwio` reader stack, so a table declared over line-delimited JSON files can be read into typed Velox vectors. Registers a `JsonReaderFactory` for the existing `FileFormat::JSON`, alongside the DWRF, Parquet, ORC, Nimble, and Text readers.

JSON has no embedded schema, so the requested `RowType` drives the read: object keys are matched to column names (case-insensitively), keys absent from the schema are ignored, and columns absent from a record are left NULL. The reader consumes JSON Lines — one complete JSON object per line — which is the shape that can be split and read in parallel. A file holding a single top-level JSON array is rejected rather than partially read.

## Reference implementation

Behavior matches `org.apache.hadoop.hive.serde2.JsonSerDe` as of **Hive 4.0.0**. Both halves of that pin are load-bearing, because "the Hive JSON SerDe" is ambiguous in two different directions:

Hive ships two similarly named classes that disagree on type mismatch. Through Hive 3.1, `org.apache.hive.hcatalog.data.JsonSerDe` reads the token stream with Jackson's strict numeric accessors and fails the query when a value's JSON type does not match its column type, whereas serde2's builds a Jackson document and coerces through `JsonNode.asLong()`/`asBoolean()`/`asText()`, which fall back to a default. From Hive 4.0.0 the HCatalog class became a thin wrapper delegating to serde2, so at that version the two names agree; the divergence only exists against Hive 3.x and earlier. This reader follows serde2.

Hive has also since changed the BOOLEAN and BINARY leaf rules on its development branch, so "serde2" alone would be underspecified. Divergences are tracked against 4.0.0 specifically.

## Semantics

The coercion rule is narrower than "always be lenient", and the boundary is deliberate:

- **Leaf type mismatches coerce silently**, matching `JsonNode` accessor defaults. A non-numeric string into `BIGINT` becomes `0` — a full fail to the default, not a partial parse, so `"12abc"` is also `0`, not `12`. `DECIMAL` has no zero-like default in Jackson and becomes NULL instead.
- **Container shape mismatches throw.** A scalar or the wrong container where `ARRAY`, `MAP`, or `ROW` is declared is a hard error, because there is no defensible default value for a container.

There is no lenient mode that skips bad records: every error that is raised throws. That is why `JsonSerDeOptions` carries no leniency toggle.

## What is supported

**Types.** `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`, `REAL`, `DOUBLE`, `BOOLEAN`, `VARCHAR`, `VARBINARY` (base64), `DECIMAL` (short and long), `DATE`, `TIMESTAMP`, and `ARRAY`, `MAP`, `ROW` nested to arbitrary depth. Anything else raises `VELOX_NYI` naming the type.

**Temporal parsing.** `DATE` and `TIMESTAMP` are parsed from JSON strings using Joda-style patterns supplied via `ReaderOptions::setJsonSerDeOptions()`, defaulting to `yyyy-MM-dd` and `yyyy-MM-dd HH:mm:ss`. A pattern carrying a timezone token names an instant rather than a wall-clock reading, so the parsed value is normalized to UTC; inputs without one are interpreted as UTC.

**Splits.** A row reader created for `[offset, offset + length)` processes exactly the records whose starting byte falls in that range, following the Presto/Hive line-split convention: the record straddling the upper boundary is read in full here and skipped by the next split via its leading partial-line skip. Concatenating splits that tile a file reproduces a whole-file read with no dropped or duplicated records.

**Compression.** `.gz`, `.deflate`, and `.zst` are inferred from the file extension. Compressed files are not byte-addressable and therefore cannot be split: the split at offset 0 decompresses and reads the whole file and later splits read nothing, which preserves correctness under a splitting engine. `.lz4`, `.lzo`, and `.snappy` are rejected explicitly rather than silently misread as plain text.

**Errors.** Parse failures report the record's byte offset into the (decompressed) stream rather than a line number, since line numbers are ambiguous once a file is split.

## Testing

116 tests in `velox/dwio/json/tests/reader/JsonReaderTest.cpp`, all passing. Beyond per-type happy paths, they pin the behavior that is easy to regress: the full-fail-to-default coercion rule and its container-shape counterpart; duplicate-key last-write-wins including the null, case, and container-value interactions; JSON `null` versus empty container versus absent field; an exhaustive split sweep over every boundary of a fixture file, including boundaries landing inside a multi-byte UTF-8 sequence and inside a JSON string literal; and byte-identical output for each supported codec against its uncompressed equivalent.

```bash
cd _build/release && ninja velox_json_reader_test
./_build/release/velox/dwio/json/tests/reader/velox_json_reader_test
```

## Out of scope for v1

- **Filter pushdown and column projection.** Projection is ignored — `next()` materializes the full file schema, which the caller can see in the result's type. A filter cannot be ignored the same way, because the rows it asked to remove would come back with nothing signalling the request was dropped, so a scan spec carrying a filter is refused at construction. Likewise a mutation carrying row-level deletions throws in `next()`. Callers needing either must apply them above this reader.
- **`SimpleDateFormat` pattern parity.** Only Joda-style patterns are accepted.
- **Writing.** Read path only.
- **`VARCHAR` text form for JSON numbers.** The reference stringifies through `JsonNode.asText()` on a `DoubleNode`, i.e. Java's `String.valueOf(double)`, so `1e3` reads back as `"1000.0"`; this reader emits the original lexeme. The semantic numeric value is preserved; only the textual representation differs.

## Known follow-ups

Two pieces of connector plumbing are intentionally not in this PR, and the reader is not reachable from a query plan without them:

- `registerJsonReaderFactory()` is currently called only from this suite; no connector or runner setup path calls it, so the format resolves to no reader factory at scan time.
- Nothing populates `ReaderOptions::setJsonSerDeOptions()` from table properties, so a table declaring custom temporal formats would silently get the defaults.

Separately, each row reader currently loads the whole file into memory and then windows to its split, making a multi-split scan O(splits × fileSize) in bytes read and resident memory. Correct, but worth narrowing to the split's byte range before this is used on large objects in remote storage.

## Compatibility

Additive only. `velox/dwio/common/Options.h` gains a `JsonSerDeOptions` struct and a paired setter/getter on `ReaderOptions`; no existing declaration changes. `FileFormat::JSON` already existed. All other files are new.
