### PR TITLE
fix(wave): Fix kernel_ld_test build break from CUDA 13 cuCtxCreate_v4 signature

### DIFF
--- a/velox/experimental/torchwave/tests/KernelLdTest.cu
+++ b/velox/experimental/torchwave/tests/KernelLdTest.cu
@@ -113,7 +113,12 @@ class KernelLdTest : public ::testing::Test {
     CUcontext ctx;
     cuCtxGetCurrent(&ctx);
     if (!ctx) {
-      if (cuCtxCreate(&ctx, 0, device) != CUDA_SUCCESS) {
+#if CUDA_VERSION >= 13000
+      auto createResult = cuCtxCreate(&ctx, nullptr, 0, device);
+#else
+      auto createResult = cuCtxCreate(&ctx, 0, device);
+#endif
+      if (createResult != CUDA_SUCCESS) {
         GTEST_SKIP() << "Failed to create CUDA context";
       }
     }


### PR DESCRIPTION
Summary:
## Root cause

`KernelLdTest.cu`'s `SetUp()` called the 3-argument CUDA Driver API form `cuCtxCreate(&ctx, 0, device)`. fbcode's CUDA toolkit is being upgraded from 12.x to 13.x (T280679656), and CUDA 13's `cuda.h` remaps the `cuCtxCreate` macro:

- `third-party/tp2/cuda/13.0/x86_64/targets/x86_64-linux/include/cuda.h:90` — `#define cuCtxCreate cuCtxCreate_v4`
- same header, line 263 — `#define CUDA_VERSION 13000`

`cuCtxCreate_v4` takes **four** arguments — `(CUcontext* pctx, CUctxCreateParams* ctxCreateParams, unsigned int flags, CUdevice dev)` — so the existing 3-argument call no longer compiles. The same remap is present in the 13.1, 13.2 and 13.3 toolkits, and `fbcode/platform/PACKAGE` already pins `"cuda": "13.3"`.

The observed error is a **compile** failure in the `cudafepp KernelLdTest.cu` action, not a runtime one:

```
fbcode/velox/experimental/torchwave/tests/KernelLdTest.cu(116): error: too few arguments in function call
        if (cuCtxCreate_v4(&ctx, 0, device) != CUDA_SUCCESS) {
                                          ^
```

It is independent of build mode — it reproduces identically under `opt-tsan` and `dev-nosan`. `KernelLdTest.cu` had not been modified since it was introduced, consistent with an external toolchain change rather than a regression in the test itself.

## Fix

Guard the call with the `#if CUDA_VERSION >= 13000` pattern already used across fbcode for this exact signature change — e.g. `fbcode/comms/tcp_devmem/unpack/batch_unpack_test.cc`, `fbcode/strobelight/tools/gpu_mem/gpu_mem_test.cpp`, `fbcode/neteng/ai/rdma-ud/UdEndpoint.cpp`, `fbcode/neteng/ai/rdma_gen/memory/GpuMemory.cpp` — passing `nullptr` for `CUctxCreateParams*` on CUDA 13+ and keeping the 3-argument call on older toolkits.

A null `CUctxCreateParams*` selects the same default context-creation behavior as the old 3-argument form, so the test's runtime behavior is unchanged on either toolkit. The result is captured in a local so the single `CUDA_SUCCESS` check and the existing `GTEST_SKIP()` fallback are shared by both branches.

Agent trajectory: https://www.internalfb.com/intern/devai/devmate/inspector/8086fdbf-8e16-40c3-b80f-f5d7e3410719/

Differential Revision: D119806136


