### PR TITLE
perf(encoding): Apply SliceEncoding value delta to sorted position streams (#18979)

### DIFF
--- a/velox/dwio/nimble/encodings/CMakeLists.txt
+++ b/velox/dwio/nimble/encodings/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(
   common/Encoding.cpp
   common/EncodingFactory.cpp
   common/EncodingLayout.cpp
+  common/EncodingUtils.cpp
   common/EncodingTypeDispatch.h
   selection/EncodingSelectionPolicy.cpp
   selection/Statistics.cpp
@@ -73,6 +74,7 @@ add_library(
   selection/EncodingSelection.h
   selection/EncodingIdentifier.h
   common/EncodingUtils.h
+  common/SortedPositionSlots.h
   common/EncodingType.h
   common/EncodingPrimitives.h
   common/EncodingPrefix.h

--- a/velox/dwio/nimble/encodings/PFOREncoding.h
+++ b/velox/dwio/nimble/encodings/PFOREncoding.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cstring>
 #include <span>
+#include <utility>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/nimble/common/Buffer.h"
@@ -27,10 +28,12 @@
 #include "velox/dwio/nimble/common/Varint.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/common/SortedPositionSlots.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelection.h"
 
@@ -193,7 +196,6 @@ class PFOREncoding final
       uint32_t numExceptions,
       uint32_t offset,
       uint32_t length,
-      velox::memory::MemoryPool* pool,
       Buffer& scratchBuffer,
       const Encoding::Options& options);
 
@@ -543,51 +545,57 @@ typename PFOREncoding<T>::ExceptionSlice PFOREncoding<T>::sliceExceptions(
     uint32_t numExceptions,
     uint32_t offset,
     uint32_t length,
-    velox::memory::MemoryPool* pool,
     Buffer& scratchBuffer,
     const Encoding::Options& options) {
   if (numExceptions == 0) {
     return {};
   }
 
-  NIMBLE_CHECK_NOT_NULL(pool);
-  ScopedVector<uint32_t> positions{numExceptions, pool, options.bufferPool};
-  auto positionsEncoding =
-      EncodingFactory(options).create(*pool, exceptionPositions, nullptr);
-  positionsEncoding->materialize(numExceptions, positions.data());
+  auto& pool = scratchBuffer.getMemoryPool();
+  const auto rangeEnd = offset + length;
+  const int64_t valueDelta = -static_cast<int64_t>(offset);
 
-  const auto sliceBegin =
-      std::lower_bound(positions.begin(), positions.end(), offset);
-  const auto sliceEnd =
-      std::lower_bound(sliceBegin, positions.end(), offset + length);
-  const auto exceptionOffset =
-      static_cast<uint32_t>(sliceBegin - positions.begin());
-  const auto slicedExceptionCount =
-      static_cast<uint32_t>(sliceEnd - sliceBegin);
+  // Locate exception-position bounds covering rows [offset, offset + length)
+  // through the shared detail::findSortedPositionSlots helper. Slice the
+  // retained range positionally through EncodingFactory::slice and hand the
+  // result to SliceEncoding::wrap. When the sliced inner encoding supports
+  // push-down (FixedBitWidth / PFOR / Constant / Nullable / Trivial), the
+  // wrapper folds |valueDelta| into the inner bytes at write time and the
+  // on-wire delta is zero. Otherwise the delta rides on the wire and the
+  // reader applies it.
+  const auto [slotStart, slotEnd] = detail::findSortedPositionSlots(
+      exceptionPositions, numExceptions, offset, rangeEnd, pool, options);
+  const uint32_t exceptionOffset = slotStart;
+  const uint32_t slicedExceptionCount = slotEnd - slotStart;
   if (slicedExceptionCount == 0) {
     return {};
   }
-
-  ScopedVector<uint32_t> rebasedPositions{
-      slicedExceptionCount, pool, options.bufferPool};
-  for (uint32_t i = 0; i < slicedExceptionCount; ++i) {
-    rebasedPositions[i] = sliceBegin[i] - offset;
-  }
+  const auto slicedInnerPositions = EncodingFactory::slice(
+      exceptionPositions,
+      exceptionOffset,
+      slicedExceptionCount,
+      scratchBuffer,
+      options);
+  const auto slicedPositions = SliceEncoding<uint32_t>::wrap(
+      slicedInnerPositions,
+      /*offset=*/0,
+      /*length=*/slicedExceptionCount,
+      scratchBuffer,
+      valueDelta,
+      options);
 
   return {
-      .positions = EncodingFactory::encodeWithCapturedLayout<uint32_t>(
-          exceptionPositions,
-          {rebasedPositions.data(), rebasedPositions.size()},
-          scratchBuffer,
-          options,
-          "Captured PFOR exception positions layout"),
+      .positions = slicedPositions,
+      // Exception values are addressed by exception slot, not by row, so they
+      // slice positionally on the same bounds.
       .values = EncodingFactory::slice(
           exceptionValues,
           exceptionOffset,
           slicedExceptionCount,
           scratchBuffer,
           options),
-      .count = slicedExceptionCount};
+      .count = slicedExceptionCount,
+  };
 }
 
 template <typename T>
@@ -636,7 +644,6 @@ std::string_view PFOREncoding<T>::slice(
       numExceptions,
       offset,
       length,
-      pool,
       scopedBuffer.get(),
       options);
 

--- a/velox/dwio/nimble/encodings/SliceEncoding.h
+++ b/velox/dwio/nimble/encodings/SliceEncoding.h
@@ -249,6 +249,19 @@ class SliceEncoding final
         encoding_->debugString(offset + 2));
   }
 
+  /// Returns the signed value delta added to every materialized value at
+  /// decode time. Zero when wrap() folded the shift into the inner encoding
+  /// at write time.
+  int64_t valueDelta() const noexcept {
+    return valueDelta_;
+  }
+
+  /// Returns the raw bytes of the inner encoding, stored verbatim after the
+  /// SliceEncoding header.
+  std::string_view innerEncoding() const noexcept {
+    return inner_;
+  }
+
   /// Wraps `encoded` so that a consumer sees `length` rows starting at
   /// `offset`, without slicing it. `encoded` is copied into `buffer`.
   ///

--- a/velox/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/velox/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -15,15 +15,79 @@
  */
 #include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 
-#include <array>
+#include <cstring>
+#include <tuple>
 #include <utility>
 
 #include "velox/dwio/nimble/common/Types.h"
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/common/SortedPositionSlots.h"
 #include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 namespace facebook::nimble {
+
+namespace {
+
+// Return value of sliceSortedPositionStream: the sliced+wrapped position
+// bytes plus the two counts the caller needs to fill in RangeCounts without
+// walking the stream a second time.
+struct SlicedSparsePositions {
+  // Encoded SliceEncoding-wrapped position stream for the requested row range.
+  std::string_view slicedPositions;
+  // Sparse-position count inside [offset, offset + length).
+  uint32_t sparseInRange;
+  // Sparse-position count strictly before |offset|.
+  uint32_t sparseBefore;
+};
+
+// Slices a SparseBool position stream (strictly ascending, terminated by a
+// sentinel at value sourceRowCount) over rows [offset, offset + length),
+// rebasing every retained position by -offset. Locates the slot bounds
+// covering the range via detail::findSortedPositionSlots, slices the
+// retained range plus one terminator slot positionally through
+// EncodingFactory::slice, and wraps the sliced bytes with SliceEncoding.
+// When the sliced inner encoding supports push-down (FixedBitWidth / PFOR /
+// Constant / Nullable / Trivial), the wrapper folds the -offset shift into
+// the inner bytes at write time and the on-wire delta is zero. Otherwise
+// the delta rides on the wire and the reader applies it.
+SlicedSparsePositions sliceSortedPositionStream(
+    std::string_view encodedPositions,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& scratchBuffer,
+    const Encoding::Options& options) {
+  auto& pool = scratchBuffer.getMemoryPool();
+  const auto rangeEnd = offset + length;
+  const int64_t valueDelta = -static_cast<int64_t>(offset);
+
+  const uint32_t positionCount =
+      EncodingPrefix::readRowCount(encodedPositions, options.useVarintRowCount);
+  const auto [slotStart, slotEnd] = detail::findSortedPositionSlots(
+      encodedPositions, positionCount, offset, rangeEnd, pool, options);
+  NIMBLE_CHECK_LT(
+      slotEnd,
+      positionCount,
+      "SparseBool positions must end in a sentinel past the slice end.");
+  const uint32_t sparseInRange = slotEnd - slotStart;
+  const uint32_t retainedCount = sparseInRange + 1;
+  const auto slicedPositions = EncodingFactory::slice(
+      encodedPositions, slotStart, retainedCount, scratchBuffer, options);
+  return {
+      .slicedPositions = SliceEncoding<uint32_t>::wrap(
+          slicedPositions,
+          /*offset=*/0,
+          /*length=*/retainedCount,
+          scratchBuffer,
+          valueDelta,
+          options),
+      .sparseInRange = sparseInRange,
+      .sparseBefore = slotStart,
+  };
+}
+
+} // namespace
 
 SparseBoolEncoding::SparseBoolEncoding(
     velox::memory::MemoryPool& pool,
@@ -252,39 +316,37 @@ std::string_view SparseBoolEncoding::slice(
   return sliceAndCount(encoded, offset, length, buffer, options).sliced;
 }
 
-std::string_view SparseBoolEncoding::encodeWithSlicedIndices(
+SparseBoolEncoding::SliceResult SparseBoolEncoding::sliceAndCount(
     std::string_view encoded,
+    uint32_t offset,
     uint32_t length,
-    std::span<const uint32_t> slicedIndicesWithSentinel,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
   NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  const auto payload = encoded.substr(
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount));
   NIMBLE_CHECK(
-      !slicedIndicesWithSentinel.empty(),
-      "SparseBool slice indices must include row-count sentinel.");
-  NIMBLE_CHECK_EQ(
-      slicedIndicesWithSentinel.back(),
-      length,
-      "SparseBool slice sentinel must match slice length.");
+      !payload.empty(), "SparseBool stream is missing its polarity byte.");
+  const bool sparseValue = static_cast<bool>(payload.front());
+  const std::string_view encodedPositions = payload.substr(sizeof(uint8_t));
 
-  const char* readPos = encoded.data() +
-      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
-  const auto sparseValue = encoding::readChar(readPos);
-  const std::string_view encodedIndices{
-      readPos, static_cast<size_t>(encoded.end() - readPos)};
-
-  const auto serializedIndices =
-      EncodingFactory::encodeWithCapturedLayout<uint32_t>(
-          encodedIndices,
-          slicedIndicesWithSentinel,
-          buffer,
-          options,
-          "Captured SparseBool index layout");
+  // The sliced positions are serialized into scratch space first because the
+  // outer encoding size depends on their size.
+  ScopedEncodingBuffer scopedBuffer{
+      &buffer.getMemoryPool(), options.encodingBufferPool};
+  const auto [slicedPositions, sparseInRange, sparseBefore] =
+      sliceSortedPositionStream(
+          encodedPositions, offset, length, scopedBuffer.get(), options);
 
   const auto prefixSize =
       EncodingPrefix::serializedSize(length, options.useVarintRowCount);
   const auto encodingSize =
-      prefixSize + SparseBoolEncoding::kPrefixSize + serializedIndices.size();
+      prefixSize + SparseBoolEncoding::kPrefixSize + slicedPositions.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   EncodingPrefix::serialize(
@@ -293,79 +355,23 @@ std::string_view SparseBoolEncoding::encodeWithSlicedIndices(
       length,
       options.useVarintRowCount,
       pos);
-  encoding::writeChar(sparseValue, pos);
-  encoding::writeBytes(serializedIndices, pos);
+  encoding::writeChar(static_cast<char>(sparseValue), pos);
+  encoding::writeBytes(slicedPositions, pos);
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
-  return {reserved, encodingSize};
-}
 
-SparseBoolEncoding::SliceResult SparseBoolEncoding::sliceAndCount(
-    std::string_view encoded,
-    uint32_t offset,
-    uint32_t length,
-    Buffer& buffer,
-    const Encoding::Options& options) {
-  auto* pool = &buffer.getMemoryPool();
-  const auto sourceRowCount =
-      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
-  NIMBLE_CHECK_LE(offset, sourceRowCount);
-  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
-  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
-
-  SparseBoolEncoding source{
-      *pool,
-      encoded,
-      [](uint32_t /*totalLength*/) -> void* { return nullptr; },
-      options};
-  const auto numSkippedSparse = source.skipSparseIndices(offset);
-
-  const auto rowEnd = source.row_ + length;
-  if (source.nextIndex_ >= rowEnd) {
-    const RangeCounts counts = source.sparseValue()
-        ? RangeCounts{
-              .numTrueBeforeRange = numSkippedSparse,
-              .numTrueInRange = 0,
-          }
-        : RangeCounts{
-              .numTrueBeforeRange = offset - numSkippedSparse,
-              .numTrueInRange = length,
-          };
-    const std::array<uint32_t, 1> slicedIndicesWithSentinel{length};
-    return {
-        .sliced = encodeWithSlicedIndices(
-            encoded, length, slicedIndicesWithSentinel, buffer, options),
-        .counts = counts,
-    };
-  }
-
-  const auto maxSlicePositions =
-      std::min<uint32_t>(length, source.indices_.rowCount() - 1);
-  ScopedVector<uint32_t> slicedIndicesWithSentinel{
-      maxSlicePositions + 1, pool, options.bufferPool};
-  slicedIndicesWithSentinel->resize(0);
-  const auto numSparseInSlice =
-      source.materializeSparseIndices(length, *slicedIndicesWithSentinel);
-  slicedIndicesWithSentinel->push_back(length);
-
-  const RangeCounts counts = source.sparseValue()
-      ? RangeCounts{
-            .numTrueBeforeRange = numSkippedSparse,
-            .numTrueInRange = numSparseInSlice,
-        }
-      : RangeCounts{
-            .numTrueBeforeRange = offset - numSkippedSparse,
-            .numTrueInRange = length - numSparseInSlice,
-        };
+  // True positions carry the value indicated by |sparseValue|, so the true
+  // counts are either the sparse counts or their complement within the range.
   return {
-      .sliced = encodeWithSlicedIndices(
-          encoded,
-          length,
-          std::span<const uint32_t>{
-              slicedIndicesWithSentinel->data(),
-              slicedIndicesWithSentinel->size()},
-          buffer,
-          options),
-      .counts = counts,
+      .sliced = {reserved, encodingSize},
+      .counts = sparseValue
+          ? RangeCounts{
+                .numTrueBeforeRange = sparseBefore,
+                .numTrueInRange = sparseInRange,
+            }
+          : RangeCounts{
+                .numTrueBeforeRange = offset - sparseBefore,
+                .numTrueInRange = length - sparseInRange,
+            },
   };
 }
 

--- a/velox/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/velox/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -19,6 +19,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/FixedBitArray.h"
+#include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "velox/dwio/nimble/encodings/common/BufferedEncoding.h"
 #include "velox/dwio/nimble/encodings/common/Encoding.h"
@@ -113,7 +114,8 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
       const Encoding::Options& options = {});
 
   /// Slices rows [offset, offset + length) and counts true values before and
-  /// inside the slice while walking sparse positions once.
+  /// inside the slice from the sparse-position bounds located during slicing,
+  /// avoiding a second pass over the position stream.
   static SliceResult sliceAndCount(
       std::string_view encoded,
       uint32_t offset,
@@ -169,15 +171,6 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   }
 
  private:
-  // Encodes a sliced SparseBool stream from sparse positions relative to the
-  // slice start and with the row-count sentinel appended.
-  static std::string_view encodeWithSlicedIndices(
-      std::string_view encoded,
-      uint32_t length,
-      std::span<const uint32_t> slicedIndicesWithSentinel,
-      Buffer& buffer,
-      const Encoding::Options& options = {});
-
   // SparseBool stores one byte after the common encoding prefix to indicate
   // whether the sparse indices refer to set bits or unset bits.
   static constexpr int kPrefixSize = sizeof(uint8_t);

--- a/velox/dwio/nimble/encodings/common/EncodingUtils.cpp
+++ b/velox/dwio/nimble/encodings/common/EncodingUtils.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/dwio/nimble/encodings/common/EncodingUtils.h"
+
+#include "velox/dwio/nimble/common/Exceptions.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/views/EncodingViewFactory.h"
+
+namespace facebook::nimble::detail {
+
+SortedPositionSlots findSortedPositionSlots(
+    std::string_view encodedPositions,
+    uint32_t positionCount,
+    uint32_t valueStartOffset,
+    uint32_t valueEndOffset,
+    velox::memory::MemoryPool& pool,
+    const Encoding::Options& options) {
+  const auto encodingType = EncodingPrefix::encodingType(encodedPositions);
+  if (supportsEncodingView(encodingType)) {
+    auto view = detail::createTypedEncodingView<uint32_t>(
+        encodedPositions, &pool, options);
+    NIMBLE_CHECK_NOT_NULL(
+        view, "createTypedEncodingView returned null for a viewable encoding.");
+    const auto lowerBound =
+        [&](uint32_t begin, uint32_t end, uint32_t target) -> uint32_t {
+      while (begin < end) {
+        const auto middle = begin + ((end - begin) >> 1);
+        // @lint-ignore NULLSAFECLANG nullable-dereference
+        if (view->readAt(middle) < target) {
+          begin = middle + 1;
+        } else {
+          end = middle;
+        }
+      }
+      return begin;
+    };
+    const uint32_t slotStart = lowerBound(0, positionCount, valueStartOffset);
+    const uint32_t slotEnd =
+        lowerBound(slotStart, positionCount, valueEndOffset);
+    return {.slotStart = slotStart, .slotEnd = slotEnd};
+  }
+
+  // Non-viewable position encoding (Varint, DeltaEncoding, ...).
+  // Materialize every position once and binary search the decoded values.
+  // The buffer is scoped to this function; the positional slice that follows
+  // decodes from the encoded bytes again through EncodingFactory::slice.
+  ScopedVector<uint32_t> positions{positionCount, &pool, options.bufferPool};
+  EncodingFactory{options}
+      .create(pool, encodedPositions, nullptr)
+      ->materialize(positionCount, positions.data());
+  auto* const values = positions.data();
+  NIMBLE_CHECK_NOT_NULL(
+      values, "ScopedVector must own storage after positionCount reserve.");
+  const auto lowerBoundValue =
+      [&](uint32_t begin, uint32_t end, uint32_t target) -> uint32_t {
+    while (begin < end) {
+      const auto middle = begin + ((end - begin) >> 1);
+      // @lint-ignore NULLSAFECLANG nullable-dereference
+      if (values[middle] < target) {
+        begin = middle + 1;
+      } else {
+        end = middle;
+      }
+    }
+    return begin;
+  };
+  const uint32_t slotStart =
+      lowerBoundValue(0, positionCount, valueStartOffset);
+  const uint32_t slotEnd =
+      lowerBoundValue(slotStart, positionCount, valueEndOffset);
+  return {.slotStart = slotStart, .slotEnd = slotEnd};
+}
+
+} // namespace facebook::nimble::detail

--- a/velox/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/velox/dwio/nimble/encodings/common/EncodingUtils.h
@@ -39,6 +39,7 @@
 #include "velox/dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "velox/dwio/nimble/encodings/TrivialEncoding.h"
 #include "velox/dwio/nimble/encodings/VarintEncoding.h"
+#include "velox/dwio/nimble/encodings/common/SortedPositionSlots.h"
 
 namespace facebook::nimble {
 

--- a/velox/dwio/nimble/encodings/common/SortedPositionSlots.h
+++ b/velox/dwio/nimble/encodings/common/SortedPositionSlots.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/dwio/nimble/encodings/common/Encoding.h"
+
+// Sorted-position slot helper. Extracted into its own header so both
+// EncodingUtils.h and PFOREncoding.h can include it without forming an
+// include cycle (EncodingUtils.h includes PFOREncoding.h for its encoding
+// dispatch, so PFOR templates cannot include EncodingUtils.h directly).
+
+namespace facebook::nimble::detail {
+
+// Slot index range into the encoded position array returned by
+// findSortedPositionSlots. Half-open: retained slots are [slotStart, slotEnd).
+struct SortedPositionSlots {
+  uint32_t slotStart;
+  uint32_t slotEnd;
+};
+
+// Locates the slot index range covering values in
+// [valueStartOffset, valueEndOffset) in a sorted-position encoded stream.
+// Shared by SparseBoolEncoding (positions terminator) and PFOREncoding (no
+// terminator).
+//
+// Uses random-access binary search + view->readAt when the position encoding
+// has an EncodingView (Trivial, RLE, ...). Otherwise (Varint, DeltaEncoding,
+// ...) materializes every position once and binary searches the decoded
+// values; the decoded buffer is used only for the search and is released
+// when the function returns.
+//
+// Callers add wire-specific checks on the returned bounds (SparseBool
+// verifies the terminator slot lives past slotEnd).
+SortedPositionSlots findSortedPositionSlots(
+    std::string_view encodedPositions,
+    uint32_t positionCount,
+    uint32_t valueStartOffset,
+    uint32_t valueEndOffset,
+    velox::memory::MemoryPool& pool,
+    const Encoding::Options& options);
+
+} // namespace facebook::nimble::detail

--- a/velox/dwio/nimble/encodings/tests/EncodingUtilsTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/EncodingUtilsTest.cpp
@@ -18,9 +18,16 @@
 #include <array>
 #include <vector>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/FixedBitArray.h"
 #include "velox/dwio/nimble/common/Varint.h"
+#include "velox/dwio/nimble/common/Vector.h"
+#include "velox/dwio/nimble/encodings/TrivialEncoding.h"
+#include "velox/dwio/nimble/encodings/VarintEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/nimble/encodings/common/SortedPositionSlots.h"
+#include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
 using namespace facebook::nimble;
 
@@ -144,4 +151,144 @@ TEST(EncodingUtilsTest, copyPackedBitsRejectsEmptyRange) {
           /*bitCount=*/0,
           output.data()),
       "Cannot copy zero bits.");
+}
+
+class FindSortedPositionSlotsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<Buffer>(*pool_);
+  }
+
+  Vector<uint32_t> makePositions(std::initializer_list<uint32_t> values) {
+    Vector<uint32_t> v{pool_.get()};
+    v.insert(v.end(), values.begin(), values.end());
+    return v;
+  }
+
+  // Trivial encoding is viewable, so it drives the view + readAt binary-search
+  // branch of findSortedPositionSlots.
+  std::string_view encodeAsView(const Vector<uint32_t>& values) {
+    return test::Encoder<TrivialEncoding<uint32_t>>::encode(*buffer_, values);
+  }
+
+  // Varint encoding is NOT viewable, so it drives the materialize + binary-
+  // search-on-decoded-values fallback branch.
+  std::string_view encodeAsMaterialize(const Vector<uint32_t>& values) {
+    return test::Encoder<VarintEncoding<uint32_t>>::encode(*buffer_, values);
+  }
+
+  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
+  std::unique_ptr<Buffer> buffer_;
+};
+
+// Exercises both branches with the same behavioral test suite so the view and
+// materialize paths cannot silently diverge.
+TEST_F(FindSortedPositionSlotsTest, matchesLowerBoundAcrossBranches) {
+  const auto positions = makePositions({3, 7, 12, 18, 25, 30});
+  const auto positionCount = static_cast<uint32_t>(positions.size());
+
+  struct BranchCase {
+    const char* name;
+    std::string_view encoded;
+  };
+  const BranchCase branches[] = {
+      {"viewBranch", encodeAsView(positions)},
+      {"materializeBranch", encodeAsMaterialize(positions)},
+  };
+
+  struct RangeCase {
+    const char* name;
+    uint32_t lo;
+    uint32_t hi;
+    uint32_t expectedStart;
+    uint32_t expectedEnd;
+  };
+  const RangeCase ranges[] = {
+      // Strictly interior range: 12 and 18 fall inside [10, 20).
+      {"interior", 10, 20, 2, 4},
+      // lo hits the smallest position value; retains positions >= 3 and < 30.
+      {"loEqualsFirst", 3, 30, 0, 5},
+      // hi hits the largest position value; retains everything before it.
+      {"hiEqualsLast", 0, 30, 0, 5},
+      // hi past the max keeps every slot.
+      {"fullRange", 0, 100, 0, positionCount},
+      // Range that starts before the first value.
+      {"loBelowMin", 0, 5, 0, 1},
+      // Range that starts after the last value returns (positionCount,
+      // positionCount).
+      {"loAboveMax", 40, 50, positionCount, positionCount},
+      // Empty range (lo == hi) collapses both slots to the same lower_bound.
+      {"emptyAtValue", 12, 12, 2, 2},
+      {"emptyBetweenValues", 20, 20, 4, 4},
+      // Range that ends before any position keeps no slots.
+      {"hiBelowMin", 0, 3, 0, 0},
+      // Single-slot range around the last value.
+      {"singleAtEnd", 25, 30, 4, 5},
+  };
+
+  for (const auto& branch : branches) {
+    SCOPED_TRACE(branch.name);
+    for (const auto& range : ranges) {
+      SCOPED_TRACE(
+          testing::Message()
+          << range.name << " lo=" << range.lo << " hi=" << range.hi);
+      const auto [slotStart, slotEnd] = detail::findSortedPositionSlots(
+          branch.encoded,
+          positionCount,
+          range.lo,
+          range.hi,
+          *pool_,
+          /*options=*/{});
+      EXPECT_EQ(slotStart, range.expectedStart);
+      EXPECT_EQ(slotEnd, range.expectedEnd);
+    }
+  }
+}
+
+TEST_F(FindSortedPositionSlotsTest, singlePositionArray) {
+  const auto positions = makePositions({42});
+  const auto viewEncoded = encodeAsView(positions);
+  const auto materializeEncoded = encodeAsMaterialize(positions);
+
+  for (const auto encoded : {viewEncoded, materializeEncoded}) {
+    // Range strictly before the single value.
+    auto slots = detail::findSortedPositionSlots(encoded, 1, 0, 42, *pool_, {});
+    EXPECT_EQ(slots.slotStart, 0);
+    EXPECT_EQ(slots.slotEnd, 0);
+
+    // Range that spans the single value.
+    slots = detail::findSortedPositionSlots(encoded, 1, 0, 100, *pool_, {});
+    EXPECT_EQ(slots.slotStart, 0);
+    EXPECT_EQ(slots.slotEnd, 1);
+
+    // Range strictly after the single value.
+    slots = detail::findSortedPositionSlots(encoded, 1, 43, 100, *pool_, {});
+    EXPECT_EQ(slots.slotStart, 1);
+    EXPECT_EQ(slots.slotEnd, 1);
+  }
+}
+
+TEST_F(FindSortedPositionSlotsTest, positionCountSubsetSlicesLeadingPrefix) {
+  // Callers may request a search over a leading prefix of the encoded
+  // positions by passing positionCount < actual encoded row count. This mirrors
+  // the sentinel-aware usage where SparseBool keeps the trailing sentinel out
+  // of the search domain in some workflows.
+  const auto positions = makePositions({1, 2, 3, 4, 5, 6, 7, 8});
+  const auto viewEncoded = encodeAsView(positions);
+  const auto materializeEncoded = encodeAsMaterialize(positions);
+
+  for (const auto encoded : {viewEncoded, materializeEncoded}) {
+    const auto [slotStart, slotEnd] = detail::findSortedPositionSlots(
+        encoded,
+        /*positionCount=*/4,
+        /*valueStartOffset=*/2,
+        /*valueEndOffset=*/10,
+        *pool_,
+        {});
+    // Only positions {1, 2, 3, 4} are considered; slots [1..4) are >= 2 and
+    // < 10.
+    EXPECT_EQ(slotStart, 1);
+    EXPECT_EQ(slotEnd, 4);
+  }
 }

--- a/velox/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/dwio/nimble/common/Buffer.h"
 #include "velox/dwio/nimble/common/Varint.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
 #include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
 #include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
 #include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
@@ -251,9 +252,28 @@ TEST(PFOREncodingBufferPoolTest, sliceReturnsScratchBufferToPool) {
                     : static_cast<Value>(50 + (i % 64)));
   }
 
-  Vector<Value> values{pool.get()};
-  values.insert(values.end(), input.data(), input.data() + input.size());
-  const auto encoded = Encoder<EncodingType>::encode(encodeBuffer, values);
+  // Force the exception-positions child to Varint so both
+  // findSortedPositionSlots' materialize-and-search branch and
+  // EncodingFactory::slice's sliceByMaterializing branch acquire scratch
+  // ScopedVectors from |bufferPool|. Trivial / FixedBitWidth positions are
+  // sliced through zero-copy header rewrites that never touch the pool.
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyCreator creator = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  EncodingLayout varintLayout{
+      nimble::EncodingType::Varint, {}, CompressionType::Uncompressed};
+  EncodingLayout layout{
+      nimble::EncodingType::PFOR,
+      {},
+      CompressionType::Uncompressed,
+      {varintLayout, std::nullopt}};
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<Value>>(
+      std::move(layout), CompressionOptions{}, creator);
+  const auto encoded = EncodingFactory::encode<Value>(
+      std::move(policy),
+      std::span<const Value>{input.data(), input.size()},
+      encodeBuffer);
   const std::string encodedStorage{encoded};
 
   velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
@@ -710,6 +730,246 @@ TEST_F(PFOREncodingFuzzerTest, encodeRejectsEmpty) {
           std::span<const uint32_t>{empty.data(), empty.size()},
           buffer),
       "Pfor encoding cannot be used with 0 rows.");
+}
+
+// --- Slice end-to-end coverage for exception-position edge cases ----------
+
+TYPED_TEST(PFOREncodingTest, sliceWithZeroSourceExceptions) {
+  // A source with numExceptions == 0 has no exception-positions sub-stream at
+  // all. Slicing a non-empty range must still round-trip -- the slice path
+  // needs to skip the positions-stream logic entirely.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    Vector<T> valuesVec{this->pool_.get()};
+    for (uint32_t i = 0; i < 256; ++i) {
+      valuesVec.push_back(T{static_cast<uint32_t>(i)});
+    }
+    Buffer buffer{*this->pool_};
+    const auto encoded = Encoder<PFOREncoding<T>>::encode(
+        buffer,
+        valuesVec,
+        CompressionType::Uncompressed,
+        /*options=*/{},
+        /*realNestedSelection=*/true);
+
+    Buffer sliceBuffer{*this->pool_};
+    const auto sliced = PFOREncoding<T>::slice(
+        encoded, /*offset=*/10, /*length=*/100, sliceBuffer, {});
+    PFOREncoding<T> encoding{*this->pool_, sliced, nullptr, {}};
+    EXPECT_EQ(encoding.rowCount(), 100);
+
+    std::vector<T> output(100);
+    encoding.materialize(100, output.data());
+    for (uint32_t i = 0; i < 100; ++i) {
+      EXPECT_EQ(output[i], valuesVec[10 + i]) << "row " << i;
+    }
+  }
+}
+
+TYPED_TEST(PFOREncodingTest, sliceEmptyExceptionRange) {
+  // A slice that covers no exception rows falls out early: no positions stream
+  // is emitted, and the sliced Pfor decodes to the base residuals only.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    Vector<T> valuesVec{this->pool_.get()};
+    for (uint32_t i = 0; i < 256; ++i) {
+      // Only one exception, at row 0. Slicing rows [1, 1 + 100) skips it.
+      valuesVec.push_back(i == 0 ? T{999'999} : T{static_cast<uint32_t>(i)});
+    }
+    Buffer buffer{*this->pool_};
+    const auto encoded = Encoder<PFOREncoding<T>>::encode(
+        buffer,
+        valuesVec,
+        CompressionType::Uncompressed,
+        /*options=*/{},
+        /*realNestedSelection=*/true);
+
+    Buffer sliceBuffer{*this->pool_};
+    const auto sliced = PFOREncoding<T>::slice(
+        encoded, /*offset=*/1, /*length=*/100, sliceBuffer, {});
+    PFOREncoding<T> encoding{*this->pool_, sliced, nullptr, {}};
+    EXPECT_EQ(encoding.rowCount(), 100);
+
+    std::vector<T> output(100);
+    encoding.materialize(100, output.data());
+    for (uint32_t i = 0; i < 100; ++i) {
+      EXPECT_EQ(output[i], valuesVec[1 + i]) << "row " << i;
+    }
+  }
+}
+
+// Extracts the exception-positions sub-stream bytes from a PFOR<T> encoding.
+// Assumes the standard wire layout (see PFOREncoding class docstring): a
+// standard encoding prefix, sizeof(T) baseline bytes, a 1-byte baseBitWidth,
+// a numExceptions varint, then a varint-length-prefixed positions sub-stream.
+template <typename T>
+static std::string_view pforExceptionPositionsBytes(
+    std::string_view encoded,
+    bool useVarintRowCount) {
+  const auto prefixSize =
+      EncodingPrefix::prefixSize(encoded, useVarintRowCount);
+  const char* pos = encoded.data() + prefixSize;
+  pos += sizeof(T);
+  encoding::readChar(pos);
+  varint::readVarint32(&pos);
+  const auto positionsSize = varint::readVarint32(&pos);
+  return {pos, positionsSize};
+}
+
+// Peels the SliceEncoding wrapper the slice path always emits around the
+// exception-positions sub-stream and returns its inner encoding type plus
+// the on-wire value delta.
+struct PforExceptionPositionsSliceInfo {
+  EncodingType outerType;
+  EncodingType innerType;
+  int64_t valueDelta;
+};
+
+template <typename T>
+static PforExceptionPositionsSliceInfo pforExceptionPositionsSliceInfo(
+    std::string_view encoded,
+    const Encoding::Options& options,
+    velox::memory::MemoryPool& pool) {
+  const auto positionsBytes =
+      pforExceptionPositionsBytes<T>(encoded, options.useVarintRowCount);
+  const auto outerType = EncodingPrefix::encodingType(positionsBytes);
+  if (outerType != EncodingType::Slice) {
+    return {.outerType = outerType, .innerType = outerType, .valueDelta = 0};
+  }
+  SliceEncoding<uint32_t> slice{pool, positionsBytes, nullptr, options};
+  return {
+      .outerType = outerType,
+      .innerType = EncodingPrefix::encodingType(slice.innerEncoding()),
+      .valueDelta = slice.valueDelta(),
+  };
+}
+
+TYPED_TEST(PFOREncodingTest, sliceWithTrivialExceptionPositionsFallback) {
+  // Default nested selection makes the exception-positions child Trivial.
+  // The slice path re-emits the retained range through the source's captured
+  // layout, which produces another Trivial<uint32>, and lets SliceEncoding's
+  // Trivial push-down fold the -offset shift into the byte copy -- delta on
+  // the wire is zero.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    Vector<T> valuesVec{this->pool_.get()};
+    for (uint32_t i = 0; i < 300; ++i) {
+      valuesVec.push_back(
+          i % 10 == 7 ? T{100'000 + i}
+                      : T{static_cast<uint32_t>(50 + (i % 64))});
+    }
+    Buffer buffer{*this->pool_};
+    const auto encoded = Encoder<PFOREncoding<T>>::encode(
+        buffer,
+        valuesVec,
+        CompressionType::Uncompressed,
+        /*options=*/{},
+        /*realNestedSelection=*/false);
+
+    // Confirm the source really has a Trivial exception-positions child so
+    // the Trivial fallback branch is exercised.
+    const auto sourcePositionsBytes =
+        pforExceptionPositionsBytes<T>(encoded, /*useVarintRowCount=*/false);
+    ASSERT_EQ(
+        EncodingPrefix::encodingType(sourcePositionsBytes),
+        EncodingType::Trivial);
+
+    Buffer sliceBuffer{*this->pool_};
+    const auto sliced = PFOREncoding<T>::slice(
+        encoded, /*offset=*/50, /*length=*/128, sliceBuffer, {});
+    const auto info = pforExceptionPositionsSliceInfo<T>(
+        sliced, /*options=*/{}, *this->pool_);
+    EXPECT_EQ(info.outerType, EncodingType::Slice);
+    EXPECT_EQ(info.innerType, EncodingType::Trivial);
+    EXPECT_EQ(info.valueDelta, 0);
+
+    PFOREncoding<T> encoding{*this->pool_, sliced, nullptr, {}};
+    ASSERT_EQ(encoding.rowCount(), 128);
+    std::vector<T> output(128);
+    encoding.materialize(128, output.data());
+    for (uint32_t i = 0; i < 128; ++i) {
+      EXPECT_EQ(output[i], valuesVec[50 + i]) << "row " << i;
+    }
+  }
+}
+
+TYPED_TEST(PFOREncodingTest, sliceWithVarintExceptionPositionsFallback) {
+  // Force the exception-positions child to Varint, which has no
+  // SliceEncoding push-down folder. The slice path re-emits the retained
+  // range through the source's captured layout -- another Varint<uint32> --
+  // and hands it to SliceEncoding::wrap. Wrap cannot fold the shift into a
+  // Varint inner, so the -offset delta rides on the wire and the read-time
+  // shift loop applies it.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    Vector<T> valuesVec{this->pool_.get()};
+    for (uint32_t i = 0; i < 300; ++i) {
+      valuesVec.push_back(
+          i % 10 == 7 ? T{100'000 + i}
+                      : T{static_cast<uint32_t>(50 + (i % 64))});
+    }
+
+    // Replay a PFOR layout whose exception-positions child is Varint. The
+    // ReplayedEncodingSelectionPolicy routes the nested encoding through the
+    // child's layout instead of the default read-factor selector.
+    EncodingLayout varintLayout{
+        EncodingType::Varint, {}, CompressionType::Uncompressed};
+    EncodingLayout layout{
+        EncodingType::PFOR,
+        {},
+        CompressionType::Uncompressed,
+        {varintLayout, std::nullopt}};
+    ManualEncodingSelectionPolicyFactory manualFactory;
+    EncodingSelectionPolicyCreator creator =
+        [&manualFactory](DataType dataType) {
+          return manualFactory.createPolicy(dataType);
+        };
+    auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(layout), CompressionOptions{}, creator);
+
+    Buffer buffer{*this->pool_};
+    const auto encoded = EncodingFactory::encode<T>(
+        std::move(policy),
+        std::span<const T>{valuesVec.data(), valuesVec.size()},
+        buffer);
+
+    // Confirm the source really has a Varint exception-positions child so
+    // the Varint fallback branch is exercised.
+    const auto sourcePositionsBytes =
+        pforExceptionPositionsBytes<T>(encoded, /*useVarintRowCount=*/false);
+    ASSERT_EQ(
+        EncodingPrefix::encodingType(sourcePositionsBytes),
+        EncodingType::Varint);
+
+    constexpr uint32_t kOffset = 50;
+    constexpr uint32_t kLength = 128;
+    Buffer sliceBuffer{*this->pool_};
+    const auto sliced =
+        PFOREncoding<T>::slice(encoded, kOffset, kLength, sliceBuffer, {});
+    const auto info = pforExceptionPositionsSliceInfo<T>(
+        sliced, /*options=*/{}, *this->pool_);
+    EXPECT_EQ(info.outerType, EncodingType::Slice);
+    // Captured layout preserves the source's Varint shape.
+    EXPECT_EQ(info.innerType, EncodingType::Varint);
+    // Varint has no push-down folder, so the -offset shift lands on the wire.
+    EXPECT_EQ(info.valueDelta, -static_cast<int64_t>(kOffset));
+
+    PFOREncoding<T> encoding{*this->pool_, sliced, nullptr, {}};
+    ASSERT_EQ(encoding.rowCount(), kLength);
+    std::vector<T> output(kLength);
+    encoding.materialize(kLength, output.data());
+    for (uint32_t i = 0; i < kLength; ++i) {
+      EXPECT_EQ(output[i], valuesVec[kOffset + i]) << "row " << i;
+    }
+  }
 }
 
 } // namespace facebook::nimble::test

--- a/velox/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/velox/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -22,7 +22,12 @@
 #include "velox/dwio/nimble/common/Types.h"
 #include "velox/dwio/nimble/common/Vector.h"
 #include "velox/dwio/nimble/common/tests/GTestUtils.h"
-#include "velox/dwio/nimble/encodings/common/EncodingType.h"
+#include "velox/dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "velox/dwio/nimble/encodings/SliceEncoding.h"
+#include "velox/dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/dwio/nimble/encodings/common/EncodingLayout.h"
+#include "velox/dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "velox/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/dwio/nimble/encodings/tests/TestUtils.h"
 
 #include <algorithm>
@@ -823,4 +828,245 @@ TYPED_TEST(SparseBoolEncodingTest, skipAllThenMaterializeRemaining) {
   encoding->materialize(2, result.data());
   EXPECT_EQ(result[0], values[8]);
   EXPECT_EQ(result[1], values[9]);
+}
+
+// --- Slice end-to-end coverage across position child shapes ---------------
+//
+// The slice path always emits a SliceEncoding wrapper around the sliced
+// position sub-stream. Its inner is a fresh re-emit of the retained
+// positions through the source's captured encoding layout -- Trivial in,
+// Trivial out; Varint in, Varint out; and so on. When the captured layout
+// supports SliceEncoding push-down (Trivial, FixedBitWidth, ...), the
+// -offset shift is folded into the inner bytes at write time and the
+// on-wire delta is zero. Otherwise the delta rides on the SliceEncoding
+// wire and the read-time shift loop applies it.
+
+// Peels the SliceEncoding wrapper the slice path always emits and returns
+// its inner encoding type plus the on-wire value delta.
+struct SliceInnerInfo {
+  nimble::EncodingType outerType;
+  nimble::EncodingType innerType;
+  int64_t valueDelta;
+};
+
+static SliceInnerInfo sparseBoolPositionSliceInfo(
+    std::string_view encoded,
+    const nimble::Encoding::Options& options,
+    velox::memory::MemoryPool& pool) {
+  const auto payload = encoded.substr(
+      nimble::EncodingPrefix::prefixSize(encoded, options.useVarintRowCount));
+  const auto positionEnc = payload.substr(sizeof(uint8_t));
+  const auto outerType = nimble::EncodingPrefix::encodingType(positionEnc);
+  if (outerType != nimble::EncodingType::Slice) {
+    return {.outerType = outerType, .innerType = outerType, .valueDelta = 0};
+  }
+  // Constructing a SliceEncoding<uint32_t> parses the wire layout through the
+  // same code path production readers use; the accessors expose the parsed
+  // fields directly.
+  nimble::SliceEncoding<uint32_t> slice{pool, positionEnc, nullptr, options};
+  return {
+      .outerType = outerType,
+      .innerType = nimble::EncodingPrefix::encodingType(slice.innerEncoding()),
+      .valueDelta = slice.valueDelta(),
+  };
+}
+
+TYPED_TEST(SparseBoolEncodingTest, sliceWithTrivialPositionsFallback) {
+  // Default nested selection makes the sparse positions Trivial. The slice
+  // path re-emits the retained positions through the source's captured
+  // layout, which produces another Trivial<uint32>, and lets SliceEncoding's
+  // Trivial push-down fold the -offset shift into the byte copy -- delta on
+  // the wire is zero.
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, true, false, true, true, false, false});
+  const auto encoded =
+      nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  nimble::Buffer sliceBuffer{*this->pool_};
+  const auto sliced = nimble::SparseBoolEncoding::slice(
+      encoded, /*offset=*/2, /*length=*/6, sliceBuffer, options);
+  const auto info = sparseBoolPositionSliceInfo(sliced, options, *this->pool_);
+  EXPECT_EQ(info.outerType, nimble::EncodingType::Slice);
+  EXPECT_EQ(info.innerType, nimble::EncodingType::Trivial);
+  EXPECT_EQ(info.valueDelta, 0);
+  nimble::SparseBoolEncoding encoding{
+      *this->pool_,
+      sliced,
+      [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+      options};
+  ASSERT_EQ(encoding.rowCount(), 6);
+  nimble::Vector<bool> result(this->pool_.get(), 6);
+  encoding.materialize(6, result.data());
+  for (uint32_t i = 0; i < 6; ++i) {
+    EXPECT_EQ(result[i], values[2 + i]) << "row " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, sliceWithVarintPositionsFallback) {
+  // Force the sparse-positions child to Varint, which has no EncodingView and
+  // no SliceEncoding push-down folder. The slice path falls into
+  // detail::findSortedPositionSlots' materialize + binary-search branch and
+  // re-emits the retained range through the source's captured layout --
+  // another Varint<uint32>. SliceEncoding::wrap cannot fold the shift into a
+  // Varint inner, so the -offset delta rides on the wire and the read-time
+  // shift loop applies it.
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, true, false, true, true, false, false});
+
+  // Replay a SparseBool layout whose sole child (Indices) is Varint. The
+  // ReplayedEncodingSelectionPolicy routes the nested encoding through the
+  // child's layout instead of the default read-factor selector.
+  nimble::ManualEncodingSelectionPolicyFactory manualFactory;
+  nimble::EncodingSelectionPolicyCreator creator =
+      [&manualFactory](nimble::DataType dataType) {
+        return manualFactory.createPolicy(dataType);
+      };
+  nimble::EncodingLayout varintLayout{
+      nimble::EncodingType::Varint, {}, nimble::CompressionType::Uncompressed};
+  nimble::EncodingLayout layout{
+      nimble::EncodingType::SparseBool,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {varintLayout}};
+  auto policy = std::make_unique<nimble::ReplayedEncodingSelectionPolicy<bool>>(
+      std::move(layout), nimble::CompressionOptions{}, creator);
+
+  const auto encoded = nimble::EncodingFactory::encode<bool>(
+      std::move(policy),
+      std::span<const bool>{values.data(), values.size()},
+      *this->buffer_,
+      options);
+
+  // Verify the source really has a Varint positions child so the fallback
+  // branch is exercised.
+  const auto sourcePayload = encoded.substr(
+      nimble::EncodingPrefix::prefixSize(encoded, options.useVarintRowCount));
+  const auto sourcePositionEnc = sourcePayload.substr(sizeof(uint8_t));
+  ASSERT_EQ(
+      nimble::EncodingPrefix::encodingType(sourcePositionEnc),
+      nimble::EncodingType::Varint);
+
+  constexpr uint32_t kOffset = 2;
+  constexpr uint32_t kLength = 6;
+  nimble::Buffer sliceBuffer{*this->pool_};
+  const auto sliced = nimble::SparseBoolEncoding::slice(
+      encoded, kOffset, kLength, sliceBuffer, options);
+  const auto info = sparseBoolPositionSliceInfo(sliced, options, *this->pool_);
+  EXPECT_EQ(info.outerType, nimble::EncodingType::Slice);
+  // Captured layout preserves the source's Varint shape.
+  EXPECT_EQ(info.innerType, nimble::EncodingType::Varint);
+  // Varint has no push-down folder, so the -offset shift lands on the wire.
+  EXPECT_EQ(info.valueDelta, -static_cast<int64_t>(kOffset));
+  nimble::SparseBoolEncoding encoding{
+      *this->pool_,
+      sliced,
+      [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+      options};
+  ASSERT_EQ(encoding.rowCount(), kLength);
+  nimble::Vector<bool> result(this->pool_.get(), kLength);
+  encoding.materialize(kLength, result.data());
+  for (uint32_t i = 0; i < kLength; ++i) {
+    EXPECT_EQ(result[i], values[kOffset + i]) << "row " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, sliceRoundTripAtBoundaries) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, true, false, false, true, false, true});
+  const auto encoded =
+      nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options,
+          /*realNestedSelection=*/true);
+
+  struct Range {
+    const char* name;
+    uint32_t offset;
+    uint32_t length;
+  };
+  for (const auto range :
+       {Range{"singleRowAtStart", 0, 1},
+        Range{"fullRange", 0, 10},
+        Range{"singleRowAtEnd", 9, 1},
+        Range{"singleRowInside", 4, 1}}) {
+    SCOPED_TRACE(range.name);
+    nimble::Buffer sliceBuffer{*this->pool_};
+    const auto sliced = nimble::SparseBoolEncoding::slice(
+        encoded, range.offset, range.length, sliceBuffer, options);
+    nimble::SparseBoolEncoding encoding{
+        *this->pool_,
+        sliced,
+        [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+        options};
+    ASSERT_EQ(encoding.rowCount(), range.length);
+    nimble::Vector<bool> result(this->pool_.get(), range.length);
+    encoding.materialize(range.length, result.data());
+    for (uint32_t i = 0; i < range.length; ++i) {
+      EXPECT_EQ(result[i], values[range.offset + i]) << "row " << i;
+    }
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, mainlyConstantSliceUsesIsCommonSparseBool) {
+  // MainlyConstantEncodingBase::slice reaches SparseBoolEncoding::sliceAndCount
+  // for every projected MainlyConstant stream whose isCommon child is
+  // SparseBool. This is the hot path the fast-slice work was designed for.
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  // Build a MainlyConstant stream: 4096 rows with the common value 42
+  // interleaved with rare non-common values every 47 rows.
+  nimble::Vector<int32_t> values{this->pool_.get()};
+  for (uint32_t row = 0; row < 4096; ++row) {
+    values.push_back(row % 47 == 0 ? static_cast<int32_t>(1000 + row) : 42);
+  }
+  const auto encoded =
+      nimble::test::Encoder<nimble::MainlyConstantEncoding<int32_t>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options,
+          /*realNestedSelection=*/true);
+
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+  for (const auto range :
+       {Range{/*offset=*/0, /*length=*/1},
+        Range{/*offset=*/0, /*length=*/4096},
+        Range{/*offset=*/46, /*length=*/3},
+        Range{/*offset=*/47, /*length=*/1},
+        Range{/*offset=*/94, /*length=*/100},
+        Range{/*offset=*/1000, /*length=*/1000},
+        Range{/*offset=*/4095, /*length=*/1}}) {
+    SCOPED_TRACE(
+        testing::Message() << "offset=" << range.offset
+                           << ", length=" << range.length);
+    nimble::Buffer sliceBuffer{*this->pool_};
+    const auto sliced = nimble::MainlyConstantEncoding<int32_t>::slice(
+        encoded, range.offset, range.length, sliceBuffer, options);
+    auto encoding = nimble::EncodingFactory{options}.create(
+        *this->pool_, sliced, [](uint32_t /*size*/) -> void* {
+          return nullptr;
+        });
+    ASSERT_EQ(encoding->rowCount(), range.length);
+    nimble::Vector<int32_t> result(this->pool_.get(), range.length);
+    encoding->materialize(range.length, result.data());
+    for (uint32_t i = 0; i < range.length; ++i) {
+      EXPECT_EQ(result[i], values[range.offset + i]) << "row " << i;
+    }
+  }
 }


### PR DESCRIPTION
Summary:

Adds an optional signed `valueDelta` to `EncodingSliceFactory::slice()` for sorted-position streams, so slicers pass `-firstStripeOffset` and the FBW inner encodes stripe offsets relative to zero. The inner's baseline field absorbs the shift at write time (push-down from D118984537), so decode-time is unchanged; the win is a strictly smaller FBW `bitWidth` on the sliced range and one fewer scratch pass in the projector.

Wire format unchanged. Only sliced positions produced through the value-delta path see narrower packs.

Benchmark:
  fb_public_sparse cluster-index, single-thread, decode=false.
  Local devserver (3-rep median CPU/batch): -7.57% (5.020 -> 4.640 ms).
  No T3 A/B run for this diff in isolation.

Depends on D118984537.

Reviewed By: xiaoxmeng

Differential Revision: D118624057


