### PR TITLE
perf(nimble): Add a dense bulk visitor path for ALP decoding

### DIFF
--- a/velox/dwio/nimble/encodings/ALPEncoding.h
+++ b/velox/dwio/nimble/encodings/ALPEncoding.h
@@ -210,10 +210,13 @@ class ALPEncoding final
             typename DecoderVisitor::Extract,
             velox::dwio::common::ExtractToReader>) {
       constexpr vector_size_t kMinBulkRows = 128;
+      // Use a conservative cutoff based on the number of rows left to read.
+      // This is a trade-off that avoids bulk setup costs for short reads but
+      // may give up potential speedups on some smaller batches.
       if (visitor.numRows() - visitor.rowIndex() >= kMinBulkRows) {
         const auto* nulls = visitor.reader().rawNullsInReadRange();
         if (velox::dwio::common::useFastPath(visitor, nulls)) {
-          readWithVisitorBulk(visitor, params, nulls);
+          detail::readWithVisitorFast(*this, visitor, params, nulls);
           return;
         }
       }
@@ -1005,14 +1008,6 @@ class ALPEncoding final
       }
     }
     return {bestExponent, bestFactor};
-  }
-
-  template <typename Visitor>
-  FOLLY_NOINLINE void readWithVisitorBulk(
-      Visitor& visitor,
-      ReadWithVisitorParams& params,
-      const uint64_t* nulls) {
-    detail::readWithVisitorFast(*this, visitor, params, nulls);
   }
 
   // Converts a floating-point value to the integer stored by ALP.

--- a/velox/dwio/nimble/encodings/ALPEncoding.h
+++ b/velox/dwio/nimble/encodings/ALPEncoding.h
@@ -24,6 +24,7 @@
 #include <limits>
 #include <optional>
 #include <span>
+#include <type_traits>
 #include <vector>
 #include "velox/common/encode/Coding.h"
 #include "velox/dwio/nimble/common/Buffer.h"
@@ -202,6 +203,21 @@ class ALPEncoding final
 
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
+    if constexpr (
+        DecoderVisitor::dense && DecoderVisitor::kHasBulkPath &&
+        std::is_same_v<typename DecoderVisitor::DataType, cppDataType> &&
+        std::is_same_v<
+            typename DecoderVisitor::Extract,
+            velox::dwio::common::ExtractToReader>) {
+      constexpr vector_size_t kMinBulkRows = 128;
+      if (visitor.numRows() - visitor.rowIndex() >= kMinBulkRows) {
+        const auto* nulls = visitor.reader().rawNullsInReadRange();
+        if (velox::dwio::common::useFastPath(visitor, nulls)) {
+          readWithVisitorBulk(visitor, params, nulls);
+          return;
+        }
+      }
+    }
     auto skipFn = [&](auto toSkip) { pos_ += toSkip; };
     auto decodeFn = [&] {
       physicalType value = detail::alp::toPhysical<cppDataType>(decodeValue(
@@ -213,6 +229,63 @@ class ALPEncoding final
       return value;
     };
     detail::readWithVisitorSlow(visitor, params, skipFn, decodeFn);
+  }
+
+  template <bool kScatter, typename Visitor>
+  void bulkScan(
+      Visitor& visitor,
+      vector_size_t currentRow,
+      const vector_size_t* selectedRows,
+      vector_size_t numSelected,
+      const vector_size_t* scatterRows) {
+    static_assert(Visitor::dense);
+    static_assert(std::is_same_v<typename Visitor::DataType, cppDataType>);
+    if (numSelected == 0) {
+      return;
+    }
+    const auto numRows = visitor.numRows() - visitor.rowIndex();
+    auto* values = detail::mutableValues<cppDataType>(visitor, numRows);
+    auto* physicalValues = reinterpret_cast<physicalType*>(values);
+    const auto sourceStart =
+        pos_ + static_cast<uint32_t>(selectedRows[0] - currentRow);
+    const auto* encodedValues = encodedBuffer_.data() + sourceStart;
+    const auto exponent = exponent_;
+    const auto factor = factor_;
+    for (vector_size_t row = 0; row < numSelected; ++row) {
+      physicalValues[row] = detail::alp::toPhysical<cppDataType>(decodeValue(
+          velox::ZigZag::decode(encodedValues[row]), exponent, factor));
+    }
+    patchExceptions(sourceStart, numSelected, physicalValues);
+
+    if constexpr (!Visitor::kHasHook) {
+      values = reinterpret_cast<cppDataType*>(visitor.reader().rawValues());
+    }
+    auto numValues = visitor.reader().numValues();
+    int32_t* filterHits = nullptr;
+    if constexpr (Visitor::kHasFilter) {
+      filterHits = visitor.outputRows(numSelected) - numValues;
+    }
+    velox::dwio::common::processFixedWidthRun<
+        cppDataType,
+        Visitor::kFilterOnly,
+        kScatter,
+        Visitor::dense>(
+        velox::RowSet(selectedRows, numSelected),
+        0,
+        numSelected,
+        scatterRows,
+        values,
+        filterHits,
+        numValues,
+        visitor.filter(),
+        visitor.hook());
+    pos_ += selectedRows[numSelected - 1] - currentRow + 1;
+    if constexpr (!Visitor::kHasHook) {
+      visitor.addNumValues(
+          Visitor::kHasFilter ? numValues - visitor.reader().numValues()
+                              : numRows);
+    }
+    visitor.setRowIndex(visitor.numRows());
   }
 
   std::string debugString(int offset) const final {
@@ -932,6 +1005,14 @@ class ALPEncoding final
       }
     }
     return {bestExponent, bestFactor};
+  }
+
+  template <typename Visitor>
+  FOLLY_NOINLINE void readWithVisitorBulk(
+      Visitor& visitor,
+      ReadWithVisitorParams& params,
+      const uint64_t* nulls) {
+    detail::readWithVisitorFast(*this, visitor, params, nulls);
   }
 
   // Converts a floating-point value to the integer stored by ALP.

--- a/velox/dwio/nimble/encodings/benchmarks/ALPEncodingBenchmark.cpp
+++ b/velox/dwio/nimble/encodings/benchmarks/ALPEncodingBenchmark.cpp
@@ -16,36 +16,97 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <random>
 #include <span>
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <fmt/format.h>
 #include <folly/Benchmark.h>
+#include <folly/hash/SpookyHashV2.h>
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/FormatData.h"
+#include "velox/dwio/common/SelectiveColumnReader.h"
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/common/Statistics.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/encodings/ALPEncoding.h"
 #include "velox/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingUtils.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/dwio/nimble/velox/ChunkedStream.h"
+#include "velox/dwio/nimble/velox/selective/SelectiveNimbleReader.h"
+#include "velox/dwio/nimble/writer/EncodingLayoutTree.h"
+#include "velox/dwio/nimble/writer/Writer.h"
+#include "velox/vector/FlatVector.h"
 
 DEFINE_uint32(
     rows,
     65'536,
     "Values per dataset; use --bm_regex to select cases.");
+DEFINE_bool(profile, false, "Report repeated Release decode timings.");
+DEFINE_bool(e2e, false, "Benchmark Nimble file writing and selective reading.");
+DEFINE_bool(
+    force_alp,
+    false,
+    "Force ALP value streams in non-nullable E2E benchmarks.");
+DEFINE_uint32(read_batch_size, 4096, "Rows per selective reader batch.");
+DEFINE_uint32(
+    visitor_start,
+    0,
+    "Physical start row for microbenchmark visitors.");
+DEFINE_uint32(
+    visitor_rows,
+    0,
+    "Visitor row range; zero uses the remaining stream.");
+DEFINE_uint32(visitor_stride, 4, "Sparse visitor row stride.");
+DEFINE_uint32(
+    visitor_batch_size,
+    0,
+    "Selected rows per visitor call; zero reads all.");
+DEFINE_string(
+    exception_pattern,
+    "",
+    "Synthetic exceptions: none, one, four, five, all, prefix, suffix, periodic.");
+DEFINE_string(
+    profile_filter,
+    "",
+    "Only profile dataset names containing this text.");
+DEFINE_string(profile_operation, "", "Only profile this operation.");
+DEFINE_bool(
+    profile_skip_unselected_setup,
+    true,
+    "Skip constructing unselected microbenchmark fixtures.");
+DEFINE_bool(
+    profile_scalar_visitor_setup,
+    false,
+    "Use the scalar visitor for fixture validation.");
+DEFINE_uint32(profile_trials, 7, "Number of timed trials per operation.");
+DEFINE_uint32(
+    profile_min_ms,
+    20,
+    "Minimum calibrated duration per timed trial.");
 
 namespace {
 
@@ -58,8 +119,163 @@ using facebook::nimble::TypeTraits;
 using facebook::nimble::benchmarks::benchmarkPool;
 using facebook::nimble::benchmarks::nullFactory;
 namespace alp = facebook::nimble::detail::alp;
+namespace common = facebook::velox::dwio::common;
+namespace velox = facebook::velox;
+namespace nimble = facebook::nimble;
 
 constexpr uint64_t kSeed = 0x51ED0FF1CEULL;
+
+template <typename Function>
+void profileOperation(
+    const std::string& name,
+    std::string_view operation,
+    Function&& function) {
+  if (!FLAGS_profile_operation.empty() &&
+      operation != FLAGS_profile_operation) {
+    return;
+  }
+  const auto timeIterations = [&](uint64_t iterations) {
+    const auto start = std::chrono::steady_clock::now();
+    for (uint64_t iteration = 0; iteration < iterations; ++iteration) {
+      function();
+    }
+    return std::chrono::duration<double, std::nano>(
+               std::chrono::steady_clock::now() - start)
+        .count();
+  };
+
+  uint64_t iterations = 1;
+  while (timeIterations(iterations) < FLAGS_profile_min_ms * 1'000'000.0) {
+    CHECK_LE(iterations, std::numeric_limits<uint64_t>::max() / 2);
+    iterations *= 2;
+  }
+  std::vector<double> timings;
+  timings.reserve(FLAGS_profile_trials);
+  for (uint32_t trial = 0; trial < FLAGS_profile_trials; ++trial) {
+    timings.push_back(timeIterations(iterations) / iterations);
+  }
+  for (size_t trial = 0; trial < timings.size(); ++trial) {
+    fmt::print(
+        "TRIAL,{},{},{},{:.2f}\n", name, operation, trial, timings[trial]);
+  }
+  std::sort(timings.begin(), timings.end());
+  const auto middle = timings.size() / 2;
+  const double median = timings.size() % 2 == 0
+      ? (timings[middle - 1] + timings[middle]) / 2
+      : timings[middle];
+  fmt::print(
+      "PROFILE,{},{},{},{:.2f},{:.2f},{:.2f}\n",
+      name,
+      operation,
+      iterations,
+      median,
+      timings.front(),
+      timings.back());
+}
+
+class BenchmarkFormatData final : public common::FormatData {
+ public:
+  void readNulls(
+      facebook::velox::vector_size_t,
+      const uint64_t*,
+      facebook::velox::BufferPtr& nulls,
+      bool) final {
+    nulls = nullptr;
+  }
+
+  uint64_t skipNulls(uint64_t numValues, bool) final {
+    return numValues;
+  }
+
+  uint64_t skip(uint64_t numValues) final {
+    return numValues;
+  }
+
+  bool hasNulls() const final {
+    return false;
+  }
+
+  common::PositionProvider seekToRowGroup(int64_t) final {
+    static std::vector<uint64_t> positions;
+    return common::PositionProvider(positions);
+  }
+
+  void filterRowGroups(
+      const common::ScanSpec&,
+      uint64_t,
+      const common::StatsContext&,
+      FilterRowGroupsResult&) final {}
+};
+
+class BenchmarkFormatParams final : public common::FormatParams {
+ public:
+  BenchmarkFormatParams(
+      facebook::velox::memory::MemoryPool& pool,
+      common::SplitStats& stats)
+      : FormatParams(pool, stats) {}
+
+  std::unique_ptr<common::FormatData> toFormatData(
+      const std::shared_ptr<const common::TypeWithId>&,
+      const facebook::velox::common::ScanSpec&) final {
+    return std::make_unique<BenchmarkFormatData>();
+  }
+};
+
+struct VisitorInfrastructure {
+  common::SplitStats stats{common::FileFormat::NIMBLE};
+  BenchmarkFormatParams params{*benchmarkPool(), stats};
+  facebook::velox::common::ScanSpec scanSpec{"value"};
+
+  VisitorInfrastructure() {
+    scanSpec.setProjectOut(true);
+  }
+};
+
+template <typename FloatType>
+class BenchmarkColumnReader final : public common::SelectiveColumnReader {
+ public:
+  BenchmarkColumnReader(
+      const facebook::velox::TypePtr& type,
+      BenchmarkFormatParams& params,
+      facebook::velox::common::ScanSpec& scanSpec)
+      : SelectiveColumnReader(
+            type,
+            common::TypeWithId::create(type),
+            params,
+            scanSpec) {}
+
+  void prepare(const facebook::velox::RowSet& rows) {
+    this->template prepareRead<FloatType>(0, rows, nullptr);
+  }
+
+  void read(int64_t, const facebook::velox::RowSet&, const uint64_t*) final {}
+
+  void getValues(const facebook::velox::RowSet&, facebook::velox::VectorPtr*)
+      final {}
+};
+
+template <typename Visitor>
+facebook::nimble::ReadWithVisitorParams makeVisitorParams(
+    Visitor& visitor,
+    const facebook::velox::RowSet& rows) {
+  facebook::nimble::ReadWithVisitorParams params{};
+  params.prepareResultNulls = [&visitor, rows] {
+    visitor.reader().prepareNulls(rows, false, 8);
+  };
+  params.setReturnNullsMode = [&visitor, rows] {
+    visitor.reader().setReturnNullsMode(rows);
+  };
+  params.numScanned = 0;
+  return params;
+}
+
+template <typename FloatType>
+facebook::velox::TypePtr floatingPointType() {
+  if constexpr (std::is_same_v<FloatType, float>) {
+    return facebook::velox::REAL();
+  }
+  return facebook::velox::DOUBLE();
+}
 
 template <typename FloatType, typename Generator>
 std::vector<FloatType> makeValues(Generator generator) {
@@ -94,6 +310,335 @@ struct GridResult {
   bool operator==(const GridResult&) const = default;
 };
 
+enum class FileShape { Flat, Nullable, Nested, Sparse };
+
+template <typename FloatType>
+class AlpFileBenchmarkFixture {
+ public:
+  AlpFileBenchmarkFixture(
+      const std::string& name,
+      const std::vector<FloatType>& values,
+      FileShape shape)
+      : rootPool_(velox::memory::memoryManager()->addRootPool()),
+        pool_(rootPool_->addLeafChild("alp_file_benchmark")),
+        values_(values),
+        shape_(shape) {
+    auto floating = velox::BaseVector::create(
+        floatingPointType<FloatType>(), values.size(), pool_.get());
+    auto* flat = floating->template asFlatVector<FloatType>();
+    std::copy(values.begin(), values.end(), flat->mutableRawValues());
+    if (shape_ == FileShape::Nullable) {
+      for (uint32_t row = 0; row < values.size(); row += 10) {
+        flat->setNull(row, true);
+      }
+    }
+    if (shape_ == FileShape::Nested) {
+      floating = std::make_shared<velox::RowVector>(
+          pool_.get(),
+          velox::ROW({"value"}, {floating->type()}),
+          nullptr,
+          values.size(),
+          std::vector<velox::VectorPtr>{floating});
+    }
+    std::vector<std::string> names{"c0"};
+    std::vector<velox::VectorPtr> children{floating};
+    if (shape_ == FileShape::Sparse) {
+      auto selector = velox::BaseVector::create(
+          velox::BIGINT(), values.size(), pool_.get());
+      auto* raw =
+          selector->template asFlatVector<int64_t>()->mutableRawValues();
+      for (uint32_t row = 0; row < values.size(); ++row) {
+        raw[row] = row % 4;
+      }
+      names.insert(names.begin(), "selector");
+      children.insert(children.begin(), selector);
+    }
+    std::vector<velox::TypePtr> types;
+    for (const auto& child : children) {
+      types.push_back(child->type());
+    }
+    input_ = std::make_shared<velox::RowVector>(
+        pool_.get(),
+        velox::ROW(std::move(names), std::move(types)),
+        nullptr,
+        values.size(),
+        std::move(children));
+    auto ordered = values;
+    auto middle = ordered.begin() + ordered.size() / 2;
+    std::nth_element(ordered.begin(), middle, ordered.end());
+    filterUpper_ = *middle;
+    file_ = write();
+    read(false, true);
+    read(true, true);
+    printFileInfo(name);
+  }
+
+  std::string write() const {
+    nimble::WriterOptions options;
+    options.compressionOptions.compressionType =
+        nimble::CompressionType::Uncompressed;
+    options.encodingSelectionPolicyCreator = [](nimble::DataType dataType) {
+      auto candidates = nimble::ManualEncodingSelectionPolicyFactory::
+          defaultEncodingReadFactors();
+      if (dataType == nimble::DataType::Float ||
+          dataType == nimble::DataType::Double) {
+        candidates = {
+            {EncodingType::ALP, 1.0},
+            {EncodingType::Trivial, 1.0},
+            {EncodingType::FixedBitWidth, 1.0}};
+      }
+      return nimble::ManualEncodingSelectionPolicyFactory{
+          std::move(candidates), std::nullopt}
+          .createPolicy(dataType);
+    };
+    if (FLAGS_force_alp) {
+      using StreamLayouts = std::unordered_map<
+          nimble::EncodingLayoutTree::StreamIdentifier,
+          nimble::EncodingLayout>;
+      const nimble::EncodingLayout trivialLayout{
+          EncodingType::Trivial, {}, nimble::CompressionType::Uncompressed};
+      const nimble::EncodingLayout alpLayout{
+          EncodingType::ALP,
+          {},
+          nimble::CompressionType::Uncompressed,
+          {nimble::EncodingLayout{
+               EncodingType::FixedBitWidth,
+               {},
+               nimble::CompressionType::Uncompressed},
+           trivialLayout,
+           trivialLayout}};
+      const StreamLayouts valueLayout{
+          {nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+           alpLayout}};
+      std::vector<nimble::EncodingLayoutTree> children;
+      if (shape_ == FileShape::Sparse) {
+        children.emplace_back(
+            nimble::Kind::Scalar, StreamLayouts{}, "selector");
+      }
+      if (shape_ == FileShape::Nested) {
+        std::vector<nimble::EncodingLayoutTree> nested;
+        nested.emplace_back(nimble::Kind::Scalar, valueLayout, "value");
+        children.emplace_back(
+            nimble::Kind::Row, StreamLayouts{}, "c0", std::move(nested));
+      } else {
+        children.emplace_back(nimble::Kind::Scalar, valueLayout, "c0");
+      }
+      options.encodingLayoutTree.emplace(
+          nimble::Kind::Row, StreamLayouts{}, "", std::move(children));
+    }
+    std::string file;
+    nimble::Writer writer(
+        input_->type(),
+        std::make_unique<velox::InMemoryWriteFile>(&file),
+        *rootPool_,
+        std::move(options));
+    writer.write(input_);
+    writer.close();
+    return file;
+  }
+
+  uint64_t read(bool filtered, bool verify = false) const {
+    auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input_->type());
+    if (shape_ == FileShape::Sparse) {
+      scanSpec->childByName("selector")
+          ->setFilter(
+              std::make_unique<velox::common::BigintRange>(0, 0, false));
+    } else if (filtered) {
+      auto* valueSpec = scanSpec->childByName("c0");
+      if (shape_ == FileShape::Nested) {
+        valueSpec = valueSpec->childByName("value");
+      }
+      valueSpec->setFilter(
+          std::make_unique<velox::common::FloatingPointRange<FloatType>>(
+              FloatType{0}, true, false, filterUpper_, false, false, false));
+    }
+    auto options = readerOptions();
+    options.setScanSpec(scanSpec);
+    nimble::SelectiveNimbleReaderFactory factory;
+    auto reader = factory.createReader(
+        std::make_unique<common::BufferedInput>(
+            std::make_shared<velox::InMemoryReadFile>(file_), *pool_),
+        options);
+    common::RowReaderOptions rowOptions;
+    rowOptions.setScanSpec(scanSpec);
+    rowOptions.setRequestedType(velox::asRowType(input_->type()));
+    auto rowReader = reader->createRowReader(rowOptions);
+    velox::VectorPtr output =
+        velox::BaseVector::create(input_->type(), 0, pool_.get());
+    uint64_t scannedRows = 0;
+    uint64_t outputRows = 0;
+    uint64_t expectedRow = 0;
+    while (const auto scanned =
+               rowReader->next(FLAGS_read_batch_size, output)) {
+      scannedRows += scanned;
+      auto* leaf = output->as<velox::RowVector>()
+                       ->childAt(shape_ == FileShape::Sparse ? 1 : 0)
+                       ->loadedVector();
+      if (shape_ == FileShape::Nested) {
+        leaf = leaf->as<velox::RowVector>()->childAt(0)->loadedVector();
+      }
+      folly::doNotOptimizeAway(leaf);
+      outputRows += output->size();
+      if (verify) {
+        const auto* decoded =
+            leaf->template as<velox::SimpleVector<FloatType>>();
+        CHECK_NOTNULL(decoded);
+        for (velox::vector_size_t row = 0; row < output->size(); ++row) {
+          while (expectedRow < values_.size() &&
+                 !selected(expectedRow, filtered)) {
+            ++expectedRow;
+          }
+          CHECK_LT(expectedRow, values_.size());
+          CHECK_EQ(decoded->isNullAt(row), isNull(expectedRow));
+          if (!isNull(expectedRow)) {
+            CHECK_EQ(
+                alp::toPhysical<FloatType>(decoded->valueAt(row)),
+                alp::toPhysical<FloatType>(values_[expectedRow]));
+          }
+          ++expectedRow;
+        }
+      }
+    }
+    CHECK_EQ(scannedRows, values_.size());
+    if (verify) {
+      uint64_t expectedCount = 0;
+      for (uint32_t row = 0; row < values_.size(); ++row) {
+        expectedCount += selected(row, filtered);
+      }
+      CHECK_EQ(outputRows, expectedCount);
+    }
+    return outputRows;
+  }
+
+ private:
+  bool isNull(uint32_t row) const {
+    return shape_ == FileShape::Nullable && row % 10 == 0;
+  }
+
+  bool selected(uint32_t row, bool filtered) const {
+    if (shape_ == FileShape::Sparse) {
+      return row % 4 == 0;
+    }
+    return !filtered || (!isNull(row) && values_[row] <= filterUpper_);
+  }
+
+  common::ReaderOptions readerOptions() const {
+    common::ReaderOptions options(pool_.get());
+    options.setDataIoStats(std::make_shared<velox::io::IoStatistics>());
+    options.setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+    return options;
+  }
+
+  void printFileInfo(const std::string& name) const {
+    auto options = readerOptions();
+    auto tablet = nimble::TabletReader::create(
+        std::make_shared<velox::InMemoryReadFile>(file_),
+        pool_.get(),
+        nimble::TabletReader::configureOptions(options));
+    uint32_t alpChunks = 0;
+    uint32_t trivialChunks = 0;
+    uint32_t otherChunks = 0;
+    for (uint32_t stripeIndex = 0; stripeIndex < tablet->stripeCount();
+         ++stripeIndex) {
+      const auto stripe = tablet->stripeIdentifier(stripeIndex);
+      std::vector<uint32_t> streamIds(tablet->streamCount(stripe));
+      std::iota(streamIds.begin(), streamIds.end(), 0);
+      auto streams = tablet->load(stripe, streamIds);
+      for (auto& stream : streams) {
+        if (!stream) {
+          continue;
+        }
+        nimble::InMemoryChunkedStream chunks(*pool_, std::move(stream));
+        while (chunks.hasNext()) {
+          const auto chunk = chunks.nextChunk();
+          const auto dataType = nimble::EncodingPrefix::dataType(chunk);
+          if (dataType != nimble::DataType::Float &&
+              dataType != nimble::DataType::Double) {
+            continue;
+          }
+          const auto layout = nimble::EncodingLayoutCapture::capture(chunk, {});
+          const auto& valueLayout =
+              layout.encodingType() == EncodingType::Nullable
+              ? layout.child(nimble::EncodingIdentifiers::Nullable::Data)
+                    .value()
+              : layout;
+          const auto encoding = valueLayout.encodingType();
+          alpChunks += encoding == EncodingType::ALP;
+          trivialChunks += encoding == EncodingType::Trivial;
+          otherChunks += encoding != EncodingType::ALP &&
+              encoding != EncodingType::Trivial;
+        }
+      }
+    }
+    if (FLAGS_force_alp) {
+      CHECK_GT(alpChunks, 0);
+      CHECK_EQ(trivialChunks + otherChunks, 0);
+    }
+    fmt::print(
+        "FILE,{},{},{},{},{},{},{},{}\n",
+        name,
+        values_.size(),
+        file_.size(),
+        folly::hash::SpookyHashV2::Hash64(file_.data(), file_.size(), 0),
+        tablet->stripeCount(),
+        alpChunks,
+        trivialChunks,
+        otherChunks);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<FloatType> values_;
+  FileShape shape_;
+  FloatType filterUpper_;
+  velox::RowVectorPtr input_;
+  std::string file_;
+};
+
+template <typename FloatType>
+void registerFileDataset(
+    const std::string& name,
+    const std::vector<FloatType>& values) {
+  for (const auto& [shape, shapeName] :
+       {std::pair{FileShape::Flat, "Flat"},
+        std::pair{FileShape::Nullable, "Nullable"},
+        std::pair{FileShape::Nested, "Nested"},
+        std::pair{FileShape::Sparse, "Sparse"}}) {
+    const auto fileName = fmt::format("{}_{}", name, shapeName);
+    if (FLAGS_force_alp && shape == FileShape::Nullable) {
+      continue;
+    }
+    if (!FLAGS_profile_filter.empty() &&
+        fileName.find(FLAGS_profile_filter) == std::string::npos) {
+      continue;
+    }
+    auto fixture = std::make_shared<AlpFileBenchmarkFixture<FloatType>>(
+        fileName, values, shape);
+    const auto addOperation = [&](std::string_view operation, auto function) {
+      if (FLAGS_profile) {
+        profileOperation(fileName, operation, function);
+      } else {
+        folly::addBenchmark(
+            __FILE__, fmt::format("{}_{}", operation, fileName), [function] {
+              function();
+              return 1;
+            });
+      }
+    };
+    addOperation(
+        "FileWrite", [fixture] { folly::doNotOptimizeAway(fixture->write()); });
+    addOperation("FileRead", [fixture] {
+      folly::doNotOptimizeAway(fixture->read(false));
+    });
+    if (shape != FileShape::Sparse) {
+      addOperation("FileReadFilter", [fixture] {
+        folly::doNotOptimizeAway(fixture->read(true));
+      });
+    }
+  }
+}
+
 template <typename FloatType>
 class AlpBenchmarkFixture {
  public:
@@ -109,7 +654,21 @@ class AlpBenchmarkFixture {
         zigZag_(values_.size()),
         mask_(values_.size()),
         output_(values_.size()),
-        exponent_{exponent} {
+        exponent_{exponent},
+        visitorReader_{
+            floatingPointType<FloatType>(),
+            visitorInfrastructure_.params,
+            visitorInfrastructure_.scanSpec},
+        denseRows_(
+            FLAGS_visitor_rows == 0 ? values_.size() - FLAGS_visitor_start
+                                    : FLAGS_visitor_rows),
+        sparseRows_{} {
+    std::iota(denseRows_.begin(), denseRows_.end(), 0);
+    sparseRows_.reserve((denseRows_.size() - 1) / FLAGS_visitor_stride + 1);
+    for (uint64_t row = 0; row < denseRows_.size();
+         row += FLAGS_visitor_stride) {
+      sparseRows_.push_back(row);
+    }
     for (size_t row = 0; row < values_.size(); ++row) {
       physicals_[row] = alp::toPhysical<FloatType>(values_[row]);
     }
@@ -127,8 +686,13 @@ class AlpBenchmarkFixture {
 
     Buffer buffer{*benchmarkPool()};
     encoded_ = std::string{encode(buffer)};
+    Buffer alpBuffer{*benchmarkPool()};
+    alpEncoded_ = std::string{encodeAlp(alpBuffer)};
     auto encoding =
         EncodingFactory{}.create(*benchmarkPool(), encoded_, nullFactory());
+    visitorEncoding_ =
+        EncodingFactory{}.create(*benchmarkPool(), alpEncoded_, nullFactory());
+    CHECK_EQ(visitorEncoding_->encodingType(), EncodingType::ALP);
     if (encoding->encodingType() == EncodingType::ALP) {
       const char* position = encoded_.data() + encoding->dataOffset();
       const auto header = alp::readHeader(position);
@@ -140,6 +704,22 @@ class AlpBenchmarkFixture {
     for (size_t row = 0; row < values_.size(); ++row) {
       CHECK_EQ(alp::toPhysical<FloatType>(output_[row]), physicals_[row]);
     }
+
+    if (FLAGS_profile_scalar_visitor_setup) {
+      decodeVisitorDense<false>(true);
+    } else {
+      decodeVisitorDense<true>(true);
+    }
+    decodeVisitorSparse(true);
+
+    fmt::print(
+        "ALP,{},{},{},{},{}\n",
+        name,
+        values_.size(),
+        alpEncoded_.size(),
+        folly::hash::SpookyHashV2::Hash64(
+            alpEncoded_.data(), alpEncoded_.size(), 0),
+        visitorEncoding_->debugString());
 
     fmt::print(
         "{}: rows={} transform=({},0) exceptions={:.2f}% "
@@ -197,6 +777,15 @@ class AlpBenchmarkFixture {
         std::move(policy), std::span<const FloatType>{values_}, buffer);
   }
 
+  std::string_view encodeAlp(Buffer& buffer) const {
+    auto policy = std::make_unique<ManualEncodingSelectionPolicy<FloatType>>(
+        std::vector<std::pair<EncodingType, float>>{{EncodingType::ALP, 1.0}},
+        std::nullopt,
+        std::nullopt);
+    return EncodingFactory::encode<FloatType>(
+        std::move(policy), std::span<const FloatType>{values_}, buffer);
+  }
+
   void decode() {
     auto encoding =
         EncodingFactory{}.create(*benchmarkPool(), encoded_, nullFactory());
@@ -204,7 +793,77 @@ class AlpBenchmarkFixture {
     folly::doNotOptimizeAway(output_.data());
   }
 
+  void decodeReuse() {
+    visitorEncoding_->reset();
+    visitorEncoding_->materialize(values_.size(), output_.data());
+    folly::doNotOptimizeAway(output_.data());
+  }
+
+  template <bool hasBulkPath>
+  void decodeVisitorDense(bool verify = false) {
+    auto& filter = common::alwaysTrue();
+    decodeVisitor<true, hasBulkPath>(denseRows_, filter, verify);
+  }
+
+  template <bool hasBulkPath>
+  void decodeVisitorDenseFiltered() {
+    facebook::velox::common::FloatingPointRange<FloatType> filter(
+        static_cast<FloatType>(0),
+        false,
+        false,
+        static_cast<FloatType>(1'000),
+        false,
+        false,
+        false);
+    decodeVisitor<true, hasBulkPath>(denseRows_, filter, false);
+  }
+
+  void decodeVisitorSparse(bool verify = false) {
+    auto& filter = common::alwaysTrue();
+    decodeVisitor<false, true>(sparseRows_, filter, verify);
+  }
+
  private:
+  template <bool dense, bool hasBulkPath, typename Filter>
+  void decodeVisitor(
+      const std::vector<velox::vector_size_t>& selectedRows,
+      Filter& filter,
+      bool verify) {
+    visitorEncoding_->reset();
+    visitorEncoding_->skip(FLAGS_visitor_start);
+    const auto batchSize = FLAGS_visitor_batch_size == 0
+        ? selectedRows.size()
+        : FLAGS_visitor_batch_size;
+    for (size_t start = 0; start < selectedRows.size(); start += batchSize) {
+      const velox::RowSet rows{
+          selectedRows.data() + start,
+          std::min(batchSize, selectedRows.size() - start)};
+      visitorReader_.prepare(rows);
+      common::ExtractToReader extractValues(&visitorReader_);
+      common::ColumnVisitor<
+          FloatType,
+          Filter,
+          common::ExtractToReader,
+          dense,
+          hasBulkPath>
+          visitor(filter, &visitorReader_, rows, extractValues);
+      auto params = makeVisitorParams(visitor, rows);
+      params.numScanned = start == 0 ? 0 : selectedRows[start - 1] + 1;
+      nimble::callReadWithVisitor(*visitorEncoding_, visitor, params);
+      folly::doNotOptimizeAway(visitorReader_.rawValues());
+      if (verify) {
+        CHECK_EQ(visitorReader_.numValues(), rows.size());
+        const auto* output =
+            static_cast<const FloatType*>(visitorReader_.rawValues());
+        for (size_t index = 0; index < rows.size(); ++index) {
+          CHECK_EQ(
+              alp::toPhysical<FloatType>(output[index]),
+              physicals_[FLAGS_visitor_start + rows[index]]);
+        }
+      }
+    }
+  }
+
   template <bool useBatch, bool materialize>
   FOLLY_NOINLINE uint32_t
   transform(size_t size, uint8_t exponent, uint8_t factor) {
@@ -260,6 +919,12 @@ class AlpBenchmarkFixture {
   std::vector<FloatType> output_;
   uint8_t exponent_;
   std::string encoded_;
+  std::string alpEncoded_;
+  VisitorInfrastructure visitorInfrastructure_;
+  BenchmarkColumnReader<FloatType> visitorReader_;
+  std::unique_ptr<facebook::nimble::Encoding> visitorEncoding_;
+  std::vector<facebook::velox::vector_size_t> denseRows_;
+  std::vector<facebook::velox::vector_size_t> sparseRows_;
 };
 
 template <typename FloatType>
@@ -269,40 +934,139 @@ void registerDataset(
     uint8_t exponent) {
   const auto name = fmt::format(
       "{}_{}", std::is_same_v<FloatType, float> ? "Float" : "Double", dataset);
+  if (FLAGS_e2e) {
+    registerFileDataset(name, values);
+    return;
+  }
+  if (FLAGS_profile && FLAGS_profile_skip_unselected_setup &&
+      !FLAGS_profile_filter.empty() &&
+      name.find(FLAGS_profile_filter) == std::string::npos) {
+    return;
+  }
   auto fixture = std::make_shared<AlpBenchmarkFixture<FloatType>>(
       name, std::move(values), exponent);
 
+  if (FLAGS_profile) {
+    if (FLAGS_profile_filter.empty() ||
+        name.find(FLAGS_profile_filter) != std::string::npos) {
+      profileOperation(name, "DecodeConstruct", [&] { fixture->decode(); });
+      profileOperation(name, "Encode", [&] {
+        Buffer buffer{*benchmarkPool()};
+        folly::doNotOptimizeAway(fixture->encode(buffer));
+      });
+      profileOperation(name, "DecodeReuse", [&] { fixture->decodeReuse(); });
+      profileOperation(name, "VisitorDenseSlow", [&] {
+        fixture->template decodeVisitorDense<false>();
+      });
+      profileOperation(name, "VisitorDenseAuto", [&] {
+        fixture->template decodeVisitorDense<true>();
+      });
+      profileOperation(name, "VisitorFilterSlow", [&] {
+        fixture->template decodeVisitorDenseFiltered<false>();
+      });
+      profileOperation(name, "VisitorFilterAuto", [&] {
+        fixture->template decodeVisitorDenseFiltered<true>();
+      });
+      profileOperation(
+          name, "VisitorSparse", [&] { fixture->decodeVisitorSparse(); });
+    }
+    return;
+  }
+
+  auto* fixturePtr = fixture.get();
+  static std::vector<std::shared_ptr<AlpBenchmarkFixture<FloatType>>> fixtures;
+  fixtures.push_back(std::move(fixture));
+
   folly::addBenchmark(
-      __FILE__, fmt::format("TransformScalar_{}", name), [fixture] {
-        folly::doNotOptimizeAway(fixture->template runTransform<false>());
+      __FILE__, fmt::format("TransformScalar_{}", name), [fixturePtr] {
+        folly::doNotOptimizeAway(fixturePtr->template runTransform<false>());
         return 1;
       });
   folly::addBenchmark(
-      __FILE__, fmt::format("%TransformBatch_{}", name), [fixture] {
-        folly::doNotOptimizeAway(fixture->template runTransform<true>());
+      __FILE__, fmt::format("%TransformBatch_{}", name), [fixturePtr] {
+        folly::doNotOptimizeAway(fixturePtr->template runTransform<true>());
         return 1;
       });
-  folly::addBenchmark(__FILE__, fmt::format("GridScalar_{}", name), [fixture] {
-    folly::doNotOptimizeAway(fixture->template runGrid<false>());
-    return 1;
-  });
-  folly::addBenchmark(__FILE__, fmt::format("%GridBatch_{}", name), [fixture] {
-    folly::doNotOptimizeAway(fixture->template runGrid<true>());
-    return 1;
-  });
-  folly::addBenchmark(__FILE__, fmt::format("Encode_{}", name), [fixture] {
+  folly::addBenchmark(
+      __FILE__, fmt::format("GridScalar_{}", name), [fixturePtr] {
+        folly::doNotOptimizeAway(fixturePtr->template runGrid<false>());
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("%GridBatch_{}", name), [fixturePtr] {
+        folly::doNotOptimizeAway(fixturePtr->template runGrid<true>());
+        return 1;
+      });
+  folly::addBenchmark(__FILE__, fmt::format("Encode_{}", name), [fixturePtr] {
     Buffer buffer{*benchmarkPool()};
-    folly::doNotOptimizeAway(fixture->encode(buffer));
+    folly::doNotOptimizeAway(fixturePtr->encode(buffer));
     return 1;
   });
-  folly::addBenchmark(__FILE__, fmt::format("Decode_{}", name), [fixture] {
-    fixture->decode();
+  folly::addBenchmark(__FILE__, fmt::format("Decode_{}", name), [fixturePtr] {
+    fixturePtr->decode();
     return 1;
   });
+  folly::addBenchmark(
+      __FILE__, fmt::format("DecodeReuse_{}", name), [fixturePtr] {
+        fixturePtr->decodeReuse();
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("VisitorDenseSlow_{}", name), [fixturePtr] {
+        fixturePtr->template decodeVisitorDense<false>();
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("VisitorDenseAuto_{}", name), [fixturePtr] {
+        fixturePtr->template decodeVisitorDense<true>();
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("VisitorFilterSlow_{}", name), [fixturePtr] {
+        fixturePtr->template decodeVisitorDenseFiltered<false>();
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("VisitorFilterAuto_{}", name), [fixturePtr] {
+        fixturePtr->template decodeVisitorDenseFiltered<true>();
+        return 1;
+      });
+  folly::addBenchmark(
+      __FILE__, fmt::format("VisitorSparse_{}", name), [fixturePtr] {
+        fixturePtr->decodeVisitorSparse();
+        return 1;
+      });
 }
 
 template <typename FloatType>
 void registerDatasets() {
+  if (!FLAGS_exception_pattern.empty()) {
+    std::vector<FloatType> values(FLAGS_rows);
+    for (uint32_t row = 0; row < FLAGS_rows; ++row) {
+      const auto& pattern = FLAGS_exception_pattern;
+      const bool exception = pattern == "all" ||
+          (pattern == "one" && row == FLAGS_rows / 2) ||
+          (pattern == "four" && row < 4) || (pattern == "five" && row < 5) ||
+          (pattern == "prefix" && row < FLAGS_rows / 2) ||
+          (pattern == "suffix" && row >= FLAGS_rows / 2) ||
+          (pattern == "periodic" && row % 16 == 0);
+      values[row] = static_cast<FloatType>(row % 1024);
+      if (exception) {
+        const std::array<FloatType, 4> special{
+            -FloatType{0},
+            std::numeric_limits<FloatType>::infinity(),
+            -std::numeric_limits<FloatType>::infinity(),
+            alp::toLogical<FloatType>(
+                alp::toPhysical<FloatType>(
+                    std::numeric_limits<FloatType>::quiet_NaN()) |
+                (row % 256))};
+        values[row] = special[row % special.size()];
+      }
+    }
+    registerDataset(
+        "Exceptions_" + FLAGS_exception_pattern, std::move(values), 0);
+    return;
+  }
   std::uniform_int_distribution<int32_t> integers(-1'000'000, 1'000'000);
   registerDataset(
       "Integers",
@@ -368,6 +1132,22 @@ void registerDatasets() {
 int main(int argc, char** argv) {
   const folly::Init init{&argc, &argv};
   CHECK_GT(FLAGS_rows, 0);
+  CHECK_LE(FLAGS_rows, std::numeric_limits<velox::vector_size_t>::max());
+  CHECK_GT(FLAGS_read_batch_size, 0);
+  CHECK_LT(FLAGS_visitor_start, FLAGS_rows);
+  CHECK_LE(FLAGS_visitor_rows, FLAGS_rows - FLAGS_visitor_start);
+  CHECK_GT(FLAGS_visitor_stride, 0);
+  const std::array<std::string_view, 9> exceptionPatterns{
+      "", "none", "one", "four", "five", "all", "prefix", "suffix", "periodic"};
+  CHECK(
+      std::find(
+          exceptionPatterns.begin(),
+          exceptionPatterns.end(),
+          FLAGS_exception_pattern) != exceptionPatterns.end());
+  CHECK_LE(
+      FLAGS_read_batch_size, std::numeric_limits<velox::vector_size_t>::max());
+  CHECK_GT(FLAGS_profile_trials, 0);
+  CHECK_GT(FLAGS_profile_min_ms, 0);
   facebook::velox::memory::MemoryManager::initialize({});
   fmt::print(
       "Transform/encode/decode times are per {} rows; grid times are per "
@@ -376,5 +1156,7 @@ int main(int argc, char** argv) {
       ALPEncoding<double>::estimateSampleSize(FLAGS_rows));
   registerDatasets<double>();
   registerDatasets<float>();
-  folly::runBenchmarks();
+  if (!FLAGS_profile) {
+    folly::runBenchmarks();
+  }
 }

--- a/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -171,9 +171,12 @@ if(VELOX_ENABLE_BENCHMARKS)
   target_link_libraries(
     nimble_alp_encoding_benchmark
     nimble_encodings
+    nimble_velox_selective
+    nimble_writer
     nimble_common
     Folly::follybenchmark
     Folly::folly
+    velox_dwio_common
     velox_memory
     fmt::fmt
   )

--- a/velox/dwio/nimble/velox/selective/tests/CMakeLists.txt
+++ b/velox/dwio/nimble/velox/selective/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   FlatMapColumnReaderTest.cpp
   NimbleDataTest.cpp
   NullColumnReaderTest.cpp
+  ReadWithVisitorTest.cpp
   ScalarColumnReaderTest.cpp
   SelectiveNimbleReaderTest.cpp
   StringColumnReaderTest.cpp

--- a/velox/dwio/nimble/velox/selective/tests/ReadWithVisitorTest.cpp
+++ b/velox/dwio/nimble/velox/selective/tests/ReadWithVisitorTest.cpp
@@ -30,11 +30,14 @@
 #include "folly/Random.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/ColumnVisitors.h"
+#include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/ChunkHeader.h"
 #include "velox/dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/dwio/nimble/encodings/BitRangeSplitEncoding.h"
+#include "velox/dwio/nimble/encodings/NullableEncoding.h"
 #include "velox/dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingUtils.h"
@@ -97,8 +100,6 @@ class IntegerColumnReaderTestAccessor : public IntegerColumnReader {
 // Test-only accessor for FloatingPointColumnReader: exposes protected
 // prepareRead so tests can call readWithVisitor explicitly with a hand-built
 // ColumnVisitor.
-// No new data members — static_cast from the real FloatingPointColumnReader*
-// is layout-safe.
 // ---------------------------------------------------------------------------
 template <typename T>
 class FloatingPointColumnReaderTestAccessor
@@ -109,6 +110,14 @@ class FloatingPointColumnReaderTestAccessor
   void
   doPrepareRead(int64_t offset, const RowSet& rows, const uint64_t* nulls) {
     this->template prepareRead<T>(offset, rows, nulls);
+  }
+
+  const BufferPtr& resultNullsForTest() const {
+    return this->resultNulls();
+  }
+
+  void advanceReadOffset(const RowSet& rows) {
+    this->readOffset_ += rows.back() + 1;
   }
 };
 
@@ -212,8 +221,9 @@ EncodingLayout makeAlpEncodingLayout(EncodingType encodedValuesEncodingType) {
   const auto encodedValuesLayout = [&] {
     switch (encodedValuesEncodingType) {
       case EncodingType::Trivial:
+      case EncodingType::FixedBitWidth:
         return EncodingLayout{
-            EncodingType::Trivial, {}, CompressionType::Uncompressed};
+            encodedValuesEncodingType, {}, CompressionType::Uncompressed};
       case EncodingType::Dictionary:
         return EncodingLayout{
             EncodingType::Dictionary,
@@ -231,7 +241,7 @@ EncodingLayout makeAlpEncodingLayout(EncodingType encodedValuesEncodingType) {
       EncodingType::ALP,
       {},
       CompressionType::Uncompressed,
-      {encodedValuesLayout}};
+      {encodedValuesLayout, TrivialEnc{}, TrivialEnc{}}};
 }
 
 EncodingLayout makeBitRangeSplitEncodingLayout() {
@@ -268,13 +278,40 @@ WriterOptions makeSingleColumnWriterOptions(
 }
 
 template <typename T>
-std::vector<T> makeAlpFloatingPointValues() {
-  constexpr int kRows = 120;
-  std::vector<T> data(kRows);
-  for (int i = 0; i < kRows; ++i) {
-    data[i] = static_cast<T>((i % 21) - 10) / static_cast<T>(4);
+std::vector<T> makeAlpFloatingPointValues(vector_size_t rowCount = 120) {
+  std::vector<T> data(rowCount);
+  for (vector_size_t row = 0; row < rowCount; ++row) {
+    data[row] = static_cast<T>((row % 21) - 10) / static_cast<T>(4);
   }
   return data;
+}
+
+template <typename FloatType>
+std::string_view encodeNullableAlp(
+    std::span<const FloatType> data,
+    std::span<const bool> notNulls,
+    EncodingType encodedValuesEncodingType,
+    Buffer& buffer) {
+  std::vector<FloatType> nonNullValues;
+  for (size_t row = 0; row < data.size(); ++row) {
+    if (notNulls[row]) {
+      nonNullValues.push_back(data[row]);
+    }
+  }
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<FloatType>>(
+      makeAlpEncodingLayout(encodedValuesEncodingType),
+      CompressionOptions{},
+      [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
+      });
+  auto serializedValues = EncodingFactory::encode<FloatType>(
+      std::move(policy),
+      std::span<const FloatType>(nonNullValues.data(), nonNullValues.size()),
+      buffer);
+  auto serializedNulls = EncodingFactory::encode<bool>(
+      std::make_unique<TrivialNestedPolicy<bool>>(), notNulls, buffer);
+  return NullableEncoding<FloatType>::encodeNullable(
+      data.size(), serializedValues, serializedNulls, buffer);
 }
 
 // ---------------------------------------------------------------------------
@@ -286,7 +323,7 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
                             public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
-    memory::initializeMemoryManager(memory::MemoryManager::Options{});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
   bool useNonLegacy() const {
@@ -346,12 +383,16 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
 
   template <typename T>
   void testColumnReaderAlpFloatingPointRange(
-      EncodingType encodedValuesEncodingType) {
+      EncodingType encodedValuesEncodingType,
+      vector_size_t rowCount = 120) {
     SCOPED_TRACE(fmt::format("dataType={}", toString(TypeTraits<T>::dataType)));
     constexpr T kLower = static_cast<T>(-1.25);
     constexpr T kUpper = static_cast<T>(1.25);
 
-    const auto data = makeAlpFloatingPointValues<T>();
+    auto data = makeAlpFloatingPointValues<T>(rowCount);
+    data[17] = -T{0};
+    data[31] = std::numeric_limits<T>::infinity();
+    data[63] = std::numeric_limits<T>::quiet_NaN();
     auto input = makeRowVector(
         {makeFlatVector<T>(data.size(), [&](auto row) { return data[row]; })});
     auto rowType = asRowType(input->type());
@@ -408,7 +449,258 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     ASSERT_EQ(actualValues.size(), expectedValues.size());
     for (int i = 0; i < static_cast<int>(expectedValues.size()); ++i) {
       SCOPED_TRACE(fmt::format("valueIndex={}", i));
-      EXPECT_EQ(actualValues[i], expectedValues[i]);
+      EXPECT_EQ(
+          detail::alp::toPhysical<T>(actualValues[i]),
+          detail::alp::toPhysical<T>(expectedValues[i]));
+    }
+  }
+
+  template <typename FloatType>
+  void testEncodingLevelAlpNullableBatches(
+      EncodingType encodedValuesEncodingType,
+      vector_size_t batchSize,
+      bool filtered,
+      bool nullAllowed) {
+    constexpr vector_size_t kRows = 1025;
+    constexpr FloatType kLower = -1.25;
+    constexpr FloatType kUpper = 1.25;
+    auto data = makeAlpFloatingPointValues<FloatType>(kRows);
+    data[253] = -FloatType{0};
+    data[254] = std::numeric_limits<FloatType>::infinity();
+    data[255] = std::numeric_limits<FloatType>::quiet_NaN();
+    const auto isNull = [](vector_size_t row) {
+      return row < 129 || (row >= 513 && row < 641) || row % 7 == 0;
+    };
+    Vector<bool> notNulls(pool());
+    notNulls.resize(kRows);
+    for (vector_size_t row = 0; row < kRows; ++row) {
+      notNulls[row] = !isNull(row);
+    }
+    Buffer buffer(*pool());
+    auto serialized = encodeNullableAlp<FloatType>(
+        data,
+        std::span<const bool>(notNulls.data(), notNulls.size()),
+        encodedValuesEncodingType,
+        buffer);
+    auto encoding = EncodingFactory().create(*pool(), serialized, nullptr);
+    auto captured = EncodingLayoutCapture::capture(serialized, {});
+    ASSERT_EQ(encoding->encodingType(), EncodingType::Nullable);
+    ASSERT_EQ(captured.encodingType(), EncodingType::ALP);
+    const auto& childLayout =
+        captured.child(EncodingIdentifiers::ALP::EncodedValues);
+    ASSERT_TRUE(childLayout.has_value());
+    ASSERT_EQ(childLayout->encodingType(), encodedValuesEncodingType);
+    auto input = makeRowVector({makeFlatVector<FloatType>(
+        kRows, [&](auto row) { return data[row]; })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    if (filtered) {
+      scanSpec->childByName("c0")->setFilter(
+          std::make_unique<common::FloatingPointRange<FloatType>>(
+              kLower, false, false, kUpper, false, false, nullAllowed));
+    }
+    auto ownedReader =
+        buildFloatingPointReader<FloatType>(*ctx, rowType, *scanSpec);
+    auto* reader = ownedReader.get();
+    for (vector_size_t offset = 0; offset < kRows; offset += batchSize) {
+      SCOPED_TRACE(fmt::format("offset={}", offset));
+      const auto count = std::min(batchSize, kRows - offset);
+      std::vector<vector_size_t> rows(count);
+      std::iota(rows.begin(), rows.end(), 0);
+      const RowSet selectedRows(rows.data(), rows.size());
+      reader->doPrepareRead(offset, selectedRows, nullptr);
+      const auto read = [&](auto& filter) {
+        using FilterType = std::remove_reference_t<decltype(filter)>;
+        dwio::common::ExtractToReader extractValues(reader);
+        DecoderVisitor<
+            FloatType,
+            FilterType,
+            dwio::common::ExtractToReader,
+            true>
+            visitor(filter, reader, selectedRows, extractValues);
+        auto params = makeReadWithVisitorParams(visitor, selectedRows, pool());
+        dispatchCallReadWithVisitor(*encoding, visitor, params);
+      };
+      if (filtered) {
+        common::FloatingPointRange<FloatType> filter(
+            kLower, false, false, kUpper, false, false, nullAllowed);
+        read(filter);
+      } else {
+        common::AlwaysTrue filter;
+        read(filter);
+      }
+      reader->advanceReadOffset(selectedRows);
+      std::vector<vector_size_t> expectedRows;
+      for (vector_size_t row = 0; row < count; ++row) {
+        const auto sourceRow = offset + row;
+        const bool selected = !filtered ||
+            (isNull(sourceRow)
+                 ? nullAllowed
+                 : data[sourceRow] >= kLower && data[sourceRow] <= kUpper);
+        if (selected) {
+          expectedRows.push_back(row);
+        }
+      }
+      ASSERT_EQ(reader->numValues(), expectedRows.size());
+      const auto actualValues = getValues<FloatType>(reader);
+      const auto& resultNulls = reader->resultNullsForTest();
+      for (size_t index = 0; index < expectedRows.size(); ++index) {
+        const auto sourceRow = offset + expectedRows[index];
+        SCOPED_TRACE(fmt::format("sourceRow={}", sourceRow));
+        if (filtered) {
+          ASSERT_EQ(reader->outputRows().size(), expectedRows.size());
+          EXPECT_EQ(reader->outputRows()[index], expectedRows[index]);
+        }
+        const bool actualNull = resultNulls &&
+            velox::bits::isBitNull(resultNulls->template as<uint64_t>(), index);
+        EXPECT_EQ(actualNull, isNull(sourceRow));
+        if (!isNull(sourceRow)) {
+          EXPECT_EQ(
+              detail::alp::toPhysical<FloatType>(actualValues[index]),
+              detail::alp::toPhysical<FloatType>(data[sourceRow]));
+        }
+      }
+    }
+  }
+
+  template <typename FloatType>
+  void testEncodingLevelAlpNullableChunks(
+      EncodingType encodedValuesEncodingType,
+      vector_size_t firstChunkRows,
+      bool filtered,
+      bool useChunkedDecoder) {
+    constexpr vector_size_t kSecondChunkRows = 257;
+    constexpr FloatType kLower = -1.25;
+    constexpr FloatType kUpper = 1.25;
+    const auto rowCount = firstChunkRows + kSecondChunkRows;
+    auto data = makeAlpFloatingPointValues<FloatType>(rowCount);
+    Vector<bool> notNulls(pool());
+    notNulls.resize(rowCount);
+    for (vector_size_t row = 0; row < rowCount; ++row) {
+      notNulls[row] = row % 7 != 0;
+    }
+    for (const auto row : {firstChunkRows - 1, firstChunkRows, rowCount - 1}) {
+      data[row] = -FloatType{0};
+      notNulls[row] = true;
+    }
+    data[firstChunkRows + 1] = std::numeric_limits<FloatType>::infinity();
+    data[firstChunkRows + 2] = std::numeric_limits<FloatType>::quiet_NaN();
+    notNulls[firstChunkRows + 1] = true;
+    notNulls[firstChunkRows + 2] = true;
+
+    Buffer buffer(*pool());
+    std::vector<std::unique_ptr<Encoding>> chunks;
+    std::string streamData;
+    for (const auto offset : {vector_size_t{0}, firstChunkRows}) {
+      const auto count = offset == 0 ? firstChunkRows : kSecondChunkRows;
+      const auto serialized = encodeNullableAlp<FloatType>(
+          std::span<const FloatType>(data.data() + offset, count),
+          std::span<const bool>(notNulls.data() + offset, count),
+          encodedValuesEncodingType,
+          buffer);
+      chunks.push_back(EncodingFactory().create(*pool(), serialized, nullptr));
+      ASSERT_EQ(chunks.back()->encodingType(), EncodingType::Nullable);
+      const auto captured = EncodingLayoutCapture::capture(serialized, {});
+      ASSERT_EQ(captured.encodingType(), EncodingType::ALP);
+      const auto chunkOffset = streamData.size();
+      streamData.resize(chunkOffset + kChunkHeaderSize + serialized.size());
+      auto* position = streamData.data() + chunkOffset;
+      writeChunkHeader(
+          serialized.size(), CompressionType::Uncompressed, position);
+      encoding::writeBytes(serialized, position);
+    }
+
+    auto input = makeRowVector({makeFlatVector<FloatType>(
+        rowCount, [&](auto row) { return data[row]; })});
+    const auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    if (filtered) {
+      scanSpec->childByName("c0")->setFilter(
+          std::make_unique<common::FloatingPointRange<FloatType>>(
+              kLower, false, false, kUpper, false, false, false));
+    }
+    auto ownedReader =
+        buildFloatingPointReader<FloatType>(*ctx, rowType, *scanSpec);
+    auto* reader = ownedReader.get();
+    std::vector<vector_size_t> rows(rowCount);
+    std::iota(rows.begin(), rows.end(), 0);
+    const RowSet selectedRows(rows.data(), rows.size());
+    reader->doPrepareRead(0, selectedRows, nullptr);
+
+    const auto read = [&](auto& filter) {
+      using FilterType = std::remove_reference_t<decltype(filter)>;
+      dwio::common::ExtractToReader extractValues(reader);
+      DecoderVisitor<FloatType, FilterType, dwio::common::ExtractToReader, true>
+          visitor(filter, reader, selectedRows, extractValues);
+      if (useChunkedDecoder) {
+        ChunkedDecoder decoder(
+            std::make_unique<dwio::common::SeekableArrayInputStream>(
+                streamData.data(), streamData.size()),
+            nullptr,
+            false,
+            &ctx->encodingFactory,
+            pool(),
+            true);
+        decoder.readWithVisitor(visitor);
+      } else {
+        auto params = makeReadWithVisitorParams(visitor, selectedRows, pool());
+        visitor.setRows(RowSet(rows.data(), firstChunkRows));
+        dispatchCallReadWithVisitor(*chunks[0], visitor, params);
+        ASSERT_EQ(visitor.rowIndex(), firstChunkRows);
+        ASSERT_GT(reader->numValues(), 0);
+        if (filtered) {
+          ASSERT_LT(reader->numValues(), firstChunkRows);
+        }
+
+        params.numScanned = firstChunkRows;
+        visitor.setRows(selectedRows);
+        ASSERT_EQ(visitor.numRows() - visitor.rowIndex(), kSecondChunkRows);
+        ASSERT_TRUE(dwio::common::useFastPath(visitor, true));
+        dispatchCallReadWithVisitor(*chunks[1], visitor, params);
+      }
+      ASSERT_EQ(visitor.rowIndex(), rowCount);
+    };
+    if (filtered) {
+      common::FloatingPointRange<FloatType> filter(
+          kLower, false, false, kUpper, false, false, false);
+      read(filter);
+    } else {
+      common::AlwaysTrue filter;
+      read(filter);
+    }
+
+    std::vector<vector_size_t> expectedRows;
+    for (vector_size_t row = 0; row < rowCount; ++row) {
+      if (!filtered ||
+          (notNulls[row] && data[row] >= kLower && data[row] <= kUpper)) {
+        expectedRows.push_back(row);
+      }
+    }
+    ASSERT_EQ(reader->numValues(), expectedRows.size());
+    if (filtered) {
+      ASSERT_EQ(reader->outputRows().size(), expectedRows.size());
+    }
+    const auto actualValues = getValues<FloatType>(reader);
+    const auto& resultNulls = reader->resultNullsForTest();
+    for (size_t index = 0; index < expectedRows.size(); ++index) {
+      const auto sourceRow = expectedRows[index];
+      SCOPED_TRACE(fmt::format("sourceRow={}", sourceRow));
+      if (filtered) {
+        EXPECT_EQ(reader->outputRows()[index], sourceRow);
+      }
+      const bool actualNull = resultNulls &&
+          bits::isBitNull(resultNulls->template as<uint64_t>(), index);
+      EXPECT_EQ(actualNull, !notNulls[sourceRow]);
+      if (notNulls[sourceRow]) {
+        EXPECT_EQ(
+            detail::alp::toPhysical<FloatType>(actualValues[index]),
+            detail::alp::toPhysical<FloatType>(data[sourceRow]));
+      }
     }
   }
 
@@ -433,6 +725,11 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     for (int i = 0; i < kRows; ++i) {
       data[i] = static_cast<T>(valueDistribution(rng)) / static_cast<T>(100);
     }
+    for (int row = 0; row < kRows; row += 7) {
+      data[row] = -T{0};
+    }
+    data[31] = std::numeric_limits<T>::infinity();
+    data[127] = std::numeric_limits<T>::quiet_NaN();
 
     std::vector<vector_size_t> rowVec;
     for (int i = 0; i < kRows; ++i) {
@@ -451,15 +748,8 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     scanSpec->childByName("c0")->setFilter(
         std::make_unique<common::FloatingPointRange<T>>(
             kLower, false, false, kUpper, false, false, false));
-    auto root = buildReader(*ctx, rowType, *scanSpec);
-
-    auto* structReader =
-        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
-            root.get());
-    auto* reader = static_cast<FloatingPointColumnReaderTestAccessor<T>*>(
-        dynamic_cast<FloatingPointColumnReader<T, T>*>(
-            structReader->children()[0]));
-    ASSERT_NE(reader, nullptr);
+    auto ownedReader = buildFloatingPointReader<T>(*ctx, rowType, *scanSpec);
+    auto* reader = ownedReader.get();
 
     RowSet rows(rowVec.data(), rowVec.size());
     reader->doPrepareRead(0, rows, nullptr);
@@ -500,6 +790,30 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
       SCOPED_TRACE(fmt::format("valueIndex={}", i));
       EXPECT_EQ(actualValues[i], expectedValues[i]);
     }
+  }
+
+  template <typename FloatType>
+  std::unique_ptr<FloatingPointColumnReaderTestAccessor<FloatType>>
+  buildFloatingPointReader(
+      FileContext& ctx,
+      const RowTypePtr& rowType,
+      common::ScanSpec& scanSpec) {
+    NimbleParams params(
+        *pool(),
+        ctx.stats,
+        ctx.readerBase->nimbleSchema()->asRow().childAt(0),
+        *ctx.streams,
+        ctx.rowSizeTracker.get(),
+        ctx.encodingFactory,
+        useNonLegacy());
+    auto reader =
+        std::make_unique<FloatingPointColumnReaderTestAccessor<FloatType>>(
+            rowType->childAt(0),
+            ctx.readerBase->fileSchemaWithId()->childAt(0),
+            params,
+            *scanSpec.childByName("c0"));
+    ctx.streams->load();
+    return reader;
   }
 
   std::unique_ptr<dwio::common::SelectiveColumnReader> buildReader(
@@ -1339,6 +1653,116 @@ TEST_P(ReadWithVisitorNonLegacyTest, columnReaderAlpFloatAndDouble) {
   }
 }
 
+TEST_P(ReadWithVisitorNonLegacyTest, encodingLevelAlpDenseNullable) {
+  testEncodingLevelAlpNullableBatches<float>(
+      EncodingType::Trivial, 256, false, false);
+  testEncodingLevelAlpNullableBatches<double>(
+      EncodingType::Trivial, 256, false, false);
+}
+
+TEST_P(ReadWithVisitorNonLegacyTest, columnReaderAlpDenseBulkBoundaries) {
+  for (const auto rowCount : {127, 128, 129, 257, 4097}) {
+    SCOPED_TRACE(fmt::format("rowCount={}", rowCount));
+    for (const auto nestedType :
+         {EncodingType::Trivial, EncodingType::FixedBitWidth}) {
+      testColumnReaderAlpFloatingPointRange<float>(nestedType, rowCount);
+      testColumnReaderAlpFloatingPointRange<double>(nestedType, rowCount);
+    }
+  }
+}
+
+TEST_P(ReadWithVisitorNonLegacyTest, encodingLevelAlpNullableBatchBoundaries) {
+  for (const auto batchSize : {127, 128, 129, 257}) {
+    SCOPED_TRACE(fmt::format("batchSize={}", batchSize));
+    for (const auto nestedType :
+         {EncodingType::Trivial, EncodingType::FixedBitWidth}) {
+      SCOPED_TRACE(fmt::format("nestedType={}", toString(nestedType)));
+      for (const bool filtered : {false, true}) {
+        for (const bool nullAllowed : {false, true}) {
+          SCOPED_TRACE(
+              fmt::format("filtered={} nullAllowed={}", filtered, nullAllowed));
+          testEncodingLevelAlpNullableBatches<float>(
+              nestedType, batchSize, filtered, nullAllowed);
+          testEncodingLevelAlpNullableBatches<double>(
+              nestedType, batchSize, filtered, nullAllowed);
+        }
+      }
+    }
+  }
+}
+
+TEST_P(ReadWithVisitorNonLegacyTest, encodingLevelAlpNullableAcrossChunks) {
+  if (!process::hasSimd()) {
+    GTEST_SKIP() << "ALP bulk decoding requires SIMD support";
+  }
+  for (const auto firstChunkRows : {63, 129}) {
+    SCOPED_TRACE(fmt::format("firstChunkRows={}", firstChunkRows));
+    for (const auto nestedType :
+         {EncodingType::Trivial, EncodingType::FixedBitWidth}) {
+      SCOPED_TRACE(fmt::format("nestedType={}", toString(nestedType)));
+      for (const bool filtered : {false, true}) {
+        SCOPED_TRACE(fmt::format("filtered={}", filtered));
+        for (const bool useChunkedDecoder : {false, true}) {
+          SCOPED_TRACE(fmt::format("useChunkedDecoder={}", useChunkedDecoder));
+          testEncodingLevelAlpNullableChunks<float>(
+              nestedType, firstChunkRows, filtered, useChunkedDecoder);
+          testEncodingLevelAlpNullableChunks<double>(
+              nestedType, firstChunkRows, filtered, useChunkedDecoder);
+        }
+      }
+    }
+  }
+}
+
+TEST_P(ReadWithVisitorNonLegacyTest, columnReaderAlpDenseHook) {
+  class CapturingHook final : public ValueHook {
+   public:
+    void addValue(vector_size_t row, double value) final {
+      rows.push_back(row);
+      values.push_back(value);
+    }
+
+    std::vector<vector_size_t> rows;
+    std::vector<double> values;
+  };
+
+  constexpr vector_size_t kRows = 256;
+  std::vector<double> data(kRows);
+  for (vector_size_t row = 0; row < kRows; ++row) {
+    data[row] = static_cast<double>((row % 101) - 50) / 4;
+  }
+  data[17] = -0.0;
+  data[129] = std::numeric_limits<double>::infinity();
+  data[191] = detail::alp::toLogical<double>(0x7ff8000000000042ULL);
+
+  auto input = makeRowVector(
+      {makeFlatVector<double>(kRows, [&](auto row) { return data[row]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(
+      input,
+      makeSingleColumnWriterOptions(
+          makeAlpEncodingLayout(EncodingType::Trivial)));
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  CapturingHook hook;
+  auto* childSpec = scanSpec->childByName("c0");
+  childSpec->setFilter(std::make_unique<common::AlwaysTrue>());
+  childSpec->setValueHook(&hook);
+  auto root = buildReader(*ctx, rowType, *scanSpec, true);
+  readColumn(root.get(), kRows);
+
+  ASSERT_EQ(hook.rows.size(), kRows);
+  ASSERT_EQ(hook.values.size(), kRows);
+  for (vector_size_t row = 0; row < kRows; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_EQ(hook.rows[row], row);
+    EXPECT_EQ(
+        detail::alp::toPhysical<double>(hook.values[row]),
+        detail::alp::toPhysical<double>(data[row]));
+  }
+}
+
 TEST_P(
     ReadWithVisitorNonLegacyTest,
     columnReaderBitRangeSplitBigintRangeFilter) {
@@ -1644,14 +2068,8 @@ TEST_P(ReadWithVisitorNonLegacyTest, encodingLevelAlpFloatingPointRangeSparse) {
   scanSpec->childByName("c0")->setFilter(
       std::make_unique<common::FloatingPointRange<double>>(
           kLower, false, false, kUpper, false, false, false));
-  auto root = buildReader(*ctx, rowType, *scanSpec);
-
-  auto* structReader =
-      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
-  auto* reader = static_cast<FloatingPointColumnReaderTestAccessor<double>*>(
-      dynamic_cast<FloatingPointColumnReader<double, double>*>(
-          structReader->children()[0]));
-  ASSERT_NE(reader, nullptr);
+  auto ownedReader = buildFloatingPointReader<double>(*ctx, rowType, *scanSpec);
+  auto* reader = ownedReader.get();
 
   std::vector<vector_size_t> rowVec;
   for (int i = 0; i < kRows; i += 3) {
@@ -4204,7 +4622,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, readDenseMaterializedIndicesNoNulls) {
   ASSERT_EQ(reader->numValues(), 0);
 
   // Call the helper with no nulls.
-  ReadWithVisitorParams params{.numScanned = 0};
+  ReadWithVisitorParams params{};
   params.prepareResultNulls = [] {};
   detail::readDenseMaterializedIndices(
       *encoding,
@@ -4311,7 +4729,7 @@ TEST_P(ReadWithVisitorNonLegacyTest, readDenseMaterializedIndicesWithNulls) {
   // output-indexed result-nulls buffer to copy them into whenever
   // returnReaderNulls_ is false -- as it is here, the scan spec carries a
   // filter.
-  ReadWithVisitorParams params{.numScanned = 0};
+  ReadWithVisitorParams params{};
   params.prepareResultNulls = [&] {
     reader->prepareNulls(rows, /*hasNulls=*/true, /*extraRows=*/8);
   };


### PR DESCRIPTION
Add a dense bulk visitor path for ALP decoding using the shared`readWithVisitorFast` infrastructure.
  - Decode contiguous ranges and patch exceptions once per range instead
    of performing per-row exception lookups.
  - Retain scalar decoding for sparse reads, batches below 128 rows,
    and unsupported visitors.
  - Preserve encoding selection, encoded output, existing decode caches,
    and `materialize` behavior.
  - Extend the existing ALP benchmark and register reader integration tests
    in the selective-reader test target.