### PR TITLE
fix(datetime): Clamp `from_unixtime` to timestamp range

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -150,7 +150,9 @@ Date and Time Functions
     Returns the UNIX timestamp ``unixtime`` as a timestamp.  If the
     :doc:`adjust_timestamp_to_session_timezone <../../configs>` property is set
     to true, then the timestamp is adjusted to the time zone specified in
-    :doc:`session_timezone <../../configs>`.
+    :doc:`session_timezone <../../configs>`. Values above or below the range
+    representable by a timestamp are clamped to the maximum or minimum
+    timestamp, respectively.
 
 .. function:: from_unixtime(unixtime, string) -> timestamp with time zone
     :noindex:

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -38,18 +38,12 @@ FOLLY_ALWAYS_INLINE Timestamp fromUnixtime(double unixtime) {
     return Timestamp(0, 0);
   }
 
-  static const int64_t kMin = std::numeric_limits<int64_t>::min();
-
-  if (FOLLY_UNLIKELY(unixtime >= kMinDoubleAboveInt64Max)) {
+  if (FOLLY_UNLIKELY(unixtime >= static_cast<double>(Timestamp::kMaxSeconds))) {
     return Timestamp::maxMillis();
   }
 
-  if (FOLLY_UNLIKELY(unixtime <= kMin)) {
+  if (FOLLY_UNLIKELY(unixtime <= static_cast<double>(Timestamp::kMinSeconds))) {
     return Timestamp::minMillis();
-  }
-
-  if (FOLLY_UNLIKELY(std::isinf(unixtime))) {
-    return unixtime < 0 ? Timestamp::minMillis() : Timestamp::maxMillis();
   }
 
   auto seconds = std::floor(unixtime);

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -382,6 +382,8 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
   EXPECT_EQ(Timestamp(-1, 9000000), fromUnixtime(-0.991));
   EXPECT_EQ(Timestamp(1, 0), fromUnixtime(1 - 1e-10));
   EXPECT_EQ(Timestamp(4000000000, 0), fromUnixtime(4000000000));
+  EXPECT_EQ(Timestamp::maxMillis(), fromUnixtime(1'789'000'000'000'000'000.0));
+  EXPECT_EQ(Timestamp::minMillis(), fromUnixtime(-1'789'000'000'000'000'000.0));
   EXPECT_EQ(
       Timestamp(9'223'372'036'854'775, 807'000'000), fromUnixtime(3.87111e+37));
   EXPECT_EQ(Timestamp(4000000000, 123000000), fromUnixtime(4000000000.123));


### PR DESCRIPTION
Summary:
Large finite inputs such as `from_unixtime(1.789e18)` fail with `Timestamp seconds out of range`, while Presto clamps the result to the maximum timestamp.

The existing overflow guard compares input seconds with the full `int64` range. Compare against the seconds range supported by Timestamp, and document the clamping behavior.

Differential Revision: D119744889
