### PR TITLE
perf(s3): Avoid zero fill and staging copy in S3ReadFile::preadv

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -83,17 +83,25 @@ struct FileIoContext {
   /// where caching would waste resources.
   bool cacheable{false};
 
+  /// Pool for scratch memory a read needs only until it returns, such as a
+  /// staging buffer. Supplied per call because one ReadFile can serve many
+  /// queries, and the memory belongs to the query doing the read. Null means
+  /// the file allocates outside any pool.
+  memory::MemoryPool* pool{nullptr};
+
   FileIoContext() = default;
 
   explicit FileIoContext(
       IoStats* stats,
       folly::F14FastMap<std::string, std::string> fileOpts = {},
       std::shared_ptr<FileIoTracer> tracer = nullptr,
-      bool cacheable = false)
+      bool cacheable = false,
+      memory::MemoryPool* pool = nullptr)
       : ioStats(stats),
         fileOpts(std::move(fileOpts)),
         ioTracer(std::move(tracer)),
-        cacheable(cacheable) {}
+        cacheable(cacheable),
+        pool(pool) {}
 };
 
 // A read-only file.  All methods in this object should be thread safe.

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
@@ -15,9 +15,12 @@
  */
 
 #include "velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h"
+#include "velox/buffer/Buffer.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Counters.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
+
+#include <memory>
 
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>
@@ -48,6 +51,10 @@ class S3ReadFile ::Impl {
   // Gets the length of the file.
   // Checks if there are any issues reading the file.
   void initialize(const filesystems::FileOptions& options) {
+    // Captured before the early return below so a second initialize() still
+    // picks the pool up.
+    pool_ = options.pool;
+
     if (options.fileSize.has_value()) {
       VELOX_CHECK_GE(
           options.fileSize.value(), 0, "File size must be non-negative");
@@ -106,13 +113,32 @@ class S3ReadFile ::Impl {
     for (const auto range : buffers) {
       length += range.size();
     }
-    // TODO: allocate from a memory pool
-    std::string result(length, 0);
-    preadInternal(offset, length, static_cast<char*>(result.data()));
+
+    // One range needs no staging buffer, read straight into it.
+    if (buffers.size() == 1 && buffers[0].data() != nullptr) {
+      preadInternal(offset, length, buffers[0].data());
+      return length;
+    }
+
+    // Staged through one buffer because S3 GetObject cannot serve multiple
+    // ranges. Allocated from the query's pool so the memory is accounted for,
+    // left uninitialised because preadInternal overwrites it anyway.
+    char* staging;
+    BufferPtr pooled;
+    std::unique_ptr<char[]> owned;
+    if (pool_ != nullptr) {
+      pooled = AlignedBuffer::allocate<char>(length, pool_);
+      staging = pooled->asMutable<char>();
+    } else {
+      owned.reset(new char[length]);
+      staging = owned.get();
+    }
+
+    preadInternal(offset, length, staging);
     size_t resultOffset = 0;
     for (auto range : buffers) {
       if (range.data()) {
-        memcpy(range.data(), &(result.data()[resultOffset]), range.size());
+        memcpy(range.data(), staging + resultOffset, range.size());
       }
       resultOffset += range.size();
     }
@@ -164,6 +190,7 @@ class S3ReadFile ::Impl {
   }
 
   Aws::S3::S3Client* client_;
+  memory::MemoryPool* pool_{nullptr};
   std::string bucket_;
   std::string key_;
   int64_t length_ = -1;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
@@ -51,10 +51,6 @@ class S3ReadFile ::Impl {
   // Gets the length of the file.
   // Checks if there are any issues reading the file.
   void initialize(const filesystems::FileOptions& options) {
-    // Captured before the early return below so a second initialize() still
-    // picks the pool up.
-    pool_ = options.pool;
-
     if (options.fileSize.has_value()) {
       VELOX_CHECK_GE(
           options.fileSize.value(), 0, "File size must be non-negative");
@@ -121,13 +117,13 @@ class S3ReadFile ::Impl {
     }
 
     // Staged through one buffer because S3 GetObject cannot serve multiple
-    // ranges. Allocated from the query's pool so the memory is accounted for,
+    // ranges. Allocated from the caller's pool so the memory is accounted for,
     // left uninitialised because preadInternal overwrites it anyway.
     char* staging;
     BufferPtr pooled;
     std::unique_ptr<char[]> owned;
-    if (pool_ != nullptr) {
-      pooled = AlignedBuffer::allocate<char>(length, pool_);
+    if (context.pool != nullptr) {
+      pooled = AlignedBuffer::allocate<char>(length, context.pool);
       staging = pooled->asMutable<char>();
     } else {
       owned.reset(new char[length]);
@@ -190,7 +186,6 @@ class S3ReadFile ::Impl {
   }
 
   Aws::S3::S3Client* client_;
-  memory::MemoryPool* pool_{nullptr};
   std::string bucket_;
   std::string key_;
   int64_t length_ = -1;

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -75,6 +75,49 @@ TEST_F(S3FileSystemTest, writeAndRead) {
   readData(readFile.get());
 }
 
+TEST_F(S3FileSystemTest, preadvStagesInCallerPool) {
+  const char* bucketName = "data";
+  const char* file = "preadv.txt";
+  const auto filename = localPath(bucketName) + "/" + file;
+  const auto s3File = s3URI(bucketName, file);
+  addBucket(bucketName);
+  {
+    LocalWriteFile writeFile(filename);
+    writeData(&writeFile);
+  }
+  filesystems::S3FileSystem s3fs(bucketName, minioServer_->s3Config());
+  auto readFile = s3fs.openFileForRead(s3File);
+  auto rootPool =
+      memory::memoryManager()->addRootPool("preadvStagesInCallerPool");
+  auto pool = rootPool->addLeafChild("leaf");
+  FileIoContext context;
+  context.pool = pool.get();
+
+  // A single range is read straight into its buffer, so nothing is staged.
+  char single[10];
+  ASSERT_EQ(
+      readFile->preadv(
+          0, {folly::Range<char*>(single, sizeof(single))}, context),
+      sizeof(single));
+  EXPECT_EQ(std::string_view(single, sizeof(single)), "aaaaabbbbb");
+  EXPECT_EQ(pool->peakBytes(), 0);
+
+  // Ranges split by a gap are read as one span staged in the caller's pool,
+  // which is released before preadv returns.
+  char head[5];
+  char tail[5];
+  const std::vector<folly::Range<char*>> buffers = {
+      folly::Range<char*>(head, sizeof(head)),
+      folly::Range<char*>(nullptr, (char*)(uint64_t)(5 + kOneMB)),
+      folly::Range<char*>(tail, sizeof(tail)),
+  };
+  ASSERT_EQ(readFile->preadv(0, buffers, context), 15 + kOneMB);
+  EXPECT_EQ(std::string_view(head, sizeof(head)), "aaaaa");
+  EXPECT_EQ(std::string_view(tail, sizeof(tail)), "ddddd");
+  EXPECT_GE(pool->peakBytes(), 15 + kOneMB);
+  EXPECT_EQ(pool->usedBytes(), 0);
+}
+
 TEST_F(S3FileSystemTest, invalidCredentialsConfig) {
   {
     std::unordered_map<std::string, std::string> config(

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -80,7 +80,8 @@ class BufferedInput {
                 stats,
                 ioStats,
                 std::move(fileReadOps),
-                cacheable),
+                cacheable,
+                &pool),
             pool,
             maxMergeDistance,
             wsVRLoad) {}

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -66,9 +66,10 @@ ReadFileInputStream::ReadFileInputStream(
     IoStatistics* stats,
     velox::IoStats* ioStats,
     folly::F14FastMap<std::string, std::string> fileOpts,
-    bool cacheable)
+    bool cacheable,
+    memory::MemoryPool* pool)
     : InputStream(readFile->getName(), metricsLog, stats, ioStats),
-      fileIoContext_(ioStats, std::move(fileOpts), nullptr, cacheable),
+      fileIoContext_(ioStats, std::move(fileOpts), nullptr, cacheable, pool),
       readFile_(std::move(readFile)) {}
 
 void ReadFileInputStream::read(

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -139,14 +139,16 @@ class InputStream {
 /// An input stream that reads from an already opened ReadFile.
 class ReadFileInputStream final : public InputStream {
  public:
-  /// Takes shared ownership of |readFile|.
+  /// Takes shared ownership of |readFile|. 'pool' is passed to every read for
+  /// the scratch memory it needs; it must outlive this stream.
   explicit ReadFileInputStream(
       std::shared_ptr<velox::ReadFile>,
       const MetricsLogPtr& metricsLog = MetricsLog::voidLog(),
       IoStatistics* stats = nullptr,
       velox::IoStats* ioStats = nullptr,
       folly::F14FastMap<std::string, std::string> fileReadOps = {},
-      bool cacheable = false);
+      bool cacheable = false,
+      memory::MemoryPool* pool = nullptr);
 
   ~ReadFileInputStream() override = default;
 


### PR DESCRIPTION
`S3ReadFile::preadv`reads several ranges of a file with one S3 GET, through a staging buffer that spans all of them. The buffer was a `std::string`, so it was zero filled before the GET overwrite every byte. Each range was then copied out of it. With a single range, the staging buffer does no useful work.

This patch contains 3 optimizations:
- A single range is now read straight into its destination, no staging, (In one run of TPCH Q21, 331 of the 666 preadv calls are single range).
- Multiple ranges still go through a staging buffer, because S3 GetObject serves one range per request. But the staging buffer is no longer zero filled. Before the change, 17% of the samples under preadv were spent outside the S3 read, zero filling and copying:

  ```
  17724  S3ReadFile::Impl::preadv
  14719    S3ReadFile::Impl::preadInternal
   1542    __bzero
   1387    _platform_memmove
     76    _szone_free, free_medium
  ```

  After is 5%.

- Allocated the buffer from the caller's memory pool, so that it can be tracked and reduce memory allocation overhead.  And resolves the `TODO: allocate from a memory pool`.