### PR TITLE
feat(encoding): Push down value delta into inner encoding at wrap time (#18972)

### DIFF
--- a/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/velox/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -1238,7 +1238,12 @@ std::string_view BlockBitPackingEncoding<T>::slice(
     return encodedBlockRange;
   }
   return SliceEncoding<T>::wrap(
-      encodedBlockRange, skipLeadingRows, length, buffer, options);
+      encodedBlockRange,
+      skipLeadingRows,
+      length,
+      buffer,
+      /*valueDelta=*/0,
+      options);
 }
 
 template <typename T>

--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   SharedDictionaryCatalog.cpp
   SharedDictionaryCatalog.h
   SharedDictionaryEncoding.cpp
+  SliceEncoding.cpp
   SparseBoolEncoding.cpp
   TrivialEncoding.cpp
   common/Encoding.cpp

--- a/velox/dwio/nimble/encodings/RLEEncoding.h
+++ b/velox/dwio/nimble/encodings/RLEEncoding.h
@@ -294,6 +294,7 @@ class RLEEncodingBase
         slicedRuns.leadingSkipRows,
         length,
         buffer,
+        /*valueDelta=*/0,
         options);
   }
 

--- a/velox/dwio/nimble/encodings/SliceEncoding.cpp
+++ b/velox/dwio/nimble/encodings/SliceEncoding.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+
+namespace facebook::nimble {
+
+namespace {
+
+// Forward declarations for the dispatch pair -- `applyValueDeltaToNullable`
+// needs to recurse into `applyValueDeltaPushdown` for its values child.
+bool canApplyValueDeltaPushdown(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount);
+
+size_t applyValueDeltaPushdown(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount,
+    char* dest);
+
+// Rewrites the physical baseline value stored at `dest` by adding `delta`.
+// The baseline occupies sizeof(Physical) bytes at `dest`; the caller
+// dispatches to the right Physical based on the inner encoding's DataType
+// byte in its prefix (see applyValueDeltaInPlace). Uses memcpy so `dest`
+// may be arbitrarily aligned.
+template <typename Physical>
+void applyValueDeltaInPlaceTyped(char* dest, int64_t delta) {
+  Physical value;
+  // @lint-ignore NULLSAFECLANG nullable-argument
+  std::memcpy(&value, dest, sizeof(value));
+  value = static_cast<Physical>(value + static_cast<Physical>(delta));
+  // @lint-ignore NULLSAFECLANG nullable-argument
+  std::memcpy(dest, &value, sizeof(value));
+}
+
+void applyValueDeltaInPlace(char* dest, DataType dataType, int64_t delta) {
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (dataType) {
+    case DataType::Int8:
+    case DataType::Uint8:
+      applyValueDeltaInPlaceTyped<uint8_t>(dest, delta);
+      return;
+    case DataType::Int16:
+    case DataType::Uint16:
+      applyValueDeltaInPlaceTyped<uint16_t>(dest, delta);
+      return;
+    case DataType::Int32:
+    case DataType::Uint32:
+      applyValueDeltaInPlaceTyped<uint32_t>(dest, delta);
+      return;
+    case DataType::Int64:
+    case DataType::Uint64:
+      applyValueDeltaInPlaceTyped<uint64_t>(dest, delta);
+      return;
+    default:
+      NIMBLE_UNREACHABLE(
+          "SliceEncoding push-down expects an integer inner data type, got: {}",
+          dataType);
+  }
+}
+
+// Copies `rowCount` physical values from `src` to `dst`, adding `delta` to
+// each value as it is copied. Each byte in the destination range is written
+// exactly once (no memcpy-then-edit). memcpy is used rather than typed stores
+// because `src`/`dst` may not be aligned for the target type. The per-value
+// shift is vectorised via xsimd where a batch fits (bulk lanes at SIMD width
+// for the physical type), with a scalar tail handling any remainder. This
+// matches velox's own load-add-store idiom (see
+// velox/dwio/nimble/encodings/selection/Statistics.cpp) -- velox exposes
+// simdFill / setAll / gather helpers but none cover the constant-add case,
+// so we use the xsimd primitives velox itself uses.
+template <typename Physical>
+void applyValueDeltaToTrivialPayloadTyped(
+    const char* src,
+    uint32_t rowCount,
+    int64_t delta,
+    char* dst) {
+  const auto typedDelta = static_cast<Physical>(delta);
+  const size_t stride = sizeof(Physical);
+  using Batch = xsimd::batch<Physical>;
+  constexpr uint32_t kLanes = static_cast<uint32_t>(Batch::size);
+  const Batch deltaVec = Batch::broadcast(typedDelta);
+  uint32_t i = 0;
+  for (; i + kLanes <= rowCount; i += kLanes) {
+    // @lint-ignore NULLSAFECLANG nullable-arithmetic
+    (Batch::load_unaligned(
+         reinterpret_cast<const Physical*>(src + i * stride)) +
+     deltaVec)
+        // @lint-ignore NULLSAFECLANG nullable-arithmetic
+        .store_unaligned(reinterpret_cast<Physical*>(dst + i * stride));
+  }
+  for (; i < rowCount; ++i) {
+    Physical value;
+    // @lint-ignore NULLSAFECLANG nullable-arithmetic
+    std::memcpy(&value, src + i * stride, stride);
+    value = static_cast<Physical>(value + typedDelta);
+    // @lint-ignore NULLSAFECLANG nullable-arithmetic
+    std::memcpy(dst + i * stride, &value, stride);
+  }
+}
+
+void applyValueDeltaToTrivialPayload(
+    const char* src,
+    uint32_t rowCount,
+    DataType dataType,
+    int64_t delta,
+    char* dst) {
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (dataType) {
+    case DataType::Int8:
+    case DataType::Uint8:
+      applyValueDeltaToTrivialPayloadTyped<uint8_t>(src, rowCount, delta, dst);
+      return;
+    case DataType::Int16:
+    case DataType::Uint16:
+      applyValueDeltaToTrivialPayloadTyped<uint16_t>(src, rowCount, delta, dst);
+      return;
+    case DataType::Int32:
+    case DataType::Uint32:
+      applyValueDeltaToTrivialPayloadTyped<uint32_t>(src, rowCount, delta, dst);
+      return;
+    case DataType::Int64:
+    case DataType::Uint64:
+      applyValueDeltaToTrivialPayloadTyped<uint64_t>(src, rowCount, delta, dst);
+      return;
+    default:
+      NIMBLE_UNREACHABLE(
+          "SliceEncoding push-down expects an integer Trivial data type, got: {}",
+          dataType);
+  }
+}
+
+// Shared baseline-rewrite folder used by FixedBitWidth, PFOR, and Constant:
+// all three push down via "memcpy inner verbatim, then rewrite the
+// uncompressed baseline field in the header." They differ only in where the
+// baseline sits relative to the encoding prefix:
+//   FBW:      [prefix][compression byte][baseline][bitWidth][packed bytes]
+//             -> rewriteOffset = 1 (skip compression byte)
+//   PFOR:     [prefix][baseline][baseBitWidth][varint numExceptions]...
+//             -> rewriteOffset = 0
+//             (base residuals and exception values are both baseline-relative,
+//              see PFOREncoding::patchExceptions, so one edit shifts both)
+//   Constant: [prefix][value]  -- the single stored value IS the baseline
+//             -> rewriteOffset = 0
+// The compression indicator (when present, FBW) governs only the packed
+// region that follows the baseline, so the baseline is always written
+// uncompressed and can be rewritten in place.
+size_t applyValueDeltaByRewrite(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount,
+    DataType dataType,
+    uint32_t rewriteOffset,
+    char* dest) {
+  // @lint-ignore NULLSAFECLANG nullable-argument
+  std::memcpy(dest, inner.data(), inner.size());
+  const uint32_t prefixSize =
+      EncodingPrefix::prefixSize(inner, useVarintRowCount);
+  applyValueDeltaInPlace(dest + prefixSize + rewriteOffset, dataType, delta);
+  // Push-down is size-preserving: same # of bytes written as the source.
+  return inner.size();
+}
+
+// Trivial (numeric, uncompressed) push-down. Wire layout after the standard
+// prefix is:
+//   1 byte:            compression type (must be Uncompressed here)
+//   rowCount*phys:     the raw values
+// Header (prefix + compression byte) is copied verbatim; each value is shifted
+// while it is copied so no byte is written twice.
+size_t applyValueDeltaToTrivial(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount,
+    DataType dataType,
+    char* dest) {
+  const uint32_t prefixSize =
+      EncodingPrefix::prefixSize(inner, useVarintRowCount);
+  const uint32_t headerSize = prefixSize + sizeof(uint8_t);
+  // @lint-ignore NULLSAFECLANG nullable-argument
+  std::memcpy(dest, inner.data(), headerSize);
+  const uint32_t rowCount =
+      EncodingPrefix::readRowCount(inner, useVarintRowCount);
+  applyValueDeltaToTrivialPayload(
+      inner.data() + headerSize, rowCount, dataType, delta, dest + headerSize);
+  return inner.size();
+}
+
+// Nullable push-down. Wire layout after the standard prefix is:
+//   4 bytes:           non-null child encoding size (valuesSize)
+//   valuesSize bytes:  non-null child encoding
+//   remaining bytes:   nulls child encoding
+// The nulls child is a bool stream and is copied verbatim; the shift only
+// applies to decoded non-null values, so we recurse into the values child.
+size_t applyValueDeltaToNullable(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount,
+    char* dest) {
+  const uint32_t prefixSize =
+      EncodingPrefix::prefixSize(inner, useVarintRowCount);
+
+  // Copy `[prefix][4-byte valuesSize]` verbatim.
+  const uint32_t headerSize = prefixSize + sizeof(uint32_t);
+  // @lint-ignore NULLSAFECLANG nullable-argument
+  std::memcpy(dest, inner.data(), headerSize);
+
+  const char* sizePos = inner.data() + prefixSize;
+  const uint32_t valuesSize = encoding::readUint32(sizePos);
+
+  // Recurse into the values child at its destination offset.
+  const std::string_view valuesInner{inner.data() + headerSize, valuesSize};
+  applyValueDeltaPushdown(
+      valuesInner, delta, useVarintRowCount, dest + headerSize);
+
+  // Copy the nulls child verbatim. A valid Nullable input always carries a
+  // non-empty nulls sub-stream (the encoding wouldn't be Nullable otherwise),
+  // so this is asserted rather than runtime-guarded.
+  const size_t offsetAfterValues = headerSize + valuesSize;
+  const size_t nullsSize = inner.size() - offsetAfterValues;
+  NIMBLE_DCHECK_GT(
+      nullsSize, 0, "Nullable input must carry a non-empty nulls sub-stream.");
+  // @lint-ignore NULLSAFECLANG nullable-argument
+  std::memcpy(
+      dest + offsetAfterValues, inner.data() + offsetAfterValues, nullsSize);
+  return inner.size();
+}
+
+// True iff the inner encoding's DataType is one of the integer widths the
+// baseline/payload helpers dispatch on. Everything else (Bool, Float, Double,
+// String, Undefined) cannot carry an additive shift.
+bool isPushDownableIntegerType(DataType dataType) {
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (dataType) {
+    case DataType::Int8:
+    case DataType::Uint8:
+    case DataType::Int16:
+    case DataType::Uint16:
+    case DataType::Int32:
+    case DataType::Uint32:
+    case DataType::Int64:
+    case DataType::Uint64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Main can-apply dispatch: returns true iff a subsequent applyValueDelta-
+// Pushdown() call on the same (inner, delta) pair would succeed. Walks
+// Nullable chains, checks Trivial compression state, and rejects any
+// non-integer inner that isn't a structural wrapper. Backs
+// SliceEncodingPushDown::canApply().
+bool canApplyValueDeltaPushdown(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount) {
+  const auto encodingType = EncodingPrefix::encodingType(inner);
+  const auto dataType = EncodingPrefix::dataType(inner);
+
+  // Every push-down case that reads the inner as integer bytes requires an
+  // integer physical type; reject non-integer dataTypes here so the switch
+  // cases below can assume integer bytes without re-checking. Nullable is
+  // the sole exemption -- it does not read the inner as integer bytes at
+  // this layer and instead recurses into its values child, whose own call
+  // re-checks dataType. Any future structural-wrapper encoding that
+  // recurses would also need to be exempted here. Non-push-down encodings
+  // (RLE, Dictionary, ...) still reach the switch and return false via the
+  // fall-through list; the early-return is just an equivalent short-circuit
+  // for their non-integer variant.
+  if (encodingType != EncodingType::Nullable &&
+      !isPushDownableIntegerType(dataType)) {
+    return false;
+  }
+
+  // Exhaustive over EncodingType with no default arm so that adding a new
+  // encoding type fails the build until the author declares whether its
+  // wire layout can absorb a constant shift. See applyValueDeltaPushdown()
+  // for the mirror-image dispatch that must be updated in lockstep.
+  switch (encodingType) {
+    case EncodingType::FixedBitWidth:
+    case EncodingType::PFOR:
+    case EncodingType::Constant:
+      return true;
+
+    case EncodingType::Trivial: {
+      // Compressed Trivial cannot be shifted without decompressing first, so
+      // let the read-time loop handle the shift instead.
+      const uint32_t prefixSize =
+          EncodingPrefix::prefixSize(inner, useVarintRowCount);
+      const auto compression = static_cast<CompressionType>(inner[prefixSize]);
+      return compression == CompressionType::Uncompressed;
+    }
+
+    case EncodingType::Nullable: {
+      // The nulls child is a bool stream and never shifts. Recurse into the
+      // values child -- push-down succeeds iff the values child can itself
+      // absorb the shift.
+      const uint32_t prefixSize =
+          EncodingPrefix::prefixSize(inner, useVarintRowCount);
+      const char* pos = inner.data() + prefixSize;
+      const uint32_t valuesSize = encoding::readUint32(pos);
+      const std::string_view valuesInner{pos, valuesSize};
+      // A Nullable wrapper preserves the physical type of its values child, so
+      // no need to re-check dataType here -- the recursive call will.
+      return canApplyValueDeltaPushdown(valuesInner, delta, useVarintRowCount);
+    }
+
+    // Everything below cannot fold the delta into its own bytes at write
+    // time. RLE / Dictionary / Huffman / MainlyConstant / BlockBitPacking /
+    // ... have no single baseline field to rewrite. SharedDictionary could
+    // in principle carry a shift (its values are alphabet-resolved integers)
+    // but folding into the shared alphabet would mutate state visible to
+    // other consumers, and folding into the indices would resolve to wrong
+    // alphabet entries -- so push-down declines and the read-time materialize
+    // loop adds the delta to the values after the alphabet resolves them.
+    // The other listed encodings are simply not push-down-implemented.
+    case EncodingType::RLE:
+    case EncodingType::Dictionary:
+    case EncodingType::Sentinel:
+    case EncodingType::SparseBool:
+    case EncodingType::Varint:
+    case EncodingType::Delta:
+    case EncodingType::MainlyConstant:
+    case EncodingType::Prefix:
+    case EncodingType::ALP:
+    case EncodingType::SimdForBitpack:
+    case EncodingType::BlockBitPacking:
+    case EncodingType::SubIntSplit:
+    case EncodingType::FrequencyPartition:
+    case EncodingType::FOR:
+    case EncodingType::Fsst:
+    case EncodingType::Huffman:
+    case EncodingType::DeltaBlock:
+    case EncodingType::SharedDictionary:
+    case EncodingType::Slice:
+    case EncodingType::EliasFano:
+    case EncodingType::BitRangeSplit:
+      return false;
+  }
+  NIMBLE_UNREACHABLE(
+      "SliceEncoding push-down saw an unknown EncodingType: {}", encodingType);
+}
+
+// Main apply dispatch: writes the shifted inner bytes into `dest` and returns
+// the number of bytes written (== `inner.size()` -- push-down is size-
+// preserving). Caller MUST have gotten `true` from
+// canApplyValueDeltaPushdown() on the same (inner, delta). Backs
+// SliceEncodingPushDown::apply().
+size_t applyValueDeltaPushdown(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount,
+    char* dest) {
+  const auto encodingType = EncodingPrefix::encodingType(inner);
+  const auto dataType = EncodingPrefix::dataType(inner);
+
+  // Exhaustive over EncodingType with no default arm so that adding a new
+  // encoding type fails the build until the author declares whether it has
+  // a folder. Must be kept in lockstep with canApplyValueDeltaPushdown() --
+  // every encoding that returns true there must have a folder branch here.
+  switch (encodingType) {
+    case EncodingType::FixedBitWidth:
+      // FBW header: [prefix][compression byte][baseline][bitWidth][packed].
+      // Skip the 1-byte compression indicator to land on the baseline.
+      return applyValueDeltaByRewrite(
+          inner,
+          delta,
+          useVarintRowCount,
+          dataType,
+          /*rewriteOffset=*/1,
+          dest);
+
+    case EncodingType::PFOR:
+    case EncodingType::Constant:
+      // PFOR:     [prefix][baseline][baseBitWidth][varint numExceptions]...
+      // Constant: [prefix][value]  -- the value IS the baseline.
+      // Both place the baseline immediately after the standard prefix.
+      return applyValueDeltaByRewrite(
+          inner,
+          delta,
+          useVarintRowCount,
+          dataType,
+          /*rewriteOffset=*/0,
+          dest);
+
+    case EncodingType::Trivial:
+      return applyValueDeltaToTrivial(
+          inner, delta, useVarintRowCount, dataType, dest);
+
+    case EncodingType::Nullable:
+      return applyValueDeltaToNullable(inner, delta, useVarintRowCount, dest);
+
+    // Drift guard: canApplyValueDeltaPushdown() returns false for every
+    // encoding listed below (and for the recursive Nullable-with-unsupported-
+    // child case), so the caller (wrap()) should have taken the on-wire delta
+    // path instead of invoking us. Hitting any of these means the two
+    // functions diverged and produced inconsistent answers for the same
+    // inner.
+    case EncodingType::RLE:
+    case EncodingType::Dictionary:
+    case EncodingType::Sentinel:
+    case EncodingType::SparseBool:
+    case EncodingType::Varint:
+    case EncodingType::Delta:
+    case EncodingType::MainlyConstant:
+    case EncodingType::Prefix:
+    case EncodingType::ALP:
+    case EncodingType::SimdForBitpack:
+    case EncodingType::BlockBitPacking:
+    case EncodingType::SubIntSplit:
+    case EncodingType::FrequencyPartition:
+    case EncodingType::FOR:
+    case EncodingType::Fsst:
+    case EncodingType::Huffman:
+    case EncodingType::DeltaBlock:
+    case EncodingType::SharedDictionary:
+    case EncodingType::Slice:
+    case EncodingType::EliasFano:
+    case EncodingType::BitRangeSplit:
+      NIMBLE_UNREACHABLE(
+          "SliceEncoding push-down invoked on unsupported inner encoding: {}",
+          encodingType);
+  }
+  NIMBLE_UNREACHABLE(
+      "SliceEncoding push-down saw an unknown EncodingType: {}", encodingType);
+}
+
+} // namespace
+
+bool SliceEncodingBase::canApplyValueDeltaPushdown(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount) {
+  return ::facebook::nimble::canApplyValueDeltaPushdown(
+      inner, delta, useVarintRowCount);
+}
+
+size_t SliceEncodingBase::applyValueDeltaPushdown(
+    std::string_view inner,
+    int64_t delta,
+    bool useVarintRowCount,
+    char* dest) {
+  return ::facebook::nimble::applyValueDeltaPushdown(
+      inner, delta, useVarintRowCount, dest);
+}
+
+} // namespace facebook::nimble

--- a/velox/dwio/nimble/encodings/SliceEncoding.h
+++ b/velox/dwio/nimble/encodings/SliceEncoding.h
@@ -51,19 +51,74 @@
 /// established a per-slice baseline (e.g. so a downstream FBW inner can pack in
 /// fewer bits) record the shift here rather than mutating the copied inner
 /// bytes.
+///
+/// Composition: a SliceEncoding may itself be wrapped by another SliceEncoding.
+/// Each layer applies its own delta after its inner materialize() completes,
+/// so deltas accumulate additively across layers.
+///
+/// When the inner encoding structurally supports it, wrap() folds the delta
+/// into the copied inner bytes at write time (baseline rewrite for
+/// FixedBitWidth / PFOR / Constant, per-value shift-during-copy for
+/// uncompressed Trivial, recurse into the values child for Nullable). In that
+/// case the on-wire delta is zero and the decode-time shift loop is skipped.
+/// Otherwise the delta rides on the wire and the reader applies it at
+/// materialize(). Push-down declines fall into three categories:
+///   * No push-down implemented (RLE, Dictionary, Huffman, MainlyConstant,
+///     BlockBitPacking, ...): no baseline field to rewrite.
+///   * SharedDictionary: could carry a shift over its resolved values but
+///     folding into the shared alphabet would mutate state visible to other
+///     consumers, and folding into the indices would resolve to wrong
+///     alphabet entries; the read-time loop shifts values after alphabet
+///     resolution instead.
+///   * Runtime-conditional: compressed Trivial, or Nullable whose values
+///     child cannot itself absorb the shift.
 
 namespace facebook::nimble {
 
-// Data layout is:
-// Standard Encoding prefix (size varies with Options::useVarintRowCount),
-//     whose row count is the SLICE length, not the inner encoding's row count.
-// 4 bytes: row offset into the inner encoding at which the slice begins.
-// 1-10 bytes: zigzag varint value delta added to every materialized value at
-//     decode time. Zero delta occupies 1 byte.
-// remaining bytes: the inner encoding, verbatim.
+// Base class holding SliceEncoding::wrap()'s non-templated push-down helpers.
+// Kept as a non-template base so the bodies compile once (moving them onto
+// SliceEncoding<T> would recompile per T). SliceEncoding<T> inherits so wrap()
+// can call the helpers as inherited protected static methods.
+class SliceEncodingBase {
+ protected:
+  // Runtime probe: returns true iff a subsequent applyValueDeltaPushdown() on
+  // the same (inner, delta) pair would succeed. Walks Nullable chains and
+  // checks Trivial compression state so per-encoding runtime conditions are
+  // honoured. `useVarintRowCount` must match the option under which `inner`
+  // was produced (Nimble uses one consistent value across a whole encoding
+  // tree, so callers forward the outer SliceEncoding wrap options).
+  static bool canApplyValueDeltaPushdown(
+      std::string_view inner,
+      int64_t delta,
+      bool useVarintRowCount);
+
+  // Writes shifted inner bytes into `dest` and returns the number of bytes
+  // written (invariant: equal to `inner.size()`). Caller guarantees the
+  // destination has that much space reserved. Caller MUST have gotten `true`
+  // from canApplyValueDeltaPushdown() first -- hitting an unsupported case
+  // here fires NIMBLE_UNREACHABLE. `useVarintRowCount` has the same meaning
+  // as in canApplyValueDeltaPushdown(). The returned size is used by wrap()
+  // as a drift guard: if a folder ever writes fewer or more bytes than the
+  // source inner, the outer post-write assertion fires instead of silently
+  // corrupting the wire.
+  static size_t applyValueDeltaPushdown(
+      std::string_view inner,
+      int64_t delta,
+      bool useVarintRowCount,
+      char* dest);
+};
+
+/// Data layout is:
+/// Standard Encoding prefix (size varies with Options::useVarintRowCount),
+///     whose row count is the SLICE length, not the inner encoding's row count.
+/// 4 bytes: row offset into the inner encoding at which the slice begins.
+/// 1-10 bytes: zigzag varint value delta added to every materialized value at
+///     decode time. Zero delta occupies 1 byte.
+/// remaining bytes: the inner encoding, verbatim.
 template <typename T>
 class SliceEncoding final
-    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+    : public SliceEncodingBase,
+      public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
  public:
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
@@ -199,17 +254,27 @@ class SliceEncoding final
   ///
   /// `valueDelta` is added to every materialized value at decode time. It is
   /// only representable for non-bool integer physical types; passing a
-  /// non-zero delta for any other T is rejected at write time, as is passing a
-  /// non-zero delta whose inner encoding is a SharedDictionary (its logical
-  /// values are indirected through an alphabet and cannot be shifted by a
-  /// constant).
+  /// non-zero delta for any other T is rejected at write time. SharedDictionary
+  /// inner is accepted -- push-down cannot fold the delta into the shared
+  /// alphabet or the indices, so the delta rides on the wire and is applied
+  /// to alphabet-resolved values at materialize().
+  ///
+  /// When `valueDelta` is non-zero and the inner encoding structurally
+  /// supports it, the delta is folded into the copied inner bytes at write
+  /// time and the on-wire delta is zero -- the decode-time shift loop then
+  /// skips itself. Otherwise the delta rides on the wire and is applied at
+  /// materialize().
+  ///
+  /// Wrapping a SliceEncoding stream inside another wrap() is supported; the
+  /// outer delta accumulates with the inner delta at read time (each layer
+  /// applies its own delta after its inner materialize()).
   static std::string_view wrap(
       std::string_view encoded,
       uint32_t offset,
       uint32_t length,
       Buffer& buffer,
-      const Encoding::Options& options,
-      int64_t valueDelta = 0) {
+      int64_t valueDelta = 0,
+      const Encoding::Options& options = {}) {
     if constexpr (!kSupportsValueDelta) {
       NIMBLE_CHECK_EQ(
           valueDelta,
@@ -221,12 +286,24 @@ class SliceEncoding final
     // shared alphabet would mutate state visible to other consumers, and
     // folding into the indices would resolve to wrong alphabet entries), so
     // the shift stays on the wire and the read-time materialize loop adds
-    // delta to the values the alphabet resolves. Callers still opt out via
-    // the compile-time `kSupportsValueDelta` guard for physical types that
-    // cannot carry a shift (bool, non-integer).
+    // delta to the values the alphabet resolves. Physical types that cannot
+    // carry a shift (bool, non-integer) are still rejected up-front by the
+    // compile-time `kSupportsValueDelta` check above.
+
+    // Decide whether push-down applies. When it can, the on-wire delta is
+    // zero and the decode-time loop is skipped; when it can't, the delta
+    // rides on the wire and the reader applies it.
+    bool pushdownValueDelta = false;
+    if (valueDelta != 0) {
+      pushdownValueDelta = canApplyValueDeltaPushdown(
+          encoded, valueDelta, options.useVarintRowCount);
+    }
+    const int64_t storedDelta = pushdownValueDelta ? 0 : valueDelta;
+
+    // Compute exact wrapper size and reserve.
     const auto prefixSize =
         EncodingPrefix::serializedSize(length, options.useVarintRowCount);
-    const auto zigzaggedDelta = zigzag::zigzagEncode64(valueDelta);
+    const auto zigzaggedDelta = zigzag::zigzagEncode64(storedDelta);
     const auto deltaSize = varint::varintSize(zigzaggedDelta);
     const auto encodingSize =
         prefixSize + sizeof(uint32_t) + deltaSize + encoded.size();
@@ -240,8 +317,19 @@ class SliceEncoding final
         pos);
     encoding::writeUint32(offset, pos);
     varint::writeVarint(zigzaggedDelta, &pos);
-    std::memcpy(pos, encoded.data(), encoded.size());
-    pos += encoded.size();
+
+    // Write the inner bytes. Push-down folders write directly into the
+    // reserved region -- no scratch buffer allocation. Folders that use a
+    // baseline field (FixedBitWidth, PFOR, Constant) memcpy the source first
+    // then rewrite the baseline in place; Trivial shifts values while copying.
+    // Each folder returns the number of bytes it wrote so the post-write
+    // assertion can catch any drift between the reserved size and what the
+    // folder produced.
+    const size_t bytesWritten = pushdownValueDelta
+        ? applyValueDeltaPushdown(
+              encoded, valueDelta, options.useVarintRowCount, pos)
+        : (std::memcpy(pos, encoded.data(), encoded.size()), encoded.size());
+    pos += bytesWritten;
     NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
     return {reserved, encodingSize};
   }

--- a/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -23,17 +23,24 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Buffer.h"
+#include "velox/dwio/nimble/common/Varint.h"
 #include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/common/Zigzag.h"
 #include "velox/dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "velox/dwio/nimble/encodings/ConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/DictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/EliasFanoEncoding.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/HuffmanEncoding.h"
 #include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/NullableEncoding.h"
+#include "velox/dwio/nimble/encodings/PFOREncoding.h"
 #include "velox/dwio/nimble/encodings/RLEEncoding.h"
 #include "velox/dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
@@ -98,6 +105,21 @@ class SliceEncodingTest : public ::testing::Test {
     nimble::Vector<T> output{pool_.get(), rowCount};
     encoding.materialize(rowCount, output.data());
     return std::vector<T>(output.begin(), output.end());
+  }
+
+  // Extracts the on-wire valueDelta of a SliceEncoding blob without
+  // constructing the encoding. Push-down success is signalled by a stored
+  // delta of zero even when the caller asked for a non-zero delta.
+  // `useVarintRowCount` MUST match the option under which `wrapped` was
+  // produced -- the prefix size depends on it and parsing with the wrong
+  // value slides the read past the intended byte.
+  int64_t readStoredValueDelta(
+      std::string_view wrapped,
+      bool useVarintRowCount = false) {
+    const uint32_t prefixSize =
+        nimble::EncodingPrefix::prefixSize(wrapped, useVarintRowCount);
+    const char* pos = wrapped.data() + prefixSize + sizeof(uint32_t);
+    return nimble::zigzag::zigzagDecode64(nimble::varint::readVarint64(&pos));
   }
 
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
@@ -650,7 +672,7 @@ TEST_F(SliceEncodingTest, zeroDeltaTrivialRoundTrip) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/1, /*length=*/4, *buffer_, {}, /*valueDelta=*/0);
+      encoded, /*offset=*/1, /*length=*/4, *buffer_, /*valueDelta=*/0, {});
 
   auto encoding = createEncoding(wrapped);
   EXPECT_EQ(encoding->rowCount(), 4);
@@ -665,7 +687,7 @@ TEST_F(SliceEncodingTest, zeroDeltaFixedBitWidthRoundTrip) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/0);
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, /*valueDelta=*/0, {});
 
   auto encoding = createEncoding(wrapped);
   EXPECT_EQ(encoding->rowCount(), 3);
@@ -680,7 +702,7 @@ TEST_F(SliceEncodingTest, zeroDeltaConstantRoundTrip) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/2, /*length=*/3, *buffer_, {}, /*valueDelta=*/0);
+      encoded, /*offset=*/2, /*length=*/3, *buffer_, /*valueDelta=*/0, {});
 
   auto encoding = createEncoding(wrapped);
   EXPECT_EQ(encoding->rowCount(), 3);
@@ -698,7 +720,7 @@ TEST_F(SliceEncodingTest, zeroDeltaCostsOneByte) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/0, /*length=*/5, *buffer_, {}, /*valueDelta=*/0);
+      encoded, /*offset=*/0, /*length=*/5, *buffer_, /*valueDelta=*/0, {});
 
   const auto prefixSize = nimble::EncodingPrefix::serializedSize(
       /*rowCount=*/5, /*useVarint=*/false);
@@ -714,7 +736,7 @@ TEST_F(SliceEncodingTest, positiveDeltaFixedBitWidth) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/5);
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, /*valueDelta=*/5, {});
 
   auto encoding = createEncoding(wrapped);
   EXPECT_EQ(encoding->rowCount(), 3);
@@ -733,7 +755,7 @@ TEST_F(SliceEncodingTest, positiveDeltaLargeInt32) {
 
   constexpr int64_t kDelta = std::numeric_limits<int32_t>::max() / 2;
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/0, /*length=*/4, *buffer_, {}, kDelta);
+      encoded, /*offset=*/0, /*length=*/4, *buffer_, kDelta, {});
 
   auto encoding = createEncoding(wrapped);
   const std::vector<int32_t> expected{
@@ -751,7 +773,7 @@ TEST_F(SliceEncodingTest, positiveDeltaTrivialUint64) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<uint64_t>::wrap(
-      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/1000);
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, /*valueDelta=*/1000, {});
 
   auto encoding = createEncoding(wrapped);
   const std::vector<uint64_t> expected{1020, 1030, 1040};
@@ -765,7 +787,7 @@ TEST_F(SliceEncodingTest, negativeDeltaTrivialInt32) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/0, /*length=*/4, *buffer_, {}, /*valueDelta=*/-3);
+      encoded, /*offset=*/0, /*length=*/4, *buffer_, /*valueDelta=*/-3, {});
 
   auto encoding = createEncoding(wrapped);
   const std::vector<int32_t> expected{97, 98, 99, 100};
@@ -783,8 +805,8 @@ TEST_F(SliceEncodingTest, negativeDeltaLargeInt64) {
       /*offset=*/0,
       /*length=*/3,
       *buffer_,
-      {},
-      /*valueDelta=*/-1'000'000);
+      /*valueDelta=*/-1'000'000,
+      {});
 
   auto encoding = createEncoding(wrapped);
   const std::vector<int64_t> expected{1'000'000, 1'000'001, 1'000'002};
@@ -801,7 +823,7 @@ TEST_F(SliceEncodingTest, uint32DeltaWrapsAsPhysicalAdd) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
-      encoded, /*offset=*/0, /*length=*/3, *buffer_, {}, /*valueDelta=*/-6);
+      encoded, /*offset=*/0, /*length=*/3, *buffer_, /*valueDelta=*/-6, {});
 
   auto encoding = createEncoding(wrapped);
   const auto out = materialize<uint32_t>(*encoding, 3);
@@ -821,7 +843,7 @@ TEST_F(SliceEncodingTest, rejectDeltaOnFloat) {
 
   EXPECT_THROW(
       nimble::SliceEncoding<float>::wrap(
-          encoded, /*offset=*/0, /*length=*/3, *buffer_, {}, /*valueDelta=*/5),
+          encoded, /*offset=*/0, /*length=*/3, *buffer_, /*valueDelta=*/5, {}),
       nimble::NimbleInternalError);
 }
 
@@ -832,7 +854,7 @@ TEST_F(SliceEncodingTest, rejectDeltaOnBool) {
 
   EXPECT_THROW(
       nimble::SliceEncoding<bool>::wrap(
-          encoded, /*offset=*/0, /*length=*/6, *buffer_, {}, /*valueDelta=*/3),
+          encoded, /*offset=*/0, /*length=*/6, *buffer_, /*valueDelta=*/3, {}),
       nimble::NimbleInternalError);
 }
 
@@ -850,7 +872,7 @@ TEST_F(SliceEncodingTest, rejectDeltaOnString) {
 
   EXPECT_THROW(
       nimble::SliceEncoding<std::string_view>::wrap(
-          encoded, /*offset=*/0, /*length=*/3, *buffer_, {}, /*valueDelta=*/1),
+          encoded, /*offset=*/0, /*length=*/3, *buffer_, /*valueDelta=*/1, {}),
       nimble::NimbleInternalError);
 }
 
@@ -880,16 +902,16 @@ TEST_F(SliceEncodingTest, wrapAcceptsDeltaOnSharedDictionaryInner) {
           /*offset=*/0,
           /*length=*/0,
           *buffer_,
-          {},
-          /*valueDelta=*/1));
+          /*valueDelta=*/1,
+          {}));
   EXPECT_NO_THROW(
       nimble::SliceEncoding<int32_t>::wrap(
           syntheticInner,
           /*offset=*/0,
           /*length=*/0,
           *buffer_,
-          {},
-          /*valueDelta=*/0));
+          /*valueDelta=*/0,
+          {}));
 }
 
 TEST_F(SliceEncodingTest, deltaAppliesOverSharedDictionaryInner) {
@@ -923,8 +945,8 @@ TEST_F(SliceEncodingTest, deltaAppliesOverSharedDictionaryInner) {
       /*offset=*/0,
       /*length=*/static_cast<uint32_t>(indices.size()),
       *buffer_,
-      options,
-      delta);
+      delta,
+      options);
 
   auto encoding = createEncoding(wrapped, options);
   const std::vector<int32_t> expected{15, 25, 35, 45, 35, 25};
@@ -938,7 +960,7 @@ TEST_F(SliceEncodingTest, zeroDeltaOnFloatOK) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<float>::wrap(
-      encoded, /*offset=*/1, /*length=*/2, *buffer_, {}, /*valueDelta=*/0);
+      encoded, /*offset=*/1, /*length=*/2, *buffer_, /*valueDelta=*/0, {});
 
   auto encoding = createEncoding(wrapped);
   const std::vector<float> expected{2.5f, 3.5f};
@@ -952,7 +974,7 @@ TEST_F(SliceEncodingTest, zeroDeltaOnBoolStillWorks) {
       *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<bool>::wrap(
-      encoded, /*offset=*/1, /*length=*/4, *buffer_, {}, /*valueDelta=*/0);
+      encoded, /*offset=*/1, /*length=*/4, *buffer_, /*valueDelta=*/0, {});
 
   auto encoding = createEncoding(wrapped);
   EXPECT_EQ(encoding->rowCount(), 4);
@@ -971,7 +993,7 @@ TEST_F(SliceEncodingTest, resetPreservesDelta) {
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
-      encoded, /*offset=*/1, /*length=*/3, *buffer_, {}, /*valueDelta=*/7);
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, /*valueDelta=*/7, {});
 
   auto encoding = createEncoding(wrapped);
 
@@ -988,16 +1010,545 @@ TEST_F(SliceEncodingTest, rejectDeltaOutOfPhysicalTypeRangeOnRead) {
   // wrap() has no range check on the delta today, so a caller can hand it a
   // value that does not fit in the physical type. The constructor's guard
   // catches it -- otherwise materialize() would silently alias the shift.
-  // Use RLE as the inner: it is stable across follow-up push-down work as an
-  // encoding that never absorbs a delta, so the out-of-range delta stays on
-  // the wire where the reader-side guard can see it.
+  // Use RLE as the inner: it declines push-down so the out-of-range delta
+  // stays on the wire where the reader-side guard can see it.
   const auto values = makeVector<int8_t>({10, 10, 10, 20});
   const auto encoded =
       nimble::test::Encoder<nimble::RLEEncoding<int8_t>>::encode(
           *buffer_, values);
 
   const auto wrapped = nimble::SliceEncoding<int8_t>::wrap(
-      encoded, /*offset=*/0, /*length=*/4, *buffer_, {}, /*valueDelta=*/500);
+      encoded, /*offset=*/0, /*length=*/4, *buffer_, /*valueDelta=*/500, {});
 
   EXPECT_THROW(createEncoding(wrapped), nimble::NimbleInternalError);
+}
+
+// --- Value delta push-down ------------------------------------------------
+//
+// When the inner encoding structurally supports it, wrap() folds the delta
+// into the copied inner bytes at write time and stores zero on the wire, so
+// the read-time shift loop is skipped. When it does not, the delta rides on
+// the wire and the read-time loop applies it as the fallback.
+
+TEST_F(SliceEncodingTest, pushDownFixedBitWidth) {
+  const auto values = makeVector<int32_t>({100, 101, 102, 103, 104});
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, /*valueDelta=*/1000, {});
+
+  // Push-down absorbs the delta into the inner FBW's baseline field, so the
+  // on-wire delta is zero.
+  EXPECT_EQ(readStoredValueDelta(wrapped), 0);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{1101, 1102, 1103};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownPfor) {
+  // PFOR needs at least one outlier to select a base bit width worth checking,
+  // but even a run of near-min values exercises the baseline-shift path.
+  const auto values =
+      makeVector<int32_t>({500, 501, 502, 503, 504, 505, 506, 507});
+  const auto encoded =
+      nimble::test::Encoder<nimble::PFOREncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/2, /*length=*/4, *buffer_, /*valueDelta=*/10, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), 0);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{512, 513, 514, 515};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownConstant) {
+  const auto values = makeVector<int32_t>({42, 42, 42, 42, 42, 42});
+  const auto encoded =
+      nimble::test::Encoder<nimble::ConstantEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/2, /*length=*/3, *buffer_, /*valueDelta=*/-8, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), 0);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{34, 34, 34};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownTrivialUint32) {
+  const auto values = makeVector<uint32_t>({10, 20, 30, 40, 50});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, /*valueDelta=*/1000, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), 0);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<uint32_t> expected{1020, 1030, 1040};
+  EXPECT_EQ(materialize<uint32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownNullableTrivialChild) {
+  // Nullable+Trivial values child: push-down recurses into the values child
+  // and shifts each stored non-null value in place; the nulls sub-stream is
+  // copied verbatim. `values` is the non-null-values array; `nulls` marks
+  // which of the row_count rows are non-null (true = non-null).
+  const auto values = makeVector<uint32_t>({10, 30, 50});
+  const auto nulls = makeVector<bool>({true, false, true, false, true});
+  const auto encoded =
+      nimble::test::Encoder<nimble::NullableEncoding<uint32_t>>::encodeNullable(
+          *buffer_, values, nulls);
+
+  const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
+      encoded,
+      /*offset=*/0,
+      /*length=*/5,
+      *buffer_,
+      /*valueDelta=*/500,
+      {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), 0);
+
+  auto encoding = createEncoding(wrapped);
+  nimble::Vector<uint32_t> output{pool_.get(), 5};
+  encoding->materialize(5, output.data());
+  // Non-null positions (0, 2, 4) carry shifted values; null positions (1, 3)
+  // are left at Nullable's default fill (0) because the push-down leaves the
+  // null slots untouched and the read-time shift loop is skipped.
+  EXPECT_EQ(output[0], 510u);
+  EXPECT_EQ(output[2], 530u);
+  EXPECT_EQ(output[4], 550u);
+  // Pin the default null-slot fill: skipping the read-time shift loop
+  // must not alias the previous buffer contents into the null slots.
+  EXPECT_EQ(output[1], 0u);
+  EXPECT_EQ(output[3], 0u);
+}
+
+TEST_F(SliceEncodingTest, pushDownFallbackRle) {
+  // RLE cannot absorb a constant shift structurally, so the delta stays on
+  // the wire and the read-time loop applies it.
+  const auto values = makeVector<int32_t>({10, 10, 11, 11, 11, 12, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  constexpr int64_t kDelta = 1000;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/5, *buffer_, kDelta, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), kDelta);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{1010, 1011, 1011, 1011, 1012};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 5), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownFallbackDictionary) {
+  const auto values = makeVector<int32_t>({10, 20, 10, 30, 20, 10});
+  const auto encoded =
+      nimble::test::Encoder<nimble::DictionaryEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  constexpr int64_t kDelta = 1000;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/4, *buffer_, kDelta, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), kDelta);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{1020, 1010, 1030, 1020};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownFallbackHuffman) {
+  const auto values = makeVector<int32_t>({10, 20, 10, 30, 20, 10, 40, 10});
+  const auto encoded =
+      nimble::test::Encoder<nimble::HuffmanEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  constexpr int64_t kDelta = 1000;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/5, *buffer_, kDelta, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), kDelta);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{1020, 1010, 1030, 1020, 1010};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 5), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownRejectsCompressedTrivial) {
+  // Compressed Trivial hides its values behind the compressor, so we cannot
+  // shift them in place -- the read-time loop takes over instead. Use a
+  // pattern the compressor won't reject as "not worth it" (Zstd falls back
+  // to Uncompressed when compressed bytes exceed input bytes, so we need
+  // enough repetition to make a compressed representation smaller).
+  nimble::Vector<int32_t> values{pool_.get()};
+  for (int i = 0; i < 200; ++i) {
+    values.push_back(10 + (i % 4));
+  }
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Zstd);
+
+  // Confirm the encoder actually landed on a compressed representation, so
+  // the "rejects compressed Trivial" property is really being exercised.
+  const uint32_t prefixSize = nimble::EncodingPrefix::serializedSize(
+      /*rowCount=*/static_cast<uint32_t>(values.size()),
+      /*useVarint=*/false);
+  ASSERT_NE(
+      static_cast<nimble::CompressionType>(encoded[prefixSize]),
+      nimble::CompressionType::Uncompressed);
+
+  constexpr int64_t kDelta = 1000;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, kDelta, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), kDelta);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{
+      static_cast<int32_t>(values[1]) + 1000,
+      static_cast<int32_t>(values[2]) + 1000,
+      static_cast<int32_t>(values[3]) + 1000};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownRejectsNullableWithRleChild) {
+  // Manually build a Nullable whose values child is an RLE. The Trivial-based
+  // Encoder helper always picks Trivial for both children, so use the two-
+  // stream encodeNullable() overload to bolt an RLE values child in place.
+  const auto values = makeVector<int32_t>({10, 10, 20, 20, 30});
+  const auto nulls = makeVector<bool>({true, true, true, true, true});
+  const auto rleValues =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values);
+  const auto trivialNulls =
+      nimble::test::Encoder<nimble::TrivialEncoding<bool>>::encode(
+          *buffer_, nulls);
+  const auto encoded = nimble::NullableEncoding<int32_t>::encodeNullable(
+      /*rowCount=*/5, rleValues, trivialNulls, *buffer_, {});
+
+  constexpr int64_t kDelta = 1000;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/5, *buffer_, kDelta, {});
+
+  // Nullable's values child is RLE (not push-downable), so the delta rides
+  // on the wire and the read-time loop applies it.
+  EXPECT_EQ(readStoredValueDelta(wrapped), kDelta);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{1010, 1010, 1020, 1020, 1030};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 5), expected);
+}
+
+TEST_F(SliceEncodingTest, zeroDeltaSkipsPushDownMachinery) {
+  // With delta=0 the wrap() decision short-circuits before ever asking the
+  // push-down helpers, so a push-downable inner produces the same wire bytes
+  // as any other zero-delta wrap -- i.e. inner-bytes copied verbatim.
+  const auto values = makeVector<int32_t>({100, 101, 102, 103, 104});
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/5, *buffer_, /*valueDelta=*/0, {});
+
+  const uint32_t prefixSize = nimble::EncodingPrefix::serializedSize(
+      /*rowCount=*/5, /*useVarint=*/false);
+  const auto innerOnWire = std::string_view{
+      wrapped.data() + prefixSize + sizeof(uint32_t) + /*deltaVarint=*/1,
+      encoded.size()};
+  EXPECT_EQ(innerOnWire, encoded);
+
+  auto encoding = createEncoding(wrapped);
+  const std::vector<int32_t> expected{100, 101, 102, 103, 104};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 5), expected);
+}
+
+TEST_F(SliceEncodingTest, pushDownDeclinesForNullableSharedDictionary) {
+  // Hand-craft a Nullable whose values child is a synthetic SharedDictionary
+  // prefix. wrap() recurses through Nullable, hits the SharedDictionary child,
+  // and gets false back from SliceEncodingPushDown::canApply -- so the delta
+  // rides on the wire instead of being folded into a nonsensical shift of the
+  // shared- dictionary indices.
+  const uint32_t sharedDictPrefixSize = nimble::EncodingPrefix::serializedSize(
+      /*rowCount=*/0, /*useVarint=*/false);
+  char* sharedDictReserved = buffer_->reserve(sharedDictPrefixSize);
+  char* sharedDictPos = sharedDictReserved;
+  nimble::EncodingPrefix::serialize(
+      nimble::EncodingType::SharedDictionary,
+      nimble::DataType::Uint32,
+      /*rowCount=*/0,
+      /*useVarint=*/false,
+      sharedDictPos);
+  const std::string_view sharedDictInner{
+      sharedDictReserved, sharedDictPrefixSize};
+
+  const auto nulls = makeVector<bool>({true, true, true});
+  const auto trivialNulls =
+      nimble::test::Encoder<nimble::TrivialEncoding<bool>>::encode(
+          *buffer_, nulls);
+
+  const auto nullableWrapped =
+      nimble::NullableEncoding<uint32_t>::encodeNullable(
+          /*rowCount=*/3, sharedDictInner, trivialNulls, *buffer_, {});
+
+  constexpr int64_t kDelta = 5;
+  const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
+      nullableWrapped, /*offset=*/0, /*length=*/3, *buffer_, kDelta, {});
+
+  EXPECT_EQ(readStoredValueDelta(wrapped), kDelta);
+}
+
+TEST_F(SliceEncodingTest, pushDownNullableFixedBitWidthChild) {
+  // Nullable+FixedBitWidth values child: push-down recurses into the values
+  // child and rewrites its baseline in place; nulls sub-stream copied verbatim.
+  const auto values = makeVector<uint32_t>({100, 200, 300});
+  const auto nulls = makeVector<bool>({true, false, true, false, true});
+  const auto encoded =
+      nimble::test::Encoder<nimble::NullableEncoding<uint32_t>>::encodeNullable(
+          *buffer_, values, nulls);
+
+  constexpr int64_t kDelta = 42;
+  const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
+      encoded, /*offset=*/0, /*length=*/5, *buffer_, kDelta, {});
+
+  // Push-down folded the delta into the FBW child's baseline, so the on-wire
+  // delta is zero.
+  EXPECT_EQ(readStoredValueDelta(wrapped), 0);
+
+  auto encoding = createEncoding(wrapped);
+  nimble::Vector<uint32_t> output{pool_.get(), 5};
+  encoding->materialize(5, output.data());
+  EXPECT_EQ(output[0], 142u);
+  EXPECT_EQ(output[2], 242u);
+  EXPECT_EQ(output[4], 342u);
+  EXPECT_EQ(output[1], 0u);
+  EXPECT_EQ(output[3], 0u);
+}
+
+TEST_F(SliceEncodingTest, pushDownSliceOfSlice) {
+  // Slice inside Slice: SliceEncodingPushDown::canApply does not natively fold
+  // across SliceEncoding, so the outer delta rides on the wire. At read time
+  // each layer applies its own delta after its inner materialize() completes,
+  // so the deltas accumulate additively.
+  const auto values = makeVector<int32_t>({100, 101, 102, 103, 104, 105});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  constexpr int64_t kInnerDelta = 3;
+  const auto innerWrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded,
+      /*offset=*/1,
+      /*length=*/4,
+      *buffer_,
+      /*valueDelta=*/kInnerDelta,
+      {});
+
+  constexpr int64_t kOuterDelta = 20;
+  const auto outerWrapped = nimble::SliceEncoding<int32_t>::wrap(
+      innerWrapped,
+      /*offset=*/0,
+      /*length=*/4,
+      *buffer_,
+      /*valueDelta=*/kOuterDelta,
+      {});
+
+  // The outer delta rides on the wire because the inner Slice is not a
+  // push-down target.
+  EXPECT_EQ(readStoredValueDelta(outerWrapped), kOuterDelta);
+
+  auto encoding = createEncoding(outerWrapped);
+  // Source[1..4) = {101, 102, 103, 104}; +inner(3) +outer(20) = {124..127}.
+  const std::vector<int32_t> expected{124, 125, 126, 127};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 4), expected);
+}
+
+TEST_F(SliceEncodingTest, extremeDeltaInt64Roundtrip) {
+  // Push-down for compressed Trivial is rejected, so INT64_MAX / INT64_MIN
+  // deltas ride on the wire and take a full 10-byte zigzag varint.
+  nimble::Vector<int64_t> values{pool_.get()};
+  for (int64_t i = 0; i < 200; ++i) {
+    values.push_back(int64_t{100} + (i % 4));
+  }
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int64_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Zstd);
+  const uint32_t innerPrefixSize = nimble::EncodingPrefix::serializedSize(
+      /*rowCount=*/static_cast<uint32_t>(values.size()),
+      /*useVarint=*/false);
+  ASSERT_NE(
+      static_cast<nimble::CompressionType>(encoded[innerPrefixSize]),
+      nimble::CompressionType::Uncompressed);
+
+  for (const int64_t kDelta :
+       {std::numeric_limits<int64_t>::max(),
+        std::numeric_limits<int64_t>::min()}) {
+    SCOPED_TRACE(kDelta);
+    const auto wrapped = nimble::SliceEncoding<int64_t>::wrap(
+        encoded, /*offset=*/0, /*length=*/3, *buffer_, kDelta, {});
+    EXPECT_EQ(readStoredValueDelta(wrapped), kDelta);
+
+    const uint32_t outerPrefixSize = nimble::EncodingPrefix::serializedSize(
+        /*rowCount=*/3, /*useVarint=*/false);
+    const size_t expectedSize = outerPrefixSize + sizeof(uint32_t) +
+        /*deltaVarint=*/10 + encoded.size();
+    EXPECT_EQ(wrapped.size(), expectedSize);
+
+    auto encoding = createEncoding(wrapped);
+    const std::vector<int64_t> expected{
+        static_cast<int64_t>(
+            static_cast<uint64_t>(values[0]) + static_cast<uint64_t>(kDelta)),
+        static_cast<int64_t>(
+            static_cast<uint64_t>(values[1]) + static_cast<uint64_t>(kDelta)),
+        static_cast<int64_t>(
+            static_cast<uint64_t>(values[2]) + static_cast<uint64_t>(kDelta))};
+    EXPECT_EQ(materialize<int64_t>(*encoding, 3), expected);
+  }
+}
+
+// --- Push-down under useVarintRowCount --------------------------------------
+//
+// Production callers set Options::useVarintRowCount, so exercise the write /
+// read path (prefix layout differs, and push-down folders derive their offsets
+// from prefixSize) with the flag toggled.
+
+class SliceEncodingPushDownVarintTest
+    : public SliceEncodingTest,
+      public ::testing::WithParamInterface<bool> {};
+
+INSTANTIATE_TEST_SUITE_P(_, SliceEncodingPushDownVarintTest, ::testing::Bool());
+
+TEST_P(SliceEncodingPushDownVarintTest, pushDownFixedBitWidth) {
+  const bool useVarint = GetParam();
+  const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+  const auto values = makeVector<int32_t>({100, 101, 102, 103, 104});
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Uncompressed, options);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/3, *buffer_, /*valueDelta=*/7, options);
+
+  EXPECT_EQ(readStoredValueDelta(wrapped, useVarint), 0);
+
+  auto encoding = createEncoding(wrapped, options);
+  const std::vector<int32_t> expected{108, 109, 110};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_P(SliceEncodingPushDownVarintTest, pushDownConstant) {
+  const bool useVarint = GetParam();
+  const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+  const auto values = makeVector<int32_t>({42, 42, 42, 42, 42, 42});
+  const auto encoded =
+      nimble::test::Encoder<nimble::ConstantEncoding<int32_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Uncompressed, options);
+
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded,
+      /*offset=*/2,
+      /*length=*/3,
+      *buffer_,
+      /*valueDelta=*/-8,
+      options);
+
+  EXPECT_EQ(readStoredValueDelta(wrapped, useVarint), 0);
+
+  auto encoding = createEncoding(wrapped, options);
+  const std::vector<int32_t> expected{34, 34, 34};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 3), expected);
+}
+
+TEST_P(SliceEncodingPushDownVarintTest, pushDownTrivialUint32) {
+  const bool useVarint = GetParam();
+  const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+  const auto values = makeVector<uint32_t>({10, 20, 30, 40, 50});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Uncompressed, options);
+
+  const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
+      encoded,
+      /*offset=*/1,
+      /*length=*/3,
+      *buffer_,
+      /*valueDelta=*/1000,
+      options);
+
+  EXPECT_EQ(readStoredValueDelta(wrapped, useVarint), 0);
+
+  auto encoding = createEncoding(wrapped, options);
+  const std::vector<uint32_t> expected{1020, 1030, 1040};
+  EXPECT_EQ(materialize<uint32_t>(*encoding, 3), expected);
+}
+
+TEST_P(SliceEncodingPushDownVarintTest, pushDownNullableTrivialChild) {
+  const bool useVarint = GetParam();
+  const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+  const auto values = makeVector<uint32_t>({10, 30, 50});
+  const auto nulls = makeVector<bool>({true, false, true, false, true});
+  const auto encoded =
+      nimble::test::Encoder<nimble::NullableEncoding<uint32_t>>::encodeNullable(
+          *buffer_,
+          values,
+          nulls,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  const auto wrapped = nimble::SliceEncoding<uint32_t>::wrap(
+      encoded,
+      /*offset=*/0,
+      /*length=*/5,
+      *buffer_,
+      /*valueDelta=*/500,
+      options);
+
+  EXPECT_EQ(readStoredValueDelta(wrapped, useVarint), 0);
+
+  auto encoding = createEncoding(wrapped, options);
+  nimble::Vector<uint32_t> output{pool_.get(), 5};
+  encoding->materialize(5, output.data());
+  EXPECT_EQ(output[0], 510u);
+  EXPECT_EQ(output[2], 530u);
+  EXPECT_EQ(output[4], 550u);
+  EXPECT_EQ(output[1], 0u);
+  EXPECT_EQ(output[3], 0u);
+}
+
+TEST_P(SliceEncodingPushDownVarintTest, pushDownFallbackRle) {
+  const bool useVarint = GetParam();
+  const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+  const auto values = makeVector<int32_t>({10, 10, 11, 11, 11, 12, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Uncompressed, options);
+
+  constexpr int64_t kDelta = 1000;
+  const auto wrapped = nimble::SliceEncoding<int32_t>::wrap(
+      encoded, /*offset=*/1, /*length=*/5, *buffer_, kDelta, options);
+
+  EXPECT_EQ(readStoredValueDelta(wrapped, useVarint), kDelta);
+
+  auto encoding = createEncoding(wrapped, options);
+  const std::vector<int32_t> expected{1010, 1011, 1011, 1011, 1012};
+  EXPECT_EQ(materialize<int32_t>(*encoding, 5), expected);
 }


### PR DESCRIPTION
Summary:

D118624059 added a signed `valueDelta` to `SliceEncoding` that is applied
to every materialized value at decode time via a per-batch shift loop. For
inner encodings that already carry a baseline (FixedBitWidth, PFOR,
Constant), a single value (Constant), or a wrapping shell around a
shiftable child (Nullable, uncompressed Trivial), the shift can equally
well be folded into the copied inner bytes at wrap time — after which the
on-wire delta is zero and the decode-time loop is skipped.

This diff adds that push-down. `SliceEncoding::wrap()` becomes a two-phase
decide-then-write:

1. Decide. When `valueDelta != 0`, reject encodings that are semantically
   unshiftable (SharedDictionary), then ask
   `slice_encoding_detail::canApplyValueDeltaTo(inner, delta, useVarint)`
   whether the specific `(inner, delta)` pair is push-downable. The probe
   walks Nullable chains and checks Trivial compression state so runtime
   conditions are honoured.

2. Write. When push-down applies,
   `slice_encoding_detail::applyValueDeltaTo(inner, delta, dest, useVarint)`
   writes the shifted inner bytes directly into the reserved region — no
   scratch buffer — and the on-wire delta is stored as zero. Otherwise the
   inner is memcpy'd verbatim and the original delta rides on the wire.

The push-down folders live inside a new `SliceEncoding.cpp`
(`SliceEncoding` was header-only before this diff):

  * FixedBitWidth: copy inner verbatim, rewrite the baseline field.
  * PFOR: copy inner verbatim, rewrite the baseline field (base residuals
    and exception values are both baseline-relative, so one edit shifts
    everything by the same amount).
  * Constant: copy inner verbatim, rewrite the single stored value.
  * Trivial (uncompressed only): copy header verbatim, then shift each
    payload value while it is copied so no byte is written twice.
  * Nullable: copy prefix + 4-byte values-size verbatim, recurse into the
    values sub-stream at the correct destination offset, then copy the
    nulls sub-stream verbatim.

Design decisions worth calling out:

  * `canApplyValueDeltaTo` recurses into the Nullable values child (the
    nulls child is a bool stream and never shifts). So a Nullable whose
    values child is RLE reports non-push-downable and falls through to the
    read-time loop.
  * Trivial compression is inspected at probe time: uncompressed → push
    down; compressed → false → decode-time loop takes over.
  * `useVarintRowCount` is threaded through the helpers so they know how
    to size the standard prefix. Nimble uses one consistent value across
    a whole encoding tree, so wrap()'s options carry to the inner.
  * `isValueDeltaUnsupported(EncodingType)` is an inline helper in the
    header; today it only guards SharedDictionary.
  * Both `canApplyValueDeltaTo` and `applyValueDeltaTo` dispatch on
    `EncodingType` via exhaustive `switch` statements with no `default:`
    arm, so adding a new `EncodingType` fails the build under
    `-Werror=switch` until the author declares whether it has a folder.

The one-copy guarantee: the push-down folders write directly into the
caller-provided destination pointer; they do NOT allocate their own
scratch buffer. Baseline-edit folders memcpy the inner and then re-write a
handful of baseline bytes (still writing to `dest`, not to anywhere
intermediate). Trivial's per-value shift is a single write per byte via
memcpy-into-`dest`.

Depends on D118624059.

Reviewed By: xiaoxmeng

Differential Revision: D118984537


