### PR TITLE
feat(functions): Support named rows in simple UDFs (#18934)

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -390,7 +390,8 @@ struct TypeAnalysis<Row<T...>> {
   using child_types = std::tuple<T...>;
 
   template <size_t N>
-  using child_type_at = typename std::tuple_element<N, child_types>::type;
+  using child_type_at =
+      FieldType<typename std::tuple_element<N, child_types>::type>;
 
   void run(TypeAnalysisResults& results) {
     results.stats.concreteCount++;
@@ -404,12 +405,23 @@ struct TypeAnalysis<Row<T...>> {
             results.out << ", ";
           }
           first = false;
-          TypeAnalysis<T>().run(results);
+          if constexpr (FieldTraits<T>::hasName) {
+            results.out << '"';
+            for (const auto character : FieldTraits<T>::name) {
+              if (character == '"') {
+                results.out << '"';
+              }
+              results.out << character;
+            }
+            results.out << "\" ";
+          }
+          TypeAnalysis<FieldType<T>>().run(results);
           fieldTypes.push_back(results.physicalType);
         }(),
         ...);
     results.out << ")";
-    results.physicalType = ROW(std::move(fieldTypes));
+    results.physicalType =
+        ROW({std::string(FieldTraits<T>::name)...}, std::move(fieldTypes));
   }
 };
 

--- a/velox/core/tests/TypeAnalysisTest.cpp
+++ b/velox/core/tests/TypeAnalysisTest.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <type_traits>
+
 #include "velox/core/SimpleFunctionMetadata.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/types/JsonType.h"
@@ -194,6 +196,10 @@ TEST_F(TypeAnalysisTest, testStringType) {
   testStringType<Array<int32_t>>({"array(integer)"});
   testStringType<Map<Any, int32_t>>({"map(any, integer)"});
   testStringType<Row<int32_t, int32_t>>({"row(integer, integer)"});
+  using NamedRow = Row<Field<"x", int32_t>, Field<"y", int32_t>>;
+  static_assert(
+      std::is_same_v<TypeAnalysis<NamedRow>::child_type_at<0>, int32_t>);
+  testStringType<NamedRow>({"row(\"x\" integer, \"y\" integer)"});
 
   testStringType<Any>({"any"});
   testStringType<Generic<T1>>({"__user_T1"});
@@ -405,6 +411,8 @@ TEST_F(TypeAnalysisTest, physicalType) {
 
   testPhysicalType<Row<int32_t, Array<double>, Variadic<bool>>>(
       ROW({INTEGER(), ARRAY(DOUBLE()), BOOLEAN()}));
+  testPhysicalType<Row<Field<"x", int32_t>, Field<"y", int32_t>>>(
+      ROW({{"x", INTEGER()}, {"y", INTEGER()}}));
 
   testPhysicalType<Json>(VARCHAR());
   testPhysicalType<Array<Json>>(ARRAY(VARCHAR()));

--- a/velox/expression/CastTypeChecker.h
+++ b/velox/expression/CastTypeChecker.h
@@ -69,8 +69,8 @@ struct CastTypeChecker<Row<T...>> {
   static bool check(const TypePtr& vectorType) {
     int index = 0;
     return TypeKind::ROW == vectorType->kind() &&
-        (CastTypeChecker<T>::check(vectorType->childAt(index++)) && ... &&
-         true);
+        (CastTypeChecker<FieldType<T>>::check(vectorType->childAt(index++)) &&
+         ... && true);
   }
 };
 

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1034,7 +1034,7 @@ struct HasGeneric<Array<V>> {
 template <typename... T>
 struct HasGeneric<Row<T...>> {
   static constexpr bool value() {
-    return (HasGeneric<T>::value() || ...);
+    return (HasGeneric<FieldType<T>>::value() || ...);
   }
 };
 
@@ -1063,7 +1063,7 @@ struct AllGenericExceptTop<Map<K, V>> {
 template <typename... T>
 struct AllGenericExceptTop<Row<T...>> {
   static constexpr bool value() {
-    return (isGenericType<T>::value && ...);
+    return (isGenericType<FieldType<T>>::value && ...);
   }
 };
 

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -89,9 +89,9 @@ struct resolver<Map<K, V>> {
 
 template <typename... T>
 struct resolver<Row<T...>> {
-  using in_type = NullableRowView<T...>;
-  using null_free_in_type = NullFreeRowView<T...>;
-  using out_type = RowWriter<T...>;
+  using in_type = NullableRowView<FieldType<T>...>;
+  using null_free_in_type = NullFreeRowView<FieldType<T>...>;
+  using out_type = RowWriter<FieldType<T>...>;
 };
 
 template <typename V>

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -467,6 +467,9 @@ struct VectorReader<Row<T...>> {
   using exec_in_t = typename VectorExec::resolver<Row<T...>>::in_type;
   using exec_null_free_in_t =
       typename VectorExec::template resolver<Row<T...>>::null_free_in_type;
+  template <typename U>
+  using field_reader_t = std::unique_ptr<VectorReader<FieldType<U>>>;
+  using child_readers_t = std::tuple<field_reader_t<T>...>;
 
   explicit VectorReader(const DecodedVector* decoded)
       : decoded_(*decoded),
@@ -536,17 +539,17 @@ struct VectorReader<Row<T...>> {
 
  private:
   template <size_t... I>
-  std::tuple<std::unique_ptr<VectorReader<T>>...> prepareChildReaders(
+  child_readers_t prepareChildReaders(
       const in_vector_t& vector,
       std::index_sequence<I...>) {
-    return {std::make_unique<VectorReader<T>>(
+    return {std::make_unique<VectorReader<FieldType<T>>>(
         detail::decode(childrenDecoders_[I], *vector_.childAt(I)))...};
   }
 
   const DecodedVector& decoded_;
   const in_vector_t& vector_;
   std::vector<DecodedVector> childrenDecoders_;
-  std::tuple<std::unique_ptr<VectorReader<T>>...> childReaders_;
+  child_readers_t childReaders_;
 };
 
 template <typename T>

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -251,7 +251,7 @@ struct VectorWriter<Map<K, V>> : public VectorWriterBase {
 
 template <typename... T>
 struct VectorWriter<Row<T...>> : public VectorWriterBase {
-  using children_types = std::tuple<T...>;
+  using children_types = std::tuple<FieldType<T>...>;
   using vector_t = typename TypeToFlatVector<Row<T...>>::type;
   using exec_out_t = typename VectorExec::resolver<Row<T...>>::out_type;
 
@@ -348,7 +348,7 @@ struct VectorWriter<Row<T...>> : public VectorWriterBase {
     }
   }
 
-  RowWriter<T...> writer_{};
+  exec_out_t writer_{};
   vector_t* rowVector_ = nullptr;
 };
 

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -359,6 +359,30 @@ TEST_F(SimpleFunctionTest, rowReader) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(SimpleFunctionTest, namedRow) {
+  registerFunction<
+      RowWriterFunction,
+      Row<Field<"first", int64_t>, Field<"second", double>>,
+      int64_t>({"named_row_writer_func"});
+  registerFunction<
+      RowReaderFunction,
+      int64_t,
+      Row<Field<"first", int64_t>, Field<"second", double>>>(
+      {"named_row_reader_func"});
+
+  const auto input = makeRowVector({makeFlatVector<int64_t>(
+      rowVectorCol1.size(), [](auto row) { return row; })});
+  const auto namedRow = evaluate<RowVector>("named_row_writer_func(c0)", input);
+  EXPECT_EQ(
+      namedRow->type()->asRow().names(),
+      std::vector<std::string>({"first", "second"}));
+
+  assertEqualVectors(
+      vectorMaker_.flatVector(rowVectorCol1),
+      evaluate<FlatVector<int64_t>>(
+          "named_row_reader_func(c0)", makeRowVector({namedRow})));
+}
+
 // Function that takes a tuple of an array and a double.
 template <typename T>
 struct RowArrayReaderFunction {

--- a/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
@@ -36,7 +36,7 @@ void registerSimpleBingTileFunctions(const std::string& prefix) {
       {prefix + "bing_tile_zoom_level"});
   registerFunction<
       BingTileCoordinatesFunction,
-      Row<int32_t, int32_t>,
+      Row<Field<"x", int32_t>, Field<"y", int32_t>>,
       BingTile>({prefix + "bing_tile_coordinates"});
 
   // Parent/child tiles

--- a/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
@@ -276,6 +276,17 @@ TEST_F(BingTileFunctionsTest, bingTileCoordinates) {
   testBingTileCoordinates(1, 1, std::nullopt);
 }
 
+TEST_F(BingTileFunctionsTest, bingTileCoordinatesFieldNames) {
+  auto input = makeSingleXYZoomRow(127, 11, 8);
+
+  assertEqualVectors(
+      makeFlatVector<int32_t>({127}),
+      evaluate("bing_tile_coordinates(bing_tile(c0, c1, c2)).x", input));
+  assertEqualVectors(
+      makeFlatVector<int32_t>({11}),
+      evaluate("bing_tile_coordinates(bing_tile(c0, c1, c2)).y", input));
+}
+
 TEST_F(BingTileFunctionsTest, bingTileParentNoZoom) {
   const auto testBingTileParent = [&](std::optional<int32_t> x,
                                       std::optional<int32_t> y,

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -61,7 +61,9 @@ struct CppToType<Array<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
 template <typename... T>
 struct CppToType<Row<T...>> : public TypeTraits<TypeKind::ROW> {
   static auto create() {
-    return ROW({CppToType<T>::create()...});
+    return ROW(
+        {std::string(FieldTraits<T>::name)...},
+        {CppToType<FieldType<T>>::create()...});
   }
 };
 
@@ -189,10 +191,11 @@ struct MaterializeType<Map<K, V>> {
 
 template <typename... T>
 struct MaterializeType<Row<T...>> {
-  using nullable_t =
-      std::tuple<std::optional<typename MaterializeType<T>::nullable_t>...>;
+  using nullable_t = std::tuple<
+      std::optional<typename MaterializeType<FieldType<T>>::nullable_t>...>;
 
-  using null_free_t = std::tuple<typename MaterializeType<T>::null_free_t...>;
+  using null_free_t =
+      std::tuple<typename MaterializeType<FieldType<T>>::null_free_t...>;
   static constexpr bool requiresMaterialization = true;
 };
 

--- a/velox/type/SimpleFunctionTags.h
+++ b/velox/type/SimpleFunctionTags.h
@@ -18,9 +18,11 @@
 /// Tag types naming the argument and return types of simple functions.
 /// SimpleFunctionApi.h maps these onto the runtime type system.
 
+#include <array>
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 
@@ -176,16 +178,87 @@ struct Array {
 template <typename ELEMENT>
 using ArrayWriterT = Array<ELEMENT>;
 
+/// Holds a string literal for use as a non-type template parameter.
+template <size_t N>
+struct FixedStringLiteral {
+  char value[N]{};
+
+  explicit(false) constexpr FixedStringLiteral(const char (&input)[N]) {
+    for (size_t i = 0; i < N; ++i) {
+      value[i] = input[i];
+    }
+  }
+
+  constexpr std::string_view view() const {
+    return {value, N - 1};
+  }
+};
+
+template <size_t N>
+FixedStringLiteral(const char (&)[N]) -> FixedStringLiteral<N>;
+
+/// Associates a field name with a type in a Row simple-function signature.
+template <FixedStringLiteral Name, typename T>
+struct Field {
+  using type = T;
+  static constexpr std::string_view name = Name.view();
+
+ private:
+  Field() {}
+};
+
+template <typename T>
+struct FieldTraits {
+  using type = T;
+  static constexpr bool hasName = false;
+  static constexpr std::string_view name{""};
+};
+
+template <FixedStringLiteral Name, typename T>
+struct FieldTraits<Field<Name, T>> {
+  using type = T;
+  static constexpr bool hasName = true;
+  static constexpr std::string_view name = Name.view();
+};
+
+template <typename T>
+using FieldType = typename FieldTraits<T>::type;
+
 template <typename... T>
 struct Row {
   template <size_t idx>
-  using type_at = typename std::tuple_element<idx, std::tuple<T...>>::type;
+  using type_at =
+      FieldType<typename std::tuple_element<idx, std::tuple<T...>>::type>;
 
   static const size_t size_ = sizeof...(T);
 
   static_assert(
-      std::conjunction<std::bool_constant<!isVariadicType<T>::value>...>::value,
+      std::conjunction<
+          std::bool_constant<!isVariadicType<FieldType<T>>::value>...>::value,
       "Struct fields cannot be Variadic");
+  static_assert(
+      (FieldTraits<T>::hasName && ...) || (!FieldTraits<T>::hasName && ...),
+      "Struct fields must be either all named or all unnamed");
+  static_assert(
+      ((!FieldTraits<T>::hasName || !FieldTraits<T>::name.empty()) && ...),
+      "Struct field names cannot be empty");
+  static_assert(
+      [] {
+        constexpr std::array<std::string_view, sizeof...(T)> names{
+            FieldTraits<T>::name...};
+        for (size_t i = 0; i < names.size(); ++i) {
+          if (names[i].empty()) {
+            continue;
+          }
+          for (size_t j = i + 1; j < names.size(); ++j) {
+            if (names[i] == names[j]) {
+              return false;
+            }
+          }
+        }
+        return true;
+      }(),
+      "Struct field names must be unique");
 
  private:
   Row() {}


### PR DESCRIPTION
Summary:

Simple functions can now declare named row fields with `Row<Field<"x", int32_t>, ...>`. This enables dereferences such as `bing_tile_coordinates(...).x`, which previously failed because the function returned `row(integer, integer)`.

`Field` retains the compile-time field name while readers and writers operate on its underlying type. Register `bing_tile_coordinates` as `row(x integer, y integer)` to match Presto.

Reviewed By: Yuhta

Differential Revision: D119436922


