### PR TITLE
fix: Remove extra format placeholder in freeCapacityLocked

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -1477,7 +1477,7 @@ void SharedArbitrator::freeCapacityLocked(
   if (FOLLY_UNLIKELY(
           freeNonReservedCapacity_ + freeReservedCapacity_ > capacity_)) {
     VELOX_FAIL(
-        "Free capacity {}/{} is larger than the max capacity {}, {}",
+        "Free capacity {}/{} is larger than the max capacity {}",
         succinctBytes(freeNonReservedCapacity_),
         succinctBytes(freeReservedCapacity_),
         succinctBytes(capacity_));


### PR DESCRIPTION
The format string has four '{}' placeholders but only three arguments.
If the check fires, fmt::vformat throws format_error("argument not
found") instead of building the intended VeloxRuntimeError.