### PR TITLE
fix(gpu): Add missing includes for CUDA 13 (#18947)

### DIFF
--- a/velox/experimental/gpu/tests/BlockingQueueTest.cu
+++ b/velox/experimental/gpu/tests/BlockingQueueTest.cu
@@ -17,7 +17,10 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <algorithm>
+#include <atomic>
+#include <cuda/atomic> // @manual
 #include <mutex>
+#include <thread>
 #include "velox/experimental/gpu/BlockingQueue.h"
 #include "velox/experimental/gpu/Common.h"
 

--- a/velox/experimental/gpu/tests/DependencyWatchTest.cu
+++ b/velox/experimental/gpu/tests/DependencyWatchTest.cu
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <cuda/atomic> // @manual
+#include <thread>
 #include "velox/experimental/gpu/Common.h"
 
 DEFINE_int32(grid_size, 1024, "");


### PR DESCRIPTION
Summary:

The `velox/experimental/gpu` tests did not compile against CUDA 13:

    BlockingQueueTest.cu(83): error: namespace "std" has no member "atomic_int64_t"
    BlockingQueueTest.cu(198): error: namespace "cuda" has no member "atomic"
    DependencyWatchTest.cu(64): error: name followed by "::" must be a class or namespace name

Both files use `std::thread`, `std::atomic_int64_t` and `cuda::atomic` without including `<thread>`, `<atomic>` or `<cuda/atomic>`. The CUDA 12 toolkit headers pulled those in transitively; the CUDA 13 ones no longer do.

Differential Revision: D119540840


