### PR TITLE
perf(memory): Avoid redundant parameter copies

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -258,7 +258,7 @@ uint16_t MemoryManager::alignment() const {
 }
 
 std::shared_ptr<MemoryPoolImpl> MemoryManager::createRootPool(
-    std::string poolName,
+    const std::string& poolName,
     std::unique_ptr<MemoryReclaimer>& reclaimer,
     MemoryPool::Options& options) {
   auto pool = std::make_shared<MemoryPoolImpl>(

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -312,7 +312,7 @@ class MemoryManager {
 
  private:
   std::shared_ptr<MemoryPoolImpl> createRootPool(
-      std::string poolName,
+      const std::string& poolName,
       std::unique_ptr<MemoryReclaimer>& reclaimer,
       MemoryPool::Options& options);
 

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -441,7 +441,7 @@ size_t MemoryPool::getPreferredSize(size_t size) {
 void MemoryPool::setPreferredSize(
     std::function<size_t(size_t)> getPreferredSizeFunc) {
   VELOX_CHECK_NOT_NULL(getPreferredSizeFunc);
-  getPreferredSize_ = getPreferredSizeFunc;
+  getPreferredSize_ = std::move(getPreferredSizeFunc);
 }
 
 MemoryPoolImpl::MemoryPoolImpl(


### PR DESCRIPTION
`MemoryManager::createRootPool()` took the pool name by value, but it
only forwards the name to `MemoryPoolImpl`, whose constructor takes
`const std::string&`. The by-value copy was never consumed. Take the
name by const reference instead, matching the rest of the pool
creation call chain. This saves one string copy per root pool
creation.

`MemoryPool::setPreferredSize()` took its `std::function` parameter by
value but copy-assigned it to `getPreferredSize_`. Every call paid a
second deep copy of the callable state. Move the parameter into the
member instead, saving one deep copy of the callable per call.