### PR TITLE
refactor(sequence): Migrate Sequence Storage callers off nimble kLegacy (#18948)

### DIFF
--- a/velox/dwio/nimble/serializer/Options.h
+++ b/velox/dwio/nimble/serializer/Options.h
@@ -280,9 +280,12 @@ struct SerializerOptions {
 
 struct DeserializerOptions {
   /// Whether the serialized data has a header byte.
-  /// - false (default): Legacy format (version 0) with no header.
-  /// - true: Version is auto-detected from the first byte of serialized data.
-  bool hasHeader{false};
+  /// - false: Legacy format (version 0) with no header. Retained for callers
+  ///   still reading pre-header raw payloads during the kLegacy deprecation.
+  /// - true (default): Version is auto-detected from the first byte of
+  ///   serialized data. Matches every current writer; callers that used to
+  ///   set this explicitly no longer need to.
+  bool hasHeader{true};
 
   /// Output type for deserializing flatmap columns as struct (ROW).
   /// When provided, each top-level flatmap column whose corresponding field in

--- a/velox/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -111,7 +111,7 @@ TEST(OptionsTest, serializerOptionsWithFlatMapColumns) {
 TEST(OptionsTest, deserializerOptionsDefaults) {
   DeserializerOptions options{};
 
-  EXPECT_FALSE(options.hasHeader);
+  EXPECT_TRUE(options.hasHeader);
   EXPECT_EQ(options.decodeExecutor, nullptr);
   EXPECT_EQ(options.maxDecodeParallelism, 0u);
   EXPECT_TRUE(options.decodePools.empty());

--- a/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
+++ b/velox/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
@@ -3312,7 +3312,8 @@ TEST_F(SerializationTest, serializerDefaultWritesNoHeaderLegacy) {
 
   Deserializer deserializer{
       SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
-      pool_.get()};
+      pool_.get(),
+      DeserializerOptions{.hasHeader = false}};
   velox::VectorPtr output;
   deserializer.deserialize(blob, output);
   ASSERT_EQ(output->size(), row->size());


### PR DESCRIPTION
Summary:

Sequence Storage half of the kLegacy Nimble format deprecation. Split from D118851903 (which does the full format-library removal) so the SS behavioral change lands independently.

**Depends on D119409427** (configerator): drops `test_nimble_version_legacy_explicit_passes` from `sequence_storage_config.ctest`, the only configerator consumer of `Nimble(version=0)`. Land D119409427 first so this diff can be simplified (the `kRetiredLegacyVersion` shim in `NimbleCommon.cpp` becomes unnecessary once no config path exercises `version=0`).

**Scope of this diff:**

Outside `fbcode/velox/`:
- `datainfra/sequence/encoding/NimbleCommon.cpp`: `Nimble()` unset config resolves to `kSerialization` instead of `kLegacy`; retired wire version 0 also upgrades to `kSerialization`. Legacy per-stream compression branch dropped (unreachable now). `createNimbleDeserializerOptions` continues to set `hasHeader = true` explicitly.
- `datainfra/sequence/encoding/NimbleThrift.h`: `NimbleThriftSerializer` requires `SerializationVersion::kSerialization` instead of `kLegacy` (matches the new `NimbleCommon` output).
- 20+ non-SS writer/deserializer callers migrated (admarket, koski, xldb, rexdb, scribe, columnstore, datainfra/impulse, datainfra/tulib, dwio/serializer, laser, rocks, zippydb, instagram, fb_velox, f3): each `SerializerOptions{}` that used to rely on the `nullopt` version default now explicitly sets `.version = SerializationVersion::kSerialization`; each `.hasHeader = true` becomes a no-op given the bridge default.
- 64 koski expect-test baselines regenerated (`koski_tester_outputs/*.plan` and `*.out` for `EventBasedFeatureTruncationUdfTest`, `EbfDecodeAndMergeUdfTest`, `SFNReconstructFeaturesUdfTest`, `ExpandEventSquenceToRowsBinaryTest`). Regenerated because the wire byte emitted by the migrated writers flips from v0 to v4.

Inside `fbcode/velox/dwio/nimble/serializer/` (bridge only — full removal is in child D118851903):
- `Options.h`: `DeserializerOptions::hasHeader` default flips `false` → `true`. `SerializerOptions::version` default kept at `nullopt` (callers set explicitly).
- `SerializationHeader.h`: `readSerializationHeader` grows `bool hasHeader = true` default arg.
- `StreamData.h/.cpp`: adds a `StreamData(stringBuffers, pool)` 2-arg convenience overload; stored `options_` by value to avoid dangling-reference from the new default arg.
- `StreamDataParser.h`: adds `DeserializerOptions options = {}` default arg.
- 2 velox test updates (`OptionsTest.deserializerOptionsDefaults` now expects `hasHeader == true`; `serializerDefaultWritesNoHeaderLegacy` passes explicit `.hasHeader = false` on the Deserializer to preserve its intent).

Reviewed By: xiaoxmeng

Differential Revision: D118984813


