### PR TITLE
fix(wave): Unbreak the CUDA 13.3 and sm_100 builds (#18965)

### DIFF
--- a/velox/experimental/wave/common/Block.cuh
+++ b/velox/experimental/wave/common/Block.cuh
@@ -20,6 +20,7 @@
 #include <cub/block/block_reduce.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
+#include <cuda/std/functional>
 #include "velox/experimental/wave/common/CudaUtil.cuh"
 
 /// Utilities for  booleans and indices and thread blocks.
@@ -123,7 +124,7 @@ __device__ inline void blockSum(Getter getter, void* shmem, T* result) {
   auto* temp = reinterpret_cast<typename BlockReduceT::TempStorage*>(shmem);
   T data[1];
   data[0] = getter();
-  T aggregate = BlockReduceT(*temp).Reduce(data, cub::Sum());
+  T aggregate = BlockReduceT(*temp).Reduce(data, cuda::std::plus<>{});
 
   if (threadIdx.x == 0) {
     result[blockIdx.x] = aggregate;
@@ -222,7 +223,7 @@ void __device__ partitionRows(
   using Scan = cub::BlockScan<int32_t, kBlockSize>;
   constexpr int32_t kWarpThreads = 1 << CUB_LOG_WARP_THREADS(0);
   auto warp = threadIdx.x / kWarpThreads;
-  auto lane = cub::LaneId();
+  auto lane = LaneId();
   extern __shared__ __align__(16) char smem[];
   auto* counters = reinterpret_cast<uint32_t*>(
       numPartitions <= kBlockSize ? smem

--- a/velox/experimental/wave/common/tests/BlockTest.cu
+++ b/velox/experimental/wave/common/tests/BlockTest.cu
@@ -400,7 +400,7 @@ void __global__ __launch_bounds__(1024) hashTestKernel(
       int32_t end = begin + probe->numRows[blockIdx.x];
 
       for (auto i = begin + threadIdx.x; i < end; i += blockDim.x) {
-        table->updatingProbe<TestingRow>(i, cub::LaneId(), i < end, ops);
+        table->updatingProbe<TestingRow>(i, LaneId(), i < end, ops);
       }
       break;
     }

--- a/velox/experimental/wave/common/tests/CudaTest.cu
+++ b/velox/experimental/wave/common/tests/CudaTest.cu
@@ -807,6 +807,9 @@ void __global__ __launch_bounds__(1024) addOne4x64BranchKernel(
     params.l1 = *addCast<long2>(numbers, sizeof(int64_t) * index);
     params.l2 =
         *addCast<long2>(numbers, sizeof(int64_t) * (index + halfStride));
+    // Unrolling would emit the asm block, and so the labels it defines, more
+    // than once in the same function.
+#pragma unroll 1
     for (auto counter = 0; counter < repeats; ++counter) {
       asm volatile(
           "ts: .branchtargets BLK0, BLK1, BLK2, BLK3, BLK4, BLK5, BLK6, BLK7, BLK8, BLK9, BLK10, BLK11, BLK12, BLK13, BLK14, BLK15, BLK16, BLK17, BLK18, BLK19, BLK20, BLK21, BLK22, BLK23, BLK24, BLK25, BLK26, BLK27, BLK28, BLK29, BLK30, BLK31;");

--- a/velox/experimental/wave/common/tests/Updates.cuh
+++ b/velox/experimental/wave/common/tests/Updates.cuh
@@ -108,7 +108,7 @@ void __device__ testSumAtomicCoalesceShmem(TestingRow* rows, HashProbe* probe) {
   auto indices = keys[0];
   auto deltas = keys[1];
   auto base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
-  int32_t lane = cub::LaneId();
+  int32_t lane = LaneId();
   int32_t end = base + probe->numRows[blockIdx.x];
   extern __shared__ char smem[];
 
@@ -148,7 +148,7 @@ void __device__ testSumAtomicCoalesceShfl(TestingRow* rows, HashProbe* probe) {
   auto indices = keys[0];
   auto deltas = keys[1];
   auto base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
-  int32_t lane = cub::LaneId();
+  int32_t lane = LaneId();
   int32_t end = base + probe->numRows[blockIdx.x];
 
   for (auto count = base; count < end; count += blockDim.x) {
@@ -187,7 +187,7 @@ void __device__ testSumMtxCoalesce(TestingRow* rows, HashProbe* probe) {
   auto indices = keys[0];
   auto deltas = keys[1];
   auto base = probe->numRowsPerThread * blockDim.x * blockIdx.x;
-  int32_t lane = cub::LaneId();
+  int32_t lane = LaneId();
   int32_t end = base + probe->numRows[blockIdx.x];
 
   for (auto count = base; count < end; count += blockDim.x) {


### PR DESCRIPTION
Summary:

Two independent failures stop the Wave GPU code from building. They are fixed together because they hit the same targets, and fixing only the first leaves the build red.

Compiling against CUDA 13.3 fails:

    Block.cuh(126): error: namespace "cub" has no member "Sum"
    Block.cuh(225): error: namespace "cub" has no member "LaneId"

CCCL 3.0 removed both names; they were deprecated back in CCCL 2.7. `cub::Sum` becomes `cuda::std::plus<>`, which is what CCCL's own deprecation message names. For the lane id this uses the in-repo `LaneId()` from `BitUtil.cuh`, which returns `threadIdx.x % kWarpThreads`, rather than CCCL's suggested `cuda::ptx::get_sreg_laneid()`. That choice is about portability: `get_sreg_laneid()` does not exist in the CUDA that fbcode builds Wave with by default, so it breaks `mode/opt` and `mode/dev-nosan` even though it compiles under 13.3. Every call site here already assumes one-dimensional blocks, so the modulo form is equivalent.

Lowering the `sm_100` cubin then fails in `ptxas`:

    error   : Duplicate definition of label 'ts'
    error   : Duplicate definition of label 'BLK0'

`addOne4x64BranchKernel` uses inline PTX that defines the labels `ts` and `BLK0`..`BLK31` by name. Those names are fixed, so the asm can only appear once per function, but the loop around it was free to unroll and emit it several times. `#pragma unroll 1` pins it to one copy, matching `addOneBranchKernel`, which has carried that pragma for the same reason.

Differential Revision: D119727740


