### PR TITLE
build(ci): Always build gflags and glog in release mode

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -86,7 +86,10 @@ function install_gflags {
   # Remove an older version if present.
   dnf remove -y gflags
   wget_and_untar https://github.com/gflags/gflags/archive/"${GFLAGS_VERSION}".tar.gz gflags
-  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON
+  # Always Release. A Debug gflags installs as libgflags_debug.so instead of
+  # libgflags.so, so a binary linked against it will not start in an image that
+  # has the Release build. We never need to debug into gflags itself.
+  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DCMAKE_BUILD_TYPE=Release
   # CentOS 9 does not include ${INSTALL_PREFIX}/lib in the default ldconfig
   # search paths. Register it so that downstream builds (e.g. fbthrift's
   # thrift1 compiler) can find libgflags.so at runtime.

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -224,7 +224,10 @@ function install_re2 {
 
 function install_glog {
   wget_and_untar https://github.com/google/glog/archive/"${GLOG_VERSION}".tar.gz glog
-  cmake_install_dir glog -DBUILD_SHARED_LIBS=ON
+  # Always Release. A Debug glog installs as libglogd.so instead of libglog.so,
+  # so a binary linked against it will not start in an image that has the
+  # Release build. We never need to debug into glog itself.
+  cmake_install_dir glog -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
 }
 
 function install_lzo {

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -111,7 +111,8 @@ function install_velox_deps_from_brew {
 
 function install_gflags {
   wget_and_untar https://github.com/gflags/gflags/archive/"${GFLAGS_VERSION}".tar.gz gflags
-  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON
+  # Always Release; see the note in setup-centos9.sh.
+  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DCMAKE_BUILD_TYPE=Release
 }
 
 function install_s3 {

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -83,7 +83,8 @@ function install_gflags {
   # Remove an older version if present.
   dnf remove -y gflags
   wget_and_untar https://github.com/gflags/gflags/archive/"${GFLAGS_VERSION}".tar.gz gflags
-  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64
+  # Always Release; see the note in setup-centos9.sh.
+  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64 -DCMAKE_BUILD_TYPE=Release
 }
 
 function install_cuda {


### PR DESCRIPTION
gflags and glog rename themselves in Debug builds: `libgflags.so` becomes
`libgflags_debug.so`, `libglog.so` becomes `libglogd.so`.

We compile the fuzzers in one image and run them in another, so when the
compile image moved to Debug dependencies the run jobs stopped starting:

    error while loading shared libraries: libgflags_debug.so.2.3

So build both as Release, always. We never debug into either one, and they're
the only two dependencies that rename like this.

Has to merge and the images rebuilt before #18905 can pass.
