### PR TITLE
fix(expression): Rescale a decimal bound to a shared type variable (#18945)

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -115,6 +115,23 @@ bool checkNamedRowField(
   return true;
 }
 
+// The coercion that takes 'actualType' to 'boundType', the type a variable
+// resolved to across every argument sharing it.
+//
+// Two DECIMALs of different precision or scale are different types that share
+// a name, which the coercer reports as interchangeable at no cost. Reaching
+// the bound type still means rescaling the value, so say so here.
+std::optional<Coercion> coerceToBoundType(
+    const TypeCoercer& coercer,
+    const TypePtr& actualType,
+    const TypePtr& boundType) {
+  if (actualType->isDecimal() && boundType->isDecimal() &&
+      !actualType->equivalent(*boundType)) {
+    return Coercion{.type = boundType, .cost = 1};
+  }
+  return coercer.coerce(actualType, boundType);
+}
+
 } // namespace
 
 bool SignatureBinder::tryBindWithCoercions(std::vector<Coercion>& coercions) {
@@ -189,7 +206,8 @@ bool SignatureBinder::tryBind(
           }
 
           for (auto i = numFormalArgs; i < numActualTypes; i++) {
-            if (auto coercion = coercer_.coerce(actualTypes_[i], firstType)) {
+            if (auto coercion =
+                    coerceToBoundType(coercer_, actualTypes_[i], firstType)) {
               if (coercion->cost > 0) {
                 coercions[i] = Coercion{firstType, coercion->cost};
               }
@@ -287,7 +305,8 @@ std::optional<bool> SignatureBinderBase::checkSetTypeVariable(
     VELOX_CHECK(bindingIt != typeVariablesBindings_.end());
 
     const auto& boundType = bindingIt->second;
-    const auto availableCoercion = coercer_.coerce(actualType, boundType);
+    const auto availableCoercion =
+        coerceToBoundType(coercer_, actualType, boundType);
     VELOX_CHECK(availableCoercion.has_value());
 
     if (availableCoercion->cost > 0) {

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -2022,6 +2022,63 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
   }
 }
 
+// Two DECIMALs of different precision or scale bound to one type variable, as
+// the comparison functions declare (`boolean(T, T)`). The type system
+// reconciles them through LongDecimalType::commonSuperType, so the pair binds
+// and the narrower argument is coerced.
+TEST(SignatureBinderTest, decimalPairOnOneTypeVariable) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("T")
+                       .returnType("boolean")
+                       .argumentType("T")
+                       .argumentType("T")
+                       .build();
+
+  // Same backing type, different scale.
+  {
+    std::vector<TypePtr> actualTypes{DECIMAL(18, 2), DECIMAL(18, 4)};
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
+    std::vector<Coercion> coercions;
+    ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+    // 16 integral digits and 4 fractional ones hold both.
+    VELOX_ASSERT_EQ_TYPES(coercions[0].type, DECIMAL(20, 4));
+    VELOX_ASSERT_EQ_TYPES(coercions[1].type, DECIMAL(20, 4));
+  }
+
+  // The variadic tail reconciles the same way.
+  {
+    auto variadic = exec::FunctionSignatureBuilder()
+                        .typeVariable("T")
+                        .returnType("boolean")
+                        .argumentType("T")
+                        .variableArity("T")
+                        .build();
+    std::vector<TypePtr> actualTypes{
+        DECIMAL(18, 2), DECIMAL(18, 4), DECIMAL(20, 1)};
+    exec::SignatureBinder binder(
+        *variadic, actualTypes, TypeCoercer::defaults());
+    std::vector<Coercion> coercions;
+    ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+    // 19 integral digits and 4 fractional ones hold all three.
+    VELOX_ASSERT_EQ_TYPES(coercions[0].type, DECIMAL(23, 4));
+    VELOX_ASSERT_EQ_TYPES(coercions[1].type, DECIMAL(23, 4));
+    VELOX_ASSERT_EQ_TYPES(coercions[2].type, DECIMAL(23, 4));
+  }
+
+  // Different backing types: DECIMAL(18, 2) is BIGINT, DECIMAL(38, 2) is
+  // HUGEINT, which is what a join sees as mismatched key kinds.
+  {
+    std::vector<TypePtr> actualTypes{DECIMAL(38, 2), DECIMAL(18, 2)};
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
+    std::vector<Coercion> coercions;
+    ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+    ASSERT_EQ(coercions[0].type, nullptr);
+    VELOX_ASSERT_EQ_TYPES(coercions[1].type, DECIMAL(38, 2));
+  }
+}
+
 TEST(SignatureBinderTest, aggregateUnknownArgTieStaysAmbiguous) {
   // Aggregate mirror of the scalar cardinality(null) carve-out: aggregate and
   // window signatures don't model null-on-null, so an UNKNOWN argument matching


### PR DESCRIPTION
Summary:

Comparing two DECIMALs of different precision or scale does not resolve:

    SELECT CAST(1 AS DECIMAL(18,2)) = CAST(1 AS DECIMAL(18,4))

    Scalar function eq not registered with arguments:
    (DECIMAL(18, 2), DECIMAL(18, 4))

Comparisons declare `boolean(T, T)`, so both arguments bind one type variable. `SignatureBinder` settles such a variable across all the arguments first, widening it through `leastCommonSuperType`, which reconciles two decimals via `LongDecimalType::commonSuperType`. That part works: the pair binds, and the variable holds a type wide enough for both.

What was missing is the cast. The second pass, which records what each argument needs to reach the bound type, asks `TypeCoercer::coerce`, and that short-circuits on matching type names — deliberately, since DECIMAL to DECIMAL is the type system's business rather than a dialect rule. So it answers "interchangeable, no cost" for two decimals that are not, no coercion is recorded, and the caller emits a comparison over mismatched decimals. Nothing rejects that expression until it is compiled, or until a join notices its key types have different backing kinds:

    (HUGEINT vs. BIGINT) Join key types on the left and right sides must match

The binder now says what reaching the bound type costs when both types are decimals and they differ, in the shared helper both the fixed and the variadic argument paths use.

The rescale is priced at 1, the same as DECIMAL to REAL. An overload set offering a decimal form and a real form of the same function would now tie where it did not before; I did not find one, and a lower price would make the decimal form always win, which is what Presto does.

Differential Revision: D119534190
