### PR TITLE
feat(map): Support FlatMap in MakeRowFromMap

### DIFF
--- a/velox/functions/lib/MakeRowFromMap.h
+++ b/velox/functions/lib/MakeRowFromMap.h
@@ -19,6 +19,7 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatMapVector.h"
 #include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox::functions {
@@ -139,11 +140,12 @@ class MakeRowFromMap {
   using KeyType = typename TypeTraits<KeyKind>::NativeType;
 
  public:
-  MakeRowFromMap(const MakeRowFromMapOptions& options)
+  explicit MakeRowFromMap(const MakeRowFromMapOptions& options)
       : replaceNulls_(options.replaceNulls),
         allowTopLevelNulls_(options.allowTopLevelNulls),
         throwOnDuplicateKeys_(options.throwOnDuplicateKeys),
         outputFieldNames_(options.outputFieldNames),
+        keysToProject_(options.keysToProject),
         inputKeyType_(options.keysToProject->type()) {
     VELOX_USER_CHECK_NOT_NULL(options.keysToProject);
     VELOX_USER_CHECK_GT(
@@ -187,7 +189,7 @@ class MakeRowFromMap {
   void createKeyToFieldIndexMap(const VectorPtr& keysToProject) {
     keyToIndex_.reserve(keysToProject->size());
     auto keysToProjectVec = keysToProject->template as<SimpleVector<KeyType>>();
-    for (size_t i = 0; i < keysToProjectVec->size(); ++i) {
+    for (vector_size_t i = 0; i < keysToProjectVec->size(); ++i) {
       VELOX_USER_CHECK(
           !keysToProjectVec->isNullAt(i),
           "Keys to project cannot contain null");
@@ -204,6 +206,10 @@ class MakeRowFromMap {
       exec::EvalCtx* evalCtx) {
     exec::LocalDecodedVector decodedMap(evalCtx);
     decodedMap.get()->decode(vector, rows);
+    if (auto flatMap = decodedMap->base()->as<FlatMapVector>()) {
+      return flatMapToRowVector(*flatMap, *decodedMap, rows, evalCtx);
+    }
+
     auto mapBase = decodedMap->base()->asUnchecked<MapVector>();
     exec::LocalDecodedVector decodedKeys(evalCtx);
     decodedKeys.get()->decode(*mapBase->mapKeys());
@@ -297,6 +303,80 @@ class MakeRowFromMap {
         std::move(children));
   }
 
+  // Projects only requested key streams without materializing the FlatMap.
+  VectorPtr flatMapToRowVector(
+      const FlatMapVector& flatMap,
+      const DecodedVector& decodedMap,
+      const SelectivityVector& rows,
+      exec::EvalCtx* evalCtx) const {
+    const auto& valueType = flatMap.valueType();
+    const auto outputSize = rows.end();
+    auto vectorPool = evalCtx ? evalCtx->vectorPool() : nullptr;
+    std::vector<VectorPtr> children;
+    children.reserve(keysToProject_->size());
+    for (vector_size_t i = 0; i < keysToProject_->size(); ++i) {
+      if (replaceNulls_) {
+        children.push_back(
+            MakeRowFromMapDefaults::createFlat(
+                valueType, outputSize, *flatMap.pool(), vectorPool));
+      } else {
+        children.push_back(
+            vectorPool
+                ? vectorPool->get(valueType, outputSize)
+                : BaseVector::create(valueType, outputSize, flatMap.pool()));
+        bits::fillBits(
+            children.back()->mutableRawNulls(), 0, outputSize, bits::kNull);
+      }
+    }
+
+    auto outputNulls =
+        (!replaceNulls_ && allowTopLevelNulls_ && decodedMap.mayHaveNulls())
+        ? allocateNulls(outputSize, flatMap.pool(), bits::kNotNull)
+        : nullptr;
+    if (outputNulls) {
+      auto* rawNulls = outputNulls->asMutable<uint64_t>();
+      rows.applyToSelected([&](vector_size_t row) {
+        if (decodedMap.isNullAt(row)) {
+          bits::setNull(rawNulls, row, true);
+        }
+      });
+    }
+
+    for (vector_size_t field = 0; field < keysToProject_->size(); ++field) {
+      const auto channel = flatMap.getKeyChannel(keysToProject_, field);
+      if (!channel.has_value()) {
+        continue;
+      }
+      const auto& mapValues = flatMap.mapValuesAt(*channel);
+      if (!mapValues) {
+        continue;
+      }
+      exec::LocalDecodedVector decodedValues(evalCtx);
+      decodedValues.get()->decode(*mapValues);
+
+      std::vector<BaseVector::CopyRange> copyRanges;
+      copyRanges.reserve(rows.countSelected());
+      rows.applyToSelected([&](vector_size_t row) {
+        if (decodedMap.isNullAt(row)) {
+          return;
+        }
+        const auto sourceIndex = decodedMap.index(row);
+        if (flatMap.isInMap(*channel, sourceIndex) &&
+            !decodedValues->isNullAt(sourceIndex)) {
+          copyRanges.push_back({decodedValues->index(sourceIndex), row, 1});
+        }
+      });
+      children[field]->copyRanges(decodedValues->base(), copyRanges);
+    }
+
+    return std::make_shared<RowVector>(
+        flatMap.pool(),
+        ROW(outputFieldNames_, valueType),
+        std::move(outputNulls),
+        outputSize,
+        std::move(children));
+  }
+
   void ensureValidFieldNames(const std::vector<std::string>& fieldNames) {
     std::unordered_set<std::string> fieldNamesSet;
     for (const auto& fieldName : fieldNames) {
@@ -311,6 +391,7 @@ class MakeRowFromMap {
   const bool allowTopLevelNulls_{false};
   const bool throwOnDuplicateKeys_{true};
   const std::vector<std::string> outputFieldNames_;
+  const VectorPtr keysToProject_;
   const TypePtr inputKeyType_;
   folly::F14FastMap<KeyType, size_t> keyToIndex_;
 };

--- a/velox/functions/lib/tests/MakeRowFromMapTest.cpp
+++ b/velox/functions/lib/tests/MakeRowFromMapTest.cpp
@@ -238,7 +238,7 @@ class MakeRowFroMapTest : public testing::Test, public test::VectorTestBase {
       return std::nullopt;
     };
     // Verify expected values
-    rows.applyToSelected([&](auto row) {
+    rows.applyToSelected([&](vector_size_t row) {
       // Check for top-level nulls if allowed
       if (options.allowTopLevelNulls && !options.replaceNulls &&
           decodedInput.isNullAt(row)) {
@@ -247,9 +247,10 @@ class MakeRowFroMapTest : public testing::Test, public test::VectorTestBase {
       }
       // For every projected key, find the corresponding value in the original
       // map and verify its correctly set in the result.
-      for (int64_t key : {1, 2}) {
+      for (column_index_t field = 0; field < 2; ++field) {
+        const int64_t key = field + 1;
         auto valueIdx = findValueIdx(row, key);
-        auto child = result->as<RowVector>()->childAt(key - 1);
+        auto child = result->as<RowVector>()->childAt(field);
         if (valueIdx.has_value() && !mapValues->isNullAt(valueIdx.value())) {
           ASSERT_TRUE(!child->isNullAt(row));
           if (child->type()->kind() == TypeKind::OPAQUE) {
@@ -335,7 +336,6 @@ class MakeRowFroMapTest : public testing::Test, public test::VectorTestBase {
                 createSelectivityVector(testCase->size(), selectedRowsStr);
             options.replaceNulls = replaceNulls;
             options.allowTopLevelNulls = allowTopLevelNulls;
-            std::optional<exec::EvalCtx> evalCtx;
             if (useEvalCtx) {
               exec::EvalCtx evalCtx(
                   execCtx_.get(), &dummyExprSet, dummyRowVector.get());
@@ -365,12 +365,79 @@ class MakeRowFroMapTest : public testing::Test, public test::VectorTestBase {
 TEST_F(MakeRowFroMapTest, basic) {
   EXPECT_EQ(NonPOD::alive, 0);
   auto testCases = makeTestCases();
-  for (auto& testCase : testCases) {
-    executeTestCase(testCase);
-    break;
-  }
+  executeTestCase(testCases.front());
   testCases.clear();
   EXPECT_EQ(NonPOD::alive, 0);
+}
+
+TEST_F(MakeRowFroMapTest, flatMap) {
+  auto flatMap = makeFlatMapVectorFromJson<int64_t, int64_t>({
+      "{1:10, 2:20, 3:30}",
+      "{2:21, 4:40}",
+      "{1:null, 2:22}",
+      "{4:40}",
+      "{1:15}",
+      "{}",
+      "null",
+  });
+  MakeRowFromMapOptions options{
+      .keysToProject = makeFlatVector<int64_t>({1, 2, 5}),
+      .outputFieldNames = {"key1", "key2", "key5"},
+      .replaceNulls = false,
+      .allowTopLevelNulls = false,
+      .throwOnDuplicateKeys = false};
+  SelectivityVector rows(flatMap->size());
+
+  auto expected = makeRowVector(
+      options.outputFieldNames,
+      {makeNullableFlatVector<int64_t>(
+           {10,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            15,
+            std::nullopt,
+            std::nullopt}),
+       makeNullableFlatVector<int64_t>(
+           {20,
+            21,
+            22,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt}),
+       makeAllNullFlatVector<int64_t>(flatMap->size())});
+  test::assertEqualVectors(
+      expected, toRowVector<TypeKind::BIGINT>(*flatMap, options, rows));
+
+  const auto reverseIndices = makeIndicesInReverse(flatMap->size());
+  const auto wrappedFlatMap = BaseVector::wrapInDictionary(
+      nullptr, reverseIndices, flatMap->size(), flatMap);
+  const auto wrappedExpected = BaseVector::wrapInDictionary(
+      nullptr, reverseIndices, expected->size(), expected);
+  test::assertEqualVectors(
+      wrappedExpected,
+      toRowVector<TypeKind::BIGINT>(*wrappedFlatMap, options, rows));
+
+  options.allowTopLevelNulls = true;
+  expected = makeRowVector(
+      options.outputFieldNames,
+      {expected->childAt(0), expected->childAt(1), expected->childAt(2)},
+      [](vector_size_t row) { return row == 6; });
+  test::assertEqualVectors(
+      expected, toRowVector<TypeKind::BIGINT>(*flatMap, options, rows));
+
+  options.replaceNulls = true;
+  options.allowTopLevelNulls = false;
+  expected = makeRowVector(
+      options.outputFieldNames,
+      {makeFlatVector<int64_t>({10, 0, 0, 0, 15, 0, 0}),
+       makeFlatVector<int64_t>({20, 21, 22, 0, 0, 0, 0}),
+       makeFlatVector<int64_t>({0, 0, 0, 0, 0, 0, 0})});
+  exec::EvalCtx evalCtx(execCtx_.get(), &dummyExprSet, dummyRowVector.get());
+  test::assertEqualVectors(
+      expected,
+      toRowVector<TypeKind::BIGINT>(*flatMap, options, rows, &evalCtx));
 }
 
 TEST_F(MakeRowFroMapTest, unknownTypeValues) {


### PR DESCRIPTION
Summary:
`MakeRowFromMap` failed with `Wrong type cast expected MapVector, but got FlatMapVector` when its input used FlatMap storage.

The converter now projects requested FlatMap key streams directly and preserves missing-key, null-value, padded-default, top-level-null, and wrapped-vector semantics without expanding the full map.

Differential Revision: D119595480


