### PR TITLE
fix(build): Patch folly's aarch64 SVE tag-match to build under GCC

### DIFF
--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -44,7 +44,9 @@ FetchContent_Declare(
   folly
   URL ${VELOX_FOLLY_SOURCE_URL}
   URL_HASH ${VELOX_FOLLY_BUILD_SHA256_CHECKSUM}
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/folly-no-export.patch ${glog_patch}
+  PATCH_COMMAND
+    git apply ${CMAKE_CURRENT_LIST_DIR}/folly-no-export.patch
+    ${CMAKE_CURRENT_LIST_DIR}/folly-sve-neonq-reinterpret.patch ${glog_patch}
   OVERRIDE_FIND_PACKAGE
   SYSTEM
   EXCLUDE_FROM_ALL

--- a/CMake/resolve_dependency_modules/folly/folly-sve-neonq-reinterpret.patch
+++ b/CMake/resolve_dependency_modules/folly/folly-sve-neonq-reinterpret.patch
@@ -1,0 +1,44 @@
+Fix the aarch64 SVE tag-match path in folly's ConcurrentHashMap so it builds
+under GCC.
+
+SIMDTable::Chunk::tagMatchIter() packs the two 64-bit tag words into a
+uint64x2_t and hands it straight to svset_neonq_u8(), whose second parameter is
+a uint8x16_t. clang's default of -flax-vector-conversions=integer lets that
+implicit bitcast through; GCC defaults to no lax vector conversions and rejects
+it:
+
+  folly/concurrency/detail/ConcurrentHashMap-detail.h:1035:63:
+  error: cannot convert 'uint64x2_t' to '__Uint8x16_t'
+
+So under GCC every translation unit that instantiates ConcurrentHashMap fails to
+compile once the target has SVE and <arm_neon_sve_bridge.h> is available - which
+is what get_cxx_flags() selects on Neoverse N2/V1/V2 and NVIDIA Olympus hosts
+(-mcpu=neoverse-v2 and friends). Velox CI never sees it: its arm64 runners are
+Neoverse N1, which has no SVE, so the guarded block is not compiled there.
+
+Introduced upstream in folly 12fa4cb487 ("Enhance concurrent hashmap with SVE",
+2026-03-02), so it first bites at FB_OS_VERSION v2026.07.13.00. folly CI builds
+with clang only and never sees it either.
+
+Add the explicit reinterpret. It is a pure type pun that emits no instruction,
+and it is exactly what the NEON fallback branch of the same function already
+does a dozen lines below (vceqq_u8(vreinterpretq_u8_u64(vec), needleV)), so
+codegen under clang is unchanged.
+
+Upstream: https://github.com/facebook/folly/pull/PR_NUMBER
+Drop this patch once folly carries the fix.
+
+--- a/folly/concurrency/detail/ConcurrentHashMap-detail.h
++++ b/folly/concurrency/detail/ConcurrentHashMap-detail.h
+@@ -1032,7 +1032,10 @@
+       vec[0] = low;
+       vec[1] = hi;
+       // test if any match is found
+-      outPred = svmatch_u8(pred, svset_neonq_u8(svundef_u8(), vec), needleV);
++      outPred = svmatch_u8(
++          pred,
++          svset_neonq_u8(svundef_u8(), vreinterpretq_u8_u64(vec)),
++          needleV);
+       // get info from every byte into the bottom half of every uint16_t
+       // by shifting right 4, then round to get it into a 64-bit vector
+       uint8x8_t maskV = vshrn_n_u16(

--- a/scripts/docker/centos-multi.dockerfile
+++ b/scripts/docker/centos-multi.dockerfile
@@ -45,6 +45,7 @@ COPY scripts/setup-centos9.sh /
 COPY CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /
 COPY CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /
 COPY CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /
+COPY CMake/resolve_dependency_modules/folly/folly-sve-neonq-reinterpret.patch /
 
 ARG VELOX_BUILD_SHARED=ON
 # Building libvelox.so requires folly and gflags to be built shared as well for now
@@ -76,7 +77,8 @@ ENV UV_TOOL_BIN_DIR=/usr/local/bin \
 # https://github.com/apache/arrow/pull/45424
 ENV CMAKE_POLICY_VERSION_MINIMUM="3.5" \
     VELOX_ARROW_CMAKE_PATCH="/arrow-testing-boost.patch /cmake-compatibility.patch" \
-    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch"
+    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch" \
+    VELOX_FOLLY_SVE_PATCH="/folly-sve-neonq-reinterpret.patch"
 
 # Ensure libraries installed to INSTALL_PREFIX are found at runtime (e.g.
 # thrift1 needs libgflags.so.2.2 when folly links gflags statically but

--- a/scripts/docker/fedora.dockerfile
+++ b/scripts/docker/fedora.dockerfile
@@ -26,6 +26,7 @@ COPY scripts/setup-fedora.sh /
 COPY CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /
 COPY CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /
 COPY CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /
+COPY CMake/resolve_dependency_modules/folly/folly-sve-neonq-reinterpret.patch /
 
 ARG VELOX_BUILD_SHARED=ON
 # Building libvelox.so requires folly and gflags to be built shared as well for now
@@ -42,7 +43,8 @@ ENV UV_TOOL_BIN_DIR=/usr/local/bin \
 # CMake 4.0 removed support for cmake minimums of <=3.5 and will fail builds, this overrides it
 ENV CMAKE_POLICY_VERSION_MINIMUM="3.5" \
     VELOX_ARROW_CMAKE_PATCH="/cmake-compatibility.patch /arrow-testing-boost.patch" \
-    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch"
+    VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch" \
+    VELOX_FOLLY_SVE_PATCH="/folly-sve-neonq-reinterpret.patch"
 
 # Some CMake configs contain the hard coded prefix '/deps', we need to replace that with
 # the future location to avoid build errors in the base-image

--- a/scripts/docker/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/docker/ubuntu-22.04-cpp.dockerfile
@@ -47,9 +47,11 @@ COPY scripts /velox/scripts/
 COPY CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /
 COPY CMake/resolve_dependency_modules/arrow/arrow-testing-boost.patch /
 COPY CMake/resolve_dependency_modules/openzl/openzl-cxx-standard.patch /
+COPY CMake/resolve_dependency_modules/folly/folly-sve-neonq-reinterpret.patch /
 
 ENV VELOX_ARROW_CMAKE_PATCH="/cmake-compatibility.patch /arrow-testing-boost.patch" \
     VELOX_OPENZL_CMAKE_PATCH="/openzl-cxx-standard.patch" \
+    VELOX_FOLLY_SVE_PATCH="/folly-sve-neonq-reinterpret.patch" \
     UV_TOOL_BIN_DIR=/usr/local/bin \
     UV_INSTALL_DIR=/usr/local/bin
 

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -22,6 +22,7 @@ source "$SCRIPT_DIR"/setup-versions.sh
 VELOX_BUILD_SHARED=${VELOX_BUILD_SHARED:-"OFF"}        #Build folly and gflags shared for use in libvelox.so.
 VELOX_ARROW_CMAKE_PATCH=${VELOX_ARROW_CMAKE_PATCH:-""} # avoid error due to +u
 VELOX_OPENZL_CMAKE_PATCH=${VELOX_OPENZL_CMAKE_PATCH:-""}
+VELOX_FOLLY_SVE_PATCH=${VELOX_FOLLY_SVE_PATCH:-""}
 CMAKE_BUILD_TYPE="${BUILD_TYPE:-Release}"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 BUILD_GEOS="${BUILD_GEOS:-true}"
@@ -49,6 +50,24 @@ function install_fmt {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/"${FB_OS_VERSION}".tar.gz folly
+  (
+    # folly's aarch64 SVE tag-match path hands a uint64x2_t to svset_neonq_u8(),
+    # which takes a uint8x16_t; GCC rejects the implicit vector conversion that
+    # clang allows. Apply the same patch the BUNDLED CMake resolver uses so both
+    # resolution modes build on GCC.
+    if [ -z "$VELOX_FOLLY_SVE_PATCH" ]; then
+      # A different path is needed when building the Dockerfile.
+      ABSOLUTE_SCRIPTDIR=$(realpath "$SCRIPT_DIR")
+      VELOX_FOLLY_SVE_PATCH="$ABSOLUTE_SCRIPTDIR/../CMake/resolve_dependency_modules/folly/folly-sve-neonq-reinterpret.patch"
+    fi
+
+    cd "$DEPENDENCY_DIR"/folly || exit 1
+    if command -v patch >/dev/null 2>&1; then
+      patch -p1 -i "$VELOX_FOLLY_SVE_PATCH" || exit 1
+    else
+      git apply "$VELOX_FOLLY_SVE_PATCH" || exit 1
+    fi
+  ) || exit 1
   local FOLLY_FLAGS=(-DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}")
   # When folly is static, use static gflags to avoid dual gflags flag
   # registration when .so plugins are dlopen'd (both the binary and plugin


### PR DESCRIPTION
## Description

Building C++ Presto on ARM with GCC breaks because of this. The patch included here was submitted upstream as facebook/folly#2698. This PR is just to enable ARM builds until the problem is fixed; drop `folly-sve-neonq-reinterpret.patch` and its call sites once a `FB_OS_VERSION` bump picks the fix up. What follows is an AI diagnosis of the problem. 

Building Velox with GCC 14+ (which is required for GPU C++ Presto) on an aarch64 host that has SVE fails in every translation unit that instantiates `folly::ConcurrentHashMap`:

```
/usr/local/include/folly/concurrency/detail/ConcurrentHashMap-detail.h:1035:63:
error: cannot convert 'uint64x2_t' to '__Uint8x16_t'
 1035 |   outPred = svmatch_u8(pred, svset_neonq_u8(svundef_u8(), vec), needleV);
      |                                                           ^~~
```

folly's `SIMDTable::Chunk::tagMatchIter()` packs the two 64-bit tag words into a `uint64x2_t` and hands it straight to `svset_neonq_u8()`, whose second parameter is a `uint8x16_t`. clang defaults to `-flax-vector-conversions=integer` and lets that implicit bitcast through; GCC defaults to no lax vector conversions and rejects it.

**Which builds break.** The block is gated on `FOLLY_ARM_FEATURE_NEON_SVE_BRIDGE`, which is `__ARM_FEATURE_SVE && __has_include(<arm_neon_sve_bridge.h>)`. SVE comes from the `-mcpu=neoverse-n2`, `-mcpu=neoverse-v1`, `-mcpu=neoverse-v2` and `-mcpu=olympus` flags `get_cxx_flags()` selects out of MIDR_EL1; the bridge header first ships in GCC 14 (gcc-mirror [`c53536078`](https://github.com/gcc-mirror/gcc/commit/c53536078), "aarch64: SVE/NEON Bridging intrinsics"; it is absent from the `releases/gcc-13` branch). So it is Graviton3/4, NVIDIA Grace and Olympus hosts compiling with a GCC 14 or newer toolchain. x86 never compiles the path, older GCCs compile it out, and clang builds are unaffected. And because the fault is in a header, the compiler that decides is the one compiling the consuming translation unit, not the one that built folly: ours installs folly with gcc-toolset-12, which has no bridge header, and then breaks on `-mcpu=neoverse-v2` when a Presto native translation unit including that installed header is compiled with gcc-toolset-14.

The "bug" (assuming it is one) entered folly in [`12fa4cb487`](https://github.com/facebook/folly/commit/12fa4cb487) ("Enhance concurrent hashmap with SVE", 2026-03-02) — after `v2026.01.05.00`, before `v2026.07.13.00` — so moving `FB_OS_VERSION` to the July tag is what exposed it. It is still there in `v2026.09.07.00`; folly [`7031d8bebb`] https://github.com/facebook/folly/commit/7031d8bebb) only renamed the guard and narrowed it to SVE2.

## The fix

Carry the one-line reinterpret that the NEON fallback branch of the same folly function already uses:

```diff
-      outPred = svmatch_u8(pred, svset_neonq_u8(svundef_u8(), vec), needleV);
+      outPred = svmatch_u8(
+          pred,
+          svset_neonq_u8(svundef_u8(), vreinterpretq_u8_u64(vec)),
+          needleV);
```

`vreinterpretq_u8_u64` is a pure type pun — no instruction is emitted, so codegen under clang is unchanged. That keeps the SVE2 `svmatch` fast path, unlike the alternative of switching the path off with `-DFOLLY_ARM_FEATURE_NEON_SVE_BRIDGE=0`.

## Applied in both resolution modes

- `CMake/resolve_dependency_modules/folly/CMakeLists.txt` `PATCH_COMMAND` — the BUNDLED FetchContent path.
- `scripts/setup-common.sh` `install_folly()` — the SYSTEM folly the dependency images install into `/usr/local`, which is the one that actually broke for us (`-- [folly] Using SYSTEM folly` / `Found folly: /usr/local`). It had no patch step at all; the hook mirrors `install_openzl()` a few lines below, and `VELOX_FOLLY_SVE_PATCH` is declared next to `VELOX_ARROW_CMAKE_PATCH` / `VELOX_OPENZL_CMAKE_PATCH` so `install_folly()` survives the `set -u` that `scripts/setup-centos9.sh` and Prestissimo's `setup-centos.sh` enable before installing dependencies.
- `scripts/docker/{centos-multi,fedora,ubuntu-22.04-cpp}.dockerfile` — the three images that run `install_folly()`. They copy individual scripts rather than the source tree, so `install_folly()`'s in-tree fallback (`$SCRIPT_DIR/../CMake/...`) does not exist inside them — `SCRIPT_DIR` is `/` for the centos and fedora images and `/velox/scripts` for the ubuntu one — and `patch` would fail on a missing file. Ship the patch and point `VELOX_FOLLY_SVE_PATCH` at it, exactly as these dockerfiles already do for the arrow and openzl patches.
-  `.github/workflows/linux-build-base.yml` — the four `Install Dependencies`  steps that reinstall dependencies when a PR touches `scripts/setup-*` do  `cp scripts/setup-* /` and then `bash /setup-<distro>.sh`, so `SCRIPT_DIR` is  `/` there too and the in-tree fallback cannot resolve. They already pass  `VELOX_OPENZL_CMAKE_PATCH` explicitly for exactly that reason (one of them says so in a comment); `VELOX_FOLLY_SVE_PATCH` goes next to it.

## Testing

- The patch applies cleanly to folly `v2026.07.13.00` source in **both** the tarballs Velox fetches — the release tarball used by the BUNDLED resolver (`folly-v2026.07.13.00.tar.gz`, sha256 matches `VELOX_FOLLY_BUILD_SHA256_CHECKSUM`) and the `archive/refs/tags` tarball used by `install_folly()` — with both `git apply --check` and `patch -p1`, and `folly-no-export.patch` still applies alongside it.
- `install_folly()` exercised under `set -eu` with `VELOX_FOLLY_SVE_PATCH` unset in a source checkout: the fallback path resolves and the patch applies.
- Because it touches `scripts/setup-*.sh` and `scripts/docker/*.dockerfile`, this PR runs `Build & Push Docker Images`, so `centos9-arm64` and `adapters-arm64` build natively on `ubuntu-24.04-arm` — i.e. CI does exercise `install_folly()` with this patch applied on Arm, even though gcc-toolset-12 compiles the guarded block out.
- The fix itself cross-compiled at `-mcpu=neoverse-v2 -O2 -std=gnu++20` with `aarch64-linux-gnu-g++ 14.2.0` and `clang 19.1.7`: GCC rejects the folly code before the patch and accepts it after; clang's generated instructions are byte-identical before and after (`fmov` / `mov v.d[1]` / `match`), confirming the reinterpret costs nothing.
