### PR TITLE
fix(core): Synchronize QueryCtx release callback registration

### DIFF
--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -89,7 +89,14 @@ QueryCtx::QueryCtx(
 }
 
 QueryCtx::~QueryCtx() {
-  for (auto& cb : releaseCallbacks_) {
+  // Move the callbacks out before running them: a callback may re-enter
+  // QueryCtx, which would deadlock on mutex_ if it were held here.
+  std::deque<ReleaseCallback> callbacks;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    callbacks.swap(releaseCallbacks_);
+  }
+  for (auto& cb : callbacks) {
     try {
       cb();
     } catch (const std::exception& e) {

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -288,7 +288,10 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   /// Note: Callbacks are invoked in registration order. Exceptions thrown by
   /// callbacks are caught and logged; they do not prevent subsequent callbacks
   /// from running.
+  ///
+  /// Safe to call concurrently from multiple tasks of the same query.
   void addReleaseCallback(ReleaseCallback callback) {
+    std::lock_guard<std::mutex> l(mutex_);
     releaseCallbacks_.push_back(std::move(callback));
   }
 
@@ -515,6 +518,7 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   std::vector<ContinuePromise> arbitrationPromises_;
   std::shared_ptr<filesystems::TokenProvider> fsTokenProvider_;
   // Callbacks invoked before destruction to clean up external resources.
+  // Guarded by mutex_; tasks of one query register concurrently.
   std::deque<ReleaseCallback> releaseCallbacks_;
 
   // A function that constructs a custom trace ctx object.

--- a/velox/core/tests/QueryCtxTest.cpp
+++ b/velox/core/tests/QueryCtxTest.cpp
@@ -15,6 +15,9 @@
  */
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/QueryCtx.h"
 
@@ -82,6 +85,39 @@ TEST_F(QueryCtxTest, releaseCallbacks) {
   // After QueryCtx destruction, all callbacks should have been invoked.
   ASSERT_EQ(callbackCount, 2);
   ASSERT_EQ(capturedQueryId, "test_query_id");
+}
+
+TEST_F(QueryCtxTest, concurrentReleaseCallbackRegistration) {
+  constexpr int32_t kNumThreads = 8;
+  constexpr int32_t kCallbacksPerThread = 500;
+  std::atomic<int32_t> callbackCount{0};
+
+  {
+    auto queryCtx = QueryCtx::create(
+        nullptr,
+        QueryConfig{{}},
+        std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+        nullptr,
+        nullptr,
+        nullptr,
+        "test_query_id");
+
+    // Tasks of one query register release callbacks from their own threads.
+    std::vector<std::thread> threads;
+    threads.reserve(kNumThreads);
+    for (int32_t i = 0; i < kNumThreads; ++i) {
+      threads.emplace_back([&]() {
+        for (int32_t j = 0; j < kCallbacksPerThread; ++j) {
+          queryCtx->addReleaseCallback([&callbackCount]() { ++callbackCount; });
+        }
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  }
+
+  ASSERT_EQ(callbackCount, kNumThreads * kCallbacksPerThread);
 }
 
 TEST_F(QueryCtxTest, releaseCallbackException) {


### PR DESCRIPTION
`QueryCtx::addReleaseCallback()` pushes onto a `std::deque` without taking
`mutex_`, even though the member sits right next to the mutex that guards the
rest of the class. Nothing stops two threads from calling it at once.

That turns out to be reachable today. `HashTableCache` registers a callback
when it caches a hash table, and tasks of a single query run on their own
threads, so two tasks finishing a build at the same time will both append to
the same deque. I ran into this from a second caller I'm adding for GPU memory
accounting, but the `HashTableCache` path is already there.

It is not subtle when it goes wrong. A test that registers callbacks from
eight threads segfaults on 9 of 10 runs before the fix and passes 10 of 10
after:

```
$ velox_core_test --gtest_filter='*concurrentReleaseCallbackRegistration*'
139 0 139 139 139 139 139 139 139 139   # before
0 0 0 0 0 0 0 0 0 0                     # after
```

The fix is to take `mutex_` in `addReleaseCallback()`.

The destructor also changes. It used to iterate `releaseCallbacks_` directly,
which is safe on its own since nothing else can reach the object by then, but
holding the lock across the callbacks would deadlock if one of them re-enters
`QueryCtx` — and the whole point of these callbacks is to let external code
clean up query-scoped state. So it swaps the deque out under the lock and runs
the callbacks after releasing it.

Registration order is preserved, and the existing behaviour of catching and
logging exceptions from callbacks is unchanged.
