### PR TITLE
docs(core): Correct ScanBatchEvent::numRows semantics

### DIFF
--- a/velox/core/ScanBatchEvent.h
+++ b/velox/core/ScanBatchEvent.h
@@ -24,7 +24,8 @@ namespace facebook::velox::core {
 struct ScanBatchEvent {
   virtual ~ScanBatchEvent() = default;
 
-  /// Post-pushdown, pre-remaining-filter row count.
+  /// Rows read from storage, mid-pushdown: after row-group pruning, before
+  /// per-row filter evaluation and the remaining filter.
   uint64_t numRows{0};
   /// Wall time spent producing this batch in microseconds.
   uint64_t wallTimeMicros{0};


### PR DESCRIPTION
Summary: The comment described `numRows` as a post-pushdown count. It is the value `RowReader::next()` returns, which excludes rows skipped by row-group pruning on statistics but still counts rows later rejected by per-row filter evaluation.

Differential Revision: D119713486


