### PR TITLE
build(cudf): Update cudf pin to 26.10

### DIFF
--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -93,19 +93,11 @@ block(SCOPE_FOR VARIABLES)
   set(BUILD_TESTS OFF)
   set(CUDF_BUILD_TESTUTIL OFF)
   set(CUDF_BUILD_STREAMS_TEST_UTIL OFF)
+  # Keep spdlog/nvcomp shared to avoid multiple copies of spdlog in the final binary.
   set(CUDF_BUILD_STATIC_DEPS OFF)
   set(BUILD_SHARED_LIBS ON)
   set(KvikIO_BUILD_NSYS_PLUGIN OFF)
 
-  # TODO(mh,bd): Remove this once we have a permanent solution for the spdlog/fmt
-  # incompatibility.
-
-  # cuDF (via rapids_logger) pins spdlog 1.14.1, which is incompatible with
-  # the fmt 11.2.0 that Velox builds. Override the rapids-cmake/CPM spdlog
-  # version to 1.15.3, which is fmt 11.2 compatible.
-  # RAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE is honored by every rapids_cpm_init,
-  # so the override applies before rapids_logger fetches spdlog.
-  set(RAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE "${CMAKE_CURRENT_LIST_DIR}/cudf-cpm-overrides.json")
 
   FetchContent_Declare(
     rapids-cmake

--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -17,12 +17,12 @@ include_guard(GLOBAL)
 # 4.0 is the minimum version required by cudf
 cmake_minimum_required(VERSION 4.0)
 
-# rapids_cmake commit 9c0829e from 2026-07-23 (release/26.08 branch)
-set(VELOX_rapids_cmake_VERSION 26.08)
-set(VELOX_rapids_cmake_COMMIT 9c0829ec73702b3df8a5c2ec43f6aaabe5f1e5ec)
+# rapids_cmake commit 5df8fd1 from 2026-09-08 (release/26.10 branch)
+set(VELOX_rapids_cmake_VERSION 26.10)
+set(VELOX_rapids_cmake_COMMIT 5df8fd1ea26515b6b50fa94844ef1855e457048c)
 set(
   VELOX_rapids_cmake_BUILD_SHA256_CHECKSUM
-  3582f621f3b3d63952aafd716985901a075f2ad85602073973f3619761723962
+  f7cb91451aeae915f066907f9ae4eb555348fb62db1857c205a67691816c78c3
 )
 set(
   VELOX_rapids_cmake_SOURCE_URL
@@ -30,22 +30,22 @@ set(
 )
 velox_resolve_dependency_url(rapids_cmake)
 
-# rmm commit 1a39f9e from 2026-07-24 (release/26.08 branch)
-set(VELOX_rmm_VERSION 26.08)
-set(VELOX_rmm_COMMIT 1a39f9e81c467b1a9522a4dcec8b5581ae165fef)
+# rmm commit 9a693e0 from 2026-09-10 (release/26.10 branch)
+set(VELOX_rmm_VERSION 26.10)
+set(VELOX_rmm_COMMIT 9a693e042004e1da9d2e2db018ce2c2963437d59)
 set(
   VELOX_rmm_BUILD_SHA256_CHECKSUM
-  d8b82bc491a2c5b093cdfb4e1fb99630ccf16d1cbd69bc74451fbb56efc3e68c
+  98916c2801fd9ad72eba8bb95ac45813ac933a4877d2d43445fa174402949063
 )
 set(VELOX_rmm_SOURCE_URL "https://github.com/rapidsai/rmm/archive/${VELOX_rmm_COMMIT}.tar.gz")
 velox_resolve_dependency_url(rmm)
 
-# kvikio commit 93606c0 from 2026-07-23 (release/26.08 branch)
-set(VELOX_kvikio_VERSION 26.08)
-set(VELOX_kvikio_COMMIT 93606c074f3d863a7052af25afae569f72cb3304)
+# kvikio commit 3ea0db0 from 2026-09-10 (release/26.10 branch)
+set(VELOX_kvikio_VERSION 26.10)
+set(VELOX_kvikio_COMMIT 3ea0db06a308925097e6fe84628f5888efca13b8)
 set(
   VELOX_kvikio_BUILD_SHA256_CHECKSUM
-  882e1b7c8950c0bf3520c3c317b0d85da2c91b66d90f3ff44ae81a60166979f3
+  b2c8418ef8eba3f08c4dcb859b3df44711b5ae5cbbf85fc8c5c09992bfb1f9bc
 )
 set(
   VELOX_kvikio_SOURCE_URL
@@ -53,12 +53,12 @@ set(
 )
 velox_resolve_dependency_url(kvikio)
 
-# cudf commit 5beaa59 from 2026-07-27 (release/26.08 branch)
-set(VELOX_cudf_VERSION 26.08 CACHE STRING "cudf version")
-set(VELOX_cudf_COMMIT 5beaa5954688fcb12236ffb434e192ea2c77db30)
+# cudf commit 456580f from 2026-09-11 (release/26.10 branch)
+set(VELOX_cudf_VERSION 26.10 CACHE STRING "cudf version")
+set(VELOX_cudf_COMMIT 456580fcdd726380dcb3de6b9686e7d47d6dd0a2)
 set(
   VELOX_cudf_BUILD_SHA256_CHECKSUM
-  1fc77d1ddf97ede67b783bbabacf69d658254be30b2859299f4255525443b1d3
+  160ff8be040c434c9f51fe3e41f08d26421c41710a8adabe559b1f994ad06959
 )
 set(VELOX_cudf_SOURCE_URL "https://github.com/rapidsai/cudf/archive/${VELOX_cudf_COMMIT}.tar.gz")
 velox_resolve_dependency_url(cudf)
@@ -74,12 +74,12 @@ else()
 endif()
 if(UCX_FOUND)
   message(STATUS "Found UCX: ${UCX_LIBRARY} (headers: ${UCX_INCLUDE_DIR}) -- ucxx will be fetched")
-  # ucxx commit b7faed1 from 2026-07-23 (release/0.51 branch)
-  set(VELOX_ucxx_VERSION 0.51)
-  set(VELOX_ucxx_COMMIT b7faed1a2e8038f63676183cdb056c3b69daa15d)
+  # ucxx commit 22d9c90 from 2026-09-09 (release/0.52 branch)
+  set(VELOX_ucxx_VERSION 0.52)
+  set(VELOX_ucxx_COMMIT 22d9c90a40055d439c3ec58f2606f2af620c5d71)
   set(
     VELOX_ucxx_BUILD_SHA256_CHECKSUM
-    3eb5ff5459dde31edf344f24f0b3086550be70961038b69229b05973b6f37524
+    cfb042ede89913744033aadacbe6768700a8ee8fe357cb80cbf47f14c9d4df5c
   )
   set(VELOX_ucxx_SOURCE_URL "https://github.com/rapidsai/ucxx/archive/${VELOX_ucxx_COMMIT}.tar.gz")
   velox_resolve_dependency_url(ucxx)
@@ -93,7 +93,9 @@ block(SCOPE_FOR VARIABLES)
   set(BUILD_TESTS OFF)
   set(CUDF_BUILD_TESTUTIL OFF)
   set(CUDF_BUILD_STREAMS_TEST_UTIL OFF)
+  set(CUDF_BUILD_STATIC_DEPS OFF)
   set(BUILD_SHARED_LIBS ON)
+  set(KvikIO_BUILD_NSYS_PLUGIN OFF)
 
   # TODO(mh,bd): Remove this once we have a permanent solution for the spdlog/fmt
   # incompatibility.
@@ -163,6 +165,19 @@ block(SCOPE_FOR VARIABLES)
     cudf
     PRIVATE -Wno-non-virtual-dtor -Wno-missing-field-initializers -Wno-deprecated-copy -Wno-restrict
   )
+  target_link_libraries(cudf PUBLIC $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>)
+
+  # cuDF orders nvcomp_static after its whole-archived rmm and rapids_logger
+  # dependencies. Apply the same ordering to its whole-archived spdlog target.
+  if(
+    CUDF_nvcomp_TARGET STREQUAL "nvcomp::nvcomp_static"
+    AND TARGET spdlog::spdlog
+  )
+    get_target_property(_spdlog_link spdlog::spdlog NAME)
+    target_link_libraries(
+      ${_spdlog_link} INTERFACE $<BUILD_LOCAL_INTERFACE:nvcomp::nvcomp_static>
+    )
+  endif()
 
   unset(BUILD_SHARED_LIBS)
   unset(BUILD_TESTING CACHE)

--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -167,18 +167,6 @@ block(SCOPE_FOR VARIABLES)
   )
   target_link_libraries(cudf PUBLIC $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>)
 
-  # cuDF orders nvcomp_static after its whole-archived rmm and rapids_logger
-  # dependencies. Apply the same ordering to its whole-archived spdlog target.
-  if(
-    CUDF_nvcomp_TARGET STREQUAL "nvcomp::nvcomp_static"
-    AND TARGET spdlog::spdlog
-  )
-    get_target_property(_spdlog_link spdlog::spdlog NAME)
-    target_link_libraries(
-      ${_spdlog_link} INTERFACE $<BUILD_LOCAL_INTERFACE:nvcomp::nvcomp_static>
-    )
-  endif()
-
   unset(BUILD_SHARED_LIBS)
   unset(BUILD_TESTING CACHE)
 endblock()

--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -98,7 +98,6 @@ block(SCOPE_FOR VARIABLES)
   set(BUILD_SHARED_LIBS ON)
   set(KvikIO_BUILD_NSYS_PLUGIN OFF)
 
-
   FetchContent_Declare(
     rapids-cmake
     URL ${VELOX_rapids_cmake_SOURCE_URL}

--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -165,8 +165,6 @@ block(SCOPE_FOR VARIABLES)
     cudf
     PRIVATE -Wno-non-virtual-dtor -Wno-missing-field-initializers -Wno-deprecated-copy -Wno-restrict
   )
-  target_link_libraries(cudf PUBLIC $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>)
-
   unset(BUILD_SHARED_LIBS)
   unset(BUILD_TESTING CACHE)
 endblock()

--- a/velox/experimental/cudf/CudfDefaultStreamOverload.h
+++ b/velox/experimental/cudf/CudfDefaultStreamOverload.h
@@ -25,13 +25,13 @@
 // The definition lives in GpuResources.cpp (which does NOT include
 // CudfNoDefaults.h, so it can call the real cudf::get_default_stream()).
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace cudf {
 
 struct allow_default_stream_t {};
 constexpr allow_default_stream_t allow_default_stream{};
 
-rmm::cuda_stream_view const get_default_stream(allow_default_stream_t);
+cuda::stream_ref const get_default_stream(allow_default_stream_t);
 
 } // namespace cudf

--- a/velox/experimental/cudf/CudfNoDefaults.h
+++ b/velox/experimental/cudf/CudfNoDefaults.h
@@ -21,7 +21,7 @@
 // for stream and mr parameters at compile time.
 //
 // cudf public APIs declare defaults like:
-//   rmm::cuda_stream_view stream = cudf::get_default_stream(),
+//   cuda::stream_ref stream = cudf::get_default_stream(),
 //   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()
 //
 // When a call site omits stream or mr, the compiler generates a call to these
@@ -45,7 +45,7 @@ namespace cudf {
 
 __attribute__((
     error("cudf default stream argument used. Pass stream explicitly."),
-    noinline)) rmm::cuda_stream_view const get_default_stream();
+    noinline)) cuda::stream_ref const get_default_stream();
 
 __attribute__((
     error("cudf default memory resource argument used. Pass mr explicitly."),

--- a/velox/experimental/cudf/benchmarks/CudfInteropBenchmark.cpp
+++ b/velox/experimental/cudf/benchmarks/CudfInteropBenchmark.cpp
@@ -39,7 +39,7 @@ class CudfInteropBenchmark {
     BaseVector::flattenVector(flatData);
     auto cudfTable = with_arrow::toCudfTable(
         std::static_pointer_cast<RowVector>(flatData), pool_.get(), stream, mr);
-    stream.synchronize();
+    stream.sync();
     VELOX_CHECK_NOT_NULL(cudfTable);
     VELOX_CHECK_EQ(cudfTable->num_rows(), flatData->size());
     return cudfTable;
@@ -50,7 +50,7 @@ class CudfInteropBenchmark {
       const RowTypePtr& rowType) {
     auto veloxData = with_arrow::toVeloxColumn(
         cudfTable->view(), pool_.get(), rowType, stream, mr);
-    stream.synchronize();
+    stream.sync();
     VELOX_CHECK_NOT_NULL(veloxData);
     VELOX_CHECK_EQ(veloxData->size(), cudfTable->num_rows());
   }
@@ -69,7 +69,7 @@ class CudfInteropBenchmark {
     auto mr = cudf::get_current_device_resource_ref();
     auto cudfTable = with_arrow::toCudfTable(
         std::static_pointer_cast<RowVector>(flatData), pool_.get(), stream, mr);
-    stream.synchronize();
+    stream.sync();
     VELOX_CHECK_NOT_NULL(cudfTable);
     VELOX_CHECK_EQ(cudfTable->num_rows(), flatData->size());
     return cudfTable;
@@ -80,7 +80,7 @@ class CudfInteropBenchmark {
       const RowTypePtr& rowType) {
     auto veloxData = with_arrow::toVeloxColumn(
         cudfTable->view(), pool_.get(), rowType, stream, mr);
-    stream.synchronize();
+    stream.sync();
     VELOX_CHECK_NOT_NULL(veloxData);
     VELOX_CHECK_EQ(veloxData->size(), cudfTable->num_rows());
   }
@@ -124,7 +124,7 @@ class CudfInteropBenchmark {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  cuda::stream_ref stream = cudf::get_default_stream();
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref();
 };
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
@@ -160,7 +160,7 @@ void CudfHiveDataSink::appendData(RowVectorPtr input) {
   auto stream = cudfGlobalStreamPool().get_stream();
   auto cudfInput =
       with_arrow::toCudfTable(input, input->pool(), stream, get_temp_mr());
-  stream.synchronize();
+  stream.sync();
   VELOX_CHECK_NOT_NULL(
       cudfInput, "Failed to convert input RowVectorPtr to cudf::table");
 
@@ -178,7 +178,7 @@ void CudfHiveDataSink::appendData(RowVectorPtr input) {
 std::unique_ptr<cudf::io::chunked_parquet_writer>
 CudfHiveDataSink::createCudfWriter(
     cudf::table_view cudfTable,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   // Create a table_input_metadata from the input
   auto tableInputMetadata = createCudfTableInputMetadata(cudfTable);
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.h
@@ -309,7 +309,7 @@ class CudfHiveDataSink : public DataSink {
   // Creates a new cudf chunked parquet writer.
   std::unique_ptr<cudf::io::chunked_parquet_writer> createCudfWriter(
       cudf::table_view cudfTable,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   cudf::io::table_input_metadata createCudfTableInputMetadata(
       cudf::table_view cudfTable);
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -266,7 +266,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
         cudfRemainingFilterExpression_->eval(inputViews, stream, get_temp_mr());
     auto originalTable =
         std::make_unique<cudf::table>(std::move(cudfTableColumns));
-    cudfTable = cudf::apply_boolean_mask(
+    cudfTable = cudf::apply_retention_mask(
         *originalTable, asView(filterResult), stream, get_output_mr());
   }
   totalRemainingFilterTime_.fetch_add(
@@ -293,7 +293,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
             pool_, outputType_, nRows, std::move(cudfTable), stream)
       : with_arrow::toVeloxColumn(
             cudfTable->view(), pool_, outputType_, stream, get_temp_mr());
-  stream.synchronize();
+  stream.sync();
 
   VELOX_CHECK_NOT_NULL(output, "Cudf to Velox conversion yielded a nullptr");
 

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -95,7 +95,7 @@ std::unique_ptr<cudf::column> rebuildWithTransformedChildren(
 std::unique_ptr<cudf::column> castDecimalColumns(
     std::unique_ptr<cudf::column> col,
     const TypePtr& veloxType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Decimal type (base case)
   if (veloxType->isDecimal()) {
@@ -145,7 +145,7 @@ std::unique_ptr<cudf::column> castDecimalColumns(
 std::unique_ptr<cudf::table> castDecimalColumnsToVeloxTypes(
     std::unique_ptr<cudf::table>&& table,
     const RowTypePtr& rowType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto numColumns =
       std::min<size_t>(table->view().num_columns(), rowType->size());
@@ -239,7 +239,7 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::next(
 
   // Launch host callback to calculate timing when scan completes
   cudaLaunchHostFunc(
-      stream_.value(), &CudfSplitReader::totalScanTimeCalculator, callbackData);
+      stream_.get(), &CudfSplitReader::totalScanTimeCalculator, callbackData);
 
   return std::move(chunkOpt.value());
 }

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -133,7 +133,7 @@ class CudfSplitReader : public NvtxHelper {
   std::shared_ptr<io::IoStatistics> ioStatistics_;
   std::shared_ptr<IoStats> ioStats_;
 
-  cuda::stream_ref stream_{cudaStream_t{nullptr}};
+  cuda::stream_ref stream_{cudaStream_t{cudaStreamDefault}};
 
   // Parquet metadata(s) for the current split(s).
   std::vector<cudf::io::parquet::FileMetaData> fileMetaData_;

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -133,7 +133,7 @@ class CudfSplitReader : public NvtxHelper {
   std::shared_ptr<io::IoStatistics> ioStatistics_;
   std::shared_ptr<IoStats> ioStats_;
 
-  cuda::stream_ref stream_;
+  cuda::stream_ref stream_{cudaStream_t{nullptr}};
 
   // Parquet metadata(s) for the current split(s).
   std::vector<cudf::io::parquet::FileMetaData> fileMetaData_;

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -87,7 +87,7 @@ class CudfSplitReader : public NvtxHelper {
   virtual std::optional<std::unique_ptr<cudf::table>> next(uint64_t size);
 
   /// Get the stream.
-  rmm::cuda_stream_view stream() const {
+  cuda::stream_ref stream() const {
     return stream_;
   }
 
@@ -133,7 +133,7 @@ class CudfSplitReader : public NvtxHelper {
   std::shared_ptr<io::IoStatistics> ioStatistics_;
   std::shared_ptr<IoStats> ioStats_;
 
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
 
   // Parquet metadata(s) for the current split(s).
   std::vector<cudf::io::parquet::FileMetaData> fileMetaData_;

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.cpp
@@ -82,15 +82,15 @@ void BufferedInputDataSource::enqueueForDevice(
   auto inputStream = input_->enqueue({offset, size});
   std::shared_ptr sharedStream(std::move(inputStream));
   pendingDeviceLoads_.push_back(
-      [dst, size, sharedStream](rmm::cuda_stream_view stream) {
+      [dst, size, sharedStream](cuda::stream_ref stream) {
         std::vector<uint8_t> buffer(size);
         sharedStream->readFully(reinterpret_cast<char*>(buffer.data()), size);
         CUDF_CUDA_TRY(cudaMemcpyAsync(
-            dst, buffer.data(), size, cudaMemcpyDefault, stream.value()));
+            dst, buffer.data(), size, cudaMemcpyDefault, stream.get()));
       });
 }
 
-void BufferedInputDataSource::load(rmm::cuda_stream_view stream) {
+void BufferedInputDataSource::load(cuda::stream_ref stream) {
   input_->load(velox::dwio::common::LogType::FILE);
   std::lock_guard<std::mutex> lock(ioBatchMutex());
   for (auto& deviceLoad : pendingDeviceLoads_) {
@@ -139,7 +139,7 @@ std::future<size_t> BufferedInputDataSource::device_read_async(
     size_t offset,
     size_t size,
     uint8_t* dst,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   VELOX_CHECK(input_->executor() != nullptr, "IO executor is not initialized");
   auto future = folly::via(input_->executor())
                     .thenValue([this, offset, size, dst, stream](auto&&) {
@@ -149,7 +149,7 @@ std::future<size_t> BufferedInputDataSource::device_read_async(
                           hostBuffer->data(),
                           hostBuffer->size(),
                           cudaMemcpyDefault,
-                          stream.value()));
+                          stream.get()));
                       return hostBuffer->size();
                     });
   return toStdFuture(std::move(future));
@@ -177,7 +177,7 @@ std::tuple<
 fetchByteRangesAsync(
     std::shared_ptr<cudf::io::datasource> dataSource,
     cudf::host_span<const cudf::io::text::byte_range_info> byteRanges,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Pad buffer sizes to be a multiple of 8 bytes. Required by
   // `decode_page_data_kernel` in cuDF Parquet reader.
@@ -231,7 +231,7 @@ fetchByteRangesAsync(
 
     // load buffered input data source
     auto syncFunction = [](std::shared_ptr<cudf::io::datasource> dataSource,
-                           rmm::cuda_stream_view stream) {
+                           cuda::stream_ref stream) {
       auto buffer =
           checkedPointerCast<BufferedInputDataSource>(dataSource.get());
       buffer->load(stream);
@@ -288,7 +288,7 @@ fetchByteRangesAsync(
 
   // device_read_async is not guaranteed to follow stream-ordering (see
   // datasource API docs)
-  stream.synchronize();
+  stream.sync();
 
   {
     std::lock_guard<std::mutex> lock(ioBatchMutex());
@@ -317,7 +317,7 @@ fetchByteRangesAsync(
                       hostBuffer->data(),
                       hostBuffer->size(),
                       cudaMemcpyDefault,
-                      stream.value()));
+                      stream.get()));
                   return ioSize;
                 }));
       }

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
@@ -28,7 +28,7 @@
 #include <cudf/io/text/byte_range_info.hpp>
 #include <cudf/io/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 #include <rmm/resource_ref.hpp>
 
 #include <vector>
@@ -63,21 +63,21 @@ class BufferedInputDataSource : public cudf::io::datasource {
       size_t offset,
       size_t size,
       uint8_t* dst,
-      rmm::cuda_stream_view stream) override;
+      cuda::stream_ref stream) override;
 
   // Use the enqueue API from dwio::common::BufferedInput.
   // Pass a device buffer to copy to after load.
   void enqueueForDevice(uint64_t offset, uint64_t size, uint8_t* dst);
 
   // loads and copies to device.
-  void load(rmm::cuda_stream_view stream);
+  void load(cuda::stream_ref stream);
 
  private:
   void readContiguous(size_t offset, size_t size, uint8_t* dst);
 
   std::shared_ptr<facebook::velox::dwio::common::BufferedInput> input_;
   const size_t fileSize_;
-  std::vector<std::function<void(rmm::cuda_stream_view stream)>>
+  std::vector<std::function<void(cuda::stream_ref stream)>>
       pendingDeviceLoads_;
 };
 
@@ -113,7 +113,7 @@ std::tuple<
 fetchByteRangesAsync(
     std::shared_ptr<cudf::io::datasource> dataSource,
     cudf::host_span<const cudf::io::text::byte_range_info> byteRanges,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 } // namespace facebook::velox::cudf_velox::connector::hive

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
@@ -28,8 +28,9 @@
 #include <cudf/io/text/byte_range_info.hpp>
 #include <cudf/io/types.hpp>
 
-#include <cuda/stream>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream>
 
 #include <vector>
 
@@ -77,8 +78,7 @@ class BufferedInputDataSource : public cudf::io::datasource {
 
   std::shared_ptr<facebook::velox::dwio::common::BufferedInput> input_;
   const size_t fileSize_;
-  std::vector<std::function<void(cuda::stream_ref stream)>>
-      pendingDeviceLoads_;
+  std::vector<std::function<void(cuda::stream_ref stream)>> pendingDeviceLoads_;
 };
 
 /**

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfDeletionVectorReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfDeletionVectorReader.cpp
@@ -104,7 +104,7 @@ CudfDeletionVectorReader::CudfDeletionVectorReader(
       dvFile_.recordCount);
 }
 
-void CudfDeletionVectorReader::loadBitmap(rmm::cuda_stream_view stream) {
+void CudfDeletionVectorReader::loadBitmap(cuda::stream_ref stream) {
   if (loaded_) {
     return;
   }
@@ -290,7 +290,7 @@ CudfDeletionVectorReader::loadBlobSource() {
 void CudfDeletionVectorReader::buildBitmap(
     cudf::roaring_bitmap_type bitmapType,
     std::string_view roaringBitmapPayload,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   auto const* bitmapBytes =
       reinterpret_cast<cuda::std::byte const*>(roaringBitmapPayload.data());
   auto const bitmapSize = roaringBitmapPayload.size();
@@ -307,7 +307,7 @@ void CudfDeletionVectorReader::buildBitmap(
 void CudfDeletionVectorReader::applyDeletes(
     cudf::mutable_column_view const& deleteMask,
     cudf::column_view const& rowIndex,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr) {
   if (rowIndex.size() == 0) {
     return;

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfDeletionVectorReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfDeletionVectorReader.h
@@ -25,7 +25,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/roaring_bitmap.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>
@@ -68,7 +68,7 @@ class CudfDeletionVectorReader {
   void applyDeletes(
       cudf::mutable_column_view const& rowMask,
       cudf::column_view const& rowIndex,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref temp_mr);
 
  private:
@@ -91,12 +91,12 @@ class CudfDeletionVectorReader {
   void buildBitmap(
       cudf::roaring_bitmap_type bitmapType,
       std::string_view roaringBitmapPayload,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   // Loads the deletion vector blob from the Puffin file, strips the DV-v1
   // envelope, and constructs the cuco roaring bitmap. Called lazily on the
   // first `applyDeletionVector` call.
-  void loadBitmap(rmm::cuda_stream_view stream);
+  void loadBitmap(cuda::stream_ref stream);
 
   // Opaque wrapper class for cuco's 32 or 64 bit roaring bitmap
   std::unique_ptr<cudf::roaring_bitmap> bitmap_;

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.cpp
@@ -204,7 +204,11 @@ void CudfEqualityDeleteFileReader::buildHashJoin(cuda::stream_ref stream) {
   // null_equality::EQUAL per Iceberg spec (NULL == NULL for equality deletes).
   // distinct_hash_join treats all NaNs as equal by default.
   deleteHashJoin_ = std::make_unique<cudf::distinct_hash_join>(
-      deleteKeyTable_->view(), cudf::null_equality::EQUAL, 0.5, stream);
+      deleteKeyTable_->view(),
+      cudf::null_equality::EQUAL,
+      0.5,
+      stream,
+      get_temp_mr());
 }
 
 void CudfEqualityDeleteFileReader::buildEqualityColumnIndices(

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.cpp
@@ -181,13 +181,13 @@ void CudfEqualityDeleteFileReader::directReadEqualityDeleteFile(
   auto stream = cudfGlobalStreamPool().get_stream();
   deleteKeyTable_ =
       cudf::io::read_parquet(options, stream, get_output_mr()).tbl;
-  stream.synchronize();
+  stream.sync();
 
   VELOX_CHECK_NOT_NULL(deleteKeyTable_);
   numDeleteKeys_ = deleteKeyTable_->num_rows();
 }
 
-void CudfEqualityDeleteFileReader::buildHashJoin(rmm::cuda_stream_view stream) {
+void CudfEqualityDeleteFileReader::buildHashJoin(cuda::stream_ref stream) {
   if (deleteHashJoin_) {
     return;
   }
@@ -239,7 +239,7 @@ void CudfEqualityDeleteFileReader::applyDeletes(
     cudf::table_view table,
     const std::vector<std::string>& inputColumnNames,
     cudf::mutable_column_view const& deleteMask,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   const auto numRows = table.num_rows();
   if (empty() or numRows == 0) {
     return;

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.h
@@ -29,9 +29,10 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <cuda/stream>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream>
 
 #include <folly/Executor.h>
 

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfEqualityDeleteFileReader.h
@@ -29,7 +29,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -115,7 +115,7 @@ class CudfEqualityDeleteFileReader {
       cudf::table_view table,
       const std::vector<std::string>& inputColumnNames,
       cudf::mutable_column_view const& rowMask,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   /// Returns the number of delete key tuples loaded from the file.
   size_t numDeleteKeys() const {
@@ -131,7 +131,7 @@ class CudfEqualityDeleteFileReader {
  private:
   // Lazily builds the distinct_hash_join on the first `applyDeletes` call.
   // Converts `deleteRows_` to a GPU table if needed.
-  void buildHashJoin(rmm::cuda_stream_view stream);
+  void buildHashJoin(cuda::stream_ref stream);
 
   // Eagerly reads the Parquet-format equality delete file into the
   // deleteKeyTable_ cudf table.

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.cu
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.cu
@@ -79,7 +79,7 @@ void applyBitmapToMask(
     std::size_t numRows,
     cudf::column_view const& rowIndex,
     cudf::mutable_column_view const& deleteMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr) {
   auto iter = cuda::counting_iterator{0};
   thrust::transform(
@@ -93,7 +93,7 @@ void applyBitmapToMask(
 
 cudf::size_type countDeletedRows(
     cudf::column_view const& deleteMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr) {
   return static_cast<cudf::size_type>(thrust::count(
       rmm::exec_policy_nosync(stream, temp_mr),
@@ -105,7 +105,7 @@ cudf::size_type countDeletedRows(
 void scatterDeletesToMask(
     cudf::mutable_column_view const& deleteMask,
     cudf::device_span<const cudf::size_type> indices,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr) {
   // Alternate: Use `cudf::scatter` but it produces a new column.
   auto iter = cuda::constant_iterator<bool>(true);
@@ -121,7 +121,7 @@ void scatter32BitDVMatchesToMask(
     cudf::column_view const& rowIndex,
     cudf::column_view const& dvMatches,
     cudf::mutable_column_view const& deleteMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr) {
   auto indices = cuda::counting_iterator<cudf::size_type>{0};
   thrust::transform(
@@ -139,7 +139,7 @@ void fillSequence(
     cudf::mutable_column_view const& rowIndices,
     ValueType startRow,
     int64_t numRows,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr) {
   auto rowIndexIter = rowIndices.begin<ValueType>();
   thrust::sequence(
@@ -153,14 +153,14 @@ template void fillSequence<uint32_t>(
     cudf::mutable_column_view const&,
     uint32_t,
     int64_t,
-    rmm::cuda_stream_view,
+    cuda::stream_ref,
     rmm::device_async_resource_ref);
 
 template void fillSequence<uint64_t>(
     cudf::mutable_column_view const&,
     uint64_t,
     int64_t,
-    rmm::cuda_stream_view,
+    cuda::stream_ref,
     rmm::device_async_resource_ref);
 
 } // namespace facebook::velox::cudf_velox::connector::hive::iceberg

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
@@ -21,7 +21,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -47,7 +47,7 @@ void applyBitmapToMask(
     std::size_t numRows,
     cudf::column_view const& rowIndex,
     cudf::mutable_column_view const& deleteMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr);
 
 /// Counts the number of deleted rows (set to `true`) in the supplied deletion
@@ -58,7 +58,7 @@ void applyBitmapToMask(
 /// @return Number of deleted rows
 cudf::size_type countDeletedRows(
     cudf::column_view const& deleteMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr);
 
 /// Scatters deletes to the deletion mask at positions indicated by `indices`
@@ -70,7 +70,7 @@ cudf::size_type countDeletedRows(
 void scatterDeletesToMask(
     cudf::mutable_column_view const& deleteMask,
     cudf::device_span<const cudf::size_type> indices,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr);
 
 /// Scatters only the 32-bit DV matches to the output deletion mask whose
@@ -85,7 +85,7 @@ void scatter32BitDVMatchesToMask(
     cudf::column_view const& rowIndex,
     cudf::column_view const& dvMatches,
     cudf::mutable_column_view const& deleteMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr);
 
 /// Fills a sequence of row indices into a column.
@@ -99,7 +99,7 @@ void fillSequence(
     cudf::mutable_column_view const& rowIndices,
     ValueType startRow,
     int64_t numRows,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref temp_mr);
 
 } // namespace facebook::velox::cudf_velox::connector::hive::iceberg

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
@@ -21,9 +21,10 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <cuda/stream>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -287,10 +287,10 @@ std::pair<std::size_t, std::size_t> CudfIcebergSplitReader::rowRange(
       rowIndex.begin<uint64_t>(),
       sizeof(uint64_t),
       cudaMemcpyDefault,
-      stream_.value()));
+      stream_.get()));
 
   if (pushdownFilter() == nullptr) {
-    stream_.synchronize();
+    stream_.sync();
     return {startRow, static_cast<std::size_t>(rowIndex.size())};
   }
 
@@ -300,8 +300,8 @@ std::pair<std::size_t, std::size_t> CudfIcebergSplitReader::rowRange(
       rowIndex.end<uint64_t>() - 1,
       sizeof(uint64_t),
       cudaMemcpyDefault,
-      stream_.value()));
-  stream_.synchronize();
+      stream_.get()));
+  stream_.sync();
 
   VELOX_CHECK_LE(startRow, endRow);
   return {startRow, static_cast<std::size_t>(endRow - startRow + 1)};
@@ -447,7 +447,7 @@ CudfIcebergSplitReader::readNextChunk() {
     VELOX_CHECK_NOT_NULL(filter);
     auto filterMask = cudf::compute_column(
         cudfTable->view(), *filter, stream_, get_temp_mr());
-    cudfTable = cudf::apply_boolean_mask(
+    cudfTable = cudf::apply_retention_mask(
         cudfTable->view(), filterMask->view(), stream_, get_output_mr());
   }
 
@@ -654,7 +654,7 @@ void CudfIcebergSplitReader::readPositionalDeleteBitmap(
       deleteBitmap_->as<uint8_t>(),
       numBitmaskBytes,
       cudaMemcpyDefault,
-      stream_.value()));
+      stream_.get()));
 }
 
 void CudfIcebergSplitReader::applyPositionalDeletes(

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -371,7 +371,7 @@ CudfIcebergSplitReader::readNextChunk() {
           deleteMask_->mutable_view().data<bool>(),
           false,
           numRows * sizeof(bool),
-          stream_));
+          stream_.get()));
     }
 
     // Set the current mutable view into the deleteMask_ column.

--- a/velox/experimental/cudf/exec/CudfAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfAggregation.cpp
@@ -160,7 +160,7 @@ bool hasCompanionAggregates(
 std::unique_ptr<cudf::column> applyMask(
     cudf::column_view values,
     cudf::column_view mask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // copy_if_else(lhs, rhs, bool_mask): out[i] = (mask.valid(i) && mask[i]) ?
   // lhs[i] : rhs. A null mask element is treated as false, so mask-false and
@@ -177,7 +177,7 @@ std::unique_ptr<cudf::column> materializeMaskedColumn(
     cudf::table_view const& input,
     uint32_t inputIndex,
     std::optional<uint32_t> maskIndex,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (!maskIndex.has_value()) {
     return nullptr;
@@ -188,7 +188,7 @@ std::unique_ptr<cudf::column> materializeMaskedColumn(
 
 std::unique_ptr<cudf::column> maskToValidityColumn(
     cudf::column_view mask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // bools_to_mask sets bit i iff mask[i] is true; a false or null entry clears
   // it. Using that bitmask as the column's validity makes COUNT_VALID over the

--- a/velox/experimental/cudf/exec/CudfAggregation.h
+++ b/velox/experimental/cudf/exec/CudfAggregation.h
@@ -108,7 +108,7 @@ std::vector<ResolvedAggregateInfo> resolveAggregateInfos(
 std::unique_ptr<cudf::column> applyMask(
     cudf::column_view values,
     cudf::column_view mask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 // Materializes the masked raw-input value column for an aggregate: when
@@ -121,7 +121,7 @@ std::unique_ptr<cudf::column> materializeMaskedColumn(
     cudf::table_view const& input,
     uint32_t inputIndex,
     std::optional<uint32_t> maskIndex,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 // Returns a BOOL8 column whose validity is exactly "mask is true": a true entry
@@ -130,7 +130,7 @@ std::unique_ptr<cudf::column> materializeMaskedColumn(
 // count(*)/count(const).
 std::unique_ptr<cudf::column> maskToValidityColumn(
     cudf::column_view mask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 // Result of buildAggregationInputChannels: a channel permutation that places

--- a/velox/experimental/cudf/exec/CudfAssignUniqueId.cpp
+++ b/velox/experimental/cudf/exec/CudfAssignUniqueId.cpp
@@ -86,7 +86,7 @@ bool CudfAssignUniqueId::isFinished() {
 
 std::unique_ptr<cudf::column> CudfAssignUniqueId::generateIdColumn(
     vector_size_t size,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::vector<int64_t> starts, sizes;
   starts.reserve(size / kRowIdsPerRequest + 1);

--- a/velox/experimental/cudf/exec/CudfAssignUniqueId.h
+++ b/velox/experimental/cudf/exec/CudfAssignUniqueId.h
@@ -62,7 +62,7 @@ class CudfAssignUniqueId : public CudfOperatorBase {
  private:
   std::unique_ptr<cudf::column> generateIdColumn(
       vector_size_t size,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   void requestRowIds();

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -184,7 +184,7 @@ RowVectorPtr CudfFromVelox::doGetOutput() {
 
 void CudfFromVelox::doClose() {
   // TODO(kn): Remove default stream after redesign of CudfFromVelox
-  cudf::get_default_stream(cudf::allow_default_stream).synchronize();
+  cudf::get_default_stream(cudf::allow_default_stream).sync();
   Operator::close();
   inputs_.clear();
 }
@@ -247,7 +247,7 @@ RowVectorPtr CudfToVelox::convertFrontToVelox() {
   auto tableView = cudfVector->getTableView();
   auto output = with_arrow::toVeloxColumn(
       tableView, pool(), outputType_, "", stream, get_temp_mr());
-  stream.synchronize();
+  stream.sync();
   output->setType(outputType_);
   return output;
 }
@@ -274,7 +274,7 @@ RowVectorPtr CudfToVelox::convertFrontToVelox() {
 //      result to Velox in one shot.  This preserves the GPU-side merge
 //      that avoids emitting many undersized Velox batches downstream.
 //
-// In both cases exactly one toVeloxColumn + stream.synchronize() is issued
+// In both cases exactly one toVeloxColumn + stream.sync() is issued
 // per output batch, regardless of how many GPU inputs were consumed.
 RowVectorPtr CudfToVelox::doGetOutput() {
   if (finished_) {
@@ -345,7 +345,7 @@ RowVectorPtr CudfToVelox::doGetOutput() {
       auto tableView = concatTable->view();
       veloxBuffer_ = with_arrow::toVeloxColumn(
           tableView, pool(), outputType_, "", stream, get_temp_mr());
-      stream.synchronize();
+      stream.sync();
       veloxBuffer_->setType(outputType_);
       veloxOffset_ = 0;
       averageRowSize_ = std::nullopt;

--- a/velox/experimental/cudf/exec/CudfDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfDistinct.cpp
@@ -77,13 +77,13 @@ void CudfDistinct::computePartialDistinctStreaming(CudfVectorPtr tbl) {
     // We need to join the input table stream on the partial output stream to
     // make sure the input table is available when we do the concat.
     cudf::detail::join_streams(
-        std::vector<rmm::cuda_stream_view>{inputTableStream},
+        std::vector<cuda::stream_ref>{inputTableStream},
         partialOutputStream);
 
     auto concatenatedTable =
         cudf::concatenate(tablesToConcat, partialOutputStream, get_output_mr());
     cudf::detail::join_streams(
-        std::vector<rmm::cuda_stream_view>{partialOutputStream},
+        std::vector<cuda::stream_ref>{partialOutputStream},
         inputTableStream);
 
     // Do a distinct on the concatenated results.
@@ -122,7 +122,7 @@ void CudfDistinct::doAddInput(RowVectorPtr input) {
 CudfVectorPtr CudfDistinct::getDistinctKeys(
     cudf::table_view tableView,
     std::vector<column_index_t> const& groupByKeys,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   auto result = cudf::distinct(
       tableView.select(groupByKeys.begin(), groupByKeys.end()),
       {groupingKeyOutputChannels_.begin(), groupingKeyOutputChannels_.end()},
@@ -203,7 +203,7 @@ RowVectorPtr CudfDistinct::doGetOutput() {
       std::exchange(inputs_, {}), inputType_, stream, get_output_mr());
 
   // Release input data after synchronizing.
-  stream.synchronize();
+  stream.sync();
   inputs_.clear();
 
   if (noMoreInput_) {

--- a/velox/experimental/cudf/exec/CudfDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfDistinct.cpp
@@ -77,14 +77,12 @@ void CudfDistinct::computePartialDistinctStreaming(CudfVectorPtr tbl) {
     // We need to join the input table stream on the partial output stream to
     // make sure the input table is available when we do the concat.
     cudf::detail::join_streams(
-        std::vector<cuda::stream_ref>{inputTableStream},
-        partialOutputStream);
+        std::vector<cuda::stream_ref>{inputTableStream}, partialOutputStream);
 
     auto concatenatedTable =
         cudf::concatenate(tablesToConcat, partialOutputStream, get_output_mr());
     cudf::detail::join_streams(
-        std::vector<cuda::stream_ref>{partialOutputStream},
-        inputTableStream);
+        std::vector<cuda::stream_ref>{partialOutputStream}, inputTableStream);
 
     // Do a distinct on the concatenated results.
     // Keep concatenatedTable alive while we use its view.

--- a/velox/experimental/cudf/exec/CudfDistinct.h
+++ b/velox/experimental/cudf/exec/CudfDistinct.h
@@ -52,7 +52,7 @@ class CudfDistinct : public CudfOperatorBase {
   CudfVectorPtr getDistinctKeys(
       cudf::table_view tableView,
       std::vector<column_index_t> const& groupByKeys,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   CudfVectorPtr releaseAndResetBufferedResult();
 

--- a/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
+++ b/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
@@ -79,7 +79,7 @@ void CudfEnforceSingleRow::doNoMoreInput() {
     auto stream = cudf::get_default_stream(cudf::allow_default_stream);
     auto cudfTable =
         with_arrow::toCudfTable(nullRow, pool(), stream, get_output_mr());
-    stream.synchronize();
+    stream.sync();
     input_ = std::make_shared<CudfVector>(
         pool(), outputType_, 1, std::move(cudfTable), stream);
   }

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -258,7 +258,7 @@ RowVectorPtr CudfFilterProject::doGetOutput() {
 
 void CudfFilterProject::filter(
     std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   // Evaluate the Filter
   std::vector<cudf::column_view> inputViews;
   inputViews.reserve(inputTableColumns.size());
@@ -287,7 +287,7 @@ void CudfFilterProject::filter(
   if (shouldApplyFilter) {
     auto filterTable =
         std::make_unique<cudf::table>(std::move(inputTableColumns));
-    auto filteredTable = cudf::apply_boolean_mask(
+    auto filteredTable = cudf::apply_retention_mask(
         *filterTable, filterColumnView, stream, get_output_mr());
     inputTableColumns = filteredTable->release();
   }
@@ -295,7 +295,7 @@ void CudfFilterProject::filter(
 
 std::vector<std::unique_ptr<cudf::column>> CudfFilterProject::project(
     std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<cudf::column_view> inputViews;
   inputViews.reserve(inputTableColumns.size());
   for (auto& col : inputTableColumns) {

--- a/velox/experimental/cudf/exec/CudfFilterProject.h
+++ b/velox/experimental/cudf/exec/CudfFilterProject.h
@@ -43,11 +43,11 @@ class CudfFilterProject : public CudfOperatorBase {
 
   void filter(
       std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   std::vector<std::unique_ptr<cudf::column>> project(
       std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
     return exec::BlockingReason::kNotBlocked;

--- a/velox/experimental/cudf/exec/CudfGroupId.h
+++ b/velox/experimental/cudf/exec/CudfGroupId.h
@@ -74,7 +74,7 @@ class CudfGroupId : public CudfOperatorBase {
   cudf::size_type inputSize_{0};
 
   /// Stream associated with the input data.
-  cuda::stream_ref inputStream_;
+  cuda::stream_ref inputStream_{cudaStream_t{nullptr}};
 
   /// Index of the grouping set to output in the next getOutput call.
   size_t groupingSetIndex_{0};

--- a/velox/experimental/cudf/exec/CudfGroupId.h
+++ b/velox/experimental/cudf/exec/CudfGroupId.h
@@ -74,7 +74,7 @@ class CudfGroupId : public CudfOperatorBase {
   cudf::size_type inputSize_{0};
 
   /// Stream associated with the input data.
-  cuda::stream_ref inputStream_{cudaStream_t{nullptr}};
+  cuda::stream_ref inputStream_{cudaStream_t{cudaStreamDefault}};
 
   /// Index of the grouping set to output in the next getOutput call.
   size_t groupingSetIndex_{0};

--- a/velox/experimental/cudf/exec/CudfGroupId.h
+++ b/velox/experimental/cudf/exec/CudfGroupId.h
@@ -74,7 +74,7 @@ class CudfGroupId : public CudfOperatorBase {
   cudf::size_type inputSize_{0};
 
   /// Stream associated with the input data.
-  rmm::cuda_stream_view inputStream_;
+  cuda::stream_ref inputStream_;
 
   /// Index of the grouping set to output in the next getOutput call.
   size_t groupingSetIndex_{0};

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -80,7 +80,7 @@ size_t scaleStreamingGroupbyCapacity(
 std::unique_ptr<cudf::column> castStreamingOutput(
     std::unique_ptr<cudf::column> column,
     const TypePtr& type,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   const auto outputType = cudf_velox::veloxToCudfDataType(type);
   if (column->type() != outputType) {
@@ -115,7 +115,7 @@ struct SimpleStreamingGroupbyAggregator final : StreamingGroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     return castStreamingOutput(
         std::move(results[resultIndex_].results[0]), resultType, stream, mr);
@@ -170,7 +170,7 @@ struct StreamingGroupbyAverageAggregator final : StreamingGroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     auto sum = std::move(results[sumResultIndex_].results[0]);
     auto count = std::move(results[countResultIndex_].results[0]);
@@ -222,7 +222,7 @@ struct SimpleGroupbyAggregator final : GroupbyAggregator {
   void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     VELOX_CHECK(
         constant == nullptr,
@@ -235,7 +235,7 @@ struct SimpleGroupbyAggregator final : GroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     auto column = std::move(results[outputIndex_].results[0]);
     const auto cudfType = cudf_velox::veloxToCudfDataType(resultType);
@@ -269,7 +269,7 @@ void addDecimalSumCountRequestsAfterDecode(
     cudf::column_view encodedColumn,
     int32_t scale,
     std::vector<cudf::groupby::aggregation_request>& requests,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     uint32_t& sumIdx,
     uint32_t& countIdx,
     std::unique_ptr<cudf::column>& decodedSum,
@@ -301,7 +301,7 @@ void addDecimalDecodedSumCountRequests(
     uint32_t inputIndex,
     const TypePtr& resultType,
     std::vector<cudf::groupby::aggregation_request>& requests,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     uint32_t& sumIdx,
     uint32_t& countIdx,
     std::unique_ptr<cudf::column>& decodedSum,
@@ -326,7 +326,7 @@ void addDecimalFinalSumOnlyRequest(
     uint32_t inputIndex,
     const TypePtr& resultType,
     std::vector<cudf::groupby::aggregation_request>& requests,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     uint32_t& sumIdx,
     std::unique_ptr<cudf::column>& decodedSum) {
   validateIntermediateColumnType(tbl.column(inputIndex));
@@ -345,7 +345,7 @@ void addDecimalRawPartialSingleSumRequest(
     cudf::column_view input,
     std::vector<cudf::groupby::aggregation_request>& requests,
     bool includeCountAggregation,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     uint32_t& sumIdx,
     std::unique_ptr<cudf::column>& castedInput) {
   auto inputView = castDecimal64InputToDecimal128(input, castedInput, stream);
@@ -373,7 +373,7 @@ struct GroupbyDecimalSumAggregator : GroupbyAggregator {
   void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     if (step == core::AggregationNode::Step::kIntermediate) {
       addDecimalDecodedSumCountRequests(
@@ -406,7 +406,7 @@ struct GroupbyDecimalSumAggregator : GroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     auto col = std::move(results[sumIdx_].results[0]);
     if (step == core::AggregationNode::Step::kPartial) {
@@ -454,7 +454,7 @@ struct GroupbyDecimalAvgAggregator : GroupbyAggregator {
   void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref /*mr*/) override {
     VELOX_CHECK(!maskIndex.has_value(), "decimal avg does not support masks");
     if (step == core::AggregationNode::Step::kIntermediate ||
@@ -483,7 +483,7 @@ struct GroupbyDecimalAvgAggregator : GroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     auto col = std::move(results[sumIdx_].results[0]);
     if (step == core::AggregationNode::Step::kSingle) {
@@ -533,7 +533,7 @@ struct GroupbyCountAggregator : GroupbyAggregator {
   void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     // kCountAll and kNullConstant both submit a count-all-rows request;
     // kNullConstant overrides the result with zeros in makeOutputColumn.
@@ -574,7 +574,7 @@ struct GroupbyCountAggregator : GroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     auto col = std::move(results[outputIndex_].results[0]);
     if (inputKind_ == CountInputKind::kNullConstant) {
@@ -610,7 +610,7 @@ struct GroupbyMeanAggregator : GroupbyAggregator {
   void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
-      rmm::cuda_stream_view /*stream*/,
+      cuda::stream_ref /*stream*/,
       rmm::device_async_resource_ref /*mr*/) override {
     VELOX_CHECK(!maskIndex.has_value(), "avg does not support masks");
     switch (step) {
@@ -659,7 +659,7 @@ struct GroupbyMeanAggregator : GroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     const auto& outputType = asRowType(resultType);
     switch (step) {
@@ -785,7 +785,7 @@ struct GroupbyStddevSampAggregator : GroupbyAggregator {
   void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
-      rmm::cuda_stream_view /*stream*/,
+      cuda::stream_ref /*stream*/,
       rmm::device_async_resource_ref /*mr*/) override {
     VELOX_CHECK(!maskIndex.has_value(), "stddev does not support masks");
     auto& request = requests.emplace_back();
@@ -821,7 +821,7 @@ struct GroupbyStddevSampAggregator : GroupbyAggregator {
 
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     switch (step) {
       case core::AggregationNode::Step::kSingle:
@@ -923,7 +923,7 @@ struct GroupbyStddevSampAggregator : GroupbyAggregator {
       std::unique_ptr<cudf::column> count,
       std::unique_ptr<cudf::column> mean,
       std::unique_ptr<cudf::column> m2,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     const auto& outputType = asRowType(resultType);
     auto const cudfCountType =
@@ -1093,7 +1093,7 @@ column_index_t StreamingGroupbyAggregator::prepareColumn(
 cudf::column_view GroupbyAggregator::materializeMaskedInput(
     cudf::table_view const& tbl,
     uint32_t valueIdx,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (!maskIndex.has_value()) {
     return tbl.column(valueIdx);
@@ -1343,7 +1343,7 @@ void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr input) {
     streamingGroupbyStream_ = inputStream;
   }
   const auto stateStream = *streamingGroupbyStream_;
-  const bool needsStreamJoin = stateStream.value() != inputStream.value();
+  const bool needsStreamJoin = stateStream.get() != inputStream.get();
   if (needsStreamJoin) {
     if (!streamingGroupbyEvent_) {
       streamingGroupbyEvent_ =
@@ -1402,7 +1402,7 @@ void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr input) {
         // streaming_groupby's destructor has no stream parameter. Ensure the
         // merge has finished reading the old persistent state before dropping
         // it.
-        stateStream.synchronize();
+        stateStream.sync();
         streamingGroupby_ = std::move(replacement);
         streamingGroupbyCapacity_ = newCapacity;
 
@@ -1453,7 +1453,7 @@ CudfVectorPtr CudfGroupby::finalizeStreamingGroupby() {
 
   // libcudf finalization reads persistent state asynchronously. Its destructor
   // has no stream parameter, so wait before releasing that state.
-  stream.synchronize();
+  stream.sync();
   streamingGroupby_.reset();
   streamingGroupbyStream_.reset();
   streamingGroupbyEvent_.reset();
@@ -1617,12 +1617,12 @@ void CudfGroupby::computeFinalGroupbyIncrementally(CudfVectorPtr tbl) {
 
   auto finalStream = bufferedResult_->stream();
   cudf::detail::join_streams(
-      std::vector<rmm::cuda_stream_view>{inputTableStream}, finalStream);
+      std::vector<cuda::stream_ref>{inputTableStream}, finalStream);
 
   auto concatenatedTable =
       cudf::concatenate(tablesToConcat, finalStream, get_temp_mr());
   cudf::detail::join_streams(
-      std::vector<rmm::cuda_stream_view>{finalStream}, inputTableStream);
+      std::vector<cuda::stream_ref>{finalStream}, inputTableStream);
   auto compactedOutput = doGroupByAggregation(
       concatenatedTable->view(),
       groupingKeyOutputChannels_,
@@ -1705,7 +1705,7 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
     std::vector<column_index_t> const& groupByKeys,
     std::vector<std::unique_ptr<GroupbyAggregator>>& aggregators,
     TypePtr const& outputType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto groupbyKeyView =
       tableView.select(groupByKeys.begin(), groupByKeys.end());
@@ -1826,7 +1826,7 @@ RowVectorPtr CudfGroupby::doGetOutput() {
         outputType_,
         stream,
         get_output_mr());
-    stream.synchronize();
+    stream.sync();
     bufferedResult_.reset();
     return result;
   }
@@ -1841,7 +1841,7 @@ RowVectorPtr CudfGroupby::doGetOutput() {
       std::exchange(inputs_, {}), inputType_, stream, get_temp_mr());
 
   // Release input data after synchronizing.
-  stream.synchronize();
+  stream.sync();
   inputs_.clear();
 
   if (noMoreInput_) {

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -1315,8 +1315,8 @@ CudfGroupby::createStreamingGroupby(size_t capacity) {
       keyIndices,
       requests,
       static_cast<cudf::size_type>(capacity),
-      ignoreNullKeys_ ? cudf::null_policy::EXCLUDE
-                      : cudf::null_policy::INCLUDE);
+      ignoreNullKeys_ ? cudf::null_policy::EXCLUDE : cudf::null_policy::INCLUDE,
+      get_temp_mr());
 }
 
 void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr input) {
@@ -1872,7 +1872,7 @@ void CudfGroupby::doClose() {
   if (streamingGroupby_ && streamingGroupbyStream_.has_value()) {
     // Match rebuild and finalization: wait before dropping persistent state
     // that an asynchronous aggregate or merge may still reference.
-    streamingGroupbyStream_->synchronize();
+    streamingGroupbyStream_->sync();
   }
   streamingGroupby_.reset();
   streamingGroupbyEvent_.reset();

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -57,7 +57,7 @@ struct StreamingGroupbyAggregator {
   // Consumes the result positions recorded by addStreamingRequest().
   virtual std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) = 0;
 
   virtual ~StreamingGroupbyAggregator() = default;
@@ -82,12 +82,12 @@ struct GroupbyAggregator {
   virtual void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) = 0;
 
   virtual std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) = 0;
 
   virtual ~GroupbyAggregator() = default;
@@ -114,7 +114,7 @@ struct GroupbyAggregator {
   cudf::column_view materializeMaskedInput(
       cudf::table_view const& tbl,
       uint32_t valueIdx,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
  private:
@@ -187,7 +187,7 @@ class CudfGroupby : public CudfOperatorBase {
       std::vector<column_index_t> const& groupByKeys,
       std::vector<std::unique_ptr<GroupbyAggregator>>& aggregators,
       TypePtr const& outputType,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   CudfVectorPtr releaseAndResetBufferedResult();
@@ -242,7 +242,7 @@ class CudfGroupby : public CudfOperatorBase {
   std::vector<std::unique_ptr<StreamingGroupbyAggregator>>
       streamingGroupbyAggregators_;
   std::unique_ptr<cudf::groupby::streaming_groupby> streamingGroupby_;
-  std::optional<rmm::cuda_stream_view> streamingGroupbyStream_;
+  std::optional<cuda::stream_ref> streamingGroupbyStream_;
   std::unique_ptr<CudaEvent> streamingGroupbyEvent_;
   size_t streamingGroupbyCapacity_{0};
 };

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -49,10 +49,10 @@
 #include <cudf/stream_compaction.hpp>
 #include <cudf/unary.hpp>
 
-#include <cuda/stream>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream>
 #include <nvtx3/nvtx3.hpp>
 
 #include <algorithm>
@@ -753,9 +753,17 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::unfilteredOutput(
   auto leftInput = leftTableView.select(outputLayout_.probeColumnIndices);
   auto rightInput = rightTableView.select(outputLayout_.buildColumnIndices);
   auto leftResult = cudf::gather(
-      leftInput, leftIndicesCol, oobPolicy, stream, get_output_mr());
+      leftInput,
+      leftIndicesCol,
+      oobPolicy,
+      stream,
+      cudf::memory_resources{get_output_mr(), get_temp_mr()});
   auto rightResult = cudf::gather(
-      rightInput, rightIndicesCol, oobPolicy, stream, get_output_mr());
+      rightInput,
+      rightIndicesCol,
+      oobPolicy,
+      stream,
+      cudf::memory_resources{get_output_mr(), get_temp_mr()});
 
   if (CudfConfig::getInstance().debugEnabled) {
     VLOG(1) << "Left result number of columns: " << leftResult->num_columns();
@@ -785,9 +793,17 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::filteredOutput(
         cudf::column_view)> func,
     cuda::stream_ref stream) {
   auto leftResult = cudf::gather(
-      leftTableView, leftIndicesCol, oobPolicy, stream, get_output_mr());
+      leftTableView,
+      leftIndicesCol,
+      oobPolicy,
+      stream,
+      cudf::memory_resources{get_output_mr(), get_temp_mr()});
   auto rightResult = cudf::gather(
-      rightTableView, rightIndicesCol, oobPolicy, stream, get_output_mr());
+      rightTableView,
+      rightIndicesCol,
+      oobPolicy,
+      stream,
+      cudf::memory_resources{get_output_mr(), get_temp_mr()});
   auto leftColsSize = leftResult->num_columns();
   auto rightColsSize = rightResult->num_columns();
 
@@ -1444,7 +1460,8 @@ CudfHashJoinProbe::leftSemiFilterJoin(
       cudf::filtered_join filter_join(
           rightTableView.select(rightKeyIndices_),
           cudf::null_equality::UNEQUAL,
-          stream);
+          stream,
+          get_temp_mr());
       leftJoinIndices = filter_join.semi_join(
           leftTableView.select(leftKeyIndices_), stream, get_temp_mr());
     }
@@ -2013,7 +2030,8 @@ CudfHashJoinProbe::rightSemiFilterJoin(
     cudf::filtered_join filter_join(
         leftTableView.select(leftKeyIndices_),
         cudf::null_equality::UNEQUAL,
-        stream);
+        stream,
+        get_temp_mr());
     rightJoinIndices = filter_join.semi_join(
         rightTableView.select(rightKeyIndices_), stream, get_temp_mr());
   }
@@ -2088,7 +2106,8 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::antiJoin(
       cudf::filtered_join filter_join(
           rightTableView.select(rightKeyIndices_),
           cudf::null_equality::UNEQUAL,
-          stream);
+          stream,
+          get_temp_mr());
       leftJoinIndices = filter_join.anti_join(
           leftTableView.select(leftKeyIndices_), stream, get_temp_mr());
     }

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -49,7 +49,7 @@
 #include <cudf/stream_compaction.hpp>
 #include <cudf/unary.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -67,7 +67,7 @@ vector_size_t filteredOutputNumRows(
     bool zeroColumnOutput,
     cudf::column_view filterColumn,
     const std::vector<std::unique_ptr<cudf::column>>& joinedCols,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref tempMr) {
   if (!zeroColumnOutput) {
     return joinedCols.empty() ? 0 : joinedCols[0]->size();
@@ -94,7 +94,7 @@ enum class MaskType { kMatched, kUnmatched };
 std::unique_ptr<cudf::column> getMaskedIndices(
     cudf::column_view mask,
     MaskType maskType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto seq = cudf::sequence(
       mask.size(),
@@ -104,7 +104,7 @@ std::unique_ptr<cudf::column> getMaskedIndices(
       mr);
 
   auto indicesTable = maskType == MaskType::kMatched
-      ? cudf::apply_boolean_mask(
+      ? cudf::apply_retention_mask(
             cudf::table_view{{seq->view()}}, mask, stream, mr)
       : cudf::apply_deletion_mask(
             cudf::table_view{{seq->view()}}, mask, stream, mr);
@@ -119,7 +119,7 @@ class ProbeMatchTracker {
  public:
   ProbeMatchTracker(
       cudf::size_type numProbeRows,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto falseScalar = cudf::numeric_scalar<bool>(false, true, stream, mr);
     matchCol_ =
@@ -135,7 +135,7 @@ class ProbeMatchTracker {
   // Mark probe rows present in matchedLeftIndices as matched.
   void update(
       cudf::column_view matchedLeftIndices,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto matchedInBatch = cudf::contains(
         matchedLeftIndices, probeRowIndices_->view(), stream, mr);
@@ -146,13 +146,13 @@ class ProbeMatchTracker {
         cudf::data_type{cudf::type_id::BOOL8},
         stream,
         mr);
-    stream.synchronize();
+    stream.sync();
     matchCol_ = std::move(updatedMatch);
   }
 
   // Returns indices of probe rows that were never matched.
   std::unique_ptr<cudf::column> getUnmatchedIndices(
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     return getMaskedIndices(
         matchCol_->view(), MaskType::kUnmatched, stream, mr);
@@ -160,7 +160,7 @@ class ProbeMatchTracker {
 
   // Returns indices of probe rows that matched in at least one build batch.
   std::unique_ptr<cudf::column> getMatchedIndices(
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     return getMaskedIndices(matchCol_->view(), MaskType::kMatched, stream, mr);
   }
@@ -224,12 +224,12 @@ std::optional<CudfHashJoinBridge::hash_type> CudfHashJoinBridge::hashOrFuture(
   return std::nullopt;
 }
 
-void CudfHashJoinBridge::setBuildStream(rmm::cuda_stream_view buildStream) {
+void CudfHashJoinBridge::setBuildStream(cuda::stream_ref buildStream) {
   std::lock_guard<std::mutex> l(mutex_);
   buildStream_ = buildStream;
 }
 
-std::optional<rmm::cuda_stream_view> CudfHashJoinBridge::getBuildStream() {
+std::optional<cuda::stream_ref> CudfHashJoinBridge::getBuildStream() {
   std::lock_guard<std::mutex> l(mutex_);
   return buildStream_;
 }
@@ -502,7 +502,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
   }
 }
 
-void CudfHashJoinProbe::waitForBuildReady(rmm::cuda_stream_view stream) {
+void CudfHashJoinProbe::waitForBuildReady(cuda::stream_ref stream) {
   if (buildReadyEvent_ != nullptr) {
     buildReadyEvent_->waitOn(stream);
   }
@@ -660,7 +660,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
       // Drivers without lastProbeStream_ (no probe batches) are skipped:
       // their flags are all-false from host-synchronized init with no pending
       // GPU work.
-      std::vector<rmm::cuda_stream_view> inputStreams;
+      std::vector<cuda::stream_ref> inputStreams;
       if (lastProbeStream_.has_value()) {
         inputStreams.push_back(lastProbeStream_.value());
       }
@@ -702,11 +702,11 @@ void CudfHashJoinProbe::doNoMoreInput() {
           // binary_operation is async on `stream`; the old column destructs via
           // cudaFreeAsync on its allocation stream (not `stream`), so the free
           // can race the kernel. Drain `stream` before the move-assign.
-          stream.synchronize();
+          stream.sync();
           rightMatchedFlags_[p] = std::move(or_result);
         }
       }
-      stream.synchronize();
+      stream.sync();
     }
     return;
   }
@@ -746,7 +746,7 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::unfilteredOutput(
     cudf::column_view leftIndicesCol,
     cudf::table_view rightTableView,
     cudf::column_view rightIndicesCol,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<std::unique_ptr<cudf::column>> joinedCols;
   auto const numRows = static_cast<vector_size_t>(
       std::max(leftIndicesCol.size(), rightIndicesCol.size()));
@@ -771,7 +771,7 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::unfilteredOutput(
     // Ensure deallocation of build table happens after probe gathers
     cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
   }
-  stream.synchronize();
+  stream.sync();
   return {std::make_unique<cudf::table>(std::move(joinedCols)), numRows};
 }
 
@@ -783,7 +783,7 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::filteredOutput(
     std::function<std::vector<std::unique_ptr<cudf::column>>(
         std::vector<std::unique_ptr<cudf::column>>&&,
         cudf::column_view)> func,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   auto leftResult = cudf::gather(
       leftTableView, leftIndicesCol, oobPolicy, stream, get_output_mr());
   auto rightResult = cudf::gather(
@@ -828,7 +828,7 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::filteredOutput(
     // Ensure any deallocation of join indices is ordered wrt probe gathers
     cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
   }
-  stream.synchronize();
+  stream.sync();
   return {std::make_unique<cudf::table>(std::move(joinedCols)), numRows};
 }
 
@@ -840,7 +840,7 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::filteredOutputIndices(
     cudf::table_view extendedLeftView,
     cudf::table_view extendedRightView,
     cudf::join_kind joinKind,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   // Use extended views (with precomputed columns) for filter evaluation
   auto [filteredLeftJoinIndices, filteredRightJoinIndices] =
       cudf::filter_join_indices(
@@ -871,7 +871,7 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::filteredOutputIndices(
 
 std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
     cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
 
   auto& rightTables = hashObject_.value().first;
@@ -937,7 +937,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
                 cudf::column_view filterColumn) {
               auto filterTable =
                   std::make_unique<cudf::table>(std::move(joinedCols));
-              auto filteredTable = cudf::apply_boolean_mask(
+              auto filteredTable = cudf::apply_retention_mask(
                   *filterTable, filterColumn, stream, get_output_mr());
               return filteredTable->release();
             };
@@ -963,7 +963,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
 
 std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
     cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
 
   auto& rightTables = hashObject_.value().first;
@@ -1041,14 +1041,14 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
                 cudf::column_view filterColumn) {
               auto filterTable =
                   std::make_unique<cudf::table>(std::move(joinedCols));
-              auto filteredTable = cudf::apply_boolean_mask(
+              auto filteredTable = cudf::apply_retention_mask(
                   *filterTable, filterColumn, stream, get_output_mr());
               joinedCols = filteredTable->release();
 
               // Filter left join indices with the same mask to track which
               // probe rows passed the filter.
               auto leftIdxCol = cudf::column_view{leftIndicesSpanCopy};
-              auto filteredIdxTable = cudf::apply_boolean_mask(
+              auto filteredIdxTable = cudf::apply_retention_mask(
                   cudf::table_view{std::vector<cudf::column_view>{leftIdxCol}},
                   filterColumn,
                   stream,
@@ -1142,7 +1142,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
 
 std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
     cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
 
   auto& rightTables = hashObject_.value().first;
@@ -1188,7 +1188,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
       // binary_operation is async on `stream`; the old column destructs via
       // cudaFreeAsync on its allocation stream (not `stream`), so the free
       // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
+      stream.sync();
       rightMatchedFlags_[i] = std::move(updatedFlags);
     }
 
@@ -1210,7 +1210,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
             // apply the filter
             auto filterTable =
                 std::make_unique<cudf::table>(std::move(joinedCols));
-            auto filteredTable = cudf::apply_boolean_mask(
+            auto filteredTable = cudf::apply_retention_mask(
                 *filterTable, filterColumn, stream, get_output_mr());
             joinedCols = filteredTable->release();
 
@@ -1218,7 +1218,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
             // matched right indices filter rightJoinIndices with the same mask
             // to update matched flags
             auto rightIdxCol = cudf::column_view{rightIndicesSpan};
-            auto filteredIdxTable = cudf::apply_boolean_mask(
+            auto filteredIdxTable = cudf::apply_retention_mask(
                 cudf::table_view{std::vector<cudf::column_view>{rightIdxCol}},
                 filterColumn,
                 stream,
@@ -1253,7 +1253,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
             // binary_operation is async on `stream`; the old column destructs
             // via cudaFreeAsync on its allocation stream (not `stream`), so the
             // free can race the kernel. Drain `stream` before the move-assign.
-            stream.synchronize();
+            stream.sync();
             rightMatchedFlags = std::move(updatedFlags);
             return std::move(joinedCols);
           };
@@ -1278,7 +1278,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
 
 std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
     cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
 
   auto& rightTables = hashObject_.value().first;
@@ -1313,7 +1313,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
         cudf::data_type{cudf::type_id::BOOL8},
         stream,
         get_temp_mr());
-    stream.synchronize();
+    stream.sync();
     rightMatchedFlags_[batchIdx] = std::move(updatedFlags);
   };
 
@@ -1416,7 +1416,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
 std::vector<CudfHashJoinProbe::JoinOutput>
 CudfHashJoinProbe::leftSemiFilterJoin(
     cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
 
   auto& rightTables = hashObject_.value().first;
@@ -1483,7 +1483,7 @@ namespace {
 /// Returns a column where row[i] = true if ANY key column is NULL at row i.
 std::unique_ptr<cudf::column> createProbeKeyNullMask(
     cudf::table_view keyView,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto numRows = keyView.num_rows();
 
@@ -1515,7 +1515,7 @@ std::unique_ptr<cudf::column> createProbeKeyNullMask(
 std::unique_ptr<cudf::column> applyNullMask(
     cudf::column_view col,
     cudf::column_view nullMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Create a null scalar (valid=false means NULL)
   auto nullScalar = cudf::numeric_scalar<bool>(false, false, stream, mr);
@@ -1534,7 +1534,7 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::column>>
 createCrossProductIndices(
     cudf::column_view leftIndices,
     cudf::column_view rightIndices,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto numLeft = leftIndices.size();
   auto numRight = rightIndices.size();
@@ -1581,7 +1581,7 @@ createCrossProductIndices(
 std::vector<CudfHashJoinProbe::JoinOutput>
 CudfHashJoinProbe::leftSemiProjectJoin(
     cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
 
   // For now, AST support is necessary to filter join output
@@ -1705,7 +1705,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
         cudf::data_type{cudf::type_id::BOOL8},
         stream,
         get_output_mr());
-    stream.synchronize();
+    stream.sync();
     matchCol = std::move(updatedMatch);
   }
 
@@ -1976,7 +1976,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
   if (buildStream_.has_value()) {
     cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
   }
-  stream.synchronize();
+  stream.sync();
 
   auto output = std::make_unique<cudf::table>(std::move(outputCols));
   cudfOutputs.push_back(
@@ -1987,7 +1987,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
 std::vector<CudfHashJoinProbe::JoinOutput>
 CudfHashJoinProbe::rightSemiFilterJoin(
     cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
 
   auto& rightTables = hashObject_.value().first;
@@ -2034,7 +2034,7 @@ CudfHashJoinProbe::rightSemiFilterJoin(
 
 std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::antiJoin(
     cudf::table_view leftTableViewParam,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<JoinOutput> cudfOutputs;
   auto& rightTables = hashObject_.value().first;
 
@@ -2155,7 +2155,7 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
         if (!outputLayout_.buildColumnIndices.empty()) {
           auto rightInput =
               rightTable->view().select(outputLayout_.buildColumnIndices);
-          auto unmatchedRight = cudf::apply_boolean_mask(
+          auto unmatchedRight = cudf::apply_retention_mask(
               rightInput, boolMask->view(), stream, get_output_mr());
           auto rightCols = unmatchedRight->release();
           outputLayout_.scatterBuildColumns(outCols, rightCols);
@@ -2332,7 +2332,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
           false_scalar, n, initStream, get_temp_mr());
       rightMatchedFlags_.push_back(std::move(flags_col));
     }
-    initStream.synchronize();
+    initStream.sync();
   }
 
   // Precompute right table columns if filter exists (once when build is done)
@@ -2359,7 +2359,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
       cachedRightPrecomputed_.push_back(std::move(rightPrecomputed));
       cachedExtendedRightViews_.push_back(extendedView);
     }
-    initStream.synchronize();
+    initStream.sync();
   }
 
   // Check if build side has any null keys (needed for null-aware left semi

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -32,7 +32,7 @@
 #include <cudf/join/hash_join.hpp>
 #include <cudf/table/table.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 
@@ -69,9 +69,9 @@ class CudfHashJoinBridge : public exec::JoinBridge {
   std::optional<hash_type> hashOrFuture(ContinueFuture* future);
 
   // Store and retrieve the CUDA stream used for building the hash join.
-  void setBuildStream(rmm::cuda_stream_view buildStream);
+  void setBuildStream(cuda::stream_ref buildStream);
 
-  std::optional<rmm::cuda_stream_view> getBuildStream();
+  std::optional<cuda::stream_ref> getBuildStream();
 
   void setBuildReadyEvent(std::shared_ptr<CudaEvent> buildReadyEvent);
 
@@ -82,7 +82,7 @@ class CudfHashJoinBridge : public exec::JoinBridge {
    * operators */
   std::optional<hash_type> hashObject_;
   /** @brief CUDA stream used by build operator for proper synchronization */
-  std::optional<rmm::cuda_stream_view> buildStream_;
+  std::optional<cuda::stream_ref> buildStream_;
   /** @brief Event recorded after build-side CUDA work is ready for probes */
   std::shared_ptr<CudaEvent> buildReadyEvent_;
 };
@@ -178,7 +178,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   void doClose() override;
 
  private:
-  void waitForBuildReady(rmm::cuda_stream_view stream);
+  void waitForBuildReady(cuda::stream_ref stream);
 
   std::shared_ptr<const core::HashJoinNode> joinNode_;
   /** @brief Hash tables and join objects received from build operator */
@@ -231,7 +231,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   bool skipInput_{false};
 
   /** @brief CUDA stream from build operator for synchronization */
-  std::optional<rmm::cuda_stream_view> buildStream_;
+  std::optional<cuda::stream_ref> buildStream_;
   /** @brief Event recorded after build-side CUDA work is ready for probes */
   std::shared_ptr<CudaEvent> buildReadyEvent_;
   /** @brief CUDA event for coordinating stream synchronization */
@@ -260,7 +260,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// to skip: the driver loop guarantees all addInput batches are consumed by
   /// getOutput() before noMoreInput() fires, and unset flags remain in their
   /// host-synchronized all-false init state with no pending GPU work.
-  std::optional<rmm::cuda_stream_view> lastProbeStream_;
+  std::optional<cuda::stream_ref> lastProbeStream_;
 
   static constexpr auto oobPolicy = cudf::out_of_bounds_policy::NULLIFY;
 
@@ -277,7 +277,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> innerJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Performs left join between probe table and all build tables.
    * @param leftTableView Probe-side table view to join
@@ -286,7 +286,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> leftJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Performs right join between probe table and all build tables.
    * @param leftTableView Probe-side table view to join
@@ -295,7 +295,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> rightJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Performs full outer join between probe table and all build tables.
    * @param leftTableView Probe-side table view to join
@@ -304,7 +304,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> fullJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Performs left semi filter join between probe table and all build
    * tables.
@@ -314,7 +314,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> leftSemiFilterJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Performs left semi project join between probe table and all build
    * tables. Returns all probe rows with a boolean match column indicating
@@ -325,7 +325,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> leftSemiProjectJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Performs right semi filter join between probe table and all build
    * tables.
@@ -335,7 +335,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> rightSemiFilterJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Performs anti join between probe table and all build tables.
    * @param leftTableView Probe-side table view to join
@@ -344,7 +344,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    */
   std::vector<JoinOutput> antiJoin(
       cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Constructs join output table without applying filter conditions.
    * @param leftTableView Input probe table view
@@ -359,7 +359,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
       cudf::column_view leftIndicesCol,
       cudf::table_view rightTableView,
       cudf::column_view rightIndicesCol,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
   /**
    * @brief Constructs join output table with filter condition applied.
    * @param leftTableView Input probe table view
@@ -378,7 +378,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
       std::function<std::vector<std::unique_ptr<cudf::column>>(
           std::vector<std::unique_ptr<cudf::column>>&&,
           cudf::column_view)> func,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   JoinOutput filteredOutputIndices(
       cudf::table_view leftTableView,
@@ -388,7 +388,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
       cudf::table_view extendedLeftView,
       cudf::table_view extendedRightView,
       cudf::join_kind joinKind,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 };
 
 /**

--- a/velox/experimental/cudf/exec/CudfJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfJoin.cpp
@@ -55,7 +55,7 @@ void fillNullColumns(
     const RowTypePtr& inputType,
     std::vector<std::unique_ptr<cudf::column>>& outCols,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   for (const auto& proj : projections) {
     auto cudfDataType =
         veloxToCudfDataType(inputType->childAt(proj.inputChannel));
@@ -147,14 +147,14 @@ void CudfJoinOutputLayout::scatterBuildColumns(
 void CudfJoinOutputLayout::fillNullProbeColumns(
     std::vector<std::unique_ptr<cudf::column>>& outCols,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream) const {
+    cuda::stream_ref stream) const {
   fillNullColumns(probeProjections_, probeType_, outCols, numRows, stream);
 }
 
 void CudfJoinOutputLayout::fillNullBuildColumns(
     std::vector<std::unique_ptr<cudf::column>>& outCols,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream) const {
+    cuda::stream_ref stream) const {
   fillNullColumns(buildProjections_, buildType_, outCols, numRows, stream);
 }
 

--- a/velox/experimental/cudf/exec/CudfJoin.h
+++ b/velox/experimental/cudf/exec/CudfJoin.h
@@ -26,7 +26,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>
@@ -79,11 +79,11 @@ struct CudfJoinOutputLayout {
   void fillNullProbeColumns(
       std::vector<std::unique_ptr<cudf::column>>& outCols,
       cudf::size_type numRows,
-      rmm::cuda_stream_view stream) const;
+      cuda::stream_ref stream) const;
   void fillNullBuildColumns(
       std::vector<std::unique_ptr<cudf::column>>& outCols,
       cudf::size_type numRows,
-      rmm::cuda_stream_view stream) const;
+      cuda::stream_ref stream) const;
 
   /// Read-only access to the probe-side projections, for call sites that
   /// copy from column_views instead of moving gathered columns.

--- a/velox/experimental/cudf/exec/CudfLocalMerge.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalMerge.cpp
@@ -191,7 +191,7 @@ RowVectorPtr CudfLocalMerge::mergeSources() {
   }
 
   std::vector<cudf::table_view> tableViews;
-  std::vector<rmm::cuda_stream_view> inputStreams;
+  std::vector<cuda::stream_ref> inputStreams;
   std::vector<CudfVectorPtr> inputs;
   tableViews.reserve(numBatches);
   inputStreams.reserve(numBatches);

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
@@ -126,7 +126,7 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
   } else {
     VELOX_CHECK(seenStateStream_.has_value());
     const auto stateStream = seenStateStream_.value();
-    const std::vector<rmm::cuda_stream_view> stateStreams{stateStream};
+    const std::vector<cuda::stream_ref> stateStreams{stateStream};
     cudf::detail::join_streams(stateStreams, stream);
 
     // Subsequent batch: probe the persistent filter — no hash table rebuild.

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
@@ -118,9 +118,9 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
         newRowIndicesCol->view(),
         cudf::out_of_bounds_policy::DONT_CHECK,
         stream,
-        tempMr);
+        cudf::memory_resources{tempMr, tempMr});
     seenFilter_ = std::make_unique<cudf::filtered_join>(
-        seenKeys_->view(), cudf::null_equality::EQUAL, stream);
+        seenKeys_->view(), cudf::null_equality::EQUAL, stream, tempMr);
     seenStateStream_ = stream;
 
   } else {
@@ -137,7 +137,7 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
         batchDistinctIdxCol->view(),
         cudf::out_of_bounds_policy::DONT_CHECK,
         stream,
-        tempMr);
+        cudf::memory_resources{tempMr, tempMr});
 
     // Anti-join against the persistent seenFilter_ to find new keys.
     auto newKeyLocalIndices =
@@ -160,7 +160,7 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
               localCol,
               cudf::out_of_bounds_policy::DONT_CHECK,
               stream,
-              tempMr);
+              cudf::memory_resources{tempMr, tempMr});
 
           // Append only the new unique keys to seenKeys_ and rebuild the
           // filter.
@@ -169,7 +169,7 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
               localCol,
               cudf::out_of_bounds_policy::DONT_CHECK,
               stream,
-              tempMr);
+              cudf::memory_resources{tempMr, tempMr});
 
           // Append new keys and rebuild the filter. This concatenates all seen
           // keys on every batch that introduces new keys, which is O(D) per
@@ -197,7 +197,7 @@ RowVectorPtr CudfMarkDistinct::doGetOutput() {
 
     if (updatedSeenKeys) {
       auto updatedSeenFilter = std::make_unique<cudf::filtered_join>(
-          updatedSeenKeys->view(), cudf::null_equality::EQUAL, stream);
+          updatedSeenKeys->view(), cudf::null_equality::EQUAL, stream, tempMr);
       seenFilter_ = std::move(updatedSeenFilter);
       seenKeys_ = std::move(updatedSeenKeys);
       seenStateStream_ = stream;

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.h
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.h
@@ -84,7 +84,7 @@ class CudfMarkDistinct : public CudfOperatorBase {
   std::unique_ptr<cudf::filtered_join> seenFilter_;
 
   /// Stream on which the current seenKeys_ and seenFilter_ state was built.
-  std::optional<rmm::cuda_stream_view> seenStateStream_;
+  std::optional<cuda::stream_ref> seenStateStream_;
 
   /// Reusable event for ordering state lifetime across input streams.
   std::unique_ptr<CudaEvent> cudaEvent_;

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -123,12 +123,12 @@ std::shared_ptr<CudaEvent> CudfNestedLoopJoinBridge::getBuildReadyEvent() {
 }
 
 void CudfNestedLoopJoinBridge::setBuildStream(
-    rmm::cuda_stream_view buildStream) {
+    cuda::stream_ref buildStream) {
   std::lock_guard<std::mutex> l(mutex_);
   buildStream_ = buildStream;
 }
 
-std::optional<rmm::cuda_stream_view>
+std::optional<cuda::stream_ref>
 CudfNestedLoopJoinBridge::getBuildStream() {
   std::lock_guard<std::mutex> l(mutex_);
   return buildStream_;
@@ -435,7 +435,7 @@ void CudfNestedLoopJoinProbe::doNoMoreInput() {
     // but not GPU streams. A peer's CPU thread may have returned from
     // getOutput() while its GPU work (updating buildMatchedFlags_) is still
     // in flight. join_streams establishes GPU-side ordering.
-    std::vector<rmm::cuda_stream_view> inputStreams;
+    std::vector<cuda::stream_ref> inputStreams;
     if (lastProbeStream_.has_value()) {
       inputStreams.push_back(lastProbeStream_.value());
     }
@@ -473,7 +473,7 @@ void CudfNestedLoopJoinProbe::doNoMoreInput() {
       // binary_operation is async on `stream`; the old column destructs via
       // cudaFreeAsync on its allocation stream (not `stream`), so the free
       // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
+      stream.sync();
       buildMatchedFlags_ = std::move(orResult);
     }
   }
@@ -544,7 +544,7 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
         cudf::numeric_scalar<bool>(false, true, initStream, get_temp_mr());
     buildMatchedFlags_ = cudf::make_column_from_scalar(
         falseScalar, numRows, initStream, get_temp_mr());
-    initStream.synchronize();
+    initStream.sync();
   }
 
   // Precompute build-side sub-expressions for filter evaluation (once, here,
@@ -561,14 +561,14 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
         precomputeStream);
     buildExtendedView_ =
         makeExtendedTableView(buildData_->table->view(), buildPrecomputed_);
-    precomputeStream.synchronize();
+    precomputeStream.sync();
   }
 
   return exec::BlockingReason::kNotBlocked;
 }
 
 void CudfNestedLoopJoinProbe::waitForBuildReady(
-    rmm::cuda_stream_view probeStream) {
+    cuda::stream_ref probeStream) {
   if (buildReadyEvent_ != nullptr) {
     // joinWithBuildBatch() is called once per probe input batch, and each
     // call gets a fresh stream from cudfGlobalStreamPool(). The event was
@@ -583,7 +583,7 @@ void CudfNestedLoopJoinProbe::waitForBuildReady(
 }
 
 void CudfNestedLoopJoinProbe::recordReadCompletion(
-    rmm::cuda_stream_view probeStream) {
+    cuda::stream_ref probeStream) {
   if (buildStream_.has_value()) {
     // buildData_'s underlying device memory is allocated on buildStream_
     // (see CudfNestedLoopJoinBuild::doNoMoreInput()), so its eventual free
@@ -606,7 +606,7 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::column>>
 CudfNestedLoopJoinProbe::crossJoinConditionalIndices(
     cudf::table_view probeTableView,
     cudf::table_view buildView,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     bool needBuildIndices) {
   VELOX_NVTX_FUNC_RANGE();
   auto mr = get_temp_mr();
@@ -676,13 +676,13 @@ CudfNestedLoopJoinProbe::crossJoinConditionalIndices(
   auto filterColumn = filterEvaluator_->eval(combinedViews, stream, mr);
   auto mask = asView(filterColumn);
 
-  auto filteredProbeIndices = cudf::apply_boolean_mask(
+  auto filteredProbeIndices = cudf::apply_retention_mask(
       cudf::table_view{{probeIndices->view()}}, mask, stream, mr);
   auto probeIndicesCols = filteredProbeIndices->release();
 
   std::unique_ptr<cudf::column> filteredBuildIndicesCol;
   if (needBuildIndices) {
-    auto filteredBuildIndices = cudf::apply_boolean_mask(
+    auto filteredBuildIndices = cudf::apply_retention_mask(
         cudf::table_view{{buildIndices->view()}}, mask, stream, mr);
     filteredBuildIndicesCol = std::move(filteredBuildIndices->release()[0]);
   }
@@ -692,7 +692,7 @@ CudfNestedLoopJoinProbe::crossJoinConditionalIndices(
 std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::crossJoinZeroColumnBuild(
     cudf::table_view probeView,
     cudf::size_type buildRows,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   // With no build columns, the cross join only multiplies probe cardinality:
   // repeat each probe row buildRows times (probe-major, matching
   // cudf::cross_join's row order). The output is exactly the probe output
@@ -714,7 +714,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
     cudf::table_view probeTableView,
     cudf::table_view buildView,
     cudf::size_type buildRows,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   VELOX_NVTX_FUNC_RANGE();
 
   // Both call sites are in doGetOutput(), which already waits for the
@@ -831,7 +831,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
           cudf::data_type{cudf::type_id::BOOL8},
           stream,
           get_temp_mr());
-      stream.synchronize();
+      stream.sync();
       buildMatchedFlags_ = std::move(updatedFlags);
     }
 
@@ -895,7 +895,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
 
 std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
     cudf::table_view probeTableView,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   cudf::size_type numUnmatched;
   std::unique_ptr<cudf::table> unmatchedProbe;
 
@@ -944,7 +944,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
 }
 
 RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   // Unfiltered cross_join already emitted every build row, so no mismatches
   // to emit. buildMatchedFlags_ is not allocated in that case.
   if (!buildMatchedFlags_) {

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -122,14 +122,12 @@ std::shared_ptr<CudaEvent> CudfNestedLoopJoinBridge::getBuildReadyEvent() {
   return buildReadyEvent_;
 }
 
-void CudfNestedLoopJoinBridge::setBuildStream(
-    cuda::stream_ref buildStream) {
+void CudfNestedLoopJoinBridge::setBuildStream(cuda::stream_ref buildStream) {
   std::lock_guard<std::mutex> l(mutex_);
   buildStream_ = buildStream;
 }
 
-std::optional<cuda::stream_ref>
-CudfNestedLoopJoinBridge::getBuildStream() {
+std::optional<cuda::stream_ref> CudfNestedLoopJoinBridge::getBuildStream() {
   std::lock_guard<std::mutex> l(mutex_);
   return buildStream_;
 }
@@ -567,8 +565,7 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
   return exec::BlockingReason::kNotBlocked;
 }
 
-void CudfNestedLoopJoinProbe::waitForBuildReady(
-    cuda::stream_ref probeStream) {
+void CudfNestedLoopJoinProbe::waitForBuildReady(cuda::stream_ref probeStream) {
   if (buildReadyEvent_ != nullptr) {
     // joinWithBuildBatch() is called once per probe input batch, and each
     // call gets a fresh stream from cudfGlobalStreamPool(). The event was
@@ -649,13 +646,13 @@ CudfNestedLoopJoinProbe::crossJoinConditionalIndices(
       probeIndices->view(),
       cudf::out_of_bounds_policy::DONT_CHECK,
       stream,
-      mr);
+      cudf::memory_resources{mr, get_temp_mr()});
   auto gatheredBuild = cudf::gather(
       buildView,
       buildIndices->view(),
       cudf::out_of_bounds_policy::DONT_CHECK,
       stream,
-      mr);
+      cudf::memory_resources{mr, get_temp_mr()});
 
   std::vector<cudf::column_view> combinedViews;
   auto gatheredProbeView = gatheredProbe->view();
@@ -845,14 +842,14 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
         leftIndicesView,
         cudf::out_of_bounds_policy::DONT_CHECK,
         stream,
-        get_output_mr());
+        cudf::memory_resources{get_output_mr(), get_temp_mr()});
 
     auto gatheredBuild = cudf::gather(
         buildGatherView,
         rightIndicesView,
         cudf::out_of_bounds_policy::DONT_CHECK,
         stream,
-        get_output_mr());
+        cudf::memory_resources{get_output_mr(), get_temp_mr()});
 
     std::vector<std::unique_ptr<cudf::column>> outCols(numOutputColumns);
     auto probeCols = gatheredProbe->release();

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -30,7 +30,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/table/table.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 
@@ -82,14 +82,14 @@ class CudfNestedLoopJoinBridge : public exec::JoinBridge {
   // stream-ordered free (enqueued on this same stream, since that's where
   // it was allocated) can't race a still-in-flight probe read. See
   // CudfNestedLoopJoinProbe::recordReadCompletion().
-  void setBuildStream(rmm::cuda_stream_view buildStream);
+  void setBuildStream(cuda::stream_ref buildStream);
 
-  std::optional<rmm::cuda_stream_view> getBuildStream();
+  std::optional<cuda::stream_ref> getBuildStream();
 
  private:
   std::optional<build_data_type> data_;
   std::shared_ptr<CudaEvent> buildReadyEvent_;
-  std::optional<rmm::cuda_stream_view> buildStream_;
+  std::optional<cuda::stream_ref> buildStream_;
 };
 
 /// Accumulates build-side input for nested loop join.
@@ -216,7 +216,7 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
       cudf::table_view probeTableView,
       cudf::table_view buildView,
       cudf::size_type buildRows,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   /// Produces the cross-join output when the build side has zero columns.
   /// cudf::cross_join cannot be used because a zero-column build table reports
@@ -224,22 +224,22 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   std::unique_ptr<cudf::table> crossJoinZeroColumnBuild(
       cudf::table_view probeView,
       cudf::size_type buildRows,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   /// Emits probe rows that had no match across all build batches, with null
   /// build columns. Used for left/full joins after all build batches exhausted.
   std::unique_ptr<cudf::table> emitProbeMismatchRows(
       cudf::table_view probeTableView,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   /// Emits build rows that had no match across all probe inputs, with null
   /// probe columns. Used for right/full joins after all probes finish. Only
   /// called by the last driver after merging flags from all peers.
-  RowVectorPtr emitBuildMismatchRows(rmm::cuda_stream_view stream);
+  RowVectorPtr emitBuildMismatchRows(cuda::stream_ref stream);
 
   // Makes the given probe stream wait on the build-ready event before it
   // reads build-side data. See buildReadyEvent_.
-  void waitForBuildReady(rmm::cuda_stream_view probeStream);
+  void waitForBuildReady(cuda::stream_ref probeStream);
 
   // Records completion of a read of build-side state on probeStream, and
   // makes buildStream_ wait on it. Must be called after every read of
@@ -248,7 +248,7 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   // before buildData_'s eventual stream-ordered free (enqueued on
   // buildStream_) can run - matching CudfHashJoinProbe's pattern. A no-op
   // if buildStream_ was never fetched (e.g. build side never ran).
-  void recordReadCompletion(rmm::cuda_stream_view probeStream);
+  void recordReadCompletion(cuda::stream_ref probeStream);
 
   /// Evaluates a join condition that isn't AST-representable (e.g. `probe.col
   /// LIKE build.pattern`) by materializing the probe x build cross product
@@ -260,7 +260,7 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   crossJoinConditionalIndices(
       cudf::table_view probeTableView,
       cudf::table_view buildView,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       bool needBuildIndices = true);
 
   bool isLeftOrFullJoin() const {
@@ -337,7 +337,7 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   // Last CUDA stream used for probing, needed for join_streams in
   // noMoreInput() to ensure GPU-side ordering before the cross-peer
   // buildMatchedFlags_ merge (right/full join only).
-  std::optional<rmm::cuda_stream_view> lastProbeStream_;
+  std::optional<cuda::stream_ref> lastProbeStream_;
 
   // Build-ready event, fetched once from the bridge in isBlocked() -
   // already created and recorded by the build side, so waitForBuildReady()
@@ -350,7 +350,7 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   // probe batch's completion, so buildData_'s eventual stream-ordered free
   // (enqueued on this same stream) is correctly ordered after all reads -
   // see CudfNestedLoopJoinBridge::setBuildStream().
-  std::optional<rmm::cuda_stream_view> buildStream_;
+  std::optional<cuda::stream_ref> buildStream_;
   // Reused event for recordReadCompletion()'s record-then-wait pattern.
   // Safe to reuse across calls since each call finishes using the current
   // recording (via waitOn()) before the next call re-records it.

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -17,6 +17,7 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/DebugUtil.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 
 #include "velox/common/base/SpillConfig.h"
@@ -126,6 +127,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
         nvtxMethods_(nvtxMethods) {}
 
   void addInput(RowVectorPtr input) final {
+    ensureCudaContextForThread();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kAddInput, className_);
     doAddInput(std::move(input));
@@ -133,6 +135,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
   RowVectorPtr getOutput() final {
+    ensureCudaContextForThread();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
     auto result = doGetOutput();
@@ -141,6 +144,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
   void noMoreInput() final {
+    ensureCudaContextForThread();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kNoMoreInput, className_);
     doNoMoreInput();
@@ -148,6 +152,9 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
   void close() final {
+    // close() may run on a different thread than construction so bind the
+    // context here too.
+    ensureCudaContextForThread();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kClose, className_);
     doClose();
@@ -205,6 +212,7 @@ class CudfSourceOperatorBase : public exec::SourceOperator, public NvtxHelper {
         nvtxMethods_(nvtxMethods) {}
 
   RowVectorPtr getOutput() final {
+    ensureCudaContextForThread();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
     auto result = doGetOutput();
@@ -213,6 +221,9 @@ class CudfSourceOperatorBase : public exec::SourceOperator, public NvtxHelper {
   }
 
   void close() final {
+    // close() may run on a different thread than construction so bind the
+    // context here too.
+    ensureCudaContextForThread();
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kClose, className_);
     doClose();

--- a/velox/experimental/cudf/exec/CudfReduce.cpp
+++ b/velox/experimental/cudf/exec/CudfReduce.cpp
@@ -74,7 +74,7 @@ using facebook::velox::cudf_velox::validateIntermediateColumnType;
         cudf::table_view const& input,                                         \
         TypePtr const& outputType,                                             \
         vector_size_t /* inputRowCount */,                                     \
-        cuda::stream_ref stream,                                          \
+        cuda::stream_ref stream,                                               \
         rmm::device_async_resource_ref mr) override {                          \
       auto const aggRequest =                                                  \
           cudf::make_##name##_aggregation<cudf::reduce_aggregation>();         \
@@ -674,7 +674,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
     auto inputTable = cudf::table_view({input.column(inputIndex)});
 
     cudf::approx_distinct_count sketch{
-        inputTable, precision_, kNullPolicy, kNanPolicy, stream};
+        inputTable, precision_, kNullPolicy, kNanPolicy, stream, mr};
 
     return makeSketchColumn(sketch.sketch(), stream, mr);
   }

--- a/velox/experimental/cudf/exec/CudfReduce.cpp
+++ b/velox/experimental/cudf/exec/CudfReduce.cpp
@@ -74,7 +74,7 @@ using facebook::velox::cudf_velox::validateIntermediateColumnType;
         cudf::table_view const& input,                                         \
         TypePtr const& outputType,                                             \
         vector_size_t /* inputRowCount */,                                     \
-        rmm::cuda_stream_view stream,                                          \
+        cuda::stream_ref stream,                                          \
         rmm::device_async_resource_ref mr) override {                          \
       auto const aggRequest =                                                  \
           cudf::make_##name##_aggregation<cudf::reduce_aggregation>();         \
@@ -111,7 +111,7 @@ struct ReduceCountAggregator : ReduceAggregator {
       cudf::table_view const& input,
       TypePtr const& outputType,
       vector_size_t inputRowCount,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     if (exec::isRawInput(step)) {
       int64_t count;
@@ -188,7 +188,7 @@ struct ReduceMeanAggregator : ReduceAggregator {
       cudf::table_view const& input,
       TypePtr const& outputType,
       vector_size_t /* inputRowCount */,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     VELOX_CHECK(!maskIndex.has_value(), "avg does not support masks");
     switch (step) {
@@ -288,7 +288,7 @@ struct ReduceMeanAggregator : ReduceAggregator {
 cudf_velox::DecimalSumStateColumns makeSumCountColumns(
     cudf::scalar const& sumScalar,
     cudf::scalar const& countScalar,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   cudf_velox::DecimalSumStateColumns cols;
   cols.sum = cudf::make_column_from_scalar(sumScalar, 1, stream, mr);
@@ -298,7 +298,7 @@ cudf_velox::DecimalSumStateColumns makeSumCountColumns(
 
 std::unique_ptr<cudf::column> partialDecimalSumCountToSerializedString(
     cudf::column_view inputCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::unique_ptr<cudf::column> castedInput;
   inputCol = castDecimal64InputToDecimal128(inputCol, castedInput, stream);
@@ -326,7 +326,7 @@ std::unique_ptr<cudf::column> partialDecimalSumCountToSerializedString(
 cudf_velox::DecimalSumStateColumns mergeSerializedDecimalSumState(
     cudf::column_view inputCol,
     int32_t scale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto const sumAgg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
   auto sumAndCount =
@@ -349,7 +349,7 @@ cudf_velox::DecimalSumStateColumns mergeSerializedDecimalSumState(
 std::unique_ptr<cudf::column> intermediateDecimalMergeSerializedString(
     cudf::column_view inputCol,
     int32_t scale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto merged = mergeSerializedDecimalSumState(inputCol, scale, stream, mr);
   return serializeDecimalPartialOrIntermediateState(
@@ -360,7 +360,7 @@ std::unique_ptr<cudf::column> finalDecimalAvgFromSerializedString(
     cudf::column_view inputCol,
     int32_t scale,
     TypePtr const& resultType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto merged = mergeSerializedDecimalSumState(inputCol, scale, stream, mr);
   return finalizeDecimalAverage(
@@ -370,7 +370,7 @@ std::unique_ptr<cudf::column> finalDecimalAvgFromSerializedString(
 std::unique_ptr<cudf::column> singleDecimalAvgFromRawColumn(
     cudf::column_view inputCol,
     TypePtr const& resultType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::unique_ptr<cudf::column> castedInput;
   inputCol = castDecimal64InputToDecimal128(inputCol, castedInput, stream);
@@ -393,7 +393,7 @@ std::unique_ptr<cudf::column> singleDecimalAvgFromRawColumn(
 std::unique_ptr<cudf::column> singleOrRawDecimalSumWithCast(
     cudf::column_view inputCol,
     TypePtr const& outputType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto const sumAgg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
   auto const cudfOutType = cudf_velox::veloxToCudfDataType(outputType);
@@ -410,7 +410,7 @@ std::unique_ptr<cudf::column> singleOrRawDecimalSumWithCast(
 std::unique_ptr<cudf::column> reduceIntermediateDecimalFromSerializedColumn(
     cudf::column_view inputCol,
     TypePtr const& outputType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   validateIntermediateColumnType(inputCol);
   // outputType here could be DECIMAL or VARBINARY
@@ -423,7 +423,7 @@ std::unique_ptr<cudf::column> reduceIntermediateDecimalFromSerializedColumn(
 std::unique_ptr<cudf::column> reduceFinalDecimalSumFromSerializedColumn(
     cudf::column_view inputCol,
     TypePtr const& outputType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   validateIntermediateColumnType(inputCol);
   auto scale = getDecimalPrecisionScale(*outputType).second;
@@ -436,7 +436,7 @@ std::unique_ptr<cudf::column> reduceFinalDecimalSumFromSerializedColumn(
 std::unique_ptr<cudf::column> reduceFinalDecimalAvgFromSerializedColumn(
     cudf::column_view inputCol,
     TypePtr const& outputType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   validateIntermediateColumnType(inputCol);
   auto scale = getDecimalPrecisionScale(*outputType).second;
@@ -461,7 +461,7 @@ struct ReduceDecimalSumAggregator : ReduceAggregator {
       cudf::table_view const& input,
       TypePtr const& outputType,
       vector_size_t /* inputRowCount */,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     // Mask applies only at raw-input steps (kSingle/kPartial), where maskIndex
     // is set. Null-inject masked rows so cuDF's null-excluding sum and count
@@ -500,7 +500,7 @@ struct ReduceDecimalAvgAggregator : ReduceAggregator {
       cudf::table_view const& input,
       TypePtr const& outputType,
       vector_size_t /* inputRowCount */,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     // Decimal avg uses a dedicated path that does not honor masks; masked avg
     // already falls back to CPU (see canReduceBeEvaluatedByCudf).
@@ -548,7 +548,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
       cudf::table_view const& input,
       TypePtr const& outputType,
       vector_size_t /* inputRowCount */,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) override {
     VELOX_CHECK(
         !maskIndex.has_value(), "approx_distinct does not support masks");
@@ -564,7 +564,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
  private:
   std::unique_ptr<cudf::column> makeSketchColumn(
       cuda::std::span<cuda::std::byte const> sketch_bytes,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto sketch_size = static_cast<cudf::size_type>(sketch_bytes.size());
 
@@ -575,7 +575,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
         offsets,
         2 * sizeof(cudf::size_type),
         cudaMemcpyHostToDevice,
-        stream.value()));
+        stream.get()));
 
     rmm::device_buffer chars_buffer{sketch_bytes.size(), stream, mr};
     CUDF_CUDA_TRY(cudaMemcpyAsync(
@@ -583,10 +583,10 @@ struct ApproxDistinctAggregator : ReduceAggregator {
         sketch_bytes.data(),
         sketch_bytes.size(),
         cudaMemcpyDeviceToDevice,
-        stream.value()));
+        stream.get()));
 
     // Sync stream before stack-allocated offsets goes out of scope
-    stream.synchronize();
+    stream.sync();
 
     auto offsets_column = std::make_unique<cudf::column>(
         cudf::data_type{cudf::type_id::INT32},
@@ -607,7 +607,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
   auto mergeSketchesAndApply(
       cudf::column_view const& sketch_column,
       Func&& func,
-      rmm::cuda_stream_view stream) {
+      cuda::stream_ref stream) {
     auto strings_col = cudf::strings_column_view(sketch_column);
     auto offsets_col = strings_col.offsets();
     auto chars_ptr = strings_col.chars_begin(stream);
@@ -619,8 +619,8 @@ struct ApproxDistinctAggregator : ReduceAggregator {
         offsets_col.begin<cudf::size_type>(),
         num_offsets * sizeof(cudf::size_type),
         cudaMemcpyDeviceToHost,
-        stream.value()));
-    stream.synchronize(); // Need host_offsets before proceeding
+        stream.get()));
+    stream.sync(); // Need host_offsets before proceeding
 
     cudf::size_type first_offset = host_offsets[0];
     cudf::size_type first_size = host_offsets[1] - first_offset;
@@ -634,7 +634,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
         chars_ptr + first_offset,
         static_cast<std::size_t>(first_size),
         cudaMemcpyDeviceToDevice,
-        stream.value()));
+        stream.get()));
 
     cudf::approx_distinct_count merged_sketch(
         cuda::std::span<cuda::std::byte>(
@@ -655,7 +655,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
             chars_ptr + start_offset,
             size,
             cudaMemcpyDeviceToDevice,
-            stream.value()));
+            stream.get()));
 
         merged_sketch.merge(
             cuda::std::span<cuda::std::byte>(
@@ -669,7 +669,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
 
   std::unique_ptr<cudf::column> doPartialReduce(
       cudf::table_view const& input,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto inputTable = cudf::table_view({input.column(inputIndex)});
 
@@ -681,7 +681,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
 
   std::unique_ptr<cudf::column> doIntermediateReduce(
       cudf::table_view const& input,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto sketch_column = input.column(inputIndex);
 
@@ -699,7 +699,7 @@ struct ApproxDistinctAggregator : ReduceAggregator {
 
   std::unique_ptr<cudf::column> doFinalReduce(
       cudf::table_view const& input,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto sketch_column = input.column(inputIndex);
 
@@ -899,7 +899,7 @@ void CudfReduce::doAddInput(RowVectorPtr input) {
 
 CudfVectorPtr CudfReduce::doGlobalAggregation(
     cudf::table_view tableView,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::vector<std::unique_ptr<cudf::column>> resultColumns;
   resultColumns.reserve(aggregators_.size());
@@ -938,7 +938,7 @@ RowVectorPtr CudfReduce::doGetOutput() {
       std::move(inputs_), inputType_, stream, get_temp_mr());
 
   // Release input data after synchronizing.
-  stream.synchronize();
+  stream.sync();
   inputs_.clear();
 
   if (noMoreInput_) {

--- a/velox/experimental/cudf/exec/CudfReduce.h
+++ b/velox/experimental/cudf/exec/CudfReduce.h
@@ -31,7 +31,7 @@ struct ReduceAggregator {
       cudf::table_view const& input,
       TypePtr const& outputType,
       vector_size_t inputRowCount,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) = 0;
 
   virtual ~ReduceAggregator() = default;
@@ -101,7 +101,7 @@ class CudfReduce : public CudfOperatorBase {
  private:
   CudfVectorPtr doGlobalAggregation(
       cudf::table_view tableView,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   std::shared_ptr<const core::AggregationNode> aggregationNode_;

--- a/velox/experimental/cudf/exec/CudfTopN.cpp
+++ b/velox/experimental/cudf/exec/CudfTopN.cpp
@@ -122,7 +122,7 @@ std::unique_ptr<cudf::table> CudfTopN::getTopK(
       cudf::out_of_bounds_policy::DONT_CHECK,
       cudf::negative_index_policy::NOT_ALLOWED,
       stream,
-      mr);
+      cudf::memory_resources{mr, get_temp_mr()});
 }
 
 // helper to get topk of a table

--- a/velox/experimental/cudf/exec/CudfTopN.cpp
+++ b/velox/experimental/cudf/exec/CudfTopN.cpp
@@ -73,10 +73,10 @@ CudfTopN::CudfTopN(
 CudfVectorPtr CudfTopN::mergeTopK(
     std::vector<CudfVectorPtr> topNBatches,
     int32_t k,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::vector<cudf::table_view> tableViews;
-  std::vector<rmm::cuda_stream_view> inputStreams;
+  std::vector<cuda::stream_ref> inputStreams;
   tableViews.reserve(topNBatches.size());
   inputStreams.reserve(topNBatches.size());
   for (const auto& batch : topNBatches) {
@@ -108,7 +108,7 @@ CudfVectorPtr CudfTopN::mergeTopK(
 std::unique_ptr<cudf::table> CudfTopN::getTopK(
     cudf::table_view const& values,
     int32_t k,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto keys = values.select(sortKeys_);
   auto const indices =

--- a/velox/experimental/cudf/exec/CudfTopN.h
+++ b/velox/experimental/cudf/exec/CudfTopN.h
@@ -57,14 +57,14 @@ class CudfTopN : public CudfOperatorBase {
   CudfVectorPtr mergeTopK(
       std::vector<CudfVectorPtr> topNBatches,
       int32_t k,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   CudfVectorPtr getTopKBatch(CudfVectorPtr cudfInput, int32_t k);
   std::unique_ptr<cudf::table> getTopK(
       cudf::table_view const& values,
       int32_t k,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   // As the inputs are added to TopN operator, we use topNBatches_

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -37,7 +37,7 @@ namespace {
 cudf::table_view makePartitionKeys(
     cudf::table_view sortedView,
     const std::vector<cudf::size_type>& partitionKeyIndices,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr,
     std::unique_ptr<cudf::column>& singlePartitionCol) {
   if (!partitionKeyIndices.empty()) {
@@ -57,7 +57,7 @@ cudf::table_view makePartitionKeys(
 std::unique_ptr<cudf::column> computeRowNumbers(
     cudf::table_view view,
     const std::vector<cudf::size_type>& partitionKeyIndices,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::unique_ptr<cudf::column> singlePartitionCol;
   auto partKeys = makePartitionKeys(
@@ -75,7 +75,7 @@ std::unique_ptr<cudf::column> computeRowNumbers(
 std::unique_ptr<cudf::column> makeLimitMask(
     const cudf::column& rowNums,
     int32_t limit,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto limitScalar = cudf::numeric_scalar<int64_t>(limit, true, stream, mr);
   return cudf::binary_operation(
@@ -153,7 +153,7 @@ CudfTopNRowNumber::CudfTopNRowNumber(
 
 CudfVectorPtr CudfTopNRowNumber::reduceBatchToLocalCandidates(
     const CudfVectorPtr& cudfInput,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto inputView = cudfInput->getTableView();
   auto keyTable = inputView.select(allSortKeys_);
@@ -173,7 +173,7 @@ CudfVectorPtr CudfTopNRowNumber::reduceBatchToLocalCandidates(
   // Filter the sort permutation to the surviving rows before gathering the
   // full payload, so batches with many rows per partition don't pay for
   // materializing rows that will be pruned immediately after.
-  auto filteredIndicesTable = cudf::apply_boolean_mask(
+  auto filteredIndicesTable = cudf::apply_retention_mask(
       cudf::table_view{{indices->view()}}, mask->view(), stream, mr);
   auto filteredIndices = filteredIndicesTable->view().column(0);
 
@@ -196,9 +196,9 @@ CudfVectorPtr CudfTopNRowNumber::reduceBatchToLocalCandidates(
 CudfVectorPtr CudfTopNRowNumber::mergeAndPruneCandidates(
     const CudfVectorPtr& previous,
     const CudfVectorPtr& incoming,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
-  std::vector<rmm::cuda_stream_view> inputStreams{
+  std::vector<cuda::stream_ref> inputStreams{
       previous->stream(), incoming->stream()};
   cudf::detail::join_streams(inputStreams, stream);
 
@@ -214,7 +214,7 @@ CudfVectorPtr CudfTopNRowNumber::mergeAndPruneCandidates(
       computeRowNumbers(merged->view(), partitionKeyIndices_, stream, mr);
   auto mask = makeLimitMask(*rowNums, limit_, stream, mr);
   auto pruned =
-      cudf::apply_boolean_mask(merged->view(), mask->view(), stream, mr);
+      cudf::apply_retention_mask(merged->view(), mask->view(), stream, mr);
 
   auto const size = pruned->num_rows();
   return std::make_shared<CudfVector>(

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -165,7 +165,7 @@ CudfVectorPtr CudfTopNRowNumber::reduceBatchToLocalCandidates(
       cudf::out_of_bounds_policy::DONT_CHECK,
       cudf::negative_index_policy::NOT_ALLOWED,
       stream,
-      mr);
+      cudf::memory_resources{mr, get_temp_mr()});
   auto rowNums = computeRowNumbers(
       sortedKeyTable->view(), localPartitionKeyIndices_, stream, mr);
   auto mask = makeLimitMask(*rowNums, limit_, stream, mr);
@@ -183,7 +183,7 @@ CudfVectorPtr CudfTopNRowNumber::reduceBatchToLocalCandidates(
       cudf::out_of_bounds_policy::DONT_CHECK,
       cudf::negative_index_policy::NOT_ALLOWED,
       stream,
-      mr);
+      cudf::memory_resources{mr, get_temp_mr()});
   auto const size = localCandidatesTable->num_rows();
   return std::make_shared<CudfVector>(
       cudfInput->pool(),

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -61,7 +61,7 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   /// then gathers the full payload for the surviving rows.
   CudfVectorPtr reduceBatchToLocalCandidates(
       const CudfVectorPtr& cudfInput,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   /// Merges two candidate sets (each already sorted by partition+ordering
@@ -71,7 +71,7 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   CudfVectorPtr mergeAndPruneCandidates(
       const CudfVectorPtr& previous,
       const CudfVectorPtr& incoming,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   const std::shared_ptr<const core::TopNRowNumberNode> node_;

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -181,7 +181,7 @@ cudf::rank_method toRankMethod(const std::string& name) {
 
 std::unique_ptr<cudf::column> makeConstantOnesColumn(
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream, mr);
   return cudf::make_column_from_scalar(oneScalar, numRows, stream, mr);
@@ -191,7 +191,7 @@ cudf::column_view makeCountStarInputColumn(
     const cudf::table_view& sortedView,
     cudf::size_type logicalRowCount,
     ColumnOrView& owner,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (sortedView.num_columns() > 0) {
     return sortedView.column(0);
@@ -214,7 +214,7 @@ std::unique_ptr<cudf::column> computeGlobalAggregate(
     bool isCountStar,
     cudf::data_type resultType,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::unique_ptr<cudf::scalar> resultScalar;
   if (baseName == "sum") {
@@ -748,7 +748,7 @@ void CudfWindow::computeRankColumnsBatch(
     const std::vector<std::pair<size_t, std::string>>& pendingRanks,
     cudf::groupby::groupby* rankGrouper,
     std::vector<std::unique_ptr<cudf::column>>& windowResultCols,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   if (pendingRanks.empty()) {
     return;
@@ -838,7 +838,7 @@ std::unique_ptr<cudf::column> CudfWindow::computeLeadLagColumn(
     cudf::column_view inputCol,
     const core::WindowNode::Function& func,
     const std::string& baseName,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   VELOX_CHECK_LE(
       func.functionCall->inputs().size(),
@@ -889,7 +889,7 @@ std::unique_ptr<cudf::column> CudfWindow::invokeGroupedRollingWindow(
     const core::WindowNode::Function& func,
     std::unique_ptr<cudf::rolling_aggregation> agg,
     bool isFullPartition,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   // RANGE frames are handled by the batched grouped_range_rolling_window path
   // in doGetOutput (see toBatchRangeWindowTypes). canRunOnGPU only accepts
@@ -924,7 +924,7 @@ std::unique_ptr<cudf::column> CudfWindow::computeNthValueColumn(
     const core::WindowNode::Function& func,
     const std::string& baseName,
     bool isFullPartition,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   auto nullPolicy = func.ignoreNulls ? cudf::null_policy::EXCLUDE
                                      : cudf::null_policy::INCLUDE;
@@ -948,7 +948,7 @@ std::unique_ptr<cudf::column> CudfWindow::computeAggregateColumn(
     const core::WindowNode::Function& func,
     const std::string& baseName,
     bool isCountStar,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   // The unpartitioned, sort-key-less full-partition case is already
   // dispatched to computeGlobalAggregate() directly from doGetOutput(), so
@@ -1260,7 +1260,7 @@ void CudfWindow::doClose() {
   Operator::close();
   // Release GPU allocations only after pending work on stream_ completes.
   if (streamAcquired_) {
-    stream_.synchronize();
+    stream_.sync();
   }
   inputBatches_.clear();
   sortedData_.reset();

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -162,7 +162,7 @@ class CudfWindow : public CudfOperatorBase {
   // Sorted and concatenated input data, prepared in doNoMoreInput().
   std::unique_ptr<cudf::table> sortedData_;
   cudf::size_type logicalRowCount_{0};
-  cuda::stream_ref stream_{cudaStream_t{nullptr}};
+  cuda::stream_ref stream_{cudaStream_t{cudaStreamDefault}};
   bool streamAcquired_{false};
 
   bool finished_ = false;

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -27,7 +27,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 #include <optional>
@@ -106,7 +106,7 @@ class CudfWindow : public CudfOperatorBase {
       const std::vector<std::pair<size_t, std::string>>& pendingRanks,
       cudf::groupby::groupby* rankGrouper,
       std::vector<std::unique_ptr<cudf::column>>& windowResultCols,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   std::unique_ptr<cudf::column> computeLeadLagColumn(
@@ -114,7 +114,7 @@ class CudfWindow : public CudfOperatorBase {
       cudf::column_view inputCol,
       const core::WindowNode::Function& func,
       const std::string& baseName,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   // Compute first_value or last_value via cudf rolling window APIs.
@@ -124,7 +124,7 @@ class CudfWindow : public CudfOperatorBase {
       const core::WindowNode::Function& func,
       const std::string& baseName,
       bool isFullPartition,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   // Compute aggregate window functions (sum, min, max, count, avg)
@@ -135,7 +135,7 @@ class CudfWindow : public CudfOperatorBase {
       const core::WindowNode::Function& func,
       const std::string& baseName,
       bool isCountStar,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   // Dispatch ROWS window frames to grouped_rolling_window. RANGE frames are
@@ -146,7 +146,7 @@ class CudfWindow : public CudfOperatorBase {
       const core::WindowNode::Function& func,
       std::unique_ptr<cudf::rolling_aggregation> agg,
       bool isFullPartition,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   std::shared_ptr<const core::WindowNode> windowNode_;
@@ -162,7 +162,7 @@ class CudfWindow : public CudfOperatorBase {
   // Sorted and concatenated input data, prepared in doNoMoreInput().
   std::unique_ptr<cudf::table> sortedData_;
   cudf::size_type logicalRowCount_{0};
-  rmm::cuda_stream_view stream_{};
+  cuda::stream_ref stream_{};
   bool streamAcquired_{false};
 
   bool finished_ = false;

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -162,7 +162,7 @@ class CudfWindow : public CudfOperatorBase {
   // Sorted and concatenated input data, prepared in doNoMoreInput().
   std::unique_ptr<cudf::table> sortedData_;
   cudf::size_type logicalRowCount_{0};
-  cuda::stream_ref stream_{};
+  cuda::stream_ref stream_{cudaStream_t{nullptr}};
   bool streamAcquired_{false};
 
   bool finished_ = false;

--- a/velox/experimental/cudf/exec/DebugUtil.cpp
+++ b/velox/experimental/cudf/exec/DebugUtil.cpp
@@ -23,12 +23,12 @@ namespace facebook::velox::cudf_velox {
 
 std::string DebugUtil::toString(
     const cudf::table_view& table,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     vector_size_t from,
     vector_size_t to) {
   auto rowVector =
       with_arrow::toVeloxColumn(table, pool_.get(), "", stream, get_temp_mr());
-  stream.synchronize();
+  stream.sync();
   return rowVector->toString(from, to);
 }
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/DebugUtil.h
+++ b/velox/experimental/cudf/exec/DebugUtil.h
@@ -38,7 +38,7 @@ class DebugUtil {
  public:
   std::string toString(
       const cudf::table_view& table,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       vector_size_t from,
       vector_size_t to);
 

--- a/velox/experimental/cudf/exec/DecimalAggregationDevice.cu
+++ b/velox/experimental/cudf/exec/DecimalAggregationDevice.cu
@@ -141,13 +141,13 @@ template <typename BuildOp>
 void launchDeviceFor(
     cudf::size_type size,
     BuildOp buildOp,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   if (size == 0) {
     return;
   }
   auto op = buildOp();
   cub::DeviceFor::ForEachN(
-      cuda::counting_iterator<cudf::size_type>{0}, size, op, stream.value());
+      cuda::counting_iterator<cudf::size_type>{0}, size, op, stream.get());
   CUDF_CUDA_TRY(cudaGetLastError());
 }
 
@@ -166,7 +166,7 @@ struct StateValidPredicate {
 std::pair<rmm::device_buffer, cudf::size_type> buildStateValidityMaskImpl(
     const cudf::column_view& sumCol,
     const cudf::column_view& countCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto numRows = sumCol.size();
   if (numRows == 0) {
@@ -212,7 +212,7 @@ concept ValidDecimalPackStorageTypes =
 struct fillOffsetsForDecimalSumStateKernel {
   cudf::mutable_column_view offsetsView;
   cudf::size_type numRows;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   template <typename OffsetT>
     requires OffsetStorageType<OffsetT>
@@ -240,7 +240,7 @@ struct unpackDecimalSumStateKernel {
   cudf::mutable_column_view countView;
   cudf::size_type numRows;
   cudf::bitmask_type const* nullMask;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   template <typename OffsetT>
     requires OffsetStorageType<OffsetT>
@@ -272,7 +272,7 @@ struct averageRoundDecimalSumKernel {
   const int64_t* counts;
   cudf::mutable_column_view outView;
   cudf::size_type numRows;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   template <typename SumT>
     requires DecimalSumStorageType<SumT>
@@ -302,7 +302,7 @@ struct packDecimalSumStateKernel {
   cudf::column_view offsetsView;
   uint8_t* chars;
   cudf::size_type numRows;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   template <typename SumT, typename OffsetT>
     requires ValidDecimalPackStorageTypes<SumT, OffsetT>
@@ -332,7 +332,7 @@ void fillOffsetsForDecimalSumState(
     cudf::type_id offsetType,
     cudf::mutable_column_view offsetsView,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   cudf::type_dispatcher(
       cudf::data_type{offsetType},
       fillOffsetsForDecimalSumStateKernel{offsetsView, numRows, stream});
@@ -346,7 +346,7 @@ void unpackDecimalSumState(
     cudf::mutable_column_view countView,
     cudf::size_type numRows,
     cudf::bitmask_type const* nullMask,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   cudf::type_dispatcher(
       cudf::data_type{offsetType},
       unpackDecimalSumStateKernel{
@@ -359,7 +359,7 @@ void averageRoundDecimalSum(
     const int64_t* counts,
     cudf::mutable_column_view outView,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   cudf::type_dispatcher<cudf::dispatch_storage_type>(
       cudf::data_type{sumType},
       averageRoundDecimalSumKernel{sumCol, counts, outView, numRows, stream});
@@ -373,7 +373,7 @@ void packDecimalSumState(
     cudf::column_view offsetsView,
     uint8_t* chars,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   cudf::double_type_dispatcher<cudf::dispatch_storage_type>(
       cudf::data_type{sumType},
       cudf::data_type{offsetType},
@@ -384,7 +384,7 @@ void packDecimalSumState(
 std::pair<rmm::device_buffer, cudf::size_type> buildStateValidityMask(
     const cudf::column_view& sumCol,
     const cudf::column_view& countCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   return buildStateValidityMaskImpl(sumCol, countCol, stream, mr);
 }

--- a/velox/experimental/cudf/exec/DecimalAggregationDevice.h
+++ b/velox/experimental/cudf/exec/DecimalAggregationDevice.h
@@ -18,7 +18,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -46,7 +46,7 @@ void fillOffsetsForDecimalSumState(
     cudf::type_id offsetType,
     cudf::mutable_column_view offsetsView,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * Encodes each row's partial sum and count into the fixed-width device layout
@@ -70,7 +70,7 @@ void packDecimalSumState(
     cudf::column_view offsetsView,
     uint8_t* chars,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * Inverse of packDecimalSumState.
@@ -95,7 +95,7 @@ void unpackDecimalSumState(
     cudf::mutable_column_view countView,
     cudf::size_type numRows,
     cudf::bitmask_type const* nullMask,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * Per-row half-up integer divide of sum by count; count == 0 writes zero
@@ -115,7 +115,7 @@ void averageRoundDecimalSum(
     const int64_t* counts,
     cudf::mutable_column_view outView,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * Builds a null mask for rows where sum and count are both valid and count is
@@ -130,7 +130,7 @@ void averageRoundDecimalSum(
 std::pair<rmm::device_buffer, cudf::size_type> buildStateValidityMask(
     const cudf::column_view& sumCol,
     const cudf::column_view& countCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 } // namespace facebook::velox::cudf_velox::detail

--- a/velox/experimental/cudf/exec/DecimalAggregationDevice.h
+++ b/velox/experimental/cudf/exec/DecimalAggregationDevice.h
@@ -18,9 +18,10 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <cuda/stream>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp
+++ b/velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp
@@ -39,7 +39,7 @@ void validateIntermediateColumnType(cudf::column_view const& column) {
 cudf::column_view castDecimal64InputToDecimal128(
     cudf::column_view inputCol,
     std::unique_ptr<cudf::column>& holder,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   if (inputCol.type().id() != cudf::type_id::DECIMAL64) {
     return inputCol;
   }
@@ -53,7 +53,7 @@ cudf::column_view castDecimal64InputToDecimal128(
 
 std::unique_ptr<cudf::column> castCountColumnToInt64(
     std::unique_ptr<cudf::column> count,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   if (count->type().id() != cudf::type_id::INT64) {
     count = cudf::cast(
         *count, cudf::data_type{cudf::type_id::INT64}, stream, get_temp_mr());
@@ -64,7 +64,7 @@ std::unique_ptr<cudf::column> castCountColumnToInt64(
 std::unique_ptr<cudf::column> serializeDecimalPartialOrIntermediateState(
     std::unique_ptr<cudf::column> sum,
     std::unique_ptr<cudf::column> count,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   count = castCountColumnToInt64(std::move(count), stream);
   return serializeDecimalSumState(sum->view(), count->view(), stream, mr);
@@ -74,7 +74,7 @@ std::unique_ptr<cudf::column> finalizeDecimalAverage(
     std::unique_ptr<cudf::column> sum,
     std::unique_ptr<cudf::column> count,
     const TypePtr& resultType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   count = castCountColumnToInt64(std::move(count), stream);
   auto avgCol = computeDecimalAverage(sum->view(), count->view(), stream, mr);

--- a/velox/experimental/cudf/exec/DecimalAggregationHostOps.h
+++ b/velox/experimental/cudf/exec/DecimalAggregationHostOps.h
@@ -20,7 +20,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 
@@ -52,7 +52,7 @@ void validateIntermediateColumnType(cudf::column_view const& column);
 cudf::column_view castDecimal64InputToDecimal128(
     cudf::column_view inputCol,
     std::unique_ptr<cudf::column>& holder,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * Ensures the partial-row count column is INT64, casting with the temporary
@@ -65,7 +65,7 @@ cudf::column_view castDecimal64InputToDecimal128(
  */
 std::unique_ptr<cudf::column> castCountColumnToInt64(
     std::unique_ptr<cudf::column> count,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * Normalizes the count column to INT64, then encodes sum and count into a
@@ -82,7 +82,7 @@ std::unique_ptr<cudf::column> castCountColumnToInt64(
 std::unique_ptr<cudf::column> serializeDecimalPartialOrIntermediateState(
     std::unique_ptr<cudf::column> sum,
     std::unique_ptr<cudf::column> count,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -102,7 +102,7 @@ std::unique_ptr<cudf::column> finalizeDecimalAverage(
     std::unique_ptr<cudf::column> sum,
     std::unique_ptr<cudf::column> count,
     const TypePtr& resultType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/DecimalAggregationState.cpp
+++ b/velox/experimental/cudf/exec/DecimalAggregationState.cpp
@@ -33,7 +33,7 @@ namespace facebook::velox::cudf_velox {
 DecimalSumStateColumns deserializeDecimalSumState(
     const cudf::column_view& stateCol,
     int32_t scale,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   VELOX_CHECK(
       stateCol.type().id() == cudf::type_id::STRING,
       "Decimal sum state requires STRING/VARBINARY column (type is {})",
@@ -148,7 +148,7 @@ DecimalSumStateColumns deserializeDecimalSumState(
 std::unique_ptr<cudf::column> serializeDecimalSumState(
     const cudf::column_view& sumCol,
     const cudf::column_view& countCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   VELOX_CHECK(
       countCol.type().id() == cudf::type_id::INT64,
@@ -231,7 +231,7 @@ std::unique_ptr<cudf::column> serializeDecimalSumState(
 std::unique_ptr<cudf::column> computeDecimalAverage(
     const cudf::column_view& sumCol,
     const cudf::column_view& countCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   VELOX_CHECK(
       countCol.type().id() == cudf::type_id::INT64,

--- a/velox/experimental/cudf/exec/DecimalAggregationState.h
+++ b/velox/experimental/cudf/exec/DecimalAggregationState.h
@@ -18,7 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 
@@ -46,7 +46,7 @@ struct DecimalSumStateColumns {
 DecimalSumStateColumns deserializeDecimalSumState(
     const cudf::column_view& stateCol,
     int32_t scale,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * Encodes partial decimal SUM state (DECIMAL64 or DECIMAL128 sums plus INT64
@@ -65,7 +65,7 @@ DecimalSumStateColumns deserializeDecimalSumState(
 std::unique_ptr<cudf::column> serializeDecimalSumState(
     const cudf::column_view& sumCol,
     const cudf::column_view& countCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -84,7 +84,7 @@ std::unique_ptr<cudf::column> serializeDecimalSumState(
 std::unique_ptr<cudf::column> computeDecimalAverage(
     const cudf::column_view& sumCol,
     const cudf::column_view& countCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -30,6 +30,8 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/prefetch_resource_adaptor.hpp>
 
+#include <cuda_runtime.h>
+
 #include <common/base/Exceptions.h>
 
 #include <cstdlib>
@@ -84,6 +86,51 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
 cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {
   return cudf::detail::current_cuda_stream_pool();
 };
+
+namespace {
+
+// Device owning the registration-time primary context
+int cudfContextDevice = -1;
+
+} // namespace
+
+void setCudfContextDevice(int device) {
+  cudfContextDevice = device;
+}
+
+void ensureCudaContextForThread() {
+  // Create and push the device's primary context on this thread, at most once.
+  static thread_local bool initialized = false;
+  if (initialized) {
+    return;
+  }
+
+  // Device is recorded by setCudfContextDevice() from registerCudf().
+  VELOX_CHECK_GE(
+      cudfContextDevice,
+      0,
+      "cuDF is not yet registered. Please call registerCudf() first.");
+  VELOX_CHECK_EQ(
+      static_cast<int>(cudaSuccess),
+      static_cast<int>(cudaSetDevice(cudfContextDevice)),
+      "Failed to set CUDA device for cuDF worker thread",
+      cudfContextDevice);
+  VELOX_CHECK_EQ(
+      static_cast<int>(cudaSuccess),
+      static_cast<int>(cudaFree(nullptr)),
+      "Failed to initialize CUDA context on cuDF worker thread");
+  VELOX_CHECK_EQ(
+      static_cast<int>(cudaSuccess),
+      static_cast<int>(cudaGetDevice(&cudfContextDevice)),
+      "Failed to get current CUDA device ordinal");
+
+  initialized = true;
+}
+
+cuda::stream_ref getDefaultStreamForCurrentThread() {
+  ensureCudaContextForThread();
+  return cudf::get_default_stream(cudf::allow_default_stream);
+}
 
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> output_mr_;

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -82,7 +82,7 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
 }
 
 cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {
-  return cudf::detail::global_cuda_stream_pool();
+  return cudf::detail::current_cuda_stream_pool();
 };
 
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
@@ -99,7 +99,7 @@ rmm::device_async_resource_ref get_output_mr() {
 // __attribute__((error)). The overload below calls the real function.
 namespace cudf {
 
-rmm::cuda_stream_view const get_default_stream(allow_default_stream_t) {
+cuda::stream_ref const get_default_stream(allow_default_stream_t) {
   return cudf::get_default_stream();
 }
 

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -34,19 +34,31 @@ extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
 /// Returns the memory resource designated for output vector allocations.
 rmm::device_async_resource_ref get_output_mr();
 
-/**
- * @brief Creates a memory resource based on the given mode.
- *
- * @param mode rmm::mr::pool_memory_resource mode.
- * @param percent The initial percent of GPU memory to allocate for memory
- * resource.
- */
+/// Creates a memory resource based on the given mode.
+///
+/// @param mode rmm::mr::pool_memory_resource mode.
+/// @param percent The initial percent of GPU memory to allocate for memory
+/// resource.
 [[nodiscard]] cuda::mr::any_resource<cuda::mr::device_accessible>
 createMemoryResource(std::string_view mode, int percent);
 
-/**
- * @brief Returns the global CUDA stream pool used by cudf.
- */
+/// Returns the global CUDA stream pool used by cudf.
 [[nodiscard]] cudf::detail::cuda_stream_pool& cudfGlobalStreamPool();
+
+/// Records the CUDA device owning the primary context, so worker threads can
+/// bind it via `ensureCudaContextForThread()`.
+///
+/// @param device The CUDA device ordinal that was current during registration.
+void setCudfContextDevice(int device);
+
+/// Binds the primary CUDA context on the calling thread, once (thread-local).
+/// Needed as `cuda::stream_ref` uses the driver API, which does not lazily
+/// create a context like the runtime API does.
+void ensureCudaContextForThread();
+
+/// Ensures that the calling thread has a CUDA context and returns the
+/// `cudf::get_default_stream()`. Use it for host-thread stream work outside
+/// cuDF operators.
+[[nodiscard]] cuda::stream_ref getDefaultStreamForCurrentThread();
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -309,6 +309,13 @@ void registerCudf() {
   CUDF_FUNC_RANGE();
   cudaFree(nullptr); // Initialize CUDA context at startup
 
+  // Record this context's device so worker threads can bind it later (see
+  // ensureCudaContextForThread()).
+  int contextDevice = -1;
+  cudaGetDevice(&contextDevice);
+  VELOX_CHECK_GE(contextDevice, 0, "Failed to get current CUDA device ordinal");
+  setCudfContextDevice(contextDevice);
+
   const std::string mrMode = CudfConfig::getInstance().memoryResource;
   auto mr = cudf_velox::createMemoryResource(
       mrMode, CudfConfig::getInstance().memoryPercent);

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -83,7 +83,7 @@ vector_size_t checkedVectorSize(size_t rowCount) {
 
 std::unique_ptr<cudf::table> concatenateTables(
     std::vector<std::unique_ptr<cudf::table>> tables,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Check for empty vector
   VELOX_CHECK_GT(tables.size(), 0);
@@ -127,14 +127,14 @@ std::unique_ptr<cudf::table> makeEmptyTable(TypePtr const& inputType) {
 std::unique_ptr<cudf::table> getConcatenatedTable(
     std::vector<CudfVectorPtr>&& tables,
     const TypePtr& tableType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Check for empty vector
   if (tables.size() == 0) {
     return makeEmptyTable(tableType);
   }
 
-  auto inputStreams = std::vector<rmm::cuda_stream_view>();
+  auto inputStreams = std::vector<cuda::stream_ref>();
   auto tableViews = std::vector<cudf::table_view>();
 
   inputStreams.reserve(tables.size());
@@ -162,7 +162,7 @@ std::unique_ptr<cudf::table> getConcatenatedTable(
 std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
     std::vector<CudfVectorPtr>&& tables,
     const TypePtr& tableType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::vector<std::unique_ptr<cudf::table>> concatTables;
   // Check for empty vector
@@ -171,7 +171,7 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
     return concatTables;
   }
 
-  auto inputStreams = std::vector<rmm::cuda_stream_view>();
+  auto inputStreams = std::vector<cuda::stream_ref>();
   auto tableViews = std::vector<cudf::table_view>();
 
   inputStreams.reserve(tables.size());
@@ -224,7 +224,7 @@ std::vector<CudfVectorPtr> getConcatenatedCudfVectorsBatched(
     memory::MemoryPool* pool,
     std::vector<CudfVectorPtr>&& vectors,
     const TypePtr& tableType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   VELOX_CHECK_NOT_NULL(pool);
 
@@ -274,8 +274,8 @@ std::vector<CudfVectorPtr> getConcatenatedCudfVectorsBatched(
 
 void streamsWaitForStream(
     CudaEvent& event,
-    std::span<const rmm::cuda_stream_view> streams,
-    rmm::cuda_stream_view stream) {
+    std::span<const cuda::stream_ref> streams,
+    cuda::stream_ref stream) {
   event.recordFrom(stream);
   for (const auto& strm : streams) {
     event.waitOn(strm);
@@ -299,13 +299,13 @@ CudaEvent::CudaEvent(CudaEvent&& other) noexcept : event_(other.event_) {
   other.event_ = nullptr;
 }
 
-const CudaEvent& CudaEvent::recordFrom(rmm::cuda_stream_view stream) const {
-  CUDF_CUDA_TRY(cudaEventRecord(event_, stream.value()));
+const CudaEvent& CudaEvent::recordFrom(cuda::stream_ref stream) const {
+  CUDF_CUDA_TRY(cudaEventRecord(event_, stream.get()));
   return *this;
 }
 
-const CudaEvent& CudaEvent::waitOn(rmm::cuda_stream_view stream) const {
-  CUDF_CUDA_TRY(cudaStreamWaitEvent(stream.value(), event_, 0));
+const CudaEvent& CudaEvent::waitOn(cuda::stream_ref stream) const {
+  CUDF_CUDA_TRY(cudaStreamWaitEvent(stream.get(), event_, 0));
   return *this;
 }
 
@@ -326,8 +326,8 @@ std::string stripFunctionPrefix(
 
 void orderCudfVectorDeallocationsAfterStream(
     std::span<const CudfVectorPtr> vectors,
-    std::span<const rmm::cuda_stream_view> inputStreams,
-    rmm::cuda_stream_view stream) {
+    std::span<const cuda::stream_ref> inputStreams,
+    cuda::stream_ref stream) {
   bool allRebound = true;
   for (const auto& vector : vectors) {
     VELOX_CHECK_NOT_NULL(vector);

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -20,7 +20,7 @@
 
 #include <cudf/table/table.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 #include <span>
@@ -30,7 +30,7 @@ namespace facebook::velox::cudf_velox {
 // Concatenate a vector of cuDF tables into a single table
 [[nodiscard]] std::unique_ptr<cudf::table> concatenateTables(
     std::vector<std::unique_ptr<cudf::table>> tables,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -55,7 +55,7 @@ namespace facebook::velox::cudf_velox {
 [[nodiscard]] std::unique_ptr<cudf::table> getConcatenatedTable(
     std::vector<CudfVectorPtr>&& tables,
     const TypePtr& tableType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -88,7 +88,7 @@ namespace facebook::velox::cudf_velox {
 getConcatenatedTableBatched(
     std::vector<CudfVectorPtr>&& tables,
     const TypePtr& tableType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -102,7 +102,7 @@ getConcatenatedTableBatched(
     memory::MemoryPool* pool,
     std::vector<CudfVectorPtr>&& vectors,
     const TypePtr& tableType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -161,7 +161,7 @@ class CudaEvent {
    * @param stream The CUDA stream in which to record the event
    * @return Reference to this CudaEvent for method chaining
    */
-  const CudaEvent& recordFrom(rmm::cuda_stream_view stream) const;
+  const CudaEvent& recordFrom(cuda::stream_ref stream) const;
 
   /**
    * @brief Makes the specified stream wait until this event has been recorded.
@@ -174,7 +174,7 @@ class CudaEvent {
    * @param stream The CUDA stream that should wait for this event
    * @return Reference to this CudaEvent for method chaining
    */
-  const CudaEvent& waitOn(rmm::cuda_stream_view stream) const;
+  const CudaEvent& waitOn(cuda::stream_ref stream) const;
 
  private:
   cudaEvent_t event_{};
@@ -193,8 +193,8 @@ class CudaEvent {
  */
 void streamsWaitForStream(
     CudaEvent& event,
-    std::span<const rmm::cuda_stream_view> streams,
-    rmm::cuda_stream_view stream);
+    std::span<const cuda::stream_ref> streams,
+    cuda::stream_ref stream);
 
 /**
  * @brief Orders CudfVector deallocations after work on a target stream.
@@ -206,8 +206,8 @@ void streamsWaitForStream(
  */
 void orderCudfVectorDeallocationsAfterStream(
     std::span<const CudfVectorPtr> vectors,
-    std::span<const rmm::cuda_stream_view> inputStreams,
-    rmm::cuda_stream_view stream);
+    std::span<const cuda::stream_ref> inputStreams,
+    cuda::stream_ref stream);
 
 /// Extract the base function name from a possibly-prefixed name.
 /// Handles both Presto-style "presto.default.lag" and simple "lag".

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -29,7 +29,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <arrow/c/bridge.h>
 #include <arrow/io/interfaces.h>
@@ -117,7 +117,7 @@ namespace with_arrow {
 std::unique_ptr<cudf::table> toCudfTable(
     const facebook::velox::RowVectorPtr& veloxTable,
     facebook::velox::memory::MemoryPool* pool,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr,
     std::optional<std::string> timestampTimeZone) {
   TimestampUnit unit;
@@ -165,7 +165,7 @@ std::unique_ptr<cudf::table> toCudfTable(
   // which defers reading the host source buffers until the stream reaches
   // each copy.  The Arrow arrays must therefore stay alive until the stream
   // has executed those copies.
-  stream.synchronize();
+  stream.sync();
 
   // Release Arrow resources
   if (arrowArray.release) {
@@ -214,7 +214,7 @@ RowVectorPtr toVeloxColumn(
     memory::MemoryPool* pool,
     const std::vector<cudf::column_metadata>& metadata,
     const RowTypePtr* outputType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // To avoid ownership issues, we make copies of the Arrow objects
   // returned from cuDF as unique_ptrs, then mark the originals as
@@ -306,7 +306,7 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     facebook::velox::memory::MemoryPool* pool,
     std::string namePrefix,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto metadata = getMetadata(table.begin(), table.end(), namePrefix);
   return toVeloxColumn(table, pool, metadata, nullptr, stream, mr);
@@ -317,7 +317,7 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     facebook::velox::memory::MemoryPool* pool,
     const facebook::velox::RowTypePtr& outputType,
     std::string namePrefix,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto metadata = getMetadata(table.begin(), table.end(), namePrefix);
   return toVeloxColumn(table, pool, metadata, &outputType, stream, mr);
@@ -328,7 +328,7 @@ RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     memory::MemoryPool* pool,
     const TypePtr& type,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Recursively generate metadata using Velox type names for all columns.
   // This assumes 'type' is a RowType and its children match the cudf table

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.h
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.h
@@ -22,7 +22,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace facebook::velox::cudf_velox {
 
@@ -33,7 +33,7 @@ namespace with_arrow {
 std::unique_ptr<cudf::table> toCudfTable(
     const facebook::velox::RowVectorPtr& veloxTable,
     facebook::velox::memory::MemoryPool* pool,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr,
     std::optional<std::string> timestampTimeZone = std::nullopt);
 
@@ -41,7 +41,7 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     facebook::velox::memory::MemoryPool* pool,
     std::string namePrefix,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 // Accepts a Velox TypePtr for recursive metadata construction.
@@ -50,14 +50,14 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     facebook::velox::memory::MemoryPool* pool,
     const facebook::velox::RowTypePtr& outputType,
     std::string namePrefix,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 facebook::velox::RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     facebook::velox::memory::MemoryPool* pool,
     const TypePtr& type,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 } // namespace with_arrow

--- a/velox/experimental/cudf/expression/ArrayAccessFunctions.cpp
+++ b/velox/experimental/cudf/expression/ArrayAccessFunctions.cpp
@@ -84,7 +84,7 @@ cudf::data_type indexDataType() {
 
 std::unique_ptr<cudf::column> extractNullIndex(
     cudf::lists_column_view const& listsView,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto nullIndex = cudf::numeric_scalar<cudf::size_type>(0, false, stream, mr);
   auto nullIndices =
@@ -121,7 +121,7 @@ std::optional<int64_t> normalizeConstantIndex(
 
 std::unique_ptr<cudf::column> sanitizeBoolMask(
     cudf::column_view mask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Comparisons against null inputs produce nulls. Treat them as false before
   // combining masks or reducing them to decide whether to throw.
@@ -132,7 +132,7 @@ std::unique_ptr<cudf::column> sanitizeBoolMask(
 std::unique_ptr<cudf::column> combineBoolMasks(
     cudf::column_view lhs,
     cudf::column_view rhs,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // These are BOOL8 value columns, not validity bitmasks. cudf::bitmask_or
   // would combine null masks instead of row-wise boolean values.
@@ -148,7 +148,7 @@ std::unique_ptr<cudf::column> combineBoolMasks(
 std::unique_ptr<cudf::column> mergeBoolMasks(
     std::unique_ptr<cudf::column> lhs,
     std::unique_ptr<cudf::column> rhs,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (lhs == nullptr) {
     return rhs;
@@ -162,7 +162,7 @@ std::unique_ptr<cudf::column> mergeBoolMasks(
 
 bool maskHasTrue(
     cudf::column_view mask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (mask.is_empty()) {
     return false;
@@ -184,7 +184,7 @@ bool maskHasTrue(
 std::unique_ptr<cudf::column> applyNullMask(
     cudf::column_view col,
     cudf::column_view nullMask,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto nullScalar =
       cudf::make_default_constructed_scalar(col.type(), stream, mr);
@@ -195,7 +195,7 @@ std::unique_ptr<cudf::column> applyNullMask(
 std::unique_ptr<cudf::column> castSizes(
     cudf::column_view const& sizesView,
     cudf::data_type indexType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   return indexType.id() == cudf::type_id::INT32
       ? std::make_unique<cudf::column>(sizesView, stream)
@@ -207,7 +207,7 @@ std::unique_ptr<cudf::column> outOfBoundsMask(
     cudf::column_view const& normalized,
     cudf::column_view const& sizes,
     const ArrayAccessPolicy& policy,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto zero = cudf::numeric_scalar<IndexType>(0, true, stream, mr);
   std::unique_ptr<cudf::column> lowerBound;
@@ -295,7 +295,7 @@ std::unique_ptr<cudf::column> normalizeAndValidateIndicesTyped(
     cudf::column_view const& rawIndexView,
     cudf::column_view const& sizesView,
     const ArrayAccessPolicy& policy,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto sizes = castSizes(sizesView, rawIndexView.type(), stream, mr);
   auto zero = cudf::numeric_scalar<IndexType>(0, true, stream, mr);
@@ -402,7 +402,7 @@ std::unique_ptr<cudf::column> normalizeAndValidateIndices(
     cudf::column_view const& rawIndexView,
     cudf::column_view const& sizesView,
     const ArrayAccessPolicy& policy,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   switch (rawIndexView.type().id()) {
     case cudf::type_id::INT8:
@@ -427,7 +427,7 @@ void validateConstantIndex(
     int64_t originalIndex,
     cudf::size_type normalizedIndex,
     cudf::column_view const& sizesView,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto indexScalar =
       cudf::numeric_scalar<cudf::size_type>(normalizedIndex, true, stream, mr);
@@ -451,7 +451,7 @@ void validateConstantIndex(
 std::unique_ptr<cudf::column> makeRepeatedArrayColumn(
     const velox::VectorPtr& arrayVector,
     cudf::size_type size,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // CudfFunction::eval receives columns only for non literal inputs. For a
   // constant array literal like subscript(array[1, 1, 0], groupid + 1), the
@@ -531,7 +531,7 @@ class ArrayAccessFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     // Case 1: constant array, variable index.
     //
@@ -601,7 +601,7 @@ class ArrayAccessFunction : public CudfFunction {
   ColumnOrView extractLiteralIndex(
       cudf::lists_column_view const& listsView,
       cudf::column_view const& sizesView,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const {
     if (!constantIndex_.has_value()) {
       // A null literal index returns one null result per input array row.

--- a/velox/experimental/cudf/expression/AstExpression.cpp
+++ b/velox/experimental/cudf/expression/AstExpression.cpp
@@ -80,7 +80,7 @@ void ASTExpression::close() {
 
 ColumnOrView ASTExpression::eval(
     std::vector<cudf::column_view> inputColumnViews,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr,
     bool finalize) {
   auto precomputedColumns = precomputeSubexpressions(

--- a/velox/experimental/cudf/expression/AstExpression.h
+++ b/velox/experimental/cudf/expression/AstExpression.h
@@ -56,7 +56,7 @@ class ASTExpression : public CudfExpression {
 
   ColumnOrView eval(
       std::vector<cudf::column_view> inputColumnViews,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr,
       bool finalize = false) override;
 

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -697,7 +697,7 @@ std::vector<ColumnOrView> precomputeSubexpressions(
     const std::vector<PrecomputeInstruction>& precomputeInstructions,
     const std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const RowTypePtr& inputRowSchema,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<ColumnOrView> precomputedColumns;
   precomputedColumns.reserve(precomputeInstructions.size());
 

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -96,7 +96,7 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
     T value,
     bool isNull,
     std::optional<cudf::type_id> toType = std::nullopt,
-    rmm::cuda_stream_view stream =
+    cuda::stream_ref stream =
         cudf::get_default_stream(cudf::allow_default_stream)) {
   auto mr = get_temp_mr();
 
@@ -109,28 +109,28 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
       auto micros = isNull ? 0 : value.toMicros();
       auto scalar = std::make_unique<cudf::timestamp_scalar<CudfTimestampType>>(
           CudfTimestampType{cudf::duration_us{micros}}, !isNull, stream, mr);
-      stream.synchronize();
+      stream.sync();
       return scalar;
     } else if (unit == cudf::type_id::TIMESTAMP_NANOSECONDS) {
       using CudfTimestampType = cudf::timestamp_ns;
       auto nanos = isNull ? 0 : value.toNanos();
       auto scalar = std::make_unique<cudf::timestamp_scalar<CudfTimestampType>>(
           CudfTimestampType{cudf::duration_ns{nanos}}, !isNull, stream, mr);
-      stream.synchronize();
+      stream.sync();
       return scalar;
     } else if (unit == cudf::type_id::TIMESTAMP_MILLISECONDS) {
       using CudfTimestampType = cudf::timestamp_ms;
       auto millis = isNull ? 0 : value.toMillis();
       auto scalar = std::make_unique<cudf::timestamp_scalar<CudfTimestampType>>(
           CudfTimestampType{cudf::duration_ms{millis}}, !isNull, stream, mr);
-      stream.synchronize();
+      stream.sync();
       return scalar;
     } else if (unit == cudf::type_id::TIMESTAMP_SECONDS) {
       using CudfTimestampType = cudf::timestamp_s;
       auto seconds = isNull ? 0 : value.getSeconds();
       auto scalar = std::make_unique<cudf::timestamp_scalar<CudfTimestampType>>(
           CudfTimestampType{cudf::duration_s{seconds}}, !isNull, stream, mr);
-      stream.synchronize();
+      stream.sync();
       return scalar;
     } else {
       VELOX_FAIL("Unsupported timestamp unit: {}", static_cast<int32_t>(unit));
@@ -148,7 +148,7 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
         using CudfDecimalType = cudf::fixed_point_scalar<numeric::decimal64>;
         auto scalar = std::make_unique<CudfDecimalType>(
             value, cudfScale, !isNull, stream, mr);
-        stream.synchronize();
+        stream.sync();
         return scalar;
       } else if (type->kind() == TypeKind::HUGEINT) {
         auto const decimalType =
@@ -158,7 +158,7 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
         using CudfDecimalType = cudf::fixed_point_scalar<numeric::decimal128>;
         auto scalar = std::make_unique<CudfDecimalType>(
             value, cudfScale, !isNull, stream, mr);
-        stream.synchronize();
+        stream.sync();
         return scalar;
       }
       VELOX_UNREACHABLE(
@@ -170,7 +170,7 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
       if constexpr (std::is_same_v<T, CudfDurationType::rep>) {
         auto scalar = std::make_unique<cudf::duration_scalar<CudfDurationType>>(
             value, !isNull, stream, mr);
-        stream.synchronize();
+        stream.sync();
         return scalar;
       }
     } else if (type->isDate()) {
@@ -178,14 +178,14 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
       if constexpr (std::is_same_v<T, CudfDateType::rep>) {
         auto scalar = std::make_unique<cudf::timestamp_scalar<CudfDateType>>(
             value, !isNull, stream, mr);
-        stream.synchronize();
+        stream.sync();
         return scalar;
       }
     } else if (toType.has_value()) {
       if (toType == cudf::type_id::DURATION_DAYS) {
         auto scalar = std::make_unique<cudf::duration_scalar<cudf::duration_D>>(
             value, !isNull, stream, mr);
-        stream.synchronize();
+        stream.sync();
         return scalar;
       }
       VELOX_FAIL(
@@ -193,7 +193,7 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
     } else {
       auto scalar =
           std::make_unique<cudf::numeric_scalar<T>>(value, !isNull, stream, mr);
-      stream.synchronize();
+      stream.sync();
       return scalar;
     }
     VELOX_FAIL("Unsupported fixed-width scalar type");
@@ -202,7 +202,7 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
       std::is_same_v<T, std::string>) {
     auto scalar = std::make_unique<cudf::string_scalar>(
         std::string_view(value.data(), value.size()), !isNull, stream, mr);
-    stream.synchronize();
+    stream.sync();
     return scalar;
   }
   VELOX_NYI("Scalar creation not implemented for type {}", type->toString());
@@ -213,7 +213,7 @@ static std::unique_ptr<cudf::scalar> createCudfScalar(
     const core::ConstantTypedExpr& value,
     memory::MemoryPool* pool,
     std::optional<cudf::type_id> toType = std::nullopt,
-    rmm::cuda_stream_view stream =
+    cuda::stream_ref stream =
         cudf::get_default_stream(cudf::allow_default_stream)) {
   using T = typename TypeTraits<Kind>::NativeType;
   const auto valueVector = value.hasValueVector()
@@ -228,7 +228,7 @@ inline std::unique_ptr<cudf::scalar> makeScalarFromConstantExpr(
     const core::TypedExprPtr& expr,
     memory::MemoryPool* pool,
     std::optional<cudf::type_id> toType = std::nullopt,
-    rmm::cuda_stream_view stream =
+    cuda::stream_ref stream =
         cudf::get_default_stream(cudf::allow_default_stream)) {
   auto constExpr =
       std::dynamic_pointer_cast<const core::ConstantTypedExpr>(expr);

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -17,6 +17,7 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 
 #include "velox/core/Expressions.h"
 #include "velox/type/Timestamp.h"
@@ -96,8 +97,7 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
     T value,
     bool isNull,
     std::optional<cudf::type_id> toType = std::nullopt,
-    cuda::stream_ref stream =
-        cudf::get_default_stream(cudf::allow_default_stream)) {
+    cuda::stream_ref stream = getDefaultStreamForCurrentThread()) {
   auto mr = get_temp_mr();
 
   // Synchronize before returning as scalar construction can enqueue an
@@ -213,8 +213,7 @@ static std::unique_ptr<cudf::scalar> createCudfScalar(
     const core::ConstantTypedExpr& value,
     memory::MemoryPool* pool,
     std::optional<cudf::type_id> toType = std::nullopt,
-    cuda::stream_ref stream =
-        cudf::get_default_stream(cudf::allow_default_stream)) {
+    cuda::stream_ref stream = getDefaultStreamForCurrentThread()) {
   using T = typename TypeTraits<Kind>::NativeType;
   const auto valueVector = value.hasValueVector()
       ? value.valueVector()
@@ -228,8 +227,7 @@ inline std::unique_ptr<cudf::scalar> makeScalarFromConstantExpr(
     const core::TypedExprPtr& expr,
     memory::MemoryPool* pool,
     std::optional<cudf::type_id> toType = std::nullopt,
-    cuda::stream_ref stream =
-        cudf::get_default_stream(cudf::allow_default_stream)) {
+    cuda::stream_ref stream = getDefaultStreamForCurrentThread()) {
   auto constExpr =
       std::dynamic_pointer_cast<const core::ConstantTypedExpr>(expr);
   VELOX_CHECK_NOT_NULL(constExpr);

--- a/velox/experimental/cudf/expression/DateTruncFunction.cpp
+++ b/velox/experimental/cudf/expression/DateTruncFunction.cpp
@@ -106,12 +106,12 @@ DateTruncFunction::DateTruncFunction(
       std::make_unique<cudf::numeric_scalar<int32_t>>(3, true, stream, mr);
   negOneScalar_ =
       std::make_unique<cudf::numeric_scalar<int32_t>>(-1, true, stream, mr);
-  stream.synchronize();
+  stream.sync();
 }
 
 ColumnOrView DateTruncFunction::eval(
     std::vector<ColumnOrView>& inputColumns,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   VELOX_CHECK_EQ(inputColumns.size(), 1, "date_trunc expects one column input");
   auto inputCol = asView(inputColumns[0]);

--- a/velox/experimental/cudf/expression/DateTruncFunction.cpp
+++ b/velox/experimental/cudf/expression/DateTruncFunction.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
 #include "velox/experimental/cudf/expression/DateTruncFunction.h"
 
@@ -98,7 +99,7 @@ DateTruncFunction::DateTruncFunction(
         isTimestamp, "date_trunc {} requires timestamp input", *unitString);
   }
 
-  auto stream = cudf::get_default_stream(cudf::allow_default_stream);
+  auto stream = getDefaultStreamForCurrentThread();
   auto mr = get_temp_mr();
   oneScalar_ =
       std::make_unique<cudf::numeric_scalar<int32_t>>(1, true, stream, mr);

--- a/velox/experimental/cudf/expression/DateTruncFunction.h
+++ b/velox/experimental/cudf/expression/DateTruncFunction.h
@@ -36,7 +36,7 @@ class DateTruncFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override;
 
  private:

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
@@ -69,9 +69,7 @@ void checkDecimalDivideTypes(cudf::type_id inType, cudf::type_id outType) {
   }
 }
 
-void finalizeDivideOutputNullCount(
-    cudf::column& out,
-    cuda::stream_ref stream) {
+void finalizeDivideOutputNullCount(cudf::column& out, cuda::stream_ref stream) {
   if (out.size() == 0) {
     return;
   }

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
@@ -31,7 +31,7 @@ namespace {
 
 __int128_t getDecimalScalarValue(
     const cudf::scalar& s,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   if (s.type().id() == cudf::type_id::DECIMAL64) {
     auto const& dec =
         static_cast<cudf::fixed_point_scalar<numeric::decimal64> const&>(s);
@@ -47,7 +47,7 @@ __int128_t getDecimalScalarValue(
 std::unique_ptr<cudf::column> makeAllNullDecimalColumn(
     cudf::data_type outputType,
     cudf::size_type size,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   return cudf::make_fixed_width_column(
       outputType, size, cudf::mask_state::ALL_NULL, stream, mr);
@@ -71,7 +71,7 @@ void checkDecimalDivideTypes(cudf::type_id inType, cudf::type_id outType) {
 
 void finalizeDivideOutputNullCount(
     cudf::column& out,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   if (out.size() == 0) {
     return;
   }
@@ -87,7 +87,7 @@ std::unique_ptr<cudf::column> decimalDivide(
     const cudf::column_view& rhs,
     cudf::data_type outputType,
     int32_t aRescale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   VELOX_CHECK_EQ(lhs.size(), rhs.size(), "Decimal divide requires equal sizes");
   // Use VELOX_CHECK (not _EQ) so failed checks do not pass cudf::type_id into
@@ -130,7 +130,7 @@ std::unique_ptr<cudf::column> decimalDivide(
     const cudf::scalar& rhs,
     cudf::data_type outputType,
     int32_t aRescale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   VELOX_CHECK_GE(
       aRescale, 0, "Decimal divide requires non-negative rescale factor");
@@ -172,7 +172,7 @@ std::unique_ptr<cudf::column> decimalDivide(
     const cudf::column_view& rhs,
     cudf::data_type outputType,
     int32_t aRescale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   VELOX_CHECK_GE(
       aRescale, 0, "Decimal divide requires non-negative rescale factor");

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.h
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.h
@@ -20,7 +20,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 
@@ -46,7 +46,7 @@ std::unique_ptr<cudf::column> decimalDivide(
     const cudf::column_view& rhs,
     cudf::data_type outputType,
     int32_t aRescale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -70,7 +70,7 @@ std::unique_ptr<cudf::column> decimalDivide(
     const cudf::scalar& rhs,
     cudf::data_type outputType,
     int32_t aRescale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /**
@@ -93,7 +93,7 @@ std::unique_ptr<cudf::column> decimalDivide(
     const cudf::column_view& rhs,
     cudf::data_type outputType,
     int32_t aRescale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/expression/DecimalExpressionKernelsGpu.cu
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernelsGpu.cu
@@ -208,14 +208,15 @@ template <typename BuildOp>
 bool launchDecimalDivide(
     cudf::size_type size,
     BuildOp buildOp,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   if (size == 0) {
     return true;
   }
-  rmm::device_scalar<int32_t> overflowFlag{0, stream};
+  int32_t initialOverflowFlag{0};
+  rmm::device_scalar<int32_t> overflowFlag{initialOverflowFlag, stream};
   auto op = buildOp(overflowFlag.data());
   cub::DeviceFor::ForEachN(
-      cuda::counting_iterator<cudf::size_type>{0}, size, op, stream.value());
+      cuda::counting_iterator<cudf::size_type>{0}, size, op, stream.get());
   CUDF_CUDA_TRY(cudaGetLastError());
   return overflowFlag.value(stream) == 0;
 }
@@ -235,7 +236,7 @@ struct divideColumnColumnKernel {
   const cudf::column_view& rhs;
   cudf::mutable_column_view out;
   __int128_t rescaleFactor;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   template <typename InT, typename OutT>
     requires ValidDecimalDivideStorageTypes<InT, OutT>
@@ -265,7 +266,7 @@ struct divideColumnScalarKernel {
   __int128_t rhsValue;
   cudf::mutable_column_view out;
   __int128_t rescaleFactor;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   template <typename InT, typename OutT>
     requires ValidDecimalDivideStorageTypes<InT, OutT>
@@ -294,7 +295,7 @@ struct divideScalarColumnKernel {
   const cudf::column_view& rhs;
   cudf::mutable_column_view out;
   __int128_t rescaleFactor;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   template <typename InT, typename OutT>
     requires ValidDecimalDivideStorageTypes<InT, OutT>
@@ -325,7 +326,7 @@ bool decimalDivideColumnColumn(
     const cudf::column_view& rhs,
     cudf::mutable_column_view out,
     __int128_t rescaleFactor,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   return cudf::double_type_dispatcher<cudf::dispatch_storage_type>(
       cudf::data_type{inType},
       cudf::data_type{outType},
@@ -339,7 +340,7 @@ bool decimalDivideColumnScalar(
     __int128_t rhsValue,
     cudf::mutable_column_view out,
     __int128_t rescaleFactor,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   return cudf::double_type_dispatcher<cudf::dispatch_storage_type>(
       cudf::data_type{inType},
       cudf::data_type{outType},
@@ -353,7 +354,7 @@ bool decimalDivideScalarColumn(
     const cudf::column_view& rhs,
     cudf::mutable_column_view out,
     __int128_t rescaleFactor,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   return cudf::double_type_dispatcher<cudf::dispatch_storage_type>(
       cudf::data_type{inType},
       cudf::data_type{outType},

--- a/velox/experimental/cudf/expression/DecimalExpressionKernelsGpu.h
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernelsGpu.h
@@ -18,7 +18,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <cstdint>
 
@@ -49,7 +49,7 @@ bool decimalDivideColumnColumn(
     const cudf::column_view& rhs,
     cudf::mutable_column_view out,
     __int128_t rescaleFactor,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * @brief Fixed-point decimal division with a column lhs and scalar rhs.
@@ -75,7 +75,7 @@ bool decimalDivideColumnScalar(
     __int128_t rhsValue,
     cudf::mutable_column_view out,
     __int128_t rescaleFactor,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 /**
  * @brief Fixed-point decimal division with a scalar lhs and column rhs.
@@ -101,6 +101,6 @@ bool decimalDivideScalarColumn(
     const cudf::column_view& rhs,
     cudf::mutable_column_view out,
     __int128_t rescaleFactor,
-    rmm::cuda_stream_view stream);
+    cuda::stream_ref stream);
 
 } // namespace facebook::velox::cudf_velox::detail

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Validation.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
@@ -1509,7 +1510,7 @@ class LikeFunction : public CudfFunction {
           // sequences for every batch, so cache those tiny helper columns once
           // here. Constant patterns are validated on the host and don't need
           // these columns.
-          auto stream = cudf::get_default_stream(cudf::allow_default_stream);
+          auto stream = getDefaultStreamForCurrentThread();
           auto mr = get_temp_mr();
           targetsColumn_ = makeEscapeTargetsColumn(escape_[0], stream, mr);
           replacementsColumn_ = makeEscapeReplacementsColumn(stream, mr);

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -80,7 +80,7 @@ namespace {
 
 bool decimalScalarIsZero(
     const cudf::scalar& scalar,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   if (!scalar.is_valid(stream)) {
     return false;
   }
@@ -101,7 +101,7 @@ bool decimalScalarIsZero(
 
 bool hasDecimalZero(
     const cudf::column_view& col,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (col.is_empty()) {
     return false;
@@ -140,7 +140,7 @@ bool hasDecimalZero(
 std::unique_ptr<cudf::scalar> castDecimalScalar(
     const cudf::scalar& src,
     cudf::data_type targetType,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (!src.is_valid(stream)) {
     VELOX_CHECK(
@@ -338,7 +338,7 @@ bool canBeEvaluatedByCudf(const core::TypedExprPtr& expr) {
 void checkAllTrue(
     cudf::column_view cond,
     std::string_view userMessage,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   if (cond.is_empty() || cond.null_count() == cond.size()) {
     return;
@@ -375,7 +375,7 @@ class SplitFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     cudf::string_scalar delimiterScalar(delimiter_, true, stream, mr);
@@ -405,7 +405,7 @@ class CastFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::cast(inputCol, targetCudfType_, stream, mr);
@@ -426,7 +426,7 @@ class CardinalityFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::lists::count_elements(inputCol, stream, mr);
@@ -441,7 +441,7 @@ class IsNullFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     VELOX_CHECK_EQ(inputColumns.size(), 1, "is_null expects 1 input");
     return cudf::is_null(asView(inputColumns[0]), stream, mr);
@@ -456,7 +456,7 @@ class IsNotNullFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     VELOX_CHECK_EQ(inputColumns.size(), 1, "isnotnull expects 1 input");
     return cudf::is_valid(asView(inputColumns[0]), stream, mr);
@@ -491,7 +491,7 @@ class RoundFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     auto inputTypeId = inputCol.type().id();
@@ -591,7 +591,7 @@ class BinaryFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto isComparisonOp = [](cudf::binary_operator op) {
       switch (op) {
@@ -903,7 +903,7 @@ class LogicalFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     // If there are no input columns, the result is a scalar.
     const size_t rowCount =
@@ -1011,7 +1011,7 @@ class UnaryFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     return cudf::unary_operation(asView(inputColumns[0]), op_, stream, mr);
   }
@@ -1042,7 +1042,7 @@ class BetweenFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     // return (value >= min) && (value <= max)
     std::unique_ptr<cudf::column> geResultColumn, leResultColumn;
@@ -1149,7 +1149,7 @@ class GreatestLeastFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     // All inputs were constant -- return the pre-folded scalar as a column.
     if (order_.empty()) {
@@ -1203,7 +1203,7 @@ class SwitchFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     if (left_ == nullptr && right_ == nullptr) {
       return cudf::copy_if_else(
@@ -1254,7 +1254,7 @@ class CoalesceFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     // Coalesce is practically a cudf::replace_nulls over multiple columns.
     // Starting from first column, we keep calling replace nulls with
@@ -1311,7 +1311,7 @@ class ExtractComponentFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::datetime::extract_datetime_component(
@@ -1344,7 +1344,7 @@ class QuarterFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::datetime::extract_quarter(inputCol, stream, mr);
@@ -1360,7 +1360,7 @@ class DayOfYearFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::datetime::day_of_year(inputCol, stream, mr);
@@ -1376,7 +1376,7 @@ class WeekFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     auto weekStrings = cudf::strings::from_timestamps(
@@ -1400,7 +1400,7 @@ class YearOfWeekFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     auto yearStrings = cudf::strings::from_timestamps(
@@ -1422,7 +1422,7 @@ class LengthFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::strings::count_characters(inputCol, stream, mr);
@@ -1438,7 +1438,7 @@ class LowerFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::strings::to_lower(inputCol, stream, mr);
@@ -1454,7 +1454,7 @@ class UpperFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     return cudf::strings::to_upper(inputCol, stream, mr);
@@ -1517,7 +1517,7 @@ class LikeFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     size_t nextInput = 0;
     VELOX_CHECK(
@@ -1600,17 +1600,17 @@ class LikeFunction : public CudfFunction {
 
   static std::unique_ptr<cudf::column> makeEscapeTargetsColumn(
       char escape,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   static std::unique_ptr<cudf::column> makeEscapeReplacementsColumn(
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   void validatePatternColumn(
       cudf::column_view patternColumn,
       char escape,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   bool inputIsConstant_{false};
@@ -1650,7 +1650,7 @@ void LikeFunction::validateConstantPattern(
 
 std::unique_ptr<cudf::column> LikeFunction::makeEscapeTargetsColumn(
     char escape,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   // Build the three legal escape sequences so column-pattern LIKE ESCAPE can
   // strip them before checking whether any invalid escape usage remains. This
@@ -1675,26 +1675,26 @@ std::unique_ptr<cudf::column> LikeFunction::makeEscapeTargetsColumn(
       mr);
   // The temporary scalars and string_view array above back async work used to
   // build the output column, so wait for the stream before returning.
-  stream.synchronize();
+  stream.sync();
   return targetsColumn;
 }
 
 std::unique_ptr<cudf::column> LikeFunction::makeEscapeReplacementsColumn(
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   cudf::string_scalar emptyString("", true, stream, mr);
   auto replacementsColumn =
       cudf::make_column_from_scalar(emptyString, 1, stream, mr);
   // make_column_from_scalar(string_scalar) reads the scalar's device string
   // data asynchronously, so keep the scalar alive until the stream completes.
-  stream.synchronize();
+  stream.sync();
   return replacementsColumn;
 }
 
 void LikeFunction::validatePatternColumn(
     cudf::column_view patternColumn,
     char escape,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   VELOX_CHECK_NOT_NULL(targetsColumn_);
   VELOX_CHECK_NOT_NULL(replacementsColumn_);
@@ -1772,7 +1772,7 @@ class StringPatternPredicateFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     size_t nextInput = 0;
     auto rowCount = inputColumns.empty() ? vector_size_t{1}
@@ -1813,13 +1813,13 @@ class StringPatternPredicateFunction : public CudfFunction {
   virtual std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::string_scalar const& patternScalar,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const = 0;
 
   virtual std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::column_view patternCol,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const = 0;
 
   bool inputIsConstant_{false};
@@ -1839,7 +1839,7 @@ class StartswithFunction : public StringPatternPredicateFunction {
   std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::string_scalar const& patternScalar,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     return cudf::strings::starts_with(inputCol, patternScalar, stream, mr);
   }
@@ -1847,7 +1847,7 @@ class StartswithFunction : public StringPatternPredicateFunction {
   std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::column_view patternCol,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     return cudf::strings::starts_with(inputCol, patternCol, stream, mr);
   }
@@ -1862,7 +1862,7 @@ class EndswithFunction : public StringPatternPredicateFunction {
   std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::string_scalar const& patternScalar,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     return cudf::strings::ends_with(inputCol, patternScalar, stream, mr);
   }
@@ -1870,7 +1870,7 @@ class EndswithFunction : public StringPatternPredicateFunction {
   std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::column_view patternCol,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     return cudf::strings::ends_with(inputCol, patternCol, stream, mr);
   }
@@ -1885,7 +1885,7 @@ class ContainsFunction : public StringPatternPredicateFunction {
   std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::string_scalar const& patternScalar,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     return cudf::strings::contains(inputCol, patternScalar, stream, mr);
   }
@@ -1893,7 +1893,7 @@ class ContainsFunction : public StringPatternPredicateFunction {
   std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::column_view patternCol,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     return cudf::strings::contains(inputCol, patternCol, stream, mr);
   }
@@ -1915,7 +1915,7 @@ class ConcatFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     // Validate sizes.
     VELOX_CHECK_EQ(
@@ -1994,7 +1994,7 @@ class RowConstructorFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     VELOX_CHECK(
         !inputColumns.empty(),
@@ -2024,7 +2024,7 @@ class RowConstructorFunction : public CudfFunction {
  private:
   static std::unique_ptr<cudf::column> makeOwnedColumn(
       ColumnOrView& holder,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   std::vector<std::unique_ptr<cudf::scalar>> literals_;
@@ -2033,7 +2033,7 @@ class RowConstructorFunction : public CudfFunction {
 
 std::unique_ptr<cudf::column> RowConstructorFunction::makeOwnedColumn(
     ColumnOrView& holder,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   return std::visit(
       [&](auto& value) -> std::unique_ptr<cudf::column> {
@@ -2817,7 +2817,7 @@ std::shared_ptr<FunctionExpression> FunctionExpression::create(
 std::unique_ptr<cudf::column> FunctionExpression::makeStructChildColumn(
     ColumnOrView& structColumn,
     cudf::size_type childIndex,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   return std::visit(
       [&](auto& value) -> std::unique_ptr<cudf::column> {
@@ -2854,7 +2854,7 @@ std::unique_ptr<cudf::column> FunctionExpression::makeStructChildColumn(
 
 ColumnOrView FunctionExpression::eval(
     std::vector<cudf::column_view> inputColumnViews,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr,
     bool finalize) {
   // Top-level field access (or chain of field accesses on input columns) maps

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -78,9 +78,7 @@ namespace facebook::velox::cudf_velox {
 // Implementation details in anonymous namespace
 namespace {
 
-bool decimalScalarIsZero(
-    const cudf::scalar& scalar,
-    cuda::stream_ref stream) {
+bool decimalScalarIsZero(const cudf::scalar& scalar, cuda::stream_ref stream) {
   if (!scalar.is_valid(stream)) {
     return false;
   }
@@ -546,17 +544,22 @@ __device__ void velox_round_double(
           cudf::scalar_column_view(decimalsView),
           cudf::scalar_column_view(factorView),
       };
-      return cudf::transform_extended(
-          transformInputs,
-          kUdf,
+      const cudf::transform_output transformOutputs[] = {{
           cudf::data_type{cudf::type_id::FLOAT64},
+          cudf::output_nullability::PRESERVE,
+      }};
+      auto transformed = cudf::transform(
+          kUdf,
           cudf::udf_source_type::CUDA,
-          std::nullopt,
           cudf::null_aware::NO,
           std::nullopt,
-          cudf::output_nullability::PRESERVE,
+          transformInputs,
+          transformOutputs,
+          {},
+          std::nullopt,
           stream,
           mr);
+      return std::move(transformed->release().front());
     }
 
     return cudf::round_decimal(

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.h
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.h
@@ -77,7 +77,7 @@ inline std::vector<cudf::column_view> tableViewToColumnViews(
 void checkAllTrue(
     cudf::column_view cond,
     std::string_view userMessage,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 class CudfFunction {
@@ -85,7 +85,7 @@ class CudfFunction {
   virtual ~CudfFunction() = default;
   virtual ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const = 0;
 };
 
@@ -140,7 +140,7 @@ class CudfExpression {
 
   virtual ColumnOrView eval(
       std::vector<cudf::column_view> inputColumnViews,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr,
       bool finalize = false) = 0;
 };
@@ -156,7 +156,7 @@ class FunctionExpression : public CudfExpression {
 
   ColumnOrView eval(
       std::vector<cudf::column_view> inputColumnViews,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr,
       bool finalize = false) override;
 
@@ -170,7 +170,7 @@ class FunctionExpression : public CudfExpression {
   static std::unique_ptr<cudf::column> makeStructChildColumn(
       ColumnOrView& structColumn,
       cudf::size_type childIndex,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr);
 
   core::TypedExprPtr expr_;

--- a/velox/experimental/cudf/expression/JitExpression.cpp
+++ b/velox/experimental/cudf/expression/JitExpression.cpp
@@ -31,7 +31,7 @@ void JitExpression::close() {
 
 ColumnOrView JitExpression::eval(
     std::vector<cudf::column_view> inputColumnViews,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr,
     bool finalize) {
   auto precomputedColumns = precomputeSubexpressions(

--- a/velox/experimental/cudf/expression/JitExpression.h
+++ b/velox/experimental/cudf/expression/JitExpression.h
@@ -38,7 +38,7 @@ class JitExpression : public CudfExpression {
   // Evaluates the expression tree for the given input columns
   ColumnOrView eval(
       std::vector<cudf::column_view> inputColumnViews,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr,
       bool finalize = false) override;
 

--- a/velox/experimental/cudf/expression/NullMask.cpp
+++ b/velox/experimental/cudf/expression/NullMask.cpp
@@ -28,7 +28,7 @@ namespace facebook::velox::cudf_velox {
 void mergeNullSourceNullsIntoResult(
     cudf::column& result,
     cudf::column_view nullSourceColumn,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   mergeNullSourceNullsIntoResult(
       result, std::vector<cudf::column_view>{nullSourceColumn}, stream, mr);
@@ -37,7 +37,7 @@ void mergeNullSourceNullsIntoResult(
 void mergeNullSourceNullsIntoResult(
     cudf::column& result,
     const std::vector<cudf::column_view>& nullSourceColumns,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::vector<cudf::column_view> nullableSourceColumns;
   nullableSourceColumns.reserve(nullSourceColumns.size());

--- a/velox/experimental/cudf/expression/NullMask.h
+++ b/velox/experimental/cudf/expression/NullMask.h
@@ -19,7 +19,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <vector>
 
@@ -29,7 +29,7 @@ namespace facebook::velox::cudf_velox {
 void mergeNullSourceNullsIntoResult(
     cudf::column& result,
     cudf::column_view nullSourceColumn,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 /// Merges nulls from multiple secondary inputs into an already materialized
@@ -37,7 +37,7 @@ void mergeNullSourceNullsIntoResult(
 void mergeNullSourceNullsIntoResult(
     cudf::column& result,
     const std::vector<cudf::column_view>& nullSourceColumns,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr);
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/expression/PrestoFunctions.cpp
+++ b/velox/experimental/cudf/expression/PrestoFunctions.cpp
@@ -107,7 +107,7 @@ class SubstrFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     auto inputCol = asView(inputColumns[0]);
     const auto start = std::optional<cudf::size_type>{start_};

--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
@@ -49,7 +49,7 @@ const cudf::ast::expression& createRangeExpr(
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const cudf::ast::expression& columnRef,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   using Op = cudf::ast::ast_operator;
   using Operation = cudf::ast::operation;
@@ -65,7 +65,7 @@ const cudf::ast::expression& createRangeExpr(
 
   auto addLiteral = [&](auto value) -> const cudf::ast::expression& {
     scalars.emplace_back(std::make_unique<ScalarT>(value, true, stream, mr));
-    stream.synchronize();
+    stream.sync();
     return tree.push(
         cudf::ast::literal{*static_cast<ScalarT*>(scalars.back().get())});
   };
@@ -255,7 +255,7 @@ auto createFloatingPointRangeExpr(
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const cudf::ast::expression& columnRef,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) -> const cudf::ast::expression& {
   return createRangeExpr<
       facebook::velox::common::FloatingPointRange<T>,
@@ -267,7 +267,7 @@ const cudf::ast::expression& createBytesRangeExpr(
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const cudf::ast::expression& columnRef,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   return createRangeExpr<
       facebook::velox::common::BytesRange,
@@ -284,7 +284,7 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerInListExpr(
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const cudf::ast::expression& columnRef,
-    rmm::cuda_stream_view /*stream*/,
+    cuda::stream_ref /*stream*/,
     rmm::device_async_resource_ref /*mr*/,
     const TypePtr& columnTypePtr) {
   using NativeT = typename TypeTraits<Kind>::NativeType;
@@ -453,7 +453,7 @@ cudf::ast::expression const& createAstFromSubfieldFilterImpl(
       scalars.emplace_back(
           std::make_unique<cudf::numeric_scalar<bool>>(
               matchesTrue, true, stream, mr));
-      stream.synchronize();
+      stream.sync();
       auto const& matchesBoolExpr = tree.push(
           cudf::ast::literal{
               *static_cast<cudf::numeric_scalar<bool>*>(scalars.back().get())});

--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
 #include "velox/experimental/cudf/expression/SubfieldFiltersToAst.h"
 
@@ -361,7 +362,7 @@ cudf::ast::expression const& createAstFromSubfieldFilterImpl(
   using Op = cudf::ast::ast_operator;
   using Operation = cudf::ast::operation;
 
-  auto stream = cudf::get_default_stream(cudf::allow_default_stream);
+  auto stream = getDefaultStreamForCurrentThread();
   auto mr = get_temp_mr();
 
   switch (filter.kind()) {

--- a/velox/experimental/cudf/expression/prestosql/DateAddFunction.cpp
+++ b/velox/experimental/cudf/expression/prestosql/DateAddFunction.cpp
@@ -76,7 +76,7 @@ int32_t checkedScaleValue(int64_t value, int32_t scale) {
 void checkValueRange(
     cudf::column_view valueCol,
     cudf::column_view dateCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   constexpr auto kMin = std::numeric_limits<int32_t>::min();
   constexpr auto kMax = std::numeric_limits<int32_t>::max();
@@ -125,7 +125,7 @@ std::unique_ptr<cudf::column> scaleToInt32(
     cudf::column_view valueCol,
     cudf::column_view dateCol,
     int32_t scale,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   checkValueRange(valueCol, dateCol, stream, mr);
 
@@ -198,7 +198,7 @@ DateAddFunction::DateAddFunction(
 
 ColumnOrView DateAddFunction::eval(
     std::vector<ColumnOrView>& inputColumns,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   // Walk the non-literal inputs in argument order. Constants were captured at
   // construction time and never appear in inputColumns, so the first slot
@@ -235,7 +235,7 @@ ColumnOrView DateAddFunction::eval(
 ColumnOrView DateAddFunction::evalDayBased(
     cudf::column_view dateCol,
     std::optional<cudf::column_view> valueCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   const auto outType = cudf::data_type(cudf::type_id::TIMESTAMP_DAYS);
   const auto scale = unitScale(unit_);
@@ -263,7 +263,7 @@ ColumnOrView DateAddFunction::evalDayBased(
 ColumnOrView DateAddFunction::evalMonthBased(
     cudf::column_view dateCol,
     std::optional<cudf::column_view> valueCol,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   const auto scale = unitScale(unit_);
 

--- a/velox/experimental/cudf/expression/prestosql/DateAddFunction.h
+++ b/velox/experimental/cudf/expression/prestosql/DateAddFunction.h
@@ -42,7 +42,7 @@ class DateAddFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override;
 
  private:
@@ -51,7 +51,7 @@ class DateAddFunction : public CudfFunction {
   ColumnOrView evalDayBased(
       cudf::column_view dateCol,
       std::optional<cudf::column_view> valueCol,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   /// Adds value*scale months (where scale comes from unit_) to dateCol. When
@@ -59,7 +59,7 @@ class DateAddFunction : public CudfFunction {
   ColumnOrView evalMonthBased(
       cudf::column_view dateCol,
       std::optional<cudf::column_view> valueCol,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const;
 
   // Unit of the increment; one of {kDay, kWeek, kMonth, kQuarter, kYear}.

--- a/velox/experimental/cudf/expression/prestosql/DatePlusIntervalFunction.cpp
+++ b/velox/experimental/cudf/expression/prestosql/DatePlusIntervalFunction.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/expression/prestosql/DatePlusIntervalFunction.h"
 
 #include "velox/common/memory/Memory.h"
@@ -43,7 +44,7 @@ DatePlusIntervalFunction::DatePlusIntervalFunction(
       expr->inputs()[1]->type()->isIntervalDayTime(),
       "Second argument to plus must be an interval day to second");
 
-  auto stream = cudf::get_default_stream(cudf::allow_default_stream);
+  auto stream = getDefaultStreamForCurrentThread();
   auto mr = get_temp_mr();
 
   // If the interval is a constant, extract it at construction time and

--- a/velox/experimental/cudf/expression/prestosql/DatePlusIntervalFunction.cpp
+++ b/velox/experimental/cudf/expression/prestosql/DatePlusIntervalFunction.cpp
@@ -75,12 +75,12 @@ DatePlusIntervalFunction::DatePlusIntervalFunction(
     zeroScalar_ = std::make_unique<cudf::numeric_scalar<int64_t>>(
         int64_t{0}, true, stream, mr);
   }
-  stream.synchronize();
+  stream.sync();
 }
 
 ColumnOrView DatePlusIntervalFunction::eval(
     std::vector<ColumnOrView>& inputColumns,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   auto dateCol = asView(inputColumns[0]);
 

--- a/velox/experimental/cudf/expression/prestosql/DatePlusIntervalFunction.h
+++ b/velox/experimental/cudf/expression/prestosql/DatePlusIntervalFunction.h
@@ -32,7 +32,7 @@ class DatePlusIntervalFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override;
 
  private:

--- a/velox/experimental/cudf/expression/sparksql/DateAddFunction.cpp
+++ b/velox/experimental/cudf/expression/sparksql/DateAddFunction.cpp
@@ -38,7 +38,7 @@ DateAddFunction::DateAddFunction(
 
 ColumnOrView DateAddFunction::eval(
     std::vector<ColumnOrView>& inputColumns,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   auto inputCol = asView(inputColumns[0]);
   return cudf::binary_operation(

--- a/velox/experimental/cudf/expression/sparksql/DateAddFunction.h
+++ b/velox/experimental/cudf/expression/sparksql/DateAddFunction.h
@@ -32,7 +32,7 @@ class DateAddFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override;
 
  private:

--- a/velox/experimental/cudf/expression/sparksql/HashFunction.cpp
+++ b/velox/experimental/cudf/expression/sparksql/HashFunction.cpp
@@ -70,7 +70,7 @@ HashFunction::HashFunction(
 
 ColumnOrView HashFunction::eval(
     std::vector<ColumnOrView>& inputColumns,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const {
   VELOX_CHECK(!inputColumns.empty());
   auto inputTableView = convertToTableView(inputColumns);

--- a/velox/experimental/cudf/expression/sparksql/HashFunction.h
+++ b/velox/experimental/cudf/expression/sparksql/HashFunction.h
@@ -29,7 +29,7 @@ class HashFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override;
 
  private:

--- a/velox/experimental/cudf/expression/sparksql/SubStringFunction.cpp
+++ b/velox/experimental/cudf/expression/sparksql/SubStringFunction.cpp
@@ -100,7 +100,7 @@ class SubStringFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& inputColumns,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) const override {
     VELOX_CHECK(
         !inputColumns.empty(),
@@ -272,7 +272,7 @@ class SubStringFunction : public CudfFunction {
 
   static std::unique_ptr<cudf::column> makeWideIndexColumn(
       cudf::column_view indexColumn,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto casted = cudf::cast(
         indexColumn, cudf::data_type{cudf::type_to_id<int64_t>()}, stream, mr);
@@ -288,7 +288,7 @@ class SubStringFunction : public CudfFunction {
 
   static std::unique_ptr<cudf::column> makeIndexColumn(
       cudf::column_view indexColumn,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto casted = cudf::cast(
         indexColumn,
@@ -308,7 +308,7 @@ class SubStringFunction : public CudfFunction {
   static std::unique_ptr<cudf::column> makeInputLengthColumn64(
       cudf::size_type inputLength,
       cudf::size_type rowCount,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     cudf::numeric_scalar<int64_t> inputLengthScalar(
         inputLength, true, stream, mr);
@@ -319,7 +319,7 @@ class SubStringFunction : public CudfFunction {
   static std::unique_ptr<cudf::column> clampStopColumn(
       cudf::column_view stopColumn,
       cudf::column_view inputLengthColumn64,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     cudf::numeric_scalar<int64_t> zero(0, true, stream, mr);
     cudf::numeric_scalar<int64_t> noUpperBound(0, false, stream, mr);
@@ -352,7 +352,7 @@ class SubStringFunction : public CudfFunction {
       cudf::column_view preLengthStartColumn64,
       WideLength const& length64,
       cudf::column_view inputLengthColumn64,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto unclampedStop = cudf::binary_operation(
         preLengthStartColumn64,
@@ -369,7 +369,7 @@ class SubStringFunction : public CudfFunction {
       cudf::column_view preLengthStartColumn64,
       cudf::size_type length,
       cudf::column_view inputLengthColumn64,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     cudf::numeric_scalar<int64_t> length64(length, true, stream, mr);
     return makeStopColumnFromWideInputs(
@@ -380,7 +380,7 @@ class SubStringFunction : public CudfFunction {
       cudf::column_view preLengthStartColumn64,
       cudf::column_view lengthColumn64,
       cudf::column_view inputLengthColumn64,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     return makeStopColumnFromWideInputs(
         preLengthStartColumn64,
@@ -393,7 +393,7 @@ class SubStringFunction : public CudfFunction {
   static StartColumns makeStartColumns(
       cudf::column_view startColumn,
       cudf::column_view inputLengthColumn64,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     auto startValues = makeWideIndexColumn(startColumn, stream, mr);
     cudf::numeric_scalar<int64_t> zero(0, true, stream, mr);
@@ -470,7 +470,7 @@ class SubStringFunction : public CudfFunction {
       cudf::column_view inputLengthColumn64,
       int32_t rawStartValue,
       cudf::size_type rowCount,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     cudf::numeric_scalar<int64_t> zero(0, true, stream, mr);
     if (rawStartValue > 0) {
@@ -496,7 +496,7 @@ class SubStringFunction : public CudfFunction {
       cudf::column_view inputLengthColumn64,
       int32_t rawStartValue,
       cudf::size_type rowCount,
-      rmm::cuda_stream_view stream,
+      cuda::stream_ref stream,
       rmm::device_async_resource_ref mr) {
     if (rawStartValue > 0) {
       cudf::numeric_scalar<cudf::size_type> adjustedStart(

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -57,8 +57,8 @@ class TestCudaStream {
     }
   }
 
-  rmm::cuda_stream_view view() const {
-    return rmm::cuda_stream_view{stream_};
+  cuda::stream_ref view() const {
+    return cuda::stream_ref{stream_};
   }
 
   cudaStream_t value() const {
@@ -134,7 +134,7 @@ void get_property(
     cuda::mr::device_accessible) noexcept {}
 
 std::unique_ptr<cudf::table> makeTable(
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   std::array<int32_t, 4> values{{1, 2, 3, 4}};
   rmm::device_buffer data(values.size() * sizeof(int32_t), stream, mr);
@@ -143,7 +143,7 @@ std::unique_ptr<cudf::table> makeTable(
       values.data(),
       values.size() * sizeof(int32_t),
       cudaMemcpyHostToDevice,
-      stream.value()));
+      stream.get()));
 
   std::vector<std::unique_ptr<cudf::column>> columns;
   columns.push_back(
@@ -157,7 +157,7 @@ std::unique_ptr<cudf::table> makeTable(
 }
 
 std::unique_ptr<cudf::packed_table> makePackedTable(
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     RecordingAsyncDeviceResource& resource) {
   auto table = makeTable(stream, cudf::get_current_device_resource_ref());
   auto packedColumns = cudf::pack(
@@ -166,7 +166,7 @@ std::unique_ptr<cudf::packed_table> makePackedTable(
       rmm::to_device_async_resource_ref_checked(&resource));
   // CudfVector does not join producer streams. Synchronize the packing stream
   // before handing the packed table to CudfVector.
-  stream.synchronize();
+  stream.sync();
   auto tableView = cudf::unpack(packedColumns);
   return std::make_unique<cudf::packed_table>(
       cudf::packed_table{tableView, std::move(packedColumns)});

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -183,7 +183,7 @@ TEST_F(CudfVectorTest, retainedSizeReportsDeviceStorage) {
   TestCudaStream stream;
   auto table =
       makeTable(stream.view(), cudf::get_current_device_resource_ref());
-  stream.view().synchronize();
+  stream.view().sync();
 
   CudfVector vector(
       pool_.get(),
@@ -204,7 +204,7 @@ TEST_F(CudfVectorTest, rebindOwnedTableDeallocationStream) {
   auto table = makeTable(
       allocationStream.view(),
       rmm::to_device_async_resource_ref_checked(&resource));
-  allocationStream.view().synchronize();
+  allocationStream.view().sync();
 
   auto vector = std::make_shared<CudfVector>(
       pool_.get(),
@@ -268,7 +268,7 @@ TEST_F(CudfVectorTest, packedTableReleaseUsesMaterializationStream) {
 
   EXPECT_GT(resource.deallocationCount(), 0);
   EXPECT_EQ(resource.lastDeallocationStream(), targetStream.value());
-  targetStream.view().synchronize();
+  targetStream.view().sync();
   EXPECT_EQ(materialized->num_columns(), 1);
   EXPECT_EQ(materialized->num_rows(), 4);
 }

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -58,7 +58,7 @@ constexpr int kBitsPerWord = 8 * sizeof(cudf::bitmask_type);
 
 std::pair<rmm::device_buffer, cudf::size_type> makeNullMask(
     const std::vector<bool>& valid,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   auto numBits = static_cast<cudf::size_type>(valid.size());
   if (numBits == 0) {
     return {rmm::device_buffer{}, 0};
@@ -83,9 +83,9 @@ std::pair<rmm::device_buffer, cudf::size_type> makeNullMask(
         host.data(),
         host.size() * sizeof(cudf::bitmask_type),
         cudaMemcpyHostToDevice,
-        stream.value());
+        stream.get());
     VELOX_CHECK_EQ(0, static_cast<int>(status));
-    stream.synchronize();
+    stream.sync();
   }
   return {std::move(mask), nullCount};
 }
@@ -122,7 +122,7 @@ std::unique_ptr<cudf::column> makeFixedWidthColumn(
     cudf::data_type type,
     const std::vector<T>& values,
     const std::vector<bool>* valid,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   auto col = cudf::make_fixed_width_column(
       type,
       static_cast<cudf::size_type>(values.size()),
@@ -134,9 +134,9 @@ std::unique_ptr<cudf::column> makeFixedWidthColumn(
         values.data(),
         values.size() * sizeof(T),
         cudaMemcpyHostToDevice,
-        stream.value());
+        stream.get());
     VELOX_CHECK_EQ(0, static_cast<int>(status));
-    stream.synchronize();
+    stream.sync();
   }
   if (valid) {
     auto [mask, nullCount] = makeNullMask(*valid, stream);
@@ -150,7 +150,7 @@ std::unique_ptr<cudf::column> makeDecimalColumn(
     const std::vector<T>& values,
     int32_t scale,
     const std::vector<bool>* valid,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   cudf::type_id typeId = std::is_same_v<T, int64_t> ? cudf::type_id::DECIMAL64
                                                     : cudf::type_id::DECIMAL128;
   cudf::data_type type{typeId, -scale};
@@ -160,7 +160,7 @@ std::unique_ptr<cudf::column> makeDecimalColumn(
 std::unique_ptr<cudf::column> makeInt64Column(
     const std::vector<int64_t>& values,
     const std::vector<bool>* valid,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   return makeFixedWidthColumn(
       cudf::data_type{cudf::type_id::INT64}, values, valid, stream);
 }
@@ -168,7 +168,7 @@ std::unique_ptr<cudf::column> makeInt64Column(
 template <typename T>
 std::vector<T> copyColumnData(
     const cudf::column_view& view,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<T> host(view.size());
   if (view.size() == 0) {
     return host;
@@ -178,15 +178,15 @@ std::vector<T> copyColumnData(
       view.data<T>(),
       view.size() * sizeof(T),
       cudaMemcpyDeviceToHost,
-      stream.value());
+      stream.get());
   VELOX_CHECK_EQ(0, static_cast<int>(status));
-  stream.synchronize();
+  stream.sync();
   return host;
 }
 
 std::vector<cudf::bitmask_type> copyNullMask(
     const cudf::column_view& view,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   auto numWords = cudf::num_bitmask_words(view.size());
   std::vector<cudf::bitmask_type> host(numWords, 0);
   if (!view.nullable() || numWords == 0) {
@@ -197,9 +197,9 @@ std::vector<cudf::bitmask_type> copyNullMask(
       view.null_mask(),
       host.size() * sizeof(cudf::bitmask_type),
       cudaMemcpyDeviceToHost,
-      stream.value());
+      stream.get());
   VELOX_CHECK_EQ(0, static_cast<int>(status));
-  stream.synchronize();
+  stream.sync();
   return host;
 }
 
@@ -1383,9 +1383,9 @@ TEST_F(CudfDecimalTest, decimalDeserializeSumStateAllNull) {
       offsetsPtr,
       0,
       static_cast<size_t>(numRows + 1) * sizeof(int32_t),
-      stream.value());
+      stream.get());
   VELOX_CHECK_EQ(0, static_cast<int>(status));
-  stream.synchronize();
+  stream.sync();
 
   std::vector<bool> valid(numRows, false);
   auto [nullMask, nullCount] = makeNullMask(valid, stream);

--- a/velox/experimental/cudf/tests/FunctionRegistryTest.cpp
+++ b/velox/experimental/cudf/tests/FunctionRegistryTest.cpp
@@ -42,7 +42,7 @@ class TagFunction : public CudfFunction {
 
   ColumnOrView eval(
       std::vector<ColumnOrView>& /*inputColumns*/,
-      rmm::cuda_stream_view /*stream*/,
+      cuda::stream_ref /*stream*/,
       rmm::device_async_resource_ref /*mr*/) const override {
     VELOX_UNREACHABLE("TagFunction::eval should not be called in these tests");
   }

--- a/velox/experimental/cudf/tests/InteropTest.cpp
+++ b/velox/experimental/cudf/tests/InteropTest.cpp
@@ -52,7 +52,7 @@ class InteropTest : public ::testing::Test, public VectorTestBase {
     // Convert cudf -> Velox using the existing Arrow path.
     auto result = cudf_velox::with_arrow::toVeloxColumn(
         cudfTable->view(), pool_.get(), input->type(), stream, mr);
-    stream.synchronize();
+    stream.sync();
 
     // Verify.
     test::assertEqualVectors(input, result);

--- a/velox/experimental/cudf/tests/NullMaskTest.cpp
+++ b/velox/experimental/cudf/tests/NullMaskTest.cpp
@@ -61,7 +61,7 @@ cudf::size_type countNulls(const std::vector<bool>& valid) {
 
 rmm::device_buffer makeNullMask(
     const std::vector<bool>& valid,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto size = checkedSize(valid);
   auto nullMask =
@@ -77,13 +77,13 @@ rmm::device_buffer makeNullMask(
       hostMask.data(),
       hostMask.size() * sizeof(cudf::bitmask_type),
       cudaMemcpyHostToDevice,
-      stream.value()));
+      stream.get()));
   return nullMask;
 }
 
 std::unique_ptr<cudf::column> makeNullableIntColumn(
     const std::vector<bool>& valid,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto size = checkedSize(valid);
   return std::make_unique<cudf::column>(
@@ -96,7 +96,7 @@ std::unique_ptr<cudf::column> makeNullableIntColumn(
 
 std::vector<cudf::bitmask_type> copyNullMaskToHost(
     cudf::column_view column,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   std::vector<cudf::bitmask_type> hostMask(
       cudf::num_bitmask_words(column.size()));
   CUDF_CUDA_TRY(cudaMemcpyAsync(
@@ -104,15 +104,15 @@ std::vector<cudf::bitmask_type> copyNullMaskToHost(
       column.null_mask(),
       hostMask.size() * sizeof(cudf::bitmask_type),
       cudaMemcpyDeviceToHost,
-      stream.value()));
-  stream.synchronize();
+      stream.get()));
+  stream.sync();
   return hostMask;
 }
 
 void assertValidity(
     cudf::column_view column,
     const std::vector<bool>& expectedValid,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   ASSERT_EQ(column.size(), checkedSize(expectedValid));
   EXPECT_EQ(column.null_count(), countNulls(expectedValid));
   if (!column.has_nulls()) {
@@ -130,7 +130,7 @@ void assertValidity(
 
 class NullMaskTest : public ::testing::Test {
  protected:
-  rmm::cuda_stream_view stream_{cudf::get_default_stream()};
+  cuda::stream_ref stream_{cudf::get_default_stream()};
   rmm::device_async_resource_ref mr_{cudf::get_current_device_resource_ref()};
 };
 

--- a/velox/experimental/cudf/tests/iceberg/CudfDeletionVectorReaderTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfDeletionVectorReaderTest.cpp
@@ -181,7 +181,7 @@ std::vector<IndexType> expandRuns(
 // empty deletion mask (no rows deleted yet).
 std::unique_ptr<cudf::column> makeDeletionColumn(
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto falseScalar = cudf::numeric_scalar<bool>(false, true, stream, mr);
   return cudf::make_column_from_scalar(falseScalar, numRows, stream, mr);
@@ -192,7 +192,7 @@ void applyDeletes(
     cudf::mutable_column_view const& deleteMask,
     uint64_t startRow,
     cudf::size_type numRows,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto rowIndex = cudf::make_numeric_column(
       cudf::data_type{cudf::type_id::UINT64},
@@ -207,7 +207,7 @@ void applyDeletes(
 
 std::unique_ptr<cudf::column> makeRowIndexColumn(
     const std::vector<uint64_t>& rowIndexHost,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) {
   auto rowIndex = cudf::make_numeric_column(
       cudf::data_type{cudf::type_id::UINT64},
@@ -220,7 +220,7 @@ std::unique_ptr<cudf::column> makeRowIndexColumn(
       rowIndexHost.data(),
       rowIndexHost.size() * sizeof(uint64_t),
       cudaMemcpyDefault,
-      stream.value()));
+      stream.get()));
   return rowIndex;
 }
 
@@ -230,7 +230,7 @@ template <typename IndexType>
 std::vector<IndexType> getSetBits(
     const cudf::column_view& deleteMask,
     std::size_t numRows,
-    rmm::cuda_stream_view stream) {
+    cuda::stream_ref stream) {
   VELOX_CHECK_EQ(deleteMask.size(), static_cast<cudf::size_type>(numRows));
   VELOX_CHECK(deleteMask.type().id() == cudf::type_id::BOOL8);
 
@@ -240,8 +240,8 @@ std::vector<IndexType> getSetBits(
       deleteMask.data<bool>(),
       numRows * sizeof(bool),
       cudaMemcpyDefault,
-      stream.value()));
-  stream.synchronize();
+      stream.get()));
+  stream.sync();
 
   std::vector<IndexType> setBits;
   setBits.reserve(numRows);

--- a/velox/experimental/cudf/tests/iceberg/CudfDeletionVectorReaderTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfDeletionVectorReaderTest.cpp
@@ -638,7 +638,7 @@ TEST_F(CudfDeletionVectorReaderTest, deleteOverflowing64BitRowIndices) {
       initialMask.data(),
       initialMask.size() * sizeof(bool),
       cudaMemcpyDefault,
-      stream().value()));
+      stream().get()));
   reader.applyDeletes(
       deleteMask->mutable_view(), rowIndex->view(), stream(), mr());
 
@@ -689,7 +689,7 @@ TEST_F(CudfDeletionVectorReaderTest, applyBitmapToMaskByRowIndex) {
       &bitmap,
       sizeof(bitmap),
       cudaMemcpyDefault,
-      stream().value()));
+      stream().get()));
 
   std::vector<uint64_t> rowIndexHost = {99, 100, 101, 103, 104};
   auto rowIndex = makeRowIndexColumn(rowIndexHost, stream(), mr());
@@ -700,7 +700,7 @@ TEST_F(CudfDeletionVectorReaderTest, applyBitmapToMaskByRowIndex) {
       &deleted,
       sizeof(deleted),
       cudaMemcpyDefault,
-      stream().value()));
+      stream().get()));
 
   facebook::velox::cudf_velox::connector::hive::iceberg::applyBitmapToMask(
       cudf::device_span<const cudf::bitmask_type>(

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
@@ -167,7 +167,7 @@ void CudfHiveConnectorTestBase::writeToFile(
           vector->pool(),
           stream,
           cudf::get_current_device_resource_ref());
-      stream.synchronize();
+      stream.sync();
       cudfTables.emplace_back(std::move(cudfTable));
     }
   }
@@ -205,7 +205,7 @@ void CudfHiveConnectorTestBase::writeToFile(
   auto stream = cudf::get_default_stream();
   auto cudfTable = with_arrow::toCudfTable(
       vector, vector->pool(), stream, cudf::get_current_device_resource_ref());
-  stream.synchronize();
+  stream.sync();
   auto tableInputMetadata = cudf::io::table_input_metadata(cudfTable->view());
   fillColumnNames(tableInputMetadata, rowType);
   auto options =

--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -98,9 +98,9 @@ std::pair<uint64_t, std::unique_ptr<cudf::table>> getTableSize(
 }
 
 void logDefaultStreamIfNeeded(
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     const char* constructorName) {
-  if (stream.value() != rmm::cuda_stream_default.value()) {
+  if (stream.get() != rmm::cuda_stream_default.value()) {
     return;
   }
   LOG(WARNING) << constructorName
@@ -115,7 +115,7 @@ CudfVector::CudfVector(
     TypePtr type,
     vector_size_t size,
     std::unique_ptr<cudf::table>&& table,
-    rmm::cuda_stream_view stream)
+    cuda::stream_ref stream)
     : RowVector(
           pool,
           std::move(type),
@@ -138,7 +138,7 @@ CudfVector::CudfVector(
     TypePtr type,
     vector_size_t size,
     std::unique_ptr<cudf::packed_table>&& packedTable,
-    rmm::cuda_stream_view stream)
+    cuda::stream_ref stream)
     : RowVector(
           pool,
           std::move(type),
@@ -171,20 +171,20 @@ std::unique_ptr<cudf::table> CudfVector::release() {
   auto mr = packedPtr->data.gpu_data->memory_resource();
   packedPtr->data.gpu_data->set_stream(stream_);
   auto materializedTable = std::make_unique<cudf::table>(tabView_, stream_, mr);
-  stream_.synchronize();
+  stream_.sync();
   // Clear the packed table since we've materialized
   packedPtr.reset();
   return materializedTable;
 }
 
-bool CudfVector::rebindStream(rmm::cuda_stream_view stream) {
+bool CudfVector::rebindStream(cuda::stream_ref stream) {
   if (auto* tablePtr =
           std::get_if<std::unique_ptr<cudf::table>>(&tableStorage_)) {
     if (!*tablePtr) {
       return false;
     }
 
-    if (stream_.value() == stream.value()) {
+    if (stream_.get() == stream.get()) {
       return true;
     }
 

--- a/velox/experimental/cudf/vector/CudfVector.h
+++ b/velox/experimental/cudf/vector/CudfVector.h
@@ -22,7 +22,7 @@
 #include <cudf/contiguous_split.hpp>
 #include <cudf/table/table.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <memory>
 #include <utility>
@@ -48,7 +48,7 @@ class CudfVector : public RowVector {
       TypePtr type,
       vector_size_t size,
       std::unique_ptr<cudf::table>&& table,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
   /// Constructs a CudfVector from packed_table.
   /// The packed data is retained and tabView_ references the table view inside
@@ -58,9 +58,9 @@ class CudfVector : public RowVector {
       TypePtr type,
       vector_size_t size,
       std::unique_ptr<cudf::packed_table>&& packedTable,
-      rmm::cuda_stream_view stream);
+      cuda::stream_ref stream);
 
-  rmm::cuda_stream_view stream() const {
+  cuda::stream_ref stream() const {
     return stream_;
   }
 
@@ -77,7 +77,7 @@ class CudfVector : public RowVector {
   /// This only changes future stream/deallocation association. It does not make
   /// 'stream' wait on the previous stream or any producer stream.
   /// Returns false when the storage cannot be rebound without materializing.
-  bool rebindStream(rmm::cuda_stream_view stream);
+  bool rebindStream(cuda::stream_ref stream);
 
   uint64_t estimateFlatSize() const override;
 
@@ -95,7 +95,7 @@ class CudfVector : public RowVector {
   // packedTable_->table.
   cudf::table_view tabView_;
 
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
   uint64_t flatSize_;
 };
 


### PR DESCRIPTION
## Description

This PR updates the cudf pin for velox-cudf to branch `release/26.10`. 

Includes the following mass find-replace changes for:
- `rmm::cuda_stream_view → cuda::stream_ref`
- `stream.value() → stream.get()`
- `stream.synchronize() → stream.sync()`
- `global_cuda_stream_pool() → current_cuda_stream_pool()`
- `apply_boolean_mask() → apply_retention_mask()`
- `stream().view().synchronize() → stream().view().sync()`
- `cudf::transform_extended(...) → cudf::transform(...)`
- `<rmm/cuda_stream_view.hpp> → <cuda/stream>`

Additional changes:
- Supply memory resources or `cudf::memory_resources{}` to libcudf APIs that now need it
- Stream members explicitly init `cuda::stream_ref stream_{cudaStream_t{nullptr}}`
- Ensure a current CUDA contextxon each thread before `cuda::stream_ref::sync()` in cuDF operator entry points (via `ensureCudaContextForThread()`), and expression-function and AST construction (via `getDefaultStreamForCurrentThread()`).

## Checklist
- [x] All velox-cudf tests pass 
- [x] I am familiar with the contributing guide and code of conduct