### PR TITLE
fix(exec): Guard cached right-side joins

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3572,6 +3572,11 @@ class HashJoinNode : public AbstractJoinNode {
         !cacheKey_.has_value() || useHashTableCache_,
         "cacheKey can only be set when useHashTableCache is enabled");
     VELOX_USER_CHECK(
+        !useHashTableCache_ ||
+            !(isRightJoin() || isFullJoin() || isRightSemiFilterJoin() ||
+              isRightSemiProjectJoin() || isRightAntiJoin()),
+        "Hash table caching does not support right-side joins");
+    VELOX_USER_CHECK(
         !cacheKey_.has_value() || !cacheKey_->empty(),
         "cacheKey must be non-empty if set");
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -102,8 +102,9 @@ set(
   WindowFunctionRegistryTest.cpp
   StreamingEnforceDistinctTest.cpp
   HashBitRangeTest.cpp
-  # group4 (~575s): HashJoinTest ~575 + 9 lightweight
+  # group4 (~575s): HashJoinTest ~575 + 10 lightweight
   HashJoinTest.cpp
+  HashJoinWithCacheTest.cpp
   SpillTest.cpp
   WindowTest.cpp
   PrefixSortTest.cpp


### PR DESCRIPTION
Hash table caching shares the build-side table across tasks. Right-side joins mutate the table's `probed` flags while producing their final output, so reusing a cached table can leak probe state from an earlier task and produce incorrect results.

Reject hash table caching for join types that require right-side probing.

Also register the existing `HashJoinWithCacheTest.cpp` in `velox_exec_test`; it was added #15754 but was never included in the CMake source list.